### PR TITLE
RavenDB-14274 - uploading a backup without creating a temp file on disk

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupConfiguration.cs
@@ -8,6 +8,7 @@ namespace Raven.Client.Documents.Operations.Backups
     public class BackupConfiguration : IDynamicJson
     {
         public BackupType BackupType { get; set; }
+        public BackupUploadMode BackupUploadMode { get; set; }
         public SnapshotSettings SnapshotSettings { get; set; }
         public BackupEncryptionSettings BackupEncryptionSettings { get; set; }
         public LocalSettings LocalSettings { get; set; }
@@ -101,6 +102,7 @@ namespace Raven.Client.Documents.Operations.Backups
             return new DynamicJsonValue
             {
                 [nameof(BackupType)] = BackupType,
+                [nameof(BackupUploadMode)] = BackupUploadMode,
                 [nameof(SnapshotSettings)] = SnapshotSettings?.ToJson(),
                 [nameof(BackupEncryptionSettings)] = BackupEncryptionSettings?.ToJson(),
                 [nameof(LocalSettings)] = LocalSettings?.ToJson(),

--- a/src/Raven.Client/Documents/Operations/Backups/BackupUploadMode.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupUploadMode.cs
@@ -1,0 +1,7 @@
+namespace Raven.Client.Documents.Operations.Backups;
+
+public enum BackupUploadMode
+{
+    Default,
+    DirectUpload
+}

--- a/src/Raven.Server/Config/Categories/BackupConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BackupConfiguration.cs
@@ -60,7 +60,6 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Backup.CloudStorageOperationTimeoutInMin", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting CloudStorageOperationTimeout { get; set; }
 
-
         [Description("EXPERT: Indicates which library to use when doing Azure backups.")]
         [DefaultValue(false)]
         [ConfigurationEntry("Backup.Azure.Legacy", ConfigurationEntryScope.ServerWideOnly)]

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                 Name = backupName,
             };
 
-            var backupTask = new BackupTask(RequestHandler.Database, backupParameters, backupConfiguration, token, Logger, RequestHandler.Database.PeriodicBackupRunner._forTestingPurposes);
+            var backupTask = BackupUtils.GetBackupTask(RequestHandler.Database, backupParameters, backupConfiguration, token, Logger, RequestHandler.Database.PeriodicBackupRunner._forTestingPurposes);
             var threadName = $"Backup thread {backupName} for database '{RequestHandler.Database.Name}'";
 
             var t = RequestHandler.Database.Operations.AddLocalOperation(

--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -11,13 +11,14 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Util;
+using Raven.Server.Documents.PeriodicBackup.DirectUpload;
 using Raven.Server.Documents.PeriodicBackup.Restore;
 using Sparrow;
 using Size = Sparrow.Size;
 
 namespace Raven.Server.Documents.PeriodicBackup.Aws
 {
-    public sealed class RavenAwsS3Client : IDisposable
+    public sealed class RavenAwsS3Client : IDirectUploader, IDisposable
     {
         private readonly Progress _progress;
         private readonly CancellationToken _cancellationToken;
@@ -103,6 +104,11 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             AsyncHelpers.RunSync(() => PutObjectAsync(key, stream, metadata));
         }
 
+        public IMultiPartUploader GetUploader(string key, Dictionary<string, string> metadata)
+        {
+            return new AwsS3MultiPartUploader(_client, _bucketName, _progress, key, metadata, _cancellationToken);
+        }
+
         public async Task PutObjectAsync(string key, Stream stream, Dictionary<string, string> metadata)
         {
             //TestConnection();
@@ -120,43 +126,19 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                 {
                     _progress?.UploadProgress.ChangeType(UploadType.Chunked);
 
-                    var multipartRequest = new InitiateMultipartUploadRequest { Key = key, BucketName = _bucketName };
+                    var multiPartUploader = new AwsS3MultiPartUploader(_client, _bucketName, _progress, key, metadata, _cancellationToken);
 
-                    FillMetadata(multipartRequest.Metadata, metadata);
-
-                    var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken);
-                    var partNumber = 1;
-                    var partEtags = new List<PartETag>();
+                    await multiPartUploader.InitializeAsync();
 
                     while (stream.Position < streamLength)
                     {
                         var leftToUpload = streamLength - stream.Position;
                         var toUpload = Math.Min(MinOnePartUploadSizeLimit.GetValue(SizeUnit.Bytes), leftToUpload);
 
-                        var uploadResponse = await _client
-                            .UploadPartAsync(new UploadPartRequest
-                            {
-                                Key = key,
-                                BucketName = _bucketName,
-                                InputStream = stream,
-                                PartNumber = partNumber++,
-                                PartSize = toUpload,
-                                UploadId = initiateResponse.UploadId,
-                                StreamTransferProgress = (_, args) =>
-                                {
-                                    _progress?.UploadProgress.ChangeState(UploadState.Uploading);
-                                    _progress?.UploadProgress.UpdateUploaded(args.IncrementTransferred);
-                                    _progress?.OnUploadProgress?.Invoke();
-                                }
-                            }, _cancellationToken);
-
-                        partEtags.Add(new PartETag(uploadResponse.PartNumber, uploadResponse.ETag));
+                        await multiPartUploader.UploadPartAsync(stream, toUpload);
                     }
 
-                    await _client.CompleteMultipartUploadAsync(
-                        new CompleteMultipartUploadRequest { UploadId = initiateResponse.UploadId, BucketName = _bucketName, Key = key, PartETags = partEtags },
-                        _cancellationToken);
-
+                    await multiPartUploader.CompleteUploadAsync();
                     return;
                 }
 
@@ -377,7 +359,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             }
         }
 
-        private static void FillMetadata(MetadataCollection collection, IDictionary<string, string> metadata)
+        public static void FillMetadata(MetadataCollection collection, IDictionary<string, string> metadata)
         {
             if (metadata == null)
                 return;

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupConfigurationHelper.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupConfigurationHelper.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using NCrontab.Advanced;
 using Raven.Client.Documents.Operations.Backups;
@@ -88,6 +90,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
 
             AssertBackupConfigurationInternal(configuration);
+            AssertDirectUpload(configuration);
 
             var retentionPolicy = configuration.RetentionPolicy;
             if (retentionPolicy != null && retentionPolicy.Disabled == false)
@@ -125,6 +128,40 @@ namespace Raven.Server.Documents.PeriodicBackup
                         throw new ArgumentException(error);
                 }
             }
+        }
+
+        private static void AssertDirectUpload(PeriodicBackupConfiguration configuration)
+        {
+            if (configuration.BackupUploadMode != BackupUploadMode.DirectUpload)
+                return;
+
+            var backupToLocalFolder = BackupConfiguration.CanBackupUsing(configuration.LocalSettings);
+            GetBackupDestinationForDirectUpload(backupToLocalFolder, configuration); // will throw if destination isn't set correctly
+        }
+
+        internal static BackupConfiguration.BackupDestination GetBackupDestinationForDirectUpload(bool backupToLocalFolder, BackupConfiguration configuration)
+        {
+            if (backupToLocalFolder)
+            {
+                throw new NotSupportedException("Trying to use direct upload when we configure a backup to a local folder.");
+            }
+
+            var hasAws = BackupConfiguration.CanBackupUsing(configuration.S3Settings);
+            var hasGlacier = BackupConfiguration.CanBackupUsing(configuration.GlacierSettings);
+            var hasAzure = BackupConfiguration.CanBackupUsing(configuration.AzureSettings);
+            var hasGoogleCloud = BackupConfiguration.CanBackupUsing(configuration.GoogleCloudSettings);
+            var hasFtp = BackupConfiguration.CanBackupUsing(configuration.FtpSettings);
+
+            var destinations = new List<bool> { hasAws, hasGlacier, hasAzure, hasGoogleCloud, hasFtp };
+            if (destinations.Count(x => x) != 1)
+            {
+                throw new NotSupportedException("Cannot use direct upload when we configure more than one destination.");
+            }
+
+            if (hasAws)
+                return BackupConfiguration.BackupDestination.AmazonS3;
+
+            throw new NotSupportedException("No supported backup destination for direct upload was set.");
         }
 
         public static void AssertDestinationAndRegionAreAllowed(BackupConfiguration configuration, ServerStore serverStore)

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -11,6 +11,8 @@ using Raven.Client.Documents.Smuggler;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Server.Config.Settings;
+using Raven.Server.Documents.PeriodicBackup.Aws;
+using Raven.Server.Documents.PeriodicBackup.DirectUpload;
 using Raven.Server.Documents.PeriodicBackup.Restore;
 using Raven.Server.Documents.PeriodicBackup.Retention;
 using Raven.Server.Json;
@@ -26,19 +28,23 @@ using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server.Json.Sync;
+using Sparrow.Utils;
 using BackupUtils = Raven.Server.Utils.BackupUtils;
 using StorageEnvironmentType = Voron.StorageEnvironmentWithType.StorageEnvironmentType;
 
 namespace Raven.Server.Documents.PeriodicBackup
 {
-    public sealed class BackupTask
+    public class BackupTask
     {
         public static string DateTimeFormat = "yyyy-MM-dd-HH-mm-ss";
         private const string LegacyDateTimeFormat = "yyyy-MM-dd-HH-mm";
         private const string InProgressExtension = ".in-progress";
 
-        private readonly DocumentDatabase _database;
-        private readonly BackupConfiguration _configuration;
+        protected readonly DocumentDatabase Database;
+        protected readonly BackupConfiguration Configuration;
+        protected readonly BackupResult BackupResult;
+        protected readonly RetentionPolicyBaseParameters RetentionPolicyParameters;
+
         private readonly PeriodicBackupStatus _previousBackupStatus;
         internal readonly bool _isFullBackup;
         private readonly bool _isOneTimeBackup;
@@ -47,17 +53,17 @@ namespace Raven.Server.Documents.PeriodicBackup
         private readonly PathSetting _tempBackupPath;
         private readonly Logger _logger;
         public readonly OperationCancelToken TaskCancelToken;
-        private readonly BackupResult _backupResult;
         private readonly bool _isServerWide;
         private readonly bool _isBackupEncrypted;
-        private readonly RetentionPolicyBaseParameters _retentionPolicyParameters;
         private Action<IOperationProgress> _onProgress;
         private readonly string _taskName;
         internal PeriodicBackupRunner.TestingStuff _forTestingPurposes;
         private readonly DateTime _startTimeUtc;
+        protected Action OnBackupException;
+
         public BackupTask(DocumentDatabase database, BackupParameters backupParameters, BackupConfiguration configuration, OperationCancelToken token, Logger logger, PeriodicBackupRunner.TestingStuff forTestingPurposes = null)
         {
-            _database = database;
+            Database = database;
             _taskName = backupParameters.Name;
             _operationId = backupParameters.OperationId;
             _previousBackupStatus = backupParameters.BackupStatus;
@@ -66,18 +72,19 @@ namespace Raven.Server.Documents.PeriodicBackup
             _isFullBackup = backupParameters.IsFullBackup;
             _backupToLocalFolder = backupParameters.BackupToLocalFolder;
             _tempBackupPath = backupParameters.TempBackupPath;
-            _configuration = configuration;
+            Configuration = configuration;
             _logger = logger;
             _isServerWide = backupParameters.Name?.StartsWith(ServerWideBackupConfiguration.NamePrefix, StringComparison.OrdinalIgnoreCase) ?? false;
-            _isBackupEncrypted = IsBackupEncrypted(_database, _configuration);
+            _isBackupEncrypted = IsBackupEncrypted(Database, Configuration);
             _forTestingPurposes = forTestingPurposes;
-            _backupResult = GenerateBackupResult();
-            TaskCancelToken = token ?? new OperationCancelToken(_database.DatabaseShutdown, CancellationToken.None);
+            BackupResult = GenerateBackupResult();
 
-            _retentionPolicyParameters = new RetentionPolicyBaseParameters
+            TaskCancelToken = token ?? new OperationCancelToken(Database.DatabaseShutdown, CancellationToken.None);
+
+            RetentionPolicyParameters = new RetentionPolicyBaseParameters
             {
                 RetentionPolicy = backupParameters.RetentionPolicy,
-                DatabaseName = _database.Name,
+                DatabaseName = Database.Name,
                 IsFullBackup = _isFullBackup,
                 OnProgress = AddInfo,
                 CancellationToken = TaskCancelToken.Token
@@ -98,8 +105,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                     throw new Exception(nameof(_forTestingPurposes.SimulateFailedBackup));
                 if (_forTestingPurposes != null && _forTestingPurposes.OnBackupTaskRunHoldBackupExecution != null)
                     _forTestingPurposes.OnBackupTaskRunHoldBackupExecution.Task.Wait();
-                if (_database.ForTestingPurposes != null && _database.ForTestingPurposes.ActionToCallOnGetTempPath != null)
-                    _database.ForTestingPurposes.ActionToCallOnGetTempPath.Invoke(_tempBackupPath);
+                if (Database.ForTestingPurposes != null && Database.ForTestingPurposes.ActionToCallOnGetTempPath != null)
+                    Database.ForTestingPurposes.ActionToCallOnGetTempPath.Invoke(_tempBackupPath);
 
                 if (runningBackupStatus.LocalBackup == null)
                     runningBackupStatus.LocalBackup = new LocalBackup();
@@ -111,7 +118,7 @@ namespace Raven.Server.Documents.PeriodicBackup
 
                 if (_logger.IsInfoEnabled)
                 {
-                    var fullBackupText = "a " + (_configuration.BackupType == BackupType.Backup ? "full backup" : "snapshot");
+                    var fullBackupText = "a " + (Configuration.BackupType == BackupType.Backup ? "full backup" : "snapshot");
                     _logger.Info($"Creating {(_isFullBackup ? fullBackupText : "an incremental backup")}");
                 }
 
@@ -121,7 +128,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     _previousBackupStatus.LastRaftIndex ??= new LastRaftIndex();
 
                     // no-op if nothing has changed
-                    var (currentLastEtag, currentChangeVector) = _database.ReadLastEtagAndChangeVector();
+                    var (currentLastEtag, currentChangeVector) = Database.ReadLastEtagAndChangeVector();
                     var currentLastRaftIndex = GetDatabaseEtagForBackup();
 
                     // if we come from old version the _previousBackupStatus won't have LastRaftIndex
@@ -139,23 +146,23 @@ namespace Raven.Server.Documents.PeriodicBackup
                         runningBackupStatus.LastIncrementalBackup = _startTimeUtc;
                         runningBackupStatus.LocalBackup.LastIncrementalBackup = _startTimeUtc;
                         runningBackupStatus.LocalBackup.IncrementalBackupDurationInMs = 0;
-                        SmugglerBase.EnsureProcessed(_backupResult);
+                        SmugglerBase.EnsureProcessed(BackupResult);
                         AddInfo(message);
 
-                        return _backupResult;
+                        return BackupResult;
                     }
                 }
 
                 // update the local configuration before starting the local backup
-                var localSettings = GetBackupConfigurationFromScript(_configuration.LocalSettings, x => JsonDeserializationServer.LocalSettings(x),
-                    settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForLocal(settings, _database.Name));
+                var localSettings = GetBackupConfigurationFromScript(Configuration.LocalSettings, x => JsonDeserializationServer.LocalSettings(x),
+                    settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForLocal(settings, Database.Name));
 
                 GenerateFolderNameAndBackupDirectory(localSettings, _startTimeUtc, out var nowAsString, out var folderName, out var backupDirectory);
                 var startEtag = _isFullBackup == false ? _previousBackupStatus.LastEtag : null;
                 var startRaftIndex = _isFullBackup == false ? _previousBackupStatus.LastRaftIndex.LastEtag : null;
 
-                var fileName = GetFileName(_isFullBackup, backupDirectory.FullPath, nowAsString, _configuration.BackupType, out string backupFilePath);
-                var internalBackupResult = CreateLocalBackupOrSnapshot(runningBackupStatus, backupFilePath, startEtag, startRaftIndex);
+                var fileName = GetFileName(_isFullBackup, backupDirectory.FullPath, nowAsString, Configuration.BackupType, out string backupFilePath);
+                var internalBackupResult = CreateLocalBackupOrSnapshot(runningBackupStatus, backupFilePath, folderName, fileName, startEtag, startRaftIndex);
 
                 runningBackupStatus.LocalBackup.BackupDirectory = _backupToLocalFolder ? backupDirectory.FullPath : null;
                 runningBackupStatus.LocalBackup.TempFolderUsed = _backupToLocalFolder == false;
@@ -167,21 +174,21 @@ namespace Raven.Server.Documents.PeriodicBackup
                 }
                 finally
                 {
-                    runningBackupStatus.UploadToS3 = _backupResult.S3Backup;
-                    runningBackupStatus.UploadToAzure = _backupResult.AzureBackup;
-                    runningBackupStatus.UploadToGoogleCloud = _backupResult.GoogleCloudBackup;
-                    runningBackupStatus.UploadToGlacier = _backupResult.GlacierBackup;
-                    runningBackupStatus.UploadToFtp = _backupResult.FtpBackup;
+                    runningBackupStatus.UploadToS3 = BackupResult.S3Backup;
+                    runningBackupStatus.UploadToAzure = BackupResult.AzureBackup;
+                    runningBackupStatus.UploadToGoogleCloud = BackupResult.GoogleCloudBackup;
+                    runningBackupStatus.UploadToGlacier = BackupResult.GlacierBackup;
+                    runningBackupStatus.UploadToFtp = BackupResult.FtpBackup;
 
-                    _backupResult.LocalBackup = new LocalBackup
+                    BackupResult.LocalBackup = new LocalBackup
                     {
                         BackupDirectory = folderName,
                         FileName = fileName
                     };
 
-                    // if user did not specify local folder we delete the temporary file
                     if (_backupToLocalFolder == false)
                     {
+                        // if user did not specify a local folder, we delete the temporary file
                         DeleteFile(backupFilePath);
                     }
                 }
@@ -200,12 +207,12 @@ namespace Raven.Server.Documents.PeriodicBackup
 
                 if (_logger.IsInfoEnabled)
                 {
-                    var fullBackupText = "a " + (_configuration.BackupType == BackupType.Backup ? " full backup" : " snapshot");
+                    var fullBackupText = "a " + (Configuration.BackupType == BackupType.Backup ? " full backup" : " snapshot");
                     _logger.Info($"Successfully created {(_isFullBackup ? fullBackupText : "an incremental backup")} " +
                                  $"in {totalSw.ElapsedMilliseconds:#,#;;0} ms");
                 }
 
-                return _backupResult;
+                return BackupResult;
             }
             catch (ObjectDisposedException)
             {
@@ -232,8 +239,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_logger.IsOperationsEnabled)
                     _logger.Operations(message, e);
 
-                _database.NotificationCenter.Add(AlertRaised.Create(
-                    _database.Name,
+                Database.NotificationCenter.Add(AlertRaised.Create(
+                    Database.Name,
                     $"Periodic Backup task: '{_taskName}'",
                     message,
                     AlertType.PeriodicBackup,
@@ -254,7 +261,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                     else
                         runningBackupStatus.LastIncrementalBackupInternal = _startTimeUtc;
 
-                    runningBackupStatus.NodeTag = _database.ServerStore.NodeTag;
+                    runningBackupStatus.NodeTag = Database.ServerStore.NodeTag;
                     runningBackupStatus.DurationInMs = totalSw.ElapsedMilliseconds;
                     UpdateOperationId(runningBackupStatus);
 
@@ -264,7 +271,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         // save the backup status
                         // create a local copy of ref `runningBackupStatus` so that it can be used in the anonymous method.
                         var status = runningBackupStatus;
-                        BackupUtils.SaveBackupStatus(status, _database.Name, _database.ServerStore, _logger, _backupResult, _onProgress, TaskCancelToken);
+                        BackupUtils.SaveBackupStatus(status, Database.Name, Database.ServerStore, _logger, BackupResult, _onProgress, TaskCancelToken);
                     }
 
                     _forTestingPurposes?.AfterBackupBatchCompleted?.Invoke();
@@ -272,11 +279,11 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
         }
 
-        private T GetBackupConfigurationFromScript<T>(T backupSettings, Func<BlittableJsonReaderObject, T> deserializeSettingsFunc,
+        protected T GetBackupConfigurationFromScript<T>(T backupSettings, Func<BlittableJsonReaderObject, T> deserializeSettingsFunc,
             Action<T> updateServerWideSettingsFunc)
             where T : BackupSettings
         {
-            return GetBackupConfigurationFromScript(backupSettings, deserializeSettingsFunc, _database, updateServerWideSettingsFunc, _isServerWide);
+            return GetBackupConfigurationFromScript(backupSettings, deserializeSettingsFunc, Database, updateServerWideSettingsFunc, _isServerWide);
         }
 
         internal static T GetBackupConfigurationFromScript<T>(T backupSettings, Func<BlittableJsonReaderObject, T> deserializeSettingsFunc, DocumentDatabase documentDatabase,
@@ -380,10 +387,10 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         private long GetDatabaseEtagForBackup()
         {
-            using (_database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
             {
-                var rawRecord = _database.ServerStore.Cluster.ReadRawDatabaseRecord(context, _database.Name);
+                var rawRecord = Database.ServerStore.Cluster.ReadRawDatabaseRecord(context, Database.Name);
 
                 return rawRecord.EtagForBackup;
             }
@@ -398,7 +405,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 while (true)
                 {
                     nowAsString = GetFormattedDate(nowInLocalTime);
-                    folderName = $"{nowAsString}.ravendb-{_database.Name}-{_database.ServerStore.NodeTag}-{_configuration.BackupType.ToString().ToLower()}";
+                    folderName = $"{nowAsString}.ravendb-{Database.Name}-{Database.ServerStore.NodeTag}-{Configuration.BackupType.ToString().ToLower()}";
                     backupDirectory = _backupToLocalFolder ? new PathSetting(localSettings.FolderPath).Combine(folderName) : _tempBackupPath;
 
                     if (_backupToLocalFolder == false || DirectoryContainsBackupFiles(backupDirectory.FullPath, IsAnyBackupFile) == false)
@@ -432,7 +439,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             {
                 SnapshotBackup =
                 {
-                    Skipped = _isFullBackup == false || _configuration.BackupType == BackupType.Backup
+                    Skipped = _isFullBackup == false || Configuration.BackupType == BackupType.Backup
                 },
                 S3Backup =
                 {
@@ -550,7 +557,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             public long LastRaftIndex { get; set; }
         }
 
-        private InternalBackupResult CreateLocalBackupOrSnapshot(PeriodicBackupStatus status, string backupFilePath, long? startEtag, long? startRaftIndex)
+        private InternalBackupResult CreateLocalBackupOrSnapshot(PeriodicBackupStatus status, string backupFilePath, string folderName, string fileName, long? startEtag, long? startRaftIndex)
         {
             var internalBackupResult = new InternalBackupResult();
 
@@ -563,9 +570,9 @@ namespace Raven.Server.Documents.PeriodicBackup
                 {
                     BackupTypeValidation();
 
-                    AddInfo($"Started {GetBackupDescription(_configuration.BackupType, _isFullBackup)}");
-                    if (_configuration.BackupType == BackupType.Backup ||
-                        _configuration.BackupType == BackupType.Snapshot && _isFullBackup == false)
+                    AddInfo($"Started {GetBackupDescription(Configuration.BackupType, _isFullBackup)}");
+                    if (Configuration.BackupType == BackupType.Backup ||
+                        Configuration.BackupType == BackupType.Snapshot && _isFullBackup == false)
                     {
                         // smuggler backup
                         var options = new DatabaseSmugglerOptionsServerSide
@@ -578,7 +585,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         options.OperateOnTypes |= DatabaseItemType.Tombstones;
                         options.OperateOnTypes |= DatabaseItemType.CompareExchangeTombstones;
 
-                        var currentBackupResult = CreateBackup(options, tempBackupFilePath, startEtag, startRaftIndex);
+                        var currentBackupResult = CreateBackup(options, tempBackupFilePath, folderName, fileName, startEtag, startRaftIndex);
 
                         if (_isFullBackup)
                         {
@@ -586,8 +593,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                         }
                         else
                         {
-                            if (_backupResult.GetLastEtag() == _previousBackupStatus.LastEtag &&
-                                _backupResult.GetLastRaftIndex() == _previousBackupStatus.LastRaftIndex.LastEtag)
+                            if (BackupResult.GetLastEtag() == _previousBackupStatus.LastEtag &&
+                                BackupResult.GetLastRaftIndex() == _previousBackupStatus.LastRaftIndex.LastEtag)
                             {
                                 internalBackupResult.LastEtag = startEtag ?? 0;
                                 internalBackupResult.LastDatabaseChangeVector = _previousBackupStatus.LastDatabaseChangeVector;
@@ -604,37 +611,51 @@ namespace Raven.Server.Documents.PeriodicBackup
                         // snapshot backup
                         ValidateFreeSpaceForSnapshot(tempBackupFilePath);
 
-                        (internalBackupResult.LastEtag, internalBackupResult.LastDatabaseChangeVector) = _database.ReadLastEtagAndChangeVector();
+                        (internalBackupResult.LastEtag, internalBackupResult.LastDatabaseChangeVector) = Database.ReadLastEtagAndChangeVector();
                         internalBackupResult.LastRaftIndex = GetDatabaseEtagForBackup();
-                        var databaseSummary = _database.GetDatabaseSummary();
-                        var indexesCount = _database.IndexStore.Count;
+                        var databaseSummary = Database.GetDatabaseSummary();
+                        var indexesCount = Database.IndexStore.Count;
 
                         var totalSw = Stopwatch.StartNew();
                         var sw = Stopwatch.StartNew();
-                        var compressionAlgorithm = _configuration.SnapshotSettings?.CompressionAlgorithm ?? _database.Configuration.Backup.SnapshotCompressionAlgorithm;
-                        var compressionLevel = _configuration.SnapshotSettings?.CompressionLevel ?? _database.Configuration.Backup.SnapshotCompressionLevel;
-                        var excludeIndexes = _configuration.SnapshotSettings?.ExcludeIndexes ?? false;
-                        var smugglerResult = _database.FullBackupTo(tempBackupFilePath, compressionAlgorithm, compressionLevel, excludeIndexes,
-                            info =>
+                        var compressionAlgorithm = Configuration.SnapshotSettings?.CompressionAlgorithm ?? Database.Configuration.Backup.SnapshotCompressionAlgorithm;
+                        var compressionLevel = Configuration.SnapshotSettings?.CompressionLevel ?? Database.Configuration.Backup.SnapshotCompressionLevel;
+                        var excludeIndexes = Configuration.SnapshotSettings?.ExcludeIndexes ?? false;
+
+                        using (var stream = GetStreamForBackupDestination(tempBackupFilePath, folderName, fileName))
+                        {
+                            try
                             {
-                                AddInfo(info.Message);
+                                var smugglerResult = Database.FullBackupTo(stream, compressionAlgorithm, compressionLevel, excludeIndexes,
+                                    info =>
+                                    {
+                                        AddInfo(info.Message);
 
-                                _backupResult.SnapshotBackup.ReadCount += info.FilesCount;
-                                if (sw.ElapsedMilliseconds > 0 && info.FilesCount > 0)
-                                {
-                                    AddInfo($"Backed up {_backupResult.SnapshotBackup.ReadCount} " +
-                                            $"file{(_backupResult.SnapshotBackup.ReadCount > 1 ? "s" : string.Empty)}");
-                                    sw.Restart();
-                                }
-                            }, TaskCancelToken.Token);
+                                        BackupResult.SnapshotBackup.ReadCount += info.FilesCount;
+                                        if (sw.ElapsedMilliseconds > 0 && info.FilesCount > 0)
+                                        {
+                                            AddInfo($"Backed up {BackupResult.SnapshotBackup.ReadCount} " +
+                                                    $"file{(BackupResult.SnapshotBackup.ReadCount > 1 ? "s" : string.Empty)}");
+                                            sw.Restart();
+                                        }
+                                    }, TaskCancelToken.Token);
 
-                        EnsureSnapshotProcessed(databaseSummary, smugglerResult, indexesCount);
+                                FlushToDiskIfNeeded(stream);
 
-                        AddInfo($"Backed up {_backupResult.SnapshotBackup.ReadCount} files, " +
+                                EnsureSnapshotProcessed(databaseSummary, smugglerResult, indexesCount);
+                            }
+                            catch
+                            {
+                                OnBackupException?.Invoke();
+                                throw;
+                            }
+                        }
+
+                        AddInfo($"Backed up {BackupResult.SnapshotBackup.ReadCount} files, " +
                                 $"took: {totalSw.ElapsedMilliseconds:#,#;;0}ms");
                     }
 
-                    IOExtensions.RenameFile(tempBackupFilePath, backupFilePath);
+                    RenameFile(tempBackupFilePath, backupFilePath);
 
                     status.LocalBackup.Exception = null;
                 }
@@ -644,6 +665,7 @@ namespace Raven.Server.Documents.PeriodicBackup
 
                     // deleting the temp backup file if the backup failed
                     DeleteFile(tempBackupFilePath);
+
                     throw;
                 }
             }
@@ -651,13 +673,23 @@ namespace Raven.Server.Documents.PeriodicBackup
             if (_backupToLocalFolder)
             {
                 var sp = Stopwatch.StartNew();
-                var localRetentionPolicy = new LocalRetentionPolicyRunner(_retentionPolicyParameters, _configuration.LocalSettings.FolderPath);
+                var localRetentionPolicy = new LocalRetentionPolicyRunner(RetentionPolicyParameters, Configuration.LocalSettings.FolderPath);
                 localRetentionPolicy.Execute();
                 sp.Stop();
                 status.LocalRetentionDurationInMs = sp.ElapsedMilliseconds;
             }
 
             return internalBackupResult;
+        }
+
+        protected virtual void RenameFile(string tempBackupFilePath, string backupFilePath)
+        {
+            IOExtensions.RenameFile(tempBackupFilePath, backupFilePath);
+        }
+
+        protected virtual Stream GetStreamForBackupDestination(string filePath, string folderName, string fileName)
+        {
+            return SafeFileStream.Create(filePath, FileMode.Create);
         }
 
         public static string GetBackupDescription(BackupType backupType, bool isFull)
@@ -667,7 +699,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             return $"{isFullText} {backupTypeText}";
         }
 
-        private void DeleteFile(string path)
+        protected virtual void DeleteFile(string path)
         {
             try
             {
@@ -680,13 +712,13 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
         }
 
-        private void ValidateFreeSpaceForSnapshot(string filePath)
+        protected virtual void ValidateFreeSpaceForSnapshot(string filePath)
         {
             long totalUsedSpace = 0;
-            foreach (var mountPointUsage in _database.GetMountPointsUsage(includeTempBuffers: false))
+            foreach (var mountPointUsage in Database.GetMountPointsUsage(includeTempBuffers: false))
             {
                 if (mountPointUsage.Type == nameof(StorageEnvironmentType.Index) &&
-                   _configuration.SnapshotSettings is { ExcludeIndexes: true })
+                   Configuration.SnapshotSettings is { ExcludeIndexes: true })
                     continue;
 
                 totalUsedSpace += mountPointUsage.UsedSpace;
@@ -699,99 +731,114 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         private void BackupTypeValidation()
         {
-            if (_database.MasterKey == null &&
-                _configuration.BackupEncryptionSettings?.EncryptionMode == EncryptionMode.UseDatabaseKey)
+            if (Database.MasterKey == null &&
+                Configuration.BackupEncryptionSettings?.EncryptionMode == EncryptionMode.UseDatabaseKey)
                 throw new InvalidOperationException("Can't use database key for backup encryption, the key doesn't exist");
 
-            if (_configuration.BackupType == BackupType.Snapshot && _isFullBackup &&
-                _configuration.BackupEncryptionSettings != null &&
-                _configuration.BackupEncryptionSettings.EncryptionMode == EncryptionMode.UseProvidedKey)
+            if (Configuration.BackupType == BackupType.Snapshot && _isFullBackup &&
+                Configuration.BackupEncryptionSettings != null &&
+                Configuration.BackupEncryptionSettings.EncryptionMode == EncryptionMode.UseProvidedKey)
                 throw new InvalidOperationException("Can't snapshot an encrypted database with a different key");
         }
 
         private void EnsureSnapshotProcessed(DatabaseSummary databaseSummary, SmugglerResult snapshotSmugglerResult, long indexesCount)
         {
-            _backupResult.SnapshotBackup.Processed = true;
-            _backupResult.DatabaseRecord.Processed = true;
-            _backupResult.RevisionDocuments.Attachments.Processed = true;
-            _backupResult.Tombstones.Processed = true;
-            _backupResult.Indexes.Processed = true;
-            _backupResult.Indexes.ReadCount = indexesCount;
+            BackupResult.SnapshotBackup.Processed = true;
+            BackupResult.DatabaseRecord.Processed = true;
+            BackupResult.RevisionDocuments.Attachments.Processed = true;
+            BackupResult.Tombstones.Processed = true;
+            BackupResult.Indexes.Processed = true;
+            BackupResult.Indexes.ReadCount = indexesCount;
 
-            _backupResult.Documents.Processed = true;
-            _backupResult.Documents.ReadCount = databaseSummary.DocumentsCount;
-            _backupResult.Documents.Attachments.Processed = true;
-            _backupResult.Documents.Attachments.ReadCount = databaseSummary.AttachmentsCount;
-            _backupResult.Counters.Processed = true;
-            _backupResult.Counters.ReadCount = databaseSummary.CounterEntriesCount;
-            _backupResult.RevisionDocuments.Processed = true;
-            _backupResult.RevisionDocuments.ReadCount = databaseSummary.RevisionsCount;
-            _backupResult.Conflicts.Processed = true;
-            _backupResult.Conflicts.ReadCount = databaseSummary.ConflictsCount;
+            BackupResult.Documents.Processed = true;
+            BackupResult.Documents.ReadCount = databaseSummary.DocumentsCount;
+            BackupResult.Documents.Attachments.Processed = true;
+            BackupResult.Documents.Attachments.ReadCount = databaseSummary.AttachmentsCount;
+            BackupResult.Counters.Processed = true;
+            BackupResult.Counters.ReadCount = databaseSummary.CounterEntriesCount;
+            BackupResult.RevisionDocuments.Processed = true;
+            BackupResult.RevisionDocuments.ReadCount = databaseSummary.RevisionsCount;
+            BackupResult.Conflicts.Processed = true;
+            BackupResult.Conflicts.ReadCount = databaseSummary.ConflictsCount;
 
-            _backupResult.Identities.Processed = true;
-            _backupResult.Identities.ReadCount = snapshotSmugglerResult.Identities.ReadCount;
-            _backupResult.CompareExchange.Processed = true;
-            _backupResult.CompareExchange.ReadCount = snapshotSmugglerResult.CompareExchange.ReadCount;
-            _backupResult.CompareExchangeTombstones.Processed = true;
-            _backupResult.Subscriptions.Processed = true;
-            _backupResult.Subscriptions.ReadCount = snapshotSmugglerResult.Subscriptions.ReadCount;
+            BackupResult.Identities.Processed = true;
+            BackupResult.Identities.ReadCount = snapshotSmugglerResult.Identities.ReadCount;
+            BackupResult.CompareExchange.Processed = true;
+            BackupResult.CompareExchange.ReadCount = snapshotSmugglerResult.CompareExchange.ReadCount;
+            BackupResult.CompareExchangeTombstones.Processed = true;
+            BackupResult.Subscriptions.Processed = true;
+            BackupResult.Subscriptions.ReadCount = snapshotSmugglerResult.Subscriptions.ReadCount;
 
-            _backupResult.TimeSeries.Processed = true;
-            _backupResult.TimeSeries.ReadCount = databaseSummary.TimeSeriesSegmentsCount;
+            BackupResult.TimeSeries.Processed = true;
+            BackupResult.TimeSeries.ReadCount = databaseSummary.TimeSeriesSegmentsCount;
         }
 
-        private void AddInfo(string message)
+        protected void AddInfo(string message)
         {
-            _backupResult.AddInfo(message);
-            _onProgress.Invoke(_backupResult.Progress);
+            BackupResult.AddInfo(message);
+            _onProgress.Invoke(BackupResult.Progress);
         }
 
-        private InternalBackupResult CreateBackup(
-            DatabaseSmugglerOptionsServerSide options, string backupFilePath, long? startDocumentEtag, long? startRaftIndex)
+        private InternalBackupResult CreateBackup(DatabaseSmugglerOptionsServerSide options, string backupFilePath, string folderName, string fileName, long? startDocumentEtag, long? startRaftIndex)
         {
             // the last etag is already included in the last backup
             var currentBackupResults = new InternalBackupResult();
             startDocumentEtag = startDocumentEtag == null ? 0 : ++startDocumentEtag;
             startRaftIndex = startRaftIndex == null ? 0 : ++startRaftIndex;
 
-            using (Stream fileStream = File.Open(backupFilePath, FileMode.CreateNew))
-            using (var outputStream = GetOutputStream(fileStream))
-            using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext smugglerContext))
+            using (var stream = GetStreamForBackupDestination(backupFilePath, folderName, fileName))
+            using (var outputStream = GetOutputStream(stream))
+            using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext smugglerContext))
             {
-                var smugglerSource = _database.Smuggler.CreateSource(startDocumentEtag.Value, startRaftIndex.Value, _logger);
-                var smugglerDestination = new StreamDestination(outputStream, context, smugglerSource, _database.Configuration.Backup.CompressionAlgorithm.ToExportCompressionAlgorithm(), _database.Configuration.Backup.CompressionLevel);
-                var smuggler = _database.Smuggler.Create(
-                    smugglerSource,
-                    smugglerDestination,
-                    smugglerContext,
-                    options: options,
-                    result: _backupResult,
-                    onProgress: _onProgress,
-                    token: TaskCancelToken.Token);
-
-                smuggler.ExecuteAsync().Wait();
-
-                switch (outputStream)
+                try
                 {
-                    case EncryptingXChaCha20Poly1305Stream encryptedStream:
-                        encryptedStream.Flush(flushToDisk: true);
-                        break;
+                    var smugglerSource = Database.Smuggler.CreateSource(startDocumentEtag.Value, startRaftIndex.Value, _logger);
+                    var smugglerDestination = new StreamDestination(outputStream, context, smugglerSource, Database.Configuration.Backup.CompressionAlgorithm.ToExportCompressionAlgorithm(), Database.Configuration.Backup.CompressionLevel);
+                    var smuggler = Database.Smuggler.Create(
+                        smugglerSource,
+                        smugglerDestination,
+                        smugglerContext,
+                        options: options,
+                        result: BackupResult,
+                        onProgress: _onProgress,
+                        token: TaskCancelToken.Token);
 
-                    case FileStream file:
-                        file.Flush(flushToDisk: true);
-                        break;
+                    smuggler.ExecuteAsync().Wait();
 
-                    default:
-                        throw new InvalidOperationException($" {outputStream.GetType()} not supported");
+                    FlushToDiskIfNeeded(outputStream);
+
+                    currentBackupResults.LastEtag = smugglerSource.LastEtag;
+                    currentBackupResults.LastDatabaseChangeVector = smugglerSource.LastDatabaseChangeVector;
+                    currentBackupResults.LastRaftIndex = smugglerSource.LastRaftIndex;
+
+                    return currentBackupResults;
                 }
+                catch
+                {
+                    OnBackupException?.Invoke();
+                    throw;
+                }
+            }
+        }
 
-                currentBackupResults.LastEtag = smugglerSource.LastEtag;
-                currentBackupResults.LastDatabaseChangeVector = smugglerSource.LastDatabaseChangeVector;
-                currentBackupResults.LastRaftIndex = smugglerSource.LastRaftIndex;
+        private static void FlushToDiskIfNeeded(Stream outputStream)
+        {
+            switch (outputStream)
+            {
+                case EncryptingXChaCha20Poly1305Stream encryptedStream:
+                    encryptedStream.Flush(flushToDisk: true);
+                    break;
 
-                return currentBackupResults;
+                case FileStream file:
+                    file.Flush(flushToDisk: true);
+                    break;
+
+                case DirectUploadStream<RavenAwsS3Client>:
+                    break;
+
+                default:
+                    throw new NotSupportedException($" {outputStream.GetType()} not supported");
             }
         }
 
@@ -800,32 +847,32 @@ namespace Raven.Server.Documents.PeriodicBackup
             if (_isBackupEncrypted == false)
                 return fileStream;
 
-            if (_database.MasterKey != null && _configuration.BackupEncryptionSettings == null)
-                return new EncryptingXChaCha20Poly1305Stream(fileStream, _database.MasterKey);
+            if (Database.MasterKey != null && Configuration.BackupEncryptionSettings == null)
+                return new EncryptingXChaCha20Poly1305Stream(fileStream, Database.MasterKey);
 
-            if (_configuration.BackupEncryptionSettings.EncryptionMode == EncryptionMode.UseDatabaseKey)
-                return new EncryptingXChaCha20Poly1305Stream(fileStream, _database.MasterKey);
+            if (Configuration.BackupEncryptionSettings.EncryptionMode == EncryptionMode.UseDatabaseKey)
+                return new EncryptingXChaCha20Poly1305Stream(fileStream, Database.MasterKey);
 
             return new EncryptingXChaCha20Poly1305Stream(fileStream,
-                Convert.FromBase64String(_configuration.BackupEncryptionSettings.Key));
+                Convert.FromBase64String(Configuration.BackupEncryptionSettings.Key));
         }
 
-        private void UploadToServer(string backupPath, string folderName, string fileName)
+        protected virtual void UploadToServer(string backupFilePath, string folderName, string fileName)
         {
-            var s3Settings = GetBackupConfigurationFromScript(_configuration.S3Settings, x => JsonDeserializationServer.S3Settings(x),
-                settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForS3(settings, _database.Name));
-            var glacierSettings = GetBackupConfigurationFromScript(_configuration.GlacierSettings, x => JsonDeserializationServer.GlacierSettings(x),
-                settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForGlacier(settings, _database.Name));
-            var azureSettings = GetBackupConfigurationFromScript(_configuration.AzureSettings, x => JsonDeserializationServer.AzureSettings(x),
-                settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForAzure(settings, _database.Name));
-            var googleCloudSettings = GetBackupConfigurationFromScript(_configuration.GoogleCloudSettings, x => JsonDeserializationServer.GoogleCloudSettings(x),
-                settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForGoogleCloud(settings, _database.Name));
-            var ftpSettings = GetBackupConfigurationFromScript(_configuration.FtpSettings, x => JsonDeserializationServer.FtpSettings(x),
-                settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForFtp(settings, _database.Name));
+            var s3Settings = GetBackupConfigurationFromScript(Configuration.S3Settings, x => JsonDeserializationServer.S3Settings(x),
+                settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForS3(settings, Database.Name));
+            var glacierSettings = GetBackupConfigurationFromScript(Configuration.GlacierSettings, x => JsonDeserializationServer.GlacierSettings(x),
+                settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForGlacier(settings, Database.Name));
+            var azureSettings = GetBackupConfigurationFromScript(Configuration.AzureSettings, x => JsonDeserializationServer.AzureSettings(x),
+                settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForAzure(settings, Database.Name));
+            var googleCloudSettings = GetBackupConfigurationFromScript(Configuration.GoogleCloudSettings, x => JsonDeserializationServer.GoogleCloudSettings(x),
+                settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForGoogleCloud(settings, Database.Name));
+            var ftpSettings = GetBackupConfigurationFromScript(Configuration.FtpSettings, x => JsonDeserializationServer.FtpSettings(x),
+                settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForFtp(settings, Database.Name));
 
             TaskCancelToken.Token.ThrowIfCancellationRequested();
 
-            var uploaderSettings = new UploaderSettings(_database.Configuration.Backup)
+            var uploaderSettings = new UploaderSettings(Database.Configuration.Backup)
             {
                 S3Settings = s3Settings,
                 GlacierSettings = glacierSettings,
@@ -833,16 +880,16 @@ namespace Raven.Server.Documents.PeriodicBackup
                 GoogleCloudSettings = googleCloudSettings,
                 FtpSettings = ftpSettings,
 
-                FilePath = backupPath,
+                FilePath = backupFilePath,
                 FolderName = folderName,
                 FileName = fileName,
-                DatabaseName = _database.Name,
+                DatabaseName = Database.Name,
                 TaskName = _taskName,
 
-                BackupType = _configuration.BackupType
+                BackupType = Configuration.BackupType
             };
 
-            var backupUploader = new BackupUploader(uploaderSettings, _retentionPolicyParameters, _logger, _backupResult, _onProgress, TaskCancelToken);
+            var backupUploader = new BackupUploader(uploaderSettings, RetentionPolicyParameters, _logger, BackupResult, _onProgress, TaskCancelToken);
             backupUploader.ExecuteUpload();
         }
 
@@ -850,13 +897,13 @@ namespace Raven.Server.Documents.PeriodicBackup
         {
             runningBackupStatus.LastOperationId = _operationId;
             if (_previousBackupStatus.LastOperationId == null ||
-                _previousBackupStatus.NodeTag != _database.ServerStore.NodeTag ||
+                _previousBackupStatus.NodeTag != Database.ServerStore.NodeTag ||
                 _previousBackupStatus.Error != null)
                 return;
 
             // dismiss the previous operation
             var id = $"{NotificationType.OperationChanged}/{_previousBackupStatus.LastOperationId.Value}";
-            _database.NotificationCenter.Dismiss(id);
+            Database.NotificationCenter.Dismiss(id);
         }
 
         public static string GetDateTimeFormat(string fileName)

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
@@ -1,0 +1,30 @@
+using Raven.Server.Documents.PeriodicBackup.Aws;
+using Raven.Server.Documents.PeriodicBackup.Retention;
+using Sparrow;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public class AwsS3DirectUploadStream : DirectUploadStream<RavenAwsS3Client>
+{
+    private readonly RetentionPolicyBaseParameters _retentionPolicyParameters;
+
+    protected override long MinOnePartUploadSizeInBytes { get; }
+
+    public AwsS3DirectUploadStream(Parameters parameters) : base(parameters)
+    {
+        _retentionPolicyParameters = parameters.RetentionPolicyParameters;
+
+        MinOnePartUploadSizeInBytes = Client.MinOnePartUploadSizeLimit.GetValue(SizeUnit.Bytes);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        using (Client)
+        {
+            base.Dispose(disposing);
+
+            var runner = new S3RetentionPolicyRunner(_retentionPolicyParameters, Client);
+            runner.Execute();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3MultiPartUploader.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Util;
+using Raven.Server.Documents.PeriodicBackup.Aws;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public class AwsS3MultiPartUploader : IMultiPartUploader
+{
+    private readonly AmazonS3Client _client;
+    private readonly string _bucketName;
+    private readonly Progress _progress;
+    private readonly string _key;
+    private readonly Dictionary<string, string> _metadata;
+    private readonly CancellationToken _cancellationToken;
+
+    private string _uploadId;
+    private int _partNumber;
+    private List<PartETag> _partEtags;
+
+    public AwsS3MultiPartUploader(AmazonS3Client client, string bucketName, Progress progress, string key, Dictionary<string, string> metadata, CancellationToken cancellationToken)
+    {
+        _client = client;
+        _bucketName = bucketName;
+        _progress = progress;
+        _key = key;
+        _metadata = metadata;
+        _cancellationToken = cancellationToken;
+    }
+
+    public void Initialize()
+    {
+        AsyncHelpers.RunSync(InitializeAsync);
+    }
+
+    public async Task InitializeAsync()
+    {
+        var multipartRequest = new InitiateMultipartUploadRequest
+        {
+            Key = _key,
+            BucketName = _bucketName
+        };
+
+        RavenAwsS3Client.FillMetadata(multipartRequest.Metadata, _metadata);
+
+        var initiateResponse = await _client.InitiateMultipartUploadAsync(multipartRequest, _cancellationToken);
+        _uploadId = initiateResponse.UploadId;
+        _partNumber = 1;
+        _partEtags = new List<PartETag>();
+    }
+
+    public void UploadPart(Stream stream, long size)
+    {
+        AsyncHelpers.RunSync(() => UploadPartAsync(stream, size));
+    }
+
+    public async Task UploadPartAsync(Stream stream, long size)
+    {
+        if (_uploadId == null)
+            throw new InvalidOperationException($"You must call Initialize before uploading a part");
+
+        var uploadResponse = await _client
+            .UploadPartAsync(new UploadPartRequest
+            {
+                Key = _key,
+                BucketName = _bucketName,
+                InputStream = stream,
+                PartNumber = _partNumber++,
+                PartSize = size,
+                UploadId = _uploadId,
+                StreamTransferProgress = (_, args) =>
+                {
+                    _progress?.UploadProgress.ChangeState(UploadState.Uploading);
+                    _progress?.UploadProgress.UpdateUploaded(args.IncrementTransferred);
+                    _progress?.OnUploadProgress?.Invoke();
+                }
+            }, _cancellationToken);
+
+        _partEtags.Add(new PartETag(uploadResponse.PartNumber, uploadResponse.ETag));
+    }
+
+    public void CompleteUpload()
+    {
+        AsyncHelpers.RunSync(CompleteUploadAsync);
+    }
+
+    public async Task CompleteUploadAsync()
+    {
+        await _client.CompleteMultipartUploadAsync(
+            new CompleteMultipartUploadRequest
+            {
+                UploadId = _uploadId,
+                BucketName = _bucketName,
+                Key = _key,
+                PartETags = _partEtags
+            },
+            _cancellationToken);
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadBackupTask.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Server.Documents.PeriodicBackup.Aws;
+using Raven.Server.Json;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands;
+using Sparrow.Logging;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public class DirectUploadBackupTask : BackupTask
+{
+    private readonly BackupConfiguration.BackupDestination _destination;
+
+    internal DirectUploadBackupTask(DocumentDatabase database, BackupParameters backupParameters,
+        BackupConfiguration configuration, OperationCancelToken token, Logger logger, PeriodicBackupRunner.TestingStuff forTestingPurposes = null) : base(database, backupParameters, configuration, token, logger, forTestingPurposes)
+    {
+        _destination = BackupConfigurationHelper.GetBackupDestinationForDirectUpload(backupParameters.BackupToLocalFolder, configuration);
+    }
+
+    protected override Stream GetStreamForBackupDestination(string filePath, string folderName, string fileName)
+    {
+        switch (_destination)
+        {
+            case BackupConfiguration.BackupDestination.AmazonS3:
+                var s3Settings = GetBackupConfigurationFromScript(Configuration.S3Settings, x => JsonDeserializationServer.S3Settings(x),
+                    settings => PutServerWideBackupConfigurationCommand.UpdateSettingsForS3(settings, Database.Name));
+
+                return new AwsS3DirectUploadStream(new DirectUploadStream<RavenAwsS3Client>.Parameters
+                {
+                    ClientFactory = progress => new RavenAwsS3Client(s3Settings, Database.Configuration.Backup, progress, TaskCancelToken.Token),
+                    Key = BackupUploader.CombinePathAndKey(s3Settings.RemoteFolderName, folderName, fileName),
+                    Metadata = new Dictionary<string, string>
+                    {
+                        { "Description", BackupUploader.GetBackupDescription(Configuration.BackupType, _isFullBackup) }
+                    },
+                    IsFullBackup = _isFullBackup,
+                    RetentionPolicyParameters = RetentionPolicyParameters,
+                    CloudUploadStatus = BackupResult.S3Backup,
+                    OnBackupException = OnBackupException,
+                    OnProgress = AddInfo,
+                });
+
+            default:
+                throw new ArgumentOutOfRangeException($"Missing implementation for direct upload destination '{_destination}'");
+        }
+    }
+
+    protected override void UploadToServer(string backupFilePath, string folderName, string fileName)
+    {
+        // uploading was already done while generating the backup file.
+    }
+
+    protected override void ValidateFreeSpaceForSnapshot(string filePath)
+    {
+        // we're uploading directly without using a local file.
+    }
+
+    protected override void RenameFile(string backupFilePath, string tempBackupFilePath)
+    {
+        // we're uploading directly without using a local file.
+    }
+
+    protected override void DeleteFile(string path)
+    {
+        // we're uploading directly without using a local file.
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadStream.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Util;
+using Raven.Server.Documents.PeriodicBackup.Retention;
+using Sparrow;
+using Size = Sparrow.Size;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public abstract class DirectUploadStream<T> : Stream where T : IDirectUploader
+{
+    private readonly IMultiPartUploader _multiPartUploader;
+    private readonly CloudUploadStatus _cloudUploadStatus;
+    private readonly Action<string> _onProgress;
+    private readonly IDisposable _backupStatusIDisposable;
+
+    private long _position;
+    private MemoryStream _writeStream = new();
+    private MemoryStream _uploadStream = new();
+    private Task _uploadTask;
+    private bool _disposed;
+    private bool _abortUpload;
+
+    protected T Client { get; }
+
+    protected abstract long MinOnePartUploadSizeInBytes { get; }
+
+    protected DirectUploadStream(Parameters parameters)
+    {
+        _cloudUploadStatus = parameters.CloudUploadStatus;
+        _cloudUploadStatus.Skipped = false;
+        _backupStatusIDisposable = _cloudUploadStatus.UpdateStats(parameters.IsFullBackup);
+        _cloudUploadStatus.UploadProgress.ChangeState(UploadState.PendingUpload);
+        _onProgress = parameters.OnProgress;
+
+        var progress = Progress.Get(_cloudUploadStatus.UploadProgress, parameters.OnProgress);
+        Client = parameters.ClientFactory.Invoke(progress);
+        _multiPartUploader = Client.GetUploader(parameters.Key, parameters.Metadata);
+        _multiPartUploader.Initialize();
+
+        parameters.OnBackupException += () => _abortUpload = true;
+    }
+
+    public override void Flush()
+    {
+        // nothing to do here
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        _position += count;
+        _writeStream.Write(buffer, offset, count);
+        _cloudUploadStatus.UploadProgress.SetTotal(_position);
+
+        var toUpload = _writeStream.Position;
+        if (toUpload <= MinOnePartUploadSizeInBytes)
+            return;
+
+        if (_uploadTask != null && (_uploadTask.IsCompleted == false || _uploadTask.IsCompletedSuccessfully == false))
+        {
+            _onProgress.Invoke("Waiting for previous upload task to finish");
+            AsyncHelpers.RunSync(() => _uploadTask);
+        }
+
+        (_writeStream, _uploadStream) = (_uploadStream, _writeStream);
+        _writeStream.Position = _uploadStream.Position = 0;
+        _uploadTask = _multiPartUploader.UploadPartAsync(_uploadStream, toUpload);
+    }
+
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        _position += count;
+
+        await _writeStream.WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
+        _cloudUploadStatus.UploadProgress.SetTotal(_position);
+
+        var toUpload = _writeStream.Position;
+        if (toUpload <= MinOnePartUploadSizeInBytes)
+            return;
+
+        if (_uploadTask != null && (_uploadTask.IsCompleted == false || _uploadTask.IsCompletedSuccessfully == false))
+        {
+            _onProgress.Invoke("Waiting for previous upload task to finish");
+            await _uploadTask;
+        }
+
+        (_writeStream, _uploadStream) = (_uploadStream, _writeStream);
+        _writeStream.Position = _uploadStream.Position = 0;
+        _uploadTask = _multiPartUploader.UploadPartAsync(_uploadStream, toUpload);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_abortUpload)
+        {
+            _backupStatusIDisposable?.Dispose();
+            return;
+        }
+
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        using (_backupStatusIDisposable)
+        {
+            using (_uploadStream)
+            using (_writeStream)
+            {
+                if (_uploadTask != null && (_uploadTask.IsCompleted == false || _uploadTask.IsCompletedSuccessfully == false))
+                {
+                    _onProgress.Invoke("Waiting for previous upload task to finish");
+                    AsyncHelpers.RunSync(() => _uploadTask);
+                }
+
+                var toUpload = _writeStream.Position;
+                if (toUpload > 0)
+                {
+                    _writeStream.Position = 0;
+                    _multiPartUploader.UploadPart(_writeStream, toUpload);
+                }
+            }
+
+            _multiPartUploader.CompleteUpload();
+
+            _cloudUploadStatus.UploadProgress.SetUploaded(_position);
+            _cloudUploadStatus.UploadProgress.SetTotal(_position);
+            _cloudUploadStatus.UploadProgress.ChangeState(UploadState.Done);
+
+            _onProgress.Invoke($"Total uploaded: {new Size(_position, SizeUnit.Bytes)}");
+        }
+    }
+
+    public override bool CanRead => false;
+    public override bool CanSeek => false;
+    public override bool CanWrite => true;
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position
+    {
+        get => _position;
+        set
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    public class Parameters
+    {
+        public Func<Progress, T> ClientFactory { get; set; }
+
+        public string Key { get; set; }
+
+        public Dictionary<string, string> Metadata { get; set; }
+
+        public bool IsFullBackup { get; set; }
+
+        public RetentionPolicyBaseParameters RetentionPolicyParameters { get; set; }
+
+        public CloudUploadStatus CloudUploadStatus { get; set; }
+
+        public Action OnBackupException { get; set; }
+
+        public Action<string> OnProgress { get; set; }
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/IDirectUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/IDirectUploader.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public interface IDirectUploader
+{
+    public IMultiPartUploader GetUploader(string key, Dictionary<string, string> metadata);
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/IMultiPartUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/IMultiPartUploader.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
+
+public interface IMultiPartUploader
+{
+    void Initialize();
+
+    Task InitializeAsync();
+
+    void UploadPart(Stream stream, long size);
+
+    Task UploadPartAsync(Stream stream, long size);
+
+    void CompleteUpload();
+
+    Task CompleteUploadAsync();
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -383,7 +383,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         Name = periodicBackup.Configuration.Name
                     };
 
-                    var backupTask = new BackupTask(_database, backupParameters, periodicBackup.Configuration, token: null, _logger, _forTestingPurposes);
+                    var backupTask = BackupUtils.GetBackupTask(_database, backupParameters, periodicBackup.Configuration, token: null, _logger, _forTestingPurposes);
                     periodicBackup.CancelToken = backupTask.TaskCancelToken;
 
                     periodicBackup.RunningTask = new PeriodicBackup.RunningBackupTask

--- a/src/Raven.Server/Documents/PeriodicBackup/Progress.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Progress.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Diagnostics;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Server.Utils.Metrics;
+using Sparrow;
 
 namespace Raven.Server.Documents.PeriodicBackup
 {
@@ -13,5 +16,32 @@ namespace Raven.Server.Documents.PeriodicBackup
         public UploadProgress UploadProgress { get; }
 
         public Action OnUploadProgress { get; set; } = () => { };
+
+        public static Progress Get(UploadProgress uploadProgress, Action<string> onProgress)
+        {
+            var bytesPutsPerSec = new MeterMetric();
+
+            long lastUploadedInBytes = 0;
+            var sw = Stopwatch.StartNew();
+            var progress = new Progress(uploadProgress)
+            {
+                OnUploadProgress = () =>
+                {
+                    if (sw.ElapsedMilliseconds <= 2000)
+                        return;
+
+                    var totalUploadedInBytes = uploadProgress.UploadedInBytes;
+                    bytesPutsPerSec.MarkSingleThreaded(totalUploadedInBytes - lastUploadedInBytes);
+                    lastUploadedInBytes = totalUploadedInBytes;
+                    var uploaded = new Size(totalUploadedInBytes, SizeUnit.Bytes);
+                    var totalToUpload = new Size(uploadProgress.TotalInBytes, SizeUnit.Bytes);
+                    uploadProgress.BytesPutsPerSec = bytesPutsPerSec.MeanRate;
+                    onProgress($"Uploaded: {uploaded} / {totalToUpload}");
+                    sw.Restart();
+                }
+            };
+
+            return progress;
+        }
     }
 }

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -20,6 +20,7 @@ using Raven.Server.Config;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Documents.PeriodicBackup.DirectUpload;
 using Raven.Server.NotificationCenter;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
@@ -35,6 +36,13 @@ namespace Raven.Server.Utils;
 
 internal static class BackupUtils
 {
+    internal static BackupTask GetBackupTask(DocumentDatabase database, BackupParameters backupParameters, BackupConfiguration configuration, OperationCancelToken token, Logger logger, PeriodicBackupRunner.TestingStuff forTestingPurposes = null)
+    {
+        return configuration.BackupUploadMode == BackupUploadMode.DirectUpload
+            ? new DirectUploadBackupTask(database, backupParameters, configuration, token, logger, forTestingPurposes) 
+            : new BackupTask(database, backupParameters, configuration, token, logger, forTestingPurposes);
+    }
+
     internal static async Task<Stream> GetDecompressionStreamAsync(Stream stream, CancellationToken token = default)
     {
         var buffer = new byte[4];

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/backupConfiguration.ts
@@ -14,11 +14,21 @@ import encryptionSettings = require("models/database/tasks/periodicBackup/encryp
 import generalUtils = require("common/generalUtils");
 import backupSettings = require("models/database/tasks/periodicBackup/backupSettings");
 
+interface backupUploadModeOption {
+    name: string;
+    fullName: Raven.Client.Documents.Operations.Backups.BackupUploadMode;
+}
+
 abstract class backupConfiguration {
 
     static readonly defaultFullBackupFrequency = "0 2 * * 0";
     static readonly defaultIncrementalBackupFrequency = "0 2 * * *";
-    
+
+    static readonly backupUploadModeDictionary: backupUploadModeOption[] = [
+        { name: "Default", fullName: "Default" },
+        { name: "Direct Upload", fullName: "DirectUpload" }
+    ];
+
     taskId = ko.observable<number>();
     isManualBackup = ko.observable<boolean>(false);
     isServerWide = ko.observable<boolean>();
@@ -26,11 +36,15 @@ abstract class backupConfiguration {
     backupType = ko.observable<Raven.Client.Documents.Operations.Backups.BackupType>();
     isSnapshot = ko.pureComputed(() => this.backupType() === "Snapshot");
     backupOptions = ["Backup", "Snapshot"];
+    backupUploadModes = backupConfiguration.backupUploadModeDictionary.map(x => x.name);
+
     anyBackupTypeIsDirty: KnockoutComputed<boolean>;
     snapshot = ko.observable<snapshot>();
     
     mentorNode = ko.observable<string>();
-    
+
+    backupUploadMode = ko.observable<string>();
+
     encryptionSettings = ko.observable<encryptionSettings>();
     
     localSettings = ko.observable<localSettings>();
@@ -60,6 +74,10 @@ abstract class backupConfiguration {
                 isServerWide = false) {
         this.taskId(dto.TaskId);
         this.backupType(dto.BackupType);
+
+        const backupUploadMode = backupConfiguration.backupUploadModeDictionary.find(x => x.fullName === dto.BackupUploadMode);
+        this.backupUploadMode(backupUploadMode.name);
+
         this.localSettings(!dto.LocalSettings ? localSettings.empty("backup") : new localSettings(dto.LocalSettings, "backup"));
         this.s3Settings(!dto.S3Settings ? s3Settings.empty(serverLimits.AllowedAwsRegions, "Backup") : new s3Settings(dto.S3Settings, serverLimits.AllowedAwsRegions, "Backup"));
         this.azureSettings(!dto.AzureSettings ? azureSettings.empty("Backup") : new azureSettings(dto.AzureSettings, "Backup"));
@@ -176,6 +194,10 @@ abstract class backupConfiguration {
         this.backupType(backupType);
     }
 
+    useBackupUploadMode(backupUploadMode: string) {
+        this.backupUploadMode(backupUploadMode);
+    }
+
     getPathForCreatedBackups(backupLocationInfo: Raven.Server.Web.Studio.SingleNodeDataDirectoryResult) {
         return ko.pureComputed(() => {
             const separator = backupLocationInfo.FullPath[0] === "/" ? "/" : "\\";
@@ -201,6 +223,7 @@ abstract class backupConfiguration {
             GoogleCloudSettings: null,
             FtpSettings: null,
             MentorNode: null,
+            BackupUploadMode: "Default",
             PinToMentorNode: false,
             BackupEncryptionSettings: null,
             SnapshotSettings: null,

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/manualBackupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/manualBackupConfiguration.ts
@@ -25,6 +25,7 @@ class manualBackupConfiguration extends backupConfiguration {
 
         this.dirtyFlag = new ko.DirtyFlag([
             this.backupType,
+            this.backupUploadMode,
             this.encryptionSettings().dirtyFlag().isDirty,
             this.anyBackupTypeIsDirty
         ], false, jsonUtil.newLineNormalizingHashFunction);
@@ -48,8 +49,11 @@ class manualBackupConfiguration extends backupConfiguration {
     }
 
     toDto(): Raven.Client.Documents.Operations.Backups.BackupConfiguration {
+        const backupUploadMode = backupConfiguration.backupUploadModeDictionary.find(x => x.name === this.backupUploadMode());
+
         return {
             BackupType: this.backupType(),
+            BackupUploadMode: backupUploadMode.fullName,
             SnapshotSettings: this.snapshot().toDto(),
             BackupEncryptionSettings: this.encryptionSettings().toDto(),
             LocalSettings: this.localSettings().toDto(),

--- a/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/periodicBackup/periodicBackupConfiguration.ts
@@ -74,6 +74,7 @@ class periodicBackupConfiguration extends backupConfiguration {
             this.name,
             this.disabled,
             this.backupType,
+            this.backupUploadMode,
             this.fullBackupFrequency,
             this.fullBackupEnabled,
             this.incrementalBackupFrequency,
@@ -148,12 +149,15 @@ class periodicBackupConfiguration extends backupConfiguration {
     }
 
     toDto(): Raven.Client.Documents.Operations.Backups.PeriodicBackupConfiguration {
+        const backupUploadMode = backupConfiguration.backupUploadModeDictionary.find(x => x.name === this.backupUploadMode());
+
         return {
             TaskId: this.taskId(),
             Name: this.name(),
             Disabled: this.disabled(),
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
             PinToMentorNode: this.pinMentorNode(),
+            BackupUploadMode: backupUploadMode.fullName,
             FullBackupFrequency: this.fullBackupEnabled() ? this.fullBackupFrequency() : null,
             IncrementalBackupFrequency: this.incrementalBackupEnabled() ? this.incrementalBackupFrequency() : null,
             RetentionPolicy: this.retentionPolicy().toDto(),

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
@@ -46,6 +46,20 @@
                         </ul>
                     </div>
                 </div>
+            <div class="row margin-bottom">
+                <label class="control-label col-sm-4 col-lg-2">Backup Upload Mode</label>
+                <div class="col-sm-4">
+                    <div class="dropdown btn-block">
+                        <button class="btn btn-block dropdown-toggle text-left" type="button" data-toggle="dropdown">
+                            <span data-bind="text: backupUploadMode"></span>
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu" data-bind="foreach: backupUploadModes">
+                            <li><a href="#" data-bind="text: $data, click: $parent.useBackupUploadMode.bind($parent, $data)"></a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
                 <div class="row margin-bottom" data-bind="validationElement: backupType">
                     <label class="control-label col-sm-4 col-lg-2">Backup Type <i class="required"></i> <small><i class="backup-info icon-info text-info"></i></small></label>
                     <div class="col-sm-4" data-bind="validationOptions: { insertMessages: false }">
@@ -153,6 +167,18 @@
                                     <label for="excludeIndexes">Exclude indexes data</label>
                                 </div>
                             </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row margin-bottom">
+                <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
+                    <div class="toggle">
+                        <div class="toggle" data-placement="right" data-toggle="tooltip"
+                             title="Support direct upload to a single cloud destination without using a temp file."
+                             data-animation="true">
+                            <input id="directUpload" type="checkbox" data-bind="checked: directUpload">
+                            <label for="directUpload">Direct Upload</label>
                         </div>
                     </div>
                 </div>

--- a/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
+++ b/test/FastTests/Voron/Backups/BackupToOneZipFile.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Backups;
 using Sparrow.Json.Parsing;
+using Sparrow.Utils;
 using Xunit;
 using Voron.Impl.Backup;
 using Voron.Util.Settings;
@@ -80,7 +81,9 @@ namespace FastTests.Voron.Backups
 
                 var voronTempFileName = new VoronPathSetting(tempFileName);
 
-                database.FullBackupTo(voronTempFileName.Combine("backup-test.backup").FullPath, SnapshotBackupCompressionAlgorithm.Deflate);
+                using (var fileStream = SafeFileStream.Create(voronTempFileName.Combine("backup-test.backup").FullPath, FileMode.Create))
+                    database.FullBackupTo(fileStream, SnapshotBackupCompressionAlgorithm.Deflate);
+
                 BackupMethods.Full.Restore(voronTempFileName.Combine("backup-test.backup"), voronTempFileName.Combine("backup-test.data"));
             }
             using (CreatePersistentDocumentDatabase(Path.Combine(tempFileName, "backup-test.data"), out var database))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14274/Consider-uploading-a-backup-without-creating-a-temp-file-on-disk

### Additional description

- Upload a backup directly to the storage provider without saving a temp backup file on the disk.
- Supported only when only one destination is defined.
- Currently only `S3` is supported.

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing