### PR TITLE
RavenDB-21806 Fix warning text when using 'Limit' in RQL

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/query/query.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/query/query.html
@@ -239,7 +239,7 @@
             <div class="help-block">
                 <i class="icon-warning"></i>
                 <span>
-                    Using <code>offset</code> or <code>limit</code> in RQL for fanout indexes may produce unpredictable paging.
+                    Using <code>LIMIT</code> or <code>OFFSET</code> in RQL with <code>DISTINCT</code> or Fanout indexes may produce unpredictable paging.
                     <a href="#" target="_blank" data-bind="attr: { href: 'https://ravendb.net/l/LT8GZF/' + $root.clientVersion() }">See details.</a>
                 </span>
             </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21806

### Additional description
Fix warning text so that DISTINCT is mentioned as well.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
