### PR TITLE
RavenDB-21840: Optimizing reset mechanism to avoid memory allocation.

### DIFF
--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -145,7 +145,7 @@ namespace Corax.Querying.Matches
                 _itBuffer = (long*)bs.Ptr;
                 _containerItemsScope = _allocator.Allocate(BufferSize * sizeof(UnmanagedSpan), out bs);
                 _containerItems = (UnmanagedSpan*)bs.Ptr;
-                _pageLocator = new PageLocator(searcher._transaction.LowLevelTransaction);
+                _pageLocator = new PageLocator();
             }
 
             public void Reset(ref MultiTermMatch<TTermProvider> match)

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
@@ -282,7 +282,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
             _itBuffer = (long*)bs.Ptr;
             _containerItemsScope = llt.Allocator.Allocate(BufferSize * sizeof(UnmanagedSpan), out bs);
             _containerItems = (UnmanagedSpan*)bs.Ptr;
-            _pageLocator = new PageLocator(llt);
+            _pageLocator = llt.PageLocator;
         }
 
 
@@ -572,12 +572,9 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
         // Initialize the important infrastructure for the sorting.
         TEntryComparer entryComparer = new();
         entryComparer.Init(ref match);
-            
-        var pageCache = new PageLocator(llt);
         
-        entryComparer.SortBatch(ref match, llt, pageCache, batchResults, batchTermIds, termsPtr);
+        entryComparer.SortBatch(ref match, llt, llt.PageLocator, batchResults, batchTermIds, termsPtr);
 
-        pageCache.Release();
         bufScope.Dispose();
     }
 

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.cs
@@ -178,7 +178,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         // Initialize the important infrastructure for the sorting.
         TComparer1 entryComparer = new();
         entryComparer.Init(ref match, default, 0);
-        var pageCache = new PageLocator(llt);
+        var pageCache = llt.PageLocator;
         fixed (long* ptrBatchResults = batchResults)
         {
             var resultsPtr = new UnmanagedSpan<long>(ptrBatchResults, sizeof(long)* batchResults.Length);
@@ -196,7 +196,6 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             entryComparer.SortBatch(ref match, llt, pageCache, resultsPtr, batchTermIds, termsPtr, match._orderMetadata, comp2, comp3);
         }
 
-        pageCache.Release();
         bufScope.Dispose();
     }
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -937,6 +937,8 @@ namespace Voron.Impl
         public bool IsDisposed => _txState.HasFlag(TxState.Disposed);
 
         public NativeMemory.ThreadStats CurrentTransactionHolder { get; set; }
+        
+        public PageLocator PageLocator => _pageLocator;
 
         public void Dispose()
         {

--- a/src/Voron/PageLocator.cs
+++ b/src/Voron/PageLocator.cs
@@ -1,13 +1,12 @@
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Sparrow.Server;
-using Voron.Impl;
 
 namespace Voron
 {
 
-    public sealed unsafe class PageLocator
+    public sealed class PageLocator
     {
         [StructLayout(LayoutKind.Explicit, Size = 20)]
         private struct PageData
@@ -17,45 +16,18 @@ namespace Voron
             [FieldOffset(8)]
             public Page Page;
             [FieldOffset(16)]
+            public ushort Generation;
+            [FieldOffset(18)]
             public bool IsWritable;
         }
 
         private const long Invalid = -1;
-        private LowLevelTransaction _tx;
+        private ushort _generation = 1;
 
-        private PageData* _cache;
-        private ByteString _cacheMemory;
+        private readonly PageData[] _cache = new PageData[CacheSize];
 
         private const uint CacheSize = 1024;
         private const uint CacheMask = CacheSize - 1;
-
-        public void Release()
-        {
-            if (_tx == null)
-                return;
-
-            _tx.Allocator.Release(ref _cacheMemory);
-            _tx = null;
-            _cache = null;
-        }
-
-        public void Renew(LowLevelTransaction tx)
-        {
-            Debug.Assert(tx != null);
-
-            _tx = tx;
-
-            tx.Allocator.Allocate((int)CacheSize * sizeof(PageData), out _cacheMemory);
-            _cache = (PageData*)_cacheMemory.Ptr;
-
-            for (var i = 0; i < CacheSize; i++)
-                _cache[i].PageNumber = Invalid;
-        }
-
-        public PageLocator(LowLevelTransaction tx)
-        {
-            Renew(tx);
-        }
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -64,9 +36,9 @@ namespace Voron
             ulong bucket = (ulong)pageNumber & CacheMask;
             Debug.Assert(bucket is >= 0 and < CacheSize);
 
-            ref var node = ref _cache[bucket];
+            ref var node = ref Unsafe.Add(ref _cache[0], (int)bucket);
             page = node.Page;
-            return node.PageNumber == pageNumber && node.PageNumber != Invalid;
+            return node.Generation == _generation && node.PageNumber == pageNumber && node.PageNumber != Invalid;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -77,9 +49,21 @@ namespace Voron
 
             ref var node = ref Unsafe.Add(ref _cache[0], (int)bucket);
             page = node.Page;
-            return node.IsWritable && node.PageNumber == pageNumber && node.PageNumber != Invalid;
+            return node.Generation == _generation && node.IsWritable && node.PageNumber == pageNumber && node.PageNumber != Invalid;
         }
 
+        public void Renew()
+        {
+            _generation++;
+
+            // We are using 16 bits to store the generation, therefore if we are reusing the values after an overflow,
+            // we should reset the whole array. 
+            if (_generation == 0)
+            {
+                _generation = 1;
+                MemoryMarshal.Cast<PageData, byte>(_cache).Fill(0);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Reset(long pageNumber)
@@ -109,6 +93,7 @@ namespace Voron
             {
                 node.PageNumber = pageNumber;
                 node.Page = page;
+                node.Generation = _generation;
                 node.IsWritable = false;
             }
         }
@@ -127,6 +112,7 @@ namespace Voron
             {
                 node.PageNumber = pageNumber;
                 node.Page = page;
+                node.Generation = _generation;
                 node.IsWritable = true;
             }
         }

--- a/src/Voron/TransactionPersistentContext.cs
+++ b/src/Voron/TransactionPersistentContext.cs
@@ -32,11 +32,11 @@ namespace Voron
             if (_pageLocators.Count != 0)
             {
                 locator = _pageLocators.Pop();
-                locator.Renew(tx);
+                locator.Renew();
             }
             else
             {
-                locator = new PageLocator(tx);
+                locator = new PageLocator();
             }
             return locator;
         }
@@ -44,7 +44,6 @@ namespace Voron
         public void FreePageLocator(PageLocator locator)
         {
             Debug.Assert(locator != null);
-            locator.Release();
             if (_pageLocators.Count < 1024)
                 _pageLocators.Push(locator);
         }

--- a/test/SlowTests/Voron/Issues/RavenDB_12506.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_12506.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Voron.Issues
         {
             using (var tx = Env.WriteTransaction())
             {
-                var pageLocator = new PageLocator(tx.LowLevelTransaction);
+                var pageLocator = tx.LowLevelTransaction.PageLocator;
 
                 Assert.False(pageLocator.TryGetReadOnlyPage(-1, out _));
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21840

### Additional description

Currently the `.Reset()` operations requires us to acquire new memory and reset. This can be avoided by just including a generation counter and checking it. Since that can be done, there is no reason why we wouldn't keep the page locator cache in managed memory anyways. 

The side effect is that now we also optimized the Corax access to the page locator and reuse the transaction's one without having to initialize the memory.

### Type of change
- Optimization

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change