### PR TITLE
RavenDB-20164 Relaxing the assertion in the test

### DIFF
--- a/test/SlowTests/Issues/RavenDB_6414.cs
+++ b/test/SlowTests/Issues/RavenDB_6414.cs
@@ -61,7 +61,7 @@ namespace SlowTests.Issues
                         }
                     });
 
-                    Assert.Equal("Catastrophy", ex.Message);
+                    Assert.True(ex.ToString().Contains("Catastrophy"), $"Unexpected exception: {ex}");
 
                     // db unloaded
                     Assert.True(SpinWait.SpinUntil(() => Server.ServerStore.DatabasesLandlord.DatabasesCache.Any() == false, TimeSpan.FromMinutes(1)));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20164/SlowTests.Issues.RavenDB6414.Shouldunloaddbandsendnotificationoncatastrophicfailure

### Additional description

Test fix

### Type of change

- Test fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing test will verify the fix

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
