### PR TITLE
RavenDB-19625 Cast date stored as `JsString` to date in `TypeConverter`

### DIFF
--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -285,7 +285,15 @@ namespace Raven.Server.Utils
                     if (js.IsUndefined())
                         return DynamicNullObject.Null;
                     if (js.IsString())
-                        return js.AsString();
+                    {
+                        var jsString = js.AsString();
+
+                        if (TryConvertStringValue(jsString, out var jsDate))
+                            return jsDate;
+                        
+                        return jsString;
+                    }
+
                     if (js.IsBoolean())
                         return js.AsBoolean();
                     if (js.IsNumber())

--- a/test/SlowTests/Issues/RavenDB-19625.cs
+++ b/test/SlowTests/Issues/RavenDB-19625.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19625 : RavenTestBase
+{
+    public RavenDB_19625(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void CanQueryIndexFilteredByDateTime()
+    {
+        using (var store = GetDocumentStore())
+        {
+            store.ExecuteIndex(new QueryDateTime_Index());
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Post { Id = "posts/1", Date = DateTime.UtcNow.AddMinutes(-5) });
+
+                session.SaveChanges();
+
+                Indexes.WaitForIndexing(store);
+                
+                var res = session.Query<QueryDateTime_Index.Result, QueryDateTime_Index>()
+                    .Where(x => x.Date < DateTime.UtcNow)
+                    .ProjectInto<QueryDateTime_Index.Result>()
+                    .ToList();
+
+                Assert.NotEmpty(res);
+            }
+        }
+    }
+
+    private class Post
+    {
+        public string Id { get; set; }
+        public DateTime? Date { get; set; }
+    }
+
+    private class QueryDateTime_Index : AbstractJavaScriptIndexCreationTask
+    {
+        public class Result
+        {
+            public DateTime? Date { get; set; }
+        }
+
+        public QueryDateTime_Index()
+        {
+            Maps = new HashSet<string>
+            {
+                @"map('Posts', p => {
+                    return {
+                        Date: p.Date 
+                    };
+                });"
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19625/The-date-time-term-become-lowercase-in-map-reduce-index

### Additional description

We try to convert javascript string to date (DateTime, DateTimeOffset, etc.) in `TypeConverter` so we can properly index its field.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
