### PR TITLE
RavenDB-21644: handle usage of database cancellation token after it was disposed

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -678,7 +678,7 @@ namespace Raven.Server.Documents
                 if (_skipUsagesCount == false)
                     Interlocked.Increment(ref _parent._usages);
 
-                if (_parent.DatabaseShutdown.IsCancellationRequested)
+                if (_parent.IsShutdownRequested())
                 {
                     Dispose();
                     _parent.ThrowDatabaseShutdown();
@@ -1893,6 +1893,19 @@ namespace Raven.Server.Documents
             }
 
             return hash;
+        }
+
+        public bool IsShutdownRequested()
+        {
+            return _databaseShutdown.IsCancellationRequested;
+        }
+
+        public void ThrowIfShutdownRequested()
+        {
+            if (_databaseShutdown.IsCancellationRequested)
+            {
+                throw new OperationCanceledException($"Database '{Name}' is shutting down.");
+            }
         }
 
         internal TestingStuff ForTestingPurposesOnly()

--- a/src/Raven.Server/Documents/ETL/Handlers/EtlHandler.cs
+++ b/src/Raven.Server/Documents/ETL/Handlers/EtlHandler.cs
@@ -103,23 +103,34 @@ namespace Raven.Server.Documents.ETL.Handlers
             {
                 var etls = GetProcessesToReportOn();
 
-                var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
-                var receive = webSocket.ReceiveAsync(receiveBuffer, Database.DatabaseShutdown);
-
-                await using (var ms = new MemoryStream())
-                using (var collector = new LiveEtlPerformanceCollector(Database, etls))
+                try
                 {
-                    // 1. Send data to webSocket without making UI wait upon opening webSocket
-                    await collector.SendStatsOrHeartbeatToWebSocket(receive, webSocket, ContextPool, ms, 100);
+                    var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
+                    var receive = webSocket.ReceiveAsync(receiveBuffer, Database.DatabaseShutdown);
 
-                    // 2. Send data to webSocket when available
-                    while (Database.DatabaseShutdown.IsCancellationRequested == false)
+                    await using (var ms = new MemoryStream())
+                    using (var collector = new LiveEtlPerformanceCollector(Database, etls))
                     {
-                        if (await collector.SendStatsOrHeartbeatToWebSocket(receive, webSocket, ContextPool, ms, 4000) == false)
+                        // 1. Send data to webSocket without making UI wait upon opening webSocket
+                        await collector.SendStatsOrHeartbeatToWebSocket(receive, webSocket, ContextPool, ms, 100);
+
+                        // 2. Send data to webSocket when available
+                        while (Database.DatabaseShutdown.IsCancellationRequested == false)
                         {
-                            break;
+                            if (await collector.SendStatsOrHeartbeatToWebSocket(receive, webSocket, ContextPool, ms, 4000) == false)
+                            {
+                                break;
+                            }
                         }
                     }
+                }
+                catch (OperationCanceledException)
+                {
+                    // disposing
+                }
+                catch (ObjectDisposedException)
+                {
+                    // disposing
                 }
             }
         }

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -271,7 +271,7 @@ namespace Raven.Server.Documents.Handlers
                 }
                 catch (Exception e)
                 {
-                    if (Database.DatabaseShutdown.IsCancellationRequested)
+                    if (Database.IsShutdownRequested())
                         Database.ThrowDatabaseShutdown(e);
 
                     throw;

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -433,26 +433,37 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/subscriptions/performance/live", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, SkipUsagesCount = true)]
         public async Task PerformanceLive()
         {
-            using (var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync())
+            try
             {
-                var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
-                var receive = webSocket.ReceiveAsync(receiveBuffer, Database.DatabaseShutdown);
-
-                using (var ms = new MemoryStream())
-                using (var collector = new LiveSubscriptionPerformanceCollector(Database))
+                using (var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync())
                 {
-                    // 1. Send data to webSocket without making UI wait upon opening webSocket
-                    await collector.SendStatsOrHeartbeatToWebSocket(receive, webSocket, ContextPool, ms, 100);
+                    var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
+                    var receive = webSocket.ReceiveAsync(receiveBuffer, Database.DatabaseShutdown);
 
-                    // 2. Send data to webSocket when available
-                    while (Database.DatabaseShutdown.IsCancellationRequested == false)
+                    using (var ms = new MemoryStream())
+                    using (var collector = new LiveSubscriptionPerformanceCollector(Database))
                     {
-                        if (await collector.SendStatsOrHeartbeatToWebSocket(receive, webSocket, ContextPool, ms, 4000) == false)
+                        // 1. Send data to webSocket without making UI wait upon opening webSocket
+                        await collector.SendStatsOrHeartbeatToWebSocket(receive, webSocket, ContextPool, ms, 100);
+
+                        // 2. Send data to webSocket when available
+                        while (Database.DatabaseShutdown.IsCancellationRequested == false)
                         {
-                            break;
+                            if (await collector.SendStatsOrHeartbeatToWebSocket(receive, webSocket, ContextPool, ms, 4000) == false)
+                            {
+                                break;
+                            }
                         }
                     }
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                // disposing
+            }
+            catch (ObjectDisposedException)
+            {
+                // disposing
             }
         }
 

--- a/src/Raven.Server/NotificationCenter/Handlers/ThreadsInfoHandler.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ThreadsInfoHandler.cs
@@ -14,10 +14,21 @@ namespace Raven.Server.NotificationCenter.Handlers
         [RavenAction("/threads-info/watch", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, SkipUsagesCount = true)]
         public async Task GetThreadsInfo()
         {
-            using (var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync())
-            using (var writer  = new NotificationCenterWebSocketWriter(webSocket, ServerStore.ThreadsInfoNotifications, ServerStore.ContextPool, ServerStore.ServerShutdown))
+            try
             {
-                await writer.WriteNotifications(null);
+                using (var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync())
+                using (var writer = new NotificationCenterWebSocketWriter(webSocket, ServerStore.ThreadsInfoNotifications, ServerStore.ContextPool, ServerStore.ServerShutdown))
+                {
+                    await writer.WriteNotifications(null);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // disposing
+            }
+            catch (ObjectDisposedException)
+            {
+                // disposing
             }
         }
     }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21644

### Additional description

- Fixed test
- Catch `ObjectDisposedException` on all endpoints that have `SkipUsagesCount = true` (ws enpoints) since they may be still running after the database was disposed.

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
