### PR TITLE
RavenDB-21747 The rvn create-setup-package creates values.yaml without --generate-helm-values

### DIFF
--- a/tools/rvn/CommandLineApp.cs
+++ b/tools/rvn/CommandLineApp.cs
@@ -153,7 +153,7 @@ namespace rvn
                     var packageOutPathVal = packageOutPath.Value();
                     var certPathVal = certPath.Value();
                     var certPassTuple = certPass.Value() ?? Environment.GetEnvironmentVariable("RVN_CERT_PASS");
-                    var generateHelmValuesVal = generateHelmValues.HasValue() && generateHelmValues.Value() is null ? "values.yaml" : generateHelmValues.Value(); 
+                    var generateHelmValuesVal = generateHelmValues.HasValue() ? generateHelmValues.Value() is null ? "values.yaml": generateHelmValues.Value() : null;
 
                     return await CreateSetupPackage(new CreateSetupPackageParameters
                     {
@@ -656,7 +656,6 @@ namespace rvn
         private static CommandOption ConfigureGenerateValues(CommandLineApplication cmd)
         {
             var opt = cmd.Option("--generate-helm-values", "Path to values.yaml", CommandOptionType.SingleOrNoValue);
-            opt.DefaultValue = "values.yaml";
             return opt;
         }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21747/The-rvn-create-setup-package-creates-values.yaml-without-generate-helm-values

### Additional description

Fixed creating helm values every time someone used `rvn create-setup-package`. Deleted default value that caused `HasValue` method to return true even if there were no values passed.

_Please delete below the options that are not relevant_

### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?


- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work


- No UI work is needed
