### PR TITLE
RavenDB-19529: Missing compression dictionary (OpenTable bug fix)

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -567,7 +567,7 @@ namespace Raven.Server.Documents
                     _documentsStorage.EnsureLastEtagIsPersisted(context, existingDoc.Etag);
 
                     //make sure that the relevant collection tree exists
-                    var table = tx.OpenTable(DocsSchema, collectionName.GetTableName(CollectionTableType.Documents));
+                    var table = tx.OpenTable(_documentDatabase.GetDocsSchemaForCollection(collectionName), collectionName.GetTableName(CollectionTableType.Documents));
                     table.Delete(existingDoc.StorageId);
                 }
                 else if (existing.Tombstone != null)

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -14,7 +13,6 @@ using Voron.Data.Tables;
 using System.Linq;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
-using Raven.Client.ServerWide;
 using Sparrow.Server;
 using static Raven.Server.Documents.DocumentsStorage;
 using Constants = Raven.Client.Constants;
@@ -127,7 +125,8 @@ namespace Raven.Server.Documents
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idPtr))
             {
                 var collectionName = _documentsStorage.ExtractCollectionName(context, document);
-                var table = context.Transaction.InnerTransaction.OpenTable(GetDocsSchemaForCollection(collectionName), collectionName.GetTableName(CollectionTableType.Documents));
+                var table = context.Transaction.InnerTransaction.OpenTable(_documentDatabase.GetDocsSchemaForCollection(collectionName),
+                    collectionName.GetTableName(CollectionTableType.Documents));
             
                 var oldValue = default(TableValueReader);
                 if (knownNewId == false)
@@ -309,37 +308,6 @@ namespace Raven.Server.Documents
                     LastModified = new DateTime(modifiedTicks, DateTimeKind.Utc)
                 };
             }
-        }
-
-        public void InitializeFromDatabaseRecord(DatabaseRecord record)
-        {
-            if (_documentsCompression.Equals(record.DocumentsCompression))
-                return;
-
-            if (record.DocumentsCompression == null) // legacy configurations
-            {
-                _compressedCollections.Clear();
-                _documentsCompression = new DocumentsCompressionConfiguration(false);
-                return;
-            }
-
-            _documentsCompression = record.DocumentsCompression;
-            _compressedCollections = new HashSet<string>(record.DocumentsCompression.Collections, StringComparer.OrdinalIgnoreCase);
-        }
-
-        public DocumentsCompressionConfiguration DocumentsCompression => _documentsCompression;
-
-        private DocumentsCompressionConfiguration _documentsCompression = new DocumentsCompressionConfiguration(false, Array.Empty<string>());
-        private HashSet<string> _compressedCollections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        public TableSchema GetDocsSchemaForCollection(CollectionName collection)
-        {
-            if (_documentsCompression.CompressAllCollections || _compressedCollections.Contains(collection.Name))
-            {
-                return CompressedDocsSchema;
-            }
-
-            return DocsSchema;
         }
 
         [Conditional("DEBUG")]

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -424,20 +424,6 @@ namespace Raven.Server.Documents
             _documentsMetadataCache = obj.ImmutableExternalState as DocumentTransactionCache;
         }
 
-        public void AssertFixedSizeTrees(Transaction tx)
-        {
-            // here we validate the table fixed size indexes
-            tx.OpenTable(DocsSchema, DocsSlice).AssertValidFixedSizeTrees();
-            tx.OpenTable(DocsSchema, LastReplicatedEtagsSlice).AssertValidFixedSizeTrees();
-            tx.OpenTable(DocsSchema, GlobalTreeSlice).AssertValidFixedSizeTrees();
-        }
-
-        private static void AssertTransaction(DocumentsOperationContext context)
-        {
-            if (context.Transaction == null) //precaution
-                throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
-        }
-
         public static string GetDatabaseChangeVector(DocumentsOperationContext context)
         {
             return GetDatabaseChangeVector(context.Transaction.InnerTransaction);
@@ -900,7 +886,7 @@ namespace Raven.Server.Documents
             if (collectionName == null)
                 yield break;
 
-            var table = context.Transaction.InnerTransaction.OpenTable(DocsSchema,
+            var table = context.Transaction.InnerTransaction.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(collectionName),
                 collectionName.GetTableName(CollectionTableType.Documents));
 
             if (table == null)
@@ -1033,7 +1019,7 @@ namespace Raven.Server.Documents
             if (collectionName == null)
                 yield break;
 
-            var table = context.Transaction.InnerTransaction.OpenTable(DocsSchema,
+            var table = context.Transaction.InnerTransaction.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(collectionName),
                 collectionName.GetTableName(CollectionTableType.Documents));
 
             if (table == null)
@@ -1438,11 +1424,10 @@ namespace Raven.Server.Documents
             return ReadLastDocument(transaction, collectionName, CollectionTableType.Documents, ref result);
         }
 
-        private static bool ReadLastDocument(Transaction transaction, CollectionName collectionName, CollectionTableType collectionType, ref Table.TableValueHolder result)
+        private bool ReadLastDocument(Transaction transaction, CollectionName collectionName, CollectionTableType collectionType, ref Table.TableValueHolder result)
         {
-            var table = transaction.OpenTable(DocsSchema,
-                collectionName.GetTableName(collectionType)
-            );
+            var table = transaction.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(collectionName),
+                collectionName.GetTableName(collectionType));
 
             // ReSharper disable once UseNullPropagation
             if (table == null)
@@ -1768,7 +1753,8 @@ namespace Raven.Server.Documents
                 }
 
                 collectionName = ExtractCollectionName(context, doc.Data);
-                var table = context.Transaction.InnerTransaction.OpenTable(DocsSchema, collectionName.GetTableName(CollectionTableType.Documents));
+                var table = context.Transaction.InnerTransaction.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(collectionName),
+                    collectionName.GetTableName(CollectionTableType.Documents));
 
                 var ptr = table.DirectRead(doc.StorageId, out int size);
                 var tvr = new TableValueReader(ptr, size);
@@ -2197,7 +2183,7 @@ namespace Raven.Server.Documents
             //make sure that the relevant collection tree exists
             Table table = isTombstone ?
                 tx.OpenTable(TombstonesSchema, collectionName) :
-                tx.OpenTable(DocsSchema, collectionName);
+                tx.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(collectionObject), collectionName);
 
             table.Delete(storageId);
         }
@@ -2242,10 +2228,11 @@ namespace Raven.Server.Documents
             }
             else
             {
-                table = context.Transaction.InnerTransaction.OpenTable(DocsSchema,
+                table = context.Transaction.InnerTransaction.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(collectionName),
                     collectionName.GetTableName(CollectionTableType.Documents));
                 indexDef = DocsSchema.FixedSizeIndexes[CollectionEtagsSlice];
             }
+
             if (table == null)
             {
                 totalCount = 0;
@@ -2279,7 +2266,8 @@ namespace Raven.Server.Documents
         {
             foreach (var kvp in _collectionsCache)
             {
-                var collectionTable = context.Transaction.InnerTransaction.OpenTable(DocsSchema, kvp.Value.GetTableName(CollectionTableType.Documents));
+                var collectionTable = context.Transaction.InnerTransaction.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(kvp.Value),
+                    kvp.Value.GetTableName(CollectionTableType.Documents));
                 //This is the case where a read transaction reading a collection cached by a later write transaction we can safly ignore it.
                 if (collectionTable == null)
                 {
@@ -2354,7 +2342,7 @@ namespace Raven.Server.Documents
                 };
             }
 
-            var collectionTable = context.Transaction.InnerTransaction.OpenTable(DocsSchema,
+            var collectionTable = context.Transaction.InnerTransaction.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(collectionName),
                 collectionName.GetTableName(CollectionTableType.Documents));
 
             if (collectionTable == null)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -136,7 +135,7 @@ namespace Raven.Server.Documents.Revisions
                  };
             }
 
-            var revisionsSchema = _documentsStorage.DocumentPut.DocumentsCompression.CompressRevisions ?
+            var revisionsSchema = _database.DocumentsCompression.CompressRevisions ?
                 CompressedRevisionsSchema :
                 RevisionsSchema;
 

--- a/test/SlowTests/Issues/RavenDB_19529.cs
+++ b/test/SlowTests/Issues/RavenDB_19529.cs
@@ -1,0 +1,257 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Documents.Replication;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations.DocumentsCompression;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19529 : ReplicationTestBase
+{
+    public RavenDB_19529(ITestOutputHelper output) : base(output)
+    {
+        Assert.True(SpecificContentWithSpecificSize.Last() != CharToAppend);
+    }
+
+    // We want to reproduce very narrow conditions under which a problem occurs:
+    // 1. The document should contain random data that is difficult to compress.
+    // 2. After compression, the compressed buffer should not fit into the small section.
+    // 3. The size of the compressed buffer + sizeof(RawDataSection.RawDataEntrySizes) (4 byte) should be greater than RawDataSection.MaxItemSize (4064 bytes).
+    // 4. We want to perform a merged write transaction, within which the opening of a table of a certain collection occurs first, and then a PUT (update) command
+    //    is executed on the document specified above.
+
+    private const string SpecificContentWithSpecificSize =
+        "fR5WC1L5gHHLyuHA4\"O7/S/WUg:GXt5ViwqiPzfFoh\"k36lkf0tem\"3Ny91WM/m5zN1XfS0OIaTqdSnWeg2HfK9KDI3CG9P2qR8BTp8rdUsFSdv1n9GRyzyFrQbv5vLkh:g4Rfhuccy7Xl7OTj1nwTm7VU" +
+        "6SFVkUYC8RzdWgAwl6:42KXOWTxh8pma:73CCJz5edl7IPWMR2dSoxymRNAQI7uPdIKJ7wbIUuwIlqSV9D\"cIPQp0Iexa7d2dEG0/97JCsPdBP8zPvQwbfSEjGO/iGLMdPFTXMlRt/PaRkh7jxVWTb7zpW4F" +
+        "ZlW/YpJ4OyW\"aML73pjUhr6Qn7al30XqP9LgbufTF\"BPGsCF9DGgavUDuQnFhwZ8yvDrKugF7Zq/HHMevHREbREmu7dA:Cv7RqVtRoCQNZ75s\"MJnTPRYG5r1UACeiCAHAUhRJ:foH9IY3g5roeta707zC" +
+        "1VQE5fJl9fUdbtz0t/vtecVbwL17rXGe7K/HxGcGyq9HgcLz6Z8\"lAHCaROu6fn3anjZkSwqpeOXpTlBHyrbpTuYVzfcmTASp\"oU4:yirNN28KUXirZpz6nBftuTf1gssK2jfR89ELiM1vyVcFozJ7iDwjm" +
+        "l2Q4FLS\"AfK7yUWuN7QDEkySGfyPBKMdiOt0GY4OT2jLtUD6MMr8MDIfUIeTQXF3A18S2x3SaNFvDGqWhYkxUQdWru6QSPo9gR\"ziwhwwbvbYlxVZz76e\"h:gFGooCVI3IsxjBpxOgk:YQFnSeFXH1gmdt" +
+        "VJOiX7V1DSCmbpcD/lrTLYzudQbAntOZ4MuavmWupoY2ujhYVwKls:sa/U7Kkl2jKL1es/o1iDdWu3joiQe/U3vDO4r38REawx9Rlzb6XhuJaXBP38BgqlLhm1STiWgDNms9LMVzD:2xj9Ibw1u/t0aleA7HC" +
+        "yyEn0O:VgTvPlzNsl34wzveWy2ofvgMVMnfC9xYIZG2lCT3H2cnigadbhjCbPM8cURs/37E0ZDWn2OaaruEIUECdfcD:8Q8RVkP3f:g2cQ9UJr820QqDPPQY:H2IIUNt71sgyN0b6VTxwJQ\"6njuKjn5i1Qa" +
+        "UDUsdqayMkIf/3zBT1cthyGs1M2sbqZaRMicIg8gvB9o:OCvcxsxiLcLwWCnqeBnk8VJSdU\"WavfQT/KvOMj3VroKre22w19eq7fentFkeKjJ4nQdlS5HdEHYYTIGhlMvU7pavuU8aaD3f511PBpdxDdSxm9" +
+        "/i:AxsJKFOgRXJxr3RP9zylvumpTfqY7t:Ta9rSVePmzm\"p1AAHICJPn0OWZoDF4qE/0ObKObWT/4BClaDmSuRCu7OSfKyaC4CPQEjgfoHVLlRobMP5WRaUsu4sAEKX3f9oIn:eiwuwvv554nQYzUH8uAHz8" +
+        "iCAl7oKuVnE1bdO5ym8Pu1AlqRRrZEWEaKrWZEAo\"0/9CsGXU9an0CnV6Bm5gDP7WYhjfBGZoRzNx9tHUurcYHFct0L/pEBcHMzumz115g98ZSJQ41XfL9mlxINfH5fqiG/FTi7rqpW9JGWPv3A22Qnbga\"" +
+        "Ey2LBRFHGSwBihHFqtrHfXwCScUlidbQV3j8Kp9muS:Pb7sbgPkfiojB:KOddvc82QcHb1Z6PjTnPpZWPKffA9rim2drNu2hE/AOxLGCTI1IWgwPPkLUR1k/An3hGEStY1rvBLUW8hVi4PtXUs:8DVSNdG2AS" +
+        "72bknpksssKwVMd\"GH8yyapWcKFnwXZsNmosxf/lg0qP0jlApazTtYDA1HDYprTKUwzhtrv7psYFy/TpM4X1bhc5TzWAF2bokD4D5aTdVgQJFqgnHMHwOpMZ:mUyuzKbg2Vc1:5S:zgvnR7GZ6/h5ST:HwVc" +
+        "YLFfqPe3GkGoY6:t6IIeKCtS0Mnojftexso7bm5xiVKbCSb2/HC\"/vUhllKU3TPrIKiiXNq17nJryJM6l:CjkrhNDO23QUVnoXr2CveXO4:/TnOtuoEbvo4tV2F7S6l3n/cjFQz0qGaNtTq/9w7L1Sarw1JO" +
+        ":aydw1wHgBDLuRe9TnQTmTeaVYl0cJtV2vB17ph4:21EHQ:2iKUnUlEWobMC3MQga6\"z\"VZao//tohGG3FBNtWM7QUjuDQ9HenZMDonWpvkHsoB1/h6KNbpnRsJnl4Geh5dr7qPNptPbHdfRGUkaluCkANI" +
+        "09HhIvHfKFAUZXfYgsAmNORkdQ363fWLBfELSUhjB:zfS253zvgPt:zYLfqhzPkay0HClVg8esEPNQHTOTnE4MqULVYi3D0cUg2\"5lN2WVLQRnLthO/bhf\"1gam02FoBa1kbVry6kKxsyXmoK3RsZtVZ4vt" +
+        "Tbjz:QNW5SWZuvRuGOW6AR7N4PquXDk/2t9dPED/DiazjPtD6Cp4gtSGKR6gzN/3EFMl8FB4etegShjLGD8KVRyAMO5lBhtWD10lmQAxIlLJJOO6hEMW3wlHSj5k/dGtwgQM29MTqfn\"3jG9PR:WJWwXNYJd" +
+        "BD5eD7nYfXOidXp0Hpbp89h\"AMpECD52Zh\"zMq44emubBMN411Fvxq6DrDKgXaOTUMjOvNvQb5rQpRZ:txTb58SqR9QtxINq6G0K3gxaPjw3fJbDySUbVYUYu4def6iS6iywmrinpTf5P2vDK4toP:vECtu" +
+        "Emb89uZj6EtDiW8:G1RJ9ony7g9InLmTqVd7pncd:FV5uaF:/bbjZPhH7PHZyZsZEiAW3lR8lb3sqOyDQQKk:l1jPU7DEO4llDO46hi\"LitTEZZ7\"Li6pv0uowZ1bL2XFI0XqGZPab\"mMh:c/QZr0aJwyl" +
+        "xytDbk1QeI0dnlpFzJOYEJ3gEBMcYqtKIQfAKyCx09aiW\"aHCsSZvczKp5JTtmDYSCEbdf6aOW1quJ3y5efucJhEqwJzkFV:ENRsQmjn9\"NiC\"/0X\"CsG7MplWKjQw0Z\"Ol:lY2xEKofNlX5MmAdC8cS" +
+        "t8PT8IsWfEh2ZL9pIr/MBaSNd1wathGPoDfH:8cHQ9JO\"QOwkZXIvZLgaGL4NKvGsiJ4rMI/CpV3mWcJYLslPowwQwaSMZnLizi4dXmP30sqZOeldUvzh9VS9G1tsCdgk53uIuwY4K7MXlfJCEOrUXqm\"wZ" +
+        "SunvuQCTjdBYK4WA6J8/FYw2zO:aCbTcvDtoviouQIY\"/AM2nnS1hDJJRAEykFNvb9bCnf9ecnwDQ35pfEMB5ejnARwCRtSXxS2ULltAudbtPXMgLjEVkgy1UTfm8FotyI:9JzSuGsFFSF:j4qqh0RpnRx1T" +
+        "Qrjbr6d\"yTDpS9/k16:ntThk5ak7JOl9e/9idEW6S:mSRqup:mjxF3XmXQyLgGj6/vvdrZC13mA6bPEH043xs7cdebZaAks2b4MBqXYn1Hf2M7bcj5:G6bAeW8NuV2tFUMDk4Vy6otT\"tNvg62kKVchtIAD" +
+        "iJJY4vRHQRsE6BK2YfEOQtrVEzLpxiSssfwBu:ZgTq3/o1B9ojhXC\"iMVASO6ZwCzuxG0XZtU93bol4ab9SlyJNmBgcWE1AxQGvixt7S3OIXqFSmC0G69l1wyPEHyMH6Phpn:6m\"8ytDNtvUr9rsB3T5SwM" +
+        "XlLN6QbzGqVTs3PKhCUPyMH6I:pBN1\"TRD1sQmqDWFE0toaDYIEEiXUZMRfbmyMt/QTWA6:aKboq/\"58e2IQayOofUHLf111vlk55hiEePdWEK/R3ObMSrG7X6DJr6aHk\"7x8Axn\"vUSDH6D4KBnGcG\"" +
+        "T/V15bo:EfyCwg\"Fp9qepH8l:5UjNJkvRG7nCfXs02O8qp6QRYaIlz13fH3rs\"Ao/83n9G5kxNBTF/maIQzIEWaowQhHmJyuwucxUWuF1wbu1EbEgsrtXXD0w1OE7TDgxwqQQIjFprRAQTCXCyJmBS/7hyV" +
+        "HSOQi4r\"PI\"vCW:8HxC1/106ddZaGjJ1L33I90ZcdRfPxuWqgFKAfeCtu6\"oFEIw3wQDbHVBSZ16AD5lY/WD64w3eYcpuM8MFIoidTRRYckYkO0\"jf:GS4IqtrZ:tcOxS1W\"WU6l\"Pn/ERKYEcV8caX" +
+        "jdwJbyDkkYaZTulZFZEa9kgZNJhNfQWZwdar4sobzPUoio1epErRwxn4GCS6wpox:2x4lqMgE9tbLTpQBdudmhKcrSeYkwtF1mGmClW37FTLvM8ZnDoPkfk054P8US:Ek\"RpjIZ5Kx1bjo/jaH9pXIRHFtnF" +
+        "18LVcdV96Lt0lrw35sdrmcnWh1jitWsM7PGblv41B9:n0/HM7TIynJ2PGCd9D\"ioY24ax1xHtORsJKNMg0YRHF1glpYxjp45C:saQ7PvXKYBJMpI8fnP4bjgl2h13Ha8l/BKh0EqgLrBQKQbystJn5XQlp:c" +
+        "\"JCfLPVITpULwy/r7Ca7zngDaI30xo5M0Z2GPk:LDs4isfiZCKOVJcdiGuy36VXoBxaTIF6LE5lkfsrE5Nh60y:H7F/PP69gEq4Dm61D8CLpZiYFkKf1GSPWuzNVhAwG5q\"9QjPEN:AU8PgHs/GOBn2:wVl" +
+        "1r5g1DWtDVAgXWRmxgTulqDH3B42xNx:wCMMRC38I0LjRu8gbFCb33sbATA4BPBlFLc3IojNAwdxrA9Vm1ey:AIgZel4NaCcDl/1KudpktFb3uQ29UJyI4UM26x5YTi63U8zJmPn\"u1SD31pJfsvV4wVTn1P" +
+        "sQlralIbsuIMkySz3zT:CBiP6u5cnz8vjZiaefsvim0YKv6N/n\"NzmPLRTLd3onpZeunIzKeNqNsnkCFOijZY:B6yjMOPOF/xLklkYrEPr4YTPFomzQpj6wXr7WQhg02hFgkM;IjhHgTgHjhKllm,ngRdFDg";
+
+    private const char CharToAppend = 'a';
+
+    [Fact]
+    public async Task MergedTransaction_DeleteOneDoc_Then_PutAnotherToLargeSection_CompressionSetOnServerCreation()
+    {
+        const string specificSizeAndContentDocumentId = "users/1-A";
+        const string documentToDeleteId = "users/2-A";
+
+        using (var server = GetNewServer(new ServerCreationOptions
+                    {
+                        CustomSettings = new Dictionary<string, string>
+                        {
+                            [RavenConfiguration.GetKey(x => x.Databases.CompressAllCollectionsDefault)] = true.ToString(),
+                        }
+                    }))
+        using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false }))
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = SpecificContentWithSpecificSize }, specificSizeAndContentDocumentId);
+                await session.StoreAsync(new User { Name = "Document To Delete" }, documentToDeleteId);
+
+                await session.SaveChangesAsync();
+            }
+
+            using (var operationSession = store.OpenSession())
+            {
+                // Form a merge transaction within which there will first be a DELETE command...
+                var userToDelete = operationSession.Load<User>(documentToDeleteId);
+                operationSession.Delete(userToDelete);
+
+                // ...and then a PUT command
+                var specificSizeAndContentUser = operationSession.Load<User>(specificSizeAndContentDocumentId);
+                specificSizeAndContentUser.Name += CharToAppend;
+
+                operationSession.SaveChanges();
+            }
+
+            Assert.True(WaitForDocument<User>(store, specificSizeAndContentDocumentId, user => user.Name.Last() == CharToAppend),
+                $"The document '{specificSizeAndContentDocumentId}' wasn't updated as expected");
+        }
+    }
+
+    [Fact]
+    public async Task MergedTransaction_DeleteOneDoc_Then_PutAnotherToLargeSection_CompressionSetInTheMiddle()
+    {
+        const string specificSizeAndContentDocumentId = "users/1-A";
+        const string documentToDeleteId = "users/2-A";
+
+        using (var server = GetNewServer())
+        using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false }))
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = SpecificContentWithSpecificSize }, specificSizeAndContentDocumentId);
+                await session.StoreAsync(new User { Name = "Document To Delete" }, documentToDeleteId);
+
+                await session.SaveChangesAsync();
+            }
+
+            store.Maintenance.Send(new UpdateDocumentsCompressionConfigurationOperation(new DocumentsCompressionConfiguration { CompressAllCollections = true }));
+
+            using (var operationSession = store.OpenSession())
+            {
+                // Form a merge transaction within which there will first be a DELETE command...
+                var userToDelete = operationSession.Load<User>(documentToDeleteId);
+                operationSession.Delete(userToDelete);
+
+                // ...and then a PUT command
+                var specificSizeAndContentUser = operationSession.Load<User>(specificSizeAndContentDocumentId);
+                specificSizeAndContentUser.Name += CharToAppend;
+
+                operationSession.SaveChanges();
+            }
+
+            Assert.True(WaitForDocument<User>(store, specificSizeAndContentDocumentId, user => user.Name.Last() == CharToAppend),
+                $"The document '{specificSizeAndContentDocumentId}' wasn't updated as expected");
+        }
+    }
+
+    [Fact]
+    public async Task MergedTransaction_Conflict_Then_PutAnotherToLargeSection_CompressionSetInTheMiddle()
+    {
+        const string specificSizeAndContentDocumentId = "users/1-A";
+        const string documentToConflictId = "users/2-A";
+
+        using (var storeSrc = GetDocumentStore())
+        using (var storeDst = GetDocumentStore(new Options
+               {
+                   ModifyDatabaseRecord = record =>
+                   {
+                       record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
+                   }
+               }))
+        {
+            storeDst.Maintenance.Send(new UpdateDocumentsCompressionConfigurationOperation(new DocumentsCompressionConfiguration { CompressAllCollections = true }));
+
+            using (var sessionSrc = storeSrc.OpenSession())
+            {
+                sessionSrc.Store(new User { Name = SpecificContentWithSpecificSize }, specificSizeAndContentDocumentId);
+                sessionSrc.SaveChanges();
+            }
+
+            var taskId = SetupReplicationAsync(storeSrc, storeDst).Result.First().TaskId;
+            Assert.NotNull(WaitForDocumentToReplicate<User>(storeDst, specificSizeAndContentDocumentId, 15000));
+
+            await storeSrc.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.Replication, disable: true));
+
+            using (var sessionSrc = storeSrc.OpenSession())
+            {
+                // To create a merge transaction that will be formed after enabling replication, we first need to create a Conflict...
+                sessionSrc.Store(new User { Name = "Document To Conflict" }, documentToConflictId);
+
+                // ...and then a PUT command
+                var specificSizeAndContentUser = sessionSrc.Load<User>(specificSizeAndContentDocumentId);
+                specificSizeAndContentUser.Name += CharToAppend;
+
+                sessionSrc.SaveChanges();
+            }
+
+            using (var sessionDst = storeDst.OpenSession())
+            {
+                sessionDst.Store(new User { Name = "Another Document To Conflict" }, documentToConflictId);
+                sessionDst.SaveChanges();
+            }
+
+            await storeSrc.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.Replication, disable: false));
+
+            WaitUntilHasConflict(storeDst, documentToConflictId, count: 1);
+            Assert.True(WaitForDocument<User>(storeDst, specificSizeAndContentDocumentId, user => user.Name.Last() == CharToAppend),
+                $"The document '{specificSizeAndContentDocumentId}' wasn't replicated as expected");
+        }
+    }
+
+
+     [Fact(Skip= "Conflict for for document in different collections can be resolved only manually - Issue RavenDB-17382")]
+     public async Task MergedTransaction_ConflictForDocumentInDifferentCollection()
+     {
+         const string specificSizeAndContentDocumentId = "users/1-A";
+         const string documentToConflictId = "users/2-A";
+
+         using (var storeSrc = GetDocumentStore(new Options
+                {
+                    ModifyDatabaseRecord = record =>
+                    {
+                        record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
+                    }
+                }))
+         using (var storeDst = GetDocumentStore(new Options
+                {
+                    ModifyDatabaseRecord = record =>
+                    {
+                        record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
+                    }
+                }))
+         {
+             storeDst.Maintenance.Send(new UpdateDocumentsCompressionConfigurationOperation(new DocumentsCompressionConfiguration { CompressAllCollections = true }));
+
+             using (var session = storeSrc.OpenSession())
+             {
+                 session.Store(new User { Name = SpecificContentWithSpecificSize }, specificSizeAndContentDocumentId);
+                 session.SaveChanges();
+             }
+
+             var taskId = SetupReplicationAsync(storeSrc, storeDst).Result.First().TaskId;
+             Assert.NotNull(WaitForDocumentToReplicate<User>(storeDst, specificSizeAndContentDocumentId, 15000));
+
+             await storeSrc.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.Replication, disable: true));
+
+             using (var sessionDst = storeDst.OpenSession())
+             {
+                 sessionDst.Store(new User { Name = "Document To Conflict" }, documentToConflictId);
+                 sessionDst.SaveChanges();
+             }
+
+             using (var sessionSrc = storeSrc.OpenSession())
+             {
+                 // To create a merge transaction that will be formed after enabling replication, we first need to create a Conflict in different collection...
+                 sessionSrc.Store(new Company { Name = "Another Document To Conflict" }, documentToConflictId);
+
+                 // ...and then a PUT command
+                 var specificSizeAndContentUser = sessionSrc.Load<User>(specificSizeAndContentDocumentId);
+                 specificSizeAndContentUser.Name += CharToAppend;
+
+                 sessionSrc.SaveChanges();
+             }
+
+             await SetReplicationConflictResolutionAsync(storeDst, StraightforwardConflictResolution.ResolveToLatest);
+             await storeSrc.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.Replication, disable: false));
+
+             Assert.True(WaitForDocument<User>(storeDst, specificSizeAndContentDocumentId, user => user.Name.Last() == CharToAppend),
+                 $"The document '{specificSizeAndContentDocumentId}' wasn't replicated as expected");
+         }
+     }
+}

--- a/test/SlowTests/Issues/RavenDB_19529.cs
+++ b/test/SlowTests/Issues/RavenDB_19529.cs
@@ -141,7 +141,7 @@ public class RavenDB_19529 : ReplicationTestBase
     }
 
     [Fact]
-    public async Task MergedTransaction_Conflict_Then_PutAnotherToLargeSection_CompressionSetInTheMiddle()
+    public async Task MergedTransaction_AddConflict_Then_PutUpdateDocumentOnLargeSection_CompressionSetInTheMiddle()
     {
         const string specificSizeAndContentDocumentId = "users/1-A";
         const string documentToConflictId = "users/2-A";
@@ -196,7 +196,7 @@ public class RavenDB_19529 : ReplicationTestBase
 
 
      [Fact(Skip= "Conflict for for document in different collections can be resolved only manually - Issue RavenDB-17382")]
-     public async Task MergedTransaction_ConflictForDocumentInDifferentCollection()
+     public async Task MergedTransaction_ConflictForDocumentInDifferentCollection_Then_PutUpdateDocumentOnLargeSection_CompressionSetInTheMiddle()
      {
          const string specificSizeAndContentDocumentId = "users/1-A";
          const string documentToConflictId = "users/2-A";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19529/Missing-compression-dictionary

### Additional description

The issue arose while performing a merged write transaction. 
First, a table for a specific collection was opened. 
After that, a document that met the following criteria was updated using a `PUT` command:
1. The document should contain random data that is difficult to compress.
2. After compression, the compressed buffer should not fit into the small section.
3. The size of the `compressed buffer` + `sizeof(RawDataSection.RawDataEntrySizes)` (4 bytes) should be greater than `RawDataSection.MaxItemSize` (4064 bytes).

The crux of the problem is that upon the first opening of the table, we cache the schema for the collection and use this schema for subsequent openings of this table.

For some operations, when opening the table, we were forcibly using a non-compressed schema, which ended up in the cache. During the next table opening, we took the non-compressed schema, which is fatal for the `Update` case when the `TableValue` fits into the large section. In this case, no attempt is made to perform `builder.TryCompression` because the schema is mistakenly marked as non-compressed. The `TableValueBuilder` doesn't get marked with the `Compressed` property set to `true`, and it ends up on the same page that was earlier flagged as compressed.

As a result, during the subsequent attempt to read such a `TableValue`, we look at the flag on the page and try to decompress. To do this, we read the number of the compression dictionary, receive a _garbage_ number, and either cannot find such a number or get the message `Unknown frame descriptor on Dictionary`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed