### PR TITLE
RavenDB-21872 Avoid trigger server certificate replacement when the new certificate is the same as the currently used one

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1262,7 +1262,7 @@ namespace Raven.Server
                 
                 if (Logger.IsOperationsEnabled)
                 {
-                    Logger.Operations($"Starting certificate replication. current:{Certificate.Certificate.GetBasicCertificateInfo()}, new:{newCertificate.GetBasicCertificateInfo()}");
+                    Logger.Operations($"Starting certificate replication. current:\"{Certificate.Certificate.GetBasicCertificateInfo()}\", new:\"{newCertificate.GetBasicCertificateInfo()}\"");
                 }
                 
                 // During replacement of a cluster certificate, we must have both the new and the old server certificates registered in the server store.

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1255,14 +1255,14 @@ namespace Raven.Server
                 {
                     if (Logger.IsOperationsEnabled)
                     {
-                        Logger.Operations($"The new certificate matches the current one. No further steps needed.");
+                        Logger.Operations($"The new certificate matches the current one. No further steps needed. {Certificate.Certificate.GetBasicCertificateInfo()}");
                     }
                     return;
                 }
                 
                 if (Logger.IsOperationsEnabled)
                 {
-                    Logger.Operations($"Starting certificate replication. old:{Certificate.Certificate.Thumbprint}, new:{newCertificate.Thumbprint}");
+                    Logger.Operations($"Starting certificate replication. current:{Certificate.Certificate.GetBasicCertificateInfo()}, new:{newCertificate.GetBasicCertificateInfo()}");
                 }
                 
                 // During replacement of a cluster certificate, we must have both the new and the old server certificates registered in the server store.

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1078,7 +1078,7 @@ namespace Raven.Server
 
                 if (Logger.IsOperationsEnabled)
                 {
-                    var source = Configuration.Core.SetupMode == SetupMode.LetsEncrypt ? "Let's Encrypt" : $"executable ({Configuration.Security.CertificateRenewExec} {Configuration.Security.CertificateRenewExecArguments})";
+                    var source = Configuration.Core.SetupMode == SetupMode.LetsEncrypt ? "Let's Encrypt" : $"executable configured by ({RavenConfiguration.GetKey(x => x.Security.CertificateRenewExec)})";
                     Logger.Operations($"Got new certificate from {source}. Starting certificate replication.");
                 }
                 
@@ -1262,7 +1262,7 @@ namespace Raven.Server
                 
                 if (Logger.IsOperationsEnabled)
                 {
-                    Logger.Operations($"Starting certificate replication. current:\"{Certificate.Certificate.GetBasicCertificateInfo()}\", new:\"{newCertificate.GetBasicCertificateInfo()}\"");
+                    Logger.Operations($"Starting certificate replication. current:'{Certificate.Certificate.GetBasicCertificateInfo()}', new:'{newCertificate.GetBasicCertificateInfo()}'");
                 }
                 
                 // During replacement of a cluster certificate, we must have both the new and the old server certificates registered in the server store.

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -619,7 +619,7 @@ namespace Raven.Server.Utils
 
         public static string GetBasicCertificateInfo(this X509Certificate2 certificate)
         {
-            return $"{{\"Thumbprint\":\"{certificate.Thumbprint}\", \"Subject\":\"{certificate.Subject}\"}}";
+            return $"Thumbprint: {certificate.Thumbprint}, Subject: {certificate.Subject}";
         }
     }
     public static class PublicKeyPinningHashHelpers

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -616,6 +616,11 @@ namespace Raven.Server.Utils
 
             return CertificateLoaderUtil.CreateCertificate(certBytes, flags: CertificateLoaderUtil.FlagsForExport);
         }
+
+        public static string GetBasicCertificateInfo(this X509Certificate2 certificate)
+        {
+            return $"{{\"Thumbprint\":\"{certificate.Thumbprint}\", \"Subject\":\"{certificate.Subject}\"}}";
+        }
     }
     public static class PublicKeyPinningHashHelpers
     {

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -1253,7 +1253,7 @@ namespace Raven.Server.Utils.Cli
             [Command.TrustServerCert] = new SingleAction { NumOfArgs = 2, DelegateFunc = CommandTrustServerCert },
             [Command.TrustClientCert] = new SingleAction { NumOfArgs = 2, DelegateFunc = CommandTrustClientCert },
             [Command.GenerateClientCert] = new SingleAction { NumOfArgs = 3, DelegateFunc = CommandGenerateClientCert },
-            [Command.ReplaceClusterCert] = new SingleAction { NumOfArgs = 2, DelegateFunc = CommandReplaceClusterCert },
+            [Command.ReplaceClusterCert] = new SingleAction { NumOfArgs = 1, DelegateFunc = CommandReplaceClusterCert },
             [Command.TriggerCertificateRefresh] = new SingleAction { NumOfArgs = 1, DelegateFunc = CommandTriggerCertificateRefresh },
             [Command.Info] = new SingleAction { NumOfArgs = 0, DelegateFunc = CommandInfo },
             [Command.Logo] = new SingleAction { NumOfArgs = 0, DelegateFunc = CommandLogo },

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -41,6 +41,8 @@ namespace Raven.Server.Web.Authentication
 {
     public class AdminCertificatesHandler : ServerRequestHandler
     {
+        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<AdminCertificatesHandler>("Server");
+        
         
         public const string HasTwoFactorFieldName = "HasTwoFactor";
         public const string TwoFactorExpirationDate = "TwoFactorExpirationDate";
@@ -1079,7 +1081,10 @@ namespace Raven.Server.Web.Authentication
                             throw new InvalidOperationException("Cannot replace the server certificate. Only a ClusterAdmin can do this.");
 
                         var timeoutTask = TimeoutManager.WaitFor(TimeSpan.FromSeconds(60), ServerStore.ServerShutdown);
-
+                        if (Logger.IsOperationsEnabled)
+                        {
+                            Logger.Operations("Initiating the replacement of the certificate upon explicit request");
+                        }
                         var replicationTask = Server.StartCertificateReplicationAsync(certBytes, replaceImmediately, GetRaftRequestIdFromQuery());
 
                         await Task.WhenAny(replicationTask, timeoutTask);

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -1083,7 +1083,7 @@ namespace Raven.Server.Web.Authentication
                         var timeoutTask = TimeoutManager.WaitFor(TimeSpan.FromSeconds(60), ServerStore.ServerShutdown);
                         if (Logger.IsOperationsEnabled)
                         {
-                            Logger.Operations("Initiating the replacement of the certificate upon explicit request");
+                            Logger.Operations("Initiating the replacement of the certificate upon explicit request - \"/admin/certificates/replace-cluster-cert\".");
                         }
                         var replicationTask = Server.StartCertificateReplicationAsync(certBytes, replaceImmediately, GetRaftRequestIdFromQuery());
 

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -1083,7 +1083,7 @@ namespace Raven.Server.Web.Authentication
                         var timeoutTask = TimeoutManager.WaitFor(TimeSpan.FromSeconds(60), ServerStore.ServerShutdown);
                         if (Logger.IsOperationsEnabled)
                         {
-                            Logger.Operations("Initiating the replacement of the certificate upon explicit request - \"/admin/certificates/replace-cluster-cert\".");
+                            Logger.Operations("Initiating the replacement of the certificate upon explicit request - '/admin/certificates/replace-cluster-cert'.");
                         }
                         var replicationTask = Server.StartCertificateReplicationAsync(certBytes, replaceImmediately, GetRaftRequestIdFromQuery());
 

--- a/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
+++ b/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -14,6 +15,7 @@ using Raven.Client;
 using Raven.Client.Documents.Smuggler;
 using Raven.Server.Config;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands;
 using Raven.Server.Utils;
 using Sparrow.Platform;
 using Sparrow.Utils;
@@ -357,6 +359,88 @@ exit 0";
             var serverMasterKey = (Lazy<byte[]>)typeof(SecretProtection).GetField("_serverMasterKey", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(secrets);
             Assert.True(serverMasterKey.Value.SequenceEqual(buffer));
             Assert.True(Server.Certificate.Certificate.Equals(serverCertificate));
+        }
+
+        [Fact]
+        public async Task RenewCertificate_WhenGetTheSame_ShouldNotTriggerUpdatedServerCertificate()
+        {
+            var customSettings = new ConcurrentDictionary<string, string>();
+            var certificates = Certificates.GenerateAndSaveSelfSignedCertificate();
+
+            (string exe, string certArgs) certProcess;
+            if (PlatformDetails.RunningOnPosix)
+            {
+                var scriptPath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Guid.NewGuid().ToString(), ".sh"));
+                certProcess.certArgs = CommandLineArgumentEscaper.EscapeAndConcatenate(new List<string> { scriptPath, certificates.ServerCertificatePath });
+                certProcess.exe = "bash";
+
+                var script = "#!/bin/bash\ncat \"$1\"";
+                await File.WriteAllTextAsync(scriptPath, script);
+                Process.Start("chmod", $"700 {scriptPath}");
+            }
+            else
+            {
+                var scriptPath = Path.Combine(Path.GetTempPath(), Path.ChangeExtension(Guid.NewGuid().ToString(), ".ps1"));
+                certProcess.certArgs = CommandLineArgumentEscaper.EscapeAndConcatenate(new List<string> { "-NoProfile", scriptPath, certificates.ServerCertificatePath });
+
+                certProcess.exe = "powershell";
+                var script = @"param([string]$userArg)
+try {
+    $bytes = Get-Content -path $userArg -encoding Byte
+    $stdout = [System.Console]::OpenStandardOutput()
+    $stdout.Write($bytes, 0, $bytes.Length)
+}
+catch {
+    Write-Error $_.Exception
+    exit 1
+}
+exit 0";
+                await File.WriteAllTextAsync(scriptPath, script);
+            }
+
+            customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = "https://" + Environment.MachineName + ":0";
+            customSettings[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certificates.ServerCertificatePath;
+            customSettings[RavenConfiguration.GetKey(x => x.Security.CertificateRenewExec)] = certProcess.exe;
+            customSettings[RavenConfiguration.GetKey(x => x.Security.CertificateRenewExecArguments)] = certProcess.certArgs;
+
+            UseNewLocalServer(customSettings: customSettings, runInMemory: false);
+            // The master key loading is lazy, let's put a database secret key to invoke it.
+            X509Certificate2 serverCertificate;
+            try
+            {
+                serverCertificate = new X509Certificate2(certificates.ServerCertificatePath, (string)null,
+                    CertificateLoaderUtil.FlagsForExport | X509KeyStorageFlags.MachineKeySet);
+            }
+            catch (CryptographicException e)
+            {
+                throw new CryptographicException($"Failed to load the test certificate from {certificates}.", e);
+            }
+
+            var ts = new TaskCompletionSource();
+            Server.ServerStore.Engine.StateMachine.Changes.ValueChanged += async (index, type) =>
+            {
+                if (type == nameof(InstallUpdatedServerCertificateCommand))
+                {
+                    ts.SetResult();
+                }
+            };
+            
+            using (var store = GetDocumentStore(new Options
+                   {
+                       AdminCertificate = serverCertificate,
+                       ClientCertificate = serverCertificate,
+                   }))
+            {
+                var httpClient = store.GetRequestExecutor().HttpClient;
+                var response = await httpClient.SendAsync(new HttpRequestMessage
+                {
+                    Method = HttpMethod.Post,
+                    RequestUri = new Uri($"{Server.WebUrl}/admin/certificates/refresh")
+                });
+                Assert.True(response.IsSuccessStatusCode);
+
+                Assert.NotEqual(ts.Task, await Task.WhenAny(ts.Task, Task.Delay(5 * 1000)));
+            }
         }
     }
 }

--- a/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
+++ b/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
@@ -361,7 +361,7 @@ exit 0";
             Assert.True(Server.Certificate.Certificate.Equals(serverCertificate));
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Certificates)]
         public async Task RenewCertificate_WhenGetTheSame_ShouldNotTriggerUpdatedServerCertificate()
         {
             var customSettings = new ConcurrentDictionary<string, string>();
@@ -417,12 +417,14 @@ exit 0";
             }
 
             var ts = new TaskCompletionSource();
-            Server.ServerStore.Engine.StateMachine.Changes.ValueChanged += async (index, type) =>
+            Server.ServerStore.Engine.StateMachine.Changes.ValueChanged += (index, type) =>
             {
                 if (type == nameof(InstallUpdatedServerCertificateCommand))
                 {
                     ts.SetResult();
                 }
+
+                return Task.CompletedTask;
             };
             
             using (var store = GetDocumentStore(new Options


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21872

### Additional description
Avoid triggering the replacement of the server certificate when the new one that comes from the `CertificateRenewExec` is the same as the one that is currently used.

### Type of change
- Optimization

### How risky is the change?
- Moderate 


### Backward compatibility
- Non breaking change

### Is it platform specific issue?
- No

### Documentation update
- No documentation update is needed 

### Testing by Contributor
- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- No

### UI work
- No UI work is needed
