### PR TITLE
RavenDB-21779 look into nested ConfigurationCategories when scanning properties

### DIFF
--- a/src/Raven.Server/Config/Categories/IntegrationsConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IntegrationsConfiguration.cs
@@ -24,7 +24,8 @@ namespace Raven.Server.Config.Categories
             Initialized = true;
         }
 
-        public class PostgreSqlConfiguration : ConfigurationCategory
+        [ConfigurationCategory(ConfigurationCategoryType.Integrations)]
+        public sealed class PostgreSqlConfiguration : ConfigurationCategory
         {
             [Description("Indicates if PostgreSQL integration is enabled or not. Default: false")]
             [DefaultValue(false)]

--- a/src/Raven.Server/Config/Categories/MonitoringConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/MonitoringConfiguration.cs
@@ -42,7 +42,8 @@ namespace Raven.Server.Config.Categories
             Initialized = true;
         }
 
-        public class SnmpConfiguration : ConfigurationCategory
+        [ConfigurationCategory(ConfigurationCategoryType.Monitoring)]
+        public sealed class SnmpConfiguration : ConfigurationCategory
         {
             [Description("Indicates if SNMP is enabled or not. Default: false")]
             [DefaultValue(false)]

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -281,23 +281,37 @@ namespace Raven.Server.Config
         {
             var results = new HashSet<ConfigurationEntryMetadata>();
 
-            var type = typeof(RavenConfiguration);
-            foreach (var configurationCategoryProperty in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            foreach (var configurationCategoryProperty in typeof(RavenConfiguration).GetProperties(BindingFlags.Instance | BindingFlags.Public))
             {
                 var propertyType = configurationCategoryProperty.PropertyType;
                 if (propertyType.IsSubclassOf(typeof(ConfigurationCategory)) == false)
                     continue;
 
-                foreach (var configurationProperty in propertyType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
-                {
-                    if (configurationProperty.GetCustomAttributes<ConfigurationEntryAttribute>(inherit: true).Any() == false)
-                        continue;
-
-                    results.Add(new ConfigurationEntryMetadata(configurationCategoryProperty, configurationProperty));
-                }
+                foreach (var metadata in GetConfigurationEntryMetadataFor(configurationCategoryProperty, propertyType))
+                    results.Add(metadata);
             }
 
             return results;
+
+            static IEnumerable<ConfigurationEntryMetadata> GetConfigurationEntryMetadataFor(PropertyInfo configurationCategoryProperty, Type propertyType)
+            {
+                foreach (var configurationProperty in propertyType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+                {
+                    var configurationPropertyType = configurationProperty.PropertyType;
+                    if (configurationPropertyType.IsSubclassOf(typeof(ConfigurationCategory)))
+                    {
+                        foreach (var metadata in GetConfigurationEntryMetadataFor(configurationProperty, configurationPropertyType))
+                            yield return metadata;
+
+                        yield break;
+                    }
+
+                    if (configurationProperty.GetCustomAttributes<ConfigurationEntryAttribute>(inherit: true).Any() == false)
+                        continue;
+
+                    yield return new ConfigurationEntryMetadata(configurationCategoryProperty, configurationProperty);
+                }
+            }
         });
 
         public static bool ContainsKey(string key)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21779

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
