### PR TITLE
RavenDB-21700 - Snapshot restore is downloading the restore file twice

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -668,7 +668,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                    Directory.GetDirectories(location).Length > 0;
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             RestoreSource?.Dispose();
             OperationCancelToken?.Dispose();

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/IRestoreSource.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/IRestoreSource.cs
@@ -16,8 +16,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
         string GetBackupPath(string smugglerFile);
 
-        string GetSmugglerBackupPath(string smugglerFile);
-
         string GetBackupLocation();
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
@@ -50,11 +50,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return fileName;
         }
 
-        public string GetSmugglerBackupPath(string smugglerFile)
-        {
-            return smugglerFile;
-        }
-
         public string GetBackupLocation()
         {
             return _remoteFolderName;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
@@ -54,11 +54,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return fileName;
         }
 
-        public string GetSmugglerBackupPath(string smugglerFile)
-        {
-            return smugglerFile;
-        }
-
         public string GetBackupLocation()
         {
             return _remoteFolderName;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
@@ -47,11 +47,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return fileName;
         }
 
-        public string GetSmugglerBackupPath(string smugglerFile)
-        {
-            return Path.Combine(_backupLocation, smugglerFile);
-        }
-
         public string GetBackupLocation()
         {
             return _backupLocation;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -50,11 +50,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return fileName;
         }
 
-        public string GetSmugglerBackupPath(string smugglerFile)
-        {
-            return smugglerFile;
-        }
-
         public string GetBackupLocation()
         {
             return _remoteFolderName;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -245,10 +245,12 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
             onProgress.Invoke(Result.Progress);
 
+            if (_zipArchive == null)
+                throw new InvalidOperationException($"Restoring of smuggler values failed because {nameof(_zipArchive)} is null");
+
             var entry = _zipArchive.GetEntry(RestoreSettings.SmugglerValuesFileName);
             if (entry != null)
             {
-                using (_zipArchive)
                 await using (var input = entry.Open())
                 await using (var inputStream = GetSnapshotInputStream(input, database.Name))
                 await using (var uncompressed = await RavenServerBackupUtils.GetDecompressionStreamAsync(inputStream))
@@ -261,8 +263,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
                     await smuggler.ExecuteAsync(ensureStepsProcessed: true, isLastFile: true);
                 }
-
-                _zipArchive = null; // the zip archive is not needed anymore
             }
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -311,8 +311,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
         public override void Dispose()
         {
-            _zipArchive?.Dispose();
-            base.Dispose();
+            using (_zipArchive)
+                base.Dispose();
         }
     }
 }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -581,7 +581,7 @@ namespace Raven.Server.Web.System
                     detailedDescription: null,
                     taskFactory: async onProgress =>
                     {
-                        var restoreBackupTask = await RestoreUtils.CreateBackupTaskAsync(ServerStore, restoreConfiguration, restoreSource, operationId, cancelToken);
+                        using var restoreBackupTask = await RestoreUtils.CreateBackupTaskAsync(ServerStore, restoreConfiguration, restoreSource, operationId, cancelToken);
                         return await restoreBackupTask.ExecuteAsync(onProgress);
                     },
                     token: cancelToken);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21700/Snapshot-restore-is-downloading-the-restore-file-twice

### Additional description

Download the snapshot restore file only once for the entire restore process.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No
