### PR TITLE
RavenDB-21856 SlowTests.Issues.RavenDB_20136.DeletingDocumentWithRevisionsDoesntCorruptEtlProcess

### DIFF
--- a/test/SlowTests/Issues/RavenDB-20136.cs
+++ b/test/SlowTests/Issues/RavenDB-20136.cs
@@ -40,6 +40,15 @@ namespace SlowTests.Issues
                     session.Store(new User(), "users/1");
                     session.SaveChanges();
                 }
+                
+                var etlDone = Etl.WaitForEtlToComplete(src);
+                if (etlDone.Wait(TimeSpan.FromSeconds(30)) == false)
+                {
+                    Etl.TryGetLoadError(src.Database, configuration, out var loadError);
+                    Etl.TryGetTransformationError(src.Database, configuration, out var transformationError);
+
+                    Assert.Fail($"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
+                }
 
                 using (var session = src.OpenSession())
                 {

--- a/test/SlowTests/Issues/RavenDB-20136.cs
+++ b/test/SlowTests/Issues/RavenDB-20136.cs
@@ -32,7 +32,6 @@ namespace SlowTests.Issues
 
                 Etl.AddEtl(src, configuration, new RavenConnectionString { Name = "test", TopologyDiscoveryUrls = dst.Urls, Database = dst.Database, });
 
-                var etlDone = Etl.WaitForEtlToComplete(src, (_, statistics) => statistics.LoadSuccesses == 3);
                 var loadDone = Etl.WaitForEtlToComplete(src, (_, statistics) => statistics.LoadSuccesses == 2);
                 var deleteDone = Etl.WaitForEtlToComplete(src, (_, statistics) => statistics.LoadSuccesses == 3);
 

--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -253,6 +253,12 @@ namespace FastTests
 
                 var loadAlert = database.NotificationCenter.EtlNotifications.GetAlert<EtlErrorsDetails>(tag, $"{config.Name}/{config.Transforms.First().Name}", AlertType.Etl_LoadError);
 
+                if (loadAlert is null)
+                {
+                    error = null;
+                    return false;
+                }
+
                 var details = (EtlErrorsDetails)loadAlert.Details;
 
                 if (details.Errors.Count != 0)
@@ -286,6 +292,12 @@ namespace FastTests
                     throw new NotSupportedException($"Unknown ETL type: {typeof(T)}");
 
                 var loadAlert = database.NotificationCenter.EtlNotifications.GetAlert<EtlErrorsDetails>(tag, $"{config.Name}/{config.Transforms.First().Name}", AlertType.Etl_TransformationError);
+                
+                if (loadAlert is null)
+                {
+                    error = null;
+                    return false;
+                }
 
                 var details = (EtlErrorsDetails)loadAlert.Details;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21856

### Additional description

Handled the scenario with no ETL load/transformation alerts in the notification center associated with the ETL task, preventing NRE when checking for errors.


### Type of change

- Bug fix


### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
