### PR TITLE
RavenDB-17936 Proper handling of LINQ `SelectMany` on `ValueCollection`

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -156,7 +156,7 @@ namespace Raven.Client.Documents.Indexes
                     Out(")");
                 
                 if (instance.Type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)) && name == "Values")
-                    Out(".ToDictionary(x => x.Key, x => x.Value)");
+                    Out(".ToDictionary(e2 => e2.Key, e2 => e2.Value)");
                 
                 if (isId == false)
                     OutMemberCall(name);
@@ -1294,7 +1294,7 @@ namespace Raven.Client.Documents.Indexes
             Visit(body);
             
             if (body.NodeType == ExpressionType.MemberAccess && body.Type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)))
-                Out(".ToDictionary(x => x.Key, x => x.Value)");
+                Out(".ToDictionary(e3 => e3.Key, e3 => e3.Value)");
             
             return node;
         }

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -156,7 +156,7 @@ namespace Raven.Client.Documents.Indexes
                     Out(")");
                 
                 if (instance.Type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)) && name == "Values")
-                    Out(".ToDictionary(e1 => e1.Key, e1 => e1.Value)");
+                    Out(".ToDictionary(x => x.Key, x => x.Value)");
                 
                 if (isId == false)
                     OutMemberCall(name);
@@ -1294,7 +1294,7 @@ namespace Raven.Client.Documents.Indexes
             Visit(body);
             
             if (body.NodeType == ExpressionType.MemberAccess && body.Type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>)))
-                Out(".ToDictionary(e1 => e1.Key, e1 => e1.Value)");
+                Out(".ToDictionary(x => x.Key, x => x.Value)");
             
             return node;
         }

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicDictionary.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicDictionary.cs
@@ -588,6 +588,11 @@ namespace Raven.Server.Documents.Indexes.Static
         {
             return new DynamicDictionary(_dictionary.SelectMany(collectionSelector, resultSelector));
         }
+        
+        public IEnumerable<object> SelectMany(Func<KeyValuePair<object, object>, IEnumerable<object>> selector)
+        {
+            return _dictionary.SelectMany(selector);
+        }
 
         public IEnumerable<KeyValuePair<object, object>> Select()
         {

--- a/test/SlowTests/Issues/RavenDB-17936.cs
+++ b/test/SlowTests/Issues/RavenDB-17936.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17936 : RavenTestBase
+{
+    public RavenDB_17936(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void IndexDictionaryValuesTest()
+    {
+        using var store = GetDocumentStore();
+
+        new DocIndex().Execute(store);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Doc
+            {
+                Id = "doc-1",
+                SubDocs = new Dictionary<string, SubDoc>
+                {
+                    { "subDoc-1A", new SubDoc { SubDocId = "subDoc-1A", MultiStrValues = new[] { "val1A1", "val1A2" } } },
+                    { "subDoc-1B", new SubDoc { SubDocId = "subDoc-1B", MultiStrValues = new[] { "val1B1", "val1B2" } } },
+                }
+            });
+            
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var matchUsingSelect = session.Query<DocView, DocIndex>()
+                .Where(x => x.AllMultiStrValues.Contains("val1A1"))
+                .ToArray();
+
+            Assert.Single(matchUsingSelect);
+            Assert.Equal("doc-1", matchUsingSelect[0].Id);
+            
+            var matchUsingValuesSelectMany = session.Query<DocView, DocIndex>()
+                .Where(x => x.AllMultiStrValuesUsingValues.Contains("val1A1"))
+                .ToArray();
+
+            Assert.Single(matchUsingValuesSelectMany);
+            Assert.Equal("doc-1", matchUsingValuesSelectMany[0].Id);
+        }
+    }
+
+    private class DocIndex : AbstractIndexCreationTask<Doc>
+    {
+        public DocIndex()
+        {
+            Map = docs =>
+                from doc in docs
+                select new
+                {
+                    doc.Id,
+                    AllMultiStrValuesUsingValues = doc.SubDocs.Values.SelectMany(x => x.MultiStrValues).ToList(),
+                    AllMultiStrValues = doc.SubDocs.SelectMany(x => x.Value.MultiStrValues).ToList()
+                };
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+    
+    private class Doc
+    {
+        public string Id { get; set; }
+        public Dictionary<string, SubDoc> SubDocs { get; set; }
+    }
+
+    private class SubDoc
+    {
+        public string SubDocId { get; set; }
+        public string[] MultiStrValues { get; set; }
+    }
+
+    private class DocView
+    {
+        public string Id { get; set; }
+        public string[] AllMultiStrValues { get; set; }
+        public string[] AllMultiStrValuesUsingValues { get; set; }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void CheckNestedDictionaries()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var d1 = new Dto() 
+                { 
+                    SubDtos = new Dictionary<string, SubDto>
+                    {
+                        { "subDoc-1A", new SubDto { MultiStrValues = new Dictionary<string, string> { {"val1A1", "val1A2" } } } },
+                        { "subDoc-1B", new SubDto { MultiStrValues = new Dictionary<string, string> { {"val1B1", "val1B2" } } } }
+                    }
+                };
+                
+                session.Store(d1);
+                
+                session.SaveChanges();
+
+                var index = new DummyIndex();
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                var res = session.Query<DummyIndex.IndexResult>(index.IndexName).ProjectInto<DummyIndex.IndexResult>().ToList();
+                
+                Assert.Equal(1, res.Count);
+                Assert.NotNull(res[0]);
+            }
+        }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public class IndexResult
+        {
+            public object AllMultiStrValuesUsingValues { get; set; }
+            public object AllMultiStrValues { get; set; }
+        }
+        public DummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new IndexResult
+                {
+                    AllMultiStrValuesUsingValues = dto.SubDtos.Values.SelectMany(x => x.MultiStrValues),
+                    AllMultiStrValues = dto.SubDtos.SelectMany(x => x.Value.MultiStrValues)
+                };
+            
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+    
+    private class Dto
+    {
+        public Dictionary<string, SubDto> SubDtos { get; set; }
+    }
+
+    private class SubDto
+    {
+        public Dictionary<string, string> MultiStrValues { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17936/Selecting-multiple-values-from-Dictionary-values-in-an-index

### Additional description

We want to check on the client-side if `SelectMany` is called on `ValueCollection`, and the return type of its lambda. This allows us to use correct types for `Func` in server-side rewriter.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
