### PR TITLE
RavenDB-21613 & RavenDB-21632 Create a range mapping before performing the actual aggregation to handle cases where there are no matches, resulting in empty ranges. | do not include null value in range query result

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -147,8 +147,10 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                         continue;
 
                     collectionOfFacetValues = new FacetValues(facetQuery.Legacy);
-                    if ((result.Value.Aggregations.Count > 0) == false)
+                    if (result.Value.Aggregations.Count <= 0)
+                    {
                         collectionOfFacetValues.AddDefault(key);
+                    }
                     else
                     {
                         foreach (var aggregation in result.Value.Aggregations)
@@ -182,6 +184,9 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
             reader.Reset();
             while (reader.FindNext(fieldRootPage))
             {
+                if (reader.IsNull)
+                    continue;
+                
                 isMatching = result.RangeType switch
                 {
                     RangeType.Double => range.IsMatch(reader.CurrentDouble),

--- a/test/SlowTests/Corax/RavenDB-21613.cs
+++ b/test/SlowTests/Corax/RavenDB-21613.cs
@@ -45,7 +45,7 @@ public class RavenDB_21613 : RavenTestBase
     }
     
     [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Facets)]
-    public void Test()
+    public void CanDoAggregationOnFullYearPerDay()
     {
         using IDocumentStore store = GetDocumentStore();
         store.ExecuteIndex(new TimeRangeTestIndex("indexes/test_document-lucene", SearchEngineType.Lucene));
@@ -79,7 +79,14 @@ public class RavenDB_21613 : RavenTestBase
                 .AggregateBy(secondFacet)
                 .Execute();
 
-
+            var coraxTimestampResults = resultsCorax["Timestamp"].Values;
+            var coraxRanges = coraxTimestampResults.Select(x => x.Range).ToArray();
+            foreach (var result in results["Timestamp"].Values)
+            {
+                Assert.Contains(result.Range, coraxRanges);
+                var coraxResult = coraxTimestampResults.Single(x => x.Range == result.Range);
+                Assert.Equal(result.Count, coraxResult.Count);
+            }
         }
     }
 	

--- a/test/SlowTests/Corax/RavenDB-21613.cs
+++ b/test/SlowTests/Corax/RavenDB-21613.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Facets;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_21613 : RavenTestBase
+{
+    public RavenDB_21613(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Facets)]
+    public void RangeFacetsAreEqualBetweenSearchEnginesInCaseOfNoMatches()
+    {
+        using IDocumentStore store = GetDocumentStore();
+        store.ExecuteIndex(new TestDocumentIndex("indexes/test_document-lucene", SearchEngineType.Lucene));
+        store.ExecuteIndex(new TestDocumentIndex("indexes/test_document-corax", SearchEngineType.Corax));
+
+        Indexes.WaitForIndexing(store);
+
+        using (IDocumentSession session = store.OpenSession())
+        {
+            var luceneResults = session
+                .Query<TestDocument>("indexes/test_document-lucene")
+                .AggregateBy(facet => facet.ByRanges(d => d.Age > 99))
+                .Execute();
+            
+            var coraxResults = session
+                .Query<TestDocument>("indexes/test_document-corax")
+                .AggregateBy(facet => facet.ByRanges(d => d.Age > 99))
+                .Execute();
+             
+            Assert.Equal(luceneResults.Values.First().Values.Count, coraxResults.Values.First().Values.Count);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Facets)]
+    public void Test()
+    {
+        using IDocumentStore store = GetDocumentStore();
+        store.ExecuteIndex(new TimeRangeTestIndex("indexes/test_document-lucene", SearchEngineType.Lucene));
+        store.ExecuteIndex(new TimeRangeTestIndex("indexes/test_document-corax", SearchEngineType.Corax));
+
+        using (IDocumentSession session = store.OpenSession())
+        {
+            session.Store(new TestDocument { Timestamp = DateTime.UtcNow.AddDays(-3.4) });
+            session.Store(new TestDocument { Timestamp = DateTime.UtcNow.AddDays(-2.3) });
+            session.Store(new TestDocument { Timestamp = DateTime.UtcNow.AddDays(-5.8) });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (IDocumentSession session = store.OpenSession())
+        {
+            DateTime start = DateTime.UtcNow;
+			
+            RangeFacet<TestDocument> second = new();
+            second.Ranges.AddRange(GetRanges());
+            RangeFacet secondFacet = second;
+            
+            Dictionary<string, FacetResult> results = session
+                .Query<TestDocument>("indexes/test_document-lucene")
+                .AggregateBy(secondFacet)
+                .Execute();
+            
+            Dictionary<string, FacetResult> resultsCorax = session
+                .Query<TestDocument>("indexes/test_document-corax")
+                .AggregateBy(secondFacet)
+                .Execute();
+
+
+        }
+    }
+	
+    private static IEnumerable<Expression<Func<TestDocument, bool>>> GetRanges()
+    {
+        DateTime start = DateTime.UtcNow.AddDays(1).Date;
+        for (int count = 0; count < 365; count++)
+        {
+            DateTime to = start.AddDays(-count);
+            DateTime from = to.AddDays(-1);
+			
+            Expression<Func<TestDocument, bool>> expression = d => d.Timestamp >= from && d.Timestamp < to;
+            yield return expression;
+        }
+    }
+    
+    private class TestDocument
+    {
+        public int Age { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+
+    private class TestDocumentIndex : AbstractIndexCreationTask<TestDocument>
+    {
+        public override string IndexName { get; }
+
+        public TestDocumentIndex(string name, SearchEngineType searchEngineType)
+        {
+            IndexName = name;
+            Map = docs => from doc in docs select new { doc.Age };
+
+            SearchEngineType = searchEngineType;
+        }
+    }
+    
+    private class TimeRangeTestIndex : AbstractIndexCreationTask<TestDocument>
+    {
+        public override string IndexName { get; }
+
+        public TimeRangeTestIndex(string indexName, SearchEngineType searchEngineType)
+        {
+            Map = docs => from doc in docs select new { doc.Timestamp };
+            IndexName = indexName;
+            SearchEngineType = searchEngineType;
+        }
+    }
+}

--- a/test/SlowTests/Corax/RavenDB-21632.cs
+++ b/test/SlowTests/Corax/RavenDB-21632.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_21632 : RavenTestBase
+{
+    public RavenDB_21632(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenTheory(RavenTestCategory.Facets)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CoraxFacetWillNotCountNullValuesInRangeFacets(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        store.ExecuteIndex(new TestDocumentIndex());
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new TestDocument {Age = 12});
+            session.Store(new TestDocument {Age = 24});
+            session.Store(new TestDocument {Age = 72});
+            session.Store(new TestDocument {Age = null});
+            session.Store(new TestDocument {Age = null});
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (IDocumentSession session = store.OpenSession())
+        {
+            var results = session
+                .Query<TestDocument, TestDocumentIndex>()
+                .AggregateBy(facet => facet.ByRanges(d => d.Age < 1))
+                .Execute();
+
+            var values = results.Values.First().Values.First(x => x.Range == "Age < 1");
+
+            int count = session
+                .Query<TestDocument, TestDocumentIndex>()
+                .Count(d => d.Age < 1);
+
+            Assert.Equal(count, values.Count);
+        }
+    }
+
+
+    private class TestDocument
+    {
+        public int? Age { get; set; }
+    }
+
+    private class TestDocumentIndex : AbstractIndexCreationTask<TestDocument>
+    {
+        public override string IndexName => "indexes/test_document";
+
+        public TestDocumentIndex()
+        {
+            Map = docs => from doc in docs select new {doc.Age};
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21613


### Type of change

- Bug fix


### How risky is the change?


- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
