### PR TITLE
RavenDB-21866 : Timeseries doesn't load in ETL when filtering by series name in its original casing 

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlDocumentTransformer.cs
@@ -513,7 +513,8 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             TimeSeriesSegmentEntry segmentEntry, 
             string loadBehaviorFunction)
         {
-            if (ShouldFilterByScriptAndGetParams(docId, segmentEntry.Name, loadBehaviorFunction, out (DateTime begin, DateTime end)? toLoad)) 
+            var tsNameOriginalCasing = Database.DocumentsStorage.TimeSeriesStorage.Stats.GetTimeSeriesNameOriginalCasing(Context, segmentEntry.DocId, segmentEntry.Name);
+            if (ShouldFilterByScriptAndGetParams(docId, tsNameOriginalCasing, loadBehaviorFunction, out (DateTime begin, DateTime end)? toLoad)) 
                 return true;
 
             if (toLoad == null)

--- a/test/SlowTests/Issues/RavenDB_21866.cs
+++ b/test/SlowTests/Issues/RavenDB_21866.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Threading.Tasks;
+using SlowTests.Server.Documents.ETL;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21866 : EtlTestBase
+    {
+        public RavenDB_21866(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Etl | RavenTestCategory.TimeSeries)]
+        public async Task EtlCanLoadTimeSeriesByComparingTheNameInItsOriginalCasing()
+        {
+            const string collection = "EventDocuments";
+            const string id = $"{collection}/1";
+            const string tsName = "AppOpen";
+            const string script = @"
+loadToEventDocuments(this);
+
+function loadCountersOfEventDocumentsBehavior(documentId, counterName) {
+   return true;
+}
+
+function loadTimeSeriesOfEventDocumentsBehavior(docId, timeSeriesName) {
+   if (timeSeriesName =='AppOpen'){
+       return true;
+   }
+   return false
+}";
+
+            var (src, dest, _) = CreateSrcDestAndAddEtl(new[] { collection }, script);
+
+            var etlDone = WaitForEtl(src, (s, statistics) => statistics.LoadSuccesses > 0);
+
+            using (var session = src.OpenAsyncSession())
+            {
+                var date = DateTime.Today.ToUniversalTime();
+                var doc = new EventDocument { Name = "event", Date = date };
+                await session.StoreAsync(doc, id);
+
+                var tsFor = session.TimeSeriesFor(doc, tsName);
+                for (int i = 0; i < 10; i++)
+                {
+                    tsFor.Append(date.AddMinutes(i), i);
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            Assert.True(etlDone.Wait(TimeSpan.FromSeconds(15)));
+
+            using (var session = dest.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<EventDocument>(id);
+                Assert.NotNull(doc);
+
+                var entries = await session.TimeSeriesFor(id, tsName).GetAsync();
+                Assert.Equal(10, entries?.Length);
+            }
+
+        }
+
+        private class EventDocument
+        {
+            public DateTime Date { get; set; }
+
+            public string Name { get; set;  }
+
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21866/ETL-TimeSeries-load-behaviour-function-passes-lower-timeseries-name-as-argument

### Additional description

use `GetTimeSeriesNameOriginalCasing` when passing `timeSeriesName` to time series load behaviour function

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
