### PR TITLE
ConnectionStatusChanged is not fired after server restart

### DIFF
--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -545,7 +545,7 @@ namespace Raven.Client.Documents.Changes
                         _url = new Uri($"{_serverNode.Url}/databases/{_database}/changes"
                             .ToLower()
                             .ToWebSocketPath(), UriKind.Absolute);
-
+                        var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(new[] { _cts.Token, new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token });
                         await _client.ConnectAsync(_url, _cts.Token).ConfigureAwait(false);
                         wasConnected = true;
                         Interlocked.Exchange(ref _immediateConnection, 1);

--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -546,7 +546,7 @@ namespace Raven.Client.Documents.Changes
                             .ToLower()
                             .ToWebSocketPath(), UriKind.Absolute);
                         var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(new[] { _cts.Token, new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token });
-                        await _client.ConnectAsync(_url, _cts.Token).ConfigureAwait(false);
+                        await _client.ConnectAsync(_url, timeoutCts.Token).ConfigureAwait(false);
                         wasConnected = true;
                         Interlocked.Exchange(ref _immediateConnection, 1);
 

--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -42,7 +42,7 @@ namespace Raven.Client.Documents.Changes
 
         private readonly ConcurrentDictionary<DatabaseChangesOptions, DatabaseConnectionState> _counters = new ConcurrentDictionary<DatabaseChangesOptions, DatabaseConnectionState>();
         private int _immediateConnection;
-        
+
         private readonly TaskCompletionSource<ChangesSupportedFeatures> _supportedFeaturesTcs = new();
         internal Task<ChangesSupportedFeatures> GetSupportedFeaturesAsync() => _supportedFeaturesTcs.Task;
 
@@ -64,7 +64,7 @@ namespace Raven.Client.Documents.Changes
             {
                 if (t.Result.TopologyChange == false)
                     return;
-                
+
                 GetOrAddConnectionState("Topology", "watch-topology-change", "", "");
                 await _requestExecutor
                     .UpdateTopologyAsync(
@@ -192,7 +192,7 @@ namespace Raven.Client.Documents.Changes
 
             return taskedObservable;
         }
-        
+
         public IChangesObservable<OperationStatusChange> ForOperationId(long operationId)
         {
             var counter = GetOrAddConnectionState("operations/" + operationId, "watch-operation", "unwatch-operation", operationId.ToString());
@@ -405,7 +405,7 @@ namespace Raven.Client.Documents.Changes
             }
             catch
             {
-               // we are disposing
+                // we are disposing
             }
 
             ConnectionStatusChanged -= OnConnectionStatusChanged;
@@ -545,8 +545,13 @@ namespace Raven.Client.Documents.Changes
                         _url = new Uri($"{_serverNode.Url}/databases/{_database}/changes"
                             .ToLower()
                             .ToWebSocketPath(), UriKind.Absolute);
-                        var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(new[] { _cts.Token, new CancellationTokenSource(TimeSpan.FromSeconds(15)).Token });
-                        await _client.ConnectAsync(_url, timeoutCts.Token).ConfigureAwait(false);
+
+                        using (var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token))
+                        {
+                            timeoutCts.CancelAfter(TimeSpan.FromSeconds(15));
+                            await _client.ConnectAsync(_url, timeoutCts.Token).ConfigureAwait(false);
+                        }
+
                         wasConnected = true;
                         Interlocked.Exchange(ref _immediateConnection, 1);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21692

### Additional description

Included an additional cancellation token on the `ClientWebSocket` connect call which will abort the connection after 15 seconds to prevent hangs


### Type of change

- Bug fix

### How risky is the change?


- Moderate 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- Yes. Please list the affected platforms.
have only recreated on windows10 host and windows2012 server- 
 

### Documentation update


- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- Yes. Please list the affected features/subsystems and provide appropriate explanation
- No

### UI work

- No UI work is needed
