### PR TITLE
RavenDB-17686 - SlowTests.Server.Replication.ReplicationCleanTombstones.EtlTombstonesInTheCluster

### DIFF
--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -358,6 +358,8 @@ namespace SlowTests.Server.Replication
                     session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
                     session.Store(new User { Name = "Karmel" }, "foo/bar");
                     session.SaveChanges();
+
+                    Assert.True(await WaitForDocumentInClusterAsync<User>(cluster.Nodes, store.Database, "foo/bar", (u) => u.Name == "Karmel", TimeSpan.FromSeconds(15)));
                 }
 
                 if (sent.Wait(TimeSpan.FromSeconds(30)) == false)
@@ -416,6 +418,7 @@ namespace SlowTests.Server.Replication
 
                 var res = WaitForDocument(dest, "marker2");
                 Assert.True(res);
+                Assert.True(await WaitForChangeVectorInClusterAsync(cluster.Nodes.Where(s => (s.Disposed == false)).ToList(), store.Database));
 
                 string changeVectorMarker2;
 
@@ -436,18 +439,21 @@ namespace SlowTests.Server.Replication
                 {
                     if (server.Disposed)
                         continue;
+
                     var storage = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-                    var cleanerRes = await storage.TombstoneCleaner.ExecuteCleanup();
+                    long cleanerRes = 0;
                     using (storage.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     {
-                        var val = await WaitForValueAsync(() =>
+                        var val = await WaitForValueAsync(async () =>
                         {
+                            cleanerRes = await storage.TombstoneCleaner.ExecuteCleanup();
                             using (context.OpenReadTransaction())
                             {
                                 return storage.DocumentsStorage.GetNumberOfTombstones(context);
                             }
                         }, 0);
-                        Assert.True(0 == val, $"TombstoneCleaner result = {cleanerRes},");
+                        Assert.True(0 == val, $"TombstoneCleaner result = {cleanerRes}, actual number of existing tombstones = {val}" +
+                                              $"{Environment.NewLine}current server: {server.ServerStore.NodeTag}");
                     }
                 }
             }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17686/SlowTests.Server.Replication.ReplicationCleanTombstones.EtlTombstonesInTheCluster

### Additional description

I have reproduced the failure by changing the source database topology multiple times. It seems the problem was calling `storage.TombstoneCleaner.ExecuteCleanup()` only once. 

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
