### PR TITLE
RavenDB-21686 Assert on the proper transaction state

### DIFF
--- a/src/Raven.Server/Indexing/VoronBufferedInput.cs
+++ b/src/Raven.Server/Indexing/VoronBufferedInput.cs
@@ -235,7 +235,7 @@ public class VoronBufferedInput : BufferedIndexInput
             return; // never hit
         }
 
-        if (state.Transaction.LowLevelTransaction.IsDisposed)
+        if (state.Transaction.LowLevelTransaction.IsValid == false)
             ThrowTransactionDisposed();
         if (_cts.IsCancellationRequested)
             ThrowCancelled();

--- a/src/Raven.Server/Indexing/VoronIndexInput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexInput.cs
@@ -185,7 +185,7 @@ namespace Raven.Server.Indexing
                 return; // never hit
             }
 
-            if (state.Transaction.LowLevelTransaction.IsDisposed)
+            if (state.Transaction.LowLevelTransaction.IsValid == false)
                 ThrowTransactionDisposed();
             if (_cts.IsCancellationRequested)
                 ThrowCancelled();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21686

### Additional description

Transaction can be in 3 states. `None` (valid), `Disposed` & `Errored`

The assertion here https://github.com/ravendb/ravendb/blob/76d753ba93afeeee56d563498215783bf52a1648/src/Voron/Data/Tables/Table.cs#L2391 failed because the transaction state was `Errored` due to out of memory.

So the fix is, that the check `IsDisposed` should assert only the `Disposed` state.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
