### PR TITLE
RavenDB-21749 - WhatChanged does not return old value for RemovedFiel…

### DIFF
--- a/src/Raven.Client/Json/BlittableOperation.cs
+++ b/src/Raven.Client/Json/BlittableOperation.cs
@@ -57,6 +57,9 @@ namespace Raven.Client.Json
 
             using var orderedProperties = newBlittable.GetPropertiesByInsertionOrder();
 
+            var newProp = new BlittableJsonReaderObject.PropertyDetails();
+            var oldProp = new BlittableJsonReaderObject.PropertyDetails();
+
             foreach (var field in removedFields)
             {
                 if (field.Equals(LastModified) ||
@@ -65,11 +68,11 @@ namespace Raven.Client.Json
                     continue;
                 if (changes == null)
                     return true;
-                NewChange(fieldPath, field, null, null, docChanges, DocumentsChanges.ChangeType.RemovedField);
-            }
 
-            var newProp = new BlittableJsonReaderObject.PropertyDetails();
-            var oldProp = new BlittableJsonReaderObject.PropertyDetails();
+                var oldPropId = originalBlittable.GetPropertyIndex(field);
+                originalBlittable.GetPropertyByIndex(oldPropId, ref oldProp);
+                NewChange(fieldPath, field, null, oldProp.Value, docChanges, DocumentsChanges.ChangeType.RemovedField);
+            }
 
             for (int i = 0; i < orderedProperties.Size; i++)
             {

--- a/test/SlowTests/Client/WhatChangedTests.cs
+++ b/test/SlowTests/Client/WhatChangedTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client
+{
+    public class WhatChangedTests : RavenTestBase
+    {
+        public WhatChangedTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public class Entity
+        {
+            public Dictionary<string, string> SomeData { get; set; } = new();
+        }
+
+        // RavenDB-21749
+        [RavenFact(RavenTestCategory.ClientApi)] 
+        public async Task WhatChanged_RemovedFieldFromDictionary()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Entity { SomeData = { { "Key", "Value" } } }, "entities/1");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var entity = await session.LoadAsync<Entity>("entities/1");
+
+                entity.SomeData.Remove("Key");
+
+                var changes = session.Advanced.WhatChanged()["entities/1"];
+
+                Assert.Equal(1, changes.Length);
+                Assert.Equal(DocumentsChanges.ChangeType.RemovedField, changes[0].Change);
+                Assert.Equal("Key", changes[0].FieldName);
+                Assert.Equal("Value", changes[0].FieldOldValue); // Note: This should not be null
+                Assert.Equal(null, changes[0].FieldNewValue);
+                Assert.Equal("SomeData", changes[0].FieldPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…d on Dictionary

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21749/WhatChanged-does-not-return-old-value-for-RemovedField-on-Dictionary

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
