### PR TITLE
RavenDB-21585 - fix updating subscription task change vector & cherry pick RavenDB-19957

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -584,6 +584,8 @@ namespace Raven.Client.Documents.Subscriptions
             }
         }
 
+        protected virtual TimeSpan GetTimeToWaitBeforeConnectionRetry() => _options.TimeToWaitBeforeConnectionRetry;
+
         protected virtual void HandleSubscriberError(Exception ex)
         {
             if (_options.IgnoreSubscriberErrors == false)
@@ -836,7 +838,7 @@ namespace Raven.Client.Documents.Subscriptions
                         (bool shouldTryToReconnect, _redirectNode) = CheckIfShouldReconnectWorker(ex, AssertLastConnectionFailure, OnUnexpectedSubscriptionError);
                         if (shouldTryToReconnect)
                         {
-                            await TimeoutManager.WaitFor(_options.TimeToWaitBeforeConnectionRetry, _processingCts.Token).ConfigureAwait(false);
+                            await TimeoutManager.WaitFor(GetTimeToWaitBeforeConnectionRetry(), _processingCts.Token).ConfigureAwait(false);
 
                             if (_redirectNode == null)
                             {
@@ -909,11 +911,11 @@ namespace Raven.Client.Documents.Subscriptions
                 {
                     if (CheckIfShouldReconnectWorker(exception, assertLastConnectionFailure, onUnexpectedSubscriptionError).ShouldTryToReconnect)
                     {
-                        return (true, null);
+                        return (true, _redirectNode);
                     }
                 }
 
-                return (false, null);
+                return HandleAggregateException();
             }
 
             switch (ex)
@@ -940,11 +942,14 @@ namespace Raven.Client.Documents.Subscriptions
                 case DatabaseDisabledException:
                 case AllTopologyNodesDownException:
                     AssertLastConnectionFailure();
-                    return (true, null);
+                    return (true, _redirectNode);
 
                 case NodeIsPassiveException _:
-                case SubscriptionChangeVectorUpdateConcurrencyException _:
+                    // if we failed to talk to a node, we'll forget about it and let the topology to
+                    // redirect us to the current node
                     return (true, null);
+                case SubscriptionChangeVectorUpdateConcurrencyException _:
+                    return HandleSubscriptionChangeVectorUpdateConcurrencyException();
 
                 case SubscriptionClosedException sce:
                     return HandleSubscriptionClosedException(sce);
@@ -959,30 +964,45 @@ namespace Raven.Client.Documents.Subscriptions
                 case AuthorizationException _:
                 case SubscriberErrorException _:
                 case NotSupportedInShardingException _:
-                    _processingCts.Cancel();
-                    return (false, null);
+                    return HandleShouldNotTryToReconnect();
+
                 case RavenException re:
                     if (re.InnerException is HttpRequestException or TimeoutException)
                     {
                         goto default;
                     }
 
-                    _processingCts.Cancel();
-                    return (false, null);
+                    return HandleShouldNotTryToReconnect();
                 default:
                     onUnexpectedSubscriptionError?.Invoke(ex);
                     assertLastConnectionFailure?.Invoke();
-                    return (true, null);
+                    return (true, _redirectNode);
             }
+        }
+
+        protected virtual (bool ShouldTryToReconnect, ServerNode NodeRedirectTo) HandleShouldNotTryToReconnect()
+        {
+            _processingCts.Cancel();
+            return (false, _redirectNode);
+        }
+
+        protected virtual (bool ShouldTryToReconnect, ServerNode NodeRedirectTo) HandleAggregateException()
+        {
+            return (false, _redirectNode);
+        }
+
+        protected virtual (bool ShouldTryToReconnect, ServerNode NodeRedirectTo) HandleSubscriptionChangeVectorUpdateConcurrencyException()
+        {
+            return (true, _redirectNode);
         }
 
         protected virtual (bool ShouldTryToReconnect, ServerNode NodeRedirectTo) HandleSubscriptionClosedException(SubscriptionClosedException sce)
         {
             if (sce.CanReconnect)
-                return (true, null);
+                return (true, _redirectNode);
 
             _processingCts?.Cancel();
-            return (false, null);
+            return (false, _redirectNode);
         }
 
         protected void CloseTcpClient()

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
@@ -6,8 +6,6 @@
 
 using System;
 using Raven.Client.Documents.DataArchival;
-using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations.DataArchival;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Sparrow.Json.Parsing;
@@ -26,6 +24,8 @@ namespace Raven.Client.Documents.Subscriptions
         public DateTime? LastBatchAckTime { get; set; }  // Last time server made some progress with the subscriptions docs  
         public DateTime? LastClientConnectionTime { get; set; } // Last time any client has connected to server (connection dead or alive)
         public bool Disabled { get; set; }
+        // raft index used to create or update subscription task
+        public long LastModifiedIndex { get; set; }
 
         // the responsible node of the subscription,
         // in sharding context - orchestrator node tag
@@ -79,7 +79,8 @@ namespace Raven.Client.Documents.Subscriptions
                 [nameof(LastBatchAckTime)] = LastBatchAckTime,
                 [nameof(LastClientConnectionTime)] = LastClientConnectionTime,
                 [nameof(Disabled)] = Disabled,
-                [nameof(ArchivedDataProcessingBehavior)] = ArchivedDataProcessingBehavior
+                [nameof(ArchivedDataProcessingBehavior)] = ArchivedDataProcessingBehavior,
+                [nameof(LastModifiedIndex)] = LastModifiedIndex
             };
 
             if (ShardingState != null)

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionState.cs
@@ -25,7 +25,7 @@ namespace Raven.Client.Documents.Subscriptions
         public DateTime? LastClientConnectionTime { get; set; } // Last time any client has connected to server (connection dead or alive)
         public bool Disabled { get; set; }
         // raft index used to create or update subscription task
-        public long LastModifiedIndex { get; set; }
+        public long RaftCommandIndex { get; set; }
 
         // the responsible node of the subscription,
         // in sharding context - orchestrator node tag
@@ -80,7 +80,7 @@ namespace Raven.Client.Documents.Subscriptions
                 [nameof(LastClientConnectionTime)] = LastClientConnectionTime,
                 [nameof(Disabled)] = Disabled,
                 [nameof(ArchivedDataProcessingBehavior)] = ArchivedDataProcessingBehavior,
-                [nameof(LastModifiedIndex)] = LastModifiedIndex
+                [nameof(RaftCommandIndex)] = RaftCommandIndex
             };
 
             if (ShardingState != null)

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2040,6 +2040,7 @@ namespace Raven.Server.Documents
             internal Action Subscription_ActionToCallDuringWaitForChangedDocuments;
             internal Action<long> Subscription_ActionToCallAfterRegisterSubscriptionConnection;
             internal Action<ConcurrentSet<SubscriptionConnection>> ConcurrentSubscription_ActionToCallDuringWaitForSubscribe;
+            internal Action Subscription_ActionToCallDuringWaitForAck;
 
             internal IDisposable CallDuringWaitForChangedDocuments(Action action)
             {
@@ -2058,6 +2059,12 @@ namespace Raven.Server.Documents
                 ConcurrentSubscription_ActionToCallDuringWaitForSubscribe = action;
 
                 return new DisposableAction(() => ConcurrentSubscription_ActionToCallDuringWaitForSubscribe = null);
+            }
+            internal IDisposable CallDuringWaitForAck(Action action)
+            {
+                Subscription_ActionToCallDuringWaitForAck = action;
+
+                return new DisposableAction(() => Subscription_ActionToCallDuringWaitForAck = null);
             }
 
             internal ManualResetEvent DatabaseRecordLoadHold;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2039,6 +2039,7 @@ namespace Raven.Server.Documents
 
             internal Action Subscription_ActionToCallDuringWaitForChangedDocuments;
             internal Action<long> Subscription_ActionToCallAfterRegisterSubscriptionConnection;
+            internal Action<ConcurrentSet<SubscriptionConnection>> ConcurrentSubscription_ActionToCallDuringWaitForSubscribe;
 
             internal IDisposable CallDuringWaitForChangedDocuments(Action action)
             {
@@ -2051,6 +2052,12 @@ namespace Raven.Server.Documents
                 Subscription_ActionToCallAfterRegisterSubscriptionConnection = action;
 
                 return new DisposableAction(() => Subscription_ActionToCallAfterRegisterSubscriptionConnection = null);
+            }
+            internal IDisposable CallDuringWaitForSubscribe(Action<ConcurrentSet<SubscriptionConnection>> action)
+            {
+                ConcurrentSubscription_ActionToCallDuringWaitForSubscribe = action;
+
+                return new DisposableAction(() => ConcurrentSubscription_ActionToCallDuringWaitForSubscribe = null);
             }
 
             internal ManualResetEvent DatabaseRecordLoadHold;

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
@@ -196,7 +196,11 @@ public sealed class ShardedDocumentsDatabaseSubscriptionProcessor : DocumentsDat
         ItemsToRemoveFromResend.Clear();
         BatchItems.Clear();
 
-        return SubscriptionConnectionsState.AcknowledgeBatchAsync(Connection.LastSentChangeVectorInThisConnection, batchId, BatchItems, command => command.LastKnownSubscriptionChangeVector = changeVector);
+        return SubscriptionConnectionsState.AcknowledgeBatchAsync(Connection.LastSentChangeVectorInThisConnection, batchId, BatchItems, command =>
+        {
+            command.LastKnownSubscriptionChangeVector = changeVector;
+            command.LastModifiedIndex = Connection.LastModifiedIndex;
+        });
     }
 
     protected override ShardIncludesCommandImpl CreateIncludeCommands()

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
@@ -110,10 +110,11 @@ public sealed class SubscriptionConnectionsStateOrchestrator : AbstractSubscript
         LastChangeVectorSent = connection.SubscriptionState.ShardingState.ChangeVectorForNextBatchStartingPointForOrchestrator;
     }
 
-    public override void Initialize(OrchestratedSubscriptionConnection connection, bool afterSubscribe = false)
+    public override async Task InitializeAsync(OrchestratedSubscriptionConnection connection, bool afterSubscribe = false)
     {
-        base.Initialize(connection, afterSubscribe);
+        await base.InitializeAsync(connection, afterSubscribe);
         SetLastChangeVectorSent(connection);
+        _subscriptionState = connection.SubscriptionState;
     }
 
     protected override UpdateSubscriptionClientConnectionTime GetUpdateSubscriptionClientConnectionTime()

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
@@ -289,9 +289,19 @@ public abstract class AbstractSubscriptionStorage<TState> : AbstractSubscription
 
     public TState GetSubscriptionConnectionsState(ClusterOperationContext context, string subscriptionName)
     {
-        var subscriptionState = GetSubscriptionByName(context, subscriptionName);
+        var subscriptionBlittable = _serverStore.Cluster.Read(context, SubscriptionState.GenerateSubscriptionItemKeyName(_databaseName, subscriptionName));
+        if (subscriptionBlittable == null)
+            return null;
 
-        if (_subscriptions.TryGetValue(subscriptionState.SubscriptionId, out TState concurrentSubscription) == false)
+        if (subscriptionBlittable.TryGet(nameof(SubscriptionState.SubscriptionId), out long id) == false)
+        {
+            if (_logger.IsOperationsEnabled)
+                _logger.Info($"Could not figure out the Subscription Task ID for subscription named: '{subscriptionName}'.");
+
+            return null;
+        }
+
+        if (_subscriptions.TryGetValue(id, out TState concurrentSubscription) == false)
             return null;
 
         return concurrentSubscription;

--- a/src/Raven.Server/Documents/Subscriptions/DummySubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/DummySubscriptionConnectionsState.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client.Documents.Subscriptions;
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
 
 namespace Raven.Server.Documents.Subscriptions;
@@ -14,7 +15,8 @@ public sealed class DummySubscriptionConnectionsState : SubscriptionConnectionsS
         Query = state.Query;
     }
 
-    public override void Initialize(SubscriptionConnection connection, bool afterSubscribe = false)
+    public override Task InitializeAsync(SubscriptionConnection connection, bool afterSubscribe = false)
     {
+        return Task.CompletedTask;
     }
 }

--- a/src/Raven.Server/Documents/Subscriptions/ISubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/Subscriptions/ISubscriptionConnection.cs
@@ -35,4 +35,6 @@ public interface ISubscriptionConnection : IDisposable
     public const int WaitForChangedDocumentsTimeoutInMs = 3000;
 
     internal Task SendHeartBeatAsync(string reason);
+
+    long LastModifiedIndex { get; }
 }

--- a/src/Raven.Server/Documents/Subscriptions/Sharding/ShardSubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Sharding/ShardSubscriptionStorage.cs
@@ -79,9 +79,9 @@ public sealed class ShardSubscriptionStorage : SubscriptionStorage
         if (taskStatus.LastClientConnectionTime != null)
             return false;
 
-        // persisted subscription state has different LastModifiedIndex than state of current connection
+        // persisted subscription state has different RaftCommandIndex than state of current connection
         // the subscription was modified and needs to reconnect
-        return taskStatus.LastModifiedIndex != state.SubscriptionState.LastModifiedIndex;
+        return taskStatus.RaftCommandIndex != state.SubscriptionState.RaftCommandIndex;
     }
 
     internal override void CleanupSubscriptions()

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.Subscriptions
 
         public SubscriptionOpeningStrategy Strategy => _options.Strategy;
         public readonly string ClientUri;
-        public long LastModifiedIndex => SubscriptionState.LastModifiedIndex;
+        public long LastModifiedIndex => SubscriptionState.RaftCommandIndex;
 
         public string WorkerId => _options.WorkerId ??= Guid.NewGuid().ToString();
         public SubscriptionState SubscriptionState { get; set; }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -918,6 +918,15 @@ namespace Raven.Server.Documents.Subscriptions
             };
         }
 
+        internal async Task SendHeartBeatIfNeededAsync(Stopwatch sp, string reason)
+        {
+            if (sp.ElapsedMilliseconds >= ISubscriptionConnection.WaitForChangedDocumentsTimeoutInMs)
+            {
+                await SendHeartBeatAsync(reason);
+                sp.Restart();
+            }
+        }
+
         public async Task SendHeartBeatAsync(string reason)
         {
             try

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -62,6 +62,7 @@ namespace Raven.Server.Documents.Subscriptions
 
         public SubscriptionOpeningStrategy Strategy => _options.Strategy;
         public readonly string ClientUri;
+        public long LastModifiedIndex => SubscriptionState.LastModifiedIndex;
 
         public string WorkerId => _options.WorkerId ??= Guid.NewGuid().ToString();
         public SubscriptionState SubscriptionState { get; set; }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -107,25 +107,25 @@ namespace Raven.Server.Documents.Subscriptions
                     return;
                 }
 
-                if (connection.SubscriptionState.LastModifiedIndex < _subscriptionState.LastModifiedIndex)
+                if (connection.SubscriptionState.RaftCommandIndex < _subscriptionState.RaftCommandIndex)
                 {
                     // this connection was modified while waiting to subscribe, lets try to drop it
                     DropSingleConnection(connection, new SubscriptionClosedException($"The subscription '{_subscriptionName}' was modified, connection have to be restarted.", canReconnect: true));
                     return;
                 }
 
-                if (connection.SubscriptionState.LastModifiedIndex == _subscriptionState.LastModifiedIndex)
+                if (connection.SubscriptionState.RaftCommandIndex == _subscriptionState.RaftCommandIndex)
                 {
                     // no changes in the subscription
                     return;
                 }
 
-                if (connection.SubscriptionState.LastModifiedIndex > _subscriptionState.LastModifiedIndex)
+                if (connection.SubscriptionState.RaftCommandIndex > _subscriptionState.RaftCommandIndex)
                 {
                     // we have new connection after subscription have changed
                     // we have to wait until old connections (with smaller raft index) will get disconnected
                     // then we continue and will re-initialize 
-                    while (_connections.Any(c => c.SubscriptionState.LastModifiedIndex == _subscriptionState.LastModifiedIndex))
+                    while (_connections.Any(c => c.SubscriptionState.RaftCommandIndex == _subscriptionState.RaftCommandIndex))
                     {
                         connection.CancellationTokenSource.Token.ThrowIfCancellationRequested();
                         await Task.Delay(300);

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,6 +28,7 @@ namespace Raven.Server.Documents.Subscriptions
         private readonly SubscriptionStorage _subscriptionStorage;
         public DocumentDatabase DocumentDatabase => _subscriptionStorage._db;
         private IDisposable _disposableNotificationsRegistration;
+        private readonly SemaphoreSlim _subscriptionConnectingLock = new SemaphoreSlim(1);
 
         public SubscriptionConnectionsState(string databaseName, long subscriptionId, SubscriptionStorage storage) : base(storage._db.ServerStore, databaseName, subscriptionId, storage._db.DatabaseShutdown)
         {
@@ -71,28 +73,88 @@ namespace Raven.Server.Documents.Subscriptions
             });
         }
 
-        public override void Initialize(SubscriptionConnection connection, bool afterSubscribe = false)
+        public override async Task InitializeAsync(SubscriptionConnection connection, bool afterSubscribe = false)
         {
-            base.Initialize(connection, afterSubscribe);
+           await base.InitializeAsync(connection, afterSubscribe);
+
+           if (afterSubscribe == false)
+               return;
 
             // update the subscription data only on new concurrent connection or regular connection
-            if (afterSubscribe && _connections.Count == 1)
+            if (IsConcurrent == false)
             {
-                // update the subscription data only on new concurrent connection or regular connection
-                SetLastChangeVectorSent(connection);
+                RefreshFeatures(connection);
+                return;
+            }
 
-                using (var old = _disposableNotificationsRegistration)
+            DocumentDatabase.ForTestingPurposes?.ConcurrentSubscription_ActionToCallDuringWaitForSubscribe?.Invoke(_connections);
+
+            connection.AddToStatusDescription("Starting to subscribe.");
+            var sp = Stopwatch.StartNew();
+            while (await _subscriptionConnectingLock.WaitAsync(ISubscriptionConnection.WaitForChangedDocumentsTimeoutInMs) == false)
+            {
+                connection.CancellationTokenSource.Token.ThrowIfCancellationRequested();
+                await connection.SendHeartBeatAsync($"A connection from IP '{connection.ClientUri}' is waiting for other concurrent connections to subscribe.");
+                sp.Restart();
+            }
+
+            try
+            {
+                if (_subscriptionState == null)
                 {
-                    _disposableNotificationsRegistration = RegisterForNotificationOnNewDocuments(connection);
+                    // this connection is the first one, we initialize everything
+                    RefreshFeatures(connection);
+                    return;
                 }
+
+                if (connection.SubscriptionState.LastModifiedIndex < _subscriptionState.LastModifiedIndex)
+                {
+                    // this connection was modified while waiting to subscribe, lets try to drop it
+                    DropSingleConnection(connection, new SubscriptionClosedException($"The subscription '{_subscriptionName}' was modified, connection have to be restarted.", canReconnect: true));
+                    return;
+                }
+
+                if (connection.SubscriptionState.LastModifiedIndex == _subscriptionState.LastModifiedIndex)
+                {
+                    // no changes in the subscription
+                    return;
+                }
+
+                if (connection.SubscriptionState.LastModifiedIndex > _subscriptionState.LastModifiedIndex)
+                {
+                    // we have new connection after subscription have changed
+                    // we have to wait until old connections (with smaller raft index) will get disconnected
+                    // then we continue and will re-initialize 
+                    while (_connections.Any(c => c.SubscriptionState.LastModifiedIndex == _subscriptionState.LastModifiedIndex))
+                    {
+                        connection.CancellationTokenSource.Token.ThrowIfCancellationRequested();
+                        await Task.Delay(300);
+                        await connection.SendHeartBeatIfNeededAsync(sp, $"A connection from IP '{connection.ClientUri}' is waiting for old subscription connections to disconnect.");
+                    }
+
+                    RefreshFeatures(connection);
+                }
+            }
+            finally
+            {
+                _subscriptionConnectingLock.Release();
             }
         }
 
-        protected override void SetLastChangeVectorSent(SubscriptionConnection connection) => InitializeLastChangeVectorSent(connection.SubscriptionState.ChangeVectorForNextBatchStartingPoint);
-
-        internal void InitializeLastChangeVectorSent(string changeVectorForNextBatchStartingPoint)
+        private void RefreshFeatures(SubscriptionConnection connection)
         {
-            LastChangeVectorSent = changeVectorForNextBatchStartingPoint;
+            using (var old = _disposableNotificationsRegistration)
+            {
+                _disposableNotificationsRegistration = RegisterForNotificationOnNewDocuments(connection);
+            }
+
+            SetLastChangeVectorSent(connection);
+            _subscriptionState = connection.SubscriptionState;
+        }
+
+        protected override void SetLastChangeVectorSent(SubscriptionConnection connection)
+        {
+            LastChangeVectorSent = connection.SubscriptionState.ChangeVectorForNextBatchStartingPoint;
         }
 
         public HashSet<long> GetActiveBatches()

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -301,7 +301,7 @@ namespace Raven.Server.Documents.Subscriptions
                 LastClientConnectionTime = @base.LastClientConnectionTime;
                 Disabled = @base.Disabled;
                 ShardingState = @base.ShardingState;
-                LastModifiedIndex = @base.LastModifiedIndex;
+                RaftCommandIndex = @base.RaftCommandIndex;
             }
         }
 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -367,6 +367,8 @@ namespace Raven.Server.Documents.TcpHandlers
 
         protected override async Task OnClientAckAsync(string clientReplyChangeVector)
         {
+            _database.ForTestingPurposes?.Subscription_ActionToCallDuringWaitForAck?.Invoke();
+
             await Processor.AcknowledgeBatchAsync(CurrentBatchId, clientReplyChangeVector);
             await SendConfirmAsync(TcpConnection.DocumentDatabase.Time.GetUtcNow());
         }

--- a/src/Raven.Server/ServerWide/Commands/Sharding/PutShardedSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/PutShardedSubscriptionCommand.cs
@@ -76,7 +76,7 @@ public sealed class PutShardedSubscriptionCommand : PutSubscriptionCommand
         // the CVs were validated in handler
     }
 
-    protected override DynamicJsonValue CreateSubscriptionStateAsJson(long subscriptionId)
+    protected override DynamicJsonValue CreateSubscriptionStateAsJson(long subscriptionId, long index)
     {
         return new SubscriptionState
         {
@@ -91,7 +91,8 @@ public sealed class PutShardedSubscriptionCommand : PutSubscriptionCommand
             {
                 ChangeVectorForNextBatchStartingPointPerShard = InitialChangeVectorPerShard
             },
-            ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior
+            ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior,
+            LastModifiedIndex = index
         }.ToJson();
     }
 

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
@@ -68,7 +68,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             if (IsLegacyCommand())
             {
                 if (LastKnownSubscriptionChangeVector != subscription.ChangeVectorForNextBatchStartingPoint)
-                    throw new SubscriptionChangeVectorUpdateConcurrencyException($"Can't acknowledge subscription with name {subscriptionName} due to inconsistency in change vector progress. Probably there was an admin intervention that changed the change vector value. Stored value: {subscription.ChangeVectorForNextBatchStartingPoint}, received value: {LastKnownSubscriptionChangeVector}");
+                    throw new SubscriptionChangeVectorUpdateConcurrencyException($"Can't acknowledge subscription with name '{subscriptionName}' due to inconsistency in change vector progress. Probably there was an admin intervention that changed the change vector value. Stored value: {subscription.ChangeVectorForNextBatchStartingPoint}, received value: {LastKnownSubscriptionChangeVector}");
 
                 subscription.ChangeVectorForNextBatchStartingPoint = ChangeVector;
             }
@@ -80,9 +80,9 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             else
             {
                 // we need to check if subscription was changed since we increment the orchestrator change vector
-                if (LastModifiedIndex != subscription.LastModifiedIndex)
+                if (LastModifiedIndex != subscription.RaftCommandIndex)
                 {
-                    throw new SubscriptionChangeVectorUpdateConcurrencyException($"Can't acknowledge subscription with name '{subscriptionName}' due to changes in subscription task, current {nameof(LastModifiedIndex)} value is '{LastModifiedIndex}' but persisted value is '{subscription.LastModifiedIndex}'.{Environment.NewLine}Probably there was an admin intervention that changed the subscription change vector or query value.");
+                    throw new SubscriptionChangeVectorUpdateConcurrencyException($"Can't acknowledge subscription with name '{subscriptionName}' due to changes in subscription task, current {nameof(LastModifiedIndex)} value is '{LastModifiedIndex}' but persisted value is '{subscription.RaftCommandIndex}'.{Environment.NewLine}Probably there was an admin intervention that changed the subscription change vector or query value.");
                 }
 
                 var changeVector = context.GetChangeVector(ChangeVector);

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/AcknowledgeSubscriptionBatchCommand.cs
@@ -4,6 +4,7 @@ using Raven.Client;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Rachis;
@@ -55,7 +56,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             if (existingValue == null)
                 throw new SubscriptionDoesNotExistException($"Subscription with name '{subscriptionName}' does not exist");
 
-            var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
+            var subscription = JsonDeserializationClient.SubscriptionState(existingValue);
             AssertSubscriptionState(record, subscription, subscriptionName);
 
             if (ChangeVector == nameof(Constants.Documents.SubscriptionChangeVectorSpecialStates.DoNotChange))

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
@@ -91,7 +91,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                         AssertValidChangeVector();
                     }
 
-                    using (var receivedSubscriptionState = context.ReadObject(CreateSubscriptionStateAsJson(subscriptionId), SubscriptionName))
+                    using (var receivedSubscriptionState = context.ReadObject(CreateSubscriptionStateAsJson(subscriptionId, index), SubscriptionName))
                     {
                         ClusterStateMachine.UpdateValue(index, items, valueNameLowered, valueName, receivedSubscriptionState);
                     }
@@ -101,7 +101,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             }
         }
 
-        protected virtual DynamicJsonValue CreateSubscriptionStateAsJson(long subscriptionId)
+        protected virtual DynamicJsonValue CreateSubscriptionStateAsJson(long subscriptionId, long index)
         {
             var json = new SubscriptionState
             {
@@ -114,7 +114,8 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                 MentorNode = MentorNode,
                 PinToMentorNode = PinToMentorNode,
                 LastClientConnectionTime = null,
-                ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior
+                ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior,
+                LastModifiedIndex = index
             }.ToJson();
             return json;
         }

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/PutSubscriptionCommand.cs
@@ -115,7 +115,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
                 PinToMentorNode = PinToMentorNode,
                 LastClientConnectionTime = null,
                 ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior,
-                LastModifiedIndex = index
+                RaftCommandIndex = index
             }.ToJson();
             return json;
         }

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/UpdateSubscriptionClientConnectionTime.cs
@@ -2,6 +2,7 @@
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -32,7 +33,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
             if (existingValue == null)
                 throw new SubscriptionDoesNotExistException($"Subscription with id '{itemId}' does not exist");
 
-            var subscription = JsonDeserializationCluster.SubscriptionState(existingValue);
+            var subscription = JsonDeserializationClient.SubscriptionState(existingValue);
 
             var appropriateNode = AbstractSubscriptionStorage.GetSubscriptionResponsibleNodeForConnection(record, subscription, HasHighlyAvailableTasks);
 

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -50,8 +50,6 @@ namespace Raven.Server.ServerWide
 
         public static readonly Func<BlittableJsonReaderObject, IncrementClusterIdentitiesBatchCommand> IncrementClusterIdentitiesBatchCommand = GenerateJsonDeserializationRoutine<IncrementClusterIdentitiesBatchCommand>();
 
-        public static readonly Func<BlittableJsonReaderObject, SubscriptionState> SubscriptionState = GenerateJsonDeserializationRoutine<SubscriptionState>();
-
         public static readonly Func<BlittableJsonReaderObject, DeleteValueCommand> DeleteValueCommand = GenerateJsonDeserializationRoutine<DeleteValueCommand>();
 
         public static readonly Func<BlittableJsonReaderObject, DeleteMultipleValuesCommand> DeleteMultipleValuesCommand = GenerateJsonDeserializationRoutine<DeleteMultipleValuesCommand>();

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -1162,6 +1162,278 @@ namespace SlowTests.Client.Subscriptions
             }
         }
 
+        [RavenTheory(RavenTestCategory.Subscriptions)]
+        [InlineData(1)]
+        [InlineData(3)]
+        public async Task ConcurrentSubscriptionsShouldContinueProcessOnNewConnections(int count)
+        {
+            using (var store = GetDocumentStore())
+            {
+                var id = await store.Subscriptions.CreateAsync<User>();
+                var docs = new HashSet<string>();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new User(), $"users/{i}");
+                        session.SaveChanges();
+                    }
+
+                    var workers = new List<SubscriptionWorker<User>>();
+                    for (int j = 0; j < count; j++)
+                    {
+                        workers.Add(store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
+                        {
+                            TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1),
+                            Strategy = SubscriptionOpeningStrategy.Concurrent,
+                            MaxDocsPerBatch = 1
+                        }));
+                    }
+
+                    try
+                    {
+                        foreach (var worker in workers)
+                        {
+                            var t = worker.Run(x =>
+                            {
+                                foreach (var item in x.Items)
+                                {
+                                    docs.Add(item.Id);
+                                }
+                            });
+                        }
+
+                        await AssertWaitForTrueAsync(() => Task.FromResult(docs.Count == i + 1), Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        await AssertNoLeftovers(store, id);
+                    }
+                    finally
+                    {
+                        foreach (var w in workers)
+                        {
+                            await w.DisposeAsync();
+                        }
+                    }
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Subscriptions)]
+        [InlineData(1)]
+        [InlineData(3)]
+        public async Task ConcurrentSubscriptionsShouldContinueProcessOnNewConnectionsAfterUpdate(int count)
+        {
+            using (var store = GetDocumentStore())
+            {
+                var id = await store.Subscriptions.CreateAsync<User>(options: new SubscriptionCreationOptions<User>()
+                {
+                    Filter = user => user.Age == 0
+                });
+
+                var docs = new HashSet<string>();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    if (i > 0)
+                    {
+                        await store.Subscriptions.UpdateAsync(options: new SubscriptionUpdateOptions()
+                        {
+                            Name = id,
+                            Query = @$"declare function predicate() {{ return this.Age==={i} }}
+from 'Users' as doc
+where predicate.call(doc)"
+                        });
+                    }
+
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new User()
+                        {
+                            Age = i
+                        }, $"users/{i}");
+                        session.SaveChanges();
+                    }
+
+                    var workers = new List<SubscriptionWorker<User>>();
+                    for (int j = 0; j < count; j++)
+                    {
+                        workers.Add(store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
+                        {
+                            TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1),
+                            Strategy = SubscriptionOpeningStrategy.Concurrent,
+                            MaxDocsPerBatch = 1
+                        }));
+                    }
+
+                    try
+                    {
+                        foreach (var worker in workers)
+                        {
+                            var t = worker.Run(x =>
+                            {
+                                foreach (var item in x.Items)
+                                {
+                                    docs.Add(item.Id);
+                                }
+                            });
+                        }
+
+                        await AssertWaitForTrueAsync(() => Task.FromResult(docs.Count == i + 1), Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        await AssertNoLeftovers(store, id);
+                    }
+                    finally
+                    {
+                        foreach (var w in workers)
+                        {
+                            await w.DisposeAsync();
+                        }
+                    }
+                }
+
+                var subs = await store.Subscriptions.GetSubscriptionsAsync(0, 1024);
+                Assert.Equal(1, subs.Count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task ConcurrentSubscriptionsShouldContinueProcessOnNewConnectionsAfterUpdate_AndDisposeWhileConnecting()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var id = await store.Subscriptions.CreateAsync<User>(options: new SubscriptionCreationOptions<User>()
+                {
+                    Filter = user => user.Age == 0
+                });
+
+                var docs = new HashSet<string>();
+                var workers = new List<SubscriptionWorker<User>>();
+                try
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        if (i > 0)
+                        {
+                            // we update the subscription on each iteration
+                            // so it will process only the new created document
+                            await store.Subscriptions.UpdateAsync(options: new SubscriptionUpdateOptions()
+                            {
+                                Name = id,
+                                Query = @$"declare function predicate() {{ return this.Age==={i} }}
+from 'Users' as doc
+where predicate.call(doc)"
+                            });
+                        }
+
+                        using (var session = store.OpenSession())
+                        {
+                            session.Store(new User()
+                            {
+                                Age = i
+                            }, $"users/{i}");
+                            session.SaveChanges();
+                        }
+
+                        var w = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(id)
+                        {
+                            TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1),
+                            Strategy = SubscriptionOpeningStrategy.Concurrent,
+                            MaxDocsPerBatch = 1
+                        });
+                        workers.Add(w);
+
+                        var t2 = w.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                docs.Add(item.Id);
+                                Thread.Sleep(1000);
+                            }
+                        });
+
+                        await AssertWaitForTrueAsync(() => Task.FromResult(docs.Count == i + 1), Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        await AssertNoLeftovers(store, id);
+                    }
+                }
+                finally
+                {
+                    foreach (var w in workers)
+                    {
+                        await w.DisposeAsync();
+                    }
+                }
+
+                var subs = await store.Subscriptions.GetSubscriptionsAsync(0, 1024);
+                Assert.Equal(1, subs.Count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task ConcurrentSubscriptionsShouldProcessWhen_2_ConnectionsAreSubscribingConcurrently()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var id = await store.Subscriptions.CreateAsync<User>();
+
+                var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+                var testingStuff = db.ForTestingPurposesOnly();
+
+                using (testingStuff.CallDuringWaitForSubscribe(connections =>
+                {
+                    while (connections.Count < 2)
+                    {
+                        Thread.Sleep(111);
+                    }
+                }))
+                {
+                    await using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
+                    {
+                        TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
+                        Strategy = SubscriptionOpeningStrategy.Concurrent,
+                        MaxDocsPerBatch = 2
+                    }))
+                    await using (var secondSubscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
+                    {
+                        Strategy = SubscriptionOpeningStrategy.Concurrent,
+                        TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5),
+                        MaxDocsPerBatch = 2
+                    }))
+                    {
+                        using (var session = store.OpenSession())
+                        {
+                            session.Store(new User(), "user/1");
+                            session.Store(new User(), "user/2");
+                            session.Store(new User(), "user/3");
+                            session.Store(new User(), "user/4");
+                            session.Store(new User(), "user/5");
+                            session.Store(new User(), "user/6");
+                            session.SaveChanges();
+                        }
+
+                        var con1Docs = new List<string>();
+                        var con2Docs = new List<string>();
+
+                        var t = subscription.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                con1Docs.Add(item.Id);
+                            }
+                        });
+
+                        var _ = secondSubscription.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                con2Docs.Add(item.Id);
+                            }
+                        });
+
+                        await AssertWaitForTrueAsync(() => Task.FromResult(con1Docs.Count + con2Docs.Count == 6), Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        await AssertNoLeftovers(store, id);
+                    }
+                }
+            }
+        }
         internal class GetSubscriptionResendListCommand : RavenCommand<ResendListResult>
         {
             private readonly string _database;
@@ -1210,6 +1482,7 @@ namespace SlowTests.Client.Subscriptions
         private class User
         {
             public string Name;
+            public int Age;
         }
     }
 }

--- a/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
@@ -66,7 +66,7 @@ namespace SlowTests.Client.Subscriptions
                 Assert.True(await signalWhenStartedProcessingDoc.WaitAsync(_reasonableWaitTime));
                 var database = await GetDatabase(store.Database);
 
-                SubscriptionStorage.SubscriptionGeneralDataAndStats subscriptionState;
+                SubscriptionState subscriptionState;
                 using (database.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                 using (context.OpenReadTransaction())
                 {

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -378,7 +378,7 @@ namespace SlowTests.Client.Subscriptions
 
                     Assert.True(await ackFirstCV.WaitAsync(_reasonableWaitTime));
 
-                    SubscriptionStorage.SubscriptionGeneralDataAndStats subscriptionState;
+                    SubscriptionState subscriptionState;
                     using (database.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                     using (context.OpenReadTransaction())
                     {

--- a/test/SlowTests/Issues/RavenDB_20416.cs
+++ b/test/SlowTests/Issues/RavenDB_20416.cs
@@ -175,7 +175,7 @@ namespace SlowTests.Issues
                 {
                     var connectionState = new SubscriptionConnectionsState(store2.Database, state.SubscriptionId, db2.SubscriptionStorage);
                     state.ShardingState.ChangeVectorForNextBatchStartingPointPerShard.TryGetValue(db2.Name, out string cv);
-                    connectionState.InitializeLastChangeVectorSent(cv);
+                    connectionState.LastChangeVectorSent = cv;
                     CheckSubscriptionFetchAfterUpdateInternal(collection, db2, connectionState);
                 }
             }
@@ -183,7 +183,8 @@ namespace SlowTests.Issues
             {
                 var db2 = await Databases.GetDocumentDatabaseInstanceFor(store2);
                 var connectionState = new SubscriptionConnectionsState(store2.Database, state.SubscriptionId, db2.SubscriptionStorage);
-                connectionState.InitializeLastChangeVectorSent(state.ChangeVectorForNextBatchStartingPoint);
+                connectionState.LastChangeVectorSent = state.ChangeVectorForNextBatchStartingPoint;
+
                 CheckSubscriptionFetchAfterUpdateInternal(collection, db2, connectionState);
             }
         }

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
@@ -330,7 +330,7 @@ namespace SlowTests.Sharding.Subscriptions
                 case SubscriptionChangeVectorUpdateConcurrencyException:
                     // sometimes we may hit cv concurrency exception because of the update
                     Assert.StartsWith(
-                        $"Can't acknowledge subscription with name '{state.SubscriptionName}' due to inconsistency in change vector progress. Probably there was an admin intervention that changed the change vector value. Stored value: , received value: A:11",
+                        $"Can't acknowledge subscription with name '{state.SubscriptionName}'",
                         OnSubscriptionConnectionRetryException.Message);
                     break;
             }


### PR DESCRIPTION
### Issue link

- https://issues.hibernatingrhinos.com/issue/RavenDB-21585
- https://issues.hibernatingrhinos.com/issue/RavenDB-19957

### Additional description

- Cherry pick https://github.com/ravendb/ravendb/pull/17579/ from v5.4
- When updating the sharded subscription changevector we might do ACK command and overwrite the new CV with old one, now we will throw `SubscriptionChangeVectorUpdateConcurrencyException`
- Resend list wasn't cleaned when we were updating the sharded subscription CV to start from beginning
- Made sure to not change `_redirectNode` if it's not needed (as in v5.4), when subscription worker reconnects (after exception) we were setting `_redirectNode` to null only on few exception (like SubscriptionDoesNotBelongToNodeException)
- Now sharded workers won't reconnect in loop when they got `SubscriptionChangeVectorUpdateConcurrencyException`, the exception will occur on orchestrator and it will reconnect and spawn new sharded subscription workers (which will start sharded subscription connections) 
- Wait 3 seconds on subscription failover in case there is real error or unstable cluster

### Type of change

- Bug fix
- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
I use the newly added `LastModifiedIndex` (in RavenDB-19957) in case we have an old subscription state it would get to be default value `(0)` 

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
