### PR TITLE
RavenDB-20950 Consider not showing already set backup credentials

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/googleCloudSettings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/googleCloudSettings.ts
@@ -11,6 +11,7 @@ class googleCloudSettings extends backupSettings {
     bucket = ko.observable<string>();
     remoteFolderName = ko.observable<string>();
     googleCredentialsJson = ko.observable<string>();
+    credentialsVisible = ko.observable<boolean>(true);
 
     targetOperation: string;
     
@@ -20,10 +21,13 @@ class googleCloudSettings extends backupSettings {
         this.bucket(dto.BucketName);
         this.remoteFolderName(dto.RemoteFolderName || "");
         this.googleCredentialsJson(dto.GoogleCredentialsJson);
+        this.credentialsVisible(!dto.GoogleCredentialsJson);
 
         this.targetOperation = targetOperation;
         
         this.initValidation();
+        
+        _.bindAll(this, "toggleCredentials");
 
         this.dirtyFlag = new ko.DirtyFlag([
             this.enabled,
@@ -32,6 +36,10 @@ class googleCloudSettings extends backupSettings {
             this.googleCredentialsJson,
             this.configurationScriptDirtyFlag().isDirty
         ], false, jsonUtil.newLineNormalizingHashFunction);
+    }
+
+    toggleCredentials() {
+        this.credentialsVisible.toggle();
     }
 
     compositionComplete(view: Element, container: HTMLElement) {

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/googleCloudSettings.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/googleCloudSettings.html
@@ -15,7 +15,7 @@
 <div class="row margin-bottom" data-bind="validationElement: googleCredentialsJson">
     <label class="control-label col-xs-12 col-sm-6 col-lg-4">Google Credentials Json <i class="required"></i></label>
     <div class="col-xs-12 col-sm-6 col-lg-8">
-        <textarea rows="9" data-bind="textInput: googleCredentialsJson" class="form-control" placeholder=
+        <textarea rows="9" data-bind="textInput: googleCredentialsJson, visible: credentialsVisible" class="form-control" placeholder=
 'e.g.
 {
     "type": "service_account",
@@ -30,5 +30,12 @@
     "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/viewonly%40test-raven-237012.iam.gserviceaccount.com"
   }
         '></textarea>
+        <button class="btn btn-default margin-right-xs" data-bind="click: toggleCredentials, visible: !credentialsVisible()" title="View credentials">
+            <i class="icon-preview"></i> <span>Show credentials</span>
+        </button>
+        <button class="btn btn-info margin-right-xs" data-bind="click: toggleCredentials, visible: credentialsVisible" title="Hide credentials">
+            <i class="icon-preview-off"></i> <span>Hide credentials</span>
+        </button>
+        
     </div>
 </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20950 

### Additional description

Don't edit GCP credentials by default on edit screens

### Type of change

- New feature

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


