### PR TITLE
RavenDB-21679 Restrict the import of features with user certificates

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/SampleData/SampleDataHandlerProcessorForPostSampleData.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SampleData/SampleDataHandlerProcessorForPostSampleData.cs
@@ -1,7 +1,10 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
@@ -17,17 +20,26 @@ namespace Raven.Server.Documents.Handlers.Processors.SampleData
 
         protected override async ValueTask ExecuteSmugglerAsync(JsonOperationContext context, Stream sampleDataStream, DatabaseItemType operateOnTypes)
         {
+            var feature = HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
+
             using (var source = new StreamSource(sampleDataStream, context, RequestHandler.DatabaseName))
             {
                 var destination = RequestHandler.Database.Smuggler.CreateDestination();
+                var options = new DatabaseSmugglerOptionsServerSide
+                {
+                    OperateOnTypes = operateOnTypes,
+                    SkipRevisionCreation = true
 
-                var smuggler = RequestHandler.Database.Smuggler.Create(source, destination, context,
-                    options: new DatabaseSmugglerOptionsServerSide
-                    {
-                        OperateOnTypes = operateOnTypes,
-                        SkipRevisionCreation = true
-                    });
-
+                };
+                options.AuthorizationStatus = AuthorizationStatus.ValidUser;
+                if (feature != null )
+                {
+                    if (feature.AuthorizedDatabases.TryGetValue(RequestHandler.DatabaseName, out var databaseAccess) && databaseAccess == DatabaseAccess.Admin)
+                        options.AuthorizationStatus = AuthorizationStatus.DatabaseAdmin;
+                    if (feature.Status == RavenServer.AuthenticationStatus.ClusterAdmin)
+                        options.AuthorizationStatus = AuthorizationStatus.ClusterAdmin;
+                }
+                var smuggler = RequestHandler.Database.Smuggler.Create(source, destination, context, options);
                 await smuggler.ExecuteAsync();
             }
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/SampleData/ShardedSampleDataHandlerProcessorForPostSampleData.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/SampleData/ShardedSampleDataHandlerProcessorForPostSampleData.cs
@@ -30,9 +30,8 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.SampleData
                 SkipRevisionCreation = true
 
             };
-            if (feature == null)
-                options.AuthorizationStatus = AuthorizationStatus.ValidUser;
-            else
+            options.AuthorizationStatus = AuthorizationStatus.ValidUser;
+            if (feature != null)
                 options.AuthorizationStatus = feature.CanAccess(RequestHandler.DatabaseName, requireAdmin: true, requireWrite: false)
                     ? AuthorizationStatus.DatabaseAdmin
                     : AuthorizationStatus.ValidUser;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/SampleData/ShardedSampleDataHandlerProcessorForPostSampleData.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/SampleData/ShardedSampleDataHandlerProcessorForPostSampleData.cs
@@ -1,9 +1,11 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Raven.Client.Documents.Smuggler;
 using Raven.Server.Documents.Handlers.Processors.SampleData;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Collections;
+using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
@@ -21,7 +23,20 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.SampleData
         {
             var operationId = RequestHandler.DatabaseContext.Operations.GetNextOperationId();
             var record = RequestHandler.DatabaseContext.DatabaseRecord;
-            
+            var feature = HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
+            var options = new DatabaseSmugglerOptionsServerSide
+            {
+                OperateOnTypes = operateOnTypes,
+                SkipRevisionCreation = true
+
+            };
+            if (feature == null)
+                options.AuthorizationStatus = AuthorizationStatus.ValidUser;
+            else
+                options.AuthorizationStatus = feature.CanAccess(RequestHandler.DatabaseName, requireAdmin: true, requireWrite: false)
+                    ? AuthorizationStatus.DatabaseAdmin
+                    : AuthorizationStatus.ValidUser;
+
             using (var source = new OrchestratorStreamSource(sampleDataStream, context, RequestHandler.DatabaseName, RequestHandler.DatabaseContext.ShardCount))
             {
                 var smuggler = new ShardedDatabaseSmuggler(
@@ -30,11 +45,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.SampleData
                     context,
                     record,
                     RequestHandler.ServerStore,
-                    options: new DatabaseSmugglerOptionsServerSide
-                    {
-                        OperateOnTypes = operateOnTypes,
-                        SkipRevisionCreation = true
-                    },
+                    options,
                     result: null);
 
                 await smuggler.ExecuteAsync();

--- a/src/Raven.Server/Smuggler/Documents/Actions/DatabaseIndexActions.cs
+++ b/src/Raven.Server/Smuggler/Documents/Actions/DatabaseIndexActions.cs
@@ -30,7 +30,7 @@ public sealed class DatabaseIndexActions : IIndexActions
             _batch = _controller.CreateIndexBatch();
     }
 
-    public async ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType, AuthorizationStatus authorizationStatus)
+    public async ValueTask WriteAutoIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType, AuthorizationStatus authorizationStatus)
     {
         if (_configuration.Security.AuthenticationEnabled &&
             authorizationStatus == AuthorizationStatus.ValidUser)

--- a/src/Raven.Server/Smuggler/Documents/Actions/DatabaseIndexActions.cs
+++ b/src/Raven.Server/Smuggler/Documents/Actions/DatabaseIndexActions.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch;
 using JetBrains.Annotations;
+using Org.BouncyCastle.Security.Certificates;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Auto;
+using Raven.Server.Routing;
 using Raven.Server.Smuggler.Documents.Data;
 
 namespace Raven.Server.Smuggler.Documents.Actions;
@@ -26,8 +30,15 @@ public sealed class DatabaseIndexActions : IIndexActions
             _batch = _controller.CreateIndexBatch();
     }
 
-    public async ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType)
+    public async ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType, AuthorizationStatus authorizationStatus)
     {
+        if (_configuration.Security.AuthenticationEnabled &&
+            authorizationStatus == AuthorizationStatus.ValidUser)
+        {
+            throw new CertificateException(
+                $"Could not import '{indexDefinition.Name}' index: Your existing certificate lacks the necessary permissions to create indexes.");
+        }
+
         if (_batch != null)
         {
             await _batch.AddIndexAsync(indexDefinition, _source, _time.GetUtcNow(), RaftIdGenerator.DontCareId, _configuration.Indexing.HistoryRevisionsNumber);
@@ -38,8 +49,17 @@ public sealed class DatabaseIndexActions : IIndexActions
         await _controller.CreateIndexAsync(indexDefinition, RaftIdGenerator.DontCareId);
     }
 
-    public async ValueTask WriteIndexAsync(IndexDefinition indexDefinition)
+    public async ValueTask WriteIndexAsync(IndexDefinition indexDefinition, AuthorizationStatus authorizationStatus)
     {
+        if (_configuration.Security.AuthenticationEnabled &&
+            authorizationStatus == AuthorizationStatus.ValidUser &&
+            (indexDefinition.Type == IndexType.Map ||
+             indexDefinition.Type == IndexType.MapReduce))
+        {
+            throw new CertificateException(
+                $"Could not import '{indexDefinition.Name}' index: Your existing certificate lacks the necessary permissions to create indexes.");
+        }
+
         if (_batch != null)
         {
             await _batch.AddIndexAsync(indexDefinition, _source, _time.GetUtcNow(), RaftIdGenerator.DontCareId, _configuration.Indexing.HistoryRevisionsNumber);

--- a/src/Raven.Server/Smuggler/Documents/Actions/DatabaseRecordActions.cs
+++ b/src/Raven.Server/Smuggler/Documents/Actions/DatabaseRecordActions.cs
@@ -434,6 +434,7 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
             if (authenticationEnabled && CanAccess(authorizationStatus) == false)
             {
                 result.AddError("Import of Client Configuration was skipped due to insufficient permissions on your current certificate.");
+                result.DatabaseRecord.ErroredCount++;
             }
             else
             {

--- a/src/Raven.Server/Smuggler/Documents/Actions/DatabaseRecordActions.cs
+++ b/src/Raven.Server/Smuggler/Documents/Actions/DatabaseRecordActions.cs
@@ -58,6 +58,7 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
             return;
 
         var configuration = DatabasesLandlord.CreateDatabaseConfiguration(_server, _name, databaseRecord.Settings);
+        var authenticationEnabled = _server.Configuration.Security.AuthenticationEnabled;
 
         if (databaseRecord.ConflictSolverConfig != null && databaseRecordItemType.HasFlag(DatabaseRecordItemType.ConflictSolverConfig))
         {
@@ -90,25 +91,32 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
 
         if (databaseRecord.PeriodicBackups.Count > 0 && databaseRecordItemType.HasFlag(DatabaseRecordItemType.PeriodicBackups))
         {
-            if (_log.IsInfoEnabled)
-                _log.Info("Configuring periodic backups configuration from smuggler");
-
-            foreach (var backupConfig in databaseRecord.PeriodicBackups)
+            if (authenticationEnabled && CanAccess(authorizationStatus) == false)
             {
-                _currentDatabaseRecord?.PeriodicBackups.ForEach(x =>
-                {
-                    if (x.Name.Equals(backupConfig.Name, StringComparison.OrdinalIgnoreCase))
-                    {
-                        tasks.Add(_server.SendToLeaderAsync(new DeleteOngoingTaskCommand(x.TaskId, OngoingTaskType.Backup, _name, RaftIdGenerator.DontCareId)));
-                    }
-                });
-
-                backupConfig.TaskId = 0;
-                backupConfig.Disabled = true;
-                tasks.Add(_server.SendToLeaderAsync(new UpdatePeriodicBackupCommand(backupConfig, _name, RaftIdGenerator.DontCareId)));
+                result.AddError("Import of periodic backup was skipped due to insufficient permissions on your current certificate.");
+                result.DatabaseRecord.ErroredCount++;
             }
+            else
+            {
+                if (_log.IsInfoEnabled)
+                    _log.Info("Configuring periodic backups configuration from smuggler");
 
-            result.DatabaseRecord.PeriodicBackupsUpdated = true;
+                foreach (var backupConfig in databaseRecord.PeriodicBackups)
+                {
+                    _currentDatabaseRecord?.PeriodicBackups.ForEach(x =>
+                    {
+                        if (x.Name.Equals(backupConfig.Name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            tasks.Add(_server.SendToLeaderAsync(new DeleteOngoingTaskCommand(x.TaskId, OngoingTaskType.Backup, _name, RaftIdGenerator.DontCareId)));
+                        }
+                    });
+
+                    backupConfig.TaskId = 0;
+                    backupConfig.Disabled = true;
+                    tasks.Add(_server.SendToLeaderAsync(new UpdatePeriodicBackupCommand(backupConfig, _name, RaftIdGenerator.DontCareId)));
+                }
+                result.DatabaseRecord.PeriodicBackupsUpdated = true;
+            }
         }
 
         if (databaseRecord.SinkPullReplications.Count > 0 && databaseRecordItemType.HasFlag(DatabaseRecordItemType.SinkPullReplications))
@@ -313,28 +321,36 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
 
         if (databaseRecord.Revisions != null && databaseRecordItemType.HasFlag(DatabaseRecordItemType.Revisions))
         {
-            if (_log.IsInfoEnabled)
-                _log.Info("Configuring revisions from smuggler");
-
-            if (_currentDatabaseRecord?.Revisions != null)
+            if (authenticationEnabled && CanAccess(authorizationStatus) == false)
             {
-                foreach (var collection in _currentDatabaseRecord.Revisions.Collections)
+                result.AddError("Import of Revision configuration was skipped due to insufficient permissions on your current certificate.");
+                result.DatabaseRecord.ErroredCount++;
+            }
+            else
+            {
+                if (_log.IsInfoEnabled)
+                    _log.Info("Configuring revisions from smuggler");
+
+                if (_currentDatabaseRecord?.Revisions != null)
                 {
-                    if (databaseRecord.Revisions.Collections.TryGetValue(collection.Key, out var collectionConfiguration) == false)
+                    foreach (var collection in _currentDatabaseRecord.Revisions.Collections)
                     {
-                        databaseRecord.Revisions.Collections.Add(collection.Key, collection.Value);
-                    }
-                    else
-                    {
-                        if (collectionConfiguration.Equals(collection.Value) == false)
-                            result.AddWarning($"Revisions configuration of collection '{collection.Key}' already exist on the destination Database Record. " +
-                                              "Configuring this revisions from smuggler was skipped, even though the configuration differed from the configuration in the target database record");
+                        if (databaseRecord.Revisions.Collections.TryGetValue(collection.Key, out var collectionConfiguration) == false)
+                        {
+                            databaseRecord.Revisions.Collections.Add(collection.Key, collection.Value);
+                        }
+                        else
+                        {
+                            if (collectionConfiguration.Equals(collection.Value) == false)
+                                result.AddWarning($"Revisions configuration of collection '{collection.Key}' already exist on the destination Database Record. " +
+                                                  "Configuring this revisions from smuggler was skipped, even though the configuration differed from the configuration in the target database record");
+                        }
                     }
                 }
-            }
 
-            tasks.Add(_server.SendToLeaderAsync(new EditRevisionsConfigurationCommand(databaseRecord.Revisions, _name, RaftIdGenerator.DontCareId)));
-            result.DatabaseRecord.RevisionsConfigurationUpdated = true;
+                tasks.Add(_server.SendToLeaderAsync(new EditRevisionsConfigurationCommand(databaseRecord.Revisions, _name, RaftIdGenerator.DontCareId)));
+                result.DatabaseRecord.RevisionsConfigurationUpdated = true;
+            }
         }
 
         if (databaseRecord.RevisionsForConflicts != null && databaseRecordItemType.HasFlag(DatabaseRecordItemType.Revisions))
@@ -346,11 +362,19 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
 
         if (databaseRecord.Expiration != null && databaseRecordItemType.HasFlag(DatabaseRecordItemType.Expiration))
         {
-            if (_log.IsInfoEnabled)
-                _log.Info("Configuring expiration from smuggler");
+            if (authenticationEnabled && CanAccess(authorizationStatus) == false)
+            {
+                result.AddError("Import of Expiration was skipped due to insufficient permissions on your current certificate.");
+                result.DatabaseRecord.ErroredCount++;
+            }
+            else
+            {
+                if (_log.IsInfoEnabled)
+                    _log.Info("Configuring expiration from smuggler");
 
-            tasks.Add(_server.SendToLeaderAsync(new EditExpirationCommand(databaseRecord.Expiration, _name, RaftIdGenerator.DontCareId)));
-            result.DatabaseRecord.ExpirationConfigurationUpdated = true;
+                tasks.Add(_server.SendToLeaderAsync(new EditExpirationCommand(databaseRecord.Expiration, _name, RaftIdGenerator.DontCareId)));
+                result.DatabaseRecord.ExpirationConfigurationUpdated = true;
+            }
         }
 
         if (databaseRecord.Refresh != null && databaseRecordItemType.HasFlag(DatabaseRecordItemType.Refresh))
@@ -361,7 +385,6 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
             tasks.Add(_server.SendToLeaderAsync(new EditRefreshCommand(databaseRecord.Refresh, _name, RaftIdGenerator.DontCareId)));
             result.DatabaseRecord.RefreshConfigurationUpdated = true;
         }
-        
         
         if (databaseRecord.DataArchival != null && databaseRecordItemType.HasFlag(DatabaseRecordItemType.DataArchival))
         {
@@ -374,15 +397,23 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
 
         if (databaseRecord.RavenConnectionStrings.Count > 0 && databaseRecordItemType.HasFlag(DatabaseRecordItemType.RavenConnectionStrings))
         {
-            if (_log.IsInfoEnabled)
-                _log.Info("Configuring Raven connection strings configuration from smuggler");
-
-            foreach (var connectionString in databaseRecord.RavenConnectionStrings)
+            if (authenticationEnabled && CanAccess(authorizationStatus) == false)
             {
-                tasks.Add(_server.SendToLeaderAsync(new PutRavenConnectionStringCommand(connectionString.Value, _name, RaftIdGenerator.DontCareId)));
+                result.AddError("Import of Raven Connection Strings was skipped due to insufficient permissions on your current certificate.");
+                result.DatabaseRecord.ErroredCount++;
             }
+            else
+            {
+                if (_log.IsInfoEnabled)
+                    _log.Info("Configuring Raven connection strings configuration from smuggler");
 
-            result.DatabaseRecord.RavenConnectionStringsUpdated = true;
+                foreach (var connectionString in databaseRecord.RavenConnectionStrings)
+                {
+                    tasks.Add(_server.SendToLeaderAsync(new PutRavenConnectionStringCommand(connectionString.Value, _name, RaftIdGenerator.DontCareId)));
+                }
+
+                result.DatabaseRecord.RavenConnectionStringsUpdated = true;
+            }
         }
 
         if (databaseRecord.SqlConnectionStrings.Count > 0 && databaseRecordItemType.HasFlag(DatabaseRecordItemType.SqlConnectionStrings))
@@ -400,11 +431,18 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
 
         if (databaseRecord.Client != null && databaseRecordItemType.HasFlag(DatabaseRecordItemType.Client))
         {
-            if (_log.IsInfoEnabled)
-                _log.Info("Configuring client configuration from smuggler");
+            if (authenticationEnabled && CanAccess(authorizationStatus) == false)
+            {
+                result.AddError("Import of Client Configuration was skipped due to insufficient permissions on your current certificate.");
+            }
+            else
+            {
+                if (_log.IsInfoEnabled)
+                    _log.Info("Configuring client configuration from smuggler");
 
-            tasks.Add(_server.SendToLeaderAsync(new EditDatabaseClientConfigurationCommand(databaseRecord.Client, _name, RaftIdGenerator.DontCareId)));
-            result.DatabaseRecord.ClientConfigurationUpdated = true;
+                tasks.Add(_server.SendToLeaderAsync(new EditDatabaseClientConfigurationCommand(databaseRecord.Client, _name, RaftIdGenerator.DontCareId)));
+                result.DatabaseRecord.ClientConfigurationUpdated = true;
+            }
         }
 
         if (databaseRecord.Integrations?.PostgreSql != null && databaseRecordItemType.HasFlag(DatabaseRecordItemType.PostgreSQLIntegration))
@@ -605,6 +643,13 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
         }
 
         tasks.Clear();
+    }
+
+    private static bool CanAccess(AuthorizationStatus authorizationStatus)
+    {
+        return authorizationStatus == AuthorizationStatus.ClusterAdmin ||
+               authorizationStatus == AuthorizationStatus.Operator ||
+               authorizationStatus == AuthorizationStatus.DatabaseAdmin;
     }
 
     public ValueTask DisposeAsync()

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -79,7 +79,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface IIndexActions : IAsyncDisposable
     {
-        ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType, AuthorizationStatus authorizationStatus);
+        ValueTask WriteAutoIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType, AuthorizationStatus authorizationStatus);
 
         ValueTask WriteIndexAsync(IndexDefinition indexDefinition, AuthorizationStatus authorizationStatus);
     }

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -79,9 +79,9 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface IIndexActions : IAsyncDisposable
     {
-        ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType);
+        ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType, AuthorizationStatus authorizationStatus);
 
-        ValueTask WriteIndexAsync(IndexDefinition indexDefinition);
+        ValueTask WriteIndexAsync(IndexDefinition indexDefinition, AuthorizationStatus authorizationStatus);
     }
 
     public interface ICounterActions : INewDocumentActions

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -721,7 +721,7 @@ namespace Raven.Server.Smuggler.Documents
 
                             try
                             {
-                                await actions.WriteIndexAsync(autoMapIndexDefinition, IndexType.AutoMap, _options.AuthorizationStatus);
+                                await actions.WriteAutoIndexAsync(autoMapIndexDefinition, IndexType.AutoMap, _options.AuthorizationStatus);
                             }
                             catch (Exception e)
                             {
@@ -734,7 +734,7 @@ namespace Raven.Server.Smuggler.Documents
                             var autoMapReduceIndexDefinition = (AutoMapReduceIndexDefinition)index.IndexDefinition;
                             try
                             {
-                                await actions.WriteIndexAsync(autoMapReduceIndexDefinition, IndexType.AutoMapReduce, _options.AuthorizationStatus);
+                                await actions.WriteAutoIndexAsync(autoMapReduceIndexDefinition, IndexType.AutoMapReduce, _options.AuthorizationStatus);
                             }
                             catch (Exception e)
                             {

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -10,7 +10,6 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Smuggler;
-using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
@@ -19,6 +18,7 @@ using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.Documents.Indexes.MapReduce.Auto;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.Replication;
+using Raven.Server.Routing;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Processors;
@@ -89,6 +89,7 @@ namespace Raven.Server.Smuggler.Documents
                 var currentType = await _source.GetNextTypeAsync();
                 while (currentType != DatabaseItemType.None)
                 {
+
                     await ProcessTypeAsync(currentType, result, buildType, ensureStepsProcessed);
 
                     currentType = await _source.GetNextTypeAsync();
@@ -720,7 +721,7 @@ namespace Raven.Server.Smuggler.Documents
 
                             try
                             {
-                                await actions.WriteIndexAsync(autoMapIndexDefinition, IndexType.AutoMap);
+                                await actions.WriteIndexAsync(autoMapIndexDefinition, IndexType.AutoMap, _options.AuthorizationStatus);
                             }
                             catch (Exception e)
                             {
@@ -733,7 +734,7 @@ namespace Raven.Server.Smuggler.Documents
                             var autoMapReduceIndexDefinition = (AutoMapReduceIndexDefinition)index.IndexDefinition;
                             try
                             {
-                                await actions.WriteIndexAsync(autoMapReduceIndexDefinition, IndexType.AutoMapReduce);
+                                await actions.WriteIndexAsync(autoMapReduceIndexDefinition, IndexType.AutoMapReduce, _options.AuthorizationStatus);
                             }
                             catch (Exception e)
                             {
@@ -1221,7 +1222,7 @@ namespace Raven.Server.Smuggler.Documents
                         indexDefinitionField.Value.Analyzer = null;
                 }
 
-                await actions.WriteIndexAsync(indexDefinition);
+                await actions.WriteIndexAsync(indexDefinition, _options.AuthorizationStatus);
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1033,7 +1033,7 @@ namespace Raven.Server.Smuggler.Documents
                 _context = context;
             }
 
-            public async ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType)
+            public async ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType, AuthorizationStatus authorizationStatus)
             {
                 if (First == false)
                     Writer.WriteComma();
@@ -1053,7 +1053,7 @@ namespace Raven.Server.Smuggler.Documents
                 await Writer.MaybeFlushAsync();
             }
 
-            public async ValueTask WriteIndexAsync(IndexDefinition indexDefinition)
+            public async ValueTask WriteIndexAsync(IndexDefinition indexDefinition, AuthorizationStatus authorizationStatus)
             {
                 if (First == false)
                     Writer.WriteComma();

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1033,7 +1033,7 @@ namespace Raven.Server.Smuggler.Documents
                 _context = context;
             }
 
-            public async ValueTask WriteIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType, AuthorizationStatus authorizationStatus)
+            public async ValueTask WriteAutoIndexAsync(IndexDefinitionBaseServerSide indexDefinition, IndexType indexType, AuthorizationStatus authorizationStatus)
             {
                 if (First == false)
                     Writer.WriteComma();

--- a/test/SlowTests/RavenDB-21679.cs
+++ b/test/SlowTests/RavenDB-21679.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Http;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests
+{
+    public class RavenDB_21679 : RavenTestBase
+    {
+        public RavenDB_21679(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Certificates | RavenTestCategory.BackupExportImport)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanNotImportRestrictedFeaturesWithUserCertificate(Options options)
+        {
+            DoNotReuseServer();
+
+            var file = Path.GetTempFileName();
+            var dbName = GetDatabaseName();
+            var dbName2 = dbName + "1";
+            var certificates = Certificates.SetupServerAuthentication(serverUrl: null);
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var clientCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            {
+                [dbName] = DatabaseAccess.Admin
+            });
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate3.Value, new Dictionary<string, DatabaseAccess>
+            {
+                [dbName2] = DatabaseAccess.ReadWrite
+            });
+            IndexDefinition input;
+            using (var store = GetDocumentStore(new Options()
+                   {
+                       AdminCertificate = adminCert,
+                       ClientCertificate = clientCert,
+                       ModifyDatabaseName = _ => dbName
+                   }))
+            {
+                input = new IndexDefinition
+                {
+                    Maps = { "from user in docs.UserAndAges select new { user.Name }" },
+                    Type = IndexType.Map,
+                    Name = "Users_ByName"
+                };
+
+                await store
+                    .Maintenance
+                    .SendAsync(new PutIndexesOperation(new[] { input }));
+
+                var ravenConnectionString = new RavenConnectionString()
+                {
+                    Name = "RavenConnectionString",
+                    TopologyDiscoveryUrls = new[] { "http://localhost:8080" },
+                    Database = "Northwind",
+                };
+                var result0 = store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(ravenConnectionString));
+                Assert.NotNull(result0.RaftCommandIndex);
+
+                var backupPath = NewDataPath(suffix: "BackupFolder");
+                var expirationConfiguration = new ExpirationConfiguration
+                {
+                    Disabled = false,
+                    DeleteFrequencyInSec = 100,
+                };
+
+                await ExpirationHelper.SetupExpiration(store, Server.ServerStore, expirationConfiguration);
+
+                var backupConfiguration = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *");
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(backupConfiguration));
+
+                store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration { ReadBalanceBehavior = ReadBalanceBehavior.None, LoadBalanceBehavior = LoadBalanceBehavior.None, LoadBalancerContextSeed = 0, Disabled = false }));
+
+                await RevisionsHelper.SetupRevisionsAsync(store);
+
+                DatabaseRecord record;
+                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    record = Server.ServerStore.Cluster.ReadDatabase(context, store.Database);
+                }
+
+                Assert.True(record.RavenConnectionStrings.ContainsKey("RavenConnectionString"));
+                Assert.NotNull(record.Expiration);
+                Assert.True(record.PeriodicBackups.Count > 0);
+                Assert.NotNull(record.Client);
+                Assert.NotNull(record.Revisions);
+
+                var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+            }
+
+            using (var store = GetDocumentStore(new Options()
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = userCert,
+                ModifyDatabaseName = _ => dbName2
+            }))
+            {
+                WaitForUserToContinueTheTest(store, clientCert:userCert);
+                var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                var output = await store
+                    .Maintenance
+                    .SendAsync(new GetIndexOperation(input.Name));
+
+                Assert.Null(output);
+
+                DatabaseRecord record;
+                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    record = Server.ServerStore.Cluster.ReadDatabase(context, store.Database);
+                }
+
+                Assert.False(record.RavenConnectionStrings.ContainsKey("RavenConnectionString"));
+                Assert.Null(record.Expiration);
+                Assert.False(record.PeriodicBackups.Count > 0);
+                Assert.Null(record.Client);
+                Assert.Null(record.Revisions);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task SampleDataWithDifferentCertificates(Options options)
+        {
+            DoNotReuseServer();
+
+            var dbName = GetDatabaseName();
+            var dbName2 = dbName + "1";
+            var certificates = Certificates.SetupServerAuthentication(serverUrl: null);
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var clientCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            {
+                [dbName] = DatabaseAccess.Admin
+            });
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate3.Value, new Dictionary<string, DatabaseAccess>
+            {
+                [dbName2] = DatabaseAccess.ReadWrite
+            });
+
+            using (var store = GetDocumentStore(new Options()
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = clientCert,
+                ModifyDatabaseName = _ => dbName
+            }))
+            {
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(operateOnTypes: DatabaseSmugglerOptions.DefaultOperateOnTypes));
+                var indexDefinitions = store.Maintenance.Send(new GetIndexesOperation(0, 10));
+                Assert.Equal(7, indexDefinitions.Length);
+            }
+
+            using (var store = GetDocumentStore(new Options()
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = userCert,
+                ModifyDatabaseName = _ => dbName2
+            }))
+            {
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(operateOnTypes: DatabaseSmugglerOptions.DefaultOperateOnTypes));
+                var indexDefinitions = store.Maintenance.Send(new GetIndexesOperation(0, 10));
+                Assert.Equal(0, indexDefinitions.Length);
+            }
+        }
+    }
+}

--- a/test/SlowTests/RavenDB-21679.cs
+++ b/test/SlowTests/RavenDB-21679.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using FastTests.Utils;
@@ -12,10 +15,15 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.Expiration;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Smuggler.Documents;
+using Raven.Server.Smuggler.Documents.Data;
+using Sparrow.Utils;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -47,75 +55,17 @@ namespace SlowTests
             {
                 [dbName2] = DatabaseAccess.ReadWrite
             });
-            IndexDefinition input;
+            IndexDefinition input = await InitInfoAndExport(adminCert, clientCert, dbName, file);
+
             using (var store = GetDocumentStore(new Options()
                    {
                        AdminCertificate = adminCert,
-                       ClientCertificate = clientCert,
-                       ModifyDatabaseName = _ => dbName
+                       ClientCertificate = userCert,
+                       ModifyDatabaseName = _ => dbName2
                    }))
             {
-                input = new IndexDefinition
-                {
-                    Maps = { "from user in docs.UserAndAges select new { user.Name }" },
-                    Type = IndexType.Map,
-                    Name = "Users_ByName"
-                };
-
-                await store
-                    .Maintenance
-                    .SendAsync(new PutIndexesOperation(new[] { input }));
-
-                var ravenConnectionString = new RavenConnectionString()
-                {
-                    Name = "RavenConnectionString",
-                    TopologyDiscoveryUrls = new[] { "http://localhost:8080" },
-                    Database = "Northwind",
-                };
-                var result0 = store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(ravenConnectionString));
-                Assert.NotNull(result0.RaftCommandIndex);
-
-                var backupPath = NewDataPath(suffix: "BackupFolder");
-                var expirationConfiguration = new ExpirationConfiguration
-                {
-                    Disabled = false,
-                    DeleteFrequencyInSec = 100,
-                };
-
-                await ExpirationHelper.SetupExpiration(store, Server.ServerStore, expirationConfiguration);
-
-                var backupConfiguration = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *");
-                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(backupConfiguration));
-
-                store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration { ReadBalanceBehavior = ReadBalanceBehavior.None, LoadBalanceBehavior = LoadBalanceBehavior.None, LoadBalancerContextSeed = 0, Disabled = false }));
-
-                await RevisionsHelper.SetupRevisionsAsync(store);
-
-                DatabaseRecord record;
-                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (context.OpenReadTransaction())
-                {
-                    record = Server.ServerStore.Cluster.ReadDatabase(context, store.Database);
-                }
-
-                Assert.True(record.RavenConnectionStrings.ContainsKey("RavenConnectionString"));
-                Assert.NotNull(record.Expiration);
-                Assert.True(record.PeriodicBackups.Count > 0);
-                Assert.NotNull(record.Client);
-                Assert.NotNull(record.Revisions);
-
-                var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
-                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
-            }
-
-            using (var store = GetDocumentStore(new Options()
-            {
-                AdminCertificate = adminCert,
-                ClientCertificate = userCert,
-                ModifyDatabaseName = _ => dbName2
-            }))
-            {
                 WaitForUserToContinueTheTest(store, clientCert:userCert);
+
                 var operation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                 await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
 
@@ -140,6 +90,120 @@ namespace SlowTests
             }
         }
 
+        private async Task<IndexDefinition> InitInfoAndExport(X509Certificate2 adminCert, X509Certificate2 clientCert, string dbName, string file)
+        {
+            IndexDefinition input;
+            using (var store = GetDocumentStore(new Options() { AdminCertificate = adminCert, ClientCertificate = clientCert, ModifyDatabaseName = _ => dbName }))
+            {
+                input = new IndexDefinition { Maps = { "from user in docs.UserAndAges select new { user.Name }" }, Type = IndexType.Map, Name = "Users_ByName" };
+
+                await store
+                    .Maintenance
+                    .SendAsync(new PutIndexesOperation(new[] { input }));
+
+                var ravenConnectionString = new RavenConnectionString()
+                {
+                    Name = "RavenConnectionString", TopologyDiscoveryUrls = new[] { "http://localhost:8080" }, Database = "Northwind",
+                };
+                var result0 = store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(ravenConnectionString));
+                Assert.NotNull(result0.RaftCommandIndex);
+
+                var backupPath = NewDataPath(suffix: "BackupFolder");
+                var expirationConfiguration = new ExpirationConfiguration { Disabled = false, DeleteFrequencyInSec = 100, };
+
+                await ExpirationHelper.SetupExpiration(store, Server.ServerStore, expirationConfiguration);
+
+                var backupConfiguration = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *");
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(backupConfiguration));
+
+                store.Maintenance.Send(new PutClientConfigurationOperation(new ClientConfiguration
+                {
+                    ReadBalanceBehavior = ReadBalanceBehavior.None, LoadBalanceBehavior = LoadBalanceBehavior.None, LoadBalancerContextSeed = 0, Disabled = false
+                }));
+
+                await RevisionsHelper.SetupRevisionsAsync(store);
+
+                DatabaseRecord record;
+                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    record = Server.ServerStore.Cluster.ReadDatabase(context, store.Database);
+                }
+
+                Assert.True(record.RavenConnectionStrings.ContainsKey("RavenConnectionString"));
+                Assert.NotNull(record.Expiration);
+                Assert.True(record.PeriodicBackups.Count > 0);
+                Assert.NotNull(record.Client);
+                Assert.NotNull(record.Revisions);
+
+                var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+            }
+
+            return input;
+        }
+
+        [RavenTheory(RavenTestCategory.Certificates | RavenTestCategory.BackupExportImport)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task CanNotImportRestrictedFeaturesWithUserCertificateLogs(Options options)
+        {
+            DoNotReuseServer();
+
+            var file = Path.GetTempFileName();
+            var dbName = GetDatabaseName();
+            var dbName2 = dbName + "1";
+            var certificates = Certificates.SetupServerAuthentication(serverUrl: null);
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var clientCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            {
+                [dbName] = DatabaseAccess.Admin
+            });
+            var userCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate3.Value, new Dictionary<string, DatabaseAccess>
+            {
+                [dbName2] = DatabaseAccess.ReadWrite
+            });
+            await InitInfoAndExport(adminCert, clientCert, dbName, file);
+
+            using (GetDocumentStore(new Options()
+               {
+                   AdminCertificate = adminCert,
+                   ClientCertificate = userCert,
+                   ModifyDatabaseName = _ => dbName2
+               }))
+            {
+                using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+                await using (var inputStream = File.OpenRead(file))
+                await using (var stream = ZstdStream.Decompress(inputStream))
+                {
+                    Assert.NotNull(stream);
+
+                    using (DocumentDatabase database = Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(dbName2).Result)
+                    using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    using (var source = new StreamSource(stream, context, database.Name))
+                    {
+                        var destination = database.Smuggler.CreateDestination();
+                        var smuggler = database.Smuggler.Create(source, destination, context, new DatabaseSmugglerOptionsServerSide());
+                        var result = await smuggler.ExecuteAsync().WithCancellation(cts.Token);
+
+                        Assert.Equal(5, result.DatabaseRecord.ErroredCount);
+                        Assert.Equal(1, result.Indexes.ErroredCount);
+
+                        var featuresList = new List<string>()
+                        {
+                            "periodic backup",
+                            "Revision configuration",
+                            "Expiration",
+                            "Raven Connection Strings",
+                            "Client Configuration"
+                        };
+                        foreach (var feature in featuresList)
+                        {
+                            Assert.True(result.Messages.Any(x => x.Contains($"Import of {feature} was skipped due to insufficient permissions on your current certificate.")));
+                        }
+                    }
+                }
+            }
+        }
         [RavenTheory(RavenTestCategory.Certificates)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task SampleDataWithDifferentCertificates(Options options)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21679

### Additional description

When performing an import with a client certificate (read/write), we failed to enforce feature restrictions.
The import process will now skip the following restricted features: 
- Indexes ( not JavaScript)
- Connection strings
- Expiration
- Periodic backups
- Client configuration
- Revision Configuration

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.

