### PR TITLE
RavenDB-21724 : fix flaky test

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3589,7 +3589,7 @@ namespace Raven.Server.ServerWide
 
             rawRecord = new RawDatabaseRecord(context, rawRecord)
                 .GetShardedDatabaseRecord(shardNumber)
-                .Raw;
+                ?.Raw;
 
             return rawRecord;
         }

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -223,9 +223,8 @@ namespace Raven.Server.ServerWide
         {
             Sharding.Raw.TryGet(nameof(ShardingConfiguration.Shards), out BlittableJsonReaderObject shardTopologies);
             if (shardTopologies.TryGet(shardNumber.ToString(), out BlittableJsonReaderObject shardedTopology) == false)
-            {
-                throw new ArgumentException($"Can't fetch topology of shard number {shardNumber} from the raw record because it does not exist.");
-            }
+                return null;
+            
             var shardName = ShardHelper.ToShardName(DatabaseName, shardNumber);
 
             var settings = new Dictionary<string, string>();
@@ -286,7 +285,7 @@ namespace Raven.Server.ServerWide
 
                 var shardedDatabaseRecord = GetShardedDatabaseRecord(shardNumber);
                 if (nodeTag == null || shardedDatabaseRecord.Topology.RelevantFor(nodeTag))
-                    yield return GetShardedDatabaseRecord(shardNumber);
+                    yield return shardedDatabaseRecord;
             }
         }
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -756,7 +756,8 @@ namespace Raven.Server.Web.System
                                 var allNodesDeleted = true;
                                 foreach (var node in parameters.FromNodes)
                                 {
-                                    if (raw.DeletionInProgress.ContainsKey(node) == false)
+                                    var key = DatabaseRecord.GetKeyForDeletionInProgress(node, databaseName);
+                                    if (raw.DeletionInProgress.ContainsKey(key) == false)
                                         continue;
 
                                     allNodesDeleted = false;

--- a/test/SlowTests/Sharding/ShardingTopologyTests.cs
+++ b/test/SlowTests/Sharding/ShardingTopologyTests.cs
@@ -190,13 +190,7 @@ namespace SlowTests.Sharding
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(deleteShardDatabaseRes.RaftCommandIndex);
                 }
 
-                DatabaseRecord record = null;
-                await WaitAndAssertForValueAsync(async () =>
-                {
-                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                    return record.DeletionInProgress.Count;
-                }, expectedVal: 0);
-
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                 Assert.Equal(2, record.Sharding.Shards.Count);
 
                 //make sure the nodes that held the deleted shard no longer have any of this shard's db instances

--- a/test/SlowTests/Sharding/ShardingTopologyTests.cs
+++ b/test/SlowTests/Sharding/ShardingTopologyTests.cs
@@ -190,7 +190,13 @@ namespace SlowTests.Sharding
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(deleteShardDatabaseRes.RaftCommandIndex);
                 }
 
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                DatabaseRecord record = null;
+                await WaitAndAssertForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.DeletionInProgress.Count;
+                }, expectedVal: 0);
+
                 Assert.Equal(2, record.Sharding.Shards.Count);
 
                 //make sure the nodes that held the deleted shard no longer have any of this shard's db instances


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21724/SlowTests.Sharding.ShardingTopologyTests.AddAndDeleteShardFromDatabaseShardHasNoBucketsMapping

## Additional Description ##
- test failure is related to these changes : 
https://github.com/ravendb/ravendb/pull/17629

- in `AdminDatabasesHandler.Delete` - when checking if database is still in `DeletionInProgress` we need to use `GetKeyForDeletionInProgress`
- also, changed `GetShardedDatabaseRecord(shardNumber)` to return null (instead of throwing) when `shardNumber` is not in the topology.
otherwise we will get an exception when waiting for deletion to complete ([here](https://github.com/ravendb/ravendb/blob/v6.0/src/Raven.Server/Web/System/AdminDatabasesHandler.cs#L745)) if we're deleting a shard from it's single node

### Type of change

- Bug fix
- Tests stabilization 

### How risky is the change?

- Low 