### PR TITLE
RavenDB-21674 Fixing expiration tests - @expire metadata is supposed to have UTC date

### DIFF
--- a/test/SlowTests/Client/UniqueValues.cs
+++ b/test/SlowTests/Client/UniqueValues.cs
@@ -14,6 +14,7 @@ using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
@@ -456,7 +457,7 @@ namespace SlowTests.Client
                 }))
                 {
                     var result = session.Advanced.ClusterTransaction.CreateCompareExchangeValue(key, user);
-                    result.Metadata[Constants.Documents.Metadata.Expires] = dateTime.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffff");
+                    result.Metadata[Constants.Documents.Metadata.Expires] = dateTime.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
                     result.Metadata["TestString"] = str;
                     result.Metadata["TestNumber"] = num;
                     await session.SaveChangesAsync();
@@ -465,7 +466,7 @@ namespace SlowTests.Client
                 var res = await store.Operations.SendAsync(new GetCompareExchangeValueOperation<User>(key));
                 Assert.Equal(user.Name, res.Value.Name);
                 Assert.NotNull(res.Metadata);
-                Assert.Equal(dateTime.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffff"), res.Metadata[Constants.Documents.Metadata.Expires]);
+                Assert.Equal(dateTime.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite), res.Metadata[Constants.Documents.Metadata.Expires]);
                 Assert.Equal(str, res.Metadata["TestString"]);
                 Assert.Equal(num, res.Metadata["TestNumber"]);
 
@@ -504,7 +505,7 @@ namespace SlowTests.Client
                 }))
                 {
                     var result = session.Advanced.ClusterTransaction.CreateCompareExchangeValue<string>(key, "EGR");
-                    result.Metadata[Constants.Documents.Metadata.Expires] = dateTime.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffff");
+                    result.Metadata[Constants.Documents.Metadata.Expires] = dateTime.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
                     result.Metadata["TestString"] = str;
                     result.Metadata["TestNumber"] = num;
                     await session.SaveChangesAsync();
@@ -513,7 +514,7 @@ namespace SlowTests.Client
                 var res = await store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>(key));
                 Assert.Equal("EGR", res.Value);
                 Assert.NotNull(res.Metadata);
-                Assert.Equal(dateTime.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffff"), res.Metadata[Constants.Documents.Metadata.Expires]);
+                Assert.Equal(dateTime.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite), res.Metadata[Constants.Documents.Metadata.Expires]);
                 Assert.Equal(str, res.Metadata["TestString"]);
                 Assert.Equal(num, res.Metadata["TestNumber"]);
 
@@ -552,7 +553,7 @@ namespace SlowTests.Client
                 }))
                 {
                     var result = session.Advanced.ClusterTransaction.CreateCompareExchangeValue(key, 322);
-                    result.Metadata[Constants.Documents.Metadata.Expires] = dateTime.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffff");
+                    result.Metadata[Constants.Documents.Metadata.Expires] = dateTime.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
                     result.Metadata["TestString"] = str;
                     result.Metadata["TestNumber"] = num;
                     await session.SaveChangesAsync();
@@ -561,7 +562,7 @@ namespace SlowTests.Client
                 var res = await store.Operations.SendAsync(new GetCompareExchangeValueOperation<int>(key));
                 Assert.Equal(322, res.Value);
                 Assert.NotNull(res.Metadata);
-                Assert.Equal(dateTime.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffff"), res.Metadata[Constants.Documents.Metadata.Expires]);
+                Assert.Equal(dateTime.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite), res.Metadata[Constants.Documents.Metadata.Expires]);
                 Assert.Equal(str, res.Metadata["TestString"]);
                 Assert.Equal(num, res.Metadata["TestNumber"]);
 

--- a/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
+++ b/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
@@ -395,7 +395,7 @@ namespace SlowTests.Cluster
                     using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                     {
                         var result = session.Advanced.ClusterTransaction.CreateCompareExchangeValue(key, user);
-                        result.Metadata[Constants.Documents.Metadata.Expires] = expiry;
+                        result.Metadata[Constants.Documents.Metadata.Expires] = expiry.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
 
                         await session.SaveChangesAsync();
                         compareExchangeIndexes[key] = result.Index;
@@ -406,7 +406,7 @@ namespace SlowTests.Cluster
                 expiry = DateTime.Now.AddMinutes(4);
                 foreach (var kvp in compareExchanges)
                 {
-                    var metadata = new MetadataAsDictionary { [Constants.Documents.Metadata.Expires] = expiry };
+                    var metadata = new MetadataAsDictionary { [Constants.Documents.Metadata.Expires] = expiry.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite) };
                     await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>(kvp.Key, kvp.Value, compareExchangeIndexes[kvp.Key], metadata));
                 }
                 await AssertCompareExchanges(compareExchanges, store, expiry);
@@ -544,7 +544,7 @@ namespace SlowTests.Cluster
                     var expirationDate = res.Metadata.GetString(Constants.Documents.Metadata.Expires);
                     Assert.NotNull(expirationDate);
                     var dateTime = DateTime.ParseExact(expirationDate, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-                    Assert.Equal(expiry.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffff"), expirationDate);
+                    Assert.Equal(expiry.Value.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite), expirationDate);
                 }
             }
         }
@@ -562,7 +562,7 @@ namespace SlowTests.Cluster
                     var result = session.Advanced.ClusterTransaction.CreateCompareExchangeValue(key, user);
                     if (expiry != null)
                     {
-                        result.Metadata[Constants.Documents.Metadata.Expires] = expiry;
+                        result.Metadata[Constants.Documents.Metadata.Expires] = expiry?.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
                     }
                     await session.SaveChangesAsync();
                 }

--- a/test/SlowTests/Issues/RavenDB_21575.cs
+++ b/test/SlowTests/Issues/RavenDB_21575.cs
@@ -49,7 +49,7 @@ public class RavenDB_21575 : RavenTestBase
             {
                 await session.StoreAsync(company, "companies/1");
                 var metadata = session.Advanced.GetMetadataFor(company);
-                metadata[Constants.Documents.Metadata.Expires] = expiry.ToString(DefaultFormat.DateTimeFormatsToWrite);
+                metadata[Constants.Documents.Metadata.Expires] = expiry.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
                 await session.SaveChangesAsync();
             }
 
@@ -57,7 +57,7 @@ public class RavenDB_21575 : RavenTestBase
             {
                 await session.StoreAsync(company, "companies/1");
                 var metadata = session.Advanced.GetMetadataFor(company);
-                metadata[Constants.Documents.Metadata.Expires] = expiry.AddMinutes(1).ToString(DefaultFormat.DateTimeFormatsToWrite);
+                metadata[Constants.Documents.Metadata.Expires] = expiry.AddMinutes(1).ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
                 await session.SaveChangesAsync();
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21674

### Additional description

Fixing expiration tests

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing tests will verify the fix

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
