### PR TITLE
RavenDB-21766 Missing empty ETL test info text + broken OLAP ETL view

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
@@ -363,7 +363,7 @@
         </div>
     </div>
     <div class="test-container flex-grow flex-vertical" data-bind="with: test, css: { 'pe-none item-disabled': !$root.hasElasticSearchEtl }">
-        <div class="absolute-center text-center" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
+        <div class="absolute-center text-center z-1" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
             <i class="icon-info icon-xl"></i>
             Choose <strong>Document ID</strong> used for test and click <strong>Test</strong> button
         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
@@ -333,7 +333,7 @@
         </div>
     </div>
     <div class="test-container flex-grow flex-vertical" data-bind="with: test, css: { 'pe-none item-disabled': !$root.hasQueueEtl }">
-        <div class="absolute-center text-center" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
+        <div class="absolute-center text-center z-1" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
             <i class="icon-info icon-xl"></i>
             Choose <strong>Document ID</strong> used for test and click <strong>Test</strong> button
         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
@@ -380,7 +380,7 @@
         </div>
     </div>
     <div class="test-container flex-grow flex-vertical" data-bind="with: test, css: { 'pe-none item-disabled': !$root.hasOlapEtl }">
-        <div class="absolute-center text-center" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
+        <div class="absolute-center text-center z-1" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
             <i class="icon-info icon-xl"></i>
             Choose <strong>Document ID</strong> used for test and click <strong>Test</strong> button.
         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
@@ -44,12 +44,12 @@
                                     </ul>
                                 </div>
                             </div>
-                            <div data-bind="if: $root.activeDatabase() && $root.activeDatabase().isEncrypted">
+                            <div data-bind="if: $root.db && $root.db.isEncrypted">
                                 <div class="form-group">
                                     <label class="control-label">&nbsp;</label>
                                     <div class="bg-info inline-block padding padding-xs small">
                                         <i class="icon-info"></i>
-                                        Note: Database <strong data-bind="text: $root.activeDatabase().name"></strong> is encrypted
+                                        Note: Database <strong data-bind="text: $root.db.name"></strong> is encrypted
                                     </div>
                                 </div>
                                 <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
@@ -337,7 +337,7 @@
 
 
     <div class="test-container flex-grow flex-vertical" data-bind="with: test, css: { 'pe-none item-disabled': !$root.hasQueueEtl }">
-        <div class="absolute-center text-center" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
+        <div class="absolute-center text-center z-1" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
             <i class="icon-info icon-xl"></i>
             Choose <strong>Document ID</strong> used for test and click <strong>Test</strong> button
         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
@@ -373,7 +373,7 @@
         </div>
     </div>
     <div class="test-container flex-grow flex-vertical" data-bind="with: test, css: { 'pe-none item-disabled': !$root.hasRavenEtl }">
-        <div class="absolute-center text-center" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
+        <div class="absolute-center text-center z-1" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
             <i class="icon-info icon-xl"></i>
             Choose <strong>Document ID</strong> used for test and click <strong>Test</strong> button.
         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
@@ -432,7 +432,7 @@ Option unchecked: <Br />No execution will take place, only generate the SQL stat
         </div>
     </div>
     <div class="test-container flex-grow flex-vertical" data-bind="with: test, css: { 'pe-none item-disabled': !$root.hasSqlEtl }">
-        <div class="absolute-center text-center" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
+        <div class="absolute-center text-center z-1" data-bind="visible: !testAlreadyExecuted() && !loadedDocument()">
             <i class="icon-info icon-xl"></i>
             Choose <strong>Document ID</strong> used for test and click <strong>Test</strong> button.
         </div>

--- a/src/Raven.Studio/wwwroot/Content/css/styles-common-scoped.less
+++ b/src/Raven.Studio/wwwroot/Content/css/styles-common-scoped.less
@@ -2294,6 +2294,10 @@ ul.properties {
     padding-bottom: 1rem;
 }
 
+.z-1 {
+    z-index: 1;
+}
+
 @import "prism.less";
 @import "ace.less";
 @import "leaflet.less";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21766/Missing-empty-ETL-test-info-text-broken-OLAP-ETL-view

### Additional description

- Fixes test container info text z-index.
- Fixes "Can't access active database in single shard view!"

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
