### PR TITLE
RavenDB-21819 Allow user to boost spatial primitive. | Disjoint fix

### DIFF
--- a/src/Corax/Querying/Spatials/IndexSearcher.Spatial.cs
+++ b/src/Corax/Querying/Spatials/IndexSearcher.Spatial.cs
@@ -18,8 +18,10 @@ public partial class IndexSearcher
             // If either the term or the field does not exist the request will be empty. 
             return TermMatch.CreateEmpty(this, Allocator);
         }
-
-        var match = new SpatialMatch(this, _transaction.Allocator, spatialContext, field, shape, terms, error, spatialRelation, token);
+        
+        IQueryMatch match = field.HasBoost 
+            ? new SpatialMatch<HasBoosting>(this, _transaction.Allocator, spatialContext, field, shape, terms, error, spatialRelation, token)
+            : new SpatialMatch<NoBoosting>(this, _transaction.Allocator, spatialContext, field, shape, terms, error, spatialRelation, token);
         if (isNegated)
         {
             return AndNot(AllEntries(), match);

--- a/src/Corax/Utils/Spatial/SpatialUtils.cs
+++ b/src/Corax/Utils/Spatial/SpatialUtils.cs
@@ -114,7 +114,7 @@ public sealed class SpatialUtils
                     boundary = GeohashUtils.DecodeBoundary(geohashToCheck, ctx);
                 }
 
-                switch (shape.Relate(boundary))
+                switch (boundary.Relate(shape))
                 {
                     case Spatial4n.Shapes.SpatialRelation.Disjoint:
                         //Our termatch
@@ -131,10 +131,12 @@ public sealed class SpatialUtils
                         }
 
                         break;
+                    
+                    //Our figure contains whole boundary so we've to skip.
                     case Spatial4n.Shapes.SpatialRelation.Within:
-                    case Spatial4n.Shapes.SpatialRelation.Contains:
-                        //Inside figure, we can denied this geohash.
                         break;
+                    //Contains means our figure is within boundary, we've to go deeper to find out more information about it.
+                    case Spatial4n.Shapes.SpatialRelation.Contains:
                     case Spatial4n.Shapes.SpatialRelation.Intersects:
                         using (var _ = Slice.From(allocator, geohashToCheck, out var term))
                         {

--- a/test/FastTests/Corax/SpatialBoostingInCorax.cs
+++ b/test/FastTests/Corax/SpatialBoostingInCorax.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Spatial;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax;
+
+public class SpatialBoostingInCorax : RavenTestBase
+{
+    public SpatialBoostingInCorax(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void CanCoraxCalculateScoringForSpatial()
+    {
+        var docs = new List<SpatialDto>();
+        docs.Add(new SpatialDto() {Lat = 0.01, Lon = 0.01});
+        docs.Add(new SpatialDto() {Lat = 4, Lon = 4});
+        docs.Add(new SpatialDto() {Lat = 2, Lon = 2});
+        docs.Add(new SpatialDto() {Lat = 8, Lon = 8});
+        docs.Add(new SpatialDto() {Lat = 15, Lon = 15});
+        docs.Add(new SpatialDto() {Lat = 16, Lon = 16});
+
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using (var session = store.OpenSession())
+        {
+            foreach (var s in docs)
+                session.Store(s);
+            
+            session.SaveChanges();
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+            var results = session.Query<SpatialDto, Index>().Customize(i => i.WaitForNonStaleResults())
+                .Spatial("Spatial", factory => factory.WithinRadius(12 * 1.1512 * 60, 0, 0, SpatialUnits.Miles)).OrderByScore().ToList();
+            
+            Assert.Equal(4, results.Count);
+            Assert.Equal(docs[0].Id, results[0].Id);
+            Assert.Equal(docs[2].Id, results[1].Id);
+            Assert.Equal(docs[1].Id, results[2].Id);
+            Assert.Equal(docs[3].Id, results[3].Id);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void CanCoraxCalculateScoringForSpatialDisjoint()
+    {
+        var docs = new List<SpatialDto>();
+        docs.Add(new SpatialDto() {Lat = 0.01, Lon = 0.01});
+        docs.Add(new SpatialDto() {Lat = 4, Lon = 4});
+        docs.Add(new SpatialDto() {Lat = 2, Lon = 2});
+        docs.Add(new SpatialDto() {Lat = 8, Lon = 8});
+        docs.Add(new SpatialDto() {Lat = 15, Lon = 15});
+        docs.Add(new SpatialDto() {Lat = 16, Lon = 16});
+
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using (var session = store.OpenSession())
+        {
+            foreach (var s in docs)
+                session.Store(s);
+            
+            session.SaveChanges();
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+            var results = session.Query<SpatialDto, Index>().Customize(i => i.WaitForNonStaleResults())
+                .Spatial("Spatial", factory => factory.Disjoint("POLYGON ((5 10, 10 5, 15 10, 10 15, 5 10))", SpatialUnits.Miles)).OrderByScore().ToList();
+            Assert.Equal(5, results.Count);
+            Assert.Equal(docs[0].Id, results[0].Id);
+            Assert.Equal(docs[2].Id, results[1].Id);
+            Assert.Equal(docs[1].Id, results[2].Id);
+            Assert.Equal(docs[5].Id, results[3].Id);
+            Assert.Equal(docs[4].Id, results[4].Id);
+        }
+    }
+    private class Index : AbstractIndexCreationTask<SpatialDto>
+    {
+        public Index()
+        {
+            Map = dtos => dtos.Select(x => new {Spatial = CreateSpatialField(x.Lat, x.Lon)});
+        }
+    }
+
+    private class SpatialDto()
+    {
+        public double Lat { get; set; }
+        public double Lon { get; set; }
+        public string Id { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21819

### Additional description

Calculates relevance by distance to the center of the figure. When spatial relation is not disjoint, we treat the center as the most relevant point and grant it a score of 1.01 (*boostFactor).  We take the whole result set as a subset, so the farthest point returned by this query is the least relevant point and gets a score of 0.01 (just not being 0).  Scores for points in between are just proportions between the center and the farthest. On the other hand, when the query is DISJOINT, we negate the formula. Now the center is the least relevant, and the farthest is most relevant. In this case center is 0.01 but for most queries there is impossible go get this (it's possible when center is outside body of figure). This allow us to avoid cases when points are very close to each other but gets very different scores.

### Type of change

- Bug fix
- New feature

### How risky is the change?

- Low 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.


### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
