### PR TITLE
RavenDB-21617 Fix replication loop for document & attachment tombstones

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1003,22 +1003,27 @@ namespace Raven.Server.Documents
 
             var tombstoneTable = new Table(TombstonesSchema, context.Transaction.InnerTransaction);
 
-            // return tombstone in any collection with the requested id
+            Tombstone mostRecent = null;
             foreach (var (tombstoneKey, tvh) in tombstoneTable.SeekByPrimaryKeyPrefix(lowerId, Slices.Empty, 0))
             {
                 if (IsTombstoneOfId(tombstoneKey, lowerId))
                 {
-                    return new DocumentOrTombstone
+                    var current = TableValueToTombstone(context, ref tvh.Reader);
+                    mostRecent = current;
+                    if (mostRecent == null || 
+                        GetConflictStatus(context, current.ChangeVector, mostRecent.ChangeVector, ChangeVectorMode.Version) == ConflictStatus.Update)
                     {
-                        Tombstone = TableValueToTombstone(context, ref tvh.Reader)
-                    };
+                        using (var old = mostRecent)
+                        {
+                            mostRecent = current;
+                        }
+                    }
                 }
-                break;
             }
 
             return new DocumentOrTombstone
             {
-                Tombstone = null
+                Tombstone = mostRecent
             };
         }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1009,11 +1009,10 @@ namespace Raven.Server.Documents
                 if (IsTombstoneOfId(tombstoneKey, lowerId))
                 {
                     var current = TableValueToTombstone(context, ref tvh.Reader);
-                    mostRecent = current;
                     if (mostRecent == null || 
                         GetConflictStatus(context, current.ChangeVector, mostRecent.ChangeVector, ChangeVectorMode.Version) == ConflictStatus.Update)
                     {
-                        using (var old = mostRecent)
+                        using (var _ = mostRecent)
                         {
                             mostRecent = current;
                         }

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -1585,16 +1585,16 @@ namespace SlowTests.Client.Attachments
                 {
                     var result = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, hardDelete: true, fromNode: toRemove,
                         timeToWaitForConfirmation: TimeSpan.FromSeconds(60)));
-                    await mainServer.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex + 1);
+                    await mainServer.ServerStore.Cluster.WaitForIndexNotification(result.RaftCommandIndex);
                 }
                 else
                 {
                     var result0 = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, shardNumber: 0, hardDelete: true, fromNode: toRemove, timeToWaitForConfirmation: TimeSpan.FromSeconds(60)));
                     var result1 = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, shardNumber: 1, hardDelete: true, fromNode: toRemove, timeToWaitForConfirmation: TimeSpan.FromSeconds(60)));
                     var result2 = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, shardNumber: 2, hardDelete: true, fromNode: toRemove, timeToWaitForConfirmation: TimeSpan.FromSeconds(60)));
-                    await mainServer.ServerStore.Cluster.WaitForIndexNotification(result0.RaftCommandIndex + 1);
-                    await mainServer.ServerStore.Cluster.WaitForIndexNotification(result1.RaftCommandIndex + 1);
-                    await mainServer.ServerStore.Cluster.WaitForIndexNotification(result2.RaftCommandIndex + 1);
+                    await mainServer.ServerStore.Cluster.WaitForIndexNotification(result0.RaftCommandIndex);
+                    await mainServer.ServerStore.Cluster.WaitForIndexNotification(result1.RaftCommandIndex);
+                    await mainServer.ServerStore.Cluster.WaitForIndexNotification(result2.RaftCommandIndex);
                 }
 
                 using (var session = temp.OpenAsyncSession())
@@ -2959,6 +2959,9 @@ namespace SlowTests.Client.Attachments
                     //var attachmentChangeVector = context.GetChangeVector(attachment.Details.ChangeVector).Version.AsString();
                     //var attachmentChangeVector2 = context.GetChangeVector(attachment2.Details.ChangeVector).Version.AsString();
                     //Assert.Equal(attachmentChangeVector, attachmentChangeVector2);
+
+                    await EnsureNoReplicationLoopAsync(store1, mode: options.DatabaseMode);
+                    await EnsureNoReplicationLoopAsync(store2, mode: options.DatabaseMode);
                 }
             }
         }

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -320,6 +320,10 @@ namespace SlowTests.Server.Replication
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store3);
                 await EnsureReplicatingAsync(store3, store1);
+
+                await EnsureNoReplicationLoopAsync(store1, options.DatabaseMode);
+                await EnsureNoReplicationLoopAsync(store2, options.DatabaseMode);
+                await EnsureNoReplicationLoopAsync(store3, options.DatabaseMode);
             }
         }
 
@@ -390,6 +394,10 @@ namespace SlowTests.Server.Replication
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store3);
                 await EnsureReplicatingAsync(store3, store1);
+
+                await EnsureNoReplicationLoopAsync(store1, mode: options.DatabaseMode);
+                await EnsureNoReplicationLoopAsync(store2, mode: options.DatabaseMode);
+                await EnsureNoReplicationLoopAsync(store3, mode: options.DatabaseMode);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21617

### Additional description

1. Fix replication loop that was caused due to having multiple tombstones and comparing against an out dated one, causing bumping the etag and replicate it over and over again.

The fixes seems to to affect only 6.0, I was unable to create the same conditions in 5.4 due to a different code here:
6.0
https://github.com/ravendb/ravendb/blob/91b1c3246a5699be0749fc21565f7e7ddf5d0087/src/Raven.Server/Documents/Replication/ConflictManager.cs#L276
5.4
https://github.com/ravendb/ravendb/blob/41c0797f5f5bc5d6b9bbf0a9cd06db251d1297a7/src/Raven.Server/Documents/Replication/ConflictManager.cs#L276

2. conflict on attachment tombstone was resolved and put with not the merged change vector which caused sending it over again. 
Also, here is seems to be manifested only in a 6.0 sharded database, which has a different change vector format. 

I believe that those issues are the root cause to the timeouts that we had in the tests, since external replication loop would cause an excessive amount of raft commands to be generated and choke the cluster tx merger

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Current tests coverage
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
