### PR TITLE
RavenDB-21711 Implementation of RavenDB-17745 (heartbeats from bulk I…

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -121,6 +121,10 @@ namespace Raven.Client.Documents.BulkInsert
         private event EventHandler<BulkInsertOnProgressEventArgs> _onProgress;
         private bool _onProgressInitialized = false;
 
+        private DateTime _lastWriteToStream;
+        private readonly SemaphoreSlim _streamLock;
+        private readonly TimeSpan _heartbeatCheckInterval = TimeSpan.FromSeconds(StreamWithTimeout.DefaultReadTimeout.TotalSeconds / 3);
+
         public event EventHandler<BulkInsertOnProgressEventArgs> OnProgress
         {
             add
@@ -159,6 +163,19 @@ namespace Raven.Client.Documents.BulkInsert
             _generateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(_requestExecutor.Conventions,
                 entity => AsyncHelpers.RunSync(() => _requestExecutor.Conventions.GenerateDocumentIdAsync(database, entity)));
 
+            _streamLock = new SemaphoreSlim(1, 1);
+            _lastWriteToStream = DateTime.UtcNow;
+            var timerState = new TimerState { Parent = new(this) };
+
+            if (_options.ForTestingPurposes?.OverrideHeartbeatCheckInterval > 0)
+                _heartbeatCheckInterval = TimeSpan.FromMilliseconds(_options.ForTestingPurposes.OverrideHeartbeatCheckInterval / 3);
+
+            Timer timer = new(HandleHeartbeat,
+                timerState,
+                _heartbeatCheckInterval,
+                _heartbeatCheckInterval);
+            timerState.Timer = timer;
+
             _disposeOnce = new DisposeOnceAsync<SingleAttempt>(async () =>
             {
                 try
@@ -172,6 +189,7 @@ namespace Raven.Client.Documents.BulkInsert
 
                     try
                     {
+                        await _streamLock.WaitAsync().ConfigureAwait(false);
                         await _writer.DisposeAsync().ConfigureAwait(false);
                     }
                     catch (Exception e)
@@ -201,10 +219,88 @@ namespace Raven.Client.Documents.BulkInsert
                 finally
                 {
                     _resetContext.Dispose();
+                    _streamLock.Dispose();
+                    try
+                    {
+                        timer.Dispose();
+                    }
+                    catch (Exception)
+                    {
+                        // Ignore
+                    }
                 }
             });
         }
 
+        private class TimerState
+        {
+            public WeakReference<BulkInsertOperation> Parent;
+            public Timer Timer;
+        }
+
+        private static void HandleHeartbeat(object state)
+        {
+            var timerState = (TimerState)state;
+            if (timerState.Parent.TryGetTarget(out BulkInsertOperation bulkInsert) == false)
+            {
+                timerState.Timer.Dispose();
+                return;
+            }
+            _ = bulkInsert.SendHeartBeatAsync();
+        }
+
+        private async Task SendHeartBeatAsync()
+        {
+            try
+            {
+                if (DateTime.UtcNow.Ticks - _lastWriteToStream.Ticks < _heartbeatCheckInterval.Ticks)
+                    return;
+
+                if (_streamLock.Wait(0) == false)
+                    return; // if locked we are already writing
+
+                await ExecuteBeforeStore().ConfigureAwait(false);
+                EndPreviousCommandIfNeeded();
+                _options.ForTestingPurposes?.OnSendHeartBeat_DoBulkStore?.Invoke();
+                if (CheckServerVersion(_requestExecutor.LastServerVersion) == false)
+                    return;
+
+                if (_first == false)
+                {
+
+                    WriteComma();
+                }
+
+                _first = false;
+                _inProgressCommand = CommandType.None;
+                _writer.Write("{\"Type\":\"HeartBeat\"}");
+
+                await _writer.FlushIfNeeded(true).ConfigureAwait(false);
+                await _writer._requestBodyStream.FlushAsync(_token).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Ignore
+            }
+            finally
+            {
+                _streamLock.Release();
+            }
+        }
+
+        private static bool CheckServerVersion(string serverVersion)
+        {
+            if (serverVersion != null && Version.TryParse(serverVersion, out var ver))
+            {
+                // Version 6 only from 6.0.2
+                if (ver.Major == 6 && ver.Build < 2)
+                    return false;
+                // 5.4.108 or higher
+                if (ver.Major > 5 || (ver.Major == 5 && ver.Minor >= 4 && ver.Build >= 110))
+                    return true;
+            }
+            return false;
+        }
         public BulkInsertOperation(string database, IDocumentStore store, CancellationToken token = default) : this(database, store, null, token)
         {
 
@@ -269,8 +365,9 @@ namespace Raven.Client.Documents.BulkInsert
 
         public async Task StoreAsync(object entity, string id, IMetadataDictionary metadata)
         {
-            using (ConcurrencyCheck())
+            using (await ConcurrencyCheckAsync().ConfigureAwait(false))
             {
+                _lastWriteToStream = DateTime.UtcNow;
                 VerifyValidId(id);
 
                 await ExecuteBeforeStore().ConfigureAwait(false);
@@ -294,39 +391,46 @@ namespace Raven.Client.Documents.BulkInsert
 
                 EndPreviousCommandIfNeeded();
 
-                try
-                {
-                    if (_first == false)
-                    {
-                        WriteComma();
-                    }
-
-                    _first = false;
-                    _inProgressCommand = CommandType.None;
-
-                    _writer.Write("{\"Id\":\"");
-                    WriteString(id);
-                    _writer.Write("\",\"Type\":\"PUT\",\"Document\":");
-
-                    await _writer.FlushAsync().ConfigureAwait(false);
-
-                    if (_customEntitySerializer == null || _customEntitySerializer(entity, metadata, _writer.StreamWriter) == false)
-                    {
-                        using (var json = _conventions.Serialization.DefaultConverter.ToBlittable(entity, metadata, _context, _defaultSerializer))
-                            await json.WriteJsonToAsync(_writer.StreamWriter.BaseStream, _token).ConfigureAwait(false);
-                    }
-
-                    _writer.Write('}');
-
-                    await _writer.FlushIfNeeded().ConfigureAwait(false);
-
-                }
-                catch (Exception e)
-                {
-                    await HandleErrors(id, e).ConfigureAwait(false);
-                }
+                await WriteToStreamAsync(entity, id, metadata, CommandType.PUT).ConfigureAwait(false);
             }
         }
+
+        private async ValueTask WriteToStreamAsync(object entity, string id, IMetadataDictionary metadata, CommandType type)
+        {
+            try
+            {
+                if (_first == false)
+                {
+                    WriteComma();
+                }
+
+                _first = false;
+                _inProgressCommand = CommandType.None;
+
+                _writer.Write("{\"Id\":\"");
+                WriteString(id);
+                _writer.Write("\",\"Type\":\"");
+                _writer.Write(type.ToString());
+                _writer.Write("\",\"Document\":");
+
+                await _writer.FlushAsync().ConfigureAwait(false);
+
+                if (_customEntitySerializer == null || _customEntitySerializer(entity, metadata, _writer.StreamWriter) == false)
+                {
+                    using (var json = _conventions.Serialization.DefaultConverter.ToBlittable(entity, metadata, _context, _defaultSerializer))
+                        await json.WriteJsonToAsync(_writer.StreamWriter.BaseStream, _token).ConfigureAwait(false);
+                }
+
+                _writer.Write('}');
+
+                await _writer.FlushIfNeeded().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                await HandleErrors(id, e).ConfigureAwait(false);
+            }
+        }
+
 
         private async Task HandleErrors(string documentId, Exception e)
         {
@@ -349,12 +453,22 @@ namespace Raven.Client.Documents.BulkInsert
             await ThrowOnUnavailableStream(documentId, e).ConfigureAwait(false);
         }
 
-        private IDisposable ConcurrencyCheck()
+        private ValueTask<ReleaseStream> ConcurrencyCheckAsync()
         {
             if (Interlocked.CompareExchange(ref _concurrentCheck, 1, 0) == 1)
                 throw new BulkInsertInvalidOperationException("Bulk Insert store methods cannot be executed concurrently.");
+            if (_streamLock.Wait(0))
+            {
+                return new ValueTask<ReleaseStream>(new ReleaseStream(this));
+            }
 
-            return new DisposableAction(() => Interlocked.CompareExchange(ref _concurrentCheck, 0, 1));
+            return new ValueTask<ReleaseStream>(Async());
+
+            async Task<ReleaseStream> Async()
+            {
+                await _streamLock.WaitAsync(_token).ConfigureAwait(false);
+                return new ReleaseStream(this);
+            }
         }
 
         private void EndPreviousCommandIfNeeded()
@@ -600,15 +714,17 @@ namespace Raven.Client.Documents.BulkInsert
 
             public async Task IncrementAsync(string id, string name, long delta)
             {
-                using (_operation.ConcurrencyCheck())
+                using (await _operation.ConcurrencyCheckAsync().ConfigureAwait(false))
                 {
-                    await _operation.ExecuteBeforeStore().ConfigureAwait(false);
-
-                    if (_operation._inProgressCommand == CommandType.TimeSeries)
-                        TimeSeriesBulkInsert.ThrowAlreadyRunningTimeSeries();
-
                     try
                     {
+                        _operation._lastWriteToStream = DateTime.UtcNow;
+
+                        await _operation.ExecuteBeforeStore().ConfigureAwait(false);
+
+                        if (_operation._inProgressCommand == CommandType.TimeSeries)
+                            TimeSeriesBulkInsertBase.ThrowAlreadyRunningTimeSeries();
+
                         var isFirst = _id == null;
                         if (isFirst || _id.Equals(id, StringComparison.OrdinalIgnoreCase) == false)
                         {
@@ -704,12 +820,12 @@ namespace Raven.Client.Documents.BulkInsert
 
             protected async Task AppendAsyncInternal(DateTime timestamp, ICollection<double> values, string tag = null)
             {
-                using (_operation.ConcurrencyCheck())
+                using (await _operation.ConcurrencyCheckAsync().ConfigureAwait(false))
                 {
-                    await _operation.ExecuteBeforeStore().ConfigureAwait(false);
-
                     try
                     {
+                        _operation._lastWriteToStream = DateTime.UtcNow;
+                        await _operation.ExecuteBeforeStore().ConfigureAwait(false);
                         if (_first)
                         {
                             if (_operation._first == false)
@@ -898,14 +1014,15 @@ namespace Raven.Client.Documents.BulkInsert
                 PutAttachmentCommandHelper.ValidateStream(stream);
 
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, _token);
-                using (_operation.ConcurrencyCheck())
+                using (await _operation.ConcurrencyCheckAsync().ConfigureAwait(false))
                 {
-                    _operation.EndPreviousCommandIfNeeded();
-
-                    await _operation.ExecuteBeforeStore().ConfigureAwait(false);
-
                     try
                     {
+                        _operation._lastWriteToStream = DateTime.UtcNow;
+                        _operation.EndPreviousCommandIfNeeded();
+
+                        await _operation.ExecuteBeforeStore().ConfigureAwait(false);
+
                         if (_operation._first == false)
                             _operation.WriteComma();
 
@@ -936,6 +1053,20 @@ namespace Raven.Client.Documents.BulkInsert
                         await _operation.HandleErrors(id, e).ConfigureAwait(false);
                     }
                 }
+            }
+        }
+
+        private readonly struct ReleaseStream : IDisposable
+        {
+            private readonly BulkInsertOperation _bulkInsertOperation;
+            public ReleaseStream(BulkInsertOperation bulkInsertOperation)
+            {
+                _bulkInsertOperation = bulkInsertOperation;
+            }
+            public void Dispose()
+            {
+                _bulkInsertOperation._streamLock.Release();
+                Interlocked.CompareExchange(ref _bulkInsertOperation._concurrentCheck, 0, 1);
             }
         }
     }

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -24,7 +24,7 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
     private JsonOperationContext.MemoryBuffer _backgroundMemoryBuffer;
     private bool _isInitialWrite = true;
 
-    private Stream _requestBodyStream;
+    internal Stream _requestBodyStream;
 
     internal readonly BulkInsertOperation.BulkInsertStreamExposerContent StreamExposer;
 

--- a/src/Raven.Server/Documents/Handlers/BulkInsert/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsert/BulkInsertHandler.cs
@@ -23,6 +23,9 @@ namespace Raven.Server.Documents.Handlers.BulkInsert
                 {
                     using (var bulkInsertProcessor = new BulkInsertHandlerProcessor(this, Database, progress, skipOverwriteIfUnchanged, operationCancelToken.Token))
                     {
+                        if (Database.ForTestingPurposes?.BulkInsertStreamReadTimeout > 0)
+                            bulkInsertProcessor.ForTestingPurposesOnly().BulkInsertStreamReadTimeout = Database.ForTestingPurposes.BulkInsertStreamReadTimeout;
+
                         await bulkInsertProcessor.ExecuteAsync();
 
                         return bulkInsertProcessor.OperationResult;

--- a/src/Raven.Server/Documents/Sharding/Handlers/BulkInsert/ShardedBulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/BulkInsert/ShardedBulkInsertHandler.cs
@@ -15,6 +15,9 @@ public sealed class ShardedBulkInsertHandler : ShardedDatabaseRequestHandler
 
         await using (var processor = new ShardedBulkInsertHandlerProcessor(this, DatabaseContext, id, skipOverwriteIfUnchanged, operationCancelToken.Token))
         {
+            if (DatabaseContext.ForTestingPurposes?.BulkInsertStreamWriteTimeout > 0)
+                processor.ForTestingPurposesOnly().BulkInsertStreamReadTimeout = DatabaseContext.ForTestingPurposes.BulkInsertStreamWriteTimeout;
+
             await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Testing.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Testing.cs
@@ -25,6 +25,9 @@ namespace Raven.Server.Documents.Sharding
 
             internal int ModifyShardNumber(int shardNumber) =>
                 _databaseContext.ShardsTopology.Keys.ElementAt(0) == shardNumber ? _databaseContext.ShardsTopology.Keys.ElementAt(1) : shardNumber;
+
+            internal int BulkInsertStreamWriteTimeout;
+
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-17745.cs
+++ b/test/SlowTests/Issues/RavenDB-17745.cs
@@ -19,7 +19,7 @@ namespace SlowTests.Issues
         private readonly int _readTimeout = 500;
         private readonly TimeSpan _delay = TimeSpan.FromSeconds(1);
 
-        [RavenFact(RavenTestCategory.BulkInsert, Skip = "RavenDB-17745")]
+        [RavenFact(RavenTestCategory.BulkInsert)]
         public async Task BulkInsertWithDelay()
         {
             DoNotReuseServer();
@@ -59,7 +59,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.BulkInsert, Skip = "RavenDB-17745 missing 6.x impl.")]
+        [RavenFact(RavenTestCategory.BulkInsert)]
         public async Task StartStoreInTheMiddleOfAnHeartbeat()
         {
             DoNotReuseServer();
@@ -68,6 +68,80 @@ namespace SlowTests.Issues
                 var mre = new ManualResetEvent(false);
                 var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 db.ForTestingPurposesOnly().BulkInsertStreamReadTimeout = _readTimeout;
+                var bulkInsertOptions = new BulkInsertOptions();
+                bulkInsertOptions.ForTestingPurposesOnly().OverrideHeartbeatCheckInterval = _readTimeout;
+
+                using (var bulk = store.BulkInsert(bulkInsertOptions))
+                {
+                    bulkInsertOptions.ForTestingPurposesOnly().OnSendHeartBeat_DoBulkStore = () =>
+                    {
+                        mre.Set();
+                    };
+
+                    Assert.True(mre.WaitOne(_delay * 3));
+
+                    await bulk.StoreAsync(new User { Name = "Daniel" }, "users/1");
+                }
+
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("Daniel", user.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BulkInsert | RavenTestCategory.Sharding)]
+        public async Task BulkInsertWithDelaySharded()
+        {
+            DoNotReuseServer();
+            using (var store = Sharding.GetDocumentStore())
+            {
+                var orchestrator = Sharding.GetOrchestrator(store.Database);
+                orchestrator.ForTestingPurposesOnly().BulkInsertStreamWriteTimeout = _readTimeout;
+                var bulkInsertOptions = new BulkInsertOptions();
+                bulkInsertOptions.ForTestingPurposesOnly().OverrideHeartbeatCheckInterval = _readTimeout;
+
+                var bulk = store.BulkInsert(bulkInsertOptions);
+
+                await Task.Delay(_delay);
+                bulk.Store(new User { Name = "Daniel" }, "users/1");
+                bulk.Store(new User { Name = "Yael" }, "users/2");
+
+                await Task.Delay(_delay);
+                bulk.Store(new User { Name = "Ido" }, "users/3");
+                await Task.Delay(_delay);
+                bulk.Dispose();
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("Daniel", user.Name);
+
+                    user = session.Load<User>("users/2");
+                    Assert.NotNull(user);
+                    Assert.Equal("Yael", user.Name);
+
+                    user = session.Load<User>("users/3");
+                    Assert.NotNull(user);
+                    Assert.Equal("Ido", user.Name);
+                }
+
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BulkInsert | RavenTestCategory.Sharding)]
+        public async Task StartStoreInTheMiddleOfAnHeartbeatSharded()
+        {
+            DoNotReuseServer();
+            using (var store = Sharding.GetDocumentStore())
+            {
+                var mre = new ManualResetEvent(false);
+                var orchestrator = Sharding.GetOrchestrator(store.Database);
+                orchestrator.ForTestingPurposesOnly().BulkInsertStreamWriteTimeout = _readTimeout;
                 var bulkInsertOptions = new BulkInsertOptions();
                 bulkInsertOptions.ForTestingPurposesOnly().OverrideHeartbeatCheckInterval = _readTimeout;
 


### PR DESCRIPTION
…nsert)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21711


### Additional description

Implementation of RavenDB-17745 : Send heartbeats from BulkInsertOperation if there is idle time


### Type of change

- New feature

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?


- No

### UI work


- No UI work is needed
