### PR TITLE
RavenDB-21756 - make sure to drop the orchestrator connection on SubscriptionChangeVectorUpdateConcurrencyException

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -950,8 +950,8 @@ namespace Raven.Client.Documents.Subscriptions
                     // if we failed to talk to a node, we'll forget about it and let the topology to
                     // redirect us to the current node
                     return (true, null);
-                case SubscriptionChangeVectorUpdateConcurrencyException _:
-                    return HandleSubscriptionChangeVectorUpdateConcurrencyException();
+                case SubscriptionChangeVectorUpdateConcurrencyException subscriptionChangeVectorUpdateConcurrencyException:
+                    return HandleSubscriptionChangeVectorUpdateConcurrencyException(subscriptionChangeVectorUpdateConcurrencyException);
 
                 case SubscriptionClosedException sce:
                     return HandleSubscriptionClosedException(sce);
@@ -993,7 +993,7 @@ namespace Raven.Client.Documents.Subscriptions
             return (false, _redirectNode);
         }
 
-        protected virtual (bool ShouldTryToReconnect, ServerNode NodeRedirectTo) HandleSubscriptionChangeVectorUpdateConcurrencyException()
+        protected virtual (bool ShouldTryToReconnect, ServerNode NodeRedirectTo) HandleSubscriptionChangeVectorUpdateConcurrencyException(SubscriptionChangeVectorUpdateConcurrencyException subscriptionChangeVectorUpdateConcurrencyException)
         {
             return (true, _redirectNode);
         }

--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -943,7 +943,7 @@ namespace Raven.Client.Documents.Subscriptions
 
                 case DatabaseDisabledException:
                 case AllTopologyNodesDownException:
-                    AssertLastConnectionFailure();
+                    assertLastConnectionFailure?.Invoke();
                     return (true, _redirectNode);
 
                 case NodeIsPassiveException _:

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Subscriptions.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Subscriptions.cs
@@ -28,7 +28,6 @@ public partial class ShardedDatabaseContext
 
         protected override void DropSubscriptionConnections(SubscriptionConnectionsStateOrchestrator state, SubscriptionException ex)
         {
-            state.DisposeWorkers();
             foreach (var subscriptionConnection in state.GetConnections())
             {
                 state.DropSingleConnection(subscriptionConnection, ex);

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
@@ -159,9 +159,11 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
             return (true, _redirectNode);
         }
 
-        protected override (bool ShouldTryToReconnect, ServerNode NodeRedirectTo) HandleSubscriptionChangeVectorUpdateConcurrencyException()
+        protected override (bool ShouldTryToReconnect, ServerNode NodeRedirectTo) HandleSubscriptionChangeVectorUpdateConcurrencyException(SubscriptionChangeVectorUpdateConcurrencyException subscriptionChangeVectorUpdateConcurrencyException)
         {
             // the orchestrator will reconnect (and restart the sharded workers) since the subscription was changed
+            _state.DropSubscription(subscriptionChangeVectorUpdateConcurrencyException);
+
             return (false, null);
         }
 

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
@@ -108,16 +108,18 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
             // always try to reconnect until the task is canceled or assertLastConnectionFailure will throw when 'MaxErroneousPeriod' will elapse
             try
             {
-                assertLastConnectionFailure.Invoke();
-                var r = base.CheckIfShouldReconnectWorker(ex, assertLastConnectionFailure, onUnexpectedSubscriptionError, throwOnRedirectNodeNotFound: false);
-                if (_closedDueNoDocsLeft)
-                    return (ShouldTryToReconnect: false, NodeRedirectTo: null);
-
                 if (_state.CancellationTokenSource.IsCancellationRequested)
                 {
                     _processingCts.Cancel();
                     return (ShouldTryToReconnect: false, NodeRedirectTo: null);
                 }
+
+                assertLastConnectionFailure.Invoke();
+
+                var r = base.CheckIfShouldReconnectWorker(ex, assertLastConnectionFailure: null, onUnexpectedSubscriptionError, throwOnRedirectNodeNotFound: false);
+
+                if (_closedDueNoDocsLeft)
+                    return (ShouldTryToReconnect: false, NodeRedirectTo: null);
 
                 return (r.ShouldTryToReconnect, r.NodeRedirectTo);
             }

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionWorker.cs
@@ -114,7 +114,8 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
                     return (ShouldTryToReconnect: false, NodeRedirectTo: null);
                 }
 
-                assertLastConnectionFailure.Invoke();
+                // assertLastConnectionFailure will be null in case of AggregateException
+                assertLastConnectionFailure?.Invoke();
 
                 var r = base.CheckIfShouldReconnectWorker(ex, assertLastConnectionFailure: null, onUnexpectedSubscriptionError, throwOnRedirectNodeNotFound: false);
 

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/SubscriptionConnectionsStateOrchestrator.cs
@@ -180,7 +180,8 @@ public sealed class SubscriptionConnectionsStateOrchestrator : AbstractSubscript
         {
             try
             {
-                w.Value.Dispose();
+                // this code can be called from sharded worker itself (AbstractSubscriptionWorker._subscriptionTask)
+                w.Value.Dispose(waitForSubscriptionTask: false);
             }
             catch
             {

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
@@ -329,9 +329,9 @@ namespace SlowTests.Sharding.Subscriptions
                     break;
                 case SubscriptionChangeVectorUpdateConcurrencyException:
                     // sometimes we may hit cv concurrency exception because of the update
-                    Assert.StartsWith(
-                        $"Can't acknowledge subscription with name '{state.SubscriptionName}'",
-                        OnSubscriptionConnectionRetryException.Message);
+                    Assert.True(
+                        OnSubscriptionConnectionRetryException.Message.StartsWith($"Can't acknowledge subscription with name '{state.SubscriptionName}'")
+                        || OnSubscriptionConnectionRetryException.Message.StartsWith($"The subscription '{state.SubscriptionName}' was modified on shard"));
                     break;
             }
         }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21756/
### Additional description

- make sure to drop the orchestrator connection on SubscriptionChangeVectorUpdateConcurrencyException
- make sure to not wait for subscription task to complete when calling from inside the task

### Type of change

- Bug fix


### How risky is the change?

- Not relevant

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
