### PR TITLE
RavenDB-21490 Throw NotSupportedInCoraxException on attempt to dump or optimize Corax index

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
@@ -138,6 +138,7 @@ namespace Raven.Server.Documents.Handlers.Admin
             {
                 var name = GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
                 var index = Database.IndexStore.GetIndex(name);
+                
                 if (index == null)
                     IndexDoesNotExistException.ThrowFor(name);
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4968,8 +4968,7 @@ namespace Raven.Server.Documents.Indexes
 
         public void Optimize(IndexOptimizeResult result, CancellationToken token)
         {
-            if (IndexPersistence is CoraxIndexPersistence)
-                throw new NotImplementedInCoraxException($"{nameof(Optimize)} is not implemented yet.");
+            IndexPersistence.AssertCanOptimize();
 
             AssertCompactionOrOptimizationIsNotInProgress(Name, nameof(Optimize));
 
@@ -5367,11 +5366,7 @@ namespace Raven.Server.Documents.Indexes
 
         public int Dump(string path, Action<IOperationProgress> onProgress)
         {
-            if (IndexPersistence is CoraxIndexPersistence)
-            {
-                //todo maciej
-                return 0;
-            }
+            IndexPersistence.AssertCanDump();
 
             LuceneIndexPersistence indexPersistence = (LuceneIndexPersistence)IndexPersistence;
             if (Directory.Exists(path) == false)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Corax;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Indexes.Static.Counters;
@@ -25,7 +26,6 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 {
     private readonly Logger _logger;
     private readonly CoraxDocumentConverterBase _converter;
-    
     public CoraxIndexPersistence(Index index, IIndexReadOperationFactory indexReadOperationFactory) : base(index, indexReadOperationFactory)
     {
         _logger = LoggingSource.Instance.GetLogger<CoraxIndexPersistence>(index.DocumentDatabase.Name);
@@ -221,5 +221,15 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
             _converter,
             _logger
         );
+    }
+
+    public override void AssertCanOptimize()
+    {
+        throw new NotSupportedInCoraxException("Optimize is not supported in Corax.");
+    }
+
+    public override void AssertCanDump()
+    {
+        throw new NotSupportedInCoraxException("Dump is not supported in Corax.");
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexPersistenceBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexPersistenceBase.cs
@@ -21,7 +21,6 @@ namespace Raven.Server.Documents.Indexes.Persistence
         protected IIndexReadOperationFactory IndexReadOperationFactory { get; }
 
         public abstract bool HasWriter { get; }
-
         public abstract void CleanWritersIfNeeded();
 
         public abstract void Clean(IndexCleanup mode);
@@ -43,6 +42,8 @@ namespace Raven.Server.Documents.Indexes.Persistence
         public abstract bool ContainsField(string field);
         public abstract IndexFacetReadOperationBase OpenFacetedIndexReader(Transaction readTransaction);
         public abstract SuggestionIndexReaderBase OpenSuggestionIndexReader(Transaction readTransaction, string field);
+        public abstract void AssertCanOptimize();
+        public abstract void AssertCanDump();
         internal abstract void RecreateSearcher(Transaction asOfTx);
         internal abstract void RecreateSuggestionsSearchers(Transaction asOfTx);
         public abstract void DisposeWriters();

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -589,6 +589,16 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             if (_initialized == false)
                 throw new InvalidOperationException($"Index persistence for index '{_index.Definition.Name}' was not initialized.");
         }
+
+        public override void AssertCanOptimize()
+        {
+            
+        }
+        
+        public override void AssertCanDump()
+        {
+            
+        }
     }
 }
 

--- a/test/SlowTests/Issues/RavenDB-21490.cs
+++ b/test/SlowTests/Issues/RavenDB-21490.cs
@@ -1,0 +1,91 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Corax;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.ServerWide;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21490 : RavenTestBase
+{
+    public RavenDB_21490(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    private async Task OptimizeCoraxIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var index = new DummyCoraxIndex();
+                
+            await index.ExecuteAsync(store);
+                
+            await Indexes.WaitForIndexingAsync(store);
+
+            var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            
+            var indexInstance = database.IndexStore.GetIndex(index.IndexName);
+            
+            var token = new OperationCancelToken(database.DatabaseShutdown);
+            var result = new IndexOptimizeResult(index.IndexName);
+            
+            using (token)
+            using (database.PreventFromUnloadingByIdleOperations())
+            using (var indexCts = CancellationTokenSource.CreateLinkedTokenSource(token.Token, database.DatabaseShutdown))
+            {
+                var exception = Assert.Throws<NotSupportedInCoraxException>(() => indexInstance.Optimize(result, indexCts.Token));
+
+                Assert.Contains("Optimize is not supported in Corax.", exception.Message);
+            }
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    private async Task DumpCoraxIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var index = new DummyCoraxIndex();
+                
+            await index.ExecuteAsync(store);
+                
+            await Indexes.WaitForIndexingAsync(store);
+
+            var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            
+            var indexInstance = database.IndexStore.GetIndex(index.IndexName);
+            
+            var path = "dummy_path";
+            
+            var exception = Assert.Throws<NotSupportedInCoraxException>(() => indexInstance.Dump(path, onProgress => { }));
+
+            Assert.Contains("Dump is not supported in Corax.", exception.Message);
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+    }
+    
+    private class DummyCoraxIndex : AbstractIndexCreationTask<Dto>
+    {
+        public DummyCoraxIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new
+                {
+                    dto.Name
+                };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21490/Optimize-and-Dump-should-throw-NotSupportedInCorax-exception

### Additional description

We want to throw better exception for these two operations that are not supported in Corax

### Type of change

- Better exception

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
