### PR TITLE
RavenDB-21702 Handle Corax highlightings on null value

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -167,6 +167,11 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                                 nls = new string[] { t2.Item1.TrimEnd('*').TrimStart('*'), t2.Item2.TrimEnd('*').TrimStart('*') };
                                 break;
                             case string[] as1:
+                                nls = new string[as1.Length];
+                                for (int i = 0; i < as1.Length; i++)
+                                    nls[i] = as1[i].TrimEnd('*').TrimStart('*');
+                                break;
+                            case null:
                                 continue;
                             default:
                                 throw new NotSupportedException($"The type '{term.Value.Values.GetType().FullName}' is not supported.");
@@ -317,7 +322,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                                 maxFragments -= ProcessHighlightings(current, fieldDescription, fieldValue, fragments, maxFragments);
                             }
                         }
-                        else continue;
+                        else 
+                            continue;
 
                         if (string.IsNullOrWhiteSpace(fieldDescription.GroupKey) == false)
                         {

--- a/test/SlowTests/Issues/RavenDB-21702.cs
+++ b/test/SlowTests/Issues/RavenDB-21702.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21702 : RavenTestBase
+{
+    public RavenDB_21702(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public void Test()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var d1 = new Dto() { Name = "Cool and super long name just so it works in Lucene", City = null, Description = "Some dummy text that's quite long so it works in Lucene" };
+                var d2 = new Dto() { Name = null, City = null, Description = "Some dummy text that's quite long so it works in Lucene" };
+                
+                session.Store(d1);
+                session.Store(d2);
+                
+                session.SaveChanges();
+
+                var coraxIndex = new CoraxDummyIndex();
+                var luceneIndex = new LuceneDummyIndex();
+                
+                coraxIndex.Execute(store);
+                luceneIndex.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+
+                var coraxResult = session.Query<Dto>(coraxIndex.IndexName)
+                    .Where(x => x.City == null)
+                    .Search(x => x.Name, "Cool")
+                    .Search(x => x.Description, "Some")
+                    .Highlight(x => x.Name, 18, 3, out var coraxNameHighlightings)
+                    .Highlight(x => x.City, 18, 3, out var coraxCityHighlightings)
+                    .Highlight(x => x.Description, 18, 3, out var coraxDescriptionHighlightings)
+                    .ToList();
+
+                var luceneResult = session.Query<Dto>(luceneIndex.IndexName)
+                    .Where(x => x.City == null)
+                    .Search(x => x.Name, "Cool")
+                    .Search(x => x.Description, "Some")
+                    .Highlight(x => x.Name, 18, 3, out var luceneNameHighlightings)
+                    .Highlight(x => x.City, 18, 3, out var luceneCityHighlightings)
+                    .Highlight(x => x.Description, 18, 3, out var luceneDescriptionHighlightings)
+                    .ToList();
+                
+                Assert.Equal(coraxNameHighlightings.ResultIndents.Count(), 1);
+                Assert.Equal(coraxCityHighlightings.ResultIndents.Count(), 0);
+                Assert.Equal(coraxDescriptionHighlightings.ResultIndents.Count(), 2);
+                
+                Assert.Equal(luceneNameHighlightings.ResultIndents.Count(), 1);
+                Assert.Equal(luceneCityHighlightings.ResultIndents.Count(), 0);
+                Assert.Equal(luceneDescriptionHighlightings.ResultIndents.Count(), 2);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+        public string City { get; set; }
+        public string Description { get; set; }
+    }
+
+    private class CoraxDummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public CoraxDummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new { dto.Name, dto.City, dto.Description };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+            
+            Store(dto => dto.Name, FieldStorage.Yes);
+            Index(dto => dto.Name, FieldIndexing.Search);
+            TermVector(dto => dto.Name, FieldTermVector.WithPositionsAndOffsets);
+            
+            Store(dto => dto.Description, FieldStorage.Yes);
+            Index(dto => dto.Description, FieldIndexing.Search);
+            TermVector(dto => dto.Description, FieldTermVector.WithPositionsAndOffsets);
+        }
+    }
+    
+    private class LuceneDummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public LuceneDummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new { dto.Name, dto.City, dto.Description };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Lucene;
+            
+            Store(dto => dto.Name, FieldStorage.Yes);
+            Index(dto => dto.Name, FieldIndexing.Search);
+            TermVector(dto => dto.Name, FieldTermVector.WithPositionsAndOffsets);
+            
+            Store(dto => dto.Description, FieldStorage.Yes);
+            Index(dto => dto.Description, FieldIndexing.Search);
+            TermVector(dto => dto.Description, FieldTermVector.WithPositionsAndOffsets);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-21702.cs
+++ b/test/SlowTests/Issues/RavenDB-21702.cs
@@ -15,7 +15,7 @@ public class RavenDB_21702 : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
-    public void Test()
+    public void TestHighlightingOnMultipleFieldsAndNullValues()
     {
         using (var store = GetDocumentStore())
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21702/NRE-in-highlighting

### Additional description

When user tries to use Corax highlighting on a field that has only null values, eg.
```csharp
from index 'Orders/Totals'
where Company == null
include highlight(Company, 35, 2)
```
we want to have the same behavior as in Lucene, so we don't want to return any highlightings.
Additionally, we'll now properly handle term values that come in as an array.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
