### PR TITLE
RavenDB-21703 Create different CompareExchangeResult for each command attempt

### DIFF
--- a/test/SlowTests/Cluster/CompareExchangeTests.cs
+++ b/test/SlowTests/Cluster/CompareExchangeTests.cs
@@ -53,6 +53,7 @@ public class CompareExchangeTests : RavenTestBase
             var (_, result) = await leader.ServerStore.Engine.CurrentLeader.PutAsync(toRunTwiceCommand2, toRunTwiceCommand2.Timeout.Value);
             Assert.NotNull(result);
             var compareExchangeResult = (CompareExchangeCommandBase.CompareExchangeResult)result;
+            Assert.Equal(context, ((BlittableJsonReaderObject)compareExchangeResult.Value)._context);
             Assert.Equal(value, compareExchangeResult.Value);
 
             await timeoutAttemptTask;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21703

### Additional description
The bug was because two command attempts could get the same object.
To fix that a new instance is created for each CompareExchangeResult

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
