### PR TITLE
RavenDB-21802 Should_Delete_All_Documents_Without_Timeout fix

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -317,14 +317,14 @@ namespace Raven.Client.Documents.BulkInsert
 
         private async Task SendHeartBeatAsync()
         {
+            if (DateTime.UtcNow.Ticks - _lastWriteToStream.Ticks < _heartbeatCheckInterval.Ticks)
+                return;
+
+            if (_streamLock.Wait(0) == false)
+                return; // if locked we are already writing
+
             try
             {
-                if (DateTime.UtcNow.Ticks - _lastWriteToStream.Ticks < _heartbeatCheckInterval.Ticks)
-                    return;
-
-                if (_streamLock.Wait(0) == false)
-                    return; // if locked we are already writing
-
                 await ExecuteBeforeStore().ConfigureAwait(false);
                 EndPreviousCommandIfNeeded();
                 _options.ForTestingPurposes?.OnSendHeartBeat_DoBulkStore?.Invoke();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21802

### Additional description

In certain scenarios, there may arise a situation where we release the lock in the finally block without having acquired it beforehand.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
