### PR TITLE
RavenDB-21708 - fix NRE when ClusterState is null

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexLockCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexLockCommand.cs
@@ -28,6 +28,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             if (record.Indexes.TryGetValue(IndexName, out IndexDefinition staticIndex))
             {
                 staticIndex.LockMode = LockMode;
+                staticIndex.ClusterState ??= new IndexDefinitionClusterState();
                 staticIndex.ClusterState.LastIndex = etag;
             }
 

--- a/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexPriorityCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/SetIndexPriorityCommand.cs
@@ -27,12 +27,14 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             if (record.Indexes.TryGetValue(IndexName, out IndexDefinition staticIndex))
             {
                 staticIndex.Priority = Priority;
+                staticIndex.ClusterState ??= new IndexDefinitionClusterState();
                 staticIndex.ClusterState.LastIndex = etag;
             }
 
             if (record.AutoIndexes.TryGetValue(IndexName, out AutoIndexDefinition autoIndex))
             {
                 autoIndex.Priority = Priority;
+                autoIndex.ClusterState ??= new IndexDefinitionClusterState();
                 autoIndex.ClusterState.LastIndex = etag;
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21708/NRE-in-database-record

### Additional description

Regression from https://github.com/ravendb/ravendb/pull/15844.
So modifying an old index that doesn't have `ClusterState` in the definition can cause NRE in 6.0.

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed