### PR TITLE
RavenDB-19529: Missing compression dictionary (page flag bug fix)

### DIFF
--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -396,6 +396,8 @@ namespace Voron.Data.Tables
 
                     if (builder.Compressed)
                         page.Flags |= PageFlags.Compressed;
+                    else if (page.Flags.HasFlag(PageFlags.Compressed))
+                        page.Flags &= ~PageFlags.Compressed;
 
                     builder.CopyTo(pos);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19529/Missing-compression-dictionary

### Additional description

Due to the very specific conditions described in this pull request: https://github.com/ravendb/ravendb/pull/17659, we encountered a situation where we placed a `TableValue` inside a builder, which was marked with the `Compressed` property set to `false`, on the same page that had previously been marked with the `Compressed` flag.

Although the conditions for such a state to occur were excluded in the aforementioned pull request, there is still a chance to get a `TableValueBuilder` marked with the `Compressed` property set to `false` if, during the `TryCompression` stage, we couldn't compress the `TableValue`.

Several conditions must occur simultaneously:
1. The `TableValue` must be larger than 4 kilobytes + 4 bytes.
2. The `CompressedBuffer` must be larger than or equal to the `RawBuffer`.

During testing, I could not create a `TableValue` that was both sufficiently large and resistant to compression. 

However, this does not change the fact that it is necessary to remove the `Compressed` flag from the page if a non-compressed `TableValue` is placed on it.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed