### PR TITLE
RavenDB-14408 - Handle failure of ProcessResponse

### DIFF
--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -169,6 +169,8 @@ namespace Raven.Server.Documents.Handlers
             long totalDocumentsSizeInBytes;
             await using (var writer = new AsyncBlittableJsonTextWriter(queryContext.Documents, ResponseBodyStream()))
             {
+                ServerStore.ForTestingPurposes?.AdjustResult?.Invoke(result);
+
                 result.Timings = indexQuery.Timings?.ToTimings();
                 (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteDocumentQueryResultAsync(queryContext.Documents, result, metadataOnly, WriteAdditionalData(indexQuery, shouldReturnServerSideQuery), token.Token);
             }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -48,6 +48,7 @@ using Raven.Server.Documents.Indexes.Analysis;
 using Raven.Server.Documents.Indexes.Sorting;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Exceptions;
 using Raven.Server.Integrations.PostgreSQL.Commands;
@@ -3617,6 +3618,7 @@ namespace Raven.Server.ServerWide
             internal bool StopIndex;
             internal Action<CompareExchangeCommandBase> ModifyCompareExchangeTimeout;
             internal Action RestoreDatabaseAfterSavingDatabaseRecord;
+            internal Action<DocumentQueryResult> AdjustResult;
         }
         
         public readonly MemoryCache QueryClauseCache;

--- a/test/SlowTests/Issues/RavenDB_14408.cs
+++ b/test/SlowTests/Issues/RavenDB_14408.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_14408 : ClusterTestBase
+    {
+        public RavenDB_14408(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task HandleServerDownWhileReadingResponse()
+        {
+            var cluster = await CreateRaftCluster(3, leaderIndex: 2, watcherCluster: true);
+            var members = new List<string>()
+            {
+                cluster.Nodes[0].ServerStore.NodeTag,
+                cluster.Nodes[1].ServerStore.NodeTag
+            };
+            using (var store = GetDocumentStore(new Options()
+            {
+                Server = cluster.Nodes[1],
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Topology = new DatabaseTopology();
+                    record.Topology.Members = members;
+                    record.Topology.PriorityOrder = members;
+                },
+            }))
+            {
+                //create query - will immediately fill the first part of the response in the buffer
+                using (var session = store.OpenSession())
+                {
+                    // need to be enough data to fill more than one buffer
+                    for (int i = 0; i < 300; i++)
+                    {
+                        session.Store(new User(), $"Users/{i}");
+                    }
+                    session.SaveChanges();
+
+                    // bring down server while there are still things to flush
+                    var server = cluster.Nodes[0];
+                    
+                    server.ServerStore.ForTestingPurposesOnly().AdjustResult = (results) =>
+                    {
+                        var r = results.Results.Single(r => r.Id == "Users/200");
+                        r.Data = null; // throw NRE and fail when writing second batch of docs to response stream
+                    };
+                    
+                    var q = session.Advanced.RawQuery<User>("from Users");
+                    var syncedRes = q.ToList();
+                    Assert.Equal(300, syncedRes.Count());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14408

### Additional description

Client's request executor would get a successful status code but fail in `ProcessResponse()` while reading from stream. Either server restarted in the middle of writing to stream some other error interrupted the writing.
The executor would throw to client instead of failing over.

Changed so we catch the error and `HandleServerDown()` in order to mark the failure and try again with a different node.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
