### PR TITLE
RavenDB-21244 Add the process that is locking the file to the error message on Windows

### DIFF
--- a/src/Voron/Platform/Win32/Win32NativeFileMethods.cs
+++ b/src/Voron/Platform/Win32/Win32NativeFileMethods.cs
@@ -145,6 +145,8 @@ namespace Voron.Platform.Win32
         ERROR_FILE_NOT_FOUND = 0x2,
         ERROR_DISK_FULL = 0x70,
         ERROR_NOT_READY = 0x15,
+        ERROR_SHARING_VIOLATION = 0x20, // The process cannot access the file because it is being used by another process
+        ERROR_LOCK_VIOLATION = 0x20, // The process cannot access the file because another process has locked a portion of the file
         ERROR_HANDLE_DISK_FULL = 0x27
     }
 

--- a/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
+++ b/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
@@ -81,9 +81,23 @@ namespace Voron.Platform.Win32
                                                         Win32NativeFileCreationDisposition.OpenAlways, fileAttributes, IntPtr.Zero);
             if (_handle.IsInvalid)
             {
+                string message = $"Failed to open file storage of {nameof(WindowsMemoryMapPager)} for {file}";
+
                 int lastWin32ErrorCode = Marshal.GetLastWin32Error();
-                throw new IOException("Failed to open file storage of WinMemoryMapPager for " + file,
-                    new Win32Exception(lastWin32ErrorCode));
+
+                if (lastWin32ErrorCode is (int)Win32NativeFileErrors.ERROR_SHARING_VIOLATION or (int)Win32NativeFileErrors.ERROR_LOCK_VIOLATION)
+                {
+                    try
+                    {
+                        message += $". {WhoIsLocking.ThisFile(file.FullPath)}";
+                    }
+                    catch
+                    {
+                         // ignored
+                    }
+                }
+
+                throw new IOException(message, new Win32Exception(lastWin32ErrorCode));
             }
 
             try


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21244/Add-the-process-that-is-locking-the-file-to-the-error-message

### Additional description

Improving error message so a user will know the locking process name immediately

### Type of change

- Enhancement

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- Yes. Please list the affected platforms. - Windows

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
