### PR TITLE
RavenDB-20980 Memory improvements during indexing

### DIFF
--- a/src/Voron/Util/ContextBoundNativeList.cs
+++ b/src/Voron/Util/ContextBoundNativeList.cs
@@ -80,7 +80,7 @@ namespace Voron.Util
             Inner.Shrink(newSize); 
         }
 
-        public void Initialize(int count = 16)
+        public void Initialize(int count = 1)
         {
             Inner.Initialize(_ctx, count);
         }

--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -107,15 +107,15 @@ public unsafe struct NativeList<T>
         Count = newSize;
     }
 
-    public void Initialize(ByteStringContext ctx, int count = 16)
+    public void Initialize(ByteStringContext ctx, int count = 1)
     {
-        var capacity = Math.Max(16, Bits.PowerOf2(count));
+        var capacity = count == 1 ? 1 : Math.Max(1, Bits.PowerOf2(count));
         ctx.Allocate(capacity * sizeof(T), out _storage);
     }
     
     public void Grow(ByteStringContext ctx, int addition)
     {
-        var capacity = Math.Max(16, Bits.PowerOf2(Capacity + addition));
+        var capacity = Math.Max(1, Bits.PowerOf2(Capacity + addition));
         ctx.Allocate(capacity * sizeof(T), out var mem);
 
         if (_storage.HasValue)
@@ -192,7 +192,7 @@ public unsafe struct NativeList<T>
     {
         Count = 0;
     }
-
+    
 
     public Enumerator GetEnumerator() => new(RawItems, Count);
 
@@ -242,5 +242,7 @@ public unsafe struct NativeList<T>
         }
     }
 
-
+#if CORAX_MEMORY_WATCHER
+    public (long BytesUsed, long BytesAllocated) Allocations => (Count * sizeof(T), Capacity * sizeof(T));
+#endif
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20980 

### Additional description
 - Stop allocating NativeLists by default; only when necessary
 - Release memory of NativeLists after processing
 - Start indexing from fields with a higher probability of having multiple items in posting lists.

### Type of change

- Optimization

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team

- This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.


### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
