### PR TITLE
RavenDB-21609 Query has to change sorting guarantees dynamically due to primitive usage.

### DIFF
--- a/src/Corax/Querying/Matches/MemoizationMatch.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.cs
@@ -18,7 +18,6 @@ namespace Corax.Querying.Matches
 
         public SkipSortingResult AttemptToSkipSorting()
         {
-             _inner.SkipSortingResults();
              return SkipSortingResult.WillSkipSorting;
         }
 

--- a/test/SlowTests/Corax/Bugs/RavenDB-21609.cs
+++ b/test/SlowTests/Corax/Bugs/RavenDB-21609.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax.Bugs;
+
+public class RavenDB_21609 : RavenTestBase
+{
+    public RavenDB_21609(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [InlineData(218827642)] // 7228 docs
+    [InlineData(1635325874)] // 12187 docs
+    [InlineData(650027346)] // 12256 docs
+    [InlineData(2116002769)] // 15834 docs
+    public void SortingWillReturnExactlySameResultsAndQueryWithoutSortingMatch(int seed)
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        var random = new Random(seed);
+
+        var howManyTerms = random.Next(3, 20);
+        var terms = Enumerable.Range(0, howManyTerms).Select(x => "SecretName" + string.Join("", Enumerable.Range(0, x).Select(x => "a"))).ToArray();
+        var howManyDocument = random.Next(5000, 100_000);
+        List<Dto> db = new();       
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < howManyDocument; ++i)
+            {
+                var type = i % 11 == 0 ? "Best" : "Bad";
+                var version = i % 22 == 0 ? "123" : "321";
+                var name = terms[random.Next(0, terms.Length)];
+                var entity = new Dto(name, type, version, true, DateTime.Now.AddDays(i));
+                bulk.Store(entity);
+                db.Add(entity);
+            }
+        }
+
+        
+        new DtoIndex(SearchEngineType.Corax).Execute(store);
+        new DtoIndex(SearchEngineType.Lucene).Execute(store);
+        Indexes.WaitForIndexing(store);
+        
+        using var session = store.OpenSession();
+        var query = session.Query<Dto>("Corax/DtoIndex")
+            .Customize(x => x.WaitForNonStaleResults())
+            .Where(x => x.Name.StartsWith("SecretName") &&
+                        x.Version.StartsWith("123") &&
+                        x.Type == "Best")
+            .OrderByDescending(x => x.Time).ToList();
+        
+        var luceneQuery = session.Query<Dto>("Lucene/DtoIndex")
+            .Customize(x => x.WaitForNonStaleResults())
+            .Where(x => x.Name.StartsWith("SecretName") &&
+                        x.Version.StartsWith("123") &&
+                        x.Type == "Best")
+            .OrderByDescending(x => x.Time).ToList();
+        
+        var queryWithoutSorting = session.Query<Dto, DtoIndex>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .Where(x => x.Name.StartsWith("SecretName") &&
+                        x.Version.StartsWith("123") &&
+                        x.Type == "Best")
+            .ToList();
+        var linq = db.Where(x => x.Name.StartsWith("SecretName") &&
+                                 x.Version.StartsWith("123") &&
+                                 x.Type == "Best").ToList();
+        
+        Assert.Equal(linq.Count, queryWithoutSorting.Count);
+        Assert.Equal(luceneQuery.Count, queryWithoutSorting.Count);
+        Assert.Equal(queryWithoutSorting.Count, query.Count);
+    }
+
+    private record Dto(string Name, string Type, string Version, bool Boolean, DateTime Time, string Id = null);
+
+    private class DtoIndex : AbstractIndexCreationTask<Dto>
+    {
+        private string _indexName;
+        
+        public override string IndexName { get => _indexName; }
+
+        public DtoIndex()
+        {
+        }
+        
+        public DtoIndex(SearchEngineType searchEngineType)
+        {
+            Map = dtos => dtos.Select(x => new {x.Name, x.Version, x.Time, x.Type});
+
+            _indexName = (searchEngineType is Raven.Client.Documents.Indexes.SearchEngineType.Corax ? "Corax/" : "Lucene/") + "DtoIndex";
+            SearchEngineType = searchEngineType;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21609

### Additional description

```csharp
// Rationale: Even though 'and' will always return a sorted array, it only sorts locally.
// Since we designed Fill to work in a streaming manner, the user can (and in most cases will) call Fill multiple times.
// There is no guarantee that returned IDs are sorted between batches.
// To better understand the issue, let's assume we have a MultiTermMatch (startsWith) with terms "a" and "aa".
// The term "a" has documents with IDs in the range <8k; 12k>, and "aa" has older documents in the range <6k; 7k>.
// The first call will return sorted matches in the range <8k; 12k> (and will fetch all from this term)
// , so the next call will get values from <6k; 7k>.
// Therefore, if the caller is relying on _skipSortingResult, we have to change it to SortingIsRequired
// since there is no guarantee it will be sorted.
```
### Type of change

- Bug fix


### How risky is the change?

- Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
