### PR TITLE
RavenDB-19126 Throw exception for streaming document collection query with includes

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -158,6 +158,9 @@ namespace Raven.Server.Documents.Handlers.Streaming
                 }
                 var query = await IndexQueryServerSide.CreateAsync(HttpContext, GetStart(), GetPageSize(), queryContext.Documents, tracker, overrideQuery: overrideQuery);
                 query.IsStream = true;
+                
+                if (query.Metadata.Includes != null)
+                    throw new NotSupportedException("Includes are not supported by streaming query.");
 
                 var format = GetStringQueryString("format", false);
                 var debug = GetStringQueryString("debug", false);
@@ -235,6 +238,9 @@ namespace Raven.Server.Documents.Handlers.Streaming
                 var queryJson = await queryContext.Documents.ReadForMemoryAsync(stream, "index/query");
                 var query = IndexQueryServerSide.Create(HttpContext, queryJson, Database.QueryMetadataCache, tracker);
                 query.IsStream = true;
+
+                if (query.Metadata.Includes != null)
+                    throw new NotSupportedException("Includes are not supported by streaming query.");
 
                 if (TrafficWatchManager.HasRegisteredClients)
                 {

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -158,9 +158,6 @@ namespace Raven.Server.Documents.Handlers.Streaming
                 }
                 var query = await IndexQueryServerSide.CreateAsync(HttpContext, GetStart(), GetPageSize(), queryContext.Documents, tracker, overrideQuery: overrideQuery);
                 query.IsStream = true;
-                
-                if (query.Metadata.Includes != null)
-                    throw new NotSupportedException("Includes are not supported by streaming query.");
 
                 var format = GetStringQueryString("format", false);
                 var debug = GetStringQueryString("debug", false);
@@ -238,9 +235,6 @@ namespace Raven.Server.Documents.Handlers.Streaming
                 var queryJson = await queryContext.Documents.ReadForMemoryAsync(stream, "index/query");
                 var query = IndexQueryServerSide.Create(HttpContext, queryJson, Database.QueryMetadataCache, tracker);
                 query.IsStream = true;
-
-                if (query.Metadata.Includes != null)
-                    throw new NotSupportedException("Includes are not supported by streaming query.");
 
                 if (TrafficWatchManager.HasRegisteredClients)
                 {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3144,10 +3144,6 @@ namespace Raven.Server.Documents.Indexes
         {
             QueryInternalPreparation(query);
 
-            if (resultToFill.SupportsInclude == false
-                && (query.Metadata.Includes != null && query.Metadata.Includes.Length > 0))
-                throw new NotSupportedException("Includes are not supported by this type of query.");
-
             if (resultToFill.SupportsHighlighting == false && query.Metadata.HasHighlightings)
                 throw new NotSupportedException("Highlighting is not supported by this type of query.");
 
@@ -3420,10 +3416,6 @@ namespace Raven.Server.Documents.Indexes
           where TQueryResult : QueryResultServerSide<BlittableJsonReaderObject>
         {
             QueryInternalPreparation(query);
-
-            if (resultToFill.SupportsInclude == false
-                && (query.Metadata.Includes != null && query.Metadata.Includes.Length > 0))
-                throw new NotSupportedException("Includes are not supported by this type of query.");
 
             if (resultToFill.SupportsHighlighting == false && query.Metadata.HasHighlightings)
                 throw new NotSupportedException("Highlighting is not supported by this type of query.");

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3144,17 +3144,7 @@ namespace Raven.Server.Documents.Indexes
         {
             QueryInternalPreparation(query);
 
-            if (resultToFill.SupportsHighlighting == false && query.Metadata.HasHighlightings)
-                throw new NotSupportedException("Highlighting is not supported by this type of query.");
-
-            if (query.Metadata.HasHighlightings && (query.Metadata.HasIntersect || query.Metadata.HasMoreLikeThis))
-                throw new NotSupportedException("Highlighting is not supported by this type of query.");
-
-            if (resultToFill.SupportsExplanations == false && query.Metadata.HasExplanations)
-                throw new NotSupportedException("Explanations are not supported by this type of query.");
-
-            if (query.Metadata.HasExplanations && (query.Metadata.HasIntersect || query.Metadata.HasMoreLikeThis))
-                throw new NotSupportedException("Explanations are not supported by this type of query.");
+            QueryRunner.AssertValidQuery(query, resultToFill);
 
             using (var marker = MarkQueryAsRunning(query))
             {
@@ -3417,17 +3407,7 @@ namespace Raven.Server.Documents.Indexes
         {
             QueryInternalPreparation(query);
 
-            if (resultToFill.SupportsHighlighting == false && query.Metadata.HasHighlightings)
-                throw new NotSupportedException("Highlighting is not supported by this type of query.");
-
-            if (query.Metadata.HasHighlightings && (query.Metadata.HasIntersect || query.Metadata.HasMoreLikeThis))
-                throw new NotSupportedException("Highlighting is not supported by this type of query.");
-
-            if (resultToFill.SupportsExplanations == false && query.Metadata.HasExplanations)
-                throw new NotSupportedException("Explanations are not supported by this type of query.");
-
-            if (query.Metadata.HasExplanations && (query.Metadata.HasIntersect || query.Metadata.HasMoreLikeThis))
-                throw new NotSupportedException("Explanations are not supported by this type of query.");
+            QueryRunner.AssertValidQuery(query, resultToFill);
 
             using (var marker = MarkQueryAsRunning(query))
             {

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -32,6 +32,8 @@ namespace Raven.Server.Documents.Queries.Dynamic
         public override async Task<DocumentQueryResult> ExecuteQuery(IndexQueryServerSide query, QueryOperationContext queryContext, long? existingResultEtag, OperationCancelToken token)
         {
             var result = new DocumentQueryResult();
+            
+            QueryRunner.AssertValidQuery(query, result);
 
             if (queryContext.AreTransactionsOpened() == false)
                 queryContext.OpenReadTransaction();
@@ -60,6 +62,8 @@ namespace Raven.Server.Documents.Queries.Dynamic
             OperationCancelToken token)
         {
             var result = new StreamDocumentQueryResult(response, writer, queryContext.Documents, token);
+            
+            QueryRunner.AssertValidQuery(query, result);
 
             using (queryContext.OpenReadTransaction())
             {

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -136,6 +136,10 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
                 var fieldsToFetch = new FieldsToFetch(query, null, IndexType.None);
                 var includeDocumentsCommand  = new IncludeDocumentsCommand(Database.DocumentsStorage, context.Documents, query.Metadata.Includes, fieldsToFetch.IsProjection);
+                
+                if (resultToFill is StreamQueryResult<Document> && resultToFill.IncludedPaths != null && resultToFill.IncludedPaths.Length > 0)
+                    throw new NotSupportedException("Includes are not supported by this type of query");
+                
                 var includeRevisionsCommand  = new IncludeRevisionsCommand(Database, context.Documents, query.Metadata.RevisionIncludes);
                 
                 var includeCompareExchangeValuesCommand = IncludeCompareExchangeValuesCommand.ExternalScope(context, query.Metadata.CompareExchangeValueIncludes);

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -136,10 +136,6 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
                 var fieldsToFetch = new FieldsToFetch(query, null, IndexType.None);
                 var includeDocumentsCommand  = new IncludeDocumentsCommand(Database.DocumentsStorage, context.Documents, query.Metadata.Includes, fieldsToFetch.IsProjection);
-                
-                if (resultToFill is StreamQueryResult<Document> && resultToFill.IncludedPaths != null && resultToFill.IncludedPaths.Length > 0)
-                    throw new NotSupportedException("Includes are not supported by this type of query");
-                
                 var includeRevisionsCommand  = new IncludeRevisionsCommand(Database, context.Documents, query.Metadata.RevisionIncludes);
                 
                 var includeCompareExchangeValuesCommand = IncludeCompareExchangeValuesCommand.ExternalScope(context, query.Metadata.CompareExchangeValueIncludes);

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -493,5 +493,23 @@ namespace Raven.Server.Documents.Queries
                     _queryRunner._currentlyRunningQueries.TryRemove(_queryInfo);
             }
         }
+
+        public static void AssertValidQuery<TQueryResult>(IndexQueryServerSide query, QueryResultServerSide<TQueryResult> result)
+        {
+            if (result.SupportsInclude == false && query.Metadata.Includes != null && query.Metadata.Includes.Length > 0)
+                throw new NotSupportedException("Includes are not supported by this type of query.");
+            
+            if (result.SupportsHighlighting == false && query.Metadata.HasHighlightings)
+                throw new NotSupportedException("Highlighting is not supported by this type of query.");
+            
+            if (query.Metadata.HasHighlightings && (query.Metadata.HasIntersect || query.Metadata.HasMoreLikeThis))
+                throw new NotSupportedException("Highlighting is not supported by this type of query.");
+
+            if (result.SupportsExplanations == false && query.Metadata.HasExplanations)
+                throw new NotSupportedException("Explanations are not supported by this type of query.");
+
+            if (query.Metadata.HasExplanations && (query.Metadata.HasIntersect || query.Metadata.HasMoreLikeThis))
+                throw new NotSupportedException("Explanations are not supported by this type of query.");
+        }
     }
 }

--- a/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
+++ b/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
@@ -92,6 +92,29 @@ namespace SlowTests.MailingList
                 Assert.Contains("Includes are not supported by this type of query", notSupportedException.Message);
             }
         }
+        
+        [Fact]
+        public void StreamDocumentCollectionQueryWithInclude()
+        {
+            var store = GetDocumentStore();
+            Setup(store);
+            Indexes.WaitForIndexing(store);
+            using (var session = store.OpenSession())
+            {
+                var query = session.Advanced.RawQuery<ProcessStep>("from ProcessSteps include StepExecutionsId");
+                var notSupportedException = Assert.Throws<RavenException>(() =>
+                {
+                    using (var stream = session.Advanced.Stream(query))
+                    {
+                        while (stream.MoveNext())
+                        {
+
+                        }
+                    }
+                });
+                Assert.Contains("Includes are not supported by this type of query", notSupportedException.Message);
+            }
+        }
 
         void Setup(IDocumentStore store)
         {

--- a/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
+++ b/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
@@ -90,7 +90,7 @@ namespace SlowTests.MailingList
                         }
                     }
                 }).InnerException;
-                Assert.Contains("Includes are not supported by streaming query.", notSupportedException.Message);
+                Assert.Contains("Includes are not supported by this type of query.", notSupportedException.Message);
             }
         }
         
@@ -113,7 +113,7 @@ namespace SlowTests.MailingList
                         }
                     }
                 });
-                Assert.Contains("Includes are not supported by streaming query.", notSupportedException.Message);
+                Assert.Contains("Includes are not supported by this type of query.", notSupportedException.Message);
             }
         }
 

--- a/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
+++ b/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
@@ -5,6 +5,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -67,7 +68,7 @@ namespace SlowTests.MailingList
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void StreamDocumentQueryWithInclude()
         {
             var store = GetDocumentStore();
@@ -93,7 +94,7 @@ namespace SlowTests.MailingList
             }
         }
         
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void StreamDocumentCollectionQueryWithInclude()
         {
             var store = GetDocumentStore();

--- a/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
+++ b/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
@@ -89,7 +89,7 @@ namespace SlowTests.MailingList
                         }
                     }
                 }).InnerException;
-                Assert.Contains("Includes are not supported by this type of query", notSupportedException.Message);
+                Assert.Contains("Includes are not supported by streaming query.", notSupportedException.Message);
             }
         }
         
@@ -112,7 +112,7 @@ namespace SlowTests.MailingList
                         }
                     }
                 });
-                Assert.Contains("Includes are not supported by this type of query", notSupportedException.Message);
+                Assert.Contains("Includes are not supported by streaming query.", notSupportedException.Message);
             }
         }
 

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -89,7 +89,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6446;
+            const int numberToTolerate = 6445;
             if (array.Length == numberToTolerate)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19126/Streaming-query-with-includes-throws-Invalid-JSON

### Additional description

We want to throw same exception as in `Index.QueryInternal()`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
