### PR TITLE
RavenDB-21575 We must not throw on attempt to expire / refresh / archive a document which is already deleted

### DIFF
--- a/src/Raven.Server/Documents/DataArchival/DataArchivalStorage.cs
+++ b/src/Raven.Server/Documents/DataArchival/DataArchivalStorage.cs
@@ -27,9 +27,7 @@ public sealed class DataArchivalStorage : AbstractBackgroundWorkStorage
         using (var doc = Database.DocumentsStorage.Get(context, lowerId, DocumentFields.Data, throwOnConflict: true))
         {
             if (doc == null || doc.TryGetMetadata(out var metadata) == false)
-            {
-                throw new InvalidOperationException($"Failed to fetch the metadata of document '{id}'");
-            }
+                return;
 
             if (HasPassed(metadata, currentTime, MetadataPropertyName) == false)
                 return;

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -27,9 +27,7 @@ namespace Raven.Server.Documents.Expiration
                 using (var doc = Database.DocumentsStorage.Get(context, lowerId, DocumentFields.Data, throwOnConflict: true))
                 {
                     if (doc == null || doc.TryGetMetadata(out var metadata) == false)
-                    {
-                        throw new InvalidOperationException($"Failed to fetch the metadata of document '{id}'");
-                    }
+                        return;
 
                     if (HasPassed(metadata, currentTime, MetadataPropertyName) == false)
                         return;

--- a/src/Raven.Server/Documents/Refresh/RefreshStorage.cs
+++ b/src/Raven.Server/Documents/Refresh/RefreshStorage.cs
@@ -27,9 +27,7 @@ namespace Raven.Server.Documents.Refresh
             using (var doc = Database.DocumentsStorage.Get(context, lowerId, throwOnConflict: false))
             {
                 if (doc == null || doc.TryGetMetadata(out var metadata) == false)
-                {
-                    throw new InvalidOperationException($"Failed to fetch the metadata of document '{id}'");
-                }
+                    return;
 
                 if (HasPassed(metadata, currentTime, MetadataPropertyName) == false)
                     return;

--- a/test/SlowTests/Issues/RavenDB_21575.cs
+++ b/test/SlowTests/Issues/RavenDB_21575.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Orders;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Expiration;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21575 : RavenTestBase
+{
+    public RavenDB_21575(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private async Task SetupExpiration(DocumentStore store)
+    {
+        var config = new ExpirationConfiguration
+        {
+            Disabled = false,
+            DeleteFrequencyInSec = 100,
+        };
+
+        await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
+    }
+
+    [RavenFact(RavenTestCategory.ExpirationRefresh)]
+    public async Task WillNotThrowOnAttemptToExpireAlreadyDeletedDocument()
+    {
+        using (var store = GetDocumentStore())
+        {
+            await SetupExpiration(store);
+
+            var company = new Company
+            {
+                Name = "Company Name"
+            };
+            var expiry = DateTime.Now.ToUniversalTime(); 
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(company, "companies/1");
+                var metadata = session.Advanced.GetMetadataFor(company);
+                metadata[Constants.Documents.Metadata.Expires] = expiry.ToString(DefaultFormat.DateTimeFormatsToWrite);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(company, "companies/1");
+                var metadata = session.Advanced.GetMetadataFor(company);
+                metadata[Constants.Documents.Metadata.Expires] = expiry.AddMinutes(1).ToString(DefaultFormat.DateTimeFormatsToWrite);
+                await session.SaveChangesAsync();
+            }
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+            var expiredDocumentsCleaner = database.ExpiredDocumentsCleaner;
+            await expiredDocumentsCleaner.CleanupExpiredDocs();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<Company>("companies/1");
+
+                Assert.Null(loaded);
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21575

### Additional description

A document id can appear multiple times on the expiration / refresh / archival tree. Than can happen if you update the date in the relevant metadata. For expiration it means that we might attempt to delete the same document multiple times. 

Also note that the actual handling is happening under a different transaction (tx merger transaction) so it's possible that a document could be deleted by a user meanwhile.

To handle both cases we must not throw if a document doesn't exist.

### Type of change

- Regression bug fix - regression in 6.0 (in 5.4 we don't throw)

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
