### PR TITLE
RavenDB-21536 Revert "Disable codepaths with Vector128.Load on ARM platforms to avoid segmentation faults."

### DIFF
--- a/src/Corax/Utils/EntryIdEncodings.cs
+++ b/src/Corax/Utils/EntryIdEncodings.cs
@@ -7,7 +7,6 @@ using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 using Corax.Indexing;
-using Sparrow.Server.Platform;
 
 namespace Corax.Utils;
 
@@ -91,7 +90,7 @@ public static class EntryIdEncodings
             DecodeAndDiscardFrequencyClassic(entries.Slice(idX), read - idX);
         
     }
-
+    
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public static unsafe void DecodeAndDiscardFrequencyNeon(Span<long> entries, int read)
     {
@@ -131,7 +130,7 @@ public static class EntryIdEncodings
     {
         if (Avx2.IsSupported)
             DecodeAndDiscardFrequencyAvx2(entries, read);
-        else if (PlatformSpecific.IsArm == false && AdvSimd.IsSupported)
+        else if (AdvSimd.IsSupported)
             DecodeAndDiscardFrequencyNeon(entries, read);
         else
             DecodeAndDiscardFrequencyClassic(entries, read);

--- a/src/Sparrow.Server/Platform/PlatformSpecific.cs
+++ b/src/Sparrow.Server/Platform/PlatformSpecific.cs
@@ -14,10 +14,6 @@ namespace Sparrow.Server.Platform
 {
     public static unsafe class PlatformSpecific
     {
-        public static readonly bool IsArm = RuntimeInformation.ProcessArchitecture.HasFlag(Architecture.Arm) 
-                                             ||   RuntimeInformation.ProcessArchitecture.HasFlag(Architecture.Arm64);
-
-        
         public static class MemoryInformation
         {
             public static string IsSwappingOnHddInsteadOfSsd()

--- a/src/Sparrow.Server/Strings/StringsExtensions.cs
+++ b/src/Sparrow.Server/Strings/StringsExtensions.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
-using Sparrow.Server.Platform;
 
 namespace Sparrow.Server.Strings
 {
@@ -189,18 +188,6 @@ namespace Sparrow.Server.Strings
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe bool CompareConstantVector128(ref byte constantRef, byte* ptr, int size)
         {
-            if (PlatformSpecific.IsArm) // bug workaround. Should be removed after dotnet 7.0.15 release. https://github.com/ravendb/ravendb/pull/17651
-            {
-                for (int i = 0; i < size; ++i)
-                {
-                    ref var currentByte = ref Unsafe.Add(ref constantRef, i);
-                    if (*(ptr + i) != currentByte)
-                        return false;
-                }
-
-                return true;
-            }
-            
             if (size >= Vector128<byte>.Count)
             {
                 Vector128<byte> result = Vector128.Equals(

--- a/src/Voron/Data/Containers/Container.cs
+++ b/src/Voron/Data/Containers/Container.cs
@@ -9,7 +9,6 @@ using System.Runtime.Intrinsics;
 using System.Text;
 using Sparrow;
 using Sparrow.Server;
-using Sparrow.Server.Platform;
 using Voron.Data.Lookups;
 using Voron.Exceptions;
 using Voron.Global;
@@ -866,7 +865,7 @@ namespace Voron.Data.Containers
                         return (reqSize, pos + first);
                 }
             }
-            if (PlatformSpecific.IsArm == false && Vector128.IsHardwareAccelerated)
+            if (Vector128.IsHardwareAccelerated)
             {
                 for (; pos + Vector128<ushort>.Count <= numberOfOffsets; pos += Vector128<ushort>.Count)
                 {

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -7,7 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using Sparrow;
 using Sparrow.Server;
-using Sparrow.Server.Platform;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
 using Voron.Debugging;
@@ -789,7 +788,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
                 }
             }
 
-            if (PlatformSpecific.IsArm == false && Vector128.IsHardwareAccelerated)
+            if (Vector128.IsHardwareAccelerated)
             {
                 int N128 = (Vector128<ushort>.Count - 1);
                 while (newEntriesStartPtr - Vector128<ushort>.Count >= newEntriesEndPtr)

--- a/src/Voron/Util/PFor/FastPForDecoder.cs
+++ b/src/Voron/Util/PFor/FastPForDecoder.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualBasic.CompilerServices;
 using Sparrow.Binary;
 using Sparrow.Compression;
 using Sparrow.Server;
-using Sparrow.Server.Platform;
 using Voron.Data.PostingLists;
 
 namespace Voron.Util.PFor;
@@ -201,9 +200,7 @@ public unsafe struct FastPForDecoder : IDisposable
                 var ptr = (byte*)bigDeltaOffsets.RawItems[index] + 1;
                 index++;
 
-                Vector256<int> highBitsDelta = PlatformSpecific.IsArm == false 
-                    ? Vector128.Load(ptr).AsInt32().ToVector256() 
-                    : Vector256.Create(*(int*)ptr, *(int*)(ptr + sizeof(int)), *(int*)(ptr + 2 * sizeof(int)), *(int*)(ptr + 3 * sizeof(int)), 0, 0, 0, 0);
+                Vector256<int> highBitsDelta = Vector128.Load(ptr).AsInt32().ToVector256();
 
                 if ((bigDeltaOffsets.Count - index) > 0)
                 {


### PR DESCRIPTION
This reverts commit 2f68e90750b3ef8f7d812440f66d50c37e8d9d58.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21536

### Additional description

Since we moved to .NET8 we can enable intrinsic  on ARM platform.

### Type of change

- Revert workaround

### How risky is the change?


- Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

I've tested previous reproduction on ARM MacOs and it's not longer reproducible. Also .NET8 has different code-paths, see more at: https://github.com/dotnet/runtime/issues/93912#issuecomment-1778544956

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
