### PR TITLE
RavenDB-21761: Handling the Case with Two Different Schemas for One Document Collection on `tx.OpenTable()`

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -125,6 +125,9 @@ namespace Raven.Server.Documents
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idPtr))
             {
                 var collectionName = _documentsStorage.ExtractCollectionName(context, document);
+
+                _documentsStorage._forTestingPurposes?.OnBeforeOpenTableWhenPutDocumentWithSpecificId?.Invoke(id);
+
                 var table = context.Transaction.InnerTransaction.OpenTable(_documentDatabase.GetDocsSchemaForCollection(collectionName),
                     collectionName.GetTableName(CollectionTableType.Documents));
             

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -913,8 +913,17 @@ namespace Raven.Server.Documents
 
         internal class TestingStuff
         {
+            internal TestingStuff()
+            {
+            }
+
             public ManualResetEventSlim DelayDocumentLoad;
             public Action<string> OnBeforeOpenTableWhenPutDocumentWithSpecificId { get; set; }
+            public bool? IsDocumentCompressed(DocumentsOperationContext context, Slice lowerDocumentId, out bool? isLargeValue)
+            {
+                var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+                return table.ForTestingPurposesOnly().IsTableValueCompressed(lowerDocumentId, out isLargeValue);
+            }
         }
 
         public IEnumerable<Document> GetDocumentsFrom(DocumentsOperationContext context, long etag, long start, long take, DocumentFields fields = DocumentFields.All, EventHandler<InvalidOperationException> onCorruptedDataHandler = null)
@@ -2686,12 +2695,6 @@ namespace Raven.Server.Documents
         {
             var ptr = tvr.Read(index, out int size);
             return Slice.From(context.Allocator, ptr, size, ByteStringType.Immutable, out slice);
-        }
-
-        public bool? DocumentIsCompressed(DocumentsOperationContext context, Slice lowerDocumentId, out bool? isLargeValue)
-        {
-            var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
-            return table.TableValueIsCompressed(lowerDocumentId, out isLargeValue);
         }
     }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -901,7 +901,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        private TestingStuff _forTestingPurposes;
+        internal TestingStuff _forTestingPurposes;
 
         internal TestingStuff ForTestingPurposesOnly()
         {
@@ -914,6 +914,7 @@ namespace Raven.Server.Documents
         internal class TestingStuff
         {
             public ManualResetEventSlim DelayDocumentLoad;
+            public Action<string> OnBeforeOpenTableWhenPutDocumentWithSpecificId { get; set; }
         }
 
         public IEnumerable<Document> GetDocumentsFrom(DocumentsOperationContext context, long etag, long start, long take, DocumentFields fields = DocumentFields.All, EventHandler<InvalidOperationException> onCorruptedDataHandler = null)
@@ -2685,6 +2686,12 @@ namespace Raven.Server.Documents
         {
             var ptr = tvr.Read(index, out int size);
             return Slice.From(context.Allocator, ptr, size, ByteStringType.Immutable, out slice);
+        }
+
+        public bool? DocumentIsCompressed(DocumentsOperationContext context, Slice lowerDocumentId, out bool? isLargeValue)
+        {
+            var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+            return table.TableValueIsCompressed(lowerDocumentId, out isLargeValue);
         }
     }
 

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -2225,26 +2225,6 @@ namespace Voron.Data.Tables
             return report;
         }
 
-        public bool? TableValueIsCompressed(Slice key, out bool? isLargeValue)
-        {
-            if (TryFindIdFromPrimaryKey(key, out long id) == false)
-            {
-                isLargeValue = default;
-                return default;
-            }
-
-            isLargeValue = id % Constants.Storage.PageSize == 0;
-
-            if (isLargeValue.Value)
-            {
-                var page = _tx.LowLevelTransaction.GetPage(id / Constants.Storage.PageSize);
-                return page.Flags.HasFlag(PageFlags.Compressed);
-            }
-
-            var sizes = RawDataSection.GetRawDataEntrySizeFor(_tx.LowLevelTransaction, id);
-            return sizes->IsCompressed;
-        }
-
         [Conditional("DEBUG")]
         private void AssertWritableTable()
         {
@@ -2300,6 +2280,46 @@ namespace Voron.Data.Tables
                 if (_tx.LowLevelTransaction.Environment.WriteTransactionPool.BuilderUsages-- != 1)
                     throw new InvalidOperationException("Cannot use a cached table value builder when it is already removed");
 #endif
+            }
+        }
+
+        private TestingStuff _forTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (_forTestingPurposes != null)
+                return _forTestingPurposes;
+
+            return _forTestingPurposes = new TestingStuff(this);
+        }
+
+        internal class TestingStuff
+        {
+            private readonly Table _table;
+
+            public TestingStuff(Table table)
+            {
+                _table = table;
+            }
+
+            public bool? IsTableValueCompressed(Slice key, out bool? isLargeValue)
+            {
+                if (_table.TryFindIdFromPrimaryKey(key, out long id) == false)
+                {
+                    isLargeValue = default;
+                    return default;
+                }
+
+                isLargeValue = id % Constants.Storage.PageSize == 0;
+
+                if (isLargeValue.Value)
+                {
+                    var page = _table._tx.LowLevelTransaction.GetPage(id / Constants.Storage.PageSize);
+                    return page.Flags.HasFlag(PageFlags.Compressed);
+                }
+
+                var sizes = RawDataSection.GetRawDataEntrySizeFor(_table._tx.LowLevelTransaction, id);
+                return sizes->IsCompressed;
             }
         }
     }

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -2225,6 +2225,26 @@ namespace Voron.Data.Tables
             return report;
         }
 
+        public bool? TableValueIsCompressed(Slice key, out bool? isLargeValue)
+        {
+            if (TryFindIdFromPrimaryKey(key, out long id) == false)
+            {
+                isLargeValue = default;
+                return default;
+            }
+
+            isLargeValue = id % Constants.Storage.PageSize == 0;
+
+            if (isLargeValue.Value)
+            {
+                var page = _tx.LowLevelTransaction.GetPage(id / Constants.Storage.PageSize);
+                return page.Flags.HasFlag(PageFlags.Compressed);
+            }
+
+            var sizes = RawDataSection.GetRawDataEntrySizeFor(_tx.LowLevelTransaction, id);
+            return sizes->IsCompressed;
+        }
+
         [Conditional("DEBUG")]
         private void AssertWritableTable()
         {

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -38,7 +38,27 @@ namespace Voron.Impl
 
         private Dictionary<Slice, PostingList> _postingLists;
         
-        private Dictionary<Slice, Table> _tables;
+        private Dictionary<TableKey, Table> _tables;
+        private readonly struct TableKey
+        {
+            private readonly Slice _tableName;
+            private readonly bool _compressed;
+
+            public TableKey(Slice tableName, bool compressed)
+            {
+                _tableName = tableName;
+                _compressed = compressed;
+            }
+
+            private bool Equals(TableKey other) =>
+                SliceComparer.Equals(_tableName, other._tableName) && _compressed == other._compressed;
+
+            public override bool Equals(object obj) =>
+                obj is TableKey other && Equals(other);
+
+            public override int GetHashCode() =>
+                HashCode.Combine(_tableName.GetHashCode(), _compressed);
+        }
 
         private Dictionary<Slice, Tree> _trees;
 
@@ -213,21 +233,20 @@ namespace Voron.Impl
 
         public Table OpenTable(TableSchema schema, Slice name)
         {
-            _tables ??= new Dictionary<Slice, Table>(SliceStructComparer.Instance);
-
-            if (_tables.TryGetValue(name, out Table value))
-                return value;
+            _tables ??= new Dictionary<TableKey, Table>();
 
             var clonedName = name.Clone(Allocator);
+            var key = new TableKey(clonedName, schema.Compressed);
+            if (_tables.TryGetValue(key, out Table value))
+                return value;
 
             var tableTree = ReadTree(clonedName, RootObjectType.Table);
 
             if (tableTree == null)
                 return null;
 
-
             value = new Table(schema, clonedName, this, tableTree, schema.TableType);
-            _tables[clonedName] = value;
+            _tables[key] = value;
             return value;
         }
 
@@ -685,7 +704,7 @@ namespace Voron.Impl
 
             using (Slice.From(Allocator, name, ByteStringType.Immutable, out var nameSlice))
             {
-                _tables.Remove(nameSlice);
+                _tables.Remove(new TableKey(nameSlice, schema.Compressed));
             }
         }
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -39,26 +39,6 @@ namespace Voron.Impl
         private Dictionary<Slice, PostingList> _postingLists;
         
         private Dictionary<TableKey, Table> _tables;
-        private readonly struct TableKey
-        {
-            private readonly Slice _tableName;
-            private readonly bool _compressed;
-
-            public TableKey(Slice tableName, bool compressed)
-            {
-                _tableName = tableName;
-                _compressed = compressed;
-            }
-
-            private bool Equals(TableKey other) =>
-                SliceComparer.Equals(_tableName, other._tableName) && _compressed == other._compressed;
-
-            public override bool Equals(object obj) =>
-                obj is TableKey other && Equals(other);
-
-            public override int GetHashCode() =>
-                HashCode.Combine(_tableName.GetHashCode(), _compressed);
-        }
 
         private Dictionary<Slice, Tree> _trees;
 
@@ -718,6 +698,27 @@ namespace Voron.Impl
                 Allocator.Release(ref t);
                 _lowLevelTransaction.DecompressedBufferBytes -= t.Length;
             }
+        }
+
+        private readonly struct TableKey
+        {
+            private readonly Slice _tableName;
+            private readonly bool _compressed;
+
+            public TableKey(Slice tableName, bool compressed)
+            {
+                _tableName = tableName;
+                _compressed = compressed;
+            }
+
+            private bool Equals(TableKey other) =>
+                SliceComparer.Equals(_tableName, other._tableName) && _compressed == other._compressed;
+
+            public override bool Equals(object obj) =>
+                obj is TableKey other && Equals(other);
+
+            public override int GetHashCode() =>
+                HashCode.Combine(_tableName.GetHashCode(), _compressed);
         }
     }
 }

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -215,10 +215,12 @@ namespace Voron.Impl
         {
             _tables ??= new Dictionary<TableKey, Table>();
 
-            var clonedName = name.Clone(Allocator);
-            var key = new TableKey(clonedName, schema.Compressed);
+            var key = new TableKey(name, schema.Compressed);
             if (_tables.TryGetValue(key, out Table value))
                 return value;
+
+            var clonedName = name.Clone(Allocator);
+            key = new TableKey(clonedName, schema.Compressed);
 
             var tableTree = ReadTree(clonedName, RootObjectType.Table);
 

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6446;
+            const int numberToTolerate = 6442;
             if (array.Length == numberToTolerate)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21761/

### Additional description

_Continuation of https://github.com/ravendb/ravendb/pull/17659_

We have an issue that arises in the case of a merged transaction where write transactions are executed for documents of the same collection but with different schemas (compressed and non-compressed).

1. To hit this state with `RavenDB 5.4`, we need to change the compression configuration of the collection in the middle of a transaction: [scenario](https://github.com/ravendb/ravendb/pull/17659#discussion_r1387803904).
2. In the case of `RavenDB 6.0`, we hit this state if the `Data Archival` feature is used.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed