### PR TITLE
RavenDB-21780 - InvalidOperationException when trying to enforce revisions configuration on specific collections which one of them doesn't exist

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1896,7 +1896,7 @@ namespace Raven.Server.Documents.Revisions
             {
                 foreach (var collection in collections)
                 {
-                    var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: true);
+                    var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false) ?? new CollectionName(collection);
                     var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
                     var revisions = context.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
                     if (revisions == null) // there is no revisions for that collection

--- a/test/SlowTests/Issues/RavenDB_21780.cs
+++ b/test/SlowTests/Issues/RavenDB_21780.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server;
+using Raven.Server.ServerWide;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+public class RavenDB_21780 : ClusterTestBase
+{
+    public RavenDB_21780(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Revisions)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task EnforceRevisionsConfigurationForSpecificCollctionsWhichOneOfThemDoesNotExistShouldntFail(Options options)
+    {
+        using var store = GetDocumentStore(options);
+
+        var configuration = new RevisionsConfiguration
+        {
+            Default = new RevisionsCollectionConfiguration
+            {
+                Disabled = false, 
+                MinimumRevisionsToKeep = 100
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        var user = new User { Id = "Users/1", Name = "Shahar" };
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                user.Name += i;
+                await session.StoreAsync(user);
+                await session.SaveChangesAsync();
+            }
+
+            var revisionsCount = await session.Advanced.Revisions.GetCountForAsync(user.Id);
+            Assert.Equal(10, revisionsCount);
+        }
+
+
+        configuration.Default.MinimumRevisionsToKeep = 2;
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+
+        // enforce
+        var db = await Databases.GetDocumentDatabaseInstanceFor(Server, store, store.Database);
+        using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Users" }, token: token);
+
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var revisionsCount = await session.Advanced.Revisions.GetCountForAsync(user.Id);
+            Assert.Equal(2, revisionsCount);
+        }
+    }
+
+}


### PR DESCRIPTION
 InvalidOperationException when trying to enforce revisions configuration on specific collections which one of them doesn't exist

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21780/InvalidOperationException-when-trying-to-enforce-revisions-configuration-on-specific-collection-in-sharded-database

### Additional description

InvalidOperationException when trying to enforce revisions configuration on specific collections which one of them doesn't exist.
in 6.0 - revision-storage throws InvalidOperationException when trying to enforce revisions configuration on a specific collections in sharded database (if at least 1 shard doesnt contain docs from 1 of those collections).

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed

