### PR TITLE
RavenDB-21536 Disable codepaths with Vector128.Load on ARM platforms to avoid segmentation faults.

### DIFF
--- a/src/Corax/Utils/EntryIdEncodings.cs
+++ b/src/Corax/Utils/EntryIdEncodings.cs
@@ -7,6 +7,7 @@ using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 using Corax.Indexing;
+using Sparrow.Server.Platform;
 
 namespace Corax.Utils;
 
@@ -90,7 +91,7 @@ public static class EntryIdEncodings
             DecodeAndDiscardFrequencyClassic(entries.Slice(idX), read - idX);
         
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public static unsafe void DecodeAndDiscardFrequencyNeon(Span<long> entries, int read)
     {
@@ -130,7 +131,7 @@ public static class EntryIdEncodings
     {
         if (Avx2.IsSupported)
             DecodeAndDiscardFrequencyAvx2(entries, read);
-        else if (AdvSimd.IsSupported)
+        else if (PlatformSpecific.IsArm == false && AdvSimd.IsSupported)
             DecodeAndDiscardFrequencyNeon(entries, read);
         else
             DecodeAndDiscardFrequencyClassic(entries, read);

--- a/src/Sparrow.Server/Platform/PlatformSpecific.cs
+++ b/src/Sparrow.Server/Platform/PlatformSpecific.cs
@@ -14,6 +14,10 @@ namespace Sparrow.Server.Platform
 {
     public static unsafe class PlatformSpecific
     {
+        public static readonly bool IsArm = RuntimeInformation.ProcessArchitecture.HasFlag(Architecture.Arm) 
+                                             ||   RuntimeInformation.ProcessArchitecture.HasFlag(Architecture.Arm64);
+
+        
         public static class MemoryInformation
         {
             public static string IsSwappingOnHddInsteadOfSsd()

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -9,6 +9,7 @@ using System.Runtime.Intrinsics;
 using System.Text;
 using Sparrow;
 using Sparrow.Server;
+using Sparrow.Server.Platform;
 using Voron.Data.Lookups;
 using Voron.Exceptions;
 using Voron.Global;
@@ -865,7 +866,7 @@ namespace Voron.Data.Containers
                         return (reqSize, pos + first);
                 }
             }
-            if (Vector128.IsHardwareAccelerated)
+            if (PlatformSpecific.IsArm == false && Vector128.IsHardwareAccelerated)
             {
                 for (; pos + Vector128<ushort>.Count <= numberOfOffsets; pos += Vector128<ushort>.Count)
                 {

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using Sparrow;
 using Sparrow.Server;
+using Sparrow.Server.Platform;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
 using Voron.Debugging;
@@ -788,7 +789,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
                 }
             }
 
-            if (Vector128.IsHardwareAccelerated)
+            if (PlatformSpecific.IsArm == false && Vector128.IsHardwareAccelerated)
             {
                 int N128 = (Vector128<ushort>.Count - 1);
                 while (newEntriesStartPtr - Vector128<ushort>.Count >= newEntriesEndPtr)

--- a/src/Voron/Util/PFor/FastPForDecoder.cs
+++ b/src/Voron/Util/PFor/FastPForDecoder.cs
@@ -5,6 +5,7 @@ using System.Runtime.Intrinsics;
 using Sparrow.Binary;
 using Sparrow.Compression;
 using Sparrow.Server;
+using Sparrow.Server.Platform;
 using Voron.Data.PostingLists;
 
 namespace Voron.Util.PFor;
@@ -193,8 +194,12 @@ public unsafe struct FastPForDecoder : IDisposable
             Vector256<ulong> GetDeltaHighBits()
             {
                 var ptr = (byte*)bigDeltaOffsets.Pop() + 1;
-                var highBitsDelta = Vector128.Load(ptr)
-                    .AsInt32().ToVector256();
+
+                Vector256<int> highBitsDelta = PlatformSpecific.IsArm == false 
+                    ? Vector128.Load(ptr).AsInt32().ToVector256() 
+                    : Vector256.Create(*(int*)ptr, *(int*)(ptr + sizeof(int)), *(int*)(ptr + 2 * sizeof(int)), *(int*)(ptr + 3 * sizeof(int)), 0, 0, 0, 0);
+                    
+                
                 if (bigDeltaOffsets.Count > 0)
                 {
                     expectedBufferIndex = *(byte*)bigDeltaOffsets.First;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21536 
### Additional description

https://github.com/dotnet/runtime/pull/93992 will be available in 7.0.15 so let's disable instincts that may cause issues for now.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility


- Not relevant

### Is it platform specific issue?

- Yes. 
- - ARM

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
