### PR TITLE
RavenDB-21758: fix NRE

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/Sharding/ShardSubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Sharding/ShardSubscriptionStorage.cs
@@ -79,6 +79,10 @@ public sealed class ShardSubscriptionStorage : SubscriptionStorage
         if (taskStatus.LastClientConnectionTime != null)
             return false;
 
+        // the subscription connection is currently connecting
+        if (state.SubscriptionState == null)
+            return false;
+
         // persisted subscription state has different RaftCommandIndex than state of current connection
         // the subscription was modified and needs to reconnect
         return taskStatus.RaftCommandIndex != state.SubscriptionState.RaftCommandIndex;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21758

When the subscription connection is connecting it is added to the `_connections`  list (so its "active") but the `SubscriptionState` will be updated few moments later, so `state.SubscriptionState` can be null at this moment

### Type of change


- Regression bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
