### PR TITLE
RavenDB-19970 - StressTests.Client.TimeSeries.TimeSeriesStress.RapidR…

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -331,7 +331,8 @@ namespace Raven.Server.Documents.TimeSeries
             deletionRangeRequest.From = EnsureMillisecondsPrecision(deletionRangeRequest.From);
             deletionRangeRequest.To = EnsureMillisecondsPrecision(deletionRangeRequest.To);
 
-            if (InsertDeletedRange(context, deletionRangeRequest, remoteChangeVector) == null)
+            remoteChangeVector = InsertDeletedRange(context, deletionRangeRequest, remoteChangeVector);
+            if (remoteChangeVector == null)
                 return null;
 
             var collection = deletionRangeRequest.Collection;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -1000,11 +1000,10 @@ namespace Raven.Server.Documents.TimeSeries
                     return ChangeVectorUtils.MergeVectors(ReadOnlyChangeVector, _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag));
                 }
 
-                string mergedChangeVector = ChangeVectorUtils.MergeVectors(ReadOnlyChangeVector, ChangeVectorFromReplication);
                 return ChangeVectorUtils.GetConflictStatus(ChangeVectorFromReplication, ReadOnlyChangeVector) switch
                 {
-                    ConflictStatus.Update => mergedChangeVector,
-                    ConflictStatus.Conflict => ChangeVectorUtils.MergeVectors(ReadOnlyChangeVector, _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag)),
+                    ConflictStatus.Update => ChangeVectorFromReplication,
+                    ConflictStatus.Conflict => ChangeVectorUtils.MergeVectors(ChangeVectorFromReplication, _tss._documentsStorage.GetNewChangeVector(_context, _currentEtag)),
                     ConflictStatus.AlreadyMerged => ReadOnlyChangeVector,
                     _ => throw new ArgumentOutOfRangeException()
                 };


### PR DESCRIPTION
…etention

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19970/StressTests.Client.TimeSeries.TimeSeriesStress.RapidRetention

### Additional description

What’s likely to happen?

Assuming the database topology is: [A, B, C]
A performs the retention and replicate to B, C

TX1:
A replicates to B, C:
-  a deleted range request that is not covering an entire segment 1 (goes to `AppendExistingSegment`, some entries left) 
- updated segment 1

TX2:
A delete the rest segment’s live entries.


C replicates back to A (before getting TX2):
- a deleted range request
- updated segment 1

A:
Existing TS state:
- Dead segment 1 | existing change vector: `A:100`
Incoming segment 1 from C: 
- Number of live entries: 2 | change vector: `A:50, C:50`
`Conflict status == Conflict` -> goes to `SplitSegment` and appends a segment with live entries! Updated segment’s change vector: `A:101, C:50`
We override the dead segment with a newly merged one and from that point on we either have a partially live segment or a replication loop. 

Solution:
Backporting v6.0 changes (https://github.com/ravendb/ravendb/pull/16874) 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
