### PR TITLE
RavenDB-14041 : PutAttachmentCommandData with expected change vector should work

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -236,12 +236,14 @@ namespace Raven.Server.Documents
                     else
                     {
                         var putStream = true;
+                        var attachmentExists = false;
 
                         // We already asserted that the document is not in conflict, so we might have just one partial key, not more.
                         using (GetAttachmentPartialKey(context, keySlice, base64Hash.Size, lowerContentType.Size, out Slice partialKeySlice))
                         {
                             if (table.SeekOnePrimaryKeyPrefix(partialKeySlice, out TableValueReader partialTvr))
                             {
+                                attachmentExists = true;
                                 if (expectedChangeVector != null)
                                 {
                                     var oldChangeVector = TableValueToChangeVector(context, (int)AttachmentsTable.ChangeVector, ref partialTvr);
@@ -282,7 +284,7 @@ namespace Raven.Server.Documents
                             }
                         }
 
-                        if (string.IsNullOrEmpty(expectedChangeVector) == false)
+                        if (attachmentExists == false && string.IsNullOrEmpty(expectedChangeVector) == false)
                         {
                             ThrowConcurrentExceptionOnMissingAttachment(documentId, name, expectedChangeVector);
                         }

--- a/test/SlowTests/Issues/RavenDB_14041.cs
+++ b/test/SlowTests/Issues/RavenDB_14041.cs
@@ -1,0 +1,51 @@
+﻿using System.IO;
+using Raven.Client.Documents.Commands.Batches;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_14041 : ClusterTestBase
+    {
+        public RavenDB_14041(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CanUpdateAttachmentUsingPutAttachmentCommandDataWithExpectedChangeVector()
+        {
+            using (var store = GetDocumentStore())
+            {
+                const string documentId = "cats/1-A";
+                const string name = "bruhhh";
+                const string contentType = "stuff";
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), documentId);
+
+                    using var stream = new MemoryStream(new byte[] { 1, 2, 3, 4, 5 });
+                    session.Advanced.Attachments.Store(documentId, name, stream, contentType);
+
+                    session.SaveChanges();
+                }
+
+                // update attachment
+                using (var session = store.OpenSession())
+                {
+                    var attachment = session.Advanced.Attachments.Get(documentId, name);
+                    using var stream = new MemoryStream(new byte[] { 6, 7, 8, 9, 10 });
+
+                    // should not throw a concurrency exception
+                    var cmd = new PutAttachmentCommandData(documentId, name, stream, contentType, changeVector: attachment.Details.ChangeVector);
+                    session.Advanced.Defer(cmd);
+                    session.SaveChanges();
+                }
+
+            }
+        }
+    }
+
+}

--- a/test/SlowTests/Issues/RavenDB_14041.cs
+++ b/test/SlowTests/Issues/RavenDB_14041.cs
@@ -2,7 +2,6 @@
 using Raven.Client.Documents.Commands.Batches;
 using SlowTests.Core.Utils.Entities;
 using Tests.Infrastructure;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues
@@ -13,7 +12,7 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.ClientApi)]
         public void CanUpdateAttachmentUsingPutAttachmentCommandDataWithExpectedChangeVector()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14041/Issues-with-optimistic-concurrency-handeling-regarding-attachments-update

### Additional description

- `AttachmentStorage.Put` - do not throw a concurrency exception on a partial update with a valid expected change vector
- already fixed in 6.0

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
