### PR TITLE
RavenDB-21722 Disposing SNMP engine on server shutdown

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -33,7 +33,7 @@ using TimeoutException = System.TimeoutException;
 
 namespace Raven.Server.Monitoring.Snmp
 {
-    public class SnmpWatcher
+    public class SnmpWatcher : IDisposable
     {
         private readonly ConcurrentDictionary<string, SnmpDatabase> _loadedDatabases = new ConcurrentDictionary<string, SnmpDatabase>(StringComparer.OrdinalIgnoreCase);
 
@@ -619,6 +619,12 @@ namespace Raven.Server.Monitoring.Snmp
             }
 
             return result;
+        }
+
+        public void Dispose()
+        {
+            _snmpEngine?.Dispose();
+            _snmpEngine = null;
         }
 
         private class SnmpLogger : ILogger

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2731,6 +2731,7 @@ namespace Raven.Server
                     ea.Execute(() => CloseTcpListeners(_tcpListenerStatus.Listeners));
                 }
                 ea.Execute(() => PostgresServer?.Dispose());
+                ea.Execute(() => SnmpWatcher?.Dispose());
 
                 ea.Execute(() => ServerStore?.Dispose());
                 ea.Execute(() =>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21722/SnmpEngine-isnt-stopped-disposed-on-server-shutdown

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
