### PR TITLE
RavenDB-20780 Add indexing error for `Indexing.MaxStepsForScript` configuration option

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
@@ -10,6 +10,7 @@ using Jint.Native.Function;
 using Jint.Runtime;
 using Jint.Runtime.Environments;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Extensions;
 
@@ -53,6 +54,11 @@ namespace Raven.Server.Documents.Indexes.Static
                         try
                         {
                             jsItem = MapFunc.Call(JsValue.Null, _oneItemArray);
+                        }
+                        catch (StatementsCountOverflowException e)
+                        {
+                            throw new Raven.Client.Exceptions.Documents.Patching.JavaScriptException(
+                                $"The maximum number of statements executed have been reached. You can configure it by modifying the configuration option: '{RavenConfiguration.GetKey(x => x.Indexing.MaxStepsForScript)}'.", e);
                         }
                         catch (JavaScriptException jse)
                         {

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -89,7 +89,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6446;
+            const int numberToTolerate = 6445;
             if (array.Length == numberToTolerate)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20780/Add-the-configuration-option-to-fix-the-StatementsCountOverflowException-error

### Additional description

We want to throw Raven exception instead of Jint one

### Type of change

- Better exception

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
