### PR TITLE
RavenDB-17753 Server store (System) will take into account "Storage.Temp" configuration option for temporary directory

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -621,7 +621,12 @@ namespace Raven.Server.ServerWide
                 _fileLocker = new FileLocker(Path.Combine(path.FullPath, "system.lock"));
                 _fileLocker.TryAcquireWriteLock(Logger);
 
-                options = StorageEnvironmentOptions.ForPath(path.FullPath, null, null, IoChanges, CatastrophicFailureNotification);
+                string tempPath = null;
+
+                if (Configuration.Storage.TempPath != null)
+                    tempPath = Configuration.Storage.TempPath.Combine("System").FullPath;
+
+                options = StorageEnvironmentOptions.ForPath(path.FullPath, tempPath, null, IoChanges, CatastrophicFailureNotification);
                 var secretKey = Path.Combine(path.FullPath, "secret.key.encrypted");
                 if (File.Exists(secretKey))
                 {

--- a/test/SlowTests/Issues/RavenDB_17753.cs
+++ b/test/SlowTests/Issues/RavenDB_17753.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Config;
+using Raven.Server.Config.Settings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17753 : RavenTestBase
+{
+    public RavenDB_17753(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public async Task StorageTempPathIsUsedBySystemServerStore()
+    {
+        var storageTempPath = new PathSetting(NewDataPath(suffix: "_17753_temp"));
+
+        using (var server = GetNewServer(new ServerCreationOptions
+               {
+                   RunInMemory = false,
+                   CustomSettings = new Dictionary<string, string>
+                   {
+                       { RavenConfiguration.GetKey(x => x.Storage.TempPath), storageTempPath.FullPath}
+                   }
+               }))
+        {
+            var systemTempPath = server.ServerStore._env.Options.TempPath;
+
+            Assert.Equal(storageTempPath.Combine("System").FullPath, systemTempPath.FullPath);
+
+            using (var dbStore = GetDocumentStore(new Options
+                   {
+                       Server = server
+                   }))
+            {
+                var db = await GetDatabase(server, dbStore.Database);
+
+                var dbTempPath = db.DocumentsStorage.Environment.Options.TempPath;
+
+                Assert.Equal(storageTempPath.Combine("Databases").Combine(dbStore.Database).FullPath, dbTempPath.FullPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17753

### Additional description

`Storage.Temp` configuration option will be taken into account by ServerStore

### Type of change

- Enhancement

### How risky is the change?

- Moderate 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
