### PR TITLE
RavenDB-21786 PowerBI integration - skip getting unchecked property value for document which does not have the property

### DIFF
--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -134,6 +134,11 @@ namespace Raven.Server.Integrations.PostgreSQL
                 {
                     // Using GetPropertyIndex to get the properties in the right order
                     var propIndex = sample.Data.GetPropertyIndex(propertyName);
+
+                    // If the document does not have this property, there is nothing to do.
+                    if (propIndex == -1)
+                        continue;
+                    
                     sample.Data.GetPropertyByIndex(propIndex, ref prop);
                     
                     if (prop.Value == null)

--- a/test/SlowTests/Server/Integrations/PostgreSQL/RavenDB-21786.cs
+++ b/test/SlowTests/Server/Integrations/PostgreSQL/RavenDB-21786.cs
@@ -1,0 +1,73 @@
+﻿using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Raven.Client;
+using Raven.Client.Documents;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Integrations.PostgreSQL;
+
+public class RavenDB_21786 : PostgreSqlIntegrationTestBase
+{
+    public RavenDB_21786(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [Fact]
+    public async Task SkipsGettingUncheckedPropertyValue_ForDocument_WhichDoesNotHaveTheProperty()
+    {
+        const string collectionName = "Members";
+        const string query = $"from {collectionName}";
+
+        DoNotReuseServer(EnablePostgresSqlSettings);
+
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var memberWithNullSurname = new JObject
+                {
+                    ["Name"] = "Krzysztof",
+                    ["Surname"] = null,
+                    [Constants.Documents.Metadata.Key] = new JObject
+                    {
+                        [Constants.Documents.Metadata.Collection] = collectionName
+                    }
+                };
+                
+                var memberWithoutSurname = new JObject
+                {
+                    ["Name"] = "Adrian",
+                    [Constants.Documents.Metadata.Key] = new JObject
+                    {
+                        [Constants.Documents.Metadata.Collection] = collectionName
+                    }
+                };
+                
+                session.Store(memberWithNullSurname, "Members/1-A");
+                session.Store(memberWithoutSurname, "Members/2-A");
+
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var members = await session
+                    .Query<Member>()
+                    .ToListAsync();
+
+                var result = await Act(store, query, Server);
+
+                Assert.NotNull(result);
+                Assert.NotEmpty(result.Rows);
+                Assert.Equal(members.Count, result.Rows.Count);
+            }
+        }
+    }
+
+    private class Member
+    {
+        public string Name { get; set; }
+        public string Surname { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21786

### Additional description

If the first document has a null property (for example: "FirstName": null), `GenerateSchema` method skips getting the property value. If another document does not have this property, `Data.GetPropertyIndex` method returns -1. That was an issue, because `Data.GetPropertyByIndex` throws an exception for index `-1`.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
