### PR TITLE
RavenDB-21271 Kafka ETL: The usage of plain certificate in Kafka conn…

### DIFF
--- a/src/Raven.Studio/typescript/models/database/settings/connectionStringKafkaEtlModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/connectionStringKafkaEtlModel.ts
@@ -7,8 +7,13 @@ import accessManager = require("common/shell/accessManager");
 import jsonUtil = require("common/jsonUtil");
 
 class connectionOptionModel {
+    
+    static multiLineKeys: string[] = ["ssl.keystore.key", "ssl.keystore.certificate.chain", "ssl.truststore.certificates", "ssl.key.pem", "ssl.certificate.pem", "ssl.ca.pem"]; 
+    
     key = ko.observable<string>();
     value = ko.observable<string>();
+    
+    multiLine: KnockoutComputed<boolean>;
     
     isValidKeyValue = ko.observable<boolean>();
 
@@ -25,6 +30,8 @@ class connectionOptionModel {
             this.key,
             this.value,
         ], false, jsonUtil.newLineNormalizingHashFunction);
+        
+        this.multiLine = ko.pureComputed(() => connectionOptionModel.multiLineKeys.includes(this.key()));
     }
 
     private initValidation() {

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringKafka.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringKafka.html
@@ -27,7 +27,9 @@
         <div data-bind="foreach: connectionOptions">
             <div class="flex-horizontal margin-bottom-xs">
                 <input class="form-control margin-right-sm" placeholder="Option key" data-bind="textInput: key" />
-                <input class="form-control margin-right-sm" placeholder="Option value" data-bind="textInput: value" />
+                <input class="form-control margin-right-sm" placeholder="Option value" data-bind="textInput: value, visible: !multiLine()" />
+                <textarea class="form-control margin-right-sm" placeholder="Option value" data-bind="textInput: value, visible: multiLine">
+                </textarea>
                 <a title="Remove this connection option" href="#" class="btn" data-bind="click: $parent.removeConnectionOption.bind($parent, $data)">
                     <i class="icon-trash"></i>
                 </a>


### PR DESCRIPTION
…ection string options results in connection error

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21271 

### Additional description

Support for multiline options for kafka

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 
