### PR TITLE
RavenDB-21703 Deserialize result when retrieved from the history logs

### DIFF
--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -782,12 +782,19 @@ namespace Raven.Server.Rachis
                                     }
                                     else
                                     {
-                                        if (result != null && cmd.BlittableResultWriter != null)
+                                        if (result != null)
                                         {
-                                            cmd.BlittableResultWriter.CopyResult(result);
-                                            //The result are consumed by the `CopyResult` and the context of the result from `HasHistoryLog` is not valid outside
-                                            //so we `TrySetResult` to null to make sure no use of invalid context 
-                                            result = null;
+                                            if (cmd.BlittableResultWriter != null)
+                                            {
+                                                cmd.BlittableResultWriter.CopyResult(result);
+                                                //The result are consumed by the `CopyResult` and the context of the result from `HasHistoryLog` is not valid outside
+                                                //so we `TrySetResult` to null to make sure no use of invalid context 
+                                                result = null;
+                                            }
+                                            else
+                                            {
+                                                result = cmd.Command.FromRemote(result);
+                                            }
                                         }
 
                                         cmd.Tcs.TrySetResult(Task.FromResult<(long, object)>((index, result)));


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21703

### Additional description
When a complex result is retrieved from the history logs the result are serialized result on the context.
We need to deserialize them before setting the result.
This is relevant only when a command is sent multiple times and the later command is dequeued after the execution is finished.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- Should add test

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
