### PR TITLE
RavenDB-21376 When ETL task failover we leave old node info and it becomes stale

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksReducer.ts
@@ -478,13 +478,15 @@ export const ongoingTasksReducer: Reducer<OngoingTasksState, OngoingTaskReducerA
                 draft.tasks.forEach((task) => {
                     const nodeInfo = task.nodesInfo.find((x) =>
                         databaseLocationComparator(x.location, incomingLocation)
-                    );
+                    ) as WritableDraft<OngoingEtlTaskNodeInfo>;
+
                     nodeInfo.status = "failure";
                     nodeInfo.details = {
                         error: error.responseJSON.Message,
                         responsibleNode: null,
                         taskConnectionStatus: null,
                     };
+                    nodeInfo.etlProgress = null;
                 });
             });
         }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/OngoingEtlTaskDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/OngoingEtlTaskDistribution.tsx
@@ -65,9 +65,7 @@ export function OngoingEtlTaskDistribution(props: OngoingEtlTaskDistributionProp
     const { task, showPreview } = props;
     const sharded = task.nodesInfo.some((x) => x.location.shardNumber != null);
 
-    const visibleNodes = task.nodesInfo.filter(
-        (x) => x.status !== "success" || x.details.taskConnectionStatus !== "NotOnThisNode"
-    );
+    const visibleNodes = task.nodesInfo.filter((x) => x.location.nodeTag === task.shared.responsibleNodeTag);
 
     const items = visibleNodes.map((nodeInfo) => {
         const key = taskNodeInfoKey(nodeInfo);

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/SubscriptionTaskDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/SubscriptionTaskDistribution.tsx
@@ -55,9 +55,7 @@ export function SubscriptionTaskDistribution(props: OngoingEtlTaskDistributionPr
     const { task } = props;
     const sharded = task.nodesInfo.some((x) => x.location.shardNumber != null);
 
-    const visibleNodes = task.nodesInfo.filter(
-        (x) => x.status !== "success" || x.details.taskConnectionStatus !== "NotOnThisNode"
-    );
+    const visibleNodes = task.nodesInfo.filter((x) => x.location.nodeTag === task.shared.responsibleNodeTag);
 
     const items = (
         <>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21376/When-ETL-task-failover-we-leave-old-node-info-and-it-becomes-stale

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
