### PR TITLE
RavenDB-21275: make sure to not use lsv that was yielded by IEnumerable

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1080,7 +1080,7 @@ namespace Raven.Server.Documents
             return fst.NumberOfEntries;
         }
 
-        public IEnumerable<LazyStringValue> GetAllIds(DocumentsOperationContext context)
+        public IEnumerable<string> GetAllIds(DocumentsOperationContext context)
         {
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 

--- a/test/SlowTests/Sharding/Client/Operations/GetDocumentConflictsTests.cs
+++ b/test/SlowTests/Sharding/Client/Operations/GetDocumentConflictsTests.cs
@@ -137,7 +137,7 @@ namespace SlowTests.Sharding.Client.Operations
 
                 using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
-                    var ids = new LazyStringValue[10];
+                    var ids = new string[10];
                     int i = 0;
                     using (context.OpenReadTransaction())
                     {
@@ -145,7 +145,7 @@ namespace SlowTests.Sharding.Client.Operations
                         if (docCount == 0)
                             continue;
 
-                        foreach (var docId in db.DocumentsStorage.GetAllIds(context))
+                        foreach (string docId in db.DocumentsStorage.GetAllIds(context))
                         {
                             ids[i++] = docId;
                             if(i > 9)
@@ -156,7 +156,7 @@ namespace SlowTests.Sharding.Client.Operations
                     using (context.OpenWriteTransaction())
                     {
                         i = 0;
-                        foreach (var id in ids)
+                        foreach (string id in ids)
                         {
                             var doc = context.ReadObject(new DynamicJsonValue(), id);
                             db.DocumentsStorage.ConflictsStorage.AddConflict(context, id, now.AddMinutes(rand.Next(100, 10000)).Ticks, doc, $"A:{i}-A1B2C3D4E5F6G7H8I9", "users",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21275/AVE-on-test-runs

### Additional description

lsv that was yielded by IEnumerable was still used in test after enumeration completed which could lead to ave on running this test

### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
