### PR TITLE
RavenDB-21780 - InvalidOperationException when trying to enforce revisions configuration on specific collection in sharded database

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1772,16 +1772,14 @@ namespace Raven.Server.Documents.Revisions
             {
                 foreach (var collection in collections)
                 {
-                    IEnumerable<Table.TableValueHolder> table = null;
-                    var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: true);
-                    var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
+                    var tableName = new CollectionName(collection).GetTableName(CollectionTableType.Revisions);
                     var revisions = context.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
                     if (revisions == null) // there is no revisions for that collection
                     {
                         continue;
                     }
 
-                    table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
+                    var table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
 
                     collectionsTables.Add(table);
                 }

--- a/test/FastTests/Utils/RevisionsHelper.cs
+++ b/test/FastTests/Utils/RevisionsHelper.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents.Commands;
+using Raven.Server.Documents.Sharding;
 using Sparrow.Json;
 
 namespace FastTests.Utils
@@ -128,6 +129,25 @@ namespace FastTests.Utils
             var documentDatabase = await serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
             await documentDatabase.RachisLogIndexNotifications.WaitForIndexNotification(result.RaftCommandIndex.Value, serverStore.Engine.OperationTimeout);
         }
+
+        public static async Task SetupRevisionsOnShardedDatabaseAsync(IDocumentStore store, Raven.Server.ServerWide.ServerStore serverStore, RevisionsConfiguration configuration, IAsyncEnumerable<ShardedDocumentDatabase> shards)
+        {
+            if (store == null)
+                throw new ArgumentNullException(nameof(store));
+            if (serverStore == null)
+                throw new ArgumentNullException(nameof(serverStore));
+            if (configuration == null)
+                throw new ArgumentNullException(nameof(configuration));
+
+            var result = await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+            var index = result.RaftCommandIndex;
+
+            await foreach (var shard in shards)
+            {
+                await shard.RachisLogIndexNotifications.WaitForIndexNotification(index.Value, serverStore.Engine.OperationTimeout);
+            }
+        }
+
 
         private static async Task<long> SetupRevisionsInternal(Raven.Server.ServerWide.ServerStore serverStore, string database, RevisionsConfiguration configuration)
         {

--- a/test/SlowTests/Issues/RavenDB-21780.cs
+++ b/test/SlowTests/Issues/RavenDB-21780.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+public class RavenDB_21780 : ClusterTestBase
+{
+    public RavenDB_21780(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Revisions)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+    public async Task EnforceRevisionsConfigurationOnShardedDB(Options options)
+    {
+        var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
+
+        options.Server = leader;
+        options.ReplicationFactor = nodes.Count;
+
+        using var store = GetDocumentStore(options);
+
+        var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 100 } };
+        await SetupRevisionsConfiguration(options.DatabaseMode, store, configuration);
+
+        var user = new SamplesTestBase.User() { Id = "Users/1", Name = "Shahar" };
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                user.Name += i;
+                await session.StoreAsync(user);
+                await session.SaveChangesAsync();
+            }
+
+            var revisionsCount = await session.Advanced.Revisions.GetCountForAsync(user.Id);
+            Assert.Equal(10, revisionsCount);
+        }
+
+
+        configuration.Default.MinimumRevisionsToKeep = 2;
+        await SetupRevisionsConfiguration(options.DatabaseMode, store, configuration);
+
+
+        // enforce
+        var parameters = new EnforceRevisionsConfigurationOperation.Parameters { Collections = new[] { "Users" } };
+        var result = await store.Operations.SendAsync(new EnforceRevisionsConfigurationOperation(parameters));
+        await result.WaitForCompletionAsync();
+
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var revisionsCount = await session.Advanced.Revisions.GetCountForAsync(user.Id);
+            Assert.Equal(2, revisionsCount);
+        }
+    }
+
+    private async Task SetupRevisionsConfiguration(RavenDatabaseMode databaseMode, DocumentStore store, RevisionsConfiguration configuration)
+    {
+        if (databaseMode == RavenDatabaseMode.Sharded)
+        {
+            var shards = Sharding.GetShardsDocumentDatabaseInstancesFor(store);
+            await RevisionsHelper.SetupRevisionsOnShardedDatabaseAsync(store, Server.ServerStore, configuration: configuration, shards);
+        }
+        else
+        {
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+        }
+    }
+}
+


### PR DESCRIPTION
…sions configuration on specific collection in sharded database

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21780/InvalidOperationException-when-trying-to-enforce-revisions-configuration-on-specific-collection-in-sharded-database

### Additional description

InvalidOperationException when trying to enforce revisions configuration on specific collection in sharded database

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
