### PR TITLE
RavenDB-21743 `AutoMapReduceIndex` fanout index should have at least one  '[]'.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -279,7 +279,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
                 groupByFieldsPaths.Add(groupByFieldPath);
             }
 
-            Debug.Assert(groupByFieldsPaths.Count > 0);
+            Debug.Assert(groupByFieldsPaths.Count > 0, $"{nameof(AutoMapReduceIndex)}' must have at least one field with '[]'.");
 
             foreach ((_, IndexFieldBase field) in Definition.MapFields)
             {

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6442;
+            const int numberToTolerate = 6440;
             if (array.Length == numberToTolerate)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21743 

### Additional description

For fanout auto reduce indexes we're expecting to have at least one `[]` in case when we're fanouting.

When we look into code LINQ will output `FieldName[]` since we have perform aggregation via LINQ extension `GroupByArrayValues`, in other case we will get exception:
https://github.com/ravendb/ravendb/blob/f88d89715b369157070f4add8249e83f4e7b8c0f/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs#L2337-L2352

In case of raw RQL code without adding `[]` at the end we will treat whole field as normal content and aggregate by JSON of it.
Adding `[]` will set field as `GroupByArrayBehavior.ByIndividualValues`:
https://github.com/ravendb/ravendb/blob/f88d89715b369157070f4add8249e83f4e7b8c0f/src/Raven.Server/Documents/Queries/QueryMetadata.cs#L1893-L1913

and this is condition of being Fanout:
https://github.com/ravendb/ravendb/blob/f88d89715b369157070f4add8249e83f4e7b8c0f/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs#L34


I adjusted `SurpassedAutoMapReduceWillBeDeletedOrMerged` to match our real convention.

### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
