### PR TITLE
RavenDB-21638 'show backup progress' does not open dialog when clicked on non-responsible node in the Studio

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
@@ -104,8 +104,10 @@ function Details(props: PeriodicBackupPanelProps) {
 
     const localNodeTag = useAppSelector(clusterSelectors.localNodeTag);
 
+    const isResponsible = data.shared.responsibleNodeTag === localNodeTag;
+
     const onGoingBackup = data.nodesInfo.map((x) => x.details?.onGoingBackup).find((x) => x);
-    const runningOnAnotherNode = onGoingBackup && data.shared.responsibleNodeTag !== localNodeTag;
+    const runningOnAnotherNode = onGoingBackup && !isResponsible;
 
     const onGoingBackupHumanized = useMemo(() => {
         if (!onGoingBackup) {
@@ -203,7 +205,7 @@ function Details(props: PeriodicBackupPanelProps) {
                         title={backupNowBlockReason ?? "Click to trigger the backup task now"}
                     >
                         <Icon icon="backup" />
-                        <span>{backupNowInProgress ? "Show backup progress" : "Backup now"}</span>
+                        <span>{isResponsible && backupNowInProgress ? "Show backup progress" : "Backup now"}</span>
                     </Badge>
                 )}
             </RichPanelDetailItem>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21638/show-backup-progress-does-not-open-dialog-when-clicked-on-non-responsible-node-in-the-Studio

### Additional description

In this case the button will be disabled, with text "Backup now", and title "Backup in progress on node ..."

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

![image](https://github.com/ravendb/ravendb/assets/47967925/3df7a30c-d641-45ab-a5d7-a16eaf353cc5)
