### PR TITLE
RavenDB-21709 Prevent from using System store by two processes concurrently

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -108,6 +108,7 @@ namespace Raven.Server.ServerWide
         public const string LicenseLimitsStorageKey = "License/Limits/Key";
 
         private readonly CancellationTokenSource _shutdownNotification = new CancellationTokenSource();
+        private FileLocker _fileLocker;
 
         public CancellationToken ServerShutdown => _shutdownNotification.Token;
 
@@ -609,6 +610,9 @@ namespace Raven.Server.ServerWide
             }
             else
             {
+                _fileLocker = new FileLocker(Path.Combine(path.FullPath, "system.lock"));
+                _fileLocker.TryAcquireWriteLock(Logger);
+
                 options = StorageEnvironmentOptions.ForPath(path.FullPath, null, null, IoChanges, CatastrophicFailureNotification);
                 var secretKey = Path.Combine(path.FullPath, "secret.key.encrypted");
                 if (File.Exists(secretKey))
@@ -2442,7 +2446,8 @@ namespace Raven.Server.ServerWide
                         _clusterRequestExecutor,
                         ContextPool,
                         ByteStringMemoryCache.Cleaner,
-                        InitializationCompleted
+                        InitializationCompleted,
+                        _fileLocker
                     };
 
                     foreach (var disposable in toDispose)


### PR DESCRIPTION
This could happen if a service wasn't configured properly and resulted in corruptions of journal files.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21709/

### Additional description

Because of incorrect setup of RavenDB service we could end up in running two `Raven.Server` processes at the same time. In the service logs we could found:

```
systemd[1]: Stopping RavenDB...
systemd[1]: Stopped RavenDB.
cloud.sh[17294]: Received graceful exit request...
cloud.sh[17294]: Starting shut down...
systemd[1]: ravendb.service: Found left-over process 17302 (Raven.Server) in control group while starting unit. Ignoring.
systemd[1]: This usually indicates unclean termination of a previous run, or service implementation deficiencies.
systemd[1]: Started RavenDB.
```

This problem resulted in initializing and using `System` store from two processes. We failed on next startup steps of Raven.Server (System.InvalidOperationException: Could not start SNMP Engine at port 161) so the service was restarted again and resulted in errors like `Voron.Exceptions.InvalidJournalException` during the recovery on startup.

The solution is to the ensure that only single process can access `System` storage. Same as we do it for database storages.


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work

- No UI work is needed
