### PR TITLE
RavenDB-20129 - Huge documents notification isn't updated when the do…

### DIFF
--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -289,6 +289,7 @@ namespace Raven.Server.Documents
 
                 _documentDatabase.Metrics.Docs.PutsPerSec.MarkSingleThreaded(1);
                 _documentDatabase.Metrics.Docs.BytesPutsPerSec.MarkSingleThreaded(document.Size);
+                _documentDatabase.HugeDocuments.AddIfDocIsHuge(id, document.Size);
 
                 context.Transaction.AddAfterCommitNotification(new DocumentChange
                 {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1789,6 +1789,7 @@ namespace Raven.Server.Documents
                 }
 
                 EnsureLastEtagIsPersisted(context, etag);
+                DocumentDatabase.HugeDocuments.RemoveHintIfNeeded(id);
 
                 if (fromReplication == false)
                 {

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -667,7 +667,6 @@ namespace Raven.Server.Documents.Handlers
                                         var document = cmd.Document.Clone(context);
                                         var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, document, changeVector: changeVector,
                                             flags: DocumentFlags.FromClusterTransaction);
-                                        context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, document.Size);
                                         AddPutResult(putResult);
                                     }
                                     else
@@ -911,7 +910,6 @@ namespace Raven.Server.Documents.Handlers
                                 throw;
                             }
 
-                            context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(putResult.Id, cmd.Document.Size);
                             AddPutResult(putResult);
                             lastPutResult = putResult;
                             break;

--- a/src/Raven.Server/Documents/HugeDocuments.cs
+++ b/src/Raven.Server/Documents/HugeDocuments.cs
@@ -74,6 +74,25 @@ namespace Raven.Server.Documents
             }
         }
 
+        public void RemoveHintIfNeeded(string id)
+        {
+            if (_performanceHint == null)
+                return;
+
+            if (_details.HugeDocuments.ContainsKey(id) == false) 
+                return;
+
+            _needsSync = true;
+
+            _details.HugeDocuments.TryRemove(id, out _);
+
+            if (_details.HugeDocuments.Count > 0) 
+                return;
+
+            _performanceHint = null;
+            _notificationCenter.Dismiss(HugeDocumentsId);
+        }
+
         internal void UpdateHugeDocuments(object state)
         {
             try

--- a/test/SlowTests/Server/NotificationCenter/HugeDocuments.cs
+++ b/test/SlowTests/Server/NotificationCenter/HugeDocuments.cs
@@ -1,19 +1,21 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
-using FastTests;
+using FastTests.Server.Replication;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Server.Config;
+using Raven.Server.Documents;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Server.NotificationCenter
 {
-    public class HugeDocuments : RavenTestBase
+    public class HugeDocuments : ReplicationTestBase
     {
         public HugeDocuments(ITestOutputHelper output) : base(output)
         {
@@ -165,6 +167,116 @@ namespace SlowTests.Server.NotificationCenter
                         Assert.Equal(2, details.HugeDocuments.Count);
                     }
                 }
+            }
+        }
+
+        // RavenDB-20129
+        [RavenFact(RavenTestCategory.None)]
+        public async Task ShouldUpdateNotificationAfterHugeDocumentDelete()
+        {
+            using (var store = GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.PerformanceHints.HugeDocumentSize)] = "0"
+            }))
+            {
+                string documentId = "users/1";
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), documentId);
+                    session.SaveChanges();
+                }
+
+                var database = await GetDatabase(store.Database);
+
+                database.HugeDocuments.UpdateHugeDocuments(null);
+
+                AssertHugeDocumentsDetails(database, documentId);
+
+                using (var session = store.OpenSession())
+                {
+                    session.Delete(documentId);
+                    session.SaveChanges();
+                }
+
+                AssertNotificationRemoved(database);
+            }
+        }
+
+        // RavenDB-20129
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task ShouldUpdateNotificationAfterHugeDocumentDeleteFromReplication()
+        {
+            var options = new Options
+            {
+                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.PerformanceHints.HugeDocumentSize)] = "0"
+            };
+
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            {
+                string documentId = "users/1";
+                using (var session = store1.OpenSession())
+                {
+                    session.Store(new User(), documentId);
+                    session.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                Assert.NotNull(await WaitForDocumentToReplicateAsync<User>(store2, documentId, 15_000));
+
+                var database1 = await GetDatabase(store1.Database);
+                var database2 = await GetDatabase(store2.Database);
+
+                database1.HugeDocuments.UpdateHugeDocuments(null);
+                database2.HugeDocuments.UpdateHugeDocuments(null);
+
+                AssertHugeDocumentsDetails(database1, documentId);
+                AssertHugeDocumentsDetails(database2, documentId);
+
+                using (var session = store1.OpenSession())
+                {
+                    session.Delete(documentId);
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocumentDeletion(store2, documentId));
+
+                AssertNotificationRemoved(database1);
+                AssertNotificationRemoved(database2);
+            }
+        }
+
+        private void AssertHugeDocumentsDetails(DocumentDatabase database, string documentId)
+        {
+            Assert.True(database.ConfigurationStorage.NotificationsStorage.GetPerformanceHintCount() > 0);
+
+            using (database.ConfigurationStorage.NotificationsStorage.Read(Raven.Server.Documents.HugeDocuments.HugeDocumentsId, out var ntv))
+            {
+                if (ntv == null || ntv.Json.TryGet(nameof(PerformanceHint.Details), out BlittableJsonReaderObject detailsJson) == false || detailsJson == null)
+                {
+                    Assert.False(true, "Unable to read stored notification");
+                }
+                else
+                {
+                    HugeDocumentsDetails details = (HugeDocumentsDetails)DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable(
+                        typeof(HugeDocumentsDetails),
+                        detailsJson,
+                        Raven.Server.Documents.HugeDocuments.HugeDocumentsId);
+
+                    Assert.NotNull(details);
+                    Assert.Equal(1, details.HugeDocuments.Count);
+
+                    var id = details.HugeDocuments.Values.Select(x => x.Id).FirstOrDefault();
+                    Assert.Equal(documentId, id);
+                }
+            }
+        }
+
+        private void AssertNotificationRemoved(DocumentDatabase database)
+        {
+            using (database.ConfigurationStorage.NotificationsStorage.Read(Raven.Server.Documents.HugeDocuments.HugeDocumentsId, out var ntv))
+            {
+                Assert.True(ntv == null || ntv.Json.TryGet(nameof(PerformanceHint.Details), out BlittableJsonReaderObject detailsJson) == false || detailsJson == null);
             }
         }
     }


### PR DESCRIPTION
…cument is deleted

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20129/Huge-documents-notification-isnt-updated-when-the-document-is-deleted

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
