### PR TITLE
RavenDB-21709 Make sure we dispose the server in a test if we fail to initialize it

### DIFF
--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -530,19 +530,27 @@ namespace FastTests
                     DebugTag = caller
                 };
 
-                if (options.BeforeDatabasesStartup != null)
-                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().BeforeHandleClusterDatabaseChanged = options.BeforeDatabasesStartup;
+                try
+                {
+                    if (options.BeforeDatabasesStartup != null)
+                        server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().BeforeHandleClusterDatabaseChanged = options.BeforeDatabasesStartup;
 
-                server.Initialize();
-                server.ServerStore.ValidateFixedPort = false;
+                    server.Initialize();
+                    server.ServerStore.ValidateFixedPort = false;
 
-                if (options.RegisterForDisposal)
-                    ServersForDisposal.Add(server);
+                    if (options.RegisterForDisposal)
+                        ServersForDisposal.Add(server);
 
-                if (LeakedServers.TryAdd(server, server.DebugTag))
-                    server.AfterDisposal += () => LeakedServers.TryRemove(server, out _);
+                    if (LeakedServers.TryAdd(server, server.DebugTag))
+                        server.AfterDisposal += () => LeakedServers.TryRemove(server, out _);
 
-                return server;
+                    return server;
+                }
+                catch
+                {
+                    server.Dispose();
+                    throw;
+                } 
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21709

### Additional description
Fix in tests

### Type of change

- Test fix
- 
### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Existing test will verify the fix

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
