### PR TITLE
RavenDB-21710 - fixed DeleteDatabaseCommand not updating the raft etag in topology

### DIFF
--- a/test/SlowTests/Issues/RavenDB_21553.cs
+++ b/test/SlowTests/Issues/RavenDB_21553.cs
@@ -22,11 +22,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [RavenFact(RavenTestCategory.ClientApi, Skip = "fix me")]
+        [RavenFact(RavenTestCategory.ClientApi)]
         public async Task Topology_Change_Shouldnt_Trigger_SpeedTest()
         {
-            var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
-
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true);
+            
             using (var leaderStore = GetDocumentStore(new Options
             {
                 ReplicationFactor = 3,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21710

### Additional description

Request executor failed to update to the new state of topology because `DeleteDatabaseCommand` did not update the topology with the latest raft etag in its stamp. So the update function of the request executor skipped it.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change (only the leader executes this command)

### Documentation update

- No documentation update is needed 

