### PR TITLE
RavenDB-21760 Handle reserved keywords in index definition

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -183,7 +183,10 @@ namespace Raven.Client.Documents.Indexes
         {
             if (ValidCSharpName(name))
             {
-                Out("." + name);
+                if (KeywordsInCSharp.Contains(name))
+                    Out(".@" + name);
+                else
+                    Out("." + name);
             }
             else
             {
@@ -1394,7 +1397,13 @@ namespace Raven.Client.Documents.Indexes
         /// <returns></returns>
         protected override MemberAssignment VisitMemberAssignment(MemberAssignment assignment)
         {
-            Out(assignment.Member.Name);
+            var memberName = assignment.Member.Name;
+            
+            if (KeywordsInCSharp.Contains(memberName))
+                Out("@" + memberName);
+            else
+                Out(memberName);
+            
             Out(" = ");
             var constantExpression = assignment.Expression as ConstantExpression;
             if (constantExpression != null && constantExpression.Value == null)

--- a/test/SlowTests/Issues/RavenDB-21760.cs
+++ b/test/SlowTests/Issues/RavenDB-21760.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21760 : RavenTestBase
+{
+    public RavenDB_21760(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIndexDefinitionWithReservedKeywords()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var eventSchedule1 = new EventSchedule()
+                {
+                    Id = "events/1/schedule"
+                };
+                
+                var event1 = new Event()
+                {
+                    Id = "events/1", 
+                    Name = "Cool event name",
+                    @event = "Some event"
+                };
+                
+                session.Store(eventSchedule1);
+                session.Store(event1);
+                
+                session.SaveChanges();
+
+                var index = new EventIndex();
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+
+                var result = session.Query<EventIndex.Result, EventIndex>().ProjectInto<EventIndex.Result>().ToList();
+                
+                Assert.Equal(1, result.Count);
+                Assert.Equal("Cool event name", result.First().EventName);
+                Assert.Equal("Some event", result.First().@event);
+            }
+        }
+    }
+    
+    public class EventIndex : AbstractIndexCreationTask<Event, EventIndex.Result>
+    {
+        public class Result
+        {
+            public string EventName { get; set; }
+            public string @event { get; set; }
+        }
+
+        public EventIndex()
+        {
+            Map = events => from @event in events
+                let schedule = LoadDocument<EventSchedule>($"{@event.Id}/schedule")
+                select new Result
+                {
+                    EventName = @event.Name,
+                    @event = @event.@event
+                };
+            
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+    
+    public class EventSchedule
+    {
+        public string Id { get; set; }
+    }
+
+    public class Event
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string @event { get; set; }
+    }
+}
+


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21760/Index-definition-with-let-and-comparison-on-nullable-fails

### Additional description

When creating client side index definition, we want to add `@` prefix to property name if it's a reserved keyword. There are two cases we need to handle 
1. Member assignment - e.g. we want to change ```event = this0.SomeMember``` to ```@event = this0.SomeMember```.
2. Property access - e.g.  we want to change ```SomeProperty = this0.event``` to ```SomeProperty = this0.@event```.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
