### PR TITLE
RavenDB-21340 added requests per second 5s rate to the SNMP

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.7/ServerRequestsPerSecond.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.7/ServerRequestsPerSecond.cs
@@ -1,3 +1,4 @@
+using System;
 using Lextm.SharpSnmpLib;
 using Raven.Server.Utils;
 
@@ -6,16 +7,39 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
     public class ServerRequestsPerSecond : ScalarObjectBase<Gauge32>
     {
         private readonly MetricCounters _metrics;
+        private readonly RequestRateType _requestRateType;
 
-        public ServerRequestsPerSecond(MetricCounters metrics)
-            : base(SnmpOids.Server.RequestsPerSecond)
+        public ServerRequestsPerSecond(MetricCounters metrics, RequestRateType requestRateType)
+            : base(GetOid(requestRateType))
         {
             _metrics = metrics;
+            _requestRateType = requestRateType;
         }
 
         protected override Gauge32 GetData()
         {
-            return new Gauge32((int)_metrics.Requests.RequestsPerSec.OneMinuteRate);
+            return _requestRateType switch
+            {
+                RequestRateType.OneMinute => new Gauge32((int)_metrics.Requests.RequestsPerSec.OneMinuteRate),
+                RequestRateType.FiveSeconds => new Gauge32((int)_metrics.Requests.RequestsPerSec.FiveSecondRate),
+                _ => throw new ArgumentOutOfRangeException(nameof(_requestRateType), _requestRateType, null)
+            };
+        }
+
+        private static string GetOid(RequestRateType requestRateType)
+        {
+            return requestRateType switch
+            {
+                RequestRateType.OneMinute => SnmpOids.Server.RequestsPerSecond1M,
+                RequestRateType.FiveSeconds => SnmpOids.Server.RequestsPerSecond5S,
+                _ => throw new ArgumentOutOfRangeException(nameof(requestRateType), requestRateType, null)
+            };
+        }
+
+        public enum RequestRateType
+        {
+            OneMinute,
+            FiveSeconds
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -189,7 +189,10 @@ namespace Raven.Server.Monitoring.Snmp
             public const string TotalRequests = "1.7.2";
 
             [Description("Number of requests per second (one minute rate)")]
-            public const string RequestsPerSecond = "1.7.3";
+            public const string RequestsPerSecond1M = "1.7.3";
+
+            [Description("Number of requests per second (five second rate)")]
+            public const string RequestsPerSecond5S = "1.7.3.1";
 
             [Description("Average request time in milliseconds")]
             public const string RequestAverageDuration = "1.7.4";

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -386,7 +386,8 @@ namespace Raven.Server.Monitoring.Snmp
 
             store.Add(new ServerConcurrentRequests(server.Metrics));
             store.Add(new ServerTotalRequests(server.Metrics));
-            store.Add(new ServerRequestsPerSecond(server.Metrics));
+            store.Add(new ServerRequestsPerSecond(server.Metrics, ServerRequestsPerSecond.RequestRateType.OneMinute));
+            store.Add(new ServerRequestsPerSecond(server.Metrics, ServerRequestsPerSecond.RequestRateType.FiveSeconds));
             store.Add(new ServerRequestAverageDuration(server.Metrics));
 
             store.Add(new ProcessCpu(server.MetricCacher, server.CpuUsageCalculator));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21340

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
