### PR TITLE
RavenDB-19969 - StressTests.Client.TimeSeries.TimeSeriesStress.PatchTimestamp_IntegrationTest

### DIFF
--- a/test/StressTests/Client/TimeSeries/TimeSeriesStress.cs
+++ b/test/StressTests/Client/TimeSeries/TimeSeriesStress.cs
@@ -14,6 +14,7 @@ using Raven.Client.Documents.Session.TimeSeries;
 using Raven.Server.Config;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.TimeSeries.Patch;
 using SlowTests.Client.TimeSeries.Replication;
@@ -240,6 +241,8 @@ namespace StressTests.Client.TimeSeries
         [Fact]
         public async Task PatchTimestamp_IntegrationTest()
         {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+
             string[] tags = { "tag/1", "tag/2", "tag/3", "tag/4", null };
             const string timeseries = "Heartrate";
             const int timeSeriesPointsAmount = 128;
@@ -286,8 +289,13 @@ update
     }
 }"
                     }));
-                await appendOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
+#if DEBUG
+                TimeSpan time = TimeSpan.FromMinutes(8);
+#else
+                time = TimeSpan.FromMinutes(5);
+#endif
+                await appendOperation.WaitForCompletionAsync(time);
                 var deleteFrom = toAppend[timeSeriesPointsAmount * 1 / 3].Timestamp;
                 var deleteTo = toAppend[timeSeriesPointsAmount * 3 / 4].Timestamp;
                 var deleteOperation = store


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19969/StressTests.Client.TimeSeries.TimeSeriesStress.PatchTimestampIntegrationTest

### Additional description

It takes more than 5 minutes to complete the Patch operation in debug mode because we have multiple TS segments, and for each one, we call the `EnsureStatsAndDataIntegrity` method, which can be expensive. Therefore, I added 3 minutes for debug mode (should be enough). 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
