### PR TITLE
RavenDB-21663: use higher RavenDB versions

### DIFF
--- a/test/InterversionTests/BasicTests.cs
+++ b/test/InterversionTests/BasicTests.cs
@@ -29,10 +29,19 @@ namespace InterversionTests
             AssertStore(GetDocumentStore());
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Interversion | RavenTestCategory.Subscriptions, RavenPlatform.Windows | RavenPlatform.Linux)]
-        [InlineData("5.2.3")]
-        [InlineData("5.3.0-nightly-20211107-0402")]
-        public async Task SubscriptionTest(string version)
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Subscriptions, RavenPlatform.Windows | RavenPlatform.Linux)]
+        public async Task SubscriptionTestV52()
+        {
+            await SubscriptionTestInternal(Server52Version);
+        }
+
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Subscriptions, RavenPlatform.Windows | RavenPlatform.Linux)]
+        public async Task SubscriptionTestV53()
+        {
+            await SubscriptionTestInternal(Server53Version);
+        }
+
+        private async Task SubscriptionTestInternal(string version)
         {
             using (var store = await GetDocumentStoreAsync(version))
             {

--- a/test/InterversionTests/MixedClusterTests.cs
+++ b/test/InterversionTests/MixedClusterTests.cs
@@ -53,11 +53,7 @@ namespace InterversionTests
         }
 
         [RavenMultiplatformTheory(RavenTestCategory.Interversion, RavenPlatform.Windows)]
-        [InlineData("4.1.4", "4.1.4", "4.1.4")]
-        [InlineData("4.1.3", "4.1.3", "4.1.3")]
-        [InlineData("4.1.2", "4.1.2", "4.1.2")]
-        [InlineData("4.1.1", "4.1.1", "4.1.1")]
-        [InlineData("4.1.0", "4.1.0", "4.1.0")]
+        [InlineData("4.1.5", "4.1.5", "4.1.5")]
         public async Task UpgradeFromEarly41(params string[] initialVersions)
         {
             var upgradeTo = new List<string>
@@ -66,16 +62,8 @@ namespace InterversionTests
                 "current"
             };
 
-            var v411 = new Version411(this);
-            var v41X = new Version41X(this);
-
-            UpgradeTestSuit before = v41X;
-            if (initialVersions[0] == "4.1.1" || initialVersions[0] == "4.1.0")
-            {
-                before = v411;
-            }
-
-            await ExecuteUpgradeTest(initialVersions, upgradeTo, before, before, v41X);
+            var suit = new Version41X(this);
+            await ExecuteUpgradeTest(initialVersions, upgradeTo, suit, suit, suit);
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Interversion, RavenPlatform.Windows)]

--- a/test/InterversionTests/RavenDB-17518.cs
+++ b/test/InterversionTests/RavenDB-17518.cs
@@ -151,7 +151,7 @@ namespace InterversionTests
         [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task ShouldNotReplicateIncrementalTimeSeriesToOldServer2()
         {
-            const string version = "5.2.3";
+            const string version = Server52Version;
             const string incrementalTsName = Constants.Headers.IncrementalTimeSeriesPrefix + "HeartRate";
             const string docId = "users/1";
             var baseline = DateTime.UtcNow;

--- a/test/InterversionTests/RavenDB-17556.cs
+++ b/test/InterversionTests/RavenDB-17556.cs
@@ -18,7 +18,7 @@ namespace InterversionTests
         [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task IncomingReplicationShouldRejectIncrementalTimeSeriesFromOldServer()
         {
-            const string version = "5.2.3";
+            const string version = Server52Version;
             const string incrementalTsName = Constants.Headers.IncrementalTimeSeriesPrefix + "HeartRate";
             const string docId = "users/1";
 

--- a/test/InterversionTests/ReplicationTests.cs
+++ b/test/InterversionTests/ReplicationTests.cs
@@ -69,10 +69,17 @@ namespace InterversionTests
         public async Task CanReplicateToOldServerWithLowerReplicationProtocolVersionV52()
         {
             // https://issues.hibernatingrhinos.com/issue/RavenDB-17346
-            string version = "5.2.3";
+            string version = Server52Version;
             await CanReplicateToOldServerWithLowerReplicationProtocolVersion(version);
         }
 
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication, RavenPlatform.Windows | RavenPlatform.Linux)]
+        public async Task CanReplicateToOldServerWithLowerReplicationProtocolVersionV53()
+        {
+            // https://issues.hibernatingrhinos.com/issue/RavenDB-17346
+            string version = Server53Version;
+            await CanReplicateToOldServerWithLowerReplicationProtocolVersion(version);
+        }
 
         private async Task CanReplicateToOldServerWithLowerReplicationProtocolVersion(string version)
         {
@@ -95,7 +102,7 @@ namespace InterversionTests
         [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Replication | RavenTestCategory.TimeSeries, RavenPlatform.Windows | RavenPlatform.Linux)]
         public async Task ShouldNotReplicateIncrementalTimeSeriesToOldServer()
         {
-            const string version = "5.2.3";
+            const string version = Server52Version;
             const string incrementalTsName = Constants.Headers.IncrementalTimeSeriesPrefix + "HeartRate";
             const string docId = "users/1";
             var baseline = DateTime.UtcNow;

--- a/test/Tests.Infrastructure/InterversionTestBase.cs
+++ b/test/Tests.Infrastructure/InterversionTestBase.cs
@@ -43,6 +43,8 @@ namespace Tests.Infrastructure
         private static readonly ServerBuildRetriever _serverBuildRetriever = new ServerBuildRetriever();
 
         protected const string Server42Version = "4.2.124";
+        protected const string Server52Version = "5.2.100";
+        protected const string Server53Version = "5.3.100";
         protected const string Server54Version = "5.4.109";
 
         protected DocumentStore GetDocumentStore(


### PR DESCRIPTION
fix interversion tests for v6.0
https://issues.hibernatingrhinos.com/issue/RavenDB-21663/InterversionTests.MixedClusterTests