### PR TITLE
RavenDB-21659 Allow to define optional Cloud Event attributes in Queue ETL. Added the validation during the transform phase.

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Queue/CloudEventAttributes.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/CloudEventAttributes.cs
@@ -1,19 +1,35 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using CloudNative.CloudEvents;
 
 namespace Raven.Server.Documents.ETL.Providers.Queue;
 
 public class CloudEventAttributes
 {
+    internal static string PartitionKeyLowercased = nameof(PartitionKey).ToLowerInvariant();
+
     public static HashSet<string> ValidAttributeNames = new()
     {
-        nameof(Id), nameof(Type), nameof(Source), nameof(PartitionKey)
+        // required
+        nameof(Id), nameof(Type), nameof(Source),
+        CloudEventsSpecVersion.V1_0.IdAttribute.Name, CloudEventsSpecVersion.V1_0.TypeAttribute.Name, CloudEventsSpecVersion.V1_0.SourceAttribute.Name,
+
+        // optional
+        nameof(PartitionKey), nameof(DataSchema), nameof(Subject), nameof(Time),
+        PartitionKeyLowercased, CloudEventsSpecVersion.V1_0.DataSchemaAttribute.Name, CloudEventsSpecVersion.V1_0.SubjectAttribute.Name, CloudEventsSpecVersion.V1_0.TimeAttribute.Name,
     };
 
     public string Id { get; set; }
 
     public string Type { get; set; }
 
-    public string Source { get; set; }
+    public Uri Source { get; set; }
 
     public string PartitionKey { get; set; }
+
+    public Uri DataSchema { get; set; }
+
+    public string Subject { get; set; }
+
+    public DateTimeOffset? Time { get; set; }
 }

--- a/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
@@ -491,7 +491,7 @@ output('test output')"
                     Assert.Equal("myRoutingKey", result.Summary[0].Messages[0].RoutingKey);
                     Assert.Equal("orders/1-A", result.Summary[0].Messages[0].Attributes.Id);
                     Assert.Equal("com.github.users", result.Summary[0].Messages[0].Attributes.Type);
-                    Assert.Equal("/registrations/direct-signup", result.Summary[0].Messages[0].Attributes.Source);
+                    Assert.Equal("/registrations/direct-signup", result.Summary[0].Messages[0].Attributes.Source.ToString());
 
                     Assert.Equal("test output", result.DebugOutput[0]);
                 }

--- a/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_Kafka.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_Kafka.cs
@@ -1,0 +1,67 @@
+﻿using Confluent.Kafka;
+using System;
+using System.Text;
+using Newtonsoft.Json;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.ETL.Queue;
+
+public class RavenDB_21659_Kafka : KafkaEtlTestBase
+{
+    public RavenDB_21659_Kafka(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RequiresKafkaRetryFact]
+    public void CanPassOptionalAttributesToLoadToMethod()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var config = SetupQueueEtlToKafka(store,
+                @$"loadToUsers{TopicSuffix}(this, {{
+                                                            dataschema: 'urn:foo:names:specification:bar:1.2.3',
+                                                            Subject: 'my subject',
+                                                            Time: new Date()
+                                                     }})", new[] { "Users" });
+
+            var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User
+                {
+                    Name = "Arek"
+                });
+                session.SaveChanges();
+            }
+
+            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+
+            using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(new[] { $"Users{TopicSuffix}" });
+
+            var consumeResult = consumer.Consume();
+            var bytesAsString = Encoding.UTF8.GetString(consumeResult.Message.Value);
+
+            var user = JsonConvert.DeserializeObject<User>(bytesAsString);
+
+            Assert.NotNull(user);
+            Assert.Equal(user.Name, "Arek");
+
+            // validate headers
+
+            consumeResult.Message.Headers.TryGetLastBytes("ce_dataschema", out var dataSchema);
+            Assert.Equal("urn:foo:names:specification:bar:1.2.3", Encoding.UTF8.GetString(dataSchema));
+
+            consumeResult.Message.Headers.TryGetLastBytes("ce_subject", out var subject);
+            Assert.Equal("my subject", Encoding.UTF8.GetString(subject));
+
+            consumeResult.Message.Headers.TryGetLastBytes("ce_time", out var date);
+            Assert.NotEmpty(Encoding.UTF8.GetString(date));
+
+            consumer.Close();
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_RabbitMq.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_RabbitMq.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using RabbitMQ.Client;
+using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Server.Documents.ETL.Queue;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+public class RavenDB_21659_RabbitMq : RabbitMqEtlTestBase
+{
+    public RavenDB_21659_RabbitMq(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RequiresRabbitMqRetryFact]
+    public void CanPassOptionalAttributesToLoadToMethod()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var config = SetupQueueEtlToRabbitMq(store,
+                @$"loadToUsers{ExchangeSuffix}(this, {{
+                                                            DataSchema: 'http://www.my-app.com',
+                                                            subject: id(this),
+                                                            time: '2023-11-14T14:55:00.0000000',
+                                                     }})", new[] { "Users" });
+
+            var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "Arek" }, "users/1");
+                session.SaveChanges();
+            }
+
+            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+
+            using var channel = CreateRabbitMqChannel();
+            var consumer = new TestRabbitMqConsumer(channel);
+
+            channel.BasicConsume(queue: $"Users{ExchangeSuffix}", autoAck: true, consumer: consumer);
+
+            var ea = consumer.Consume();
+
+            var body = ea.Body.ToArray();
+            var bytesAsString = Encoding.UTF8.GetString(body);
+
+            var user = JsonConvert.DeserializeObject<UserData>(bytesAsString);
+
+            Assert.NotNull(user);
+            Assert.Equal(user.Name, "Arek");
+
+            var headers = ea.Properties.Headers;
+
+            Assert.Equal("http://www.my-app.com/", Encoding.UTF8.GetString((byte[])headers["cloudEvents:dataschema"]));
+            Assert.Equal("users/1", Encoding.UTF8.GetString((byte[])headers["cloudEvents:subject"]));
+            Assert.NotEmpty(Encoding.UTF8.GetString((byte[])headers["cloudEvents:time"]));
+        }
+    }
+
+    private class UserData
+    {
+        public string UserId { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -89,7 +89,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6442;
+            const int numberToTolerate = 6446;
             if (array.Length == numberToTolerate)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21659

### Additional description

Added ability to provide optional cloud events attributes: [dataschema](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema), [subject](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#subject), [time](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#time)

### Type of change

- Enhancement

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
