### PR TITLE
RavenDB-19198 Ability to sort indexes by creation time and see that time

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Sort.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/Sort.stories.tsx
@@ -8,27 +8,29 @@ export default {
     decorators: [withStorybookContexts, withBootstrap5],
 };
 
+type SortBy = "Alphabetically" | "Creation date";
+type SortDirection = "Ascending" | "Descending";
+type GroupBy = "Collection" | "None";
+
 export function Sort() {
-    const sortBy: sortItem[] = [
-        { value: "alphabetically", label: "Alphabetically" },
-        { value: "creationDate", label: "Creation date" },
-        { value: "lastIndexedDate", label: "Last indexed date" },
-        { value: "lastQueryDate", label: "Last query date" },
+    const sortBy: sortItem<SortBy>[] = [
+        { value: "Alphabetically", label: "Alphabetically" },
+        { value: "Creation date", label: "Creation date" },
     ];
 
-    const sortDirection: sortItem[] = [
-        { value: "asc", label: "Ascending", icon: "arrow-thin-top" },
-        { value: "desc", label: "Descending", icon: "arrow-thin-bottom" },
+    const sortDirection: sortItem<SortDirection>[] = [
+        { value: "Ascending", label: "Ascending", icon: "arrow-thin-top" },
+        { value: "Descending", label: "Descending", icon: "arrow-thin-bottom" },
     ];
 
-    const groupBy: sortItem[] = [
-        { value: "byCollection", label: "By collection" },
-        { value: "none", label: "none" },
+    const groupBy: sortItem<GroupBy>[] = [
+        { value: "Collection", label: "Collection" },
+        { value: "None", label: "None" },
     ];
 
-    const [selectedSortBy, setSelectedSortBy] = useState<string>(sortBy[0].value);
-    const [selectedSortDirection, setSelectedSortDirection] = useState<string>(sortDirection[0].value);
-    const [selectedGroupBy, setSelectedGroupBy] = useState<string>(groupBy[0].value);
+    const [selectedSortBy, setSelectedSortBy] = useState<SortBy>("Alphabetically");
+    const [selectedSortDirection, setSelectedSortDirection] = useState<SortDirection>("Descending");
+    const [selectedGroupBy, setSelectedGroupBy] = useState<GroupBy>("None");
 
     return (
         <div>
@@ -36,30 +38,30 @@ export function Sort() {
                 label={
                     <>
                         {sortBy.find((item) => item.value === selectedSortBy).label}{" "}
-                        {selectedSortDirection === "asc" ? (
-                            <Icon icon="arrow-thin-top" margin="ms-1" />
-                        ) : (
+                        {selectedSortDirection === "Ascending" ? (
                             <Icon icon="arrow-thin-bottom" margin="ms-1" />
-                        )}{" "}
-                        {selectedGroupBy !== "none" && (
+                        ) : (
+                            <Icon icon="arrow-thin-top" margin="ms-1" />
+                        )}
+                        {selectedGroupBy !== "None" && (
                             <span className="ms-2">{groupBy.find((item) => item.value === selectedGroupBy).label}</span>
                         )}
                     </>
                 }
             >
-                <SortDropdownRadioList
+                <SortDropdownRadioList<SortBy>
                     radioOptions={sortBy}
                     label="Sort by"
                     selected={selectedSortBy}
                     setSelected={setSelectedSortBy}
                 />
-                <SortDropdownRadioList
+                <SortDropdownRadioList<SortDirection>
                     radioOptions={sortDirection}
                     label="Sort direction"
                     selected={selectedSortDirection}
                     setSelected={setSelectedSortDirection}
                 />
-                <SortDropdownRadioList
+                <SortDropdownRadioList<GroupBy>
                     radioOptions={groupBy}
                     label="Group by"
                     selected={selectedGroupBy}

--- a/src/Raven.Studio/typescript/components/common/Sort.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/Sort.stories.tsx
@@ -1,0 +1,71 @@
+﻿import React, { useState } from "react";
+import { withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
+import { SortDropdown, SortDropdownRadioList, sortItem } from "./SortDropdown";
+import { Icon } from "./Icon";
+
+export default {
+    title: "Bits/Sort",
+    decorators: [withStorybookContexts, withBootstrap5],
+};
+
+export function Sort() {
+    const sortBy: sortItem[] = [
+        { value: "alphabetically", label: "Alphabetically" },
+        { value: "creationDate", label: "Creation date" },
+        { value: "lastIndexedDate", label: "Last indexed date" },
+        { value: "lastQueryDate", label: "Last query date" },
+    ];
+
+    const sortDirection: sortItem[] = [
+        { value: "asc", label: "Ascending", icon: "arrow-thin-top" },
+        { value: "desc", label: "Descending", icon: "arrow-thin-bottom" },
+    ];
+
+    const groupBy: sortItem[] = [
+        { value: "byCollection", label: "By collection" },
+        { value: "none", label: "none" },
+    ];
+
+    const [selectedSortBy, setSelectedSortBy] = useState<string>(sortBy[0].value);
+    const [selectedSortDirection, setSelectedSortDirection] = useState<string>(sortDirection[0].value);
+    const [selectedGroupBy, setSelectedGroupBy] = useState<string>(groupBy[0].value);
+
+    return (
+        <div>
+            <SortDropdown
+                label={
+                    <>
+                        {sortBy.find((item) => item.value === selectedSortBy).label}{" "}
+                        {selectedSortDirection === "asc" ? (
+                            <Icon icon="arrow-thin-top" margin="ms-1" />
+                        ) : (
+                            <Icon icon="arrow-thin-bottom" margin="ms-1" />
+                        )}{" "}
+                        {selectedGroupBy !== "none" && (
+                            <span className="ms-2">{groupBy.find((item) => item.value === selectedGroupBy).label}</span>
+                        )}
+                    </>
+                }
+            >
+                <SortDropdownRadioList
+                    radioOptions={sortBy}
+                    label="Sort by"
+                    selected={selectedSortBy}
+                    setSelected={setSelectedSortBy}
+                />
+                <SortDropdownRadioList
+                    radioOptions={sortDirection}
+                    label="Sort direction"
+                    selected={selectedSortDirection}
+                    setSelected={setSelectedSortDirection}
+                />
+                <SortDropdownRadioList
+                    radioOptions={groupBy}
+                    label="Group by"
+                    selected={selectedGroupBy}
+                    setSelected={setSelectedGroupBy}
+                />
+            </SortDropdown>
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/common/SortDropdown.scss
+++ b/src/Raven.Studio/typescript/components/common/SortDropdown.scss
@@ -1,0 +1,21 @@
+@use "Content/scss/bs5variables";
+.sort-dropdown {
+    .sort-dropdown-toggle {
+        background-color: bs5variables.$well-bg-var !important;
+        border-radius: bs5variables.$gutter-sm !important;
+        border-color: bs5variables.$border-color-light-var !important;
+        border-width: bs5variables.$border-width !important;
+        padding: bs5variables.$gutter-xxs bs5variables.$gutter-sm !important;
+        font-size: 13px !important;
+        color: bs5variables.$text-color-var !important;
+        min-height: 37px !important;
+        min-width: 250px;
+    }
+    .dropdown-radio-group {
+        min-width: 170px;
+    }
+
+    &.show .sort-dropdown-toggle {
+        background-color: bs5variables.$panel-bg-1-var !important;
+    }
+}

--- a/src/Raven.Studio/typescript/components/common/SortDropdown.tsx
+++ b/src/Raven.Studio/typescript/components/common/SortDropdown.tsx
@@ -1,5 +1,4 @@
 ﻿import React, { ReactNode } from "react";
-import useId from "hooks/useId";
 import "./SortDropdown.scss";
 import { Icon } from "./Icon";
 import { DropdownMenu, DropdownToggle, UncontrolledDropdown } from "reactstrap";
@@ -7,7 +6,7 @@ import { Radio } from "./Checkbox";
 import IconName from "typings/server/icons";
 
 interface SortDropdownProps {
-    label: string | ReactNode | ReactNode[];
+    label: ReactNode | ReactNode[];
     children: ReactNode | ReactNode[];
 }
 
@@ -25,23 +24,30 @@ export function SortDropdown(props: SortDropdownProps) {
     );
 }
 
-interface SortDropdownRadioListProps {
-    radioOptions: sortItem[];
-    label?: string;
-    selected: string;
-    setSelected: (value: string) => void;
+type SortableValue = string | number | boolean;
+
+export interface sortItem<T extends SortableValue = string> {
+    label: string;
+    value: T;
+    icon?: IconName;
 }
 
-export function SortDropdownRadioList<T extends string | number = string>(props: SortDropdownRadioListProps) {
+interface SortDropdownRadioListProps<T extends SortableValue = string> {
+    radioOptions: sortItem<T>[];
+    label?: string;
+    selected: T;
+    setSelected: (value: T) => void;
+}
+
+export function SortDropdownRadioList<T extends SortableValue = string>(props: SortDropdownRadioListProps<T>) {
     const { radioOptions, label, selected, setSelected } = props;
-    const uniqueId = useId("sort-dropdown-list");
 
     return (
         <div className="vstack gap-1 dropdown-radio-group">
             {label && <div className="small-label mb-2">{label}</div>}
             {radioOptions.map((item) => (
                 <Radio
-                    key={uniqueId + item.value}
+                    key={item.value.toString()}
                     selected={item.value === selected}
                     toggleSelection={() => setSelected(item.value)}
                 >
@@ -51,10 +57,4 @@ export function SortDropdownRadioList<T extends string | number = string>(props:
             ))}
         </div>
     );
-}
-
-export interface sortItem<T extends string | number = string> {
-    label: string;
-    value: T;
-    icon?: IconName;
 }

--- a/src/Raven.Studio/typescript/components/common/SortDropdown.tsx
+++ b/src/Raven.Studio/typescript/components/common/SortDropdown.tsx
@@ -1,0 +1,60 @@
+﻿import React, { ReactNode } from "react";
+import useId from "hooks/useId";
+import "./SortDropdown.scss";
+import { Icon } from "./Icon";
+import { DropdownMenu, DropdownToggle, UncontrolledDropdown } from "reactstrap";
+import { Radio } from "./Checkbox";
+import IconName from "typings/server/icons";
+
+interface SortDropdownProps {
+    label: string | ReactNode | ReactNode[];
+    children: ReactNode | ReactNode[];
+}
+
+export function SortDropdown(props: SortDropdownProps) {
+    const { label, children } = props;
+    return (
+        <UncontrolledDropdown className="sort-dropdown">
+            <DropdownToggle className="sort-dropdown-toggle d-flex align-items-center" caret>
+                <div className="flex-grow d-flex align-items-center">{label}</div>
+            </DropdownToggle>
+            <DropdownMenu className="py-4 px-5">
+                <div className="hstack gap-5">{children}</div>
+            </DropdownMenu>
+        </UncontrolledDropdown>
+    );
+}
+
+interface SortDropdownRadioListProps {
+    radioOptions: sortItem[];
+    label?: string;
+    selected: string;
+    setSelected: (value: string) => void;
+}
+
+export function SortDropdownRadioList<T extends string | number = string>(props: SortDropdownRadioListProps) {
+    const { radioOptions, label, selected, setSelected } = props;
+    const uniqueId = useId("sort-dropdown-list");
+
+    return (
+        <div className="vstack gap-1 dropdown-radio-group">
+            {label && <div className="small-label mb-2">{label}</div>}
+            {radioOptions.map((item) => (
+                <Radio
+                    key={uniqueId + item.value}
+                    selected={item.value === selected}
+                    toggleSelection={() => setSelected(item.value)}
+                >
+                    {item.icon && <Icon icon={item.icon} />}
+                    {item.label}
+                </Radio>
+            ))}
+        </div>
+    );
+}
+
+export interface sortItem<T extends string | number = string> {
+    label: string;
+    value: T;
+    icon?: IconName;
+}

--- a/src/Raven.Studio/typescript/components/models/common.ts
+++ b/src/Raven.Studio/typescript/components/models/common.ts
@@ -64,3 +64,5 @@ export interface NonShardedViewProps {
 export interface ShardedViewProps extends NonShardedViewProps {
     location?: databaseLocationSpecifier;
 }
+
+export type SortDirection = "asc" | "desc";

--- a/src/Raven.Studio/typescript/components/models/indexes.ts
+++ b/src/Raven.Studio/typescript/components/models/indexes.ts
@@ -1,5 +1,5 @@
 ﻿import IndexSourceType = Raven.Client.Documents.Indexes.IndexSourceType;
-import { loadStatus } from "./common";
+import { SortDirection, loadStatus } from "./common";
 import SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType;
 
 export type IndexStatus = "Normal" | "ErrorOrFaulty" | "Stale" | "Paused" | "Disabled" | "Idle" | "RollingDeployment";
@@ -22,6 +22,7 @@ export interface IndexSharedInfo {
     patternForReferencesToReduceOutputCollection: string;
     collectionNameForReferenceDocuments: string;
     nodesInfo: IndexNodeInfo[];
+    createdTimestamp: Date;
 }
 
 export interface IndexNodeInfo {
@@ -54,12 +55,22 @@ export interface IndexNodeInfoDetails {
     state: Raven.Client.Documents.Indexes.IndexState;
     stale: boolean;
     faulty: boolean;
+    lastIndexingTime: Date;
+    lastQueryingTime: Date;
 }
+
+export type IndexGroupBy = "Collection" | "None";
+export type IndexSortBy =
+    | Extract<keyof IndexSharedInfo, "name" | "createdTimestamp">
+    | Extract<keyof IndexNodeInfoDetails, "lastIndexingTime" | "lastQueryingTime">;
 
 export interface IndexFilterCriteria {
     searchText: string;
     statuses: IndexStatus[];
     types: IndexType[];
     showOnlyIndexesWithIndexingErrors: boolean;
-    autoRefresh: boolean; //TODO:
+    autoRefresh: boolean;
+    sortBy: IndexSortBy;
+    sortDirection: SortDirection;
+    groupBy: IndexGroupBy;
 }

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -16,6 +16,8 @@ import { Button } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import IconName from "typings/server/icons";
 import IndexDistributionStatusChecker from "./IndexDistributionStatusChecker";
+import moment = require("moment");
+import genUtils = require("common/generalUtils");
 
 interface IndexDistributionProps {
     index: IndexSharedInfo;
@@ -31,6 +33,10 @@ interface ItemWithTooltipProps {
     openFaulty: (location: databaseLocationSpecifier) => void;
     nodeInfo: IndexNodeInfo;
     sharded: boolean;
+}
+
+function getFormattedTime(date: Date): string {
+    return date ? genUtils.formatDurationByDate(moment(date)) + " ago" : "-";
 }
 
 function ItemWithTooltip(props: ItemWithTooltipProps) {
@@ -61,6 +67,8 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
                 </div>
                 <div className="entries">{entriesCount.toLocaleString()}</div>
                 <div className="errors">{nodeInfo.details?.errorCount.toLocaleString() ?? ""}</div>
+                <div>{getFormattedTime(nodeInfo.details?.lastIndexingTime)}</div>
+                <div>{getFormattedTime(nodeInfo.details?.lastQueryingTime)}</div>
 
                 <IndexProgress nodeInfo={nodeInfo} />
 
@@ -135,6 +143,12 @@ export function IndexDistribution(props: IndexDistributionProps) {
                 </div>
                 <div>
                     <Icon icon="warning" /> Errors
+                </div>
+                <div>
+                    <Icon icon="index-history" /> Indexed
+                </div>
+                <div>
+                    <Icon icon="queries" /> Queried
                 </div>
                 <div>
                     <Icon icon="changes" /> State

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -67,8 +67,8 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
                 </div>
                 <div className="entries">{entriesCount.toLocaleString()}</div>
                 <div className="errors">{nodeInfo.details?.errorCount.toLocaleString() ?? ""}</div>
-                <div>{getFormattedTime(nodeInfo.details?.lastIndexingTime)}</div>
-                <div>{getFormattedTime(nodeInfo.details?.lastQueryingTime)}</div>
+                <div className="text-center">{getFormattedTime(nodeInfo.details?.lastIndexingTime)}</div>
+                <div className="text-center">{getFormattedTime(nodeInfo.details?.lastQueryingTime)}</div>
 
                 <IndexProgress nodeInfo={nodeInfo} />
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexFilter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexFilter.tsx
@@ -1,4 +1,4 @@
-﻿import React from "react";
+﻿import React, { useState } from "react";
 import { shardingTodo } from "common/developmentHelper";
 import { IndexStatus, IndexFilterCriteria, IndexType } from "components/models/indexes";
 import { Button, Input, PopoverBody, UncontrolledPopover } from "reactstrap";
@@ -7,6 +7,7 @@ import { Icon } from "components/common/Icon";
 import { MultiCheckboxToggle } from "components/common/MultiCheckboxToggle";
 import { InputItem } from "components/models/common";
 import { Switch } from "components/common/Checkbox";
+import { SortDropdown, SortDropdownRadioList, sortItem } from "components/common/SortDropdown";
 
 interface IndexFilterProps {
     filter: IndexFilterCriteria;
@@ -94,6 +95,27 @@ export default function IndexFilter(props: IndexFilterProps) {
         );
     };
 
+    const sortBy: sortItem[] = [
+        { value: "alphabetically", label: "Alphabetically" },
+        { value: "creationDate", label: "Creation date" },
+        { value: "lastIndexedDate", label: "Last indexed date" },
+        { value: "lastQueryDate", label: "Last query date" },
+    ];
+
+    const sortDirection: sortItem[] = [
+        { value: "asc", label: "Ascending", icon: "arrow-thin-top" },
+        { value: "desc", label: "Descending", icon: "arrow-thin-bottom" },
+    ];
+
+    const groupBy: sortItem[] = [
+        { value: "byCollection", label: "By collection" },
+        { value: "none", label: "none" },
+    ];
+
+    const [selectedSortBy, setSelectedSortBy] = useState<string>(sortBy[0].value);
+    const [selectedSortDirection, setSelectedSortDirection] = useState<string>(sortDirection[0].value);
+    const [selectedGroupBy, setSelectedGroupBy] = useState<string>(groupBy[0].value);
+
     return (
         <div className="hstack flex-wrap align-items-end gap-3 my-3 justify-content-end">
             <div className="flex-grow">
@@ -134,7 +156,46 @@ export default function IndexFilter(props: IndexFilterProps) {
                 setSelectedItems={onSearchTypesChange}
                 selectAllCount={indexesCount}
             />
+            <div>
+                <div className="small-label ms-1 mb-1">Sort & Group</div>
 
+                <SortDropdown
+                    label={
+                        <>
+                            {sortBy.find((item) => item.value === selectedSortBy).label}{" "}
+                            {selectedSortDirection === "asc" ? (
+                                <Icon icon="arrow-thin-top" margin="ms-1" />
+                            ) : (
+                                <Icon icon="arrow-thin-bottom" margin="ms-1" />
+                            )}{" "}
+                            {selectedGroupBy !== "none" && (
+                                <span className="ms-2">
+                                    {groupBy.find((item) => item.value === selectedGroupBy).label}
+                                </span>
+                            )}
+                        </>
+                    }
+                >
+                    <SortDropdownRadioList
+                        radioOptions={sortBy}
+                        label="Sort by"
+                        selected={selectedSortBy}
+                        setSelected={setSelectedSortBy}
+                    />
+                    <SortDropdownRadioList
+                        radioOptions={sortDirection}
+                        label="Sort direction"
+                        selected={selectedSortDirection}
+                        setSelected={setSelectedSortDirection}
+                    />
+                    <SortDropdownRadioList
+                        radioOptions={groupBy}
+                        label="Group by"
+                        selected={selectedGroupBy}
+                        setSelected={setSelectedGroupBy}
+                    />
+                </SortDropdown>
+            </div>
             {/* TODO: `Processing Speed: <strong>${Math.floor(totalProcessedPerSecond).toLocaleString()}</strong> docs / sec`;*/}
             <Switch
                 id="autoRefresh"

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexFilter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexFilter.tsx
@@ -158,9 +158,9 @@ export default function IndexFilter(props: IndexFilterProps) {
 
 const sortByOptions: sortItem<IndexSortBy>[] = [
     { value: "name", label: "Name" },
-    { value: "createdTimestamp", label: "Creation date" },
-    { value: "lastIndexingTime", label: "Last indexing date" },
-    { value: "lastQueryingTime", label: "Last querying date" },
+    { value: "createdTimestamp", label: "Creation time" },
+    { value: "lastIndexingTime", label: "Last indexing time" },
+    { value: "lastQueryingTime", label: "Last querying time" },
 ];
 
 const sortDirectionOptions: sortItem<SortDirection>[] = [

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -197,12 +197,24 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                                 <Input type="checkbox" onChange={toggleSelection} checked={selected} />
                             )}
                         </RichPanelSelect>
-
-                        <RichPanelName>
-                            <a href={editUrl} title={index.name}>
-                                {index.name}
-                            </a>
-                        </RichPanelName>
+                        <div className="flex-grow">
+                            <RichPanelName>
+                                <a href={editUrl} title={index.name}>
+                                    {index.name}
+                                </a>
+                            </RichPanelName>
+                            <div className="small hstack gap-4">
+                                <div>
+                                    <span className="text-muted">Created:</span> <strong>3 months ago</strong>
+                                </div>
+                                <div>
+                                    <span className="text-muted">Indexed:</span> <strong>few moments ago</strong>
+                                </div>
+                                <div>
+                                    <span className="text-muted">Queried:</span> <strong>few moments ago</strong>
+                                </div>
+                            </div>
+                        </div>
                     </RichPanelInfo>
                     <RichPanelActions>
                         {!IndexUtils.hasAnyFaultyNode(index) && (

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -6,7 +6,7 @@ import IndexUtils from "../../../../utils/IndexUtils";
 import { useAccessManager } from "hooks/useAccessManager";
 import { useAppUrls } from "hooks/useAppUrls";
 import "./IndexesPage.scss";
-import { Alert, Button, Card, Col, Row, UncontrolledPopover } from "reactstrap";
+import { Button, Col, Row, UncontrolledPopover } from "reactstrap";
 import { LoadingView } from "components/common/LoadingView";
 import { StickyHeader } from "components/common/StickyHeader";
 import { BulkIndexOperationConfirm } from "components/pages/database/indexes/list/BulkIndexOperationConfirm";
@@ -17,16 +17,14 @@ import { NoIndexes } from "components/pages/database/indexes/list/partials/NoInd
 import { Icon } from "components/common/Icon";
 import { ConfirmSwapSideBySideIndex } from "./ConfirmSwapSideBySideIndex";
 import ActionContextUtils from "components/utils/actionContextUtils";
-import AboutViewFloating, { AccordionItemWrapper } from "components/common/AboutView";
-import { getLicenseLimitReachStatus, useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
+import { getLicenseLimitReachStatus } from "components/utils/licenseLimitsUtils";
 import { todo } from "common/developmentHelper";
 import { useAppSelector } from "components/store";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useRavenLink } from "components/hooks/useRavenLink";
-import FeatureAvailabilitySummaryWrapper, {
-    FeatureAvailabilityData,
-} from "components/common/FeatureAvailabilitySummary";
 import IndexesPageList, { IndexesPageListProps } from "./IndexesPageList";
+import IndexesPageLicenseLimits from "./IndexesPageLicenseLimits";
+import IndexesPageAboutView from "./IndexesPageAboutView";
 
 interface IndexesPageProps {
     db: database;
@@ -89,35 +87,11 @@ export function IndexesPage(props: IndexesPageProps) {
     const allActionContexts = ActionContextUtils.getContexts(db.getLocations());
 
     const upgradeLicenseLink = useRavenLink({ hash: "FLDLO4", isDocs: false });
-    const overviewDocsLink = useRavenLink({ hash: "8VWNHJ" });
-    const listDocsLink = useRavenLink({ hash: "7HOOEA" });
 
     const autoClusterLimit = useAppSelector(licenseSelectors.statusValue("MaxNumberOfAutoIndexesPerCluster"));
     const staticClusterLimit = useAppSelector(licenseSelectors.statusValue("MaxNumberOfStaticIndexesPerCluster"));
     const autoDatabaseLimit = useAppSelector(licenseSelectors.statusValue("MaxNumberOfAutoIndexesPerDatabase"));
     const staticDatabaseLimit = useAppSelector(licenseSelectors.statusValue("MaxNumberOfStaticIndexesPerDatabase"));
-
-    const featureAvailability = useLimitedFeatureAvailability({
-        defaultFeatureAvailability,
-        overwrites: [
-            {
-                featureName: defaultFeatureAvailability[0].featureName,
-                value: autoClusterLimit,
-            },
-            {
-                featureName: defaultFeatureAvailability[1].featureName,
-                value: staticClusterLimit,
-            },
-            {
-                featureName: defaultFeatureAvailability[2].featureName,
-                value: autoDatabaseLimit,
-            },
-            {
-                featureName: defaultFeatureAvailability[3].featureName,
-                value: staticDatabaseLimit,
-            },
-        ],
-    });
 
     const autoClusterCount = useAppSelector(licenseSelectors.limitsUsage).NumberOfAutoIndexesInCluster;
     const staticClusterCount = useAppSelector(licenseSelectors.limitsUsage).NumberOfStaticIndexesInCluster;
@@ -165,87 +139,21 @@ export function IndexesPage(props: IndexesPageProps) {
 
     return (
         <>
-            <>
-                {staticClusterLimitStatus !== "notReached" && (
-                    <Alert
-                        color={staticClusterLimitStatus === "limitReached" ? "danger" : "warning"}
-                        className="text-center mb-3"
-                    >
-                        <Icon icon="cluster" />
-                        Cluster {staticClusterLimitStatus === "limitReached" ? "has reached" : "is reaching"} the{" "}
-                        <strong>maximum number of static indexes</strong> allowed per cluster by your license{" "}
-                        <strong>
-                            ({staticClusterCount}/{staticClusterLimit})
-                        </strong>
-                        <br /> Delete unused indexes or{" "}
-                        <strong>
-                            <a href={upgradeLicenseLink} target="_blank">
-                                upgrade your license
-                            </a>
-                        </strong>
-                    </Alert>
-                )}
-
-                {autoClusterLimitStatus !== "notReached" && (
-                    <Alert
-                        color={autoClusterLimitStatus === "limitReached" ? "danger" : "warning"}
-                        className="text-center mb-3"
-                    >
-                        <Icon icon="cluster" />
-                        Cluster {autoClusterLimitStatus === "limitReached" ? "has reached" : "is reaching"} the{" "}
-                        <strong>maximum number of auto indexes</strong> allowed per cluster by your license{" "}
-                        <strong>
-                            ({autoClusterCount}/{autoClusterLimit})
-                        </strong>
-                        <br /> Delete unused indexes or{" "}
-                        <strong>
-                            <a href={upgradeLicenseLink} target="_blank">
-                                upgrade your license
-                            </a>
-                        </strong>
-                    </Alert>
-                )}
-
-                {staticDatabaseLimitStatus !== "notReached" && (
-                    <Alert
-                        color={staticDatabaseLimitStatus === "limitReached" ? "danger" : "warning"}
-                        className="text-center mb-3"
-                    >
-                        <Icon icon="database" />
-                        Database {staticDatabaseLimitStatus === "limitReached" ? "has reached" : "is reaching"} the{" "}
-                        <strong>maximum number of static indexes</strong> allowed per database by your license{" "}
-                        <strong>
-                            ({staticDatabaseCount}/{staticDatabaseLimit})
-                        </strong>
-                        <br /> Delete unused indexes or{" "}
-                        <strong>
-                            <a href={upgradeLicenseLink} target="_blank">
-                                upgrade your license
-                            </a>
-                        </strong>
-                    </Alert>
-                )}
-
-                {autoDatabaseLimitStatus !== "notReached" && (
-                    <Alert
-                        color={autoDatabaseLimitStatus === "limitReached" ? "danger" : "warning"}
-                        className="text-center mb-3"
-                    >
-                        <Icon icon="database" />
-                        Database {autoDatabaseLimitStatus === "limitReached" ? "has reached" : "is reaching"} the{" "}
-                        <strong>maximum number of auto indexes</strong> allowed per database by your license{" "}
-                        <strong>
-                            ({autoDatabaseCount}/{autoDatabaseLimit})
-                        </strong>
-                        <br /> Delete unused indexes or{" "}
-                        <strong>
-                            <a href={upgradeLicenseLink} target="_blank">
-                                upgrade your license
-                            </a>
-                        </strong>
-                    </Alert>
-                )}
-            </>
+            <IndexesPageLicenseLimits
+                staticClusterLimitStatus={staticClusterLimitStatus}
+                staticClusterCount={staticClusterCount}
+                staticClusterLimit={staticClusterLimit}
+                upgradeLicenseLink={upgradeLicenseLink}
+                autoClusterLimitStatus={autoClusterLimitStatus}
+                autoClusterCount={autoClusterCount}
+                autoClusterLimit={autoClusterLimit}
+                staticDatabaseLimitStatus={staticDatabaseLimitStatus}
+                staticDatabaseCount={staticDatabaseCount}
+                staticDatabaseLimit={staticDatabaseLimit}
+                autoDatabaseLimitStatus={autoDatabaseLimitStatus}
+                autoDatabaseCount={autoDatabaseCount}
+                autoDatabaseLimit={autoDatabaseLimit}
+            />
 
             {stats.indexes.length > 0 && (
                 <StickyHeader>
@@ -290,51 +198,12 @@ export function IndexesPage(props: IndexesPageProps) {
                             )}
                         </Col>
                         <Col xs="auto">
-                            <AboutViewFloating>
-                                <AccordionItemWrapper
-                                    icon="about"
-                                    color="info"
-                                    heading="About this view"
-                                    description="Get additional info on this feature"
-                                    targetId="about-view"
-                                >
-                                    <p>
-                                        Manage all indexes in the database from this view.
-                                        <br />
-                                        The indexes are grouped based on their associated collections.
-                                    </p>
-                                    <ul>
-                                        <li>
-                                            <strong>Detailed information</strong> for each index is provided such as:
-                                            <br />
-                                            the index type and data source, its current state, staleness status, the
-                                            number of index-entries, etc.
-                                        </li>
-                                        <li className="margin-top-xs">
-                                            <strong>Various actions</strong> can be performed such as:
-                                            <br />
-                                            create a new index, modify existing, delete, restart, disable or pause
-                                            indexing, set index priority, and more.
-                                        </li>
-                                    </ul>
-                                    <hr />
-                                    <div className="small-label mb-2">useful links</div>
-                                    <a href={overviewDocsLink} target="_blank">
-                                        <Icon icon="newtab" /> Docs - Indexes Overview
-                                    </a>
-                                    <br />
-                                    <a href={listDocsLink} target="_blank">
-                                        <Icon icon="newtab" /> Docs - Indexes List View
-                                    </a>
-                                </AccordionItemWrapper>
-                                <FeatureAvailabilitySummaryWrapper
-                                    isUnlimited={
-                                        staticClusterLimitStatus === "notReached" &&
-                                        staticDatabaseLimitStatus === "notReached"
-                                    }
-                                    data={featureAvailability}
-                                />
-                            </AboutViewFloating>
+                            <IndexesPageAboutView
+                                isUnlimited={
+                                    staticClusterLimitStatus === "notReached" &&
+                                    staticDatabaseLimitStatus === "notReached"
+                                }
+                            />
                         </Col>
                     </Row>
                     <IndexFilter
@@ -403,30 +272,3 @@ export function IndexesPage(props: IndexesPageProps) {
         </>
     );
 }
-
-const defaultFeatureAvailability: FeatureAvailabilityData[] = [
-    {
-        featureName: "Auto indexes limit per cluster",
-        community: { value: 120 },
-        professional: { value: Infinity },
-        enterprise: { value: Infinity },
-    },
-    {
-        featureName: "Static indexes limit per cluster",
-        community: { value: 60 },
-        professional: { value: Infinity },
-        enterprise: { value: Infinity },
-    },
-    {
-        featureName: "Auto indexes limit per database",
-        community: { value: 24 },
-        professional: { value: Infinity },
-        enterprise: { value: Infinity },
-    },
-    {
-        featureName: "Static indexes limit per database",
-        community: { value: 12 },
-        professional: { value: Infinity },
-        enterprise: { value: Infinity },
-    },
-];

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -18,7 +18,6 @@ import { Icon } from "components/common/Icon";
 import { ConfirmSwapSideBySideIndex } from "./ConfirmSwapSideBySideIndex";
 import ActionContextUtils from "components/utils/actionContextUtils";
 import { getLicenseLimitReachStatus } from "components/utils/licenseLimitsUtils";
-import { todo } from "common/developmentHelper";
 import { useAppSelector } from "components/store";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useRavenLink } from "components/hooks/useRavenLink";
@@ -107,8 +106,6 @@ export function IndexesPage(props: IndexesPageProps) {
 
     const isNewIndexDisabled =
         staticClusterLimitStatus === "limitReached" || staticDatabaseLimitStatus === "limitReached";
-
-    todo("Other", "Damian", "Move limits to separate component");
 
     if (loading) {
         return <LoadingView />;

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageAboutView.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageAboutView.tsx
@@ -1,0 +1,115 @@
+import AboutViewFloating, { AccordionItemWrapper } from "components/common/AboutView";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
+import { Icon } from "components/common/Icon";
+import { licenseSelectors } from "components/common/shell/licenseSlice";
+import { useRavenLink } from "components/hooks/useRavenLink";
+import { useAppSelector } from "components/store";
+import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
+import React from "react";
+
+interface IndexesPageAboutViewProps {
+    isUnlimited: boolean;
+}
+
+export default function IndexesPageAboutView({ isUnlimited }: IndexesPageAboutViewProps) {
+    const overviewDocsLink = useRavenLink({ hash: "8VWNHJ" });
+    const listDocsLink = useRavenLink({ hash: "7HOOEA" });
+
+    const autoClusterLimit = useAppSelector(licenseSelectors.statusValue("MaxNumberOfAutoIndexesPerCluster"));
+    const staticClusterLimit = useAppSelector(licenseSelectors.statusValue("MaxNumberOfStaticIndexesPerCluster"));
+    const autoDatabaseLimit = useAppSelector(licenseSelectors.statusValue("MaxNumberOfAutoIndexesPerDatabase"));
+    const staticDatabaseLimit = useAppSelector(licenseSelectors.statusValue("MaxNumberOfStaticIndexesPerDatabase"));
+
+    const featureAvailability = useLimitedFeatureAvailability({
+        defaultFeatureAvailability,
+        overwrites: [
+            {
+                featureName: defaultFeatureAvailability[0].featureName,
+                value: autoClusterLimit,
+            },
+            {
+                featureName: defaultFeatureAvailability[1].featureName,
+                value: staticClusterLimit,
+            },
+            {
+                featureName: defaultFeatureAvailability[2].featureName,
+                value: autoDatabaseLimit,
+            },
+            {
+                featureName: defaultFeatureAvailability[3].featureName,
+                value: staticDatabaseLimit,
+            },
+        ],
+    });
+
+    return (
+        <AboutViewFloating>
+            <AccordionItemWrapper
+                icon="about"
+                color="info"
+                heading="About this view"
+                description="Get additional info on this feature"
+                targetId="about-view"
+            >
+                <p>
+                    Manage all indexes in the database from this view.
+                    <br />
+                    The indexes are grouped based on their associated collections.
+                </p>
+                <ul>
+                    <li>
+                        <strong>Detailed information</strong> for each index is provided such as:
+                        <br />
+                        the index type and data source, its current state, staleness status, the number of
+                        index-entries, etc.
+                    </li>
+                    <li className="margin-top-xs">
+                        <strong>Various actions</strong> can be performed such as:
+                        <br />
+                        create a new index, modify existing, delete, restart, disable or pause indexing, set index
+                        priority, and more.
+                    </li>
+                </ul>
+                <hr />
+                <div className="small-label mb-2">useful links</div>
+                <a href={overviewDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - Indexes Overview
+                </a>
+                <br />
+                <a href={listDocsLink} target="_blank">
+                    <Icon icon="newtab" /> Docs - Indexes List View
+                </a>
+            </AccordionItemWrapper>
+            <FeatureAvailabilitySummaryWrapper isUnlimited={isUnlimited} data={featureAvailability} />
+        </AboutViewFloating>
+    );
+}
+
+const defaultFeatureAvailability: FeatureAvailabilityData[] = [
+    {
+        featureName: "Auto indexes limit per cluster",
+        community: { value: 120 },
+        professional: { value: Infinity },
+        enterprise: { value: Infinity },
+    },
+    {
+        featureName: "Static indexes limit per cluster",
+        community: { value: 60 },
+        professional: { value: Infinity },
+        enterprise: { value: Infinity },
+    },
+    {
+        featureName: "Auto indexes limit per database",
+        community: { value: 24 },
+        professional: { value: Infinity },
+        enterprise: { value: Infinity },
+    },
+    {
+        featureName: "Static indexes limit per database",
+        community: { value: 12 },
+        professional: { value: Infinity },
+        enterprise: { value: Infinity },
+    },
+];

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageLicenseLimits.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageLicenseLimits.tsx
@@ -1,0 +1,120 @@
+import { Icon } from "components/common/Icon";
+import { LicenseLimitReachStatus } from "components/utils/licenseLimitsUtils";
+import React from "react";
+import { Alert } from "reactstrap";
+
+interface IndexesPageLicenseLimitsProps {
+    staticClusterLimitStatus: LicenseLimitReachStatus;
+    staticClusterCount: number;
+    staticClusterLimit: number;
+    upgradeLicenseLink: string;
+    autoClusterLimitStatus: LicenseLimitReachStatus;
+    autoClusterCount: number;
+    autoClusterLimit: number;
+    staticDatabaseLimitStatus: LicenseLimitReachStatus;
+    staticDatabaseCount: number;
+    staticDatabaseLimit: number;
+    autoDatabaseLimitStatus: LicenseLimitReachStatus;
+    autoDatabaseCount: number;
+    autoDatabaseLimit: number;
+}
+
+export default function IndexesPageLicenseLimits({
+    staticClusterLimitStatus,
+    staticClusterCount,
+    staticClusterLimit,
+    upgradeLicenseLink,
+    autoClusterLimitStatus,
+    autoClusterCount,
+    autoClusterLimit,
+    staticDatabaseLimitStatus,
+    staticDatabaseCount,
+    staticDatabaseLimit,
+    autoDatabaseLimitStatus,
+    autoDatabaseCount,
+    autoDatabaseLimit,
+}: IndexesPageLicenseLimitsProps) {
+    return (
+        <>
+            {staticClusterLimitStatus !== "notReached" && (
+                <Alert
+                    color={staticClusterLimitStatus === "limitReached" ? "danger" : "warning"}
+                    className="text-center mb-3"
+                >
+                    <Icon icon="cluster" />
+                    Cluster {staticClusterLimitStatus === "limitReached" ? "has reached" : "is reaching"} the{" "}
+                    <strong>maximum number of static indexes</strong> allowed per cluster by your license{" "}
+                    <strong>
+                        ({staticClusterCount}/{staticClusterLimit})
+                    </strong>
+                    <br /> Delete unused indexes or{" "}
+                    <strong>
+                        <a href={upgradeLicenseLink} target="_blank">
+                            upgrade your license
+                        </a>
+                    </strong>
+                </Alert>
+            )}
+
+            {autoClusterLimitStatus !== "notReached" && (
+                <Alert
+                    color={autoClusterLimitStatus === "limitReached" ? "danger" : "warning"}
+                    className="text-center mb-3"
+                >
+                    <Icon icon="cluster" />
+                    Cluster {autoClusterLimitStatus === "limitReached" ? "has reached" : "is reaching"} the{" "}
+                    <strong>maximum number of auto indexes</strong> allowed per cluster by your license{" "}
+                    <strong>
+                        ({autoClusterCount}/{autoClusterLimit})
+                    </strong>
+                    <br /> Delete unused indexes or{" "}
+                    <strong>
+                        <a href={upgradeLicenseLink} target="_blank">
+                            upgrade your license
+                        </a>
+                    </strong>
+                </Alert>
+            )}
+
+            {staticDatabaseLimitStatus !== "notReached" && (
+                <Alert
+                    color={staticDatabaseLimitStatus === "limitReached" ? "danger" : "warning"}
+                    className="text-center mb-3"
+                >
+                    <Icon icon="database" />
+                    Database {staticDatabaseLimitStatus === "limitReached" ? "has reached" : "is reaching"} the{" "}
+                    <strong>maximum number of static indexes</strong> allowed per database by your license{" "}
+                    <strong>
+                        ({staticDatabaseCount}/{staticDatabaseLimit})
+                    </strong>
+                    <br /> Delete unused indexes or{" "}
+                    <strong>
+                        <a href={upgradeLicenseLink} target="_blank">
+                            upgrade your license
+                        </a>
+                    </strong>
+                </Alert>
+            )}
+
+            {autoDatabaseLimitStatus !== "notReached" && (
+                <Alert
+                    color={autoDatabaseLimitStatus === "limitReached" ? "danger" : "warning"}
+                    className="text-center mb-3"
+                >
+                    <Icon icon="database" />
+                    Database {autoDatabaseLimitStatus === "limitReached" ? "has reached" : "is reaching"} the{" "}
+                    <strong>maximum number of auto indexes</strong> allowed per database by your license{" "}
+                    <strong>
+                        ({autoDatabaseCount}/{autoDatabaseLimit})
+                    </strong>
+                    <br /> Delete unused indexes or{" "}
+                    <strong>
+                        <a href={upgradeLicenseLink} target="_blank">
+                            upgrade your license
+                        </a>
+                    </strong>
+                </Alert>
+            )}
+        </>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
@@ -1,0 +1,119 @@
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import IndexUtils from "components/utils/IndexUtils";
+import React from "react";
+import { Card } from "reactstrap";
+import { IndexPanel } from "./IndexPanel";
+import { IndexSharedInfo } from "components/models/indexes";
+import database from "models/resources/database";
+import { Icon } from "components/common/Icon";
+import { ResetIndexData, SwapSideBySideData } from "./useIndexesPage";
+import IndexPriority = Raven.Client.Documents.Indexes.IndexPriority;
+import IndexLockMode = Raven.Client.Documents.Indexes.IndexLockMode;
+
+export interface IndexesPageListProps {
+    db: database;
+    indexes: IndexSharedInfo[];
+    replacements: IndexSharedInfo[];
+    selectedIndexes: string[];
+    indexToHighlight: string;
+    globalIndexingStatus: "Running";
+    resetIndexData: ResetIndexData;
+    swapSideBySideData: SwapSideBySideData;
+    setIndexPriority: (index: IndexSharedInfo, priority: IndexPriority) => Promise<void>;
+    setIndexLockMode: (index: IndexSharedInfo, lockMode: IndexLockMode) => Promise<void>;
+    openFaulty: (index: IndexSharedInfo, location: databaseLocationSpecifier) => Promise<void>;
+    startIndexes: (indexes: IndexSharedInfo[]) => Promise<void>;
+    disableIndexes: (indexes: IndexSharedInfo[]) => Promise<void>;
+    pauseIndexes: (indexes: IndexSharedInfo[]) => Promise<void>;
+    confirmDeleteIndexes: (db: database, indexes: IndexSharedInfo[]) => Promise<void>;
+    toggleSelection: (index: IndexSharedInfo) => void;
+    highlightCallback: (node: HTMLElement) => void;
+}
+
+export default function IndexesPageList({
+    db,
+    indexes,
+    replacements,
+    selectedIndexes,
+    globalIndexingStatus,
+    indexToHighlight,
+    resetIndexData,
+    swapSideBySideData,
+    setIndexPriority,
+    setIndexLockMode,
+    openFaulty,
+    startIndexes,
+    disableIndexes,
+    pauseIndexes,
+    confirmDeleteIndexes,
+    toggleSelection,
+    highlightCallback,
+}: IndexesPageListProps) {
+    return (
+        <>
+            {indexes.map((index: any) => {
+                const replacement = replacements.find((x) => x.name === IndexUtils.SideBySideIndexPrefix + index.name);
+                return (
+                    <React.Fragment key={index.name}>
+                        <IndexPanel
+                            setPriority={(p) => setIndexPriority(index, p)}
+                            setLockMode={(l) => setIndexLockMode(index, l)}
+                            globalIndexingStatus={globalIndexingStatus}
+                            resetIndex={() => resetIndexData.setIndexName(index.name)}
+                            openFaulty={(location: databaseLocationSpecifier) => openFaulty(index, location)}
+                            startIndexing={() => startIndexes([index])}
+                            disableIndexing={() => disableIndexes([index])}
+                            pauseIndexing={() => pauseIndexes([index])}
+                            index={index}
+                            hasReplacement={!!replacement}
+                            database={db}
+                            deleteIndex={() => confirmDeleteIndexes(db, [index])}
+                            selected={selectedIndexes.includes(index.name)}
+                            toggleSelection={() => toggleSelection(index)}
+                            key={index.name}
+                            ref={indexToHighlight === index.name ? highlightCallback : undefined}
+                        />
+                        {replacement && (
+                            <Card className="mb-0 px-5 py-2 bg-faded-warning">
+                                <div className="flex-horizontal">
+                                    <div className="title me-4">
+                                        <Icon icon="swap" /> Side by side
+                                    </div>
+                                    <ButtonWithSpinner
+                                        color="warning"
+                                        size="sm"
+                                        onClick={() => swapSideBySideData.setIndexName(index.name)}
+                                        title="Click to replace the current index definition with the replacement index"
+                                        isSpinning={swapSideBySideData.inProgress(index.name)}
+                                        icon="force"
+                                    >
+                                        Swap now
+                                    </ButtonWithSpinner>
+                                </div>
+                            </Card>
+                        )}
+                        {replacement && (
+                            <IndexPanel
+                                setPriority={(p) => setIndexPriority(replacement, p)}
+                                setLockMode={(l) => setIndexLockMode(replacement, l)}
+                                globalIndexingStatus={globalIndexingStatus}
+                                resetIndex={() => resetIndexData.setIndexName(replacement.name)}
+                                openFaulty={(location: databaseLocationSpecifier) => openFaulty(replacement, location)}
+                                startIndexing={() => startIndexes([replacement])}
+                                disableIndexing={() => disableIndexes([replacement])}
+                                pauseIndexing={() => pauseIndexes([replacement])}
+                                index={replacement}
+                                database={db}
+                                deleteIndex={() => confirmDeleteIndexes(db, [replacement])}
+                                selected={selectedIndexes.includes(replacement.name)}
+                                toggleSelection={() => toggleSelection(replacement)}
+                                key={replacement.name}
+                                ref={undefined}
+                            />
+                        )}
+                    </React.Fragment>
+                );
+            })}
+        </>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -111,6 +111,7 @@ function mapToIndexSharedInfo(stats: IndexStats): IndexSharedInfo {
         patternForReferencesToReduceOutputCollection: stats.ReduceOutputReferencePattern,
         collectionNameForReferenceDocuments: stats.PatternReferencesCollectionName,
         searchEngine: stats.SearchEngineType,
+        createdTimestamp: stats.CreatedTimestamp ? new Date(stats.CreatedTimestamp) : null,
     };
 }
 
@@ -125,6 +126,8 @@ function mapToIndexNodeInfo(stats: IndexStats, location: databaseLocationSpecifi
             status: stats.Status,
             stale: stats.IsStale,
             faulty: stats.Type === "Faulty",
+            lastIndexingTime: stats.LastIndexingTime ? new Date(stats.LastIndexingTime) : null,
+            lastQueryingTime: stats.LastQueryingTime ? new Date(stats.LastQueryingTime) : null,
         },
         progress: null,
     };

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -40,7 +40,6 @@ import React from "react";
 import { Alert } from "reactstrap";
 import DeleteIndexesConfirmBody, { DeleteIndexesConfirmBodyProps } from "../shared/DeleteIndexesConfirmBody";
 import assertUnreachable from "components/utils/assertUnreachable";
-import moment = require("moment");
 
 type IndexEvent =
     | Raven.Client.Documents.Changes.IndexChange

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewActions.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/store/databasesViewActions.ts
@@ -6,7 +6,6 @@ import {
 } from "components/pages/resources/databases/store/databasesViewSlice";
 import databasesManager from "common/shell/databasesManager";
 import notificationCenter from "common/notifications/notificationCenter";
-import viewHelpers from "common/helpers/view/viewHelpers";
 import DatabaseUtils from "components/utils/DatabaseUtils";
 import { UnsubscribeListener } from "@reduxjs/toolkit";
 import { addAppListener } from "components/storeUtils";

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeGroup.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeGroup.tsx
@@ -12,8 +12,6 @@ import { useEventsCollector } from "hooks/useEventsCollector";
 import { useServices } from "hooks/useServices";
 import app from "durandal/app";
 import { DatabaseSharedInfo } from "components/models/databases";
-import viewHelpers from "common/helpers/view/viewHelpers";
-import genUtils from "common/generalUtils";
 import addNewNodeToDatabaseGroup from "viewmodels/resources/addNewNodeToDatabaseGroup";
 import classNames from "classnames";
 import {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditSubscriptionTaskInfoHub.tsx
@@ -75,7 +75,7 @@ export function EditSubscriptionTaskInfoHub() {
     );
 }
 
-export const defaultFeatureAvailability: FeatureAvailabilityData[] = [
+const defaultFeatureAvailability: FeatureAvailabilityData[] = [
     {
         featureName: "Concurrent Data Subscriptions",
         featureIcon: "data-subscriptions",

--- a/src/Raven.Studio/wwwroot/Content/scss/bs5variables.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/bs5variables.scss
@@ -309,7 +309,7 @@ $font-sizes: (
 $headings-margin-bottom: math.div($spacer, $gutter-ratio) !default;
 $headings-font-family: null !default;
 $headings-font-style: null !default;
-$headings-font-weight: 300 !default;
+$headings-font-weight: 400 !default;
 $headings-line-height: 1.2 !default;
 $headings-color: $text-emphasis-var !default;
 // scss-docs-end headings-variables


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19198/Ability-to-sort-indexes-by-creation-time-and-see-that-time

### Additional description

- Adds the ability to sort and group indexes.
- Displays the creation time and the last indexing and querying time. The information is visible for each node/shard, and the general information also shows the maximum value.
- Splits the IndexesPage into smaller components for better readability.

### Type of change

- New feature

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/16af13f1-54e8-44f4-9858-552083bbed9f)
