### PR TITLE
RavenDB-21681 - Replication loop and high CPU on A and C after expira…

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -306,7 +306,10 @@ namespace Raven.Server.Documents.TimeSeries
                 {
                     table.DeleteByKey(slicer.TimeSeriesKeySlice);
                     Stats.DeleteStats(context, collectionName, slicer.StatsKey);
-                    RemoveTimeSeriesNameFromMetadata(context, slicer.DocId, slicer.Name);
+
+                    if (updateMetadata)
+                        RemoveTimeSeriesNameFromMetadata(context, slicer.DocId, slicer.Name);
+
                     return remoteChangeVector;
                 }
 

--- a/test/SlowTests/Issues/RavenDB_21681.cs
+++ b/test/SlowTests/Issues/RavenDB_21681.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Expiration;
+using SlowTests.Core.Utils.Entities;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21681 : ReplicationTestBase
+    {
+        public RavenDB_21681(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Cluster | RavenTestCategory.Replication | RavenTestCategory.TimeSeries | RavenTestCategory.ExpirationRefresh)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task DeleteExpiredDocumentWithBigTimeSeriesShouldNotCauseReplicationToBreak(Options options)
+        {
+            var databaseName = GetDatabaseName();
+            var (nodes, leader) = await CreateRaftCluster(2);
+            var (_, servers) = await CreateDatabaseInClusterForMode(databaseName, 2, (nodes, leader), options.DatabaseMode);
+
+            using (var store = new DocumentStore { Database = databaseName, Urls = new[] { leader.WebUrl } }.Initialize())
+            {
+                var user = new User { Name = "Shiran" };
+
+                var expiry = DateTime.Now.AddYears(-1).ToUniversalTime();
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(user);
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    metadata[Constants.Documents.Metadata.Expires] = expiry.ToString(DefaultFormat.DateTimeFormatsToRead[0]);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var ts = session.TimeSeriesFor(user.Id, "heartbeat");
+                    for (int i = 0; i < 4_000_000; i++)
+                        ts.Append(expiry.AddMilliseconds(i), new List<double> { i, i * 100, i * 200, i * int.MaxValue });
+
+                    await session.SaveChangesAsync();
+                }
+
+                Assert.True(await WaitForChangeVectorInClusterForModeAsync(nodes, databaseName, options.DatabaseMode, 2, 30_000));
+
+                await ExpirationHelper.SetupExpirationAsync(store, new ExpirationConfiguration { Disabled = false, DeleteFrequencyInSec = 5 });
+
+                await WaitAndAssertForValueAsync(async () =>
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var u = await session.LoadAsync<User>(user.Id);
+                        return u == null;
+                    }
+
+                }, true);
+
+                var user2 = new User { Name = "Shiran2" };
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(user2);
+                    await session.SaveChangesAsync();
+                }
+
+                Assert.True(await WaitForDocumentInClusterAsync<User>(servers, databaseName, user2.Id, u => u.Name == "Shiran2", TimeSpan.FromSeconds(30)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
…tion kicks in on B

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21681/Replication-loop-and-high-CPU-on-A-and-C-after-expiration-kicks-in-on-B

### Additional description

The issue is reproducible with one expired document with big TS (~500,000 entries, ~4,000 segments).
When enabling expiration - the first node in the database topology performs the expiration - that deletes the document and the document's TS in one go (directly from the TS table). But, receiving the TS deleted range (from = `int.MinValue`; to = `int.MaxValue`) through replication omits the case where the deleted range covers the entire TS and instead deletes the TS segments one by one. That can cause (as happened in this issue) high CPU and then replication to stop responding. 


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
