### PR TITLE
RavenDB-17338 Enable some query settings only for index query

### DIFF
--- a/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
+++ b/src/Raven.Studio/typescript/models/database/query/queryCriteria.ts
@@ -54,6 +54,14 @@ class queryCriteria {
                 this.ignoreIndexQueryLimit(false);
             }
         });
+
+        this.queryText.subscribe(queryText => {
+            if (queryUtil.isDynamicQuery(queryText)) {
+                this.showFields(false);
+                this.indexEntries(false);
+                this.ignoreIndexQueryLimit(false);
+            }
+        })
     }
 
     updateUsing(storedQuery: storedQueryDto): void {

--- a/src/Raven.Studio/wwwroot/App/views/database/query/query.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/query/query.html
@@ -339,11 +339,11 @@
             <label for="disableAutoIndex">Don't create a new Auto-Index</label>
         </div>
         <div class="toggle margin-left">
-            <input id="storedFields" type="checkbox" data-bind="checked: criteria().showFields, disable: isCollectionQuery() || isGraphQuery()">
+            <input id="storedFields" type="checkbox" data-bind="checked: criteria().showFields, disable: isDynamicQuery()">
             <label for="storedFields">Show stored index fields only</label>
         </div>
         <div class="toggle margin-left">
-            <input id="rawEntries" type="checkbox" data-bind="checked: criteria().indexEntries, disable: isCollectionQuery() || isGraphQuery()">
+            <input id="rawEntries" type="checkbox" data-bind="checked: criteria().indexEntries, disable: isDynamicQuery()">
             <label for="rawEntries" data-bind="text: 'Show raw index entries instead of ' + (queryResultsContainMatchingDocuments() ? 'matching documents' : 'index results')"></label>
         </div>
         <div class="margin-left margin-left-lg" data-bind="collapse: criteria().indexEntries">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17338/The-toggle-Show-the-raw-index-entries-instead-of-index-results-is-not-always-disabled-when-running-a-collection-query

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
