### PR TITLE
RavenDB-21319 - PromoteDatabaseNodeCommand doesn't remove rehab node

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/PromoteDatabaseNodeCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PromoteDatabaseNodeCommand.cs
@@ -19,12 +19,14 @@ namespace Raven.Server.ServerWide.Commands
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
-            if (record.Topology.Promotables.Contains(NodeTag) == false)
+            if (record.Topology.Promotables.Contains(NodeTag) == false &&
+                record.Topology.Rehabs.Contains(NodeTag) == false)
                 return ;
 
             record.Topology.PromotablesStatus.Remove(NodeTag);
             record.Topology.DemotionReasons.Remove(NodeTag);
             record.Topology.Promotables.Remove(NodeTag);
+            record.Topology.Rehabs.Remove(NodeTag);
             record.Topology.Members.Add(NodeTag);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21319

### Additional description

Can now promote a rehab node (not just promotables) via the existing `PromoteDatabaseNodeOperation`.
If the node is down (for example), after grace time is over it will go back to rehab.

### Type of change

- Bug

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
