### PR TITLE
RavenDB-21852 Fixing ArgumentOutOfRangeException throw by GetOngoingTaskInfoOperation() for OngoingTaskType.QueueSink

### DIFF
--- a/src/Raven.Client/Documents/Operations/OngoingTasks/GetOngoingTaskInfoOperation.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/GetOngoingTaskInfoOperation.cs
@@ -107,8 +107,11 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
                         case OngoingTaskType.PullReplicationAsHub:
                             Result = JsonDeserializationClient.OngoingTaskPullReplicationAsHubResult(response);
                             break;
+                        case OngoingTaskType.QueueSink:
+                            Result = JsonDeserializationClient.GetOngoingTaskQueueSinkResult(response);
+                            break;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new ArgumentOutOfRangeException(nameof(_type), _type, "Unknown task type");
                     }
                 }
             }

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -310,5 +310,7 @@ namespace Raven.Client.Json.Serialization
 
         public static readonly Func<BlittableJsonReaderObject, OlapConnectionString> OlapConnectionString = GenerateJsonDeserializationRoutine<OlapConnectionString>();
 
+        public static readonly Func<BlittableJsonReaderObject, OngoingTaskQueueSink> GetOngoingTaskQueueSinkResult = GenerateJsonDeserializationRoutine<OngoingTaskQueueSink>();
+
     }
 }

--- a/src/Raven.Server/Documents/OngoingTasks/OngoingTasks.cs
+++ b/src/Raven.Server/Documents/OngoingTasks/OngoingTasks.cs
@@ -114,7 +114,7 @@ public sealed class OngoingTasks : AbstractOngoingTasks<SubscriptionConnectionsS
 
         if (tag == _server.NodeTag)
         {
-            var process = _database.EtlLoader.Processes.FirstOrDefault(x => x.ConfigurationName == config.Name);
+            var process = _database.QueueSinkLoader.Processes.FirstOrDefault(x => x.Configuration.Name == config.Name);
 
             if (process != null)
                 connectionStatus = process.GetConnectionStatus();

--- a/test/SlowTests/Server/Documents/QueueSink/RabbitMqSinkTests.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/RabbitMqSinkTests.cs
@@ -242,39 +242,6 @@ public class RabbitMqSinkTests : QueueSinkTestBase
         Assert.Equal("Script 'test' must not be empty", errors[0]);
     }
 
-    private QueueSinkConfiguration SetupRabbitMqQueueSink(DocumentStore store, string script, List<string> queues,
-        string configurationName = null, string transformationName = null)
-    {
-        var connectionStringName = $"{store.Database} to Kafka";
-
-        QueueSinkScript queueSinkScript = new QueueSinkScript
-        {
-            Name = transformationName ?? $"Queue Sink : {connectionStringName}",
-            Queues = new List<string>(queues),
-            Script = script,
-        };
-        var config = new QueueSinkConfiguration
-        {
-            Name = configurationName ?? connectionStringName,
-            ConnectionStringName = connectionStringName,
-            Scripts = { queueSinkScript },
-            BrokerType = QueueBrokerType.RabbitMq
-        };
-
-        AddQueueSink(store, config,
-            new QueueConnectionString
-            {
-                Name = connectionStringName,
-                BrokerType = QueueBrokerType.RabbitMq,
-                RabbitMqConnectionSettings = new RabbitMqConnectionSettings
-                {
-                    ConnectionString = RabbitMqConnectionString.Instance.VerifiedConnectionString.Value
-                }
-            });
-
-        return config;
-    }
-
     private IModel CreateRabbitMqProducer()
     {
         var connectionFactory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString.Instance.VerifiedConnectionString.Value) };

--- a/test/SlowTests/Server/Documents/QueueSink/RavenDB_21852.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/RavenDB_21852.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Operations.ETL.Queue;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.QueueSink;
+
+public class RavenDB_21852 : QueueSinkTestBase
+{
+    public RavenDB_21852(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public void CanGetQueueSinkTaskInfo()
+    {
+        using var store = GetDocumentStore();
+        var config = SetupRabbitMqQueueSink(store, "this['@metadata']['@collection'] = 'Users'; put(this.Id, this)",
+            new List<string>() {UsersQueueName});
+
+        var op = new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.QueueSink);
+
+        var taskInfo = (OngoingTaskQueueSink)store.Maintenance.Send(op);
+
+        Assert.NotNull(taskInfo);
+        Assert.Null(taskInfo.Error);
+        Assert.Equal(QueueBrokerType.RabbitMq, taskInfo.BrokerType);
+
+        var nonExisting = new GetOngoingTaskInfoOperation("non-existing", OngoingTaskType.QueueSink);
+
+        var nullTaskInfo = (OngoingTaskQueueSink)store.Maintenance.Send(nonExisting);
+
+        Assert.Null(nullTaskInfo);
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21852/GetOngoingTaskInfoOperation-throws-ArgumentOutOfRangeException-for-OngoingTaskType.QueueSink

### Additional description

It's been found during investigation of https://github.com/ravendb/ravendb/discussions/17891

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works
 - Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
