### PR TITLE
RavenDB-21784 Remove MySql.Data support and use MySqlConnector for backward compatibility

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlProviderParser.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlProviderParser.cs
@@ -21,7 +21,6 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
                 case "Oracle.ManagedDataAccess.Client":
                     return SqlProvider.OracleClient;
                 case "MySql.Data.MySqlClient":
-                    return SqlProvider.MySqlClient;
                 case "MySqlConnector.MySqlConnectorFactory":
                     return SqlProvider.MySqlConnectorFactory;
                 case "System.Data.SqlServerCe.3.5":

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/DbProviderFactories.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/DbProviderFactories.cs
@@ -18,7 +18,6 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                 case SqlProvider.Npgsql:
                     return NpgsqlFactory.Instance;
                 case SqlProvider.MySqlClient:
-                    return MySql.Data.MySqlClient.MySqlClientFactory.Instance;
                 case SqlProvider.MySqlConnectorFactory:
                     return MySqlConnector.MySqlConnectorFactory.Instance;
                 case SqlProvider.OracleClient:

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -515,15 +515,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                                         if (colParam is Npgsql.NpgsqlParameter || colParam is SqlParameter)
                                             colParam.Value = guid;
 
-                                        if (colParam is MySql.Data.MySqlClient.MySqlParameter mySqlParameter)
-                                        {
-                                            var arr = guid.ToByteArray();
-                                            mySqlParameter.Value = arr;
-                                            mySqlParameter.MySqlDbType = MySql.Data.MySqlClient.MySqlDbType.Binary;
-                                            mySqlParameter.Size = arr.Length;
-                                            break;
-                                        }
-                                        if (colParam is MySqlConnector.MySqlParameter mySqlConnectorParameter)
+                                        if (colParam is MySqlConnector.MySqlParameter mySqlConnectorParameter) 
                                         {
                                             var arr = guid.ToByteArray();
                                             mySqlConnectorParameter.Value = arr;
@@ -552,9 +544,6 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                                             ((Npgsql.NpgsqlParameter)colParam).NpgsqlDbType = npgsqlType;
                                             break;
                                         case SqlProvider.MySqlClient:
-                                            MySql.Data.MySqlClient.MySqlDbType mySqlDbType = ParseProviderSpecificParameterType<MySql.Data.MySqlClient.MySqlDbType>(dbTypeString);
-                                            ((MySql.Data.MySqlClient.MySqlParameter)colParam).MySqlDbType = mySqlDbType;
-                                            break;
                                         case SqlProvider.MySqlConnectorFactory:
                                             MySqlConnector.MySqlDbType mySqlConnectorDbType = ParseProviderSpecificParameterType<MySqlConnector.MySqlDbType>(dbTypeString);
                                             ((MySqlConnector.MySqlParameter)colParam).MySqlDbType = mySqlConnectorDbType;
@@ -713,15 +702,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                     {
                         if (DateTime.TryParseExact(value, DefaultFormat.OnlyDateTimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime dateTime))
                         {
-                            switch (_providerFactory.GetType().Name)
-                            {
-                                case "MySqlClientFactory":
-                                    colParam.Value = dateTime.ToString("yyyy-MM-dd HH:mm:ss.ffffff");
-                                    break;
-                                default:
-                                    colParam.Value = dateTime;
-                                    break;
-                            }
+                            colParam.Value = dateTime;
                             return true;
                         }
                     }
@@ -734,15 +715,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                         if (DateTimeOffset.TryParseExact(value, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture,
                             DateTimeStyles.RoundtripKind, out DateTimeOffset dateTimeOffset))
                         {
-                            switch (_providerFactory.GetType().Name)
-                            {
-                                case "MySqlClientFactory":
-                                    colParam.Value = dateTimeOffset.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.ffffff");
-                                    break;
-                                default:
-                                    colParam.Value = dateTimeOffset;
-                                    break;
-                            }
+                            colParam.Value = dateTimeOffset;
                             return true;
                         }
                     }

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriterSimulator.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriterSimulator.cs
@@ -86,8 +86,6 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
                             param = new Npgsql.NpgsqlParameter();
                             break;
                         case SqlProvider.MySqlClient:
-                            param = new MySql.Data.MySqlClient.MySqlParameter();
-                            break;
                         case SqlProvider.MySqlConnectorFactory:
                             param = new MySqlConnector.MySqlParameter();
                             break;

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -85,6 +85,8 @@ namespace Raven.Server.NotificationCenter.Notifications
         BlockingTombstones,
         ServerLimits,
 
-        ConflictRevisionsExceeded
+        ConflictRevisionsExceeded,
+        
+        SqlConnectionString_DeprecatedFactoryReplaced,
     }
 }

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -180,7 +180,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="MySql.Data" Version="8.1.0" />
     <PackageReference Include="MySqlConnector" Version="2.3.0" />
     <PackageReference Include="NCrontab.Advanced" Version="1.3.28" />
     <PackageReference Include="NEST" Version="7.17.5" />

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2231,7 +2231,12 @@ namespace Raven.Server.ServerWide
                     // RavenDB-21784 - Replace obsolete MySql provider name
                     var deserializedSqlConnectionString = JsonDeserializationCluster.SqlConnectionString(connectionString);
                     if (deserializedSqlConnectionString.FactoryName == "MySql.Data.MySqlClient")
+                    {
                         deserializedSqlConnectionString.FactoryName = "MySqlConnector.MySqlConnectorFactory";
+                        var alert = AlertRaised.Create(databaseName, "Deprecated MySql factory auto-updated", "MySql.Data.MySqlClient factory has been defaulted to MySqlConnector.MySqlConnectorFactory",
+                            AlertType.SqlConnectionString_DeprecatedFactoryReplaced, NotificationSeverity.Info);
+                        NotificationCenter.Add(alert);
+                    }
                     
                     command = new PutSqlConnectionStringCommand(deserializedSqlConnectionString, databaseName, raftRequestId);
                     break;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2228,7 +2228,12 @@ namespace Raven.Server.ServerWide
                     break;
 
                 case ConnectionStringType.Sql:
-                    command = new PutSqlConnectionStringCommand(JsonDeserializationCluster.SqlConnectionString(connectionString), databaseName, raftRequestId);
+                    // RavenDB-21784 - Replace obsolete MySql provider name
+                    var deserializedSqlConnectionString = JsonDeserializationCluster.SqlConnectionString(connectionString);
+                    if (deserializedSqlConnectionString.FactoryName == "MySql.Data.MySqlClient")
+                        deserializedSqlConnectionString.FactoryName = "MySqlConnector.MySqlConnectorFactory";
+                    
+                    command = new PutSqlConnectionStringCommand(deserializedSqlConnectionString, databaseName, raftRequestId);
                     break;
                 case ConnectionStringType.Olap:
                     command = new PutOlapConnectionStringCommand(JsonDeserializationCluster.OlapConnectionString(connectionString), databaseName, raftRequestId);

--- a/src/Raven.Server/SqlMigration/DatabaseDriverDispatcher.cs
+++ b/src/Raven.Server/SqlMigration/DatabaseDriverDispatcher.cs
@@ -15,7 +15,6 @@ namespace Raven.Server.SqlMigration
                 case MigrationProvider.MsSQL:
                     return new MsSqlDatabaseMigrator(connectionString);
                 case MigrationProvider.MySQL_MySql_Data:
-                    return new MySqlDatabaseMigrator(connectionString, "MySql.Data.MySqlClient");
                 case MigrationProvider.MySQL_MySqlConnector:
                     return new MySqlDatabaseMigrator(connectionString, "MySqlConnector.MySqlConnectorFactory");
                 case MigrationProvider.NpgSQL:

--- a/src/Raven.Server/SqlMigration/DatabaseDriverDispatcher.cs
+++ b/src/Raven.Server/SqlMigration/DatabaseDriverDispatcher.cs
@@ -14,7 +14,9 @@ namespace Raven.Server.SqlMigration
             {
                 case MigrationProvider.MsSQL:
                     return new MsSqlDatabaseMigrator(connectionString);
+#pragma warning disable CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySql_Data:
+#pragma warning restore CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySqlConnector:
                     return new MySqlDatabaseMigrator(connectionString, "MySqlConnector.MySqlConnectorFactory");
                 case MigrationProvider.NpgSQL:

--- a/src/Raven.Server/SqlMigration/MigrationProvider.cs
+++ b/src/Raven.Server/SqlMigration/MigrationProvider.cs
@@ -1,8 +1,11 @@
-﻿namespace Raven.Server.SqlMigration
+﻿using System;
+
+namespace Raven.Server.SqlMigration
 {
     public enum MigrationProvider
     {
         MsSQL,
+        [Obsolete("Unsupported provider. Use 'MySQL_MySqlConnector' instead.")]
         MySQL_MySql_Data,
         MySQL_MySqlConnector,
         NpgSQL,

--- a/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
+++ b/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
@@ -23,6 +23,12 @@ namespace Raven.Server.Web.Studio
             using (var sourceSqlDatabaseBlittable = await context.ReadForMemoryAsync(RequestBodyStream(), "source-database-info"))
             {
                 var sourceSqlDatabase = JsonDeserializationServer.SourceSqlDatabase(sourceSqlDatabaseBlittable);
+                
+                // RavenDB-21784 - Replace obsolete MySql provider name
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (sourceSqlDatabase.Provider == MigrationProvider.MySQL_MySql_Data)
+#pragma warning restore CS0618 // Type or member is obsolete
+                    sourceSqlDatabase.Provider = MigrationProvider.MySQL_MySqlConnector;
 
                 var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString, sourceSqlDatabase.Schemas);
                 var schema = dbDriver.FindSchema();

--- a/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
+++ b/src/Raven.Server/Web/Studio/SqlMigrationHandler.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Json.Serialization.NewtonsoftJson.Internal;
 using Raven.Server.Documents;
 using Raven.Server.Json;
+using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -28,7 +29,12 @@ namespace Raven.Server.Web.Studio
 #pragma warning disable CS0618 // Type or member is obsolete
                 if (sourceSqlDatabase.Provider == MigrationProvider.MySQL_MySql_Data)
 #pragma warning restore CS0618 // Type or member is obsolete
+                {
                     sourceSqlDatabase.Provider = MigrationProvider.MySQL_MySqlConnector;
+                    var alert = AlertRaised.Create(Database.Name, "Deprecated MySql factory auto-updated", "MySql.Data.MySqlClient factory has been defaulted to MySqlConnector.MySqlConnectorFactory",
+                            AlertType.SqlConnectionString_DeprecatedFactoryReplaced, NotificationSeverity.Info);
+                    Database.NotificationCenter.Add(alert);
+                }
 
                 var dbDriver = DatabaseDriverDispatcher.CreateDriver(sourceSqlDatabase.Provider, sourceSqlDatabase.ConnectionString, sourceSqlDatabase.Schemas);
                 var schema = dbDriver.FindSchema();

--- a/src/Raven.Studio/typescript/models/database/settings/connectionStringSqlEtlModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/connectionStringSqlEtlModel.ts
@@ -10,10 +10,10 @@ class connectionStringSqlEtlModel extends connectionStringModel {
 
     static sqlProviders: Array<valueAndLabelItem<string, string> & { tooltip: string }> = [
         { value: "System.Data.SqlClient", label: "Microsoft SQL Server", tooltip: sqlConnectionStringSyntax.mssqlSyntax },
-        { value: "MySql.Data.MySqlClient", label: "MySQL Server", tooltip: sqlConnectionStringSyntax.mysqlSyntax },
         { value: "MySqlConnector.MySqlConnectorFactory", label: "MySQL Server", tooltip: sqlConnectionStringSyntax.mysqlSyntax },
         { value: "Npgsql", label: "PostgreSQL", tooltip: sqlConnectionStringSyntax.npgsqlSyntax },
         { value: "Oracle.ManagedDataAccess.Client", label: "Oracle Database", tooltip: sqlConnectionStringSyntax.oracleSyntax },
+        { value: "MySql.Data.MySqlClient", label: "DEPRECATED: MySQL Server", tooltip: sqlConnectionStringSyntax.mysqlSyntax },
     ];
     
     connectionString = ko.observable<string>();

--- a/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
@@ -7,7 +7,7 @@ import sqlReference = require("models/database/tasks/sql/sqlReference");
 
 class sqlMigration {
 
-    static possibleProviders: Raven.Server.SqlMigration.MigrationProvider[] = ["MsSQL", "MySQL_MySql_Data", "MySQL_MySqlConnector", "NpgSQL", "Oracle"];
+    static possibleProviders: Raven.Server.SqlMigration.MigrationProvider[] = ["MsSQL", "MySQL_MySqlConnector", "NpgSQL", "Oracle", "MySQL_MySql_Data"];
     
     databaseType = ko.observable<Raven.Server.SqlMigration.MigrationProvider>("MsSQL");
     binaryToAttachment = ko.observable<boolean>(true);
@@ -163,7 +163,7 @@ class sqlMigration {
             case "MsSQL":
                 return "Microsoft SQL Server (System.Data.SqlClient)";
             case "MySQL_MySql_Data":
-                return "MySQL Server (MySql.Data.MySqlClient)";
+                return "DEPRECATED: MySQL Server (MySql.Data.MySqlClient)";
             case "MySQL_MySqlConnector":
                 return "MySQL Server (MySqlConnector.MySqlConnectorFactory)";
             case "NpgSQL":

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringSql.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringSql.html
@@ -21,6 +21,12 @@
         <ul class="dropdown-menu" data-bind="foreach: $data.constructor.sqlProviders">
             <li><a href="#" data-bind="text: $parent.fullNameFor(value), click: _.partial($parent.factoryName, value)"></a></li>
         </ul>
+        <span class="help-block" data-bind="validationMessage: factoryName"></span>
+        <div class="has-warning" data-bind="visible: factoryName() === 'MySql.Data.MySqlClient'">
+            <div class="help-block">
+                <i class="icon-warning"></i> <span> This connector is deprecated</span>
+            </div>
+        </div>
     </div>
 </div>
 <div class="form-group" data-bind="validationElement: connectionString">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
@@ -24,6 +24,11 @@
                                         </li>
                                     </ul>
                                     <span class="help-block" data-bind="validationMessage: databaseType"></span>
+                                    <div class="has-warning" data-bind="visible: databaseType() === 'MySQL_MySql_Data'">
+                                        <div class="help-block">
+                                            <i class="icon-warning"></i> <span> This connector is deprecated</span>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                             <div data-bind="visible: databaseType() === 'MsSQL', with: sqlServer">

--- a/test/FastTests/Corax/Bugs/SortingMatchHeapTests.cs
+++ b/test/FastTests/Corax/Bugs/SortingMatchHeapTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Numerics;
 using Corax.Mappings;
 using Corax.Queries;
-using Google.Protobuf.WellKnownTypes;
 using Sparrow.Server;
 using Sparrow.Threading;
 using Voron;

--- a/test/SlowTests/Issues/RavenDB-21784.cs
+++ b/test/SlowTests/Issues/RavenDB-21784.cs
@@ -1,0 +1,51 @@
+﻿using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Client.ServerWide;
+using Raven.Server.ServerWide.Context;
+using SlowTests.Server.Documents.ETL;
+using Tests.Infrastructure;
+using Tests.Infrastructure.ConnectionString;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21784: EtlTestBase
+    {
+        public RavenDB_21784 (ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [RavenFact(RavenTestCategory.Etl)]
+        public void DeprecatedFactoryNameOfMySqlConnectionStringIsBeingReplacedDuringPut()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var sqlConnectionString = new SqlConnectionString
+                {
+                    Name = "SqlConnectionString",
+                    ConnectionString = MsSqlConnectionString.Instance.VerifiedConnectionString.Value + $";Initial Catalog={store.Database}",
+                    FactoryName = "MySql.Data.MySqlClient"
+                };
+
+                var result1 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
+                Assert.NotNull(result1.RaftCommandIndex);
+
+
+                DatabaseRecord record;
+                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    record =  Server.ServerStore.Cluster.ReadDatabase(context, store.Database);
+                }
+
+                Assert.True(record.SqlConnectionStrings.ContainsKey("SqlConnectionString"));
+                Assert.Equal(sqlConnectionString.Name, record.SqlConnectionStrings["SqlConnectionString"].Name);
+                Assert.Equal(sqlConnectionString.ConnectionString, record.SqlConnectionStrings["SqlConnectionString"].ConnectionString);
+                Assert.Equal("MySqlConnector.MySqlConnectorFactory", record.SqlConnectionStrings["SqlConnectionString"].FactoryName);
+            }
+        }
+    }
+}
+
+

--- a/test/SlowTests/Issues/RavenDB_16303.cs
+++ b/test/SlowTests/Issues/RavenDB_16303.cs
@@ -193,7 +193,6 @@ loadToTestGuidEtls(item);"
                 case MigrationProvider.MsSQL:
                     return @"System.Data.SqlClient";
                 case MigrationProvider.MySQL_MySql_Data:
-                    return @"MySql.Data.MySqlClient";
                 case MigrationProvider.MySQL_MySqlConnector:
                     return @"MySqlConnector.MySqlConnectorFactory";
                 case MigrationProvider.NpgSQL:
@@ -611,10 +610,7 @@ loadToTestGuidEtls(item);"
         private static DbConnection GetMySqlConnection(MigrationProvider provider, string connectionString)
         {
             Debug.Assert(provider is MigrationProvider.MySQL_MySql_Data or MigrationProvider.MySQL_MySqlConnector);
-
-            return provider == MigrationProvider.MySQL_MySql_Data
-                ? new MySql.Data.MySqlClient.MySqlConnection(connectionString)
-                : new MySqlConnector.MySqlConnection(connectionString);
+            return new MySqlConnector.MySqlConnection(connectionString);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_16303.cs
+++ b/test/SlowTests/Issues/RavenDB_16303.cs
@@ -192,7 +192,9 @@ loadToTestGuidEtls(item);"
                     return @"Oracle.ManagedDataAccess.Client";
                 case MigrationProvider.MsSQL:
                     return @"System.Data.SqlClient";
+#pragma warning disable CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySql_Data:
+#pragma warning restore CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySqlConnector:
                     return @"MySqlConnector.MySqlConnectorFactory";
                 case MigrationProvider.NpgSQL:
@@ -246,7 +248,9 @@ loadToTestGuidEtls(item);"
                         connection.Close();
                     }
                     return;
+#pragma warning disable CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySql_Data:
+#pragma warning restore CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySqlConnector:
                     using (var connection = GetMySqlConnection(provider, connectionString))
                     {
@@ -332,7 +336,9 @@ loadToTestGuidEtls(item);"
                         connection.Close();
                     }
                     return;
+#pragma warning disable CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySql_Data:
+#pragma warning restore CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySqlConnector:
                     using (var connection = GetMySqlConnection(provider, connectionString))
                     {
@@ -407,7 +413,9 @@ loadToTestGuidEtls(item);"
                         connection.Close();
                     }
                     return;
+#pragma warning disable CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySql_Data:
+#pragma warning restore CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySqlConnector:
                     using (var connection = GetMySqlConnection(provider, connectionString))
                     {
@@ -482,7 +490,9 @@ loadToTestGuidEtls(item);"
                         connection.Close();
                     }
                     return;
+#pragma warning disable CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySql_Data:
+#pragma warning restore CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySqlConnector:
                     using (var connection = GetMySqlConnection(provider, connectionString))
                     {
@@ -565,7 +575,9 @@ loadToTestGuidEtls(item);"
                         connection.Close();
                     }
                     return;
+#pragma warning disable CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySql_Data:
+#pragma warning restore CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySqlConnector:
                     using (var connection = GetMySqlConnection(provider, connectionString))
                     {
@@ -609,7 +621,9 @@ loadToTestGuidEtls(item);"
 
         private static DbConnection GetMySqlConnection(MigrationProvider provider, string connectionString)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Debug.Assert(provider is MigrationProvider.MySQL_MySql_Data or MigrationProvider.MySQL_MySqlConnector);
+#pragma warning restore CS0618 // Type or member is obsolete
             return new MySqlConnector.MySqlConnection(connectionString);
         }
     }

--- a/test/SlowTests/Server/Documents/Migration/SqlAwareTestBase.cs
+++ b/test/SlowTests/Server/Documents/Migration/SqlAwareTestBase.cs
@@ -76,18 +76,6 @@ namespace SlowTests.Server.Documents.Migration
             switch (provider)
             {
                 case MigrationProvider.MySQL_MySql_Data:
-                {
-                    using (var connection = new MySql.Data.MySqlClient.MySqlConnection(connectionString))
-                    {
-                        connection.Open();
-                        using (var cmd = new MySql.Data.MySqlClient.MySqlCommand(query, connection))
-                        {
-                            cmd.ExecuteNonQuery();
-                        }
-                    }
-
-                    break;
-                }
                 case MigrationProvider.MySQL_MySqlConnector:
                 {
                     using (var connection = new MySqlConnector.MySqlConnection(connectionString))
@@ -257,10 +245,7 @@ namespace SlowTests.Server.Documents.Migration
         private static DbConnection GetMySqlConnection(MigrationProvider provider, string connectionString)
         {
             Debug.Assert(provider is MigrationProvider.MySQL_MySql_Data or MigrationProvider.MySQL_MySqlConnector);
-
-            return provider == MigrationProvider.MySQL_MySql_Data
-                ? new MySql.Data.MySqlClient.MySqlConnection(connectionString)
-                : new MySqlConnector.MySqlConnection(connectionString);
+            return new MySqlConnector.MySqlConnection(connectionString);
         }
 
         private static DisposableAction WithMySqlDatabase(out string connectionString, out string databaseName, string dataSet, MigrationProvider provider, bool includeData = true)

--- a/test/SlowTests/Server/Documents/Migration/SqlAwareTestBase.cs
+++ b/test/SlowTests/Server/Documents/Migration/SqlAwareTestBase.cs
@@ -75,7 +75,9 @@ namespace SlowTests.Server.Documents.Migration
         {
             switch (provider)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySql_Data:
+#pragma warning restore CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySqlConnector:
                 {
                     using (var connection = new MySqlConnector.MySqlConnection(connectionString))
@@ -131,7 +133,9 @@ namespace SlowTests.Server.Documents.Migration
         {
             switch (provider)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySql_Data:
+#pragma warning restore CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySqlConnector:
                     return WithMySqlDatabase(out connectionString, out schemaName, dataSet, provider, includeData);
                 case MigrationProvider.MsSQL:
@@ -244,7 +248,9 @@ namespace SlowTests.Server.Documents.Migration
 
         private static DbConnection GetMySqlConnection(MigrationProvider provider, string connectionString)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Debug.Assert(provider is MigrationProvider.MySQL_MySql_Data or MigrationProvider.MySQL_MySqlConnector);
+#pragma warning restore CS0618 // Type or member is obsolete
             return new MySqlConnector.MySqlConnection(connectionString);
         }
 

--- a/test/Tests.Infrastructure/ConnectionString/MySqlConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/MySqlConnectionString.cs
@@ -1,4 +1,4 @@
-﻿using MySql.Data.MySqlClient;
+﻿using MySqlConnector; // todo: check if it's ok to replace that import
 
 namespace Tests.Infrastructure.ConnectionString
 {

--- a/test/Tests.Infrastructure/ConnectionString/MySqlConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/MySqlConnectionString.cs
@@ -1,4 +1,4 @@
-﻿using MySqlConnector; // todo: check if it's ok to replace that import
+﻿using MySqlConnector;
 
 namespace Tests.Infrastructure.ConnectionString
 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21784
https://issues.hibernatingrhinos.com/issue/RavenDB-21716

### Additional description

Removed `MySql.Data.MySqlClient` package from the project.  

### Type of change
- Optimization


### How risky is the change?
- Moderate 


### Backward compatibility


- Ensured. Please explain how has it been implemented? 
- Using `MySqlConnector.MySqlConnectorFactory` instead in every previous use case.

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
