### PR TITLE
RavenDB-21739 Collections selector not working in Document Revisions

### DIFF
--- a/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
+++ b/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
@@ -26,10 +26,6 @@ class collectionsTracker {
         globalChangeVector: [] as Array<(changeVector: string) => void>
     };
 
-    onUpdateCallback: () => void = () => {
-        // empty by default
-    };
-
     onDatabaseChanged(db: database) {
         this.db = db;
         
@@ -60,8 +56,6 @@ class collectionsTracker {
         this.collections([allDocsCollection].concat(collections));
 
         this.conflictsCount(collectionsStats.numberOfConflicts);
-
-        this.onUpdateCallback();
     }
 
     getCollectionCount(collectionName: string) {

--- a/src/Raven.Studio/typescript/components/common/shell/collectionsTrackerSlice.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/collectionsTrackerSlice.ts
@@ -10,7 +10,7 @@ const collectionNames = {
 
 type CollectionName = (typeof collectionNames)[keyof typeof collectionNames] | (string & NonNullable<unknown>);
 
-interface Collection {
+export interface Collection {
     name: CollectionName;
     documentCount: number;
     lastDocumentChangeVector: string;

--- a/src/Raven.Studio/typescript/components/common/shell/setup.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/setup.ts
@@ -23,21 +23,6 @@ function updateDatabases() {
 
 const throttledUpdateDatabases = _.throttle(updateDatabases, 200);
 
-function updateReduxCollectionsTracker() {
-    globalDispatch(
-        collectionsTrackerActions.collectionsLoaded(
-            collectionsTracker.default.collections().map((x) => ({
-                name: x.name,
-                countPrefix: x.countPrefix(),
-                documentCount: x.documentCount(),
-                hasBounceClass: x.hasBounceClass(),
-                lastDocumentChangeVector: x.lastDocumentChangeVector(),
-                sizeClass: x.sizeClass(),
-            }))
-        )
-    );
-}
-
 export const throttledUpdateLicenseLimitsUsage = _.throttle(() => {
     services.licenseService
         .getClusterLimitsUsage()
@@ -87,8 +72,9 @@ function initRedux() {
         throttledUpdateLicenseLimitsUsage();
     });
 
-    collectionsTracker.default.registerOnGlobalChangeVectorUpdatedHandler(updateReduxCollectionsTracker);
-    collectionsTracker.default.onUpdateCallback = updateReduxCollectionsTracker;
+    collectionsTracker.default.collections.subscribe((collections) =>
+        globalDispatch(collectionsTrackerActions.collectionsLoaded(collections.map((x) => x.toCollectionState())))
+    );
 
     changesContext.default.connectServerWideNotificationCenter();
 }

--- a/src/Raven.Studio/typescript/models/database/documents/collection.ts
+++ b/src/Raven.Studio/typescript/models/database/documents/collection.ts
@@ -1,4 +1,5 @@
 import generalUtils = require("common/generalUtils");
+import { Collection } from "components/common/shell/collectionsTrackerSlice";
 
 class collection {
     static readonly allDocumentsCollectionName = "All Documents";
@@ -53,6 +54,16 @@ class collection {
         return new collection(collection.allDocumentsCollectionName, documentsCount);
     }
 
+    toCollectionState(): Collection {
+        return {
+            name: this.name,
+            countPrefix: this.countPrefix(),
+            documentCount: this.documentCount(),
+            hasBounceClass: this.hasBounceClass(),
+            lastDocumentChangeVector: this.lastDocumentChangeVector(),
+            sizeClass: this.sizeClass(),
+        }
+    }
 }
 
 export = collection;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21739/Collections-selector-not-working-in-Document-Revisions

### Additional description

Sets the subscription to the `collectionsTracker.default.collections` to update redux state.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
