### PR TITLE
RavenDB-21761: Handling the Case with Two Different Schemas for One Document Collection on `tx.OpenTable()` (`DataArchival` feature test)

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -129,6 +129,7 @@ namespace Raven.Server.Documents
                     _documentsStorage.ValidateId(context, lowerId, type: DocumentChangeTypes.Put, newFlags);
 
                 var collectionName = _documentsStorage.ExtractCollectionName(context, document);
+                _documentsStorage._forTestingPurposes?.OnBeforeOpenTableWhenPutDocumentWithSpecificId?.Invoke(id);
                 
                 var table = context.Transaction.InnerTransaction.OpenTable(_documentDatabase.GetDocsSchemaForCollection(collectionName, newFlags), collectionName.GetTableName(CollectionTableType.Documents));
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -806,7 +806,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        private TestingStuff _forTestingPurposes;
+        internal TestingStuff _forTestingPurposes;
 
         internal TestingStuff ForTestingPurposesOnly()
         {
@@ -819,6 +819,7 @@ namespace Raven.Server.Documents
         internal sealed class TestingStuff
         {
             public ManualResetEventSlim DelayDocumentLoad;
+            public Action<string> OnBeforeOpenTableWhenPutDocumentWithSpecificId { get; set; }
         }
         
         public IEnumerable<Document> GetDocumentsFrom(DocumentsOperationContext context, long etag, long start, long take, DocumentFields fields = DocumentFields.All, EventHandler<InvalidOperationException> onCorruptedDataHandler = null)
@@ -2779,6 +2780,12 @@ namespace Raven.Server.Documents
         {
             var ptr = tvr.Read(index, out int size);
             return Slice.From(context.Allocator, ptr, size, ByteStringType.Immutable, out slice);
+        }
+
+        public bool? DocumentIsCompressed(DocumentsOperationContext context, Slice lowerDocumentId, out bool? isLargeValue)
+        {
+            var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+            return table.TableValueIsCompressed(lowerDocumentId, out isLargeValue);
         }
     }
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -813,20 +813,23 @@ namespace Raven.Server.Documents
             if (_forTestingPurposes != null)
                 return _forTestingPurposes;
 
-            return _forTestingPurposes = new TestingStuff();
+            return _forTestingPurposes = new TestingStuff(DocsSchema);
         }
 
         internal sealed class TestingStuff
         {
-            internal TestingStuff()
+            private readonly TableSchema _docsSchema;
+
+            internal TestingStuff(TableSchema docsSchema)
             {
+                _docsSchema = docsSchema;
             }
 
             public ManualResetEventSlim DelayDocumentLoad;
             public Action<string> OnBeforeOpenTableWhenPutDocumentWithSpecificId { get; set; }
             public bool? IsDocumentCompressed(DocumentsOperationContext context, Slice lowerDocumentId, out bool? isLargeValue)
             {
-                var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+                var table = new Table(_docsSchema, context.Transaction.InnerTransaction);
                 return table.ForTestingPurposesOnly().IsTableValueCompressed(lowerDocumentId, out isLargeValue);
             }
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -818,8 +818,17 @@ namespace Raven.Server.Documents
 
         internal sealed class TestingStuff
         {
+            internal TestingStuff()
+            {
+            }
+
             public ManualResetEventSlim DelayDocumentLoad;
             public Action<string> OnBeforeOpenTableWhenPutDocumentWithSpecificId { get; set; }
+            public bool? IsDocumentCompressed(DocumentsOperationContext context, Slice lowerDocumentId, out bool? isLargeValue)
+            {
+                var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+                return table.ForTestingPurposesOnly().IsTableValueCompressed(lowerDocumentId, out isLargeValue);
+            }
         }
         
         public IEnumerable<Document> GetDocumentsFrom(DocumentsOperationContext context, long etag, long start, long take, DocumentFields fields = DocumentFields.All, EventHandler<InvalidOperationException> onCorruptedDataHandler = null)
@@ -2780,12 +2789,6 @@ namespace Raven.Server.Documents
         {
             var ptr = tvr.Read(index, out int size);
             return Slice.From(context.Allocator, ptr, size, ByteStringType.Immutable, out slice);
-        }
-
-        public bool? DocumentIsCompressed(DocumentsOperationContext context, Slice lowerDocumentId, out bool? isLargeValue)
-        {
-            var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
-            return table.TableValueIsCompressed(lowerDocumentId, out isLargeValue);
         }
     }
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -240,10 +240,12 @@ namespace Voron.Impl
         {
             _tables ??= new Dictionary<TableKey, Table>();
 
-            var clonedName = name.Clone(Allocator);
-            var key = new TableKey(clonedName, schema.Compressed);
+            var key = new TableKey(name, schema.Compressed);
             if (_tables.TryGetValue(key, out Table value))
                 return value;
+
+            var clonedName = name.Clone(Allocator);
+            key = new TableKey(clonedName, schema.Compressed);
 
             var tableTree = ReadTree(clonedName, RootObjectType.Table);
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -37,26 +37,6 @@ namespace Voron.Impl
         private Dictionary<Slice, PostingList> _postingLists;
         
         private Dictionary<TableKey, Table> _tables;
-        private readonly struct TableKey
-        {
-            private readonly Slice _tableName;
-            private readonly bool _compressed;
-
-            public TableKey(Slice tableName, bool compressed)
-            {
-                _tableName = tableName;
-                _compressed = compressed;
-            }
-
-            private bool Equals(TableKey other) =>
-                SliceComparer.Equals(_tableName, other._tableName) && _compressed == other._compressed;
-
-            public override bool Equals(object obj) =>
-                obj is TableKey other && Equals(other);
-
-            public override int GetHashCode() =>
-                HashCode.Combine(_tableName.GetHashCode(), _compressed);
-        }
 
         private Dictionary<Slice, Tree> _trees;
 
@@ -767,6 +747,27 @@ namespace Voron.Impl
             state = new Container.TransactionState(containerId);
             _containers[containerId] = state;
             return state;
+        }
+
+        private readonly struct TableKey
+        {
+            private readonly Slice _tableName;
+            private readonly bool _compressed;
+
+            public TableKey(Slice tableName, bool compressed)
+            {
+                _tableName = tableName;
+                _compressed = compressed;
+            }
+
+            private bool Equals(TableKey other) =>
+                SliceComparer.Equals(_tableName, other._tableName) && _compressed == other._compressed;
+
+            public override bool Equals(object obj) =>
+                obj is TableKey other && Equals(other);
+
+            public override int GetHashCode() =>
+                HashCode.Combine(_tableName.GetHashCode(), _compressed);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_19529.cs
+++ b/test/SlowTests/Issues/RavenDB_19529.cs
@@ -7,8 +7,11 @@ using Raven.Client.Documents.Replication;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.DocumentsCompression;
 using Raven.Server.Config;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
+using Voron;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -63,19 +66,19 @@ public class RavenDB_19529 : ReplicationTestBase
 
     private const char CharToAppend = 'a';
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Compression | RavenTestCategory.Voron)]
     public async Task MergedTransaction_DeleteOneDoc_Then_PutAnotherToLargeSection_CompressionSetOnServerCreation()
     {
         const string specificSizeAndContentDocumentId = "users/1-A";
         const string documentToDeleteId = "users/2-A";
 
         using (var server = GetNewServer(new ServerCreationOptions
-        {
-            CustomSettings = new Dictionary<string, string>
-            {
-                [RavenConfiguration.GetKey(x => x.Databases.CompressAllCollectionsDefault)] = true.ToString(),
-            }
-        }))
+                    {
+                        CustomSettings = new Dictionary<string, string>
+                        {
+                            [RavenConfiguration.GetKey(x => x.Databases.CompressAllCollectionsDefault)] = true.ToString(),
+                        }
+                    }))
         using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false }))
         {
             using (var session = store.OpenAsyncSession())
@@ -101,10 +104,19 @@ public class RavenDB_19529 : ReplicationTestBase
 
             Assert.True(WaitForDocument<User>(store, specificSizeAndContentDocumentId, user => user.Name.Last() == CharToAppend),
                 $"The document '{specificSizeAndContentDocumentId}' wasn't updated as expected");
+
+            var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
+            using (context.OpenReadTransaction())
+            using (DocumentIdWorker.GetSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
+            {
+                Assert.True(database.DocumentsStorage.DocumentIsCompressed(context, lowerDocumentId, out var isLargeValue));
+                Assert.True(isLargeValue);
+            }
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Compression | RavenTestCategory.Voron)]
     public async Task MergedTransaction_DeleteOneDoc_Then_PutAnotherToLargeSection_CompressionSetInTheMiddle()
     {
         const string specificSizeAndContentDocumentId = "users/1-A";
@@ -138,10 +150,19 @@ public class RavenDB_19529 : ReplicationTestBase
 
             Assert.True(WaitForDocument<User>(store, specificSizeAndContentDocumentId, user => user.Name.Last() == CharToAppend),
                 $"The document '{specificSizeAndContentDocumentId}' wasn't updated as expected");
+
+            var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
+            using (context.OpenReadTransaction())
+            using (DocumentIdWorker.GetSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
+            {
+                Assert.True(database.DocumentsStorage.DocumentIsCompressed(context, lowerDocumentId, out var isLargeValue));
+                Assert.True(isLargeValue);
+            }
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Compression | RavenTestCategory.Voron)]
     public async Task MergedTransaction_AddConflict_Then_PutUpdateDocumentOnLargeSection_CompressionSetInTheMiddle()
     {
         const string specificSizeAndContentDocumentId = "users/1-A";
@@ -149,12 +170,12 @@ public class RavenDB_19529 : ReplicationTestBase
 
         using (var storeSrc = GetDocumentStore())
         using (var storeDst = GetDocumentStore(new Options
-        {
-            ModifyDatabaseRecord = record =>
-            {
-                record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
-            }
-        }))
+               {
+                   ModifyDatabaseRecord = record =>
+                   {
+                       record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
+                   }
+               }))
         {
             storeDst.Maintenance.Send(new UpdateDocumentsCompressionConfigurationOperation(new DocumentsCompressionConfiguration { CompressAllCollections = true }));
 
@@ -164,7 +185,7 @@ public class RavenDB_19529 : ReplicationTestBase
                 sessionSrc.SaveChanges();
             }
 
-            var taskId = (await SetupReplicationAsync(storeSrc, storeDst)).First().TaskId;
+            var taskId = SetupReplicationAsync(storeSrc, storeDst).Result.First().TaskId;
             Assert.NotNull(WaitForDocumentToReplicate<User>(storeDst, specificSizeAndContentDocumentId, 15000));
 
             await storeSrc.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.Replication, disable: true));
@@ -192,66 +213,127 @@ public class RavenDB_19529 : ReplicationTestBase
             WaitUntilHasConflict(storeDst, documentToConflictId, count: 1);
             Assert.True(WaitForDocument<User>(storeDst, specificSizeAndContentDocumentId, user => user.Name.Last() == CharToAppend),
                 $"The document '{specificSizeAndContentDocumentId}' wasn't replicated as expected");
+
+            var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(storeDst.Database);
+            using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
+            using (context.OpenReadTransaction())
+            using (DocumentIdWorker.GetSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
+            {
+                Assert.True(database.DocumentsStorage.DocumentIsCompressed(context, lowerDocumentId, out var isLargeValue));
+                Assert.True(isLargeValue);
+            }
         }
     }
 
-
-    [Fact(Skip = "Conflict for for document in different collections can be resolved only manually - Issue RavenDB-17382")]
-    public async Task MergedTransaction_ConflictForDocumentInDifferentCollection_Then_PutUpdateDocumentOnLargeSection_CompressionSetInTheMiddle()
+    [RavenFact(RavenTestCategory.Compression | RavenTestCategory.Voron)]
+    public async Task CanHandleChangingCompressionConfigurationInTheMiddleOfTransaction()
     {
         const string specificSizeAndContentDocumentId = "users/1-A";
-        const string documentToConflictId = "users/2-A";
+        const string documentToDeleteId = "users/2-A";
 
-        using (var storeSrc = GetDocumentStore(new Options
+        using (var server = GetNewServer(new ServerCreationOptions
+               {
+                   CustomSettings = new Dictionary<string, string>
+                   {
+                       [RavenConfiguration.GetKey(x => x.Databases.CompressAllCollectionsDefault)] = true.ToString(),
+                   }
+               }))
+        using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false }))
         {
-            ModifyDatabaseRecord = record =>
+            using (var session = store.OpenAsyncSession())
             {
-                record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
-            }
-        }))
-        using (var storeDst = GetDocumentStore(new Options
-        {
-            ModifyDatabaseRecord = record =>
-            {
-                record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
-            }
-        }))
-        {
-            storeDst.Maintenance.Send(new UpdateDocumentsCompressionConfigurationOperation(new DocumentsCompressionConfiguration { CompressAllCollections = true }));
+                await session.StoreAsync(new User { Name = SpecificContentWithSpecificSize }, specificSizeAndContentDocumentId);
+                await session.StoreAsync(new User { Name = "Document To Delete" }, documentToDeleteId);
 
-            using (var session = storeSrc.OpenSession())
-            {
-                session.Store(new User { Name = SpecificContentWithSpecificSize }, specificSizeAndContentDocumentId);
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            var taskId = (await SetupReplicationAsync(storeSrc, storeDst)).First().TaskId;
-            Assert.NotNull(WaitForDocumentToReplicate<User>(storeDst, specificSizeAndContentDocumentId, 15000));
-
-            await storeSrc.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.Replication, disable: true));
-
-            using (var sessionDst = storeDst.OpenSession())
+            var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            database.DocumentsStorage.ForTestingPurposesOnly().OnBeforeOpenTableWhenPutDocumentWithSpecificId = id =>
             {
-                sessionDst.Store(new User { Name = "Document To Conflict" }, documentToConflictId);
-                sessionDst.SaveChanges();
-            }
+                if (id == specificSizeAndContentDocumentId)
+                    store.Maintenance.Send(new UpdateDocumentsCompressionConfigurationOperation(new DocumentsCompressionConfiguration { CompressAllCollections = false }));
+            };
 
-            using (var sessionSrc = storeSrc.OpenSession())
+            using (var operationSession = store.OpenSession())
             {
-                // To create a merge transaction that will be formed after enabling replication, we first need to create a Conflict in different collection...
-                sessionSrc.Store(new Company { Name = "Another Document To Conflict" }, documentToConflictId);
+                // Form a merge transaction within which there will first be a DELETE command...
+                var userToDelete = operationSession.Load<User>(documentToDeleteId);
+                operationSession.Delete(userToDelete);
 
                 // ...and then a PUT command
-                var specificSizeAndContentUser = sessionSrc.Load<User>(specificSizeAndContentDocumentId);
+                var specificSizeAndContentUser = operationSession.Load<User>(specificSizeAndContentDocumentId);
                 specificSizeAndContentUser.Name += CharToAppend;
 
-                sessionSrc.SaveChanges();
+                operationSession.SaveChanges();
             }
 
+            Assert.True(WaitForDocument<User>(store, specificSizeAndContentDocumentId, user => user.Name.Last() == CharToAppend),
+                $"The document '{specificSizeAndContentDocumentId}' wasn't updated as expected");
+
+            using (var context = DocumentsOperationContext.ShortTermSingleUse(database))
+            using (context.OpenReadTransaction())
+            using (DocumentIdWorker.GetSliceFromId(context, specificSizeAndContentDocumentId, out Slice lowerDocumentId))
+            {
+                Assert.False(database.DocumentsStorage.DocumentIsCompressed(context, lowerDocumentId, out var isLargeValue));
+                Assert.True(isLargeValue);
+            }
+        }
+    }
+
+     [Fact(Skip= "Conflict for for document in different collections can be resolved only manually - Issue RavenDB-17382")]
+     public async Task MergedTransaction_ConflictForDocumentInDifferentCollection_Then_PutUpdateDocumentOnLargeSection()
+     {
+         const string specificSizeAndContentDocumentId = "users/1-A";
+         const string documentToConflictId = "users/2-A";
+
+         using (var storeSrc = GetDocumentStore(new Options
+                {
+                    ModifyDatabaseRecord = record =>
+                    {
+                        record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
+                    }
+                }))
+         using (var storeDst = GetDocumentStore(new Options
+                {
+                    ModifyDatabaseRecord = record =>
+                    {
+                        record.ConflictSolverConfig = new ConflictSolver { ResolveToLatest = false, ResolveByCollection = new Dictionary<string, ScriptResolver>() };
+                    }
+                }))
+         {
+             storeDst.Maintenance.Send(new UpdateDocumentsCompressionConfigurationOperation(new DocumentsCompressionConfiguration { CompressAllCollections = true }));
+
+             using (var session = storeSrc.OpenSession())
+             {
+                 session.Store(new User { Name = SpecificContentWithSpecificSize }, specificSizeAndContentDocumentId);
+                 session.SaveChanges();
+             }
+
+             var taskId = SetupReplicationAsync(storeSrc, storeDst).Result.First().TaskId;
+             Assert.NotNull(WaitForDocumentToReplicate<User>(storeDst, specificSizeAndContentDocumentId, 15000));
+
+             await storeSrc.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.Replication, disable: true));
+
+             using (var sessionDst = storeDst.OpenSession())
+             {
+                 sessionDst.Store(new User { Name = "Document To Conflict" }, documentToConflictId);
+                 sessionDst.SaveChanges();
+             }
+
+             using (var sessionSrc = storeSrc.OpenSession())
+             {
+                 // To create a merge transaction that will be formed after enabling replication, we first need to create a Conflict in different collection...
+                 sessionSrc.Store(new Company { Name = "Another Document To Conflict" }, documentToConflictId);
+
+                 // ...and then a PUT command
+                var specificSizeAndContentUser = sessionSrc.Load<User>(specificSizeAndContentDocumentId);
+                specificSizeAndContentUser.Name += CharToAppend;
+                 sessionSrc.SaveChanges();
+            }
             await SetReplicationConflictResolutionAsync(storeDst, StraightforwardConflictResolution.ResolveToLatest);
             await storeSrc.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.Replication, disable: false));
-
-            Assert.True(WaitForDocument<User>(storeDst, specificSizeAndContentDocumentId, user => user.Name.Last() == CharToAppend),
+             Assert.True(WaitForDocument<User>(storeDst, specificSizeAndContentDocumentId, user => user.Name.Last() == CharToAppend),
                 $"The document '{specificSizeAndContentDocumentId}' wasn't replicated as expected");
         }
     }

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-            const int numberToTolerate = 4654;
+            const int numberToTolerate = 4650;
 
             if (array.Length == numberToTolerate)
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21761/

### Additional description

Testing of `DataArchival` feature in case of changes applied in that PR: https://github.com/ravendb/ravendb/pull/17788

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed