### PR TITLE
RDBC-763 Throwing exception when `Any` on enumerable has `and` using two different fields

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -32,6 +32,7 @@ using Raven.Client.Exceptions;
 using Raven.Client.Extensions;
 using Raven.Client.Util;
 using MethodCallExpression = System.Linq.Expressions.MethodCallExpression;
+using NotSupportedException = System.NotSupportedException;
 
 namespace Raven.Client.Documents.Linq
 {
@@ -1812,7 +1813,10 @@ The recommended method is to use full text search (mark the field as Analyzed an
                         }
                         else
                         {
-                            VisitAny(expression);
+                            using (AnyModeScope())
+                            {
+                                VisitAny(expression);
+                            }
                         }
                         break;
                     }
@@ -2164,7 +2168,14 @@ The recommended method is to use full text search (mark the field as Analyzed an
             DocumentQuery<T> documentQuery => documentQuery.SetFilterMode(@on),
             AsyncDocumentQuery<T> asyncDocumentQuery => asyncDocumentQuery.SetFilterMode(@on),
             _ => throw new NotSupportedException($"Currently {DocumentQuery.GetType()} doesn't support {nameof(LinqExtensions.Filter)}.") 
-        };        
+        };
+
+        private IDisposable AnyModeScope() => DocumentQuery switch
+        {
+            DocumentQuery<T> documentQuery => documentQuery.SetAnyMode(),
+            AsyncDocumentQuery<T> asyncDocumentQuery => asyncDocumentQuery.SetAnyMode(),
+            _ => throw new NotSupportedException($"Currently {DocumentQuery.GetType()} doesn't support {nameof(Enumerable.Any)} method.")
+        };
         
         private void AddFilterLimit(int filterLimit)
         {

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1020,6 +1020,60 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             }
         }
         
+        internal IDisposable SetAnyMode()
+        {
+            return new AnyModeScope(this);
+        }
+
+        private class AnyModeScope : IDisposable
+        {
+            private readonly AbstractDocumentQuery<T, TSelf> _documentQuery;
+            private LinkedListNode<QueryToken> _lastNodeBeforeClauseStart;
+            
+            public AnyModeScope(AbstractDocumentQuery<T, TSelf> documentQuery)
+            {
+                _documentQuery = documentQuery;
+                _lastNodeBeforeClauseStart = _documentQuery.GetCurrentWhereTokens().Last;
+            }
+            
+            public void Dispose()
+            {
+                if (_documentQuery.IndexName != null || _documentQuery.IsDynamicMapReduce)
+                    return;
+                
+                _lastNodeBeforeClauseStart ??= _documentQuery.GetCurrentWhereTokens().First;
+
+                if (_lastNodeBeforeClauseStart == null)
+                    return;
+                
+                for (var node = _lastNodeBeforeClauseStart.Next; node != null ; node = node.Next)
+                {
+                    if (node.Value is QueryOperatorToken queryOperatorToken && queryOperatorToken == QueryOperatorToken.And)
+                    {
+                        if (node.Previous?.Value is WhereToken left && node.Next?.Value is WhereToken right && left.FieldName != right.FieldName)
+                        {
+                            if (UsesKeyAndValue(left, right))
+                                continue;
+                            
+                            throw new InvalidOperationException($"Using multiple fields inside method '{nameof(Enumerable.Any)}' can lead to unexpected query results.");
+                        }
+                    }
+                }
+
+                bool UsesKeyAndValue(WhereToken left, WhereToken right)
+                {
+                    if (left.FieldName.EndsWith("Value") && right.FieldName.EndsWith("Key"))
+                        return true;
+                    
+                    if (left.FieldName.EndsWith("Key") && right.FieldName.EndsWith("Value"))
+                        return true;
+                    
+                    return false;
+                }
+            }
+        }
+    
+        
         /// <summary>
         ///   Specifies a boost weight to the previous where clause.
         ///   The higher the boost factor, the more relevant the term will be.

--- a/test/SlowTests/Issues/RDBC-763.cs
+++ b/test/SlowTests/Issues/RDBC-763.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RDBC_763 : RavenTestBase
+{
+    public RDBC_763(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void TestEnumerableMethodCallAccessingMultipleFields()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var m1 = new Member() { UserId = "abc", Role = Role.Contributor, Value = 21 };
+                var m2 = new Member() { UserId = "bcd", Role = Role.Contributor, Value = 37 };
+
+                var e1 = new Entity() { Name = "CoolName", Members = new List<Member>() { m1, m2 } };
+                
+                session.Store(m1);
+                session.Store(m2);
+                session.Store(e1);
+                
+                var ed1 = new EntityWithDict() { SomeDict = new Dictionary<string, int>{ { "a", 2 }, { "b", 1 } } };
+                
+                session.Store(ed1);
+                
+                session.SaveChanges();
+                
+                var r1 = session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.UserId == "abc"))
+                    .ToList();
+                
+                var r2 = session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.UserId == "abc") && x.Members.Any(y => y.Role == Role.Contributor) && x.Members.Any(y => y.Value == 37))
+                    .ToList();
+                
+                var r3 = session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.Value > 20 || y.Value.Equals(37)))
+                    .ToList();
+                
+                var r4 = session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.UserId.Equals("abc") || y.Value.Equals(37)))
+                    .ToList();
+                
+                // We have to stick to this behavior
+                var r5 = session.Query<EntityWithDict>()
+                    .Where(x => x.SomeDict.Any(kvp => kvp.Key == "a" && kvp.Value == 1))
+                    .ToList();
+                
+                Assert.NotEmpty(r1);
+                Assert.NotEmpty(r2);
+                Assert.NotEmpty(r3);
+                Assert.NotEmpty(r4);
+                Assert.NotEmpty(r5);
+                
+                WaitForUserToContinueTheTest(store);
+                
+                var exception1 = Assert.Throws<InvalidOperationException>(() => session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.UserId == "abc" && y.Value == 37 || y.Role == Role.Contributor))
+                    .ToList());
+
+                Assert.Contains("Using multiple fields inside method 'Any' can lead to unexpected query results.", exception1.Message);
+                
+                var exception2 = Assert.Throws<InvalidOperationException>(() => session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.UserId.Equals("abc") && y.Value.Equals(37)))
+                    .ToList());
+                
+                Assert.Contains("Using multiple fields inside method 'Any' can lead to unexpected query results.", exception2.Message);
+                
+                var exception5 = Assert.Throws<InvalidOperationException>(() => session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.Value > 20 && y.Value < 30 || y.Value.Equals(57) && y.UserId != "aaa"))
+                    .ToList());
+                
+                Assert.Contains("Using multiple fields inside method 'Any' can lead to unexpected query results.", exception5.Message);
+            }
+        }
+    }
+
+    private class Entity
+    {
+        public string Name { get; set; }
+        public List<Member> Members { get; set; }
+    }
+
+    private class Member
+    {
+        public string UserId { get; set; }
+        public int Value { get; set; }
+        public Role Role { get; set; }
+    }
+
+    private enum Role
+    {
+        Contributor
+    }
+
+    private class EntityWithDict
+    {
+        public Dictionary<string, int> SomeDict { get; set; }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Entity, DummyIndex.Result>
+    {
+        public class Result
+        {
+            public string Name { get; set; }
+            public string UserId { get; set; }
+            public Role Role { get; set; }
+            public int Value { get; set; }
+        }
+        
+        public DummyIndex()
+        {
+            Map = entities => from entity in entities
+                from member in entity.Members
+                select new { entity.Name, member.UserId, member.Role, member.Value };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBC-763/Wrong-RQL-generated-when-using-LINQ-.Any-that-contains-logical-AND-in-arrays

### Additional description

Using query such as
```csharp
var example = await session.Query<Entity>()
  .Where(x => x.Members.Any(y => y.UserId == UserId && y.Role == Role.Contributor))
  .ToArrayAsync();
```
may lead to results unexpected by the user. They expect results where a single object in `Members` list fulfills both conditions, but actually we do this check against a set of values from all objects on `Members` list. To avoid this, we'll throw an exception in such situation, but only for auto map index.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
