### PR TITLE
RavenDB-21633 - SlowTests.Client.Attachments.AttachmentsReplication.A…

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -667,7 +667,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 foreach (var documentConflict in conflicts)
                                 {
                                     if (documentConflict.Flags.Contain(DocumentFlags.HasAttachments) == false ||
-                                        ChangeVectorUtils.GetConflictStatus(cv, documentConflict.ChangeVector) == ConflictStatus.AlreadyMerged)
+                                        ChangeVector.GetConflictStatus(context, cv, documentConflict.ChangeVector) == ConflictStatus.AlreadyMerged)
                                         continue;
 
                                     // recreate attachments reference
@@ -677,7 +677,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 continue;
                             }
 
-                            if (ChangeVectorUtils.GetConflictStatus(cv, doc.ChangeVector) != ConflictStatus.AlreadyMerged || 
+                            if (ChangeVector.GetConflictStatus(context, cv, doc.ChangeVector) != ConflictStatus.AlreadyMerged || 
                                 doc.Flags.Contain(DocumentFlags.HasAttachments | DocumentFlags.Resolved))
                             {
                                 // have to load the full document

--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -127,7 +127,8 @@ public sealed class ChangeVector
     }
 
     public static ConflictStatus GetConflictStatusForDocument(ChangeVector remote, ChangeVector local) => GetConflictStatusInternal(remote?.Version, local?.Version);
-    public static ConflictStatus GetConflictStatusForDocument(IChangeVectorOperationContext context, string remote, string local) => 
+    
+    public static ConflictStatus GetConflictStatus(IChangeVectorOperationContext context, string remote, string local) => 
         GetConflictStatusInternal(context.GetChangeVector(remote)?.Version, context.GetChangeVector(local)?.Version);
 
     private ChangeVector UpdateInternal(string nodeTag, string dbId, long etag, ChangeVector changeVector, IChangeVectorOperationContext context)


### PR DESCRIPTION
…ttachmentsRevisionsReplication(options:  DatabaseMode = Sharded , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21633/SlowTests.Client.Attachments.AttachmentsReplication.AttachmentsRevisionsReplicationoptions-DatabaseMode-Sharded-SearchEngineMode

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
