### PR TITLE
RavenDB-20729 Changing the order of elements of Transactional ID used by Kafka ETL producer so it will be easier to configure ACL with the usage of well known prefix (ETL taks and script names) which is controlled by a user

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Kafka/KafkaEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Kafka/KafkaEtl.cs
@@ -26,7 +26,7 @@ public class KafkaEtl : QueueEtl<KafkaItem>
 
     public KafkaEtl(Transformation transformation, QueueEtlConfiguration configuration, DocumentDatabase database, ServerStore serverStore) : base(transformation, configuration, database, serverStore)
     {
-        TransactionalId = EnsureValidTransactionalId($"{Database.DatabaseGroupId}-{Name}");
+        TransactionalId = EnsureValidTransactionalId($"{Name}-{Database.DatabaseGroupId}");
     }
 
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20729

### Additional description

Continuation of https://github.com/ravendb/ravendb/pull/17577. 

### Type of change

- Enhancement

### How risky is the change?

- Low 

### Backward compatibility

- We have introduced it in the latest release for a user that requested it. The change made here is for the same user.

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed (this hasn't been documented yet)

### Testing by Contributor

- Not relevant

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
