### PR TITLE
RavenDB-21233: added support for ignoring the maximum steps of script…

### DIFF
--- a/src/Raven.Client/Documents/Operations/CollectionOperationOptions.cs
+++ b/src/Raven.Client/Documents/Operations/CollectionOperationOptions.cs
@@ -6,6 +6,8 @@ namespace Raven.Client.Documents.Operations
     {
         private int? _maxOpsPerSecond;
 
+        internal bool IgnoreMaxStepsForScript { get; set; }
+
         /// <summary>
         /// Limits the amount of base operation per second allowed.
         /// </summary>

--- a/src/Raven.Client/Documents/Operations/PatchByQueryOperation.cs
+++ b/src/Raven.Client/Documents/Operations/PatchByQueryOperation.cs
@@ -72,6 +72,13 @@ namespace Raven.Client.Documents.Operations
                         .Append(_options.StaleTimeout.Value);
                 }
 
+                if (_options.IgnoreMaxStepsForScript)
+                {
+                    path
+                        .Append("&ignoreMaxStepsForScript=")
+                        .Append(_options.IgnoreMaxStepsForScript);
+                }
+
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethods.Patch,

--- a/src/Raven.Client/Documents/Queries/QueryOperationOptions.cs
+++ b/src/Raven.Client/Documents/Queries/QueryOperationOptions.cs
@@ -15,6 +15,11 @@ namespace Raven.Client.Documents.Queries
         public bool AllowStale { get; set; }
 
         /// <summary>
+        /// Ignore the maximum number of statements a script can execute as defined in the server configuration.
+        /// </summary>
+        public bool IgnoreMaxStepsForScript { get; set; }
+
+        /// <summary>
         /// If AllowStale is set to false and index is stale, then this is the maximum timeout to wait for index to become non-stale. If timeout is exceeded then exception is thrown.
         /// <para>Value:</para>
         /// <para><c>null</c> by default - throw immediately if index is stale</para>

--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents
             BlittableJsonReaderObject patchArgs, Action<IOperationProgress> onProgress, OperationCancelToken token)
         {
             return ExecuteOperation(collectionName, start, take, options, Context, onProgress,
-                key => new PatchDocumentCommand(Context, key, expectedChangeVector: null, skipPatchIfChangeVectorMismatch: false, patch: (patch, patchArgs), patchIfMissing: (null, null), createIfMissing: null, Database, isTest: false, debugMode: false, collectResultsNeeded: false, returnDocument: false), token);
+                key => new PatchDocumentCommand(Context, key, expectedChangeVector: null, skipPatchIfChangeVectorMismatch: false, patch: (patch, patchArgs), patchIfMissing: (null, null), createIfMissing: null, Database, isTest: false, debugMode: false, collectResultsNeeded: false, returnDocument: false,options.IgnoreMaxStepsForScript), token);
         }
 
         protected async Task<IOperationResult> ExecuteOperation(string collectionName, long start, long take, CollectionOperationOptions options, DocumentsOperationContext context,

--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents
             BlittableJsonReaderObject patchArgs, Action<IOperationProgress> onProgress, OperationCancelToken token)
         {
             return ExecuteOperation(collectionName, start, take, options, Context, onProgress,
-                key => new PatchDocumentCommand(Context, key, expectedChangeVector: null, skipPatchIfChangeVectorMismatch: false, patch: (patch, patchArgs), patchIfMissing: (null, null), createIfMissing: null, Database, isTest: false, debugMode: false, collectResultsNeeded: false, returnDocument: false,options.IgnoreMaxStepsForScript), token);
+                key => new PatchDocumentCommand(Context, key, expectedChangeVector: null, skipPatchIfChangeVectorMismatch: false, patch: (patch, patchArgs), patchIfMissing: (null, null), createIfMissing: null, Database, isTest: false, debugMode: false, collectResultsNeeded: false, returnDocument: false, options.IgnoreMaxStepsForScript), token);
         }
 
         protected async Task<IOperationResult> ExecuteOperation(string collectionName, long start, long take, CollectionOperationOptions options, DocumentsOperationContext context,

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -637,7 +637,8 @@ namespace Raven.Server.Documents.Handlers
                 AllowStale = GetBoolValueQueryString("allowStale", required: false) ?? false,
                 MaxOpsPerSecond = GetIntValueQueryString("maxOpsPerSec", required: false),
                 StaleTimeout = GetTimeSpanQueryString("staleTimeout", required: false),
-                RetrieveDetails = GetBoolValueQueryString("details", required: false) ?? false
+                RetrieveDetails = GetBoolValueQueryString("details", required: false) ?? false,
+                IgnoreMaxStepsForScript = GetBoolValueQueryString("ignoreMaxStepsForScript", required: false) ?? false
             };
         }
     }

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -450,7 +450,7 @@ namespace Raven.Server.Documents.Patch
             bool debugMode,
             bool collectResultsNeeded,
             bool returnDocument,
-            bool ignoreMaxStepsForScript =false) : base(context, skipPatchIfChangeVectorMismatch, patch, patchIfMissing, createIfMissing, database, isTest, debugMode, collectResultsNeeded, returnDocument)
+            bool ignoreMaxStepsForScript = false) : base(context, skipPatchIfChangeVectorMismatch, patch, patchIfMissing, createIfMissing, database, isTest, debugMode, collectResultsNeeded, returnDocument)
         {
             _id = id;
             _expectedChangeVector = expectedChangeVector;
@@ -469,7 +469,7 @@ namespace Raven.Server.Documents.Patch
                 try
                 {
                     if (_ignoreMaxStepsForScript)
-                        run.ScriptEngine.ChangeMaxStatements(int.MaxValue);
+                        run.ScriptEngine.DisableMaxStatements();
 
                     using (_patchIfMissing.Run != null ? _database.Scripts.GetScriptRunner(_patchIfMissing.Run, readOnly: false, out runIfMissing) : (IDisposable)null)
                     {

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.TimeSeries;
+using Raven.Server.Extensions;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -433,7 +434,7 @@ namespace Raven.Server.Documents.Patch
     {
         private readonly string _id;
         private readonly LazyStringValue _expectedChangeVector;
-
+        private readonly bool _ignoreMaxStepsForScript;
         public PatchResult PatchResult { get; private set; }
 
         public PatchDocumentCommand(
@@ -448,11 +449,12 @@ namespace Raven.Server.Documents.Patch
             bool isTest,
             bool debugMode,
             bool collectResultsNeeded,
-            bool returnDocument) : base(context, skipPatchIfChangeVectorMismatch, patch, patchIfMissing, createIfMissing, database, isTest, debugMode, collectResultsNeeded, returnDocument)
+            bool returnDocument,
+            bool ignoreMaxStepsForScript =false) : base(context, skipPatchIfChangeVectorMismatch, patch, patchIfMissing, createIfMissing, database, isTest, debugMode, collectResultsNeeded, returnDocument)
         {
             _id = id;
             _expectedChangeVector = expectedChangeVector;
-
+            _ignoreMaxStepsForScript = ignoreMaxStepsForScript;
             if (string.IsNullOrEmpty(id) || id.EndsWith(database.IdentityPartsSeparator) || id.EndsWith('|'))
                 throw new ArgumentException($"The ID argument has invalid value: '{id}'", nameof(id));
         }
@@ -460,12 +462,26 @@ namespace Raven.Server.Documents.Patch
         protected override long ExecuteCmd(DocumentsOperationContext context)
         {
             ScriptRunner.SingleRun runIfMissing = null;
+            int originalMaxStepsForScript = context.DocumentDatabase.Configuration.Patching.MaxStepsForScript;
 
             using (_database.Scripts.GetScriptRunner(_patch.Run, readOnly: false, out var run))
-            using (_patchIfMissing.Run != null ? _database.Scripts.GetScriptRunner(_patchIfMissing.Run, readOnly: false, out runIfMissing) : (IDisposable)null)
             {
-                PatchResult = ExecuteOnDocument(context, _id, _expectedChangeVector, run, runIfMissing);
-                return 1;
+                try
+                {
+                    if (_ignoreMaxStepsForScript)
+                        run.ScriptEngine.ChangeMaxStatements(int.MaxValue);
+
+                    using (_patchIfMissing.Run != null ? _database.Scripts.GetScriptRunner(_patchIfMissing.Run, readOnly: false, out runIfMissing) : (IDisposable)null)
+                    {
+
+                        PatchResult = ExecuteOnDocument(context, _id, _expectedChangeVector, run, runIfMissing);
+                        return 1;
+                    }
+                }
+                finally
+                {
+                    run.ScriptEngine.ChangeMaxStatements(originalMaxStepsForScript);
+                }
             }
         }
 

--- a/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
@@ -128,7 +128,7 @@ namespace Raven.Server.Documents.Queries
                         isTest: false,
                         collectResultsNeeded: true,
                         returnDocument: false,
-                        ignoreMaxStepsForScript:options.IgnoreMaxStepsForScript);
+                        ignoreMaxStepsForScript: options.IgnoreMaxStepsForScript);
 
                     return new BulkOperationCommand<PatchDocumentCommand>(command, retrieveDetails,
                         x => new BulkOperationResult.PatchDetails

--- a/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
@@ -127,7 +127,8 @@ namespace Raven.Server.Documents.Queries
                         debugMode: false,
                         isTest: false,
                         collectResultsNeeded: true,
-                        returnDocument: false);
+                        returnDocument: false,
+                        ignoreMaxStepsForScript:options.IgnoreMaxStepsForScript);
 
                     return new BulkOperationCommand<PatchDocumentCommand>(command, retrieveDetails,
                         x => new BulkOperationResult.PatchDetails

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -109,6 +109,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
             return runner.ExecutePatch(query.Metadata.CollectionName, query.Start, query.PageSize, new CollectionOperationOptions
             {
+                IgnoreMaxStepsForScript = options.IgnoreMaxStepsForScript,
                 MaxOpsPerSecond = options.MaxOpsPerSecond
             }, patch, patchArgs, onProgress, token);
         }


### PR DESCRIPTION
… when patching

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21233/Add-ignore-MaxStepsForScript-limit-button-in-studio

### Additional description

added support for ignoring the maximum steps of script  when patching

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.

