### PR TITLE
RavenDB-21591: Define a heuristic for when to use the default dictionary.

### DIFF
--- a/bench/Micro.Benchmark/Benchmarks/HopeEncoder.cs
+++ b/bench/Micro.Benchmark/Benchmarks/HopeEncoder.cs
@@ -123,6 +123,7 @@ namespace Micro.Benchmark.Benchmarks
             private int _currentIdx = 0;
 
             public int Length => _values.Length;
+            public int Count { get; private set; }
 
             public bool IsNull(int i)
             {
@@ -161,6 +162,7 @@ namespace Micro.Benchmark.Benchmarks
             public void Reset()
             {
                 _currentIdx = 0;
+                Count = 0;
             }
 
             public bool MoveNext(out ReadOnlySpan<byte> result)
@@ -172,6 +174,7 @@ namespace Micro.Benchmark.Benchmarks
                 }
 
                 result = new(_values[_currentIdx++]);
+                Count++;
                 return true;
             }
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
@@ -19,7 +19,7 @@ using Constants = Raven.Client.Constants;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax;
 
-internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
+internal class CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
 {
     private sealed class Builder : IIndexEntryBuilder
     {
@@ -213,6 +213,8 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
     private readonly Size _maxAllocatedMemory;
     private readonly IndexingStatsScope _indexingStatsScope;
 
+    public int Count { get; private set; }
+
     public CoraxDocumentTrainEnumerator(TransactionOperationContext indexContext, CoraxDocumentConverterBase converter, Index index, IndexType indexType, DocumentsStorage storage, DocumentsOperationContext docsContext, HashSet<string> collections, CancellationToken token, IndexingStatsScope indexingStatsScope, int take = int.MaxValue)
     {
         _indexContext = indexContext;
@@ -232,6 +234,8 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
         _documentStorage = storage;
         _docsContext = docsContext;
         _collections = collections;
+
+        Count = 0;
     }
 
     private IEnumerable<ArraySegment<byte>> GetItems()
@@ -326,6 +330,7 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
 
     public void Reset()
     {
+        Count = 0;
         _itemsEnumerable = GetItems().GetEnumerator();
     }
 
@@ -359,6 +364,7 @@ internal struct CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
 
         var current = _itemsEnumerable.Current;
         output = current.AsSpan();
+        Count++;
         return true;
     }
 }

--- a/src/Sparrow.Server/Compression/Encoder3Gram.cs
+++ b/src/Sparrow.Server/Compression/Encoder3Gram.cs
@@ -61,7 +61,7 @@ namespace Sparrow.Server.Compression
         }
 
         public void Train<TSampleEnumerator>(in TSampleEnumerator enumerator, int dictionarySize)
-            where TSampleEnumerator : struct, IReadOnlySpanEnumerator
+            where TSampleEnumerator : IReadOnlySpanEnumerator
         {
             var symbolSelector = new Encoder3GramSymbolSelector<TSampleEnumerator>();
             var frequencyList = symbolSelector.SelectSymbols(enumerator, dictionarySize);

--- a/src/Sparrow.Server/Compression/Encoder3GramSymbolSelector.cs
+++ b/src/Sparrow.Server/Compression/Encoder3GramSymbolSelector.cs
@@ -9,7 +9,7 @@ using Sparrow.Collections;
 namespace Sparrow.Server.Compression
 {
     internal sealed unsafe class Encoder3GramSymbolSelector<TSampleEnumerator>
-        where TSampleEnumerator : struct, IReadOnlySpanEnumerator
+        where TSampleEnumerator : IReadOnlySpanEnumerator
     {
         private struct ByFrequencyComparer : IComparer<SymbolFrequency>
         {

--- a/src/Sparrow.Server/Compression/HopeEncoder.cs
+++ b/src/Sparrow.Server/Compression/HopeEncoder.cs
@@ -33,7 +33,7 @@ namespace Sparrow.Server.Compression
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Train<TSampleEnumerator>(in TSampleEnumerator enumerator, int dictionarySize)
-            where TSampleEnumerator : struct, IReadOnlySpanEnumerator
+            where TSampleEnumerator : IReadOnlySpanEnumerator
         {
             _encoder.Train(enumerator, dictionarySize);
             _maxSequenceLength = _encoder.MaxBitSequenceLength;

--- a/src/Sparrow.Server/Compression/IEncoderAlgorithm.cs
+++ b/src/Sparrow.Server/Compression/IEncoderAlgorithm.cs
@@ -8,7 +8,7 @@ namespace Sparrow.Server.Compression
         public int MinBitSequenceLength { get; }
 
         void Train<TSampleEnumerator>(in TSampleEnumerator enumerator, int dictionarySize)
-            where TSampleEnumerator : struct, IReadOnlySpanEnumerator;
+            where TSampleEnumerator : IReadOnlySpanEnumerator;
 
         void EncodeBatch<TSampleEnumerator, TOutputEnumerator>(in TSampleEnumerator data, Span<int> outputSizes, in TOutputEnumerator outputBuffer)
             where TSampleEnumerator : struct, IReadOnlySpanIndexer

--- a/src/Sparrow/SpanEnumerators.cs
+++ b/src/Sparrow/SpanEnumerators.cs
@@ -4,6 +4,7 @@ namespace Sparrow
 {
     public interface IReadOnlySpanEnumerator
     {
+        int Count { get; }
         void Reset();
         bool MoveNext(out ReadOnlySpan<byte> result);
     }

--- a/test/FastTests/Sparrow/Encoder3GramTests.cs
+++ b/test/FastTests/Sparrow/Encoder3GramTests.cs
@@ -44,6 +44,8 @@ namespace FastTests.Sparrow
 
             public int Length => _values.Length;
 
+            public int Count { get; private set;}
+
             public bool IsNull(int i)
             {
                 if (i < 0 || i >= Length)
@@ -80,6 +82,7 @@ namespace FastTests.Sparrow
             public void Reset()
             {
                 _currentIdx = 0;
+                Count = 0;
             }
 
             public bool MoveNext(out ReadOnlySpan<byte> result)
@@ -91,6 +94,7 @@ namespace FastTests.Sparrow
                 }
 
                 result = new(_values[_currentIdx++]);
+                Count++;
                 return true;
             }
         }
@@ -99,6 +103,8 @@ namespace FastTests.Sparrow
         {
             private readonly byte[][] _values;
             private int _currentIdx = 0;
+
+            public int Count { get; private set; }
 
             public int Length => _values.Length;
 
@@ -122,6 +128,7 @@ namespace FastTests.Sparrow
             public void Reset()
             {
                 _currentIdx = 0;
+                Count = 0;
             }
 
             public bool MoveNext(out ReadOnlySpan<byte> result)
@@ -133,6 +140,7 @@ namespace FastTests.Sparrow
                 }
 
                 result = _values[_currentIdx++].AsSpan();
+                Count++;
                 return true;
             }
         }
@@ -141,11 +149,14 @@ namespace FastTests.Sparrow
         private struct EmptyKeys : IReadOnlySpanIndexer, IReadOnlySpanEnumerator
         {
             public int Length => 0;
+            public int Count { get; private set; }
 
             public ReadOnlySpan<byte> this[int i] => throw new IndexOutOfRangeException();
 
             public void Reset()
-            {}
+            {
+                Count = 0;
+            }
 
             public bool MoveNext(out ReadOnlySpan<byte> result)
             {

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -7,6 +7,7 @@ using Raven.Server.Utils;
 using SlowTests.Corax;
 using SlowTests.Sharding.Cluster;
 using Xunit;
+using FastTests.Sparrow;
 
 namespace Tryouts;
 
@@ -17,7 +18,7 @@ public static class Program
         XunitLogging.RedirectStreams = false;
     }
 
-    public static async Task Main(string[] args)
+    public static void Main(string[] args)
     {
         Console.WriteLine(Process.GetCurrentProcess().Id);
 
@@ -27,13 +28,17 @@ public static class Program
 
             try
             {
-                TryRemoveDatabasesFolder();
-                using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new ShardedClusterObserverTests(testOutputHelper))
+                //TryRemoveDatabasesFolder();
+
+                Parallel.For(0, 100, x =>
                 {
-                    DebuggerAttachedTimeout.DisableLongTimespan = true;
-                    await test.ClusterObserverWillSkipCommandIfChangingTheSameDatabaseRecordTwiceInOneIteration();
-                }
+                    using (var testOutputHelper = new ConsoleTestOutputHelper())
+                    using (var test = new MemoryTests(testOutputHelper))
+                    {
+                        DebuggerAttachedTimeout.DisableLongTimespan = true;
+                        test.IncreasingSizeForLoop();
+                    }
+                });
             }
             catch (Exception e)
             {

--- a/tools/Voron.Dictionary.Generator/Program.cs
+++ b/tools/Voron.Dictionary.Generator/Program.cs
@@ -90,6 +90,7 @@ public struct StringArrayIterator : IReadOnlySpanIndexer, IReadOnlySpanEnumerato
         _values = values;
     }
 
+    public int Count { get; private set; }
     public int Length => _values.Length;
 
     public ReadOnlySpan<byte> this[int i] => Encoding.UTF8.GetBytes(_values[i]);
@@ -99,6 +100,7 @@ public struct StringArrayIterator : IReadOnlySpanIndexer, IReadOnlySpanEnumerato
     public void Reset()
     {
         _currentIdx = 0;
+        Count = 0;
     }
 
     public bool MoveNext(out ReadOnlySpan<byte> result)
@@ -110,6 +112,7 @@ public struct StringArrayIterator : IReadOnlySpanIndexer, IReadOnlySpanEnumerato
         }
         
         result = Encoding.UTF8.GetBytes(_values[_currentIdx++]);
+        Count++;
         return true;
     }
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21591

### Additional description

It turns out that we were not using the default dictionary as the code never allowed that to happen. Therefore, we were being suboptimal in the case where the index was created without sample documents. The current heuristic for when to use the default dictionary has been changed to at least require 500 documents. If there are not enough documents the overfitting would cause the compression to be suboptimal anyways, so asking for 500 documents seems a reasonable approach. 

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change
