### PR TITLE
RavenDB-21568 Reroute server dashboard to cluster dashboard

### DIFF
--- a/src/Raven.Studio/typescript/common/appUrl.ts
+++ b/src/Raven.Studio/typescript/common/appUrl.ts
@@ -768,9 +768,15 @@ class appUrl {
     }
     
     static defaultModule: any; // will be bind dynamically to avoid cycles in imports
+    static clusterDashboardModule: any; // will be bind dynamically to avoid cycles in imports
 
     static mapUnknownRoutes(router: DurandalRouter) {
         router.mapUnknownRoutes((instruction: DurandalRouteInstruction) => {
+            if (instruction.fragment === "dashboard") {
+                instruction.config.moduleId = appUrl.clusterDashboardModule;
+                return;
+            }
+            
             const queryString = instruction.queryString ? ("?" + instruction.queryString) : "";
 
             messagePublisher.reportWarning("Unknown route", "The route " + instruction.fragment + queryString + " doesn't exist, redirecting...");

--- a/src/Raven.Studio/typescript/common/shell/menu/items/rootItems.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/rootItems.ts
@@ -29,9 +29,13 @@ function bs5Item() {
 
 
 function clusterDashboard() {
+    const clusterDashboardView = require('viewmodels/resources/clusterDashboard');
+    
+    appUrl.clusterDashboardModule = clusterDashboardView;
+    
     return new leafMenuItem({
         route: ["", "clusterDashboard"],
-        moduleId: require('viewmodels/resources/clusterDashboard'),
+        moduleId: clusterDashboardView,
         title: 'Cluster Dashboard',
         tooltip: "Cluster Dashboard",
         nav: true, // todo - this needs issue RavenDB-16618 to work...


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21568 

### Additional description

Redirect from dashboard -> clusterDashboard

### Type of change
- Optimization

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

