### PR TITLE
RavenDB-21594 after merge fixes, need to use DatabaseSmugglerFactory instead of creating a destination directly

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTask.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.ServerWide;
-using Raven.Server.Smuggler.Documents;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
@@ -15,7 +14,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
         protected override async Task RestoreAsync()
         {
-            await SmugglerRestoreAsync(Database, Context, new DatabaseDestination(Database));
+            await SmugglerRestoreAsync(Database, Context, Database.Smuggler.CreateDestination());
         }
 
         protected override async Task InitializeAsync()

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             await RestoreFromSmugglerFileAsync(Progress, Database, _firstFile, Context);
             await HandleSubscriptionFromSnapshot(FilesToRestore, RestoreSettings.Subscriptions, DatabaseName, Database);
-            await SmugglerRestoreAsync(Database, Context, new SnapshotDatabaseDestination(Database, RestoreSettings.Subscriptions));
+            await SmugglerRestoreAsync(Database, Context, Database.Smuggler.CreateDestinationForSnapshotRestore(RestoreSettings.Subscriptions));
 
             Result.SnapshotRestore.Processed = true;
 

--- a/src/Raven.Server/Documents/Sharding/Smuggler/ShardedDatabaseSmugglerFactory.cs
+++ b/src/Raven.Server/Documents/Sharding/Smuggler/ShardedDatabaseSmugglerFactory.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Smuggler;
 using Raven.Server.Smuggler.Documents;
@@ -24,6 +27,11 @@ public sealed class ShardedDatabaseSmugglerFactory : AbstractDatabaseSmugglerFac
     public override DatabaseDestination CreateDestination(CancellationToken token = default)
     {
         return new ShardedDatabaseDestination(_database, token);
+    }
+
+    public override DatabaseDestination CreateDestinationForSnapshotRestore(Dictionary<string, SubscriptionState> subscriptions, CancellationToken token = default)
+    {
+        throw new NotSupportedInShardingException();
     }
 
     public override DatabaseSource CreateSource(long startDocumentEtag, long startRaftIndex, Logger logger)

--- a/src/Raven.Server/Documents/Smuggler/AbstractDatabaseSmugglerFactory.cs
+++ b/src/Raven.Server/Documents/Smuggler/AbstractDatabaseSmugglerFactory.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
@@ -13,6 +15,8 @@ namespace Raven.Server.Documents.Smuggler;
 public abstract class AbstractDatabaseSmugglerFactory
 {
     public abstract DatabaseDestination CreateDestination(CancellationToken token = default);
+
+    public abstract DatabaseDestination CreateDestinationForSnapshotRestore(Dictionary<string, SubscriptionState> subscriptions, CancellationToken token = default);
 
     public abstract DatabaseSource CreateSource(long startDocumentEtag, long startRaftIndex, Logger logger);
 

--- a/src/Raven.Server/Documents/Smuggler/DatabaseSmugglerFactory.cs
+++ b/src/Raven.Server/Documents/Smuggler/DatabaseSmugglerFactory.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
@@ -24,6 +26,11 @@ public sealed class DatabaseSmugglerFactory : AbstractDatabaseSmugglerFactory
     public override DatabaseDestination CreateDestination(CancellationToken token = default)
     {
         return new DatabaseDestination(_database, token);
+    }
+
+    public override DatabaseDestination CreateDestinationForSnapshotRestore(Dictionary<string, SubscriptionState> subscriptions, CancellationToken token = default)
+    {
+        return new SnapshotDatabaseDestination(_database, subscriptions, token);
     }
 
     public override DatabaseSource CreateSource(long startDocumentEtag, long startRaftIndex, Logger logger)

--- a/src/Raven.Server/Smuggler/Documents/SnapshotDatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/SnapshotDatabaseDestination.cs
@@ -15,7 +15,8 @@ namespace Raven.Server.Smuggler.Documents
     {
         private readonly Dictionary<string, SubscriptionState> _subscriptions;
 
-        public SnapshotDatabaseDestination(DocumentDatabase database, Dictionary<string, SubscriptionState> subscriptions, CancellationToken token = default) : base(database, token)
+        public SnapshotDatabaseDestination(DocumentDatabase database, Dictionary<string, SubscriptionState> subscriptions, CancellationToken token = default)
+            : base(database, token)
         {
             _subscriptions = subscriptions;
         }

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-            const int numberToTolerate = 4654;
+            const int numberToTolerate = 4657;
 
             if (array.Length == numberToTolerate)
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21594

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change
- 
### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
