### PR TITLE
RavenDB-21772 Tombstone cleaner can start only after the initialization of indexes

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -336,8 +336,6 @@ namespace Raven.Server.Documents
                 _addToInitLog("Initializing ETL");
                 EtlLoader.Initialize(record);
 
-                TombstoneCleaner.Start();
-
                 try
                 {
                     // we need to wait here for the task to complete
@@ -357,6 +355,8 @@ namespace Raven.Server.Documents
 
                 SubscriptionStorage.Initialize();
                 _addToInitLog("Initializing SubscriptionStorage completed");
+
+                TombstoneCleaner.Start();
 
                 _serverStore.StorageSpaceMonitor.Subscribe(this);
 


### PR DESCRIPTION
…

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21772/Tombstone-cleaner-doesnt-wait-for-indexes-to-initialize

### Additional description

We wait 5 minutes (default of `Tombstones.CleanupIntervalInMin` setting) before we run the first tombstone cleanup. But this might be not enough for large indexes to be loaded.  In result we can delete tombstones that haven't been processed yet by indexes.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
