### PR TITLE
RavenDB-21551 Fix race between deletion request and applying that on the relevant node

### DIFF
--- a/src/Raven.Client/ServerWide/Commands/WaitForRaftIndexCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/WaitForRaftIndexCommand.cs
@@ -13,6 +13,11 @@ namespace Raven.Client.ServerWide.Commands
             _index = index;
         }
 
+        public WaitForRaftIndexCommand(long index, string node) : this(index)
+        {
+            SelectedNodeTag = node;
+        }
+
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/rachis/waitfor?index={_index}";

--- a/src/Raven.Server/Extensions/HttpExtensions.cs
+++ b/src/Raven.Server/Extensions/HttpExtensions.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Extensions
                 throw new InvalidOperationException("Missing Host");
 
             string path = (request.PathBase.HasValue || request.Path.HasValue) ? (request.PathBase + request.Path).ToString() : "/";
-            return request.Scheme + "://" + request.Host + path + request.Query;
+            return request.Scheme + "://" + request.Host + path + request.QueryString;
         }
 
         public static string ExtractNodeUrlFromRequest(HttpRequest request)

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -836,7 +836,7 @@ namespace RachisTests.DatabaseCluster
 
                 await ActionWithLeader((l) => l.ServerStore.RemoveFromClusterAsync(node));
 
-                await leader.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, res.RaftCommandIndex + 1);
+                await leader.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, res.RaftCommandIndex);
                 record = await leaderStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
 
                 Assert.Null(record);
@@ -1443,7 +1443,7 @@ namespace RachisTests.DatabaseCluster
                     fromNode: toDelete.ServerStore.NodeTag, timeToWaitForConfirmation: TimeSpan.FromSeconds(15)));
 
                 await Task.WhenAll(nonDeletedNodes.Select(n =>
-                    n.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, deleteResult.RaftCommandIndex + 1)));
+                    n.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, deleteResult.RaftCommandIndex)));
 
                 var record = await nonDeletedStores[0].Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database));
                 Assert.Equal(1, record.UnusedDatabaseIds.Count);
@@ -1538,7 +1538,7 @@ namespace RachisTests.DatabaseCluster
                 var deleteResult = await nonDeletedStores[0].Maintenance.Server.SendAsync(new DeleteDatabasesOperation(database, hardDelete: true, fromNode: toDelete.ServerStore.NodeTag, timeToWaitForConfirmation: TimeSpan.FromSeconds(15)));
 
                 await Task.WhenAll(nonDeletedNodes.Select(n =>
-                    n.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, deleteResult.RaftCommandIndex + 1)));
+                    n.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, deleteResult.RaftCommandIndex)));
 
                 var record = await nonDeletedStores[0].Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database));
                 Assert.Equal(1, record.UnusedDatabaseIds.Count);
@@ -1676,12 +1676,12 @@ namespace RachisTests.DatabaseCluster
             }))
             {
                 var result = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, hardDelete: true, "A", timeToWaitForConfirmation: TimeSpan.FromSeconds(15)));
-                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(result.RaftCommandIndex + 1, TimeSpan.FromSeconds(15));
+                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(result.RaftCommandIndex, TimeSpan.FromSeconds(15));
                 var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                 Assert.Equal(1, record.UnusedDatabaseIds.Count);
 
                 result = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, hardDelete: false, "B", timeToWaitForConfirmation: TimeSpan.FromSeconds(15)));
-                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(result.RaftCommandIndex + 1, TimeSpan.FromSeconds(15));
+                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(result.RaftCommandIndex, TimeSpan.FromSeconds(15));
                 record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                 Assert.Equal(1, record.UnusedDatabaseIds.Count);
             }

--- a/test/RachisTests/SubscriptionsFailover.cs
+++ b/test/RachisTests/SubscriptionsFailover.cs
@@ -179,7 +179,7 @@ namespace RachisTests
 
                 foreach (var ravenServer in Servers)
                 {
-                    await ravenServer.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, deleteResult.RaftCommandIndex + nodesAmount).WaitWithTimeout(TimeSpan.FromSeconds(60));
+                    await ravenServer.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, deleteResult.RaftCommandIndex).WaitWithTimeout(TimeSpan.FromSeconds(60));
                 }
 
                 await Task.Delay(2000);

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -1569,7 +1569,7 @@ namespace SlowTests.Client.Attachments
                 }
 
                 var result = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, hardDelete: true, fromNode: toRemove, timeToWaitForConfirmation: TimeSpan.FromSeconds(60)));
-                await mainServer.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex + 1);
+                await mainServer.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex);
 
                 using (var session = temp.OpenAsyncSession())
                 {

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -122,7 +122,7 @@ namespace SlowTests.Issues
             var deleteResult = await store.Maintenance.Server.SendAsync(
                 new DeleteDatabasesOperation(store.Database, hardDelete: false, fromNode: notInDbGroupServer.ServerStore.NodeTag,
                     timeToWaitForConfirmation: TimeSpan.FromSeconds(30)));
-            await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(deleteResult.RaftCommandIndex + 1, TimeSpan.FromSeconds(30));
+            await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(deleteResult.RaftCommandIndex, TimeSpan.FromSeconds(30));
 
             var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
             Assert.Equal(2, record.Topology.Count);

--- a/test/SlowTests/Issues/RavenDB-17096.cs
+++ b/test/SlowTests/Issues/RavenDB-17096.cs
@@ -78,7 +78,7 @@ namespace SlowTests.Issues
                 var deletion = await src.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(src.Database, hardDelete: true, fromNode: mentorTag,
                     timeToWaitForConfirmation: TimeSpan.FromSeconds(30)));
 
-                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(deletion.RaftCommandIndex + 1, TimeSpan.FromSeconds(30));
+                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(deletion.RaftCommandIndex, TimeSpan.FromSeconds(30));
                 await RavenDB_7912.WaitForDatabaseToBeDeleted(leader, src.Database, TimeSpan.FromSeconds(15), CancellationToken.None);
                 await WaitAndAssertForValueAsync(() => GetMembersCount(src), 2);
 

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -205,7 +205,7 @@ namespace Tests.Infrastructure
             var deleteResult = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(database, hardDelete: true,
                 fromNode: toDeleteTag, timeToWaitForConfirmation: TimeSpan.FromSeconds(15)));
             await Task.WhenAll(nonDeleted.Select(n =>
-                n.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, deleteResult.RaftCommandIndex + 1)));
+                n.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, deleteResult.RaftCommandIndex)));
 
             Assert.True(await WaitForDatabaseToBeDeleted(store, database, TimeSpan.FromSeconds(15)), await Task.Run(async () =>
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21551 

### Additional description

Cluster setup: A is the Leader & B is a Watcher 
1. Create database on A & B, while B is the primary node
2. Remove node B from the database. 
The removal request must go to the leader which is node A and not the primary node of the database.
3. The client try to talk to the database on node B

Here we have a race that that leader already committed the removal request, but for him it is a noop, since we remove node B, but node A still didn't processed this command (we don't need even consensus here because B is a Watcher)

At this point from the client perspective the command succeeded, and he try to communicate with the database, but due to the race above he might get `has been unloaded and locked by DeleteDatabase` exception.

The fix here is to wait for the removal command to propagated to the relevant nodes.

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
