### PR TITLE
RavenDB-21667: When recovering we must validate every page regardless of where it came from.

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="WriteAheadJournal.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -192,7 +192,7 @@ namespace Voron.Impl.Journal
             var deleteLastJournal = false;
             for (var journalNumber = journalToStartReadingFrom; journalNumber <= logInfo.CurrentJournal; journalNumber++)
             {
-                addToInitLog?.Invoke($"Recovering journal {journalNumber} (upto last journal {logInfo.CurrentJournal})");
+                addToInitLog?.Invoke($"Recovering journal {journalNumber} (up to last journal {logInfo.CurrentJournal})");
                 var initialSize = _env.Options.InitialFileSize ?? _env.Options.InitialLogFileSize;
                 var journalRecoveryName = StorageEnvironmentOptions.JournalRecoveryName(journalNumber);
                 try
@@ -311,7 +311,7 @@ namespace Voron.Impl.Journal
                                 continue;
                             }
 
-                            _env.ValidatePageChecksum(modifiedPage, ptr);
+                            _env.ValidateInMemoryPageChecksum(modifiedPage, ptr);
 
                             overflowDetector.SetPageChecked(modifiedPage);
                         }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21667

### Additional description
Validation of some pages may be skipped during recovery because we apply an optimization for normal database operation. We are forcing now the validation of in memory pages regardless of their stored or current status. 

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change
