### PR TITLE
RavenDB-21608 Query hash calculation ignores empty string parameters

### DIFF
--- a/src/Raven.Client/Documents/Queries/HashCalculator.cs
+++ b/src/Raven.Client/Documents/Queries/HashCalculator.cs
@@ -115,7 +115,7 @@ namespace Raven.Client.Documents.Queries
 
         public void Write(string s)
         {
-            if (s == null)
+            if (string.IsNullOrEmpty(s))
             {
                 Write("null-string");
                 return;
@@ -279,21 +279,24 @@ namespace Raven.Client.Documents.Queries
 
                 case IEnumerable e:
                     bool hadEnumerableValues = false;
+                    var processedItems = 0;
+                    
                     var enumerator = e.GetEnumerator();
                     while (enumerator.MoveNext())
                     {
                         WriteParameterValue(enumerator.Current, conventions, serializer);
+                        processedItems++;
                         hadEnumerableValues = true;
                     }
-                    if (hadEnumerableValues == false)
-                    {
+
+                    if (hadEnumerableValues)
+                        Write(processedItems);
+                    else
                         Write("empty-enumerator");
-                    }
 
                     break;
 
                 default:
-
                     var valueType = value.GetType();
                     if (valueType.IsPrimitive == false)
                     {

--- a/src/Raven.Client/Documents/Queries/HashCalculator.cs
+++ b/src/Raven.Client/Documents/Queries/HashCalculator.cs
@@ -115,7 +115,7 @@ namespace Raven.Client.Documents.Queries
 
         public void Write(string s)
         {
-            if (string.IsNullOrEmpty(s))
+            if (s == null)
             {
                 Write("null-string");
                 return;
@@ -267,30 +267,35 @@ namespace Raven.Client.Documents.Queries
                     var dictionaryEnumerator = dict.GetEnumerator();
                     while (dictionaryEnumerator.MoveNext())
                     {
+                        Write("key");
                         WriteParameterValue(dictionaryEnumerator.Key, conventions, serializer);
+                        Write("value");
                         WriteParameterValue(dictionaryEnumerator.Value, conventions, serializer);
                         hadDictionaryValues = true;
                     }
+                    
                     if (hadDictionaryValues == false)
-                    {
                         Write("empty-dictionary");
-                    }
                     break;
 
                 case IEnumerable e:
                     bool hadEnumerableValues = false;
-                    var processedItems = 0;
+                    var processedEnumerableItemsCount = 0;
                     
                     var enumerator = e.GetEnumerator();
                     while (enumerator.MoveNext())
                     {
                         WriteParameterValue(enumerator.Current, conventions, serializer);
-                        processedItems++;
+                        
+                        if (enumerator.Current is string s)
+                            Write(s.Length);
+                        
+                        processedEnumerableItemsCount++;
                         hadEnumerableValues = true;
                     }
 
                     if (hadEnumerableValues)
-                        Write(processedItems);
+                        Write(processedEnumerableItemsCount);
                     else
                         Write("empty-enumerator");
 

--- a/test/SlowTests/Issues/RavenDB-21608.cs
+++ b/test/SlowTests/Issues/RavenDB-21608.cs
@@ -1,0 +1,71 @@
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Queries;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21608 : RavenTestBase
+{
+    public RavenDB_21608(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Querying)]
+    public void HashIsDifferentForDifferentContainsList()
+    {
+        var q1 = new IndexQuery
+        {
+            Query = "from index 'Grade/ByAllIds' where PayriteCode in ($p0)",
+            QueryParameters = new Parameters()
+            {
+                {"p0", new[] { "BFD1", "BDEC", "" } }
+            }
+        };
+            
+        var q2 = new IndexQuery
+        {
+            Query = "from index 'Grade/ByAllIds' where PayriteCode in ($p0)",
+            QueryParameters = new Parameters()
+            {
+                {"p0", new[] { "BFD1", "BDEC" } }
+            }
+        };
+
+        var q3 = new IndexQuery()
+        {
+            Query = "from index 'Grade/ByAllIds' where PayriteCode in ($p0)", 
+            QueryParameters = new Parameters()
+            {
+                {"p0", new[] { "BFD1", "BD", "EC" } }
+            }
+        };
+
+        var q4 = new IndexQuery()
+        {
+            Query = "from index 'Grade/ByAllIds' where PayriteCode in ($p0)", 
+            QueryParameters = new Parameters()
+            {
+                {"p0", new[] { "BFD1", "BDE", "C" } }
+            }
+        };
+        
+        var conventions = new DocumentConventions();
+        var jsonSerializer = conventions.Serialization.CreateSerializer();
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            var h1 = q1.GetQueryHash(context, conventions, jsonSerializer);
+            var h2 = q2.GetQueryHash(context, conventions, jsonSerializer);
+            var h3 = q3.GetQueryHash(context, conventions, jsonSerializer);
+            var h4 = q4.GetQueryHash(context, conventions, jsonSerializer);
+            
+            Assert.NotEqual(h1, h2);
+            Assert.NotEqual(h1, h3);
+            Assert.NotEqual(h1, h4);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21608/Query-hash-calculation-ignores-empty-string-parameters

### Additional description

Currently when we have an `IEnumerable<string>` parameter, we write its items as if they were one string. Same thing happens for key and value of dictionary parameter. 

To fix the first problem, we can write the length of every item (only for strings) right after the item itself, and after processing the whole parameter, write the amount of items we processed.
To fix the second problem I think it's enough to write `key` and `value` literals before the actual values.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Breaking change
Hash of queries with parameters will change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
