### PR TITLE
RavenDB-21746 Fix rvn init-setup-params default Addresses field values

### DIFF
--- a/tools/rvn/InitSetupParams.cs
+++ b/tools/rvn/InitSetupParams.cs
@@ -53,7 +53,7 @@ public class InitSetupParams
                     "A",
                     new NodeInfo()
                     {
-                        Addresses = new List<string>() { "https://0.0.0.0:0" },
+                        Addresses = new List<string> { "0.0.0.0" },
                         Port = 443,
                         TcpPort = 38888,
                         PublicServerUrl = "https://subdomain.example.com",
@@ -83,7 +83,7 @@ public class InitSetupParams
                     "A",
                     new NodeInfo()
                     {
-                        Addresses = new List<string>() { "https://0.0.0.0:0" },
+                        Addresses = new List<string> { "0.0.0.0" },
                         Port = 443,
                         TcpPort = 38888,
                         PublicServerUrl = "https://your-domain.development.run",
@@ -106,7 +106,7 @@ public class InitSetupParams
                     "A",
                     new NodeInfo()
                     {
-                        Addresses = new List<string>() {"http://0.0.0.0:0"},
+                        Addresses = new List<string> { "0.0.0.0" },
                         Port = 443,
                         TcpPort = 38888,
                     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21746/The-rvn-init-setup-params-builds-setup.json-with-invalid-Addresses-field

### Additional description

Setting up ravendb while using the default rvn generated setup.json caused an error due to the "https" in the Address field. Fixed it

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
