### PR TITLE
RavenDB-19969 - split test to x86 and x64

### DIFF
--- a/test/StressTests/Client/TimeSeries/TimeSeriesStress.cs
+++ b/test/StressTests/Client/TimeSeries/TimeSeriesStress.cs
@@ -238,15 +238,26 @@ namespace StressTests.Client.TimeSeries
             }
         }
 
-        [Fact]
-        public async Task PatchTimestamp_IntegrationTest()
+        [MultiplatformFact(RavenArchitecture.AllX64)]
+        public async Task PatchTimestamp_IntegrationTest_x64()
+        {
+            await PatchTimestamp_IntegrationTest(8_192);
+        }
+
+        [MultiplatformFact(RavenArchitecture.AllX86)]
+        public async Task PatchTimestamp_IntegrationTest_x86()
+        {
+            await PatchTimestamp_IntegrationTest(4_096);
+        }
+
+     
+        public async Task PatchTimestamp_IntegrationTest(int docAmount)
         {
             DebuggerAttachedTimeout.DisableLongTimespan = true;
 
             string[] tags = { "tag/1", "tag/2", "tag/3", "tag/4", null };
             const string timeseries = "Heartrate";
             const int timeSeriesPointsAmount = 128;
-            const int docAmount = 8_192;
 
             using (var store = GetDocumentStore())
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19969/StressTests.Client.TimeSeries.TimeSeriesStress.PatchTimestampIntegrationTest

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
