### PR TITLE
RavenDB-19198 Ability to sort indexes by creation time and see that time (UI improvements)

### DIFF
--- a/src/Raven.Studio/typescript/common/generalUtils.ts
+++ b/src/Raven.Studio/typescript/common/generalUtils.ts
@@ -768,6 +768,14 @@ class genUtils {
         }
         return "SomeSelected";
     }
+
+    static isServerMinDate(date: string): boolean {
+        if (!date) {
+            return false;
+        }
+        
+        return date.startsWith("0001-01-01");
+    }
 } 
 
 export = genUtils;

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -108,6 +108,10 @@ export function IndexDistribution(props: IndexDistributionProps) {
 
     const sharded = IndexUtils.isSharded(index);
 
+    const formattedCreatedTimestamp = index.createdTimestamp
+        ? genUtils.formatDurationByDate(moment(index.createdTimestamp)) + " ago"
+        : null;
+
     const items = (
         <>
             {[...index.nodesInfo]
@@ -130,39 +134,46 @@ export function IndexDistribution(props: IndexDistributionProps) {
     );
 
     return (
-        <LocationDistribution>
-            <DistributionLegend>
-                <div className="top"></div>
-                {sharded && (
-                    <div className="node">
-                        <Icon icon="node" /> Node
+        <div>
+            <LocationDistribution>
+                <DistributionLegend>
+                    <div className="top"></div>
+                    {sharded && (
+                        <div className="node">
+                            <Icon icon="node" /> Node
+                        </div>
+                    )}
+                    <div>
+                        <Icon icon="list" /> Entries
                     </div>
-                )}
-                <div>
-                    <Icon icon="list" /> Entries
+                    <div>
+                        <Icon icon="warning" /> Errors
+                    </div>
+                    <div>
+                        <Icon icon="index-history" /> Indexed
+                    </div>
+                    <div>
+                        <Icon icon="queries" /> Queried
+                    </div>
+                    <div>
+                        <Icon icon="changes" /> State
+                    </div>
+                </DistributionLegend>
+                <DistributionSummary>
+                    <div className="top">Total</div>
+                    {sharded && <div> </div>}
+                    <div>{estimatedEntries}</div>
+                    <div>{totalErrors}</div>
+                    <div></div>
+                </DistributionSummary>
+                {items}
+            </LocationDistribution>
+            {formattedCreatedTimestamp && (
+                <div className="small">
+                    <span className="text-muted">Created:</span> <strong>{formattedCreatedTimestamp}</strong>
                 </div>
-                <div>
-                    <Icon icon="warning" /> Errors
-                </div>
-                <div>
-                    <Icon icon="index-history" /> Indexed
-                </div>
-                <div>
-                    <Icon icon="queries" /> Queried
-                </div>
-                <div>
-                    <Icon icon="changes" /> State
-                </div>
-            </DistributionLegend>
-            <DistributionSummary>
-                <div className="top">Total</div>
-                {sharded && <div> </div>}
-                <div>{estimatedEntries}</div>
-                <div>{totalErrors}</div>
-                <div></div>
-            </DistributionSummary>
-            {items}
-        </LocationDistribution>
+            )}
+        </div>
     );
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -189,10 +189,6 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
 
     const reduceOutputId = useId("reduce-output-id");
 
-    const formattedCreatedTimestamp = genUtils.formatDurationByDate(moment(index.createdTimestamp)) + " ago";
-    const formattedLastIndexingTime = getFormattedMaxNodeTime(index, "lastIndexingTime");
-    const formattedLastQueryingTime = getFormattedMaxNodeTime(index, "lastQueryingTime");
-
     return (
         <>
             <RichPanel className={classNames({ "index-sidebyside": hasReplacement || isReplacement })} innerRef={ref}>
@@ -209,24 +205,6 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                                     {index.name}
                                 </a>
                             </RichPanelName>
-                            <div className="small hstack gap-4">
-                                <div>
-                                    <span className="text-muted">Created:</span>{" "}
-                                    <strong>{formattedCreatedTimestamp}</strong>
-                                </div>
-                                {formattedLastIndexingTime && (
-                                    <div>
-                                        <span className="text-muted">Indexed:</span>{" "}
-                                        <strong>{formattedLastIndexingTime}</strong>
-                                    </div>
-                                )}
-                                {formattedLastQueryingTime && (
-                                    <div>
-                                        <span className="text-muted">Queried:</span>{" "}
-                                        <strong>{formattedLastQueryingTime}</strong>
-                                    </div>
-                                )}
-                            </div>
                         </div>
                     </RichPanelInfo>
                     <RichPanelActions>
@@ -502,20 +480,6 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
             </RichPanel>
         </>
     );
-}
-
-function getFormattedMaxNodeTime<T extends IndexSharedInfo>(
-    index: T,
-    value: Extract<keyof T["nodesInfo"][number]["details"], "lastIndexingTime" | "lastQueryingTime">
-) {
-    const allDates = index.nodesInfo.map((x) => x.details?.[value]);
-    const maxDate = _.max(allDates);
-
-    if (!maxDate) {
-        return null;
-    }
-
-    return genUtils.formatDurationByDate(moment(maxDate)) + " ago";
 }
 
 function IndexSourceTypeComponent(props: { sourceType: IndexSourceType }) {

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -98,6 +98,8 @@ interface IndexesStatsState {
     resetInProgress: string[];
 }
 
+const minCreatedTimestamp = "0001-01-01T00:00:00.0000000";
+
 function mapToIndexSharedInfo(stats: IndexStats): IndexSharedInfo {
     return {
         name: stats.Name,
@@ -111,7 +113,7 @@ function mapToIndexSharedInfo(stats: IndexStats): IndexSharedInfo {
         patternForReferencesToReduceOutputCollection: stats.ReduceOutputReferencePattern,
         collectionNameForReferenceDocuments: stats.PatternReferencesCollectionName,
         searchEngine: stats.SearchEngineType,
-        createdTimestamp: stats.CreatedTimestamp ? new Date(stats.CreatedTimestamp) : null,
+        createdTimestamp: stats.CreatedTimestamp === minCreatedTimestamp ? null : new Date(stats.CreatedTimestamp),
     };
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -7,6 +7,7 @@ import { produce } from "immer";
 import { databaseLocationComparator } from "components/utils/common";
 import IndexProgress = Raven.Client.Documents.Indexes.IndexProgress;
 import { WritableDraft } from "immer/dist/types/types-external";
+import genUtils = require("common/generalUtils");
 
 interface ActionStatsLoaded {
     location: databaseLocationSpecifier;
@@ -98,8 +99,6 @@ interface IndexesStatsState {
     resetInProgress: string[];
 }
 
-const minCreatedTimestamp = "0001-01-01T00:00:00.0000000";
-
 function mapToIndexSharedInfo(stats: IndexStats): IndexSharedInfo {
     return {
         name: stats.Name,
@@ -113,7 +112,7 @@ function mapToIndexSharedInfo(stats: IndexStats): IndexSharedInfo {
         patternForReferencesToReduceOutputCollection: stats.ReduceOutputReferencePattern,
         collectionNameForReferenceDocuments: stats.PatternReferencesCollectionName,
         searchEngine: stats.SearchEngineType,
-        createdTimestamp: stats.CreatedTimestamp === minCreatedTimestamp ? null : new Date(stats.CreatedTimestamp),
+        createdTimestamp: genUtils.isServerMinDate(stats.CreatedTimestamp) ? null : new Date(stats.CreatedTimestamp),
     };
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -746,8 +746,8 @@ export const defaultFilterCriteria: IndexFilterCriteria = {
     autoRefresh: true,
     showOnlyIndexesWithIndexingErrors: false,
     searchText: "",
-    sortBy: "lastIndexingTime",
-    sortDirection: "desc",
+    sortBy: "name",
+    sortDirection: "asc",
     groupBy: "Collection",
 };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19198/Ability-to-sort-indexes-by-creation-time-and-see-that-time

### Additional description

- Changes default sort settings
- Removes Indexed/Queried time from top level info
- Moves Created time to index details

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/6b2bd427-9e6d-4a01-adde-cc99a385d554)
