### PR TITLE
RavenDB-21547 Set reasonable default Revisions limits on new configur…

### DIFF
--- a/src/Raven.Studio/typescript/models/database/documents/revisionsConfigurationEntry.ts
+++ b/src/Raven.Studio/typescript/models/database/documents/revisionsConfigurationEntry.ts
@@ -244,7 +244,7 @@ class revisionsConfigurationEntry {
         return new revisionsConfigurationEntry("",
         {
             Disabled: false,
-            MinimumRevisionsToKeep: null,
+            MinimumRevisionsToKeep: 1000,
             MinimumRevisionAgeToKeep: null,
             MaximumRevisionsToDeleteUponDocumentUpdate: null,
             PurgeOnDelete: false

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/revisions.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/revisions.html
@@ -170,6 +170,16 @@
                     <div class="bg-info padding padding-xs margin-top small" data-bind="visible: humaneRetentionDescription">
                         <div data-bind="html: humaneRetentionDescription"></div>
                     </div>
+                    
+                    <div class="bg-warning padding margin-top small flex-horizontal" data-bind="visible: !limitRevisions()">
+                        <div class="flex-start text-warning">
+                            <i class="icon-warning"></i>
+                        </div>
+                        <div>
+                            No limit has been set on the number of revisions to keep.<br />
+                            An excessive number of revisions will lead to increased storage usage and may affect system performance.
+                        </div>
+                    </div>
                     <hr>
                     <div class="text-right margin-top">
                         <button class="btn btn-default" data-bind="click: $root.exitEditMode"><i class="icon-cancel"></i><span>Cancel</span></button>


### PR DESCRIPTION
…ations

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21547 

### Additional description

Changed default revisions configuration + warn if no limits are set. 

### Type of change

- Optimization


### How risky is the change?

- Moderate 


### Backward compatibility

- Breaking change


### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.


### UI work

- No UI work is needed
