### PR TITLE
RavenDB-21654 - FHIR support

### DIFF
--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
@@ -719,7 +719,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
 
         public override void Flush()
         {
-            throw new NotSupportedException();
+            // nothing to do
         }
 
         public override void Close()

--- a/test/FastTests/Client/Documents/FHIR.cs
+++ b/test/FastTests/Client/Documents/FHIR.cs
@@ -6,6 +6,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Newtonsoft.Json;
 using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,7 +18,7 @@ namespace FastTests.Client.Documents
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi)]
         public void Fhir_Supports_Serialize_Deserialize()
         {
             using (var store = GetDocumentStore(new Options

--- a/test/FastTests/Client/Documents/FHIR.cs
+++ b/test/FastTests/Client/Documents/FHIR.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Newtonsoft.Json;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Client.Documents
+{
+    public class FHIR : RavenTestBase
+    {
+        public FHIR(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Fhir_Supports_Serialize_Deserialize()
+        {
+            using (var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = store =>
+                {
+                    var serializationConventions = (NewtonsoftJsonSerializationConventions)store.Conventions.Serialization;
+                    serializationConventions.CustomizeJsonSerializer = serializer =>
+                    {
+                        serializer.Converters.Add(new FhirResourceConverter<Patient>());
+                    };
+                }
+            }))
+            {
+                var id1 = Guid.NewGuid().ToString();
+                var id2 = Guid.NewGuid().ToString();
+
+                var pEvent1 = new Patient
+                {
+                    Id = id1,
+                    Active = true
+                };
+
+                var pEvent2 = new Patient
+                {
+                    Id = id2,
+                    Active = false
+                };
+
+                using (var session = store.OpenSession())
+                {
+                    var name1 = new HumanName
+                    {
+                        Family = "Patel",
+                        Given = new List<string>
+                        {
+                            "Sandeep",
+                            "M",
+                            "Patel"
+                        }
+                    };
+
+                    pEvent1.Name = new List<HumanName>(1) { name1 };
+                    session.Store(pEvent1);
+
+                    var name2 = new HumanName
+                    {
+                        Family = "Patel1",
+                        Given = new List<string>
+                        {
+                            "Sandeep1",
+                            "M1",
+                            "Patel1"
+                        }
+                    };
+
+                    pEvent2.Name = new List<HumanName>(1) { name2 };
+                    session.Store(pEvent2);
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    AssertPatient(id1, pEvent1);
+                    AssertPatient(id2, pEvent2);
+
+                    void AssertPatient(string id, Patient compareTo)
+                    {
+                        var patient = session.Load<Patient>(id);
+                        var metadata = session.Advanced.GetMetadataFor(patient);
+                        Assert.NotNull(metadata);
+
+                        Assert.Equal(compareTo.Active, patient.Active);
+                        Assert.Equal(compareTo.Name.Count, patient.Name.Count);
+
+                        var compareToName = compareTo.Name[0];
+                        var patientName = patient.Name[0];
+                        Assert.Equal(compareToName.Family, patientName.Family);
+                        Assert.True(compareToName.Given.SequenceEqual(patientName.Given));
+                    }
+                }
+            }
+        }
+
+        public class FhirResourceConverter<T> : JsonConverter<T> where T : Base
+        {
+            private static readonly PocoBuilderSettings _builderSettings = new()
+            {
+                IgnoreUnknownMembers = true
+            };
+
+            public override T ReadJson(JsonReader reader, Type objectType, T existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                return FhirJsonNode.Read(reader).ToPoco<T>(_builderSettings);
+            }
+
+            public override void WriteJson(JsonWriter writer, T value, JsonSerializer serializer)
+            {
+                var fhirSerializer = new FhirJsonSerializer();
+                fhirSerializer.Serialize(value, writer);
+            }
+        }
+    }
+}

--- a/test/FastTests/FastTests.csproj
+++ b/test/FastTests/FastTests.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="5.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NodaTime" Version="3.1.9" />
     <PackageReference Include="Spatial4n" Version="0.4.1.1" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21654/Support-for-FHIR-serialization-and-deserialization

### Additional description

This is Firely's official support SDK for working with [HL7 FHIR](http://www.hl7.org/fhir) is using the `Flush` method in `BlittableJsonWriter`. Since we use the `ManualBlittableJsonDocumentBuilder` we can just skip it.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
