### PR TITLE
RavenDB-21552 set fixed interval of 1 minute at which we do speed checks

### DIFF
--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -211,11 +211,8 @@ namespace Raven.Client.Http
             if (state.Failures[state.Fastest] == 0 && state.Nodes[state.Fastest].ServerRole == ServerNode.Role.Member)
                 return (state.Fastest, state.Nodes[state.Fastest]);
             
-            // if the fastest node has failures, we'll immediately schedule
-            // another run of finding who the fastest node is, in the meantime
-            // we'll just use the server preferred node or failover as usual
-            
-            SwitchToSpeedTestPhase(null);
+            // until new fastest node is selected, we'll just use the server preferred node or failover as usual
+            ScheduleSpeedTest();
             return GetPreferredNode();
         }
 
@@ -303,19 +300,24 @@ namespace Raven.Client.Http
         {
             state.Fastest = index;
             Interlocked.Exchange(ref state.SpeedTestMode, 0);
-            EnsureFastestNodeTimerExists();
-            _updateFastestNodeTimer.Change(TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
+            ScheduleSpeedTest();
         }
+
+        private readonly object _timerCreationLocker = new object();
 
         public void ScheduleSpeedTest()
         {
-            EnsureFastestNodeTimerExists();
-            SwitchToSpeedTestPhase(null);
-        }
+            if (_updateFastestNodeTimer != null)
+                return;
 
-        private void EnsureFastestNodeTimerExists()
-        {
-            _updateFastestNodeTimer ??= new Timer(SwitchToSpeedTestPhase, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            lock (_timerCreationLocker)
+            {
+                if (_updateFastestNodeTimer != null)
+                    return;
+
+                SwitchToSpeedTestPhase(null);
+                _updateFastestNodeTimer = new Timer(SwitchToSpeedTestPhase, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21552 

### Additional description

When using FastestNode we would spawn speed tests every time when current fastest node is in rehab.
With constantly changing topology, that would mean that we are always in a speed test phase mode.
In this mode we send read requests to **all** nodes in the topology.
which would destabilize the topology even further.

To avoid all this we simply do a fastest node check every minute (no matter what) and for failover in the meanwhile we use the preferred node.

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
