### PR TITLE
RavenDB-21411 Download logs - block button after click

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/adminLogs.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/adminLogs.ts
@@ -26,6 +26,7 @@ import enableAdminLogsMicrosoftCommand = require("commands/maintenance/enableAdm
 import disableAdminLogsMicrosoftCommand = require("commands/maintenance/disableAdminLogsMicrosoftCommand");
 import saveAdminLogsMicrosoftConfigurationCommand = require("commands/maintenance/saveAdminLogsMicrosoftConfigurationCommand");
 import configureMicrosoftLogsDialog = require("./configureMicrosoftLogsDialog");
+import messagePublisher from "common/messagePublisher";
 
 class heightCalculator {
     
@@ -631,10 +632,13 @@ class adminLogs extends viewModelBase {
         this.downloadLogsValidationGroup.errors.showAllMessages(false);
     }
 
-    onDownloadLogs() {
+    onDownloadLogs(_: any, event: JQueryEventObject) {
         if (!this.isValid(this.downloadLogsValidationGroup)) {
+            event.stopImmediatePropagation();
             return;
         }
+        
+        messagePublisher.reportSuccess("Your download will start shortly...");
 
         const $form = $("#downloadLogsForm");
         const url = endpoints.global.adminLogs.adminLogsDownload;
@@ -645,6 +649,8 @@ class adminLogs extends viewModelBase {
         $("[name=to]", $form).val(this.endDateToUse());
 
         $form.submit();
+        
+        return true;
     }
     
     updateMouseStatus(pressed: boolean) {

--- a/src/Raven.Studio/wwwroot/App/views/manage/adminLogs.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/adminLogs.html
@@ -204,7 +204,7 @@
                                         <button type="button" class="btn btn-default btn-sm margin-right-xs close-panel" title="Click to close dropdown">
                                             <span>Close</span>
                                         </button>
-                                        <button class="btn btn-success btn-sm" title="Click to download log files" data-bind="click: onDownloadLogs">
+                                        <button class="btn btn-success btn-sm close-panel" title="Click to download log files" data-bind="click: onDownloadLogs">
                                             <span>Download</span>
                                         </button>
                                     </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21411 

### Additional description

Better UX around download admin logs 

### Type of change

- New feature

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

