### PR TITLE
RavenDB-20426 : HandleSpecificClusterDatabaseChanged - throw if database is already faulted

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -266,9 +266,6 @@ namespace Raven.Server.Documents
                 task = TryGetOrCreateResourceStore(databaseName, ignoreBeenDeleted: true, caller: type);
             }
 
-            if (task.IsCanceled || task.IsFaulted)
-                return;
-
             var database = await task;
 
             switch (changeType)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20426/SlowTests.Issues.EncryptedDatabaseGroup.AddingNodeToEncryptedDatabaseGroupShouldThrow

### Additional description

- when adding a new node to database topology, there's a race in creating the database between `RouteInformation.TryGetHandler` (coming from `GetTcpInfoCommand`, for internal replication needs) and `DatabasesLandlord.HandleSpecificClusterDatabaseChanged`

- if `TryGetHandler` creates the database, then `HandleSpecificClusterDatabaseChanged` sees that the database is already in cache, and because the database task is `Faulted` we return without awaiting it - no exception is thrown back to `AddDatabaseNode`

- already fixed in 4.2, more than 3 years ago :) #11052

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
