### PR TITLE
RavenDB-21682 Handle multiple deletions in single batch by `TryDeleteEntryByField`. Reset number of modifications after reset of IndexWriter.

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -67,6 +67,8 @@ namespace Corax
             
             public const int DynamicField = -2;
 
+            public const int PrimaryKeyFieldId = 0;
+
             public const string SuggestionsTreePrefix = "__Suggestion_";
 
             static IndexWriter()

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexingHelpers.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexingHelpers.cs
@@ -107,7 +107,7 @@ public static class CoraxIndexingHelpers
         }
         
         //Adding id of document        
-        mappingBuilder.AddBinding(0, keyFieldName, defaultAnalyzer);
+        mappingBuilder.AddBinding(global::Corax.Constants.IndexWriter.PrimaryKeyFieldId, keyFieldName, defaultAnalyzer);
         
         foreach (var field in indexDefinition.IndexFields.Values)
         {

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-            const int numberToTolerate = 4657;
+            const int numberToTolerate = 4654;
 
             if (array.Length == numberToTolerate)
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21682 

### Additional description

- We've to handle the mechanism to ensure we do not remove twice in the same batch when removal is done via `TryDeleteEntryByField` 
- Clear counters in IndexWriter() to ensure a correct number of entries after a batch

### Type of change

- Bug fix


### How risky is the change?

- Moderate 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
