### PR TITLE
RavenDB-21824 Database state load - fail silently

### DIFF
--- a/src/Raven.Studio/typescript/commands/resources/getDatabaseStateForStudioCommand.ts
+++ b/src/Raven.Studio/typescript/commands/resources/getDatabaseStateForStudioCommand.ts
@@ -3,25 +3,23 @@ import endpoints = require("endpoints");
 import StudioDatabasesState = Raven.Server.Web.System.Processors.Studio.StudioDatabasesHandlerForGetDatabasesState.StudioDatabasesState;
 
 class getDatabaseStateForStudioCommand extends commandBase {
-
     private readonly nodeTag: string;
     private readonly databaseName: string;
-    
+
     constructor(nodeTag: string, databaseName: string) {
         super();
         this.nodeTag = nodeTag;
         this.databaseName = databaseName;
     }
-    
+
     execute(): JQueryPromise<StudioDatabasesState> {
         const url = endpoints.global.studioDatabases.studioTasksDatabasesState;
         const args = {
             nodeTag: this.nodeTag,
-            name: this.databaseName
-        }
+            name: this.databaseName,
+        };
 
-        return this.query<StudioDatabasesState>(url, args, undefined)
-            .fail((response: JQueryXHR) => this.reportError("Failed to load database state", response.responseText, response.statusText));
+        return this.query<StudioDatabasesState>(url, args, undefined);
     }
 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21824/Constant-studio-errors-when-node-is-down

### Additional description

Same as https://github.com/ravendb/ravendb/pull/17301

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
