### PR TITLE
RavenDB-21642 Support single term in In/AllIn queries.

### DIFF
--- a/src/Corax/Querying/Matches/MultiTermMatch.Erasure.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.Erasure.cs
@@ -134,6 +134,13 @@ namespace Corax.Querying.Matches
             return new MultiTermMatch(query, StaticFunctionCache<BinaryMatch>.FunctionTable);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static MultiTermMatch Create(in TermMatch query)
+        { 
+            return new MultiTermMatch(query, StaticFunctionCache<BinaryMatch>.FunctionTable);
+        }
+
+        
         private struct EmptyTermProvider : ITermProvider
         {
             public int TermsCount => 0;

--- a/test/SlowTests/Corax/RavenDB-21642.cs
+++ b/test/SlowTests/Corax/RavenDB-21642.cs
@@ -1,0 +1,67 @@
+#nullable enable
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_21642 : RavenTestBase
+{
+    public RavenDB_21642(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanUseInAndAllInWithOnlyOneElement(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        store.ExecuteIndex(new TestDocumentIndex());
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new TestDocument {Tags = null});
+            session.Store(new TestDocument {Tags = Array.Empty<string>()});
+            session.Store(new TestDocument {Tags = new string[] {"test"}});
+            session.Store(new TestDocument {Tags = new string[] {"abc", "test"}});
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var target = new []{"test"};
+            int count = session
+                .Query<TestDocument, TestDocumentIndex>()
+                .Count(d => d.Tags.ContainsAll(target));
+            Assert.Equal(2, count);
+            
+            count = session
+                .Query<TestDocument, TestDocumentIndex>()
+                .Count(d => d.Tags.In(target));
+            Assert.Equal(2, count);
+        }
+    }
+
+    private class TestDocument
+    {
+        public string[]? Tags { get; set; }
+    }
+
+    private class TestDocumentIndex : AbstractIndexCreationTask<TestDocument>
+    {
+        public override string IndexName => "indexes/test_document";
+
+        public TestDocumentIndex()
+        {
+            Map = docs => from doc in docs select new { Tags = doc.Tags == null || doc.Tags.Length == 0 ? null : doc.Tags };
+        }
+    }
+
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21642 



### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
