### PR TITLE
RavenDB-21759 - add missing LongTotalResults for Facets and Suggestions

### DIFF
--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -249,6 +249,10 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.TotalResults);
             writer.WriteComma();
 
+            writer.WritePropertyName(nameof(result.LongTotalResults));
+            writer.WriteInteger(result.LongTotalResults);
+            writer.WriteComma();
+
             if (result.CappedMaxResults != null)
             {
                 writer.WritePropertyName(nameof(result.CappedMaxResults));
@@ -273,6 +277,10 @@ namespace Raven.Server.Json
 
             writer.WritePropertyName(nameof(result.TotalResults));
             writer.WriteInteger(result.TotalResults);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(result.LongTotalResults));
+            writer.WriteInteger(result.LongTotalResults);
             writer.WriteComma();
 
             if (result.CappedMaxResults != null)

--- a/test/SlowTests/Tests/Faceted/DynamicFacets.cs
+++ b/test/SlowTests/Tests/Faceted/DynamicFacets.cs
@@ -43,11 +43,15 @@ namespace SlowTests.Tests.Faceted
                     foreach (var exp in expressions)
                     {
                         var facetResults = s.Query<Camera, CameraCostIndex>()
+                            .Statistics(out var stats)
                             .Where(exp)
                             .AggregateBy(facets)
                             .Execute();
 
                         var filteredData = cameras.Where(exp.Compile()).ToList();
+
+                        Assert.Equal(3, stats.TotalResults);
+                        Assert.Equal(stats.TotalResults, stats.LongTotalResults);
 
                         CheckFacetResultsMatchInMemoryData(facetResults, filteredData);
                     }

--- a/test/SlowTests/Tests/Suggestions/Suggestions.cs
+++ b/test/SlowTests/Tests/Suggestions/Suggestions.cs
@@ -66,11 +66,15 @@ namespace SlowTests.Tests.Suggestions
                 using (var session = store.OpenSession())
                 {
                     var suggestionQueryResult = session.Query<User>("Test")
+                        .Statistics(out var stats)
                         .SuggestUsing(x => x.ByField(y => y.Name, "Oren").WithOptions(new SuggestionOptions
                         {
                             PageSize = 10
                         }))
                         .Execute();
+
+                    Assert.Equal(1, stats.TotalResults);
+                    Assert.Equal(stats.TotalResults, stats.LongTotalResults);
 
                     Assert.Equal(0, suggestionQueryResult["Name"].Suggestions.Count);
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21759/Missing-LongTotalResults-for-Facets-and-Suggestions

### Additional description

Add missing LongTotalResults for Facets and Suggestions

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
