### PR TITLE
RavenDB-7070: Solved warnings and removed preview language usage.

### DIFF
--- a/src/Corax/Corax.csproj
+++ b/src/Corax/Corax.csproj
@@ -11,9 +11,6 @@
     <PackageTags>storage;acid;corax;ravendb;nosql</PackageTags>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;Validate</Configurations>
-    <LangVersion>preview</LangVersion>
-    <EnablePreviewFeatures>True</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>True</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <Compile Remove="Properties\AssemblyInfo.Linux.cs" />

--- a/src/Sparrow.Server/Collections/Persistent/BinaryTree.cs
+++ b/src/Sparrow.Server/Collections/Persistent/BinaryTree.cs
@@ -54,7 +54,7 @@ namespace Sparrow.Server.Collections.Persistent
         private ushort FreeNodes
         {
             get { return MemoryMarshal.Read<ushort>(_storage); }
-            set { MemoryMarshal.Write(_storage, ref value); }
+            set { MemoryMarshal.Write(_storage, in value); }
         }
 
         public int MaxNodes => _nodes.Length - 1;

--- a/src/Sparrow.Server/Compression/Encoder3Gram.cs
+++ b/src/Sparrow.Server/Compression/Encoder3Gram.cs
@@ -373,7 +373,7 @@ namespace Sparrow.Server.Compression
         public int NumberOfEntries
         {
             get { return ReadNumberOfEntries(_state); }
-            set { MemoryMarshal.Write(_state.EncodingTable, ref value);}
+            set { MemoryMarshal.Write(_state.EncodingTable, in value);}
         }
 
         private static int ReadNumberOfEntries(in TEncoderState encoderState)
@@ -389,7 +389,7 @@ namespace Sparrow.Server.Compression
             set
             {
                 byte valueAsByte = (byte)value;
-                MemoryMarshal.Write(_state.EncodingTable.Slice(4, 1), ref valueAsByte);
+                MemoryMarshal.Write(_state.EncodingTable.Slice(4, 1), in valueAsByte);
             }
         }
 
@@ -399,7 +399,7 @@ namespace Sparrow.Server.Compression
             set
             {
                 byte valueAsByte = (byte)value;
-                MemoryMarshal.Write(_state.EncodingTable.Slice(5, 1), ref valueAsByte);
+                MemoryMarshal.Write(_state.EncodingTable.Slice(5, 1), in valueAsByte);
             }
         }
 

--- a/src/Voron/Data/CompactTrees/CompactKey.cs
+++ b/src/Voron/Data/CompactTrees/CompactKey.cs
@@ -240,7 +240,8 @@ public sealed unsafe class CompactKey : IDisposable
         Unsafe.WriteUnaligned<int>(ref _storage[0], key.Length);
 
         // PERF: Between pinning the pointer and just execute the Unsafe.CopyBlock unintuitively it is faster to just copy. 
-        Unsafe.CopyBlock(ref _storage[sizeof(int)], ref Unsafe.AsRef(key[0]), (uint)key.Length);
+        ref readonly byte kPtr = ref key[0];
+        Unsafe.CopyBlock(ref _storage[sizeof(int)],  in kPtr, (uint)key.Length);
 
         _currentIdx = key.Length + sizeof(int);
 

--- a/src/Voron/Data/CompactTrees/CompactKeyCacheScope.cs
+++ b/src/Voron/Data/CompactTrees/CompactKeyCacheScope.cs
@@ -4,29 +4,30 @@ using Voron.Impl;
 
 namespace Voron.Data.CompactTrees;
 
-public readonly struct CompactKeyCacheScope : IDisposable
+public struct CompactKeyCacheScope : IDisposable
 {
     private readonly LowLevelTransaction _llt;
-    public readonly CompactKey Key;
+    private CompactKey _key;
+    public CompactKey Key => _key;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public CompactKeyCacheScope(LowLevelTransaction tx)
     {
         _llt = tx;
-        Key = tx.AcquireCompactKey();
+        _key = tx.AcquireCompactKey();
     }
 
     public CompactKeyCacheScope(LowLevelTransaction tx, ReadOnlySpan<byte> key, long dictionaryId)
     {
         _llt = tx;
-        Key = tx.AcquireCompactKey();
-        Key.Set(key);
-        Key.ChangeDictionary(dictionaryId);
+        _key = tx.AcquireCompactKey();
+        _key.Set(key);
+        _key.ChangeDictionary(dictionaryId);
     }
 
     public void Dispose()
     {
         // We are getting an unsafe references on an scoped object because we are disposing anyways. 
-        _llt.ReleaseCompactKey(ref Unsafe.AsRef(Key));
+        _llt.ReleaseCompactKey(ref _key);
     }
 }

--- a/src/Voron/Util/ActiveTransactions.cs
+++ b/src/Voron/Util/ActiveTransactions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading;
 using Sparrow.Threading;
@@ -129,7 +130,7 @@ namespace Voron.Util
             return list;
         }
 
-        private static LowLevelTransaction InvalidLowLevelTransaction = (LowLevelTransaction)FormatterServices.GetUninitializedObject(typeof(LowLevelTransaction));
+        private static readonly LowLevelTransaction InvalidLowLevelTransaction = (LowLevelTransaction)RuntimeHelpers.GetUninitializedObject(typeof(LowLevelTransaction));
 
         private readonly MultipleUseFlag _compactionInProgress = new MultipleUseFlag();
 

--- a/src/Voron/Voron.csproj
+++ b/src/Voron/Voron.csproj
@@ -10,9 +10,6 @@
     <PackageTags>storage;acid;voron;ravendb;nosql</PackageTags>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;Validate</Configurations>
-    <LangVersion>preview</LangVersion>
-    <EnablePreviewFeatures>True</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>True</GenerateRequiresPreviewFeaturesAttribute>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <Compile Remove="Properties\AssemblyInfo.Linux.cs" />


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-7070

### Additional description
Remove struct and preview C# language warnings.

### Type of change
- Bug fix

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change
