### PR TITLE
RavenDB-21805: Test for server-wide periodic backup with pinned mentor node and failure scenario

### DIFF
--- a/test/StressTests/Server/Documents/PeriodicBackup/PeriodicBackupTestsStress.cs
+++ b/test/StressTests/Server/Documents/PeriodicBackup/PeriodicBackupTestsStress.cs
@@ -1,9 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Server;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -93,6 +100,66 @@ namespace StressTests.Server.Documents.PeriodicBackup
 
                 val = WaitForValue(() => store.Maintenance.Send(getPeriodicBackupStatus).Status?.LastFullBackup != null, true, timeout: 66666, interval: 444);
                 Assert.True(val, "Failed to complete the backup in time");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster)]
+        public async Task ServerWideBackup_WithPinnedMentorNode_FailureHandling()
+        {
+            const int clusterSize = 3;
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            (List<RavenServer> nodes, RavenServer leaderServer) = await CreateRaftCluster(clusterSize);
+            var mentorNode = nodes.First(x => x != leaderServer);
+
+            using (var store = GetDocumentStore(new Options { Server = leaderServer, ReplicationFactor = 3}))
+            {
+                await Backup.FillClusterDatabaseWithRandomDataAsync(databaseSizeInMb: 1, store, clusterSize);
+
+                var result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(new ServerWideBackupConfiguration
+                {
+                    FullBackupFrequency = "* * * * *", // We will perform the backup every minute
+                    LocalSettings = new LocalSettings { FolderPath = backupPath },
+                    MentorNode = mentorNode.ServerStore.NodeTag,
+                    PinToMentorNode = true
+                }));
+
+                var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
+                var taskId = serverWideConfiguration.TaskId;
+
+                var getPeriodicBackupStatusOperation = new GetPeriodicBackupStatusOperation(taskId);
+                await WaitForValueAsync(async () =>
+                {
+                    var response = await store.Maintenance.SendAsync(getPeriodicBackupStatusOperation);
+                    return response is { Status.LastFullBackup: not null };
+                }, expectedVal: true);
+
+                // Simulate mentor node failure
+                await DisposeAndRemoveServer(mentorNode);
+
+                // Wait a minute to ensure that no node has performed a backup according to the schedule (once a minute)
+                await Task.Delay(TimeSpan.FromMinutes(1));
+                foreach (var server in nodes.Where(node => node != mentorNode))
+                {
+                    var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    Assert.NotNull(database);
+
+                    var actualNodeTag = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                    Assert.Equal(mentorNode.ServerStore.NodeTag, actualNodeTag);
+
+                    var backup = database.PeriodicBackupRunner.PeriodicBackups.SingleOrDefault();
+                    Assert.True(backup != null,
+                        $"Expected single backup task on Node '{server.ServerStore.NodeTag}' for database '{database.Name}' " +
+                        $"Number of backup tasks: '{database.PeriodicBackupRunner.PeriodicBackups.Count}'.");
+
+                    Assert.False(backup.HasScheduledBackup(),
+                        $"Expected PeriodicBackup with pinned to mentor node '{mentorNode}' to cancel " +
+                        $"the ScheduledBackup on Node '{server.ServerStore.NodeTag}', but it didn't.");
+
+                    Assert.True(backup.BackupStatus == null,
+                        $"Expected no backup on Node '{server.ServerStore.NodeTag}' as " +
+                        $"PeriodicBackup is pinned to mentor node '{mentorNode}', but a backup was performed.");
+                }
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21805

### Additional description

We need to expand our test coverage to include a scenario where a server-wide periodic backup is configured with a mentor node specifically pinned for this task. This issue involves creating a test with the following setup:

* **Scenario Configuration:** Set up a server-wide periodic backup in a cluster, pinning this task explicitly to a mentor node. This involves ensuring that the backup process is designated to occur only through the mentor node.
* **Mentor Node Failure Simulation:** After configuring the backup, the test should simulate the failure of the pinned mentor node.
* **Expected Outcome:** The crucial aspect of this test is to confirm that following the mentor node's failure, the backup process does not initiate on any other server. The system should recognize the backup task as 'ActiveByOtherNode', indicating that despite the mentor node's failure, the task remains pinned and should not activate elsewhere.

### Type of change

- Expanding test coverage

### How risky is the change?

- Low 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed