### PR TITLE
RavenDB-21726 ensure we give enough grace for loading database

### DIFF
--- a/src/Sparrow.Server/Extensions/RavenDateTimeExtensions.cs
+++ b/src/Sparrow.Server/Extensions/RavenDateTimeExtensions.cs
@@ -26,5 +26,7 @@ namespace Sparrow.Server.Extensions
 
             return scope;
         }
+
+        public static DateTime Max(DateTime dt1, DateTime dt2) => dt1 > dt2 ? dt1 : dt2;
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21726 

### Additional description

Fix regression from this PR https://github.com/ravendb/ravendb/pull/17723

The case here is that the node is responsive, but the database is still loading.
So we need to handle the case of giving grace time for a loading database.

### Type of change

- Regression bug fix

### How risky is the change?

- Moderate 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Current test coverage

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
