### PR TITLE
RavenDB-21588 Add test for range and equality check on TimeSpan values

### DIFF
--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -544,8 +544,8 @@ namespace Raven.Server.Utils
             return value;
         }
 
-        private static readonly List<string> _timeSpanPropertiesNames = typeof(TimeSpan).GetProperties().Select(i => i.Name).ToList();
-        private static readonly List<string> _timeOnlyPropertiesNames = typeof(TimeOnly).GetProperties().Select(i => i.Name).ToList();
+        private static readonly HashSet<string> _timeSpanPropertiesNames = typeof(TimeSpan).GetProperties().Select(i => i.Name).ToHashSet();
+        private static readonly HashSet<string> _timeOnlyPropertiesNames = typeof(TimeOnly).GetProperties().Select(i => i.Name).ToHashSet();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe object ConvertLazyStringValue(LazyStringValue value, StringSegment member = default, bool supportTimeOnlyDateOnly = false)

--- a/test/SlowTests/Issues/RavenDB-21588.cs
+++ b/test/SlowTests/Issues/RavenDB-21588.cs
@@ -19,7 +19,7 @@ public class RavenDB_21588 : RavenTestBase
     }
     
     [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
     public void TimeSpanInBetweenQuery(Options options)
     {
         using var store = GetDocumentStore(options);
@@ -32,8 +32,8 @@ public class RavenDB_21588 : RavenTestBase
         }
        
         using var session = store.OpenSession();
-        var timeSpan2 = new TimeSpan(9, 0, 0);
-        var timeSpan1 = new TimeSpan(8, 0, 0);
+        var timeSpan2 = new TimeSpan(0, 9, 0, 0, 0, 0);
+        var timeSpan1 = new TimeSpan(0, 9, 0, 0, 0, 0);
 
         var res1 = database.Where(p => p.TimeSpan >= timeSpan1 && p.TimeSpan <= timeSpan2).ToList();
         
@@ -45,7 +45,7 @@ public class RavenDB_21588 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
     public void TimeSpanInGteQuery(Options options)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Issues/RavenDB-21588.cs
+++ b/test/SlowTests/Issues/RavenDB-21588.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21588 : RavenTestBase
+{
+    public RavenDB_21588(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class DateAndTimeOnly
+    {
+        public TimeSpan TimeSpan { get; set; }
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void TimeSpanInBetweenQuery(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        var database = Enumerable.Range(0, 1000).Select(i => new DateAndTimeOnly() { TimeSpan = new TimeSpan(0, i, 0) }).ToList();
+
+        using (var bulkInsert = store.BulkInsert())
+        {
+            database.ForEach(i => bulkInsert.Store(i));
+        }
+       
+        using var session = store.OpenSession();
+        var timeSpan2 = new TimeSpan(9, 0, 0);
+        var timeSpan1 = new TimeSpan(8, 0, 0);
+
+        var res1 = database.Where(p => p.TimeSpan >= timeSpan1 && p.TimeSpan <= timeSpan2).ToList();
+        
+        var res2 = session.Query<DateAndTimeOnly>().Customize(i => i.WaitForNonStaleResults()).Where(p => p.TimeSpan >= timeSpan1 && p.TimeSpan <= timeSpan2).ToList();
+        
+        Assert.Equal(res1.Count, res2.Count);
+
+        Assert.All(res1, item => Assert.Contains(item.TimeSpan, res2.Select(x => x.TimeSpan)));
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void TimeSpanInGteQuery(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        
+        var database = Enumerable.Range(0, 1000).Select(i => new DateAndTimeOnly() { TimeSpan = new TimeSpan(0, i, 0) }).ToList();
+
+        using (var bulkInsert = store.BulkInsert())
+        {
+            database.ForEach(i => bulkInsert.Store(i));
+        }
+
+        using var session = store.OpenSession();
+        var timeSpan1 = new TimeSpan(8, 0, 0);
+
+        var res1 = database.Where(p => p.TimeSpan == timeSpan1).ToList();
+        var res2 = session.Query<DateAndTimeOnly>().Customize(i => i.WaitForNonStaleResults()).Where(p => p.TimeSpan == timeSpan1).ToList();
+
+        Assert.Equal(res1.Count, res2.Count);
+        Assert.All(res1, item => Assert.Contains(item.TimeSpan, res2.Select(x => x.TimeSpan)));
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21588/Range-and-equality-check-on-TimeOnly-values

### Additional description

Added test for range and equality check on TimeSpan values

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
