### PR TITLE
RavenDB-21501 - The list on the Revisions Bin never shows documents past the first 100, and the API for it does not seem to be usable

### DIFF
--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -401,7 +401,7 @@ namespace Raven.Server.Documents.Handlers
             var revisionsStorage = Database.DocumentsStorage.RevisionsStorage;
 
             var sw = Stopwatch.StartNew();
-            var etag = GetLongQueryString("etag", false) ?? long.MaxValue;
+            var etag = GetLongQueryString("etag", false) ?? 0;
             var pageSize = GetPageSize();
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2313,29 +2313,27 @@ namespace Raven.Server.Documents.Revisions
                 latestChangeVector = entry.ChangeVector;
             }
         }
-
-        public IEnumerable<Document> GetRevisionsBinEntries(DocumentsOperationContext context, long startEtag, long take)
+        
+        public IEnumerable<Document> GetRevisionsBinEntries(DocumentsOperationContext context, long skip, long take)
         {
             var table = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
-            using (GetEtagAsSlice(context, startEtag, out var slice))
+
+            foreach (var tvr in table.SeekBackwardFrom(RevisionsSchema.Indexes[DeleteRevisionEtagSlice], null, Slices.AfterAllKeys, skip))
             {
-                foreach (var tvr in table.SeekBackwardFrom(RevisionsSchema.Indexes[DeleteRevisionEtagSlice], slice))
+                if (take-- <= 0)
+                    yield break;
+
+                var etag = TableValueToEtag((int)RevisionsTable.DeletedEtag, ref tvr.Result.Reader);
+                if (etag == NotDeletedRevisionMarker)
+                    yield break;
+
+                using (TableValueToSlice(context, (int)RevisionsTable.LowerId, ref tvr.Result.Reader, out Slice lowerId))
                 {
-                    if (take-- <= 0)
-                        yield break;
-
-                    var etag = TableValueToEtag((int)RevisionsTable.DeletedEtag, ref tvr.Result.Reader);
-                    if (etag == NotDeletedRevisionMarker)
-                        yield break;
-
-                    using (TableValueToSlice(context, (int)RevisionsTable.LowerId, ref tvr.Result.Reader, out Slice lowerId))
-                    {
-                        if (IsRevisionsBinEntry(context, table, lowerId, etag) == false)
-                            continue;
-                    }
-
-                    yield return TableValueToRevision(context, ref tvr.Result.Reader);
+                    if (IsRevisionsBinEntry(context, table, lowerId, etag) == false)
+                        continue;
                 }
+
+                yield return TableValueToRevision(context, ref tvr.Result.Reader);
             }
         }
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2305,10 +2305,10 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        public void GetLatestRevisionsBinEntryEtag(DocumentsOperationContext context, long startEtag, out string latestChangeVector)
+        public void GetLatestRevisionsBinEntry(DocumentsOperationContext context, out string latestChangeVector)
         {
             latestChangeVector = null;
-            foreach (var entry in GetRevisionsBinEntries(context, startEtag, 1))
+            foreach (var entry in GetRevisionsBinEntries(context, 0, 1))
             {
                 latestChangeVector = entry.ChangeVector;
             }

--- a/src/Raven.Studio/typescript/commands/database/documents/getRevisionsBinEntryCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/getRevisionsBinEntryCommand.ts
@@ -11,7 +11,7 @@ class getRevisionsBinEntryCommand extends commandBase {
 
     execute(): JQueryPromise<pagedResult<document>> {
         const args = {
-            skip: this.skip,
+            etag: this.skip,
             pageSize: this.take
         };
 

--- a/src/Raven.Studio/typescript/commands/database/documents/getRevisionsBinEntryCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/getRevisionsBinEntryCommand.ts
@@ -5,13 +5,13 @@ import document = require("models/database/documents/document");
 
 class getRevisionsBinEntryCommand extends commandBase {
 
-    constructor(private database: database, private changeVector: string, private take: number) {
+    constructor(private database: database, private skip: number, private take: number) {
         super();
     }
 
     execute(): JQueryPromise<pagedResult<document>> {
         const args = {
-            changeVector: this.changeVector,
+            skip: this.skip,
             pageSize: this.take
         };
 

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/revisionsBin.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/revisionsBin.ts
@@ -30,8 +30,6 @@ class revisionsBin extends viewModelBase {
         delete: ko.observable<boolean>(false)
     };
 
-    private revisionsBinEntryNextChangeVector = undefined as string;
-
     private gridController = ko.observable<virtualGridController<document>>();
     private columnPreview = new columnPreviewPlugin<document>();
 
@@ -63,23 +61,16 @@ class revisionsBin extends viewModelBase {
 
     refresh() {
         eventsCollector.default.reportEvent("revisions-bin", "refresh");
-        this.revisionsBinEntryNextChangeVector = undefined;
         this.gridController().reset(true);
     }
 
     fetchRevisionsBinEntries(skip: number): JQueryPromise<pagedResult<document>> {
         const task = $.Deferred<pagedResult<document>>();
 
-        new getRevisionsBinEntryCommand(this.activeDatabase(), this.revisionsBinEntryNextChangeVector, 101)
+        new getRevisionsBinEntryCommand(this.activeDatabase(), skip, 100)
             .execute()
             .done(result => {
-                const hasMore = result.items.length === 101;
                 const totalCount = skip + result.items.length;
-                if (hasMore) {
-                    const nextItem = result.items.pop();
-                    this.revisionsBinEntryNextChangeVector = nextItem.__metadata.changeVector();
-                }
-
                 task.resolve({
                     totalResultCount: totalCount,
                     items: result.items

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/revisionsBin.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/revisionsBin.ts
@@ -67,10 +67,14 @@ class revisionsBin extends viewModelBase {
     fetchRevisionsBinEntries(skip: number): JQueryPromise<pagedResult<document>> {
         const task = $.Deferred<pagedResult<document>>();
 
-        new getRevisionsBinEntryCommand(this.activeDatabase(), skip, 100)
+        new getRevisionsBinEntryCommand(this.activeDatabase(), skip, 101)
             .execute()
             .done(result => {
+                const hasMore = result.items.length === 101;
                 const totalCount = skip + result.items.length;
+                if (hasMore) {
+                    result.items.pop();
+                }
                 task.resolve({
                     totalResultCount: totalCount,
                     items: result.items

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1249,7 +1249,7 @@ namespace Voron.Data.Tables
             return null;
         }
 
-        public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.SchemaIndexDef index, Slice prefix, Slice last, long skip)
+        public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.SchemaIndexDef index, Slice? prefix, Slice last, long skip)
         {
             var tree = GetTree(index);
             if (tree == null)
@@ -1260,11 +1260,14 @@ namespace Voron.Data.Tables
                 if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
                     yield break;
 
-                it.SetRequiredPrefix(prefix);
-                if (SliceComparer.StartWith(it.CurrentKey, it.RequiredPrefix) == false)
+                if (prefix != null)
                 {
-                    if (it.MovePrev() == false)
-                        yield break;
+                    it.SetRequiredPrefix(prefix.Value);
+                    if (SliceComparer.StartWith(it.CurrentKey, it.RequiredPrefix) == false)
+                    {
+                        if (it.MovePrev() == false)
+                            yield break;
+                    }
                 }
 
                 do

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -1381,7 +1381,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database,
                     modifyConfiguration: configuration => configuration.Collections["Users"].PurgeOnDelete = false);
 
-                var deletedRevisions = await store.Commands().GetRevisionsBinEntriesAsync(long.MaxValue);
+                var deletedRevisions = await store.Commands().GetRevisionsBinEntriesAsync(0);
                 Assert.Equal(0, deletedRevisions.Count());
 
                 var id = "users/1";
@@ -1417,7 +1417,7 @@ namespace FastTests.Server.Documents.Revisions
                 Assert.Equal(useSession ? 1 : 0, statistics.CountOfDocuments);
                 Assert.Equal(4, statistics.CountOfRevisionDocuments);
 
-                deletedRevisions = await store.Commands().GetRevisionsBinEntriesAsync(long.MaxValue);
+                deletedRevisions = await store.Commands().GetRevisionsBinEntriesAsync(0);
                 Assert.Equal(1, deletedRevisions.Count());
 
                 using (var session = store.OpenAsyncSession())

--- a/test/SlowTests/Client/RavenDB_21466.cs
+++ b/test/SlowTests/Client/RavenDB_21466.cs
@@ -70,7 +70,7 @@ namespace SlowTests.Client
                     using(database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     using (context.OpenReadTransaction())
                     {
-                        var count = database.DocumentsStorage.RevisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, long.MaxValue).Count();
+                        var count = database.DocumentsStorage.RevisionsStorage.GetRevisionsBinEntries(context, 0, long.MaxValue).Count();
                         Assert.Equal(1, count);
                     }
                 }

--- a/test/SlowTests/Issues/RavenDB-15483.cs
+++ b/test/SlowTests/Issues/RavenDB-15483.cs
@@ -65,7 +65,7 @@ namespace SlowTests.Issues
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 2).Count();
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, 0, 2).Count();
                     Assert.Equal(1, revisions);
                 }
 
@@ -74,7 +74,7 @@ namespace SlowTests.Issues
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 2).Count();
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, 0, 2).Count();
                     Assert.Equal(1, revisions);
                 }
             }
@@ -136,7 +136,7 @@ namespace SlowTests.Issues
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 6).Count();
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, 0, 6).Count();
                     Assert.Equal(1, revisions);
                 }
 
@@ -145,7 +145,7 @@ namespace SlowTests.Issues
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, long.MaxValue, 6).Count();
+                    var revisions = revisionsStorage.GetRevisionsBinEntries(context, 0, 6).Count();
                     Assert.Equal(1, revisions);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB_21501.cs
+++ b/test/SlowTests/Issues/RavenDB_21501.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21501 : ClusterTestBase
+    {
+        public RavenDB_21501(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task RevisionsBinRepeatingSameDocs()
+        {
+            using (var store = GetDocumentStore())
+            {
+                await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(new RevisionsConfiguration {Default = new RevisionsCollectionConfiguration()}));
+
+                using (var session = store.OpenSession())
+                {
+                    for (int i = 0; i < 200; i++)
+                    {
+                        session.Store(new User(), $"users/{i}");
+                    }
+                    session.SaveChanges();
+
+                    var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation("test"));
+                    Assert.Equal(200, stats.CountOfDocuments);
+
+                    for (int i = 0; i < 200; i++)
+                    {
+                        session.Delete($"users/{i}");
+                    }
+                    session.SaveChanges();
+                }
+                
+                var revsBin = await store.Commands().GetRevisionsBinEntriesAsync(0, pageSize: 100);
+                Assert.Equal(100, revsBin.Count());
+
+                revsBin = await store.Commands().GetRevisionsBinEntriesAsync(100, pageSize: 100);
+                Assert.Equal(100, revsBin.Count());
+
+                revsBin = await store.Commands().GetRevisionsBinEntriesAsync(200, pageSize: 100);
+                Assert.Equal(0, revsBin.Count());
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -556,7 +556,7 @@ namespace SlowTests.Server.Documents.Revisions
                 });
                 await SetupReplicationAsync(store1, store2);
 
-                var deletedRevisions = await store1.Commands().GetRevisionsBinEntriesAsync(long.MaxValue);
+                var deletedRevisions = await store1.Commands().GetRevisionsBinEntriesAsync(0);
                 Assert.Equal(0, deletedRevisions.Count());
 
                 var id = "users/1";
@@ -592,10 +592,10 @@ namespace SlowTests.Server.Documents.Revisions
                 Assert.Equal(4, statistics.CountOfRevisionDocuments);
 
                 //sanity
-                deletedRevisions = await store1.Commands().GetRevisionsBinEntriesAsync(long.MaxValue);
+                deletedRevisions = await store1.Commands().GetRevisionsBinEntriesAsync(0);
                 Assert.Equal(1, deletedRevisions.Count());
 
-                deletedRevisions = await store2.Commands().GetRevisionsBinEntriesAsync(long.MaxValue);
+                deletedRevisions = await store2.Commands().GetRevisionsBinEntriesAsync(0);
                 Assert.Equal(1, deletedRevisions.Count());
 
                 using (var session = store2.OpenAsyncSession())

--- a/test/SlowTests/Smuggler/SmugglerApiTests.cs
+++ b/test/SlowTests/Smuggler/SmugglerApiTests.cs
@@ -635,7 +635,7 @@ namespace SlowTests.Smuggler
                     Assert.Equal(10, stats.CountOfRevisionDocuments);
                     using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                     {
-                        var command = new GetRevisionsBinEntryCommand(long.MaxValue, 5);
+                        var command = new GetRevisionsBinEntryCommand(0, 5);
                         await store2.GetRequestExecutor().ExecuteAsync(command, context);
                         Assert.Equal(3, command.Result.Results.Length);
                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21501

### Additional description

Changed revisions bin endpoint to work the same as documents preview and v6:
Using `skip` to skip the amount of revisions already displayed and then taking the wanted `pageSize` amount.
The ep parameter representing `skip` has been left with its original names `etag` to prevent breaking change of client API.
The revision bin studio display is also not working because it is sending a change vector instead of `etag`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Breaking change - `etag` is representing the amount of docs to skip before fetching, instead of the actual etag of the revision.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed - Could not find Client API documentation for revision bin nor a dedicated Operation other than `store.Commands().GetRevisionsBinEntriesAsync();`

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- After studio change - need to manually verify

### UI work

- It requires further work in the Studio.