### PR TITLE
RavenDB-21612 - Server request metrics not displayed on the cluster dashboard

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/TrafficNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/TrafficNotificationSender.cs
@@ -32,6 +32,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
                 case ClusterDashboardPayloadType.Server:
                     return new TrafficWatchPayload
                     {
+                        RequestsPerSecond = trafficWatch.RequestsPerSecond,
                         TrafficPerDatabase = trafficWatch.Items
                     };
                 case ClusterDashboardPayloadType.Database:

--- a/src/Raven.Server/Dashboard/Cluster/Notifications/TrafficWatchPayload.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/TrafficWatchPayload.cs
@@ -30,7 +30,8 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
         public override DynamicJsonValue ToJson()
         {
             var result = new TrafficWatchPayload();
-
+            
+            result.RequestsPerSecond = RequestsPerSecond;
             foreach (TrafficWatchItem item in TrafficPerDatabase)
             {
                 result.Add(item);
@@ -73,7 +74,6 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
 
         private void Add(TrafficWatchItem item)
         {
-            RequestsPerSecond += item.RequestsPerSecond;
             AttachmentWritesPerSecond += item.AttachmentWritesPerSecond;
             AttachmentsWriteBytesPerSecond += item.AttachmentsWriteBytesPerSecond;
             CounterWritesPerSecond += item.CounterWritesPerSecond;

--- a/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
@@ -9,10 +9,10 @@ using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ETL;
-using Raven.Client.Documents.Operations.ETL.OLAP;
-using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.ETL.ElasticSearch;
+using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.ETL.Queue;
+using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Json.Serialization;
@@ -97,6 +97,8 @@ namespace Raven.Server.Dashboard
             var trafficWatch = new TrafficWatch();
             var drivesUsage = new DrivesUsage();
 
+            var rate = (int)RefreshRate.TotalSeconds;
+            trafficWatch.RequestsPerSecond = (int)Math.Ceiling(serverStore.Server.Metrics.Requests.RequestsPerSec.GetRate(rate));
             trafficWatch.AverageRequestDuration = serverStore.Server.Metrics.Requests.AverageDuration.GetRate();
 
             using (serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
@@ -128,8 +130,6 @@ namespace Raven.Server.Dashboard
                             continue;
                         }
 
-                        var rate = (int)RefreshRate.TotalSeconds;
-                        
                         var indexingSpeedItem = new IndexingSpeedItem
                         {
                             Database = database.Name,

--- a/src/Raven.Server/Dashboard/TrafficWatch.cs
+++ b/src/Raven.Server/Dashboard/TrafficWatch.cs
@@ -13,6 +13,8 @@ namespace Raven.Server.Dashboard
 
         public double AverageRequestDuration { get; set; }
 
+        public int RequestsPerSecond { get; set; }
+
         public TrafficWatch()
         {
             Items = new List<TrafficWatchItem>();
@@ -23,6 +25,7 @@ namespace Raven.Server.Dashboard
             var json = base.ToJson();
             json[nameof(Items)] = new DynamicJsonArray(Items.Select(x => x.ToJson()));
             json[nameof(AverageRequestDuration)] = AverageRequestDuration;
+            json[nameof(RequestsPerSecond)] = RequestsPerSecond;
             return json;
         }
 
@@ -44,6 +47,7 @@ namespace Raven.Server.Dashboard
             var json = base.ToJson();
             json[nameof(Items)] = items;
             json[nameof(AverageRequestDuration)] = AverageRequestDuration;
+            json[nameof(RequestsPerSecond)] = RequestsPerSecond;
             return json;
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21612

### Additional description

The `RequestsPerSecond` number showing in the studio dashboard was a sum of all database's requests on a specific node.
Therefor server requests weren't showing.
Changed so the db requests no longer sum, but instead we set `RequestsPerSecond` with the amount of all server requests (they include db requests as well).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### UI work

- No UI work is needed
