### PR TITLE
RavenDB-19481 - Fix reapply cluster transactions after restore

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -46,6 +46,7 @@ namespace Raven.Server.Documents
         private static readonly Slice LastReplicatedEtagsSlice;
         private static readonly Slice EtagsSlice;
         private static readonly Slice LastEtagSlice;
+        private static readonly Slice LastCompletedClusterTransactionIndexSlice;
         private static readonly Slice GlobalTreeSlice;
         private static readonly Slice GlobalChangeVectorSlice;
         private static readonly Slice GlobalFullChangeVectorSlice;
@@ -107,6 +108,7 @@ namespace Raven.Server.Documents
             {
                 Slice.From(ctx, "AllTombstonesEtags", ByteStringType.Immutable, out AllTombstonesEtagsSlice);
                 Slice.From(ctx, "Etags", ByteStringType.Immutable, out EtagsSlice);
+                Slice.From(ctx, "LastCompletedClusterTransactionIndex", ByteStringType.Immutable, out LastCompletedClusterTransactionIndexSlice);
                 Slice.From(ctx, "LastEtag", ByteStringType.Immutable, out LastEtagSlice);
                 Slice.From(ctx, "Docs", ByteStringType.Immutable, out DocsSlice);
                 Slice.From(ctx, "CollectionEtags", ByteStringType.Immutable, out CollectionEtagsSlice);
@@ -677,6 +679,32 @@ namespace Raven.Server.Documents
 
             return 0;
         }
+
+        public static long ReadLastCompletedClusterTransactionIndex(Transaction tx)
+        {
+            if (tx == null)
+                throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
+            var tree = tx.ReadTree(GlobalTreeSlice);
+            if (tree == null)
+            {
+                return 0;
+            }
+            var readResult = tree.Read(LastCompletedClusterTransactionIndexSlice);
+            if (readResult == null)
+            {
+                return 0;
+            }
+
+            return readResult.Reader.ReadLittleEndianInt64();
+        }
+
+        public void SetLastCompletedClusterTransactionIndex(DocumentsOperationContext context, long index)
+        {
+            var tree = context.Transaction.InnerTransaction.CreateTree(GlobalTreeSlice);
+            using (Slice.External(context.Allocator, (byte*)&index, sizeof(long), out Slice indexSlice))
+                tree.Add(LastCompletedClusterTransactionIndexSlice, indexSlice);
+        }
+
 
         public static long ReadLastEtag(Transaction tx)
         {

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -552,7 +552,7 @@ namespace Raven.Server.ServerWide.Commands
         }
 
 
-        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long take = 128)
+        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long? lastCompletedClusterTransactionIndex = null, long take = 128)
             where TTransaction : RavenTransaction
         {
             var lowerDb = database.ToLowerInvariant();
@@ -569,6 +569,8 @@ namespace Raven.Server.ServerWide.Commands
                     if (result.Database != lowerDb) // beware of reading commands of other databases.
                         continue;
                     if (result.PreviousCount < fromCount)
+                        continue;
+                    if(lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
                         continue;
                     if (take <= 0)
                         yield break;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3617,6 +3617,7 @@ namespace Raven.Server.ServerWide
             internal bool StopIndex;
             internal Action<CompareExchangeCommandBase> ModifyCompareExchangeTimeout;
             internal Action RestoreDatabaseAfterSavingDatabaseRecord;
+            internal Action<string, long, long> BeforeExecuteClusterTransaction;
         }
         
         public readonly MemoryCache QueryClauseCache;

--- a/test/SlowTests/Issues/RavenDB-19481.cs
+++ b/test/SlowTests/Issues/RavenDB-19481.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Graph;
+using FastTests.Utils;
+using Nest;
+using NetTopologySuite.Utilities;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Session;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using static Raven.Server.Smuggler.Documents.CounterItem;
+using Assert = Xunit.Assert;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19481 : RavenTestBase
+    {
+        public RavenDB_19481(ITestOutputHelper output) : base(output)
+        {
+        }
+
+
+        [RavenFact(RavenTestCategory.Smuggler)]
+        public async Task ShouldntReapplyClusterTransactionTwiceInRestore()
+        {
+            DoNotReuseServer();
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var store = GetDocumentStore())
+            {
+                const string id = "users/1";
+
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
+
+                using (var session = store.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Grisha"
+                    }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+                Assert.Equal(1, stats.CountOfRevisionDocuments);
+
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                await Backup.RunBackupAndReturnStatusAsync(Server, backupTaskId, store, isFullBackup: false, expectedEtag: 4);
+
+                var databaseName = $"restored_database-{Guid.NewGuid()}";
+
+                int failover = 0;
+                Server.ServerStore.ForTestingPurposesOnly().BeforeExecuteClusterTransaction = (dbName, lastCtxIndex, batchCount) =>
+                {
+                    if (dbName == databaseName)
+                    {
+                        if (lastCtxIndex == 0 || batchCount==1) // can happen only once
+                        {
+                            Assert.False(Interlocked.Increment(ref failover) > 1, "Cluster Transaction was reapplied");
+                        }
+                    }
+                };
+
+                using (Backup.RestoreDatabase(store,
+                           new RestoreBackupConfiguration
+                           {
+                               BackupLocation = Directory.GetDirectories(backupPath).First(),
+                               DatabaseName = databaseName
+                           }))
+                {
+                }
+
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19481/Cluster-transactions-are-reapplied-after-restore

### Additional description

Cluster transaction reply twice after restore, one time on the restore and second time on the database 'Initialize' after the restore.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- Yes. Please list the affected platforms.

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
