### PR TITLE
RavenDB-21752 - Add EP for adding 'Delete Revision' to orphaned revisions (6.0)

### DIFF
--- a/src/Raven.Client/Documents/Operations/Revisions/AdoptOrphanedRevisionsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/AdoptOrphanedRevisionsOperation.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json.Serialization;
+using Raven.Client.Json;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.Revisions;
+public sealed class AdoptOrphanedRevisionsOperation : IOperation<OperationIdResult>
+{
+    private readonly Parameters _parameters;
+
+    public sealed class Parameters : ReveisionsOperationParameters
+    {
+        public string[] Collections { get; set; } = null;
+    }
+
+    public AdoptOrphanedRevisionsOperation()
+        : this(new Parameters())
+    {
+    }
+
+    public AdoptOrphanedRevisionsOperation(Parameters parameters)
+    {
+        _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
+    }
+
+    public RavenCommand<OperationIdResult> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
+    {
+        return new AdoptOrphanedRevisionsCommand(_parameters, conventions);
+    }
+
+    internal sealed class AdoptOrphanedRevisionsCommand : RavenCommand<OperationIdResult>
+    {
+        private readonly Parameters _parameters;
+        private readonly DocumentConventions _conventions;
+
+        public AdoptOrphanedRevisionsCommand(Parameters parameters, DocumentConventions conventions)
+        {
+            _parameters = parameters;
+            _conventions = conventions;
+        }
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            var pathBuilder = new StringBuilder(node.Url)
+                .Append("/databases/")
+                .Append(node.Database)
+                .Append("/admin/revisions/orphaned/adopt");
+
+            url = pathBuilder.ToString();
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new BlittableJsonContent(async stream =>
+                {
+                    var config = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_parameters, ctx);
+                    await ctx.WriteAsync(stream, config).ConfigureAwait(false);
+                }, _conventions)
+            };
+
+            return request;
+        }
+
+        public override bool IsReadRequest => false;
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            Result = JsonDeserializationClient.OperationIdResult(response);
+        }
+    }
+}
+

--- a/src/Raven.Client/Documents/Operations/Revisions/AdoptOrphanedRevisionsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/AdoptOrphanedRevisionsOperation.cs
@@ -15,7 +15,7 @@ public sealed class AdoptOrphanedRevisionsOperation : IOperation<OperationIdResu
 {
     private readonly Parameters _parameters;
 
-    public sealed class Parameters : ReveisionsOperationParameters
+    public sealed class Parameters : IRevisionsOperationParameters
     {
         public string[] Collections { get; set; } = null;
     }

--- a/src/Raven.Client/Documents/Operations/Revisions/EnforceRevisionsConfigurationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/EnforceRevisionsConfigurationOperation.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Documents.Operations.Revisions
     {
         private readonly Parameters _parameters;
 
-        public sealed class Parameters
+        public sealed class Parameters : ReveisionsOperationParameters
         {
             public bool IncludeForceCreated { get; set; } = false;
             public string[] Collections { get; set; } = null;

--- a/src/Raven.Client/Documents/Operations/Revisions/EnforceRevisionsConfigurationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/EnforceRevisionsConfigurationOperation.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Documents.Operations.Revisions
     {
         private readonly Parameters _parameters;
 
-        public sealed class Parameters : ReveisionsOperationParameters
+        public sealed class Parameters : IRevisionsOperationParameters
         {
             public bool IncludeForceCreated { get; set; } = false;
             public string[] Collections { get; set; } = null;

--- a/src/Raven.Client/Documents/Operations/Revisions/ReveisionsOperationParameters.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/ReveisionsOperationParameters.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Raven.Client.Documents.Operations.Revisions;
+internal interface ReveisionsOperationParameters
+{
+}
+

--- a/src/Raven.Client/Documents/Operations/Revisions/ReveisionsOperationParameters.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/ReveisionsOperationParameters.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Raven.Client.Documents.Operations.Revisions;
-internal interface ReveisionsOperationParameters
+internal interface IRevisionsOperationParameters
 {
 }
 

--- a/src/Raven.Client/Documents/Operations/Revisions/RevertResult.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/RevertResult.cs
@@ -121,6 +121,51 @@ namespace Raven.Client.Documents.Operations.Revisions
         }
     }
 
+    public sealed class AdoptOrphanedRevisionsResult : OperationResult
+    {
+        public int AdoptedCount { get; set; }
+
+        public override bool CanMerge => true;
+
+        public override void MergeWith(IOperationResult result)
+        {
+            if (result is not AdoptOrphanedRevisionsResult r)
+                return;
+
+            AdoptedCount += r.AdoptedCount;
+
+            base.MergeWith(result);
+        }
+
+        public override void MergeWith(IOperationProgress progress)
+        {
+            if (progress is not AdoptOrphanedRevisionsResult r)
+                return;
+
+            AdoptedCount += r.AdoptedCount;
+
+            base.MergeWith(progress);
+        }
+
+        public override IOperationProgress Clone()
+        {
+            return new AdoptOrphanedRevisionsResult()
+            {
+                AdoptedCount = AdoptedCount,
+                ScannedDocuments = ScannedDocuments,
+                ScannedRevisions = ScannedRevisions,
+                Warnings = Warnings
+            };
+        }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+            json[nameof(AdoptedCount)] = AdoptedCount;
+            return json;
+        }
+    }
+
     public sealed class RevertResult : OperationResult
     {
         public int RevertedDocuments { get; set; }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminRevisionsHandler.cs
@@ -40,5 +40,12 @@ namespace Raven.Server.Documents.Handlers.Admin
             using (var processor = new AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration(this))
                 await processor.ExecuteAsync();
         }
+
+        [RavenAction("/databases/*/admin/revisions/orphaned/adopt", "POST", AuthorizationStatus.DatabaseAdmin)]
+        public async Task AdoptOrphans()
+        {
+            using (var processor = new AdminRevisionsHandlerProcessorForAdoptOrphanedRevisions(this))
+                await processor.ExecuteAsync();
+        }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -12,10 +12,10 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
     internal abstract class AbstractAdminRevisionsHandlerProcessorForRevisionsOperation<TRequestHandler, TOperationContext, TOperationParameters> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
         where TOperationContext : JsonOperationContext
         where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
-        where TOperationParameters : ReveisionsOperationParameters
+        where TOperationParameters : IRevisionsOperationParameters
     {
         protected OperationType _operationType;
-        public string Description { get; set; } = string.Empty;
+        public abstract string Description { get; }
 
         protected AbstractAdminRevisionsHandlerProcessorForRevisionsOperation([NotNull] TRequestHandler requestHandler, OperationType operationType) : base(requestHandler)
         {

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -2,34 +2,42 @@
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.Documents.Operations;
 using Raven.Server.Json;
 using Raven.Server.ServerWide;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
 {
-    internal abstract class AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration<TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
+    internal abstract class AbstractAdminRevisionsHandlerProcessorForRevisionsOperation<TRequestHandler, TOperationContext, TOperationParameters> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
         where TOperationContext : JsonOperationContext
         where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+        where TOperationParameters : ReveisionsOperationParameters
     {
-        protected AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+        protected OperationType _operationType;
+        public string Description { get; set; } = string.Empty;
+
+        protected AbstractAdminRevisionsHandlerProcessorForRevisionsOperation([NotNull] TRequestHandler requestHandler, OperationType operationType) : base(requestHandler)
         {
+            _operationType = operationType;
         }
 
         protected abstract long GetNextOperationId();
 
-        protected abstract void ScheduleEnforceConfigurationOperation(long operationId, EnforceRevisionsConfigurationOperation.Parameters parameters, OperationCancelToken token);
+        protected abstract void ScheduleEnforceConfigurationOperation(long operationId, TOperationParameters parameters, OperationCancelToken token);
+        protected abstract TOperationParameters GetOperationParameters(BlittableJsonReaderObject json);
+
 
         public override async ValueTask ExecuteAsync()
         {
             var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
             var operationId = RequestHandler.GetLongQueryString("operationId", false) ?? GetNextOperationId();
 
-            EnforceRevisionsConfigurationOperation.Parameters parameters;
+            TOperationParameters parameters;
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
                 var json = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "revisions/revert");
-                parameters = JsonDeserializationServer.Parameters.EnforceRevisionsConfigurationOperationParameters(json);
+                parameters = GetOperationParameters(json);
             }
 
             ScheduleEnforceConfigurationOperation(operationId, parameters, token);

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
@@ -17,8 +17,9 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
     {
         public AdminRevisionsHandlerProcessorForAdoptOrphanedRevisions([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler, OperationType.AdoptOrphanedRevisions)
         {
-            Description = $"Adopt orphaned revisions in database '{RequestHandler.DatabaseName}'.";
         }
+
+        public override string Description => $"Adopt orphaned revisions in database '{RequestHandler.DatabaseName}'.";
 
         protected override AdoptOrphanedRevisionsOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
         {

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
@@ -22,12 +22,14 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
 
         protected override AdoptOrphanedRevisionsOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
         {
-            return JsonDeserializationServer.Parameters.AdoptOrphanedRevisionsConfigurationOperationParameters(json);
+            var parameters = JsonDeserializationServer.Parameters.AdoptOrphanedRevisionsConfigurationOperationParameters(json);
+            parameters.Collections = parameters.Collections?.Length > 0 ? parameters.Collections : null;
+            return parameters;
         }
 
         protected override Task<IOperationResult> ExecuteOperation(Action<IOperationProgress> onProgress, AdoptOrphanedRevisionsOperation.Parameters parameters, OperationCancelToken token)
         {
-            return RequestHandler.Database.DocumentsStorage.RevisionsStorage.AdoptOrphanedAsync(onProgress, parameters.Collections.ToHashSet(), token);
+            return RequestHandler.Database.DocumentsStorage.RevisionsStorage.AdoptOrphanedAsync(onProgress, parameters.Collections?.ToHashSet(), token);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents.Operations;
+using Raven.Server.Json;
+using Raven.Server.ServerWide;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
+{
+    internal class AdminRevisionsHandlerProcessorForAdoptOrphanedRevisions : AdminRevisionsHandlerProcessorForRevisionsOperation<AdoptOrphanedRevisionsOperation.Parameters>
+    {
+        public AdminRevisionsHandlerProcessorForAdoptOrphanedRevisions([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler, OperationType.AdoptOrphanedRevisions)
+        {
+            Description = $"Adopt orphaned revisions in database '{RequestHandler.DatabaseName}'.";
+        }
+
+        protected override AdoptOrphanedRevisionsOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
+        {
+            return JsonDeserializationServer.Parameters.AdoptOrphanedRevisionsConfigurationOperationParameters(json);
+        }
+
+        protected override Task<IOperationResult> ExecuteOperation(Action<IOperationProgress> onProgress, AdoptOrphanedRevisionsOperation.Parameters parameters, OperationCancelToken token)
+        {
+            return RequestHandler.Database.DocumentsStorage.RevisionsStorage.AdoptOrphanedAsync(onProgress, parameters.Collections.ToHashSet(), token);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -1,37 +1,33 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Server.Documents.Operations;
+using Raven.Server.Json;
 using Raven.Server.ServerWide;
-using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 
-namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
+namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions;
+internal sealed class AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration : AdminRevisionsHandlerProcessorForRevisionsOperation<EnforceRevisionsConfigurationOperation.Parameters>
 {
-    internal sealed class AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration : AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration<DatabaseRequestHandler, DocumentsOperationContext>
+    public AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler, OperationType.EnforceRevisionConfiguration)
     {
-        public AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration([NotNull] DatabaseRequestHandler requestHandler)
-            : base(requestHandler)
-        {
-        }
+        Description = $"Enforce revision configuration in database '{RequestHandler.DatabaseName}'.";
+    }
 
-        protected override long GetNextOperationId()
-        {
-            return RequestHandler.Database.Operations.GetNextOperationId();
-        }
+    protected override EnforceRevisionsConfigurationOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
+    {
+        return JsonDeserializationServer.Parameters.EnforceRevisionsConfigurationOperationParameters(json);
+    }
 
-        protected override void ScheduleEnforceConfigurationOperation(long operationId, EnforceRevisionsConfigurationOperation.Parameters parameters, OperationCancelToken token)
-        {
-            var t = RequestHandler.Database.Operations.AddLocalOperation(
-                operationId,
-                OperationType.EnforceRevisionConfiguration,
-                $"Enforce revision configuration in database '{RequestHandler.Database.Name}'.",
-                detailedDescription: null,
-                onProgress => RequestHandler.Database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress, parameters.IncludeForceCreated, parameters.Collections, token),
-                token: token);
-
-            _ = t.ContinueWith(_ =>
-            {
-                token.Dispose();
-            });
-        }
+    protected override Task<IOperationResult> ExecuteOperation(Action<IOperationProgress> onProgress, EnforceRevisionsConfigurationOperation.Parameters parameters, OperationCancelToken token)
+    {
+        return RequestHandler.Database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress, parameters.IncludeForceCreated, 
+            parameters.Collections.ToHashSet(StringComparer.OrdinalIgnoreCase), token);
     }
 }
+

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -21,13 +21,15 @@ internal sealed class AdminRevisionsHandlerProcessorForEnforceRevisionsConfigura
 
     protected override EnforceRevisionsConfigurationOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
     {
-        return JsonDeserializationServer.Parameters.EnforceRevisionsConfigurationOperationParameters(json);
+        var parameters = JsonDeserializationServer.Parameters.EnforceRevisionsConfigurationOperationParameters(json);
+        parameters.Collections = parameters.Collections?.Length > 0 ? parameters.Collections : null;
+        return parameters;
     }
 
     protected override Task<IOperationResult> ExecuteOperation(Action<IOperationProgress> onProgress, EnforceRevisionsConfigurationOperation.Parameters parameters, OperationCancelToken token)
     {
         return RequestHandler.Database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress, parameters.IncludeForceCreated, 
-            parameters.Collections.ToHashSet(StringComparer.OrdinalIgnoreCase), token);
+            parameters.Collections?.ToHashSet(StringComparer.OrdinalIgnoreCase), token);
     }
 }
 

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -16,8 +16,10 @@ internal sealed class AdminRevisionsHandlerProcessorForEnforceRevisionsConfigura
 {
     public AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler, OperationType.EnforceRevisionConfiguration)
     {
-        Description = $"Enforce revision configuration in database '{RequestHandler.DatabaseName}'.";
     }
+
+    public override string Description => $"Enforce revision configuration in database '{RequestHandler.DatabaseName}'.";
+
 
     protected override EnforceRevisionsConfigurationOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
     {

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForRevisionsOperation.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForRevisionsOperation.cs
@@ -10,7 +10,7 @@ using Raven.Server.ServerWide.Context;
 namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
 {
     internal abstract class AdminRevisionsHandlerProcessorForRevisionsOperation<TOperationParameters> : AbstractAdminRevisionsHandlerProcessorForRevisionsOperation<DatabaseRequestHandler, DocumentsOperationContext, TOperationParameters>
-        where TOperationParameters : ReveisionsOperationParameters
+        where TOperationParameters : IRevisionsOperationParameters
     {
 
         public AdminRevisionsHandlerProcessorForRevisionsOperation([NotNull] DatabaseRequestHandler requestHandler, OperationType operationType)
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
 
         protected abstract Task<IOperationResult> ExecuteOperation(Action<IOperationProgress> onProgress, TOperationParameters parameters, OperationCancelToken token);
 
-        protected override void ScheduleEnforceConfigurationOperation(long operationId, TOperationParameters parameters, // todo: change to some AbstractAdminRevisionsHandlerProcessorForRevisionsOperation
+        protected override void ScheduleEnforceConfigurationOperation(long operationId, TOperationParameters parameters, 
             OperationCancelToken token)
         {
             var t = RequestHandler.Database.Operations.AddLocalOperation(

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForRevisionsOperation.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForRevisionsOperation.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+using System;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents.Operations;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
+{
+    internal abstract class AdminRevisionsHandlerProcessorForRevisionsOperation<TOperationParameters> : AbstractAdminRevisionsHandlerProcessorForRevisionsOperation<DatabaseRequestHandler, DocumentsOperationContext, TOperationParameters>
+        where TOperationParameters : ReveisionsOperationParameters
+    {
+
+        public AdminRevisionsHandlerProcessorForRevisionsOperation([NotNull] DatabaseRequestHandler requestHandler, OperationType operationType)
+            : base(requestHandler, operationType)
+        {
+        }
+
+        protected override long GetNextOperationId()
+        {
+            return RequestHandler.Database.Operations.GetNextOperationId();
+        }
+
+        protected abstract Task<IOperationResult> ExecuteOperation(Action<IOperationProgress> onProgress, TOperationParameters parameters, OperationCancelToken token);
+
+        protected override void ScheduleEnforceConfigurationOperation(long operationId, TOperationParameters parameters, // todo: change to some AbstractAdminRevisionsHandlerProcessorForRevisionsOperation
+            OperationCancelToken token)
+        {
+            var t = RequestHandler.Database.Operations.AddLocalOperation(
+                operationId,
+                _operationType,
+                Description,
+                detailedDescription: null,
+                 onProgress => ExecuteOperation(onProgress, parameters, token),
+                token: token);
+
+            _ = t.ContinueWith(_ =>
+            {
+                token.Dispose();
+            });
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Operations/OperationType.cs
+++ b/src/Raven.Server/Documents/Operations/OperationType.cs
@@ -77,5 +77,8 @@ public enum OperationType
     LuceneOptimizeIndex,
 
     [Description("Resharding")]
-    Resharding
+    Resharding,
+
+    [Description("Adopt Orphaned Revisions")]
+    AdoptOrphanedRevisions
 }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.Debug.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.Debug.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.Revisions
+{
+    public partial class RevisionsStorage
+    {
+        internal class TestingStuff
+        {
+            private RevisionsStorage _parent;
+
+            public TestingStuff(RevisionsStorage revisionsStorage)
+            {
+                _parent = revisionsStorage;
+            }
+
+            internal void DeleteLastRevisionFor(DocumentsOperationContext context, string id, string collection)
+            {
+                var collectionName = new CollectionName(collection);
+                using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
+                using (_parent.GetKeyPrefix(context, lowerId, out var lowerIdPrefix))
+                using (GetKeyWithEtag(context, lowerId, etag: long.MaxValue, out var compoundPrefix))
+                {
+                    var table = _parent.EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
+                    var holder = table.SeekOneBackwardFrom(_parent.RevisionsSchema.Indexes[Schemas.Revisions.IdAndEtagSlice], lowerIdPrefix, compoundPrefix);
+                    var lastRevision = TableValueToRevision(context, ref holder.Reader, DocumentFields.ChangeVector | DocumentFields.LowerId);
+                    _parent.DeleteRevisionFromTable(context, table, new Dictionary<string, Table>(), lastRevision, collectionName, context.GetChangeVector(lastRevision.ChangeVector), _parent._database.Time.GetUtcNow().Ticks, lastRevision.Flags);
+                    IncrementCountOfRevisions(context, lowerIdPrefix, -1);
+                }
+            }
+        }
+
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff(this);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -31,6 +31,7 @@ using Voron.Exceptions;
 using Voron.Impl;
 using static Raven.Server.Documents.DocumentsStorage;
 using static Raven.Server.Documents.Schemas.Revisions;
+using static Voron.Data.Tables.Table;
 using Constants = Raven.Client.Constants;
 using Size = Sparrow.Size;
 
@@ -875,7 +876,43 @@ namespace Raven.Server.Documents.Revisions
             return true;
         }
 
-        private void DeleteRevisionFromTable(DocumentsOperationContext context, Table table, Dictionary<string, Table> writeTables,
+
+        private bool ShouldAdoptRevision(DocumentsOperationContext context, Slice lowerId, Slice lowerIdPrefix, CollectionName collectionName, out Table table, out Document lastRevision)
+        {
+            lastRevision = null;
+            table = null;
+
+            var local = _documentsStorage.Get(context, lowerId, fields: DocumentFields.Default, throwOnConflict: false);
+            if (local != null) // doc isn't deleted, so we don't need to create delete revision
+                return false;
+
+            lastRevision = GetLastRevisionFor(context, lowerId, lowerIdPrefix, collectionName, out table);
+            return lastRevision != null && lastRevision.Flags.Contain(DocumentFlags.DeleteRevision) == false;
+        }
+
+        private Document GetLastRevisionFor(DocumentsOperationContext context,
+            Slice lowerId,
+            Slice lowerIdPrefix,
+            CollectionName collectionName,
+            out Table table)
+        {
+            table = null;
+
+            using (GetKeyWithEtag(context, lowerId, etag: long.MaxValue, out var compoundPrefix))
+            {
+                table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
+                var holder = table.SeekOneBackwardFrom(RevisionsSchema.Indexes[IdAndEtagSlice], lowerIdPrefix, compoundPrefix);
+                if (holder == null)
+                {
+                    table = null;
+                    return null;
+                }
+
+                return TableValueToRevision(context, ref holder.Reader, DocumentFields.ChangeVector);
+            }
+        }
+
+        internal void DeleteRevisionFromTable(DocumentsOperationContext context, Table table, Dictionary<string, Table> writeTables,
             Document revision, CollectionName collectionName,
             ChangeVector changeVector, long lastModifiedTicks, DocumentFlags flags)
         {
@@ -1660,13 +1697,73 @@ namespace Raven.Server.Documents.Revisions
         }
 
         public async Task<IOperationResult> EnforceConfigurationAsync(Action<IOperationProgress> onProgress,
-            bool includeForceCreated, // include ForceCreated revisions on deletion in case of no revisions configuration (only conflict revisions config is exist).
-            string[] collections,
+           bool includeForceCreated, // include ForceCreated revisions on deletion in case of no revisions configuration (only conflict revisions config is exist).
+           HashSet<string> collections,
+           OperationCancelToken token)
+        {
+            var result = new EnforceConfigurationResult();
+            await PerformRevisionsOperationAsync(onProgress, result,
+                (ids, res, tk) => new EnforceRevisionConfigurationCommand(this, ids, res, includeForceCreated, tk),
+                collections, token);
+
+            return result;
+        }
+
+        public async Task<IOperationResult> AdoptOrphanedAsync(Action<IOperationProgress> onProgress,
+            HashSet<string> collections,
             OperationCancelToken token)
         {
-            HashSet<string> collectionsToUse = null;
-            if (collections is { Length: > 0 })
-                collectionsToUse = new HashSet<string>(collections, StringComparer.OrdinalIgnoreCase);
+            var result = new AdoptOrphanedRevisionsCommand.AdoptOrphanedRevisionsResult();
+            await PerformRevisionsOperationAsync(onProgress, result,
+                (ids, res, tk) => new AdoptOrphanedRevisionsCommand(this, ids, result, tk),
+                collections: collections, token);
+
+            return result;
+        }
+
+        public async Task<IOperationResult> AdoptOrphanedAsync(Action<IOperationProgress> onProgress,
+            OperationCancelToken token)
+        {
+            var result = new AdoptOrphanedRevisionsCommand.AdoptOrphanedRevisionsResult();
+            await PerformRevisionsOperationAsync(onProgress, result,
+                (ids, res, tk) => new AdoptOrphanedRevisionsCommand(this, ids, result, tk),
+                collections: null, token);
+
+            return result;
+        }
+
+        private bool CanContinueBatch(List<string> idsToCheck, TimeSpan elapsed, JsonOperationContext context)
+        {
+            if (idsToCheck.Count > 1024)
+                return false;
+
+            if (elapsed > MaxEnforceConfigurationSingleBatchTime)
+                return false;
+
+            if (context.AllocatedMemory > SizeLimitInBytes)
+                return false;
+
+            return true;
+        }
+
+        private async Task PerformRevisionsOperationAsync<TOperationResult>(
+            Action<IOperationProgress> onProgress,
+            TOperationResult result,
+            Func<List<string>, TOperationResult, OperationCancelToken, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
+            HashSet<string> collections,
+            OperationCancelToken token) where TOperationResult : OperationResult
+        {
+            if (collections != null)
+            {
+                if (collections.Comparer?.Equals(StringComparer.OrdinalIgnoreCase) == false)
+                    throw new InvalidOperationException("'collections' hashset must have an 'OrdinalIgnoreCase' comparer");
+
+                foreach (var collection in collections)
+                {
+                    if (string.IsNullOrEmpty(collection))
+                        throw new InvalidOperationException("There is no collection with name which is empty string or 'null'.");
+                }
+            }
 
             var parameters = new Parameters
             {
@@ -1678,7 +1775,6 @@ namespace Raven.Server.Documents.Revisions
 
             parameters.LastScannedEtag = parameters.EtagBarrier;
 
-            var result = new EnforceConfigurationResult();
             var ids = new List<string>();
             var sw = Stopwatch.StartNew();
 
@@ -1697,7 +1793,7 @@ namespace Raven.Server.Documents.Revisions
                 {
                     using (ctx.OpenReadTransaction())
                     {
-                        var tables = GetRevisionsTables(ctx, collectionsToUse, parameters.LastScannedEtag);
+                        var tables = GetRevisionsTables(ctx, collections, parameters.LastScannedEtag);
 
                         foreach (var table in tables)
                         {
@@ -1727,40 +1823,26 @@ namespace Raven.Server.Documents.Revisions
                                     break;
                                 }
                             }
+
+                            var moreWork = true;
+                            while (moreWork)
+                            {
+                                token.Delay();
+                                var cmd = createCommand(ids, result, token);
+                                await _database.TxMerger.Enqueue(cmd);
+                                moreWork = cmd.MoreWork;
+                            }
                         }
-
-                        EnforceRevisionConfigurationCommand cmd;
-                        do
-                        {
-                            token.Delay();
-                            cmd = new EnforceRevisionConfigurationCommand(this, ids, result, includeForceCreated, token);
-                            await _database.TxMerger.Enqueue(cmd);
-                        } while (cmd.MoreWork);
                     }
+
+
                 }
-            }
-
-
-            return result;
-
-            bool CanContinueBatch(List<string> idsToCheck, TimeSpan elapsed, JsonOperationContext context)
-            {
-                if (idsToCheck.Count > 1024)
-                    return false;
-
-                if (elapsed > MaxEnforceConfigurationSingleBatchTime)
-                    return false;
-
-                if (context.AllocatedMemory > SizeLimitInBytes)
-                    return false;
-
-                return true;
             }
         }
 
-        private List<IEnumerable<Table.TableValueHolder>> GetRevisionsTables(DocumentsOperationContext context, HashSet<string> collections, long lastScannedEtag)
+        private List<IEnumerable<TableValueHolder>> GetRevisionsTables(DocumentsOperationContext context, HashSet<string> collections, long lastScannedEtag)
         {
-            var collectionsTables = new List<IEnumerable<Table.TableValueHolder>>();
+            var collectionsTables = new List<IEnumerable<TableValueHolder>>();
 
             if (collections == null)
             {
@@ -1772,7 +1854,6 @@ namespace Raven.Server.Documents.Revisions
             {
                 foreach (var collection in collections)
                 {
-                    IEnumerable<Table.TableValueHolder> table = null;
                     var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: true);
                     var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
                     var revisions = context.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
@@ -1781,7 +1862,7 @@ namespace Raven.Server.Documents.Revisions
                         continue;
                     }
 
-                    table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
+                    var table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
 
                     collectionsTables.Add(table);
                 }
@@ -1795,7 +1876,7 @@ namespace Raven.Server.Documents.Revisions
             MinimumRevisionsToKeep = 0
         };
 
-        private long EnforceConfigurationFor(DocumentsOperationContext context, string id, bool skipForceCreated, ref bool moreWork)
+        internal long EnforceConfigurationFor(DocumentsOperationContext context, string id, bool skipForceCreated, ref bool moreWork)
         {
             using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
             using (GetKeyPrefix(context, lowerId, out var lowerIdPrefix))
@@ -1845,64 +1926,80 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        private sealed class EnforceRevisionConfigurationCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
+        internal bool AdoptOrphanedFor(DocumentsOperationContext context, string id)
         {
-            private readonly RevisionsStorage _revisionsStorage;
-            private readonly List<string> _ids;
-            private readonly bool _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration;
-            private readonly EnforceConfigurationResult _result;
-            private readonly OperationCancelToken _token;
-
-            public bool MoreWork;
-
-            public EnforceRevisionConfigurationCommand(
-                RevisionsStorage revisionsStorage,
-                List<string> ids,
-                EnforceConfigurationResult result,
-                bool includeForceCreated,
-                OperationCancelToken token)
+            using (DocumentIdWorker.GetSliceFromId(context, id, out var lowerId))
+            using (GetKeyPrefix(context, lowerId, out var lowerIdPrefix))
             {
-                _revisionsStorage = revisionsStorage;
-                _ids = ids;
-                _result = result;
-                _token = token;
-                _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration = includeForceCreated;
-            }
-
-            protected override long ExecuteCmd(DocumentsOperationContext context)
-            {
-                MoreWork = false;
-                foreach (var id in _ids)
+                var collectionName = GetCollectionFor(context, lowerIdPrefix);
+                if (collectionName == null)
                 {
-                    _token.ThrowIfCancellationRequested();
-                    _result.RemovedRevisions += (int)_revisionsStorage.EnforceConfigurationFor(context, id, _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration == false, ref MoreWork);
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Tried to delete revisions for '{id}' but no collection was found.");
+                    return false;
                 }
 
-                return _ids.Count;
-            }
 
-            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
-            {
-                return new EnforceRevisionConfigurationCommandDto(_revisionsStorage, _ids, _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration);
-            }
-
-            private sealed class EnforceRevisionConfigurationCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, EnforceRevisionConfigurationCommand>
-            {
-                private readonly RevisionsStorage _revisionsStorage;
-                private readonly List<string> _ids;
-                private readonly bool _includeForceCreated;
-
-                public EnforceRevisionConfigurationCommandDto(RevisionsStorage revisionsStorage, List<string> ids, bool includeForceCreated)
+                if (ShouldAdoptRevision(context, lowerId, lowerIdPrefix, collectionName, out var table, out var lastRevision))
                 {
-                    _revisionsStorage = revisionsStorage;
-                    _ids = ids;
-                    _includeForceCreated = includeForceCreated;
+                    var lastModifiedTicks = _database.Time.GetUtcNow().Ticks;
+                    CreateDeletedRevision(context, table, id, collectionName, lastModifiedTicks, lastRevision.Flags);
+                    return true;
                 }
 
-                public EnforceRevisionConfigurationCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+                return false;
+            }
+        }
+
+        private unsafe void CreateDeletedRevision(DocumentsOperationContext context, Table table, string id, CollectionName collectionName,
+            long lastModifiedTicks, DocumentFlags flags)
+        {
+            var deleteRevisionDocument = context.ReadObject(new DynamicJsonValue
+            {
+                [Constants.Documents.Metadata.Key] = new DynamicJsonValue
                 {
-                    return new EnforceRevisionConfigurationCommand(_revisionsStorage, _ids, new EnforceConfigurationResult(), _includeForceCreated, OperationCancelToken.None);
+                    [Constants.Documents.Metadata.Collection] = collectionName.Name
                 }
+            }, "RevisionsBin");
+
+            var newEtag = _database.DocumentsStorage.GenerateNextEtag();
+            var changeVector = _documentsStorage.GetNewChangeVector(context, newEtag);
+
+            Debug.Assert(changeVector != null, "Change vector must be set");
+            flags = flags.Strip(DocumentFlags.HasAttachments);
+            flags |= DocumentFlags.HasRevisions;
+
+            using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idSlice))
+            using (Slice.From(context.Allocator, changeVector, out var changeVectorSlice))
+            {
+                using var _ = GetKeyPrefix(context, lowerId, out Slice lowerIdPrefix);
+                var newEtagSwapBytes = Bits.SwapBytes(newEtag);
+                using (table.Allocate(out TableValueBuilder tvb))
+                {
+                    tvb.Add(changeVectorSlice.Content.Ptr, changeVectorSlice.Size);
+                    tvb.Add(lowerId);
+                    tvb.Add(SpecialChars.RecordSeparator);
+                    tvb.Add(newEtagSwapBytes);
+                    tvb.Add(idSlice);
+                    tvb.Add(deleteRevisionDocument.BasePointer, deleteRevisionDocument.Size);
+                    tvb.Add((int)(DocumentFlags.DeleteRevision | flags));
+                    tvb.Add(newEtagSwapBytes);
+                    tvb.Add(lastModifiedTicks);
+                    tvb.Add(context.GetTransactionMarker());
+                    if (flags.Contain(DocumentFlags.Resolved))
+                    {
+                        tvb.Add((int)DocumentFlags.Resolved);
+                    }
+                    else
+                    {
+                        tvb.Add(0);
+                    }
+
+                    tvb.Add(Bits.SwapBytes(lastModifiedTicks));
+                    table.Insert(tvb);
+                }
+
+                IncrementCountOfRevisions(context, lowerIdPrefix, 1);
             }
         }
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1713,7 +1713,7 @@ namespace Raven.Server.Documents.Revisions
             HashSet<string> collections,
             OperationCancelToken token)
         {
-            var result = new AdoptOrphanedRevisionsCommand.AdoptOrphanedRevisionsResult();
+            var result = new AdoptOrphanedRevisionsResult();
             await PerformRevisionsOperationAsync(onProgress, result,
                 (ids, res, tk) => new AdoptOrphanedRevisionsCommand(this, ids, result, tk),
                 collections: collections, token);
@@ -1724,7 +1724,7 @@ namespace Raven.Server.Documents.Revisions
         public async Task<IOperationResult> AdoptOrphanedAsync(Action<IOperationProgress> onProgress,
             OperationCancelToken token)
         {
-            var result = new AdoptOrphanedRevisionsCommand.AdoptOrphanedRevisionsResult();
+            var result = new AdoptOrphanedRevisionsResult();
             await PerformRevisionsOperationAsync(onProgress, result,
                 (ids, res, tk) => new AdoptOrphanedRevisionsCommand(this, ids, result, tk),
                 collections: null, token);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
@@ -23,7 +23,9 @@ namespace Raven.Server.Documents.Sharding.Handlers.Admin.Processors.Revisions
 
         protected override AdoptOrphanedRevisionsOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
         {
-            return JsonDeserializationServer.Parameters.AdoptOrphanedRevisionsConfigurationOperationParameters(json);
+            var parameters = JsonDeserializationServer.Parameters.AdoptOrphanedRevisionsConfigurationOperationParameters(json);
+            parameters.Collections = parameters.Collections?.Length > 0 ? parameters.Collections : null;
+            return parameters;
         }
 
         protected override RavenCommand<OperationIdResult> GetCommand(JsonOperationContext context, int shardNumber, AdoptOrphanedRevisionsOperation.Parameters parameters)

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
@@ -14,12 +14,13 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Admin.Processors.Revisions
 {
-    internal sealed class ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions : ShardedAdminRevisionsHandlerProcessorForRevisionsOperation<AdoptOrphanedRevisionsOperation.Parameters>
+    internal sealed class ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions : ShardedAdminRevisionsHandlerProcessorForRevisionsOperation<AdoptOrphanedRevisionsOperation.Parameters, AdoptOrphanedRevisionsResult>
     {
         public ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler, OperationType.AdoptOrphanedRevisions)
         {
-            Description = $"Adopt orphaned revisions in database '{RequestHandler.DatabaseName}'.";
         }
+
+        public override string Description => $"Adopt orphaned revisions in database '{RequestHandler.DatabaseName}'.";
 
         protected override AdoptOrphanedRevisionsOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
         {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Http;
+using Raven.Server.Documents.Operations;
+using Raven.Server.Json;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Admin.Processors.Revisions
+{
+    internal sealed class ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions : ShardedAdminRevisionsHandlerProcessorForRevisionsOperation<AdoptOrphanedRevisionsOperation.Parameters>
+    {
+        public ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler, OperationType.AdoptOrphanedRevisions)
+        {
+            Description = $"Adopt orphaned revisions in database '{RequestHandler.DatabaseName}'.";
+        }
+
+        protected override AdoptOrphanedRevisionsOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
+        {
+            return JsonDeserializationServer.Parameters.AdoptOrphanedRevisionsConfigurationOperationParameters(json);
+        }
+
+        protected override RavenCommand<OperationIdResult> GetCommand(JsonOperationContext context, int shardNumber, AdoptOrphanedRevisionsOperation.Parameters parameters)
+        {
+            return new AdoptOrphanedRevisionsOperation.AdoptOrphanedRevisionsCommand(parameters, DocumentConventions.DefaultForServer);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -14,12 +14,13 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Admin.Processors.Revisions
 {
-    internal sealed class ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration : ShardedAdminRevisionsHandlerProcessorForRevisionsOperation<EnforceRevisionsConfigurationOperation.Parameters>
+    internal sealed class ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration : ShardedAdminRevisionsHandlerProcessorForRevisionsOperation<EnforceRevisionsConfigurationOperation.Parameters, EnforceConfigurationResult>
     {
         public ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler, OperationType.EnforceRevisionConfiguration)
         {
-            Description = $"Enforce revision configuration in database '{RequestHandler.DatabaseName}'.";
         }
+
+        public override string Description => $"Enforce revision configuration in database '{RequestHandler.DatabaseName}'.";
 
         protected override EnforceRevisionsConfigurationOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
         {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -1,40 +1,34 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
-using Raven.Server.Documents.Handlers.Admin.Processors.Revisions;
+using Raven.Client.Http;
 using Raven.Server.Documents.Operations;
-using Raven.Server.ServerWide;
-using Raven.Server.ServerWide.Context;
+using Raven.Server.Json;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Admin.Processors.Revisions
 {
-    internal sealed class ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration : AbstractAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    internal sealed class ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration : ShardedAdminRevisionsHandlerProcessorForRevisionsOperation<EnforceRevisionsConfigurationOperation.Parameters>
     {
-        public ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration([NotNull] ShardedDatabaseRequestHandler requestHandler) 
-            : base(requestHandler)
+        public ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler, OperationType.EnforceRevisionConfiguration)
         {
+            Description = $"Enforce revision configuration in database '{RequestHandler.DatabaseName}'.";
         }
 
-        protected override long GetNextOperationId()
+        protected override EnforceRevisionsConfigurationOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
         {
-            return RequestHandler.DatabaseContext.Operations.GetNextOperationId();
+            return JsonDeserializationServer.Parameters.EnforceRevisionsConfigurationOperationParameters(json);
         }
 
-        protected override void ScheduleEnforceConfigurationOperation(long operationId, EnforceRevisionsConfigurationOperation.Parameters parameters, OperationCancelToken token)
+        protected override RavenCommand<OperationIdResult> GetCommand(JsonOperationContext context, int shardNumber, EnforceRevisionsConfigurationOperation.Parameters parameters)
         {
-            var task = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult, EnforceConfigurationResult, EnforceConfigurationResult>(
-                operationId,
-                OperationType.EnforceRevisionConfiguration,
-                $"Enforce revision configuration in database '{RequestHandler.DatabaseName}'.",
-                detailedDescription: null,
-                (_, shardNumber) => new EnforceRevisionsConfigurationOperation.EnforceRevisionsConfigurationCommand(parameters, DocumentConventions.DefaultForServer),
-                token: token);
-
-            _ = task.ContinueWith(_ =>
-            {
-                task.Dispose();
-            });
+            return new EnforceRevisionsConfigurationOperation.EnforceRevisionsConfigurationCommand(parameters, DocumentConventions.DefaultForServer);
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -23,7 +23,9 @@ namespace Raven.Server.Documents.Sharding.Handlers.Admin.Processors.Revisions
 
         protected override EnforceRevisionsConfigurationOperation.Parameters GetOperationParameters(BlittableJsonReaderObject json)
         {
-            return JsonDeserializationServer.Parameters.EnforceRevisionsConfigurationOperationParameters(json);
+            var parameters = JsonDeserializationServer.Parameters.EnforceRevisionsConfigurationOperationParameters(json);
+            parameters.Collections = parameters.Collections?.Length > 0 ? parameters.Collections : null;
+            return parameters;
         }
 
         protected override RavenCommand<OperationIdResult> GetCommand(JsonOperationContext context, int shardNumber, EnforceRevisionsConfigurationOperation.Parameters parameters)

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForRevisionsOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Revisions/ShardedAdminRevisionsHandlerProcessorForRevisionsOperation.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Http;
+using Raven.Server.Documents.Handlers.Admin.Processors.Revisions;
+using Raven.Server.Documents.Operations;
+using Raven.Server.Json;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Admin.Processors.Revisions
+{
+    internal abstract class ShardedAdminRevisionsHandlerProcessorForRevisionsOperation<TOperationParameters> : AbstractAdminRevisionsHandlerProcessorForRevisionsOperation<ShardedDatabaseRequestHandler, TransactionOperationContext, TOperationParameters>
+        where TOperationParameters : ReveisionsOperationParameters
+    {
+
+        public ShardedAdminRevisionsHandlerProcessorForRevisionsOperation([NotNull] ShardedDatabaseRequestHandler requestHandler, OperationType operationType)
+            : base(requestHandler, operationType)
+        {
+        }
+
+        protected override long GetNextOperationId()
+        {
+            return RequestHandler.DatabaseContext.Operations.GetNextOperationId();
+        }
+
+        protected abstract RavenCommand<OperationIdResult> GetCommand(JsonOperationContext context, int shardNumber, TOperationParameters parameters);
+
+        protected override void ScheduleEnforceConfigurationOperation(long operationId, TOperationParameters parameters,  // todo: change to some AbstractAdminRevisionsHandlerProcessorForRevisionsOperation
+            OperationCancelToken token)
+        {
+            var task = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult, EnforceConfigurationResult, EnforceConfigurationResult>(
+                operationId,
+                _operationType,//OperationType.EnforceRevisionConfiguration,
+                Description,//$"Enforce revision configuration in database '{RequestHandler.Database.Name}'.",
+                detailedDescription: null,
+                (context , shardNumber) => GetCommand(context, shardNumber, parameters), //(_, shardNumber) => new EnforceRevisionsConfigurationOperation.EnforceRevisionsConfigurationCommand(parameters, DocumentConventions.DefaultForServer),
+                token: token);
+
+            _ = task.ContinueWith(_ =>
+            {
+                task.Dispose();
+            });
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/ShardedAdminRevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/ShardedAdminRevisionsHandler.cs
@@ -1,6 +1,13 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Http;
+using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.Sharding.Handlers.Admin.Processors.Revisions;
 using Raven.Server.Routing;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Admin
 {
@@ -24,6 +31,13 @@ namespace Raven.Server.Documents.Sharding.Handlers.Admin
         public async Task EnforceConfigRevisions()
         {
             using (var processor = new ShardedAdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration(this))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/revisions/orphaned/adopt", "POST")]
+        public async Task AdoptOrphans()
+        {
+            using (var processor = new ShardedAdminRevisionsHandlerProcessorForAdoptOrphanedRevisions(this))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/AdoptOrphanedRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/AdoptOrphanedRevisionsCommand.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Parsing;
+using static Raven.Server.Documents.TransactionMerger.Commands.AdoptOrphanedRevisionsCommand;
+
+namespace Raven.Server.Documents.TransactionMerger.Commands;
+internal class AdoptOrphanedRevisionsCommand : RevisionsScanningOperationCommand<AdoptOrphanedRevisionsResult>
+{
+    public AdoptOrphanedRevisionsCommand(
+        RevisionsStorage revisionsStorage,
+        List<string> ids,
+        AdoptOrphanedRevisionsResult result,
+        OperationCancelToken token) : base(revisionsStorage, ids, result, token)
+    {
+        MoreWork = false;
+    }
+
+    protected override long ExecuteCmd(DocumentsOperationContext context)
+    {
+        foreach (var id in _ids)
+        {
+            _token.ThrowIfCancellationRequested();
+            if (_revisionsStorage.AdoptOrphanedFor(context, id))
+                _result.AdoptedCount++;
+        }
+
+        return _ids.Count;
+    }
+
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+    {
+        return new AdoptOrphanedRevisionsCommandDto(_revisionsStorage, _ids);
+    }
+
+    private sealed class AdoptOrphanedRevisionsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, AdoptOrphanedRevisionsCommand>
+    {
+        private readonly RevisionsStorage _revisionsStorage;
+        private readonly List<string> _ids;
+        
+        public AdoptOrphanedRevisionsCommandDto(RevisionsStorage revisionsStorage, List<string> ids)
+        {
+            _revisionsStorage = revisionsStorage;
+            _ids = ids;
+        }
+        
+        public AdoptOrphanedRevisionsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+        {
+            return new AdoptOrphanedRevisionsCommand(_revisionsStorage, _ids, new AdoptOrphanedRevisionsResult(), OperationCancelToken.None);
+        }
+    }
+
+    public class AdoptOrphanedRevisionsResult : OperationResult
+    {
+        public long AdoptedCount { get; set; }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+            json[nameof(AdoptedCount)] = AdoptedCount;
+            return json;
+        }
+    }
+}
+

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/AdoptOrphanedRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/AdoptOrphanedRevisionsCommand.cs
@@ -57,16 +57,5 @@ internal class AdoptOrphanedRevisionsCommand : RevisionsScanningOperationCommand
         }
     }
 
-    public class AdoptOrphanedRevisionsResult : OperationResult
-    {
-        public long AdoptedCount { get; set; }
-
-        public override DynamicJsonValue ToJson()
-        {
-            var json = base.ToJson();
-            json[nameof(AdoptedCount)] = AdoptedCount;
-            return json;
-        }
-    }
 }
 

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/EnforceRevisionConfigurationCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/EnforceRevisionConfigurationCommand.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.TransactionMerger.Commands;
+
+internal sealed class EnforceRevisionConfigurationCommand : RevisionsScanningOperationCommand<EnforceConfigurationResult>
+{
+    private readonly bool _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration;
+
+    public EnforceRevisionConfigurationCommand(
+        RevisionsStorage revisionsStorage,
+        List<string> ids,
+        EnforceConfigurationResult result,
+        bool includeForceCreated,
+        OperationCancelToken token) : base(revisionsStorage, ids, result, token)
+    {
+        _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration = includeForceCreated;
+    }
+
+    protected override long ExecuteCmd(DocumentsOperationContext context)
+    {
+        MoreWork = false;
+        foreach (var id in _ids)
+        {
+            _token.ThrowIfCancellationRequested();
+            _result.RemovedRevisions += (int)_revisionsStorage.EnforceConfigurationFor(context, id, _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration == false, ref MoreWork);
+        }
+
+        return _ids.Count;
+    }
+
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+    {
+        return new EnforceRevisionConfigurationCommandDto(_revisionsStorage, _ids, _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration);
+    }
+
+    private sealed class EnforceRevisionConfigurationCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, EnforceRevisionConfigurationCommand>
+    {
+        private readonly RevisionsStorage _revisionsStorage;
+        private readonly List<string> _ids;
+        private readonly bool _includeForceCreated;
+
+        public EnforceRevisionConfigurationCommandDto(RevisionsStorage revisionsStorage, List<string> ids, bool includeForceCreated)
+        {
+            _revisionsStorage = revisionsStorage;
+            _ids = ids;
+            _includeForceCreated = includeForceCreated;
+        }
+
+        public EnforceRevisionConfigurationCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+        {
+            return new EnforceRevisionConfigurationCommand(_revisionsStorage, _ids, new EnforceConfigurationResult(), _includeForceCreated, OperationCancelToken.None);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/RevisionsScanningOperationCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/RevisionsScanningOperationCommand.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.TransactionMerger.Commands
+{
+    internal abstract class RevisionsScanningOperationCommand<TOperationResult> : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
+        where TOperationResult : OperationResult
+    {
+        public bool MoreWork;
+
+        protected readonly RevisionsStorage _revisionsStorage;
+
+        protected readonly List<string> _ids;
+
+        protected readonly OperationCancelToken _token;
+
+        protected TOperationResult _result;
+
+        public RevisionsScanningOperationCommand(
+            RevisionsStorage revisionsStorage,
+            List<string> ids,
+            TOperationResult result,
+            OperationCancelToken token)
+        {
+            _revisionsStorage = revisionsStorage;
+            _ids = ids;
+            _result = result;
+            _token = token;
+        }
+    }
+}

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -336,6 +336,8 @@ namespace Raven.Server.Json
 
             public static readonly Func<BlittableJsonReaderObject, EnforceRevisionsConfigurationOperation.Parameters> EnforceRevisionsConfigurationOperationParameters = GenerateJsonDeserializationRoutine<EnforceRevisionsConfigurationOperation.Parameters>();
 
+            public static readonly Func<BlittableJsonReaderObject, AdoptOrphanedRevisionsOperation.Parameters> AdoptOrphanedRevisionsConfigurationOperationParameters = GenerateJsonDeserializationRoutine<AdoptOrphanedRevisionsOperation.Parameters>();
+
         }
     }
 }

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -69,7 +69,8 @@ namespace FastTests.Client
                 "AddNodeToOrchestratorTopologyCommand", "RemoveNodeFromOrchestratorTopologyCommand", "GetTcpInfoForReplicationCommand", "GetCollectionFieldsCommand", "PreviewCollectionCommand",
                 "AddDatabaseShardCommand", "GetNextServerOperationIdCommand", "KillServerOperationCommand", "ModifyDatabaseTopologyCommand", "DelayBackupCommand",
                 "PutDatabaseClientConfigurationCommand", "PutDatabaseSettingsCommand", "PutDatabaseStudioConfigurationCommand", "GetTcpInfoForReplicationCommand",
-                "AddQueueSinkCommand", "UpdateQueueSinkCommand", "ConfigureDataArchivalCommand"
+                "AddQueueSinkCommand", "UpdateQueueSinkCommand", "ConfigureDataArchivalCommand",
+                "AdoptOrphanedRevisionsCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/FastTests/Issues/RavenDB-6250.cs
+++ b/test/FastTests/Issues/RavenDB-6250.cs
@@ -50,7 +50,8 @@ namespace FastTests.Issues
                 OperationType.DatabaseRevert,
                 OperationType.EnforceRevisionConfiguration,
                 OperationType.DumpRawIndexData,
-                OperationType.Resharding
+                OperationType.Resharding,
+                OperationType.AdoptOrphanedRevisions
             };
 
             var operationWithoutDetails = new HashSet<OperationType>

--- a/test/FastTests/Utils/RevisionsHelper.cs
+++ b/test/FastTests/Utils/RevisionsHelper.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents.Commands;
+using Raven.Server.Documents.Sharding;
 using Sparrow.Json;
 
 namespace FastTests.Utils
@@ -126,7 +127,26 @@ namespace FastTests.Utils
             var result = await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
 
             var documentDatabase = await serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+
             await documentDatabase.RachisLogIndexNotifications.WaitForIndexNotification(result.RaftCommandIndex.Value, serverStore.Engine.OperationTimeout);
+        }
+
+        public static async Task SetupRevisionsOnShardedDatabaseAsync(IDocumentStore store, Raven.Server.ServerWide.ServerStore serverStore, RevisionsConfiguration configuration, IAsyncEnumerable<ShardedDocumentDatabase> shards)
+        {
+            if (store == null)
+                throw new ArgumentNullException(nameof(store));
+            if (serverStore == null)
+                throw new ArgumentNullException(nameof(serverStore));
+            if (configuration == null)
+                throw new ArgumentNullException(nameof(configuration));
+
+            var result = await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+            var index = result.RaftCommandIndex;
+
+            await foreach (var shard in shards)
+            {
+                await shard.RachisLogIndexNotifications.WaitForIndexNotification(index.Value, serverStore.Engine.OperationTimeout);
+            }
         }
 
         private static async Task<long> SetupRevisionsInternal(Raven.Server.ServerWide.ServerStore serverStore, string database, RevisionsConfiguration configuration)

--- a/test/SlowTests/Issues/RavenDB-20846.cs
+++ b/test/SlowTests/Issues/RavenDB-20846.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Utils;
 using Raven.Client.Documents.Operations.Revisions;
@@ -86,7 +88,7 @@ public class RavenDB_20846 : ClusterTestBase
 
         var db = await Databases.GetDocumentDatabaseInstanceFor(store);
         using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: false, collections: new[] { "Users", "Products" }, token: token);
+            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: false, collections: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Users", "Products" }, token: token);
 
         using (var session = store.OpenAsyncSession())
         {

--- a/test/SlowTests/Issues/RavenDB-21381.cs
+++ b/test/SlowTests/Issues/RavenDB-21381.cs
@@ -42,16 +42,7 @@ namespace SlowTests.Issues
                 }
             };
 
-            if (options.DatabaseMode == RavenDatabaseMode.Sharded)
-            {
-                var shards = Sharding.GetShardsDocumentDatabaseInstancesFor(store);
-                await RevisionsHelper.SetupRevisionsOnShardedDatabaseAsync(store, Server.ServerStore, configuration: configuration, shards);
-            }
-            else
-            {
-                await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
-            }
-
+            await RevisionsHelper.SetupRevisionsAsync(store, store.Database, configuration);
 
             var user1 = new SamplesTestBase.User { Id = "Users/1-A", Name = "Shahar" };
             var user2 = new SamplesTestBase.User { Id = "Users/2-B", Name = "Shahar" };

--- a/test/SlowTests/Issues/RavenDB-21381.cs
+++ b/test/SlowTests/Issues/RavenDB-21381.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Voron.Data.Tables;
+using Xunit;
+using Xunit.Abstractions;
+using static SlowTests.Issues.RavenDB_13335;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21381 : ClusterTestBase
+    {
+        public RavenDB_21381(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Revisions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task AdoptOrphanedRevisionsTest(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 100
+                }
+            };
+
+            if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+            {
+                var shards = Sharding.GetShardsDocumentDatabaseInstancesFor(store);
+                await RevisionsHelper.SetupRevisionsOnShardedDatabaseAsync(store, Server.ServerStore, configuration: configuration, shards);
+            }
+            else
+            {
+                await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+            }
+
+
+            var user1 = new SamplesTestBase.User { Id = "Users/1-A", Name = "Shahar" };
+            var user2 = new SamplesTestBase.User { Id = "Users/2-B", Name = "Shahar" };
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.StoreAsync(user2);
+                await session.SaveChangesAsync();
+
+                for (int i = 1; i <= 10; i++)
+                {
+                    (await session.LoadAsync<SamplesTestBase.User>(user1.Id)).Name = $"Shahar{i}";
+                    (await session.LoadAsync<SamplesTestBase.User>(user2.Id)).Name = $"Shahar{i}";
+                    await session.SaveChangesAsync();
+                }
+
+                session.Delete(user1.Id);
+                session.Delete(user2.Id);
+                await session.SaveChangesAsync();
+
+                var user1RevCount = await session.Advanced.Revisions.GetCountForAsync(user1.Id);
+                Assert.Equal(12, user1RevCount);
+                var revisionsMetadata1 = await session.Advanced.Revisions.GetMetadataForAsync(user1.Id);
+                Assert.Contains(DocumentFlags.DeleteRevision.ToString(), revisionsMetadata1[0].GetString(Constants.Documents.Metadata.Flags));
+
+                var user2RevCount = await session.Advanced.Revisions.GetCountForAsync(user2.Id);
+                Assert.Equal(12, user2RevCount);
+                var revisionsMetadata2 = await session.Advanced.Revisions.GetMetadataForAsync(user2.Id);
+                Assert.Contains(DocumentFlags.DeleteRevision.ToString(), revisionsMetadata2[0].GetString(Constants.Documents.Metadata.Flags));
+            }
+
+            var dbName = store.Database;
+            if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+            {
+                var shardNumber = await Sharding.GetShardNumberForAsync(store, user1.Id);
+                dbName = ShardHelper.ToShardName(store.Database, shardNumber);
+            }
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store, dbName);
+
+            // Delete the last revision (the 'Delete Revision')
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (var tx = context.OpenWriteTransaction())
+            {
+                database.DocumentsStorage.RevisionsStorage.ForTestingPurposesOnly().DeleteLastRevisionFor(context, user1.Id, "Users");
+                tx.Commit();
+            }
+
+
+            // Assert that last revision of user1 isn't delete revision anymore (we created 11 orphaned revisions of 'Users/1-A')
+            using (var session = store.OpenAsyncSession())
+            {
+                var user1RevCount = await session.Advanced.Revisions.GetCountForAsync(user1.Id);
+                Assert.Equal(11, user1RevCount);
+                var revisionsMetadata1 = await session.Advanced.Revisions.GetMetadataForAsync(user1.Id);
+                Assert.False(revisionsMetadata1[0].GetString(Constants.Documents.Metadata.Flags).Contains(DocumentFlags.DeleteRevision.ToString()));
+
+                var user2RevCount = await session.Advanced.Revisions.GetCountForAsync(user2.Id);
+                Assert.Equal(12, user2RevCount);
+                var revisionsMetadata2 = await session.Advanced.Revisions.GetMetadataForAsync(user2.Id);
+                Assert.Contains(DocumentFlags.DeleteRevision.ToString(), revisionsMetadata2[0].GetString(Constants.Documents.Metadata.Flags));
+            }
+
+
+            // Run AdoptOrphaned and assert that new 'Delete Revision' was created again for user1
+            var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown);
+            await database.DocumentsStorage.RevisionsStorage.AdoptOrphanedAsync(null, token);
+            using (var session = store.OpenAsyncSession())
+            {
+                var user1RevCount = await session.Advanced.Revisions.GetCountForAsync(user1.Id);
+                Assert.Equal(12, user1RevCount);
+                var revisionsMetadata1 = await session.Advanced.Revisions.GetMetadataForAsync(user1.Id);
+                Assert.Contains(DocumentFlags.DeleteRevision.ToString(), revisionsMetadata1[0].GetString(Constants.Documents.Metadata.Flags));
+
+                var user2RevCount = await session.Advanced.Revisions.GetCountForAsync(user2.Id);
+                Assert.Equal(12, user2RevCount);
+                var revisionsMetadata2 = await session.Advanced.Revisions.GetMetadataForAsync(user2.Id);
+                Assert.Contains(DocumentFlags.DeleteRevision.ToString(), revisionsMetadata2[0].GetString(Constants.Documents.Metadata.Flags));
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21752/Add-EP-for-adding-Delete-Revision-to-orphaned-revisions-in-6.0

### Additional description

Add EP for adding 'Delete Revision' to orphaned revisions - in 6.0

### Type of change

- Task

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- Yes