### PR TITLE
RavenDB-21795 switched default value of Http.AllowResponseCompressionOverHttps to true

### DIFF
--- a/src/Raven.Server/Config/Categories/HttpConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/HttpConfiguration.cs
@@ -62,8 +62,8 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Http.UseResponseCompression", ConfigurationEntryScope.ServerWideOnly)]
         public bool UseResponseCompression { get; set; }
 
-        [Description("Whether Raven's HTTP server should allow response compression to happen when HTTPS is enabled. Please see http://breachattack.com/ before enabling this")]
-        [DefaultValue(false)]
+        [Description("Whether Raven's HTTP server should allow response compression to happen when HTTPS is enabled.")]
+        [DefaultValue(true)]
         [ConfigurationEntry("Http.AllowResponseCompressionOverHttps", ConfigurationEntryScope.ServerWideOnly)]
         public bool AllowResponseCompressionOverHttps { get; set; }
 

--- a/test/StressTests/Client/TimeSeries/TimeSeriesStress.cs
+++ b/test/StressTests/Client/TimeSeries/TimeSeriesStress.cs
@@ -293,7 +293,7 @@ update
 #if DEBUG
                 TimeSpan time = TimeSpan.FromMinutes(8);
 #else
-                time = TimeSpan.FromMinutes(5);
+                TimeSpan time = TimeSpan.FromMinutes(5);
 #endif
                 await appendOperation.WaitForCompletionAsync(time);
                 var deleteFrom = toAppend[timeSeriesPointsAmount * 1 / 3].Timestamp;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21795

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
