### PR TITLE
RavenDB-21848: Fix for the issue where Importing a SuperUser crashed the process

### DIFF
--- a/src/Voron/Data/Tables/TableValueCompressor.cs
+++ b/src/Voron/Data/Tables/TableValueCompressor.cs
@@ -314,8 +314,8 @@ namespace Voron.Data.Tables
                                 // ensuring that the last entry is the most recent.
                                 lastWritten = int.Parse(Path.GetFileNameWithoutExtension(zip.Entries[^1].Name));
 
-                            Debug.Assert(lastWritten >= dictionaries.State.NumberOfEntries,
-                                message: "The number of last written entry in recovery file must be equal to or greater than the total number of entries in the state. " +
+                            Debug.Assert(lastWritten <= dictionaries.State.NumberOfEntries,
+                                message: "The number of last written entry in recovery file must be equal to or less than the total number of entries in the state. " +
                                          "Any deviation from this is a bug.");
 
                             if (lastWritten == dictionaries.State.NumberOfEntries)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21848

### Additional description

The problem is related to an error in the `Debug.Assert()` logic.
### Type of change

- Regression bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed