### PR TITLE
RavenDB-21330 Error pops when TimeSeries entry value is copied to clipboard

### DIFF
--- a/src/Raven.Studio/typescript/common/copyToClipboard.ts
+++ b/src/Raven.Studio/typescript/common/copyToClipboard.ts
@@ -1,12 +1,29 @@
 ﻿import messagePublisher = require("common/messagePublisher");
 
 class copyToClipboard {
-    static async copy(toCopy: string, successMessage?: string) {
+    static copy(toCopy: string, successMessage?: string, container: Element = document.body) {
+        const dummy = document.createElement("textarea");
+        // Add it to the document
+        container.appendChild(dummy);
         try {
-            await navigator.clipboard.writeText(toCopy);
-            messagePublisher.reportSuccess(successMessage);
+            dummy.value = toCopy;
+            // Select it
+            dummy.select();
+            // Copy its contents
+            const success = document.execCommand("copy");
+
+            if (success) {
+                if (successMessage) {
+                    messagePublisher.reportSuccess(successMessage);
+                }
+            } else {
+                messagePublisher.reportWarning("Unable to copy to clipboard");
+            }
         } catch (err) {
             messagePublisher.reportWarning("Unable to copy to clipboard", err);
+        } finally {
+            // Remove it as its not needed anymore
+            container.removeChild(dummy);
         }
     }
 }

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/etlTransformOrLoadErrorDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/etlTransformOrLoadErrorDetails.ts
@@ -82,7 +82,7 @@ class etlTransformOrLoadErrorDetails extends abstractAlertDetails {
     }
     
     copyToClipboard(item: Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo) {
-        copyToClipboard.copy(item.Error, "Error has been copied to clipboard");
+        copyToClipboard.copy(item.Error, "Error has been copied to clipboard", document.getElementById("js-etl-error-details"));
     }
 
     private fetcher(): JQueryPromise<pagedResult<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>> {

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
@@ -8,7 +8,6 @@ import genericProgress = require("common/helpers/database/genericProgress");
 import delayBackupCommand = require("commands/database/tasks/delayBackupCommand");
 import viewHelpers = require("common/helpers/view/viewHelpers");
 import copyToClipboard = require("common/copyToClipboard");
-
 import ShardedSmugglerResult = Raven.Client.Documents.Smuggler.ShardedSmugglerResult;
 import CountsWithSkippedCountAndLastEtag = Raven.Client.Documents.Smuggler.SmugglerProgressBase.CountsWithSkippedCountAndLastEtag;
 import CountsWithSkippedCountAndLastEtagAndAttachments = Raven.Client.Documents.Smuggler.SmugglerProgressBase.CountsWithSkippedCountAndLastEtagAndAttachments;
@@ -613,7 +612,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
 
     copyLogs() {
         copyToClipboard.copy(this.messagesJoined(), "Copied details to clipboard.");
-}
+    }
 }
 
 export = smugglerDatabaseDetails;

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
@@ -611,7 +611,8 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
     }
 
     copyLogs() {
-        copyToClipboard.copy(this.messagesJoined(), "Copied details to clipboard.");
+        const dialogContainer = document.getElementById("exportModal");
+        copyToClipboard.copy(this.messagesJoined(), "Copied details to clipboard.", dialogContainer);
     }
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/additionalAssemblySyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/additionalAssemblySyntax.ts
@@ -17,7 +17,7 @@ class additionalAssemblySyntax extends dialogViewModelBase {
 
     copySample(sampleTitle: string) {
         const sampleText = additionalAssemblySyntax.csharpSamples.find(x => x.title === sampleTitle).text;
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly additionalSourceCsharpText =

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/additionalSourceSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/additionalSourceSyntax.ts
@@ -19,7 +19,7 @@ class additionalSourceSyntax extends dialogViewModelBase {
         const sampleText = [...additionalSourceSyntax.csharpSamples, ...additionalSourceSyntax.javascriptSamples]
             .find(x => x.title === sampleTitle).text;
 
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly additionalSourceCsharpText =

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/mapIndexSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/mapIndexSyntax.ts
@@ -15,7 +15,7 @@ class mapIndexSyntax extends dialogViewModelBase {
 
     copySample(sampleTitle: string) {
         const sampleText = mapIndexSyntax.samples.find(x => x.title === sampleTitle).text;
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly samples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/mapReduceIndexSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/mapReduceIndexSyntax.ts
@@ -17,7 +17,7 @@ class mapReduceIndexSyntax extends dialogViewModelBase {
         const sampleText = [...mapReduceIndexSyntax.linqSamples, ...mapReduceIndexSyntax.javascriptSamples]
             .find(x => x.title === sampleTitle).text;
         
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly linqSamples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/database/patch/patchSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/patch/patchSyntax.ts
@@ -18,7 +18,7 @@ class patchSyntax extends dialogViewModelBase {
 
     copySample(sampleTitle: string) {
         const sampleText = patchSyntax.samples.find(x => x.title === sampleTitle).text;
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly samples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/database/query/querySyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/query/querySyntax.ts
@@ -17,7 +17,7 @@ class querySyntax extends dialogViewModelBase {
 
     copySample(sampleTitle: string) {
         const sampleText = querySyntax.samples.find(x => x.title === sampleTitle).text;
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly samples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/database/settings/conflictResolutionScriptSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/conflictResolutionScriptSyntax.ts
@@ -29,7 +29,7 @@ return docs[0];
     }
 
     copySample() {
-        copyToClipboard.copy(conflictResolutionScriptSyntax.sampleScript, "Sample has been copied to clipboard");
+        copyToClipboard.copy(conflictResolutionScriptSyntax.sampleScript, "Sample has been copied to clipboard", this.dialogContainer);
     }
     
     scriptHtml = ko.pureComputed(() => {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/subscriptionRqlSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/subscriptionRqlSyntax.ts
@@ -15,7 +15,7 @@ class subscriptionRqlSyntax extends dialogViewModelBase {
 
     copySample(sampleTitle: string) {
         const sampleText = subscriptionRqlSyntax.samples.find(x => x.title === sampleTitle).text;
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly samples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/transformationScriptSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/transformationScriptSyntax.ts
@@ -63,7 +63,7 @@ class transformationScriptSyntax extends dialogViewModelBase {
                 genUtils.assertUnreachable(type, "Unknown studioEtlType: " + type);
         }
         
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly ravenEtlSamples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/manage/threadStackTrace.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/threadStackTrace.ts
@@ -66,7 +66,7 @@ class threadStackTrace extends dialogViewModelBase {
     }
     
     copyStackTrace(): void {
-        copyToClipboard.copy(this.stackTrace().toString(), "Stack trace has been copied to clipboard");
+        copyToClipboard.copy(this.stackTrace().toString(), "Stack trace has been copied to clipboard", this.dialogContainer);
     }
 
     isUserCode(line: string): boolean {

--- a/src/Raven.Studio/typescript/viewmodels/resources/setupEncryptionKey.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/setupEncryptionKey.ts
@@ -89,7 +89,8 @@ abstract class setupEncryptionKey {
     abstract keyDataText(): string;
     
     copyEncryptionKeyToClipboard() {
-        copyToClipboard.copy(this.keyDataText(), "Encryption key data was copied to clipboard");
+        const container = this.getContainer();
+        copyToClipboard.copy(this.keyDataText(), "Encryption key data was copied to clipboard", container);
     }
 
     downloadEncryptionKey() {

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
@@ -7,9 +7,9 @@ import moment = require("moment");
 
 
 class copyFeature implements columnPreviewFeature {
-    install($tooltip: JQuery, valueProvider: () => any, elementProvider: () => any) {
+    install($tooltip: JQuery, valueProvider: () => any, elementProvider: () => any, containerSelector: string) {
         $tooltip.on("click", ".copy", () => {
-            copyToClipboard.copy(valueProvider(), "Item has been copied to clipboard");
+            copyToClipboard.copy(valueProvider(), "Item has been copied to clipboard", document.querySelector(containerSelector));
 
             $(".copy", $tooltip).addClass("btn-success");
             $(".copy span", $tooltip)

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
@@ -111,8 +111,7 @@
             
             <div class="clearfix" data-bind="visible: !operationFailed()">
                 <div class="pull-right margin-top">
-                    <button class="btn btn-default btn-sm" data-bind="click: toggleDetails">
-                        <i class="icon-logs"></i><span data-bind="text: detailsVisible() ? 'Hide details':'Show details', clickBubble: false"></span>
+                    <button class="btn btn-default btn-sm" data-bind="click: toggleDetails, text: detailsVisible() ? 'Hide details':'Show details', clickBubble: false">
                     </button>
                 </div>
             </div>

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
@@ -111,7 +111,8 @@
             
             <div class="clearfix" data-bind="visible: !operationFailed()">
                 <div class="pull-right margin-top">
-                    <button class="btn btn-default btn-sm" data-bind="click: toggleDetails, text: detailsVisible() ? 'Hide details':'Show details', clickBubble: false">
+                    <button class="btn btn-default btn-sm" data-bind="click: toggleDetails">
+                        <i class="icon-logs"></i><span data-bind="text: detailsVisible() ? 'Hide details':'Show details', clickBubble: false"></span>
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21330/Error-pops-when-TimeSeries-entry-value-is-copied-to-clipboard

### Additional description

It reverts "RavenDB-20097 Add copy button on restore log"

### Type of change

- Bug fix

### How risky is the change?

- Low

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
