### PR TITLE
RavenDB-21597 Disabling Corax mode for tests on v5.4. |  Do not run the most expensive test on Linux to prevent crashes caused by the system's Out-Of-Memory (OOM) mechanism.

### DIFF
--- a/test/SlowTests/Corax/RavenDB-21597.cs
+++ b/test/SlowTests/Corax/RavenDB-21597.cs
@@ -1,0 +1,22 @@
+using System;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_21597 : NoDisposalNeeded
+{
+    public RavenDB_21597(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Configuration)]
+    public void CoraxTestsAreRunningOnCorrectVersionOnly()
+    {
+        if (Raven.Server.Documents.Indexes.IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion >= 60_000)
+#pragma warning disable CS0162 // Unreachable code detected
+            throw new InvalidOperationException($"The commit from 'RavenDB-21597' needs to be reverted since v6.0 in order to run all of Corax's tests properly.");
+#pragma warning restore CS0162 // Unreachable code detected
+    }
+}

--- a/test/StressTests/Corax/Bugs/PostingListTestsExtended.cs
+++ b/test/StressTests/Corax/Bugs/PostingListTestsExtended.cs
@@ -4,33 +4,40 @@ using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace SlowTests.Voron;
+namespace StressTests.Corax.Bugs;
 
 public class PostingListTestsExtended : NoDisposalNoOutputNeeded
 {
     public PostingListTestsExtended(ITestOutputHelper output) : base(output)
     {
     }
-    
+
     public static IEnumerable<object[]> Configuration =>
         new List<object[]>
         {
-            new object[] { Random.Shared.Next(), Random.Shared.Next(20000000)},
-            new object[] { Random.Shared.Next(), Random.Shared.Next(2000000)},
-            new object[] { Random.Shared.Next(), Random.Shared.Next(200000)},
-            new object[] { Random.Shared.Next(), Random.Shared.Next(20000)},
+            new object[] {Random.Shared.Next(), Random.Shared.Next(20000000)},
+            new object[] {Random.Shared.Next(), Random.Shared.Next(2000000)},
+            new object[] {Random.Shared.Next(), Random.Shared.Next(200000)},
+            new object[] {Random.Shared.Next(), Random.Shared.Next(20000)},
         };
 
-    [RavenTheory(RavenTestCategory.Voron)]
+    [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.Corax)]
     [InlineData(1337, 200000)]
     [InlineData(1064156071, 796)]
     [InlineData(511767612, 4172)]
     [InlineData(439188321, 502627)]
     [InlineData(506431817, 2)]
-    [InlineData(391060845, 31707323)]
     [InlineData(1477187726, 1828658)]
     [MemberData("Configuration")]
     public void CanDeleteAndInsertInRandomOrder(int seed, int size)
+    {
+        using var testClass = new FastTests.Voron.Sets.PostingListTests(Output);
+        testClass.CanDeleteAndInsertInRandomOrder(seed, size, 10);
+    }
+
+    [MultiplatformTheory(RavenPlatform.Windows)]
+    [InlineData(391060845, 31707323)]
+    public void CanDeleteAndInsertInRandomOrderWindows(int seed, int size)
     {
         using var testClass = new FastTests.Voron.Sets.PostingListTests(Output);
         testClass.CanDeleteAndInsertInRandomOrder(seed, size, 10);

--- a/test/Tests.Infrastructure/RavenDataAttribute.cs
+++ b/test/Tests.Infrastructure/RavenDataAttribute.cs
@@ -72,7 +72,8 @@ public class RavenDataAttribute : DataAttribute
 
     internal static IEnumerable<(RavenSearchEngineMode SearchEngineMode, RavenTestBase.Options Options)> FillOptions(RavenTestBase.Options options, RavenSearchEngineMode mode)
     {
-        if (mode.HasFlag(RavenSearchEngineMode.Corax))
+        //We do not have the possibility to easily skip the test when only inline data is Corax, so let's run it. In the case of 'All,' we will not run Corax.
+        if (mode is RavenSearchEngineMode.Corax)
         {
             var coraxOptions = options.Clone();
             coraxOptions.SearchEngineMode = RavenSearchEngineMode.Corax;

--- a/test/Tests.Infrastructure/RavenFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenFactAttribute.cs
@@ -6,10 +6,12 @@ namespace Tests.Infrastructure;
 [TraitDiscoverer("Tests.Infrastructure.XunitExtensions.RavenTraitDiscoverer", "Tests.Infrastructure")]
 public class RavenFactAttribute : FactAttribute, ITraitAttribute
 {
+    private readonly RavenTestCategory _category;
     private string _skip;
 
     public RavenFactAttribute(RavenTestCategory category)
     {
+        _category = category;
     }
 
     public bool LicenseRequired { get; set; }
@@ -22,6 +24,9 @@ public class RavenFactAttribute : FactAttribute, ITraitAttribute
             if (skip != null)
                 return skip;
 
+            if (_category.HasFlag(RavenTestCategory.Corax))
+                return RavenTheoryAttribute.CoraxSkipMessage;
+            
             if (LicenseRequiredFactAttribute.ShouldSkip(LicenseRequired))
                 return LicenseRequiredFactAttribute.SkipMessage;
 

--- a/test/Tests.Infrastructure/RavenTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/RavenTheoryAttribute.cs
@@ -6,10 +6,14 @@ namespace Tests.Infrastructure;
 [TraitDiscoverer("Tests.Infrastructure.XunitExtensions.RavenTraitDiscoverer", "Tests.Infrastructure")]
 public class RavenTheoryAttribute : TheoryAttribute, ITraitAttribute
 {
+    internal const string CoraxSkipMessage = $"Corax tests are skipped on v5.4";
+
+    private readonly RavenTestCategory _category;
     private string _skip;
 
     public RavenTheoryAttribute(RavenTestCategory category)
     {
+        _category = category;
     }
 
     public bool LicenseRequired { get; set; }
@@ -21,6 +25,11 @@ public class RavenTheoryAttribute : TheoryAttribute, ITraitAttribute
             var skip = _skip;
             if (skip != null)
                 return skip;
+
+            if (_category.HasFlag(RavenTestCategory.Corax))
+            {
+                return CoraxSkipMessage;
+            }
 
             if (LicenseRequiredFactAttribute.ShouldSkip(LicenseRequired))
                 return LicenseRequiredFactAttribute.SkipMessage;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21597 


### Type of change

- Configuration

### How risky is the change?


- Not relevant

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
