### PR TITLE
RavenDB-20122 : High CPU when watcher is waiting for the leader to come up

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -336,7 +336,14 @@ namespace Raven.Server.ServerWide
                             {
                                 var topology = GetClusterTopology();
                                 var leader = _engine.LeaderTag;
-                                if (leader == null || leader == _engine.Tag)
+
+                                if (leader == null)
+                                {
+                                    delay = ReconnectionBackoff(delay);
+                                    break;
+                                }
+
+                                if (leader == _engine.Tag)
                                     break;
 
                                 var leaderUrl = topology.GetUrlFromTag(leader);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20122/High-CPU-when-watcher-is-waiting-for-the-leader-to-come-up

### Additional description

`UpdateTopologyChangeNotification` : use reconnection backoff if cluster has no leader

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
