### PR TITLE
RavenDB-21544 - Sharding - Can't toggle subscription state for sharded db

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForPostSubscriptionTasksState.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForPostSubscriptionTasksState.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.Annotations;
+using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
@@ -7,6 +8,11 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
     {
         public OngoingTasksHandlerProcessorForPostSubscriptionTasksState([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        protected override AbstractSubscriptionStorage GetSubscriptionStorage()
+        {
+            return RequestHandler.Database.SubscriptionStorage;
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForToggleTaskState.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForToggleTaskState.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.Annotations;
+using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
@@ -11,5 +12,9 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         }
 
         protected override bool RequireAdmin { get; }
+        protected override AbstractSubscriptionStorage GetSubscriptionStorage()
+        {
+            return RequestHandler.Database.SubscriptionStorage;
+        }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForPostSubscriptionTasksState.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForPostSubscriptionTasksState.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Raven.Server.Documents.Handlers.Processors.OngoingTasks;
+using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
@@ -8,6 +9,11 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
     {
         public ShardedOngoingTasksHandlerProcessorForPostSubscriptionTasksState([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
         {
+        }
+
+        protected override AbstractSubscriptionStorage GetSubscriptionStorage()
+        {
+            return RequestHandler.DatabaseContext.SubscriptionsStorage;
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForToggleTaskState.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForToggleTaskState.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Raven.Server.Documents.Handlers.Processors.OngoingTasks;
+using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
@@ -12,5 +13,9 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
         }
 
         protected override bool RequireAdmin { get; }
+        protected override AbstractSubscriptionStorage GetSubscriptionStorage()
+        {
+            return RequestHandler.DatabaseContext.SubscriptionsStorage;
+        }
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1976,7 +1976,9 @@ namespace Raven.Server.ServerWide
                     if (taskName == null)
                     {
                         if (_server.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(dbName, out _) == false)
-                            throw new DatabaseDoesNotExistException($"Can't get subscription name because The database {dbName} does not exists");
+                            if(_server.ServerStore.DatabasesLandlord.ShardedDatabasesCache.TryGetValue(dbName, out _) == false)
+                                throw new DatabaseDoesNotExistException($"Can't get subscription name because The database {dbName} does not exists");
+
                         using (Server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
                         using (ctx.OpenReadTransaction())
                         {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -47,6 +47,7 @@ using Raven.Server.Documents.Indexes.Analysis;
 using Raven.Server.Documents.Indexes.Sorting;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Integrations.PostgreSQL.Commands;
 using Raven.Server.Json;
@@ -1967,7 +1968,7 @@ namespace Raven.Server.ServerWide
             return SendToLeaderAsync(deleteTaskCommand);
         }
 
-        public Task<(long Index, object Result)> ToggleTaskState(long taskId, string taskName, OngoingTaskType type, bool disable, string dbName, string raftRequestId)
+        public async Task<(long Index, object Result)> ToggleTaskState(long taskId, string taskName, OngoingTaskType type, bool disable, string dbName, string raftRequestId)
         {
             CommandBase disableEnableCommand;
             switch (type)
@@ -1975,16 +1976,18 @@ namespace Raven.Server.ServerWide
                 case OngoingTaskType.Subscription:
                     if (taskName == null)
                     {
-                        if (_server.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(dbName, out _) == false)
-                            if(_server.ServerStore.DatabasesLandlord.ShardedDatabasesCache.TryGetValue(dbName, out _) == false)
-                                throw new DatabaseDoesNotExistException($"Can't get subscription name because The database {dbName} does not exists");
+                        AbstractSubscriptionStorage subscriptionStorage;
+                        if(_server.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(dbName, out var database))
+                            subscriptionStorage = (await database).SubscriptionStorage;
+                        else if(_server.ServerStore.DatabasesLandlord.ShardedDatabasesCache.TryGetValue(dbName, out var shardedDatabase))
+                            subscriptionStorage = (await shardedDatabase).SubscriptionsStorage;
+                        else
+                            throw new DatabaseDoesNotExistException($"Can't get subscription name because The database {dbName} does not exists");
 
                         using (Server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
                         using (ctx.OpenReadTransaction())
                         {
-#pragma warning disable CS0618
-                            taskName = Cluster.Subscriptions.GetSubscriptionNameById(ctx, dbName, taskId);
-#pragma warning restore CS0618
+                            taskName = subscriptionStorage.GetSubscriptionNameById(ctx, taskId);
                         }
                     }
                     disableEnableCommand = new ToggleSubscriptionStateCommand(taskName, disable, dbName, raftRequestId);
@@ -1994,7 +1997,7 @@ namespace Raven.Server.ServerWide
                     disableEnableCommand = new ToggleTaskStateCommand(taskId, type, disable, dbName, raftRequestId);
                     break;
             }
-            return SendToLeaderAsync(disableEnableCommand);
+            return await SendToLeaderAsync(disableEnableCommand);
         }
 
         public Task<(long Index, object Result)> PromoteDatabaseNode(string dbName, string nodeTag, string raftRequestId)

--- a/test/SlowTests/Client/Subscriptions/Subscriptions.cs
+++ b/test/SlowTests/Client/Subscriptions/Subscriptions.cs
@@ -329,8 +329,7 @@ namespace SlowTests.Client.Subscriptions
         }
 
         [RavenTheory(RavenTestCategory.Subscriptions)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-21544")]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void CanDisableSubscription(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21544

### Additional description

Toggling failed because of checking only if non-sharded db exists.
Now only throwing if both don't exist.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
