### PR TITLE
RavenDB-21803 - fix DatabaseRecord.Topology.PriorityOrder is not cleaned when node is removed from cluster

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -437,6 +437,7 @@ namespace Raven.Client.ServerWide
             DemotionReasons.Remove(delDbFromNode);
             PromotablesStatus.Remove(delDbFromNode);
             PredefinedMentors.Remove(delDbFromNode);
+            PriorityOrder.Remove(delDbFromNode);
         }
 
         public string WhoseTaskIsIt(


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21803

### Additional description

Now removing the node from Priority Order when removing a node from the topology

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### UI work

- No UI work is needed
