### PR TITLE
RavenDB-21555 - Sharding - failing Should_Throw_DatabaseDisabledException_When_MaxErroneousPeriod_Was_Passed

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -404,6 +404,8 @@ namespace Raven.Client.Documents.Subscriptions
                     DatabaseDoesNotExistException.ThrowWithMessage(_dbName, connectionStatus.Message);
                 else if (connectionStatus.Exception.Contains(nameof(NotSupportedInShardingException)))
                     throw new NotSupportedInShardingException(connectionStatus.Message);
+                else if (connectionStatus.Exception.Contains(nameof(DatabaseDisabledException)))
+                    throw new DatabaseDisabledException(connectionStatus.Message);
             }
 
             if (connectionStatus.Type != SubscriptionConnectionServerMessage.MessageType.ConnectionStatus)

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -714,6 +714,9 @@ namespace Raven.Server.Documents
 
         private ShardedDatabaseContext GetOrAddShardedDatabaseContext(StringSegment databaseName, RawDatabaseRecord databaseRecord)
         {
+            if (databaseRecord.IsDisabled)
+                throw new DatabaseDisabledException(databaseName + " has been disabled");
+
             if (databaseRecord.Sharding.Orchestrator.Topology.RelevantFor(_serverStore.NodeTag) == false)
                 throw new DatabaseNotRelevantException($"Can't get or add orchestrator for database {databaseName} because it is not relevant on this node {_serverStore.NodeTag}");
 

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
@@ -137,7 +137,14 @@ public abstract class AbstractSubscriptionStorage
 
     public void ReleaseSubscriptionsSemaphore()
     {
-        _concurrentConnectionsSemiSemaphore.Release();
+        try
+        {
+            _concurrentConnectionsSemiSemaphore.Release();
+        }
+        catch
+        {
+            //
+        }
     }
 }
 

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
@@ -141,9 +141,9 @@ public abstract class AbstractSubscriptionStorage
         {
             _concurrentConnectionsSemiSemaphore.Release();
         }
-        catch
+        catch (ObjectDisposedException)
         {
-            //
+            // Do nothing
         }
     }
 }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -509,6 +509,9 @@ namespace Raven.Server.Documents.Subscriptions
                 if (whoseTaskIsIt == null && record.DeletionInProgress.ContainsKey(ServerStore.NodeTag))
                     throw new DatabaseDoesNotExistException(
                         $"Stopping subscription '{name}' on node {ServerStore.NodeTag}, because database '{DatabaseName}' is being deleted.");
+                
+                if (record.IsDisabled)
+                    throw new DatabaseDisabledException($"Stopping subscription '{name}' on node {ServerStore.NodeTag}, because database '{DatabaseName}' is disabled.");
 
                 if (whoseTaskIsIt != ServerStore.NodeTag)
                 {

--- a/test/SlowTests/Issues/RavenDB-17650.cs
+++ b/test/SlowTests/Issues/RavenDB-17650.cs
@@ -8,6 +8,7 @@ using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
+using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -142,8 +143,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Subscriptions)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-21555")]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task Should_Throw_DatabaseDisabledException_When_MaxErroneousPeriod_Was_Passed(Options options)
         {
             using var store = GetDocumentStore(new Options(options)
@@ -179,6 +179,69 @@ namespace SlowTests.Issues
             var cts = new CancellationTokenSource();
 
             var aggregateException = await Assert.ThrowsAsync<AggregateException>(() => worker.Run(batch => { }, cts.Token));
+            var actualExceptionWasThrown = false;
+            var subscriptionInvalidStateExceptionWasThrown = false;
+            foreach (var e in aggregateException.InnerExceptions)
+            {
+                if (e is SubscriptionInvalidStateException)
+                {
+                    subscriptionInvalidStateExceptionWasThrown = true;
+                }
+                if (e is DatabaseDisabledException)
+                {
+                    actualExceptionWasThrown = true;
+                }
+
+                if (subscriptionInvalidStateExceptionWasThrown && actualExceptionWasThrown)
+                    break;
+            }
+            Assert.True(subscriptionInvalidStateExceptionWasThrown && actualExceptionWasThrown);
+        }
+
+        [RavenTheory(RavenTestCategory.Subscriptions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Should_Throw_DatabaseDisabledException_When_MaxErroneousPeriod_Was_Passed_DuringSubscriptionInProgress(Options options)
+        {
+            using var store = GetDocumentStore(new Options(options)
+            {
+                ReplicationFactor = 1,
+                RunInMemory = false
+            });
+
+            string id = "User/33-A";
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = id, Name = "1" });
+                await session.StoreAsync(new User { Name = "2" });
+
+                await session.SaveChangesAsync();
+            }
+
+            await store.Subscriptions
+                .CreateAsync(new SubscriptionCreationOptions<User>
+                {
+                    Name = "BackgroundSubscriptionWorker"
+                });
+
+            using var worker = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions("BackgroundSubscriptionWorker")
+            {
+                MaxErroneousPeriod = TimeSpan.Zero
+            });
+
+            var cts = new CancellationTokenSource();
+            var mre = new AsyncManualResetEvent();
+
+            var t = worker.Run(batch => { mre.Set(); }, cts.Token);
+            await mre.WaitAsync(cts.Token);
+
+            // disable database
+            var disableSucceeded = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, true));
+            Assert.True(disableSucceeded.Success);
+            Assert.True(disableSucceeded.Disabled);
+
+            var aggregateException = await Assert.ThrowsAsync<AggregateException>(() => t);
+            
             var actualExceptionWasThrown = false;
             var subscriptionInvalidStateExceptionWasThrown = false;
             foreach (var e in aggregateException.InnerExceptions)

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -294,7 +294,7 @@ namespace FastTests
                                 {
                                     // check that the database wasn't deleted
                                     var record = serverOperationStore.Maintenance.Server.Send(new GetDatabaseRecordOperation(name));
-                                    if (record != null)
+                                    if (record != null && record.Disabled == false)
                                         AsyncHelpers.RunSync(() => Sharding.EnsureNoDatabaseChangeVectorLeakAsync(store.Database));
                                 }
                             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21555

### Additional description

In Sharded db we wouldn't get aggregated exception of `DisabledDatabaseException` and `InvalidSubscriptionException` as we do in non-sharded.

The difference:

In non-sharded -> the server sends back a `DatabaseDisabledException` when the subscription worker tries to connect, then the worker receives this error and rethrows. And also throws another `SubscriptionInvalidStateException` when reaching `CheckIfShouldReconnectWorker->AssertLastConnectionFailure` in the `MaxErronousPeriod` check. This causes the worker to aggregate these 2 exceptions.

In sharded -> We connect to shards regardless if the db is disabled. Then they throw `DatabaseDisabledException`. `CheckIfShouldReconnectWorker (Sharded orverride) -> AssertLastConnectionFailure` throws an `SubscriptionInvalidStateException` upon `MaxErronousPeriod` check. The Sharded worker sets `SubscriptionInvalidStateException` in the orch state's `ConnectionException` to be reported to the actual client.
Client worker reads next batch from stream and rethrows the `SubscriptionInvalidStateException` (in `AssertConnectionState`).
We don't reach `AssertLastConnectionFailure` like in the non-sharded scenario because this time the client worker gets `SubscriptionInvalidStateException` instead of `DatabaseDisabledException`. Therefore the worker doesn't aggregate exceptions.

To get the same expected exceptions as we do in non-sharded:
Added a database disabled check to the orchestrator's `HandlePath` route, to avoid connecting to an orchestrator whose sharded db is disabled in the first place.
Also added such a check in subscription worker before attempting to connect to the shards.
Added support for rethrowing `DatabaseDisabledException` exception when analyzing the reported exception in the client (non-sharded does not go through this path). If a shard throws `DatabaseDisabledException` we will not be able to handle it without this.

If db gets disabled *during* the subscription run, the shard throws an Invalid exception for a "connection terminated". Orchestrator throws `SubscriptionConnectionDownException` in `GetReplyFromClientAsync`. Exception flows up and a `SubscriptionClosedException` is reported to client, with reconnect=true. Subscription client then attempts to connect again and throws `DatabaseDisabledExeption` due to the fix above.

Additionally, the connection to shards kept failing and attempting to reconnect because we try to release a semaphore after its `DatabaseContext` is already disposed on the shard. Now fixed.

### Type of change

- Bug fix
- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

