### PR TITLE
RavenDB-21700 - Snapshot restore is downloading the restore file twice

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -955,7 +955,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             var entry = _zipArchiveForSnapshot.GetEntry(RestoreSettings.SmugglerValuesFileName);
             if (entry != null)
             {
-                using (_zipArchiveForSnapshot)
                 await using (var input = entry.Open())
                 await using (var inputStream = GetSnapshotInputStream(input, database.Name))
                 await using (var uncompressed = await RavenServerBackupUtils.GetDecompressionStreamAsync(inputStream))
@@ -969,8 +968,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
                     await smuggler.ExecuteAsync(ensureStepsProcessed: true, isLastFile: true);
                 }
-
-                _zipArchiveForSnapshot = null; // the zip archive is not needed anymore
             }
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
@@ -45,11 +45,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return fileName;
         }
 
-        protected override string GetSmugglerBackupPath(string smugglerFile)
-        {
-            return smugglerFile;
-        }
-
         protected override string GetBackupLocation()
         {
             return _remoteFolderName;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
@@ -52,11 +52,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return fileName;
         }
 
-        protected override string GetSmugglerBackupPath(string smugglerFile)
-        {
-            return smugglerFile;
-        }
-
         protected override string GetBackupLocation()
         {
             return _remoteFolderName;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
@@ -46,11 +46,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return fileName;
         }
 
-        protected override string GetSmugglerBackupPath(string smugglerFile)
-        {
-            return Path.Combine(_backupLocation, smugglerFile);
-        }
-
         protected override string GetBackupLocation()
         {
             return _backupLocation;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -48,11 +48,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return fileName;
         }
 
-        protected override string GetSmugglerBackupPath(string smugglerFile)
-        {
-            return smugglerFile;
-        }
-
         protected override string GetBackupLocation()
         {
             return _remoteFolderName;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21700/Snapshot-restore-is-downloading-the-restore-file-twice

### Additional description

Download the snapshot restore file only once for the entire restore process.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No
