### PR TITLE
RavenDB-21728: Transactions can be too big for the C# ReadOnlySpan

### DIFF
--- a/test/FastTests/Sparrow/Hashing.cs
+++ b/test/FastTests/Sparrow/Hashing.cs
@@ -310,6 +310,9 @@ namespace FastTests.Sparrow
                     var result = Hashing.XXHash64.CalculateInline(values.AsSpan().Slice(0, i), seed);
 
                     Assert.Equal(expected, result);
+
+                    result = Hashing.XXHash64.CalculateInline(valuePtr, (ulong)i, seed);
+                    Assert.Equal(expected, result);
                 }
             }
         }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21728

### Additional description

This bug actually adds a few interesting points to consider. We are spanfying the core day by day. But there are locations that are either not possible to use Span<byte> and we need to be very careful to consider those cases to deal with them one by one at the design stage of those changes. 

### Type of change

- Bug fix
- Regression bug fix
- Optimization
- New feature

### How risky is the change?
- Low

### Backward compatibility
- Non breaking change
