### PR TITLE
RavenDB-21668 - fix AccessViolationException in Auto MapReduce index

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexField.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexField.cs
@@ -162,6 +162,8 @@ namespace Raven.Server.Documents.Indexes
 
         public AutoSpatialOptions Spatial { get; set; }
 
+        public bool SamePathAsGroupByField { get; set; }
+
         public static AutoIndexField Create(string name, AutoIndexDefinition.AutoIndexFieldOptions options)
         {
             var field = new AutoIndexField

--- a/src/Raven.Server/Documents/Indexes/IndexField.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexField.cs
@@ -162,7 +162,7 @@ namespace Raven.Server.Documents.Indexes
 
         public AutoSpatialOptions Spatial { get; set; }
 
-        public bool SamePathAsGroupByField { get; set; }
+        public bool SamePathToArrayAsGroupByField { get; set; }
 
         public static AutoIndexField Create(string name, AutoIndexDefinition.AutoIndexFieldOptions options)
         {

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -257,12 +257,12 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
             // The SUM has the same path as one of the reduce keys
             // from 'Messages'
             // group by Name, Data[].Items[].ProductName
-            // select Name, sum(Data[].Items[].TotalPrice) as Total
+            // select Name, Data[].Items[].ProductName as ProductName, sum(Data[].Items[].TotalPrice) as Total
             // 
             // The SUM has a different path than any of the reduce keys
             // from 'Messages'
             // group by Name, Tries[].ResultMessage
-            // select Name, sum(Data[].Items[].TotalPrice) as Total
+            // select Name, Tries[].ResultMessage as ResultMessage, sum(Data[].Items[].TotalPrice) as Total
 
             var groupByFieldsPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach ((_, AutoIndexField value) in Definition.GroupByFields)
@@ -290,7 +290,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
 
                 var autoIndexFieldPath = autoIndexField.Name.Substring(0, lastIndexOfAutoIndexField);
 
-                if (groupByFieldsPaths.Contains(autoIndexFieldPath))
+                if (groupByFieldsPaths.Any(x => autoIndexFieldPath.StartsWith(x)))
                 {
                     autoIndexField.SamePathAsGroupByField = true;
                 }

--- a/test/SlowTests/Issues/RavenDB-21668.cs
+++ b/test/SlowTests/Issues/RavenDB-21668.cs
@@ -22,6 +22,7 @@ namespace SlowTests.Issues
                     new()
                     {
                         Name = "Initial",
+                        Numbers = new List<int> { 1, 2, 3 },
                         Tries = new List<Message.Try> { new() { ResultMessage = "Received" } },
                         Data = new List<Message.Info>
                         {
@@ -48,6 +49,7 @@ namespace SlowTests.Issues
                     new()
                     {
                         Name = "Initial",
+                        Numbers = new List<int> { 1, 2, 3 },
                         Tries = new List<Message.Try> { new() { ResultMessage = "Received" } },
                         Data = new List<Message.Info>
                         {
@@ -124,6 +126,21 @@ namespace SlowTests.Issues
                     Assert.Equal(31, dictionary["TV"]);
                     Assert.Equal(32, dictionary["Table"]);
                     Assert.Equal(3, dictionary["Laptop"]);
+
+                    rql = "from 'Messages' " +
+                          "group by Name, Numbers[] " +
+                          "select Name, Numbers[] as OriginalNumber, sum(Numbers) as Total";
+
+                    var numbersResult = session.Advanced.RawQuery<ResultSamePathNumbers>(rql).ToList();
+                    Assert.Equal(3, numbersResult.Count);
+                    Assert.True(numbersResult.Select(x => x.Name).All(x => x == "Initial"));
+
+                    Assert.Equal(1, numbersResult[0].OriginalNumber);
+                    Assert.Equal(2, numbersResult[0].Total);
+                    Assert.Equal(2, numbersResult[1].OriginalNumber);
+                    Assert.Equal(4, numbersResult[1].Total);
+                    Assert.Equal(3, numbersResult[2].OriginalNumber);
+                    Assert.Equal(6, numbersResult[2].Total);
                 }
             }
         }
@@ -132,6 +149,8 @@ namespace SlowTests.Issues
         private class Message
         {
             public string Name { get; set; }
+
+            public List<int> Numbers { get; set; }
 
             public List<Info> Data { get; set; }
 
@@ -175,5 +194,13 @@ namespace SlowTests.Issues
             public string ProductName { get; set; }
         }
 
+        private class ResultSamePathNumbers
+        {
+            public string Name { get; set; }
+
+            public double Total { get; set; }
+
+            public int OriginalNumber { get; set; }
+        }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-21668.cs
+++ b/test/SlowTests/Issues/RavenDB-21668.cs
@@ -1,0 +1,159 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21668 : RavenTestBase
+    {
+        public RavenDB_21668(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Can_Query_Map_Reduce_Index()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var messages = new List<Message>
+                {
+                    new()
+                    {
+                        Name = "Initial",
+                        Tries = new List<Message.Try> { new() { ResultMessage = "Received" } },
+                        Data = new List<Message.Info>
+                        {
+                            new()
+                            {
+                                Items = new List<Message.Info.Item>
+                                {
+                                    new() { TotalPrice = 10, ProductName = "Screen" },
+                                    new() { TotalPrice = 20, ProductName = "TV" },
+                                    new() { TotalPrice = 30, ProductName = "Screen" }
+                                },
+                            },
+                            new()
+                            {
+                                Items = new List<Message.Info.Item>
+                                {
+                                    new() { TotalPrice = 10, ProductName = "TV" },
+                                    new() { TotalPrice = 20, ProductName = "Screen" },
+                                    new() { TotalPrice = 30, ProductName = "Table" }
+                                },
+                            }
+                        }
+                    },
+                    new()
+                    {
+                        Name = "Initial",
+                        Tries = new List<Message.Try> { new() { ResultMessage = "Received" } },
+                        Data = new List<Message.Info>
+                        {
+                            new()
+                            {
+                                Items = new List<Message.Info.Item>
+                                {
+                                    new() { TotalPrice = 1, ProductName = "TV" },
+                                    new() { TotalPrice = 2, ProductName = "Table" },
+                                    new() { TotalPrice = 3, ProductName = "Laptop" }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                using (var session = store.OpenSession())
+                {
+                    foreach (var message in messages)
+                    {
+                        session.Store(message);
+                    }
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var rql = "from 'Messages' " +
+                              "group by Name, Tries[].ResultMessage " +
+                              "select sum(Data.Items[].TotalPrice) as Total";
+
+                    var results = session.Advanced.RawQuery<ResultDifferentPath>(rql).ToList();
+                    Assert.Equal(0, results.Count); // expected - wrong rql will produce 0 results
+
+                    rql = "from 'Messages' " +
+                          "group by Name, Tries[].ResultMessage " +
+                          "select Name, sum(Data[].Items[].TotalPrice) as Total";
+
+                    results = session.Advanced.RawQuery<ResultDifferentPath>(rql).ToList();
+                    Assert.Equal(1, results.Count);
+                    Assert.Equal("Initial", results[0].Name);
+                    Assert.Equal(126, results[0].Total);
+
+                    rql = "from 'Messages' " +
+                          "group by Name, Data[].Items[].ProductName " +
+                          "select Name, Data[].Items[].ProductName as ProductName, sum(Data[].Items[].TotalPrice) as Total";
+
+                    var resultsSamePath = session.Advanced.RawQuery<ResultSamePath>(rql).ToList();
+                    Assert.Equal(4, resultsSamePath.Count);
+
+                    Assert.True(resultsSamePath.Select(x => x.Name).All(x => x == "Initial"));
+
+                    Assert.Equal("Screen", resultsSamePath[0].ProductName);
+                    Assert.Equal(60, resultsSamePath[0].Total);
+
+                    Assert.Equal("TV", resultsSamePath[1].ProductName);
+                    Assert.Equal(31, resultsSamePath[1].Total);
+
+                    Assert.Equal("Table", resultsSamePath[2].ProductName);
+                    Assert.Equal(32, resultsSamePath[2].Total);
+
+                    Assert.Equal("Laptop", resultsSamePath[3].ProductName);
+                    Assert.Equal(3, resultsSamePath[3].Total);
+                }
+            }
+        }
+
+
+        private class Message
+        {
+            public string Name { get; set; }
+
+            public List<Info> Data { get; set; }
+
+            public List<Try> Tries { get; set; }
+
+            public class Try
+            {
+                public string ResultMessage { get; set; }
+            }
+
+            public class Info
+            {
+                public List<Item> Items { get; set; }
+
+                public class Item
+                {
+                    public int TotalPrice { get; set; }
+
+                    public string ProductName { get; set; }
+                }
+            }
+        }
+
+        private class ResultDifferentPath
+        {
+            public string Name { get; set; }
+
+            public double Total { get; set; }
+        }
+
+        private class ResultSamePath : ResultDifferentPath
+        {
+            public string ProductName { get; set; }
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-21668.cs
+++ b/test/SlowTests/Issues/RavenDB-21668.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using FastTests;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,7 +13,7 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Querying)]
         public void Can_Query_Map_Reduce_Index()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
- handle a reduce result that is different result from any of the reduce keys

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21668/AccessViolationException-in-Auto-MapReduce-index

### Additional description

When we have a fanout in the map-reduce index, there are 2 options: the reduce result has the same OR a different path as one of the reduce keys.
We didn't handle properly the case when we had a different path in the reduce result than any of the reduce keys.
The indexing for that document failed and we didn't clear the in-memory state afterwards.
When we indexed the next document, we were also reading data from a disposed document.

If there was no error, we would return incorrect results.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
