### PR TITLE
RavenDB-21649 : timeseries query - fix offset handling

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -771,7 +771,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
 
         private static RangeGroup InitializeRangeSpecs(string groupByTimePeriod, DateTime from, DateTime to, TimeSpan? offset)
         {
-            TimeSeriesReader.AddOffsetIfNeeded(offset, ref from, ref to);
+            (from, to) = TimeSeriesReader.AddOffsetIfNeeded(offset, from, to);
 
             if (groupByTimePeriod != null)
                 return RangeGroup.ParseRangeFromString(groupByTimePeriod, from);

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -771,16 +771,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
 
         private static RangeGroup InitializeRangeSpecs(string groupByTimePeriod, DateTime from, DateTime to, TimeSpan? offset)
         {
-            if (offset.HasValue)
-            {
-                var minWithOffset = from.Ticks + offset.Value.Ticks;
-                var maxWithOffset = to.Ticks + offset.Value.Ticks;
-
-                if (minWithOffset >= 0 && minWithOffset <= DateTime.MaxValue.Ticks)
-                    from = from.Add(offset.Value);
-                if (maxWithOffset >= 0 && maxWithOffset <= DateTime.MaxValue.Ticks)
-                    to = to.Add(offset.Value);
-            }
+            TimeSeriesReader.AddOffsetIfNeeded(offset, ref from, ref to);
 
             if (groupByTimePeriod != null)
                 return RangeGroup.ParseRangeFromString(groupByTimePeriod, from);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
@@ -119,7 +119,7 @@ namespace Raven.Server.Documents.TimeSeries
         private TimestampState[] _states = Array.Empty<TimestampState>();
         private LazyStringValue _tag;
         private TimeSeriesValuesSegment _currentSegment;
-        private TimeSpan? _offset;
+        private readonly TimeSpan? _offset;
         private DetailedSingleResult _details;
         private readonly CancellationToken _token;
 
@@ -304,6 +304,9 @@ namespace Raven.Server.Documents.TimeSeries
 
                 var baseline = new DateTime(baselineMilliseconds * 10_000, DateTimeKind.Utc);
 
+                if (_offset.HasValue)
+                    baseline = DateTime.SpecifyKind(baseline, DateTimeKind.Unspecified).Add(_offset.Value);
+                
                 if (baseline > _to)
                     yield break;
 
@@ -311,11 +314,6 @@ namespace Raven.Server.Documents.TimeSeries
                 {
                     _values = new double[_currentSegment.NumberOfValues];
                     _states = new TimestampState[_currentSegment.NumberOfValues];
-                }
-
-                if (_offset.HasValue)
-                {
-                    baseline = DateTime.SpecifyKind(baseline, DateTimeKind.Unspecified).Add(_offset.Value);
                 }
 
                 segmentResult.End = _currentSegment.GetLastTimestamp(baseline);
@@ -356,6 +354,9 @@ namespace Raven.Server.Documents.TimeSeries
 
                 var baseline = new DateTime(baselineMilliseconds * 10_000, DateTimeKind.Utc);
 
+                if (_offset.HasValue)
+                    baseline = DateTime.SpecifyKind(baseline, DateTimeKind.Unspecified).Add(_offset.Value);
+                
                 if (baseline > _to)
                     yield break;
 
@@ -367,11 +368,6 @@ namespace Raven.Server.Documents.TimeSeries
                     {
                         _values = new double[_currentSegment.NumberOfValues];
                         _states = new TimestampState[_currentSegment.NumberOfValues];
-                    }
-
-                    if (_offset.HasValue)
-                    {
-                        baseline = DateTime.SpecifyKind(baseline, DateTimeKind.Unspecified).Add(_offset.Value);
                     }
 
                     foreach (var val in YieldSegment(baseline, includeDead))

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
@@ -159,7 +159,7 @@ namespace Raven.Server.Documents.TimeSeries
                     return false;
             }
 
-            AddOffsetIfNeeded(_offset, ref _from, ref _to);
+            (_from, _to) = AddOffsetIfNeeded(_offset, _from, _to);
 
             return true;
         }
@@ -619,31 +619,26 @@ namespace Raven.Server.Documents.TimeSeries
             return (etag, changeVector, baseline);
         }
 
-        internal static void AddOffsetIfNeeded(TimeSpan? offset, ref DateTime from, ref DateTime to)
+        internal static (DateTime From, DateTime To) AddOffsetIfNeeded(TimeSpan? offset, DateTime from, DateTime to)
         {
             if (offset.HasValue == false)
-                return;
+                return (from, to);
 
-            AddOffset(offset.Value, ref from);
-            AddOffset(offset.Value, ref to);
+            from = AddOffset(offset.Value, from);
+            to = AddOffset(offset.Value, to);
+            return (from, to);
         }
 
-        private static void AddOffset(TimeSpan offset, ref DateTime date)
+        private static DateTime AddOffset(TimeSpan offset, DateTime date)
         {
             var withOffset = date.Ticks + offset.Ticks;
             if (withOffset < 0)
-            {
-                date = DateTime.MinValue;
-                return;
-            }
-
+                return DateTime.MinValue;
+            
             if (withOffset > DateTime.MaxValue.Ticks)
-            {
-                date = DateTime.MaxValue;
-                return;
-            }
-
-            date = date.Add(offset);
+                return DateTime.MaxValue;
+            
+            return date.Add(offset);
         }
     }
 

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB_21649.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB_21649.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Queries.TimeSeries;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Session.TimeSeries;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.TimeSeries.Issues;
+
+public class RavenDB_21649 : RavenTestBase
+{
+    private readonly Random _rand;
+    private const string Id = "people/1";
+    private const string SeriesName = "HeartRate";
+    private readonly int[] _entriesPerHour = { 28, 37, 28, 38, 48, 44, 43, 33, 45, 41, 39, 41 };
+
+    public RavenDB_21649(ITestOutputHelper output) : base(output)
+    {
+        _rand = new Random(12345);
+    }
+
+    [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
+    public void TimeSeriesAggregationWithDifferentTimeZoneOffsets_ShouldNotReturnPartialData()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var baseline = new DateTime(2023, 10, 15, 14, 0, 0, DateTimeKind.Utc);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Person(), Id);
+                var tsf = session.TimeSeriesFor(Id, SeriesName);
+
+                // insert 12 hours data
+                for (var i = 0; i < _entriesPerHour.Length; i++)
+                {
+                    var start = baseline.AddHours(i);
+                    var numOfEntries = _entriesPerHour[i];
+                    AddEntriesForHour(tsf, start, numOfEntries);
+                }
+
+                session.SaveChanges();
+            }
+
+            var from = new DateTime(2023, 10, 15, 4, 0, 0, DateTimeKind.Utc);
+            var to = new DateTime(2023, 10, 16, 4, 0, 0, DateTimeKind.Utc);
+
+            using (var session = store.OpenSession())
+            {
+                var aggregationWithNoOffset = session.Query<Person>()
+                    .Where(p => p.Id == Id)
+                    .Select(p => RavenQuery.TimeSeries(p, SeriesName, from, to)
+                        .GroupBy(x => x.Hours(1))
+                        .Select(x => x.Sum())
+                        .ToList())
+                    .SingleOrDefault()?.Results;
+
+                Assert.NotNull(aggregationWithNoOffset);
+                Assert.Equal(12, aggregationWithNoOffset.Length);
+                Assert.Equal(baseline, aggregationWithNoOffset[0].From);
+                Assert.Equal(baseline.AddHours(12), aggregationWithNoOffset[^1].To);
+
+                // check all timezone offsets 
+                for (var i = -12; i <= 14; i++)
+                {
+                    if (i == 0) 
+                        continue;
+
+                    var offset = TimeSpan.FromHours(i);
+
+                    var aggregationWithOffset = session.Query<Person>()
+                        .Where(p => p.Id == Id)
+                        .Select(p => RavenQuery.TimeSeries(p, SeriesName, from, to)
+                            .GroupBy(x => x.Hours(1))
+                            .Select(x => x.Sum())
+                            .Offset(offset)
+                            .ToList())
+                        .SingleOrDefault()?.Results;
+
+                    AssertAggregationResults(aggregationWithNoOffset, aggregationWithOffset, offset);
+                }
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
+    public void TimeSeriesQueryWithDifferentTimeZoneOffsets_ShouldNotReturnPartialData()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var baseline = new DateTime(2023, 10, 15, 14, 0, 0, DateTimeKind.Utc);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Person(), Id);
+                var tsf = session.TimeSeriesFor(Id, SeriesName);
+
+                // insert 12 hours data
+                for (var i = 0; i < _entriesPerHour.Length; i++)
+                {
+                    var start = baseline.AddHours(i);
+                    var numOfEntries = _entriesPerHour[i];
+                    AddEntriesForHour(tsf, start, numOfEntries);
+                }
+
+                session.SaveChanges();
+            }
+
+            var from = new DateTime(2023, 10, 15, 4, 0, 0, DateTimeKind.Utc);
+            var to = new DateTime(2023, 10, 16, 4, 0, 0, DateTimeKind.Utc);
+
+            using (var session = store.OpenSession())
+            {
+                var queryWithNoOffset = session.Query<Person>()
+                    .Where(p => p.Id == Id)
+                    .Select(p => RavenQuery.TimeSeries(p, SeriesName, from, to).ToList())
+                    .SingleOrDefault()?.Results;
+
+                Assert.NotNull(queryWithNoOffset);
+                Assert.Equal(_entriesPerHour.Sum(), queryWithNoOffset.Length);
+                Assert.True(baseline <= queryWithNoOffset[0].Timestamp);
+                Assert.True(baseline.AddHours(12) >= queryWithNoOffset[^1].Timestamp);
+
+                // check all timezone offsets 
+                for (var i = -12; i <= 14; i++)
+                {
+                    if (i == 0)
+                        continue;
+
+                    var offset = TimeSpan.FromHours(i);
+
+                    var queryWithOffset = session.Query<Person>()
+                        .Where(p => p.Id == Id)
+                        .Select(p => RavenQuery.TimeSeries(p, SeriesName, from, to)
+                            .Offset(offset)
+                            .ToList())
+                        .SingleOrDefault()?.Results;
+
+                    AssertRawResults(queryWithNoOffset, queryWithOffset, offset);
+                }
+            }
+
+        }
+    }
+
+    [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
+    public void TimeSeriesStreamQueryWithOffset_ShouldNotReturnPartialData()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var numOfEntries = TimeSpan.FromHours(1).TotalMinutes;
+            var baseline = DateTime.UtcNow.EnsureMilliseconds();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User(), "karmel");
+                var ts = session.TimeSeriesFor("karmel", "heartrate");
+                for (int i = 0; i < numOfEntries; i++)
+                {
+                    ts.Append(baseline.AddMinutes(i), i);
+                }
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var ts = session.TimeSeriesFor("karmel", "heartrate");
+                var from = baseline;
+                var to = baseline.AddHours(1);
+
+                var offset = TimeSpan.FromHours(12);
+                var baselineWithOffset = baseline.Add(offset);
+
+                using (var it = ts.Stream(from, to, offset: offset))
+                {
+                    var i = 0;
+                    while (it.MoveNext())
+                    {
+                        var entry = it.Current;
+                        Assert.Equal(baselineWithOffset.AddMinutes(i), entry.Timestamp);
+                        Assert.Equal(i, entry.Value);
+                        i++;
+                    }
+
+                    Assert.Equal(numOfEntries, i);
+                }
+            }
+        }
+    }
+
+    private static void AssertAggregationResults(IReadOnlyList<TimeSeriesRangeAggregation> originalResults, IReadOnlyList<TimeSeriesRangeAggregation> aggregationResult, TimeSpan offset)
+    {
+        Assert.NotNull(aggregationResult);
+        Assert.Equal(originalResults.Count, aggregationResult.Count);
+
+        for (int i = 0; i < originalResults.Count; i++)
+        {
+            var original = originalResults[i];
+            var withOffset = aggregationResult[i];
+
+            // from/to dates should be the same when offset added to original results 
+            Assert.Equal(original.From.Add(offset), withOffset.From);
+            Assert.Equal(original.To.Add(offset), withOffset.To);
+
+            // count and sum should be identical
+            Assert.True(original.Count.SequenceEqual(withOffset.Count));
+            Assert.True(original.Sum.SequenceEqual(withOffset.Sum));
+        }
+    }
+
+    private static void AssertRawResults(TimeSeriesEntry[] originalResults, TimeSeriesEntry[] aggregationResult, TimeSpan offset)
+    {
+        Assert.NotNull(aggregationResult);
+        Assert.Equal(originalResults.Length, aggregationResult.Length);
+
+        for (int i = 0; i < originalResults.Length; i++)
+        {
+            var original = originalResults[i];
+            var withOffset = aggregationResult[i];
+
+            // timestamp should be the same when offset added to original results 
+            Assert.Equal(original.Timestamp.Add(offset), withOffset.Timestamp);
+
+            // values should be identical
+            Assert.True(original.Values.SequenceEqual(withOffset.Values));
+        }
+    }
+
+    private void AddEntriesForHour(ISessionDocumentAppendTimeSeriesBase tsf, DateTime baseline, int numOfEntries)
+    {
+        var chosen = new HashSet<int>();
+
+        for (int i = 0; i < numOfEntries; i++)
+        {
+            int minutesToAdd;
+            while (true)
+            {
+                minutesToAdd = _rand.Next(0, 60);
+                if (chosen.Add(minutesToAdd))
+                    break;
+            }
+
+            var timestamp = baseline.AddMinutes(minutesToAdd);
+            tsf.Append(timestamp, new[] { minutesToAdd, minutesToAdd * 1.5, minutesToAdd * 0.75, 0, minutesToAdd * 1.15 });
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21649/Timeseries-aggregation-with-time-zone-offsets-returns-bad-results

### Additional description

in `TimeSeriesRetriever` :
- do not add `offset` value to the `from`/`to` parameters when creating the `TimeSeriesReader` instance
- add the offset only to the `RangeGroup` specs
- this matches the behaviour in TimeSeries stream query 

in `TimeSeriesReader` :
- start reading values according to the original `from` (without offset added)
- when iterating over segments, add the `offset` to segment's baseline **before** checking if segment is out of range 


### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
