### PR TITLE
RavenDB-21791 flags field name for decimal values in full .NET Framework is 'flags' not '_flags'

### DIFF
--- a/src/Sparrow/Utils/DecimalHelper.cs
+++ b/src/Sparrow/Utils/DecimalHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace Sparrow.Utils
 {
@@ -9,7 +10,22 @@ namespace Sparrow.Utils
 
     public class DecimalHelper
     {
-        public static readonly DecimalHelper Instance = new DecimalHelper();
+        private static readonly string FlagsFieldName;
+
+        public static readonly DecimalHelper Instance;
+
+        static DecimalHelper()
+        {
+            var decimalType = typeof(decimal);
+            if (decimalType.GetField("_flags", BindingFlags.Instance | BindingFlags.NonPublic) != null)
+                FlagsFieldName = "_flags";
+            else if (decimalType.GetField("flags", BindingFlags.Instance | BindingFlags.NonPublic) != null)
+                FlagsFieldName = "flags";
+            else
+                throw new InvalidOperationException("Could not determine name of the 'flags' field in decimal type");
+
+            Instance = new DecimalHelper();
+        }
 
         public readonly IsDoubleDelegate IsDouble;
 
@@ -21,11 +37,11 @@ namespace Sparrow.Utils
         private static Expression<IsDoubleDelegate> CreateIsDoubleMethod()
         {
             var value = Expression.Parameter(typeof(decimal).MakeByRefType(), "value");
-            
+
             var digits = Expression.RightShift(
-                Expression.And(Expression.Field(value, "_flags"), Expression.Constant(~Int32.MinValue, typeof(int))),
+                Expression.And(Expression.Field(value, FlagsFieldName), Expression.Constant(~Int32.MinValue, typeof(int))),
                 Expression.Constant(16, typeof(int)));
-            
+
             var hasDecimal = Expression.NotEqual(digits, Expression.Constant(0));
 
             // return (value.flags & ~Int32.MinValue) >> 16 != 0

--- a/test/EmbeddedTests/BasicTests.cs
+++ b/test/EmbeddedTests/BasicTests.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Embedded;
+using Sparrow.Json.Parsing;
 using Xunit;
 
 namespace EmbeddedTests
@@ -39,10 +40,16 @@ namespace EmbeddedTests
                     {
                         session.Store(new Person
                         {
-                            Name = "John"
+                            Name = "John",
+                            Amount = 55.5m
                         }, "people/1");
 
                         session.SaveChanges();
+
+                        session.Advanced.Context.ReadObject(new DynamicJsonValue
+                        {
+                            ["Value"] = 55.5m
+                        }, "");
                     }
                 }
             }
@@ -63,6 +70,7 @@ namespace EmbeddedTests
 
                         Assert.NotNull(person);
                         Assert.Equal("John", person.Name);
+                        Assert.Equal(55.5m, person.Amount);
                     }
                 }
             }
@@ -188,6 +196,8 @@ namespace EmbeddedTests
             public string Id { get; set; }
 
             public string Name { get; set; }
+
+            public decimal Amount { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21791

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
