### PR TITLE
RavenDB-21662 : fix failing interversion smuggler tests

### DIFF
--- a/test/InterversionTests/SmugglerTests.cs
+++ b/test/InterversionTests/SmugglerTests.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Smuggler.Migration;
 using Raven.Tests.Core.Utils.Entities;
@@ -397,8 +398,12 @@ namespace InterversionTests
         public async Task CanMigrateFromCurrentTo42()
         {
             using var store42 = await GetDocumentStoreAsync(Server42Version);
-            using var storeCurrent = GetDocumentStore();
-
+            using var storeCurrent = GetDocumentStore(new Options
+            {
+                // workaround for RavenDB-21687
+                ModifyDatabaseRecord = record =>
+                    record.Settings[RavenConfiguration.GetKey(x => x.ExportImport.CompressionAlgorithm)] = "Gzip"
+            });
             storeCurrent.Maintenance.Send(new CreateSampleDataOperation());
             using (var session = storeCurrent.OpenAsyncSession())
             {
@@ -441,7 +446,12 @@ namespace InterversionTests
         public async Task CanMigrateFromCurrentTo54()
         {
             using var store54 = await GetDocumentStoreAsync(Server54Version);
-            using var storeCurrent = GetDocumentStore();
+            using var storeCurrent = GetDocumentStore(new Options
+            {
+                // workaround for RavenDB-21687
+                ModifyDatabaseRecord = record => 
+                    record.Settings[RavenConfiguration.GetKey(x => x.ExportImport.CompressionAlgorithm)] = "Gzip"
+            });
 
             storeCurrent.Maintenance.Send(new CreateSampleDataOperation());
             using (var session = storeCurrent.OpenAsyncSession())

--- a/test/InterversionTests/SmugglerTests.cs
+++ b/test/InterversionTests/SmugglerTests.cs
@@ -163,7 +163,7 @@ namespace InterversionTests
             using var store42 = await GetDocumentStoreAsync(Server42Version);
             using var storeCurrent = GetDocumentStore();
             //Export
-            storeCurrent.Maintenance.Send(new CreateSampleDataOperation());
+            await storeCurrent.Maintenance.SendAsync(new CreateSampleDataOperation());
             using (var session = storeCurrent.OpenAsyncSession())
             {
                 var dateTime = new DateTime(2020, 3, 29);
@@ -177,7 +177,7 @@ namespace InterversionTests
                 await session.SaveChangesAsync();
             }
 
-            var exportOptions = new DatabaseSmugglerExportOptions();
+            var exportOptions = new DatabaseSmugglerExportOptions { CompressionAlgorithm = ExportCompressionAlgorithm.Gzip };
             if (excludeOn == ExcludeOn.Export)
                 exportOptions.OperateOnTypes &= ~(DatabaseItemType.Attachments | DatabaseItemType.RevisionDocuments | DatabaseItemType.CounterGroups);
             var exportOperation = await storeCurrent.Smuggler.ExportAsync(exportOptions, file);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21662/InterversionTests.SmugglerTests

### Additional description

- fix `CanExportFromCurrentAndImportTo42` - use `Gzip` compression for the export operation
- temp fix for `CanMigrateFromCurrentTo42` and `CanMigrateFromCurrentTo52` (details here : [RavenDB-21687](https://issues.hibernatingrhinos.com/issue/RavenDB-21687))

### Type of change

- Bug fix
- Tests stabilization

### How risky is the change?

- Low 