### PR TITLE
RavenDB-19585 - Client doesn't failover if the topology changed

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -70,8 +70,7 @@ namespace Raven.Client.Http
         private readonly string _databaseName;
 
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger<RequestExecutor>("Client");
-        private DateTime _lastReturnedResponse;
-
+        
         public readonly JsonContextPool ContextPool;
 
         public readonly AsyncLocal<AggressiveCacheOptions> AggressiveCaching = new AsyncLocal<AggressiveCacheOptions>();
@@ -326,9 +325,7 @@ namespace Raven.Client.Http
 
             _databaseName = databaseName;
             Certificate = certificate;
-
-            _lastReturnedResponse = DateTime.UtcNow;
-
+            
             Conventions = conventions.Clone();
 
             var maxNumberOfContextsToKeepInGlobalStack = PlatformDetails.Is32Bits == false
@@ -674,40 +671,29 @@ namespace Raven.Client.Http
             }
         }
 
-        private void UpdateTopologyCallback(object _)
+        internal async void UpdateTopologyCallback(object _)
         {
-            var time = DateTime.UtcNow;
-            if (time - _lastReturnedResponse <= TimeSpan.FromMinutes(5))
+            var selector = _nodeSelector;
+            if (selector == null || selector.Topology == null)
                 return;
-
-            ServerNode serverNode;
-
-            try
-            {
-                var selector = _nodeSelector;
-                if (selector == null)
-                    return;
-                var preferredNode = selector.GetPreferredNode();
-                serverNode = preferredNode.Node;
-            }
-            catch (Exception e)
-            {
-                if (Logger.IsInfoEnabled)
-                    Logger.Info("Couldn't get preferred node Topology from _updateTopologyTimer task", e);
-                return;
-            }
-            GC.KeepAlive(Task.Run(async () =>
+            
+            // Fetch topologies from all nodes, the executor's topology will be updated to the most recent one
+            foreach (var serverNode in selector.Topology.Nodes)
             {
                 try
                 {
-                    await UpdateTopologyAsync(new UpdateTopologyParameters(serverNode) { TimeoutInMs = 0, DebugTag = "timer-callback" }).ConfigureAwait(false);
+                    if(serverNode.ServerRole != ServerNode.Role.Member)
+                        continue;
+
+                    await UpdateTopologyAsync(new UpdateTopologyParameters(serverNode) {TimeoutInMs = 0, DebugTag = $"timer-callback-node-{serverNode.ClusterTag}"})
+                        .ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
                     if (Logger.IsInfoEnabled)
-                        Logger.Info("Couldn't Update Topology from _updateTopologyTimer task", e);
+                        Logger.Info($"Couldn't Update Topology from _updateTopologyTimer task when fetching from node {serverNode.ClusterTag}", e);
                 }
-            }));
+            }
         }
 
         protected async Task SingleTopologyUpdateAsync(string[] initialUrls, Guid? applicationIdentifier = null)
@@ -995,7 +981,6 @@ namespace Raven.Client.Http
 
                     OnSucceedRequest?.Invoke(this, new SucceedRequestEventArgs(_databaseName, url, response, request, attemptNum));
                     responseDispose = await command.ProcessResponse(context, Cache, response, url).ConfigureAwait(false);
-                    _lastReturnedResponse = DateTime.UtcNow;
                 }
                 finally
                 {

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -1154,6 +1154,66 @@ namespace RachisTests.DatabaseCluster
             }
         }
 
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task ClientShouldFailoverWhenTalkingToLoneDisconnectedNode()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex:0, shouldRunInMemory: false, watcherCluster: true);
+
+            using (var store = GetDocumentStore(new Options()
+            {
+                Server = nodes[1],
+                ReplicationFactor = 3
+            }))
+            {
+                store.Initialize();
+                var re = store.GetRequestExecutor(store.Database);
+
+                await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+
+                var selectorNodes = re._nodeSelector.Topology.Nodes;
+                Assert.Equal(3, selectorNodes.Count);
+                Assert.True(selectorNodes.All(x => x.ServerRole == ServerNode.Role.Member));
+
+                // disconnect nodes [1] from leader and [2]
+                var down1 = await DisposeServerAndWaitForFinishOfDisposalAsync(nodes[1]);
+
+                nodes[1] = GetNewServer(new ServerCreationOptions
+                {
+                    CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = down1.Url },
+                    RunInMemory = false,
+                    DeletePrevious = false,
+                    DataDirectory = down1.DataDirectory
+                });
+                nodes[1].ServerStore.Engine.ForTestingPurposesOnly().NodeTagsToDisconnect.Add(nodes[0].ServerStore.NodeTag);
+                nodes[1].ServerStore.Engine.ForTestingPurposesOnly().NodeTagsToDisconnect.Add(nodes[2].ServerStore.NodeTag);
+                Servers.Add(nodes[1]);
+
+                //make sure leader and follower [2] disconnected
+                var db = await Databases.GetDocumentDatabaseInstanceFor(nodes[0], store);
+                await WaitAndAssertForValueAsync(() =>
+                {
+                    var record = db.ReadDatabaseRecord();
+                    return Task.FromResult(record.Topology.Members.Count);
+                }, 2);
+
+                //executor still thinks we have 3 members
+                selectorNodes = re._nodeSelector.Topology.Nodes;
+                Assert.Equal(3, selectorNodes.Count);
+                Assert.True(selectorNodes.All(x => x.ServerRole == ServerNode.Role.Member));
+
+                //artificially call the timer func
+                re.UpdateTopologyCallback(null);
+
+                //we expect a failover and an updated request executor
+                await WaitAndAssertForValueAsync(() =>
+                {
+                    selectorNodes = re._nodeSelector.Topology.Nodes;
+                    return Task.FromResult(selectorNodes.Count(x => x.ServerRole == ServerNode.Role.Member) == 2 &&
+                                           selectorNodes.Count(x => x.ServerRole == ServerNode.Role.Rehab) == 1);
+                }, true);
+            }
+        }
+
         [Fact]
         public async Task ChangeUrlOfMultiNodeCluster()
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19585

### Additional description

In a situation of a node disconnection from the rest of the cluster and becoming candidate, the request executor of this lone node will not know it needs to do a failover.
Changed the `updateTopologyTimer` (which happens every 5 minutes) so it will perform an `UpdateTopologyAsync` on all the nodes one by one, which will update the request executor topology to the most recent one in the cluster.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### UI work

- No UI work is needed
