### PR TITLE
RavenDB-21715 Fix test DisableAutoMapReduceIndexClusterWideAndEnableA…

### DIFF
--- a/test/SlowTests/Issues/RavenDB-20922.cs
+++ b/test/SlowTests/Issues/RavenDB-20922.cs
@@ -110,20 +110,39 @@ namespace SlowTests.Issues
         public async Task DisableAutoMapReduceIndexClusterWideAndEnableAutoMapReduceIndexClusterWide()
         {
             const int numberOfNodes = 3;
-            var (_, leader) = await CreateRaftCluster(numberOfNodes);
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes);
             using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = numberOfNodes });
             var documentDatabase = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
 
             Raven.Server.Documents.Indexes.Index index = await CreateAutoMapReduceIndex(documentDatabase);
 
             await DisableIndexClusterWide(store, index.Name);
+            foreach (var server in nodes)
+            {
+                await WaitForValueAsync(async () =>
+                {
+                    documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                    return documentDatabase.IndexStore.GetIndex(index.Name).Status;
+                }, IndexRunningStatus.Disabled);
+                var autoIndex = documentDatabase.IndexStore.GetIndex(index.Name);
+                Assert.Equal(IndexState.Disabled, autoIndex.State);
+                Assert.Equal(IndexRunningStatus.Disabled, autoIndex.Status);
+            }
 
             //Enable index cluster wide
             await EnableIndexClusterWide(store, index.Name);
 
-            var autoIndex = documentDatabase.IndexStore.GetIndex(index.Name);
-            Assert.Equal(IndexState.Normal, autoIndex.State);
-            Assert.Equal(IndexRunningStatus.Running, autoIndex.Status);
+            foreach (var server in nodes)
+            {
+                await WaitForValueAsync(async () =>
+                {
+                    documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                    return documentDatabase.IndexStore.GetIndex(index.Name).Status;
+                }, IndexRunningStatus.Running);
+                var autoIndex = documentDatabase.IndexStore.GetIndex(index.Name);
+                Assert.Equal(IndexState.Normal, autoIndex.State);
+                Assert.Equal(IndexRunningStatus.Running, autoIndex.Status);
+            }
         }
 
         [RavenFact(RavenTestCategory.Indexes)]


### PR DESCRIPTION
…utoMapReduceIndexClusterWide

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21715

### Additional description

change test to check and wait all nodes status

_Please delete below the options that are not relevant_

### Type of change

- Test fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
