### PR TITLE
RavenDB-21867 Database settings view: Fix tooltip for server-wide keys

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/settings/databaseSettings.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/databaseSettings.html
@@ -96,7 +96,7 @@
                             <span data-bind="html: hasAccess() ? serverOrDefaultValue() || 'null' : effectiveValue()"></span>
                             <small data-placement="right" data-toggle="tooltip" data-animation="true" data-html="true"
                                    data-bind="visible: isServerWideOnlyEntry, attr: { title: hasAccess() ?
-                                   'This is a server-wide entry.<br>It can be edited only from the <strong>settings.json</strong> file located in your RavenDB executable folder.' :
+                                   'This is a server-wide entry.<br>It can be edited from the <strong>settings.json</strong> file located in your RavenDB executable folder.' :
                                    '' }">
                                 <small class="margin-left margin-left-sm"><i class="icon-lock fix-icon-top"></i></small>
                             </small>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21867/Database-settings-view-Fix-tooltip-for-server-wide-keys

### Additional description
Remove the word "only" - because there are 3 ways to modify:
   * settings.json
   * env vars
   * command line args

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- It has been verified by manual testing

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
