### PR TITLE
RavenDB-21850: Changes to improve the patching performance

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/IBatchCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/IBatchCommand.cs
@@ -5,6 +5,8 @@ namespace Raven.Server.Documents.Handlers.Batches.Commands;
 
 public interface IBatchCommand : IDisposable
 {
+    public bool IncludeReply { get; set; }
+
     public HashSet<string> ModifiedCollections { get; set; }
 
     public string LastChangeVector { get; set; }

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/TransactionMergedCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/TransactionMergedCommand.cs
@@ -23,9 +23,12 @@ public abstract class TransactionMergedCommand : DocumentMergedTransactionComman
 
     public bool IsClusterTransaction { get; set; }
 
+    public bool IncludeReply { get; set; }
+
     protected TransactionMergedCommand(DocumentDatabase database)
     {
         Database = database;
+        IncludeReply = true;
     }
 
     protected void AddPutResult(DocumentsStorage.PutOperationResults putResult)

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
@@ -16,7 +16,7 @@ using Sparrow.Json.Parsing;
 namespace Raven.Server.Documents.Handlers.Processors.Batches;
 
 internal abstract class AbstractBatchHandlerProcessorForBulkDocs<TBatchCommand, TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
-    where TBatchCommand : IBatchCommand
+    where TBatchCommand : class, IBatchCommand
     where TOperationContext : JsonOperationContext
     where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
 {
@@ -111,10 +111,7 @@ internal abstract class AbstractBatchHandlerProcessorForBulkDocs<TBatchCommand, 
                 if (indexBatchOptions != null)
                     command.ModifiedCollections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                if (HttpContext.Request.Query.TryGetValue("noreply", out var noReply))
-                {
-                    command.IncludeReply = !bool.Parse(noReply);
-                }
+                command.IncludeReply = RequestHandler.GetBoolValueQueryString("noreply", required: false) ?? true;
 
                 var results = await HandleTransactionAsync(context, command, indexBatchOptions, replicationBatchOptions);
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
@@ -111,6 +111,11 @@ internal abstract class AbstractBatchHandlerProcessorForBulkDocs<TBatchCommand, 
                 if (indexBatchOptions != null)
                     command.ModifiedCollections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+                if (HttpContext.Request.Query.TryGetValue("noreply", out var noReply))
+                {
+                    command.IncludeReply = !bool.Parse(noReply);
+                }
+
                 var results = await HandleTransactionAsync(context, command, indexBatchOptions, replicationBatchOptions);
 
                 if (replicationBatchOptions != null)

--- a/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommand.cs
@@ -29,6 +29,8 @@ public sealed class ShardedBatchCommand : IBatchCommand
     public ArraySegment<BatchRequestParser.CommandData> ParsedCommands;
     public List<Stream> AttachmentStreams;
 
+    public bool IncludeReply { get; set; }
+
     public HashSet<string> ModifiedCollections { get; set; }
 
     public string LastChangeVector { get; set; }
@@ -41,6 +43,8 @@ public sealed class ShardedBatchCommand : IBatchCommand
     {
         _context = context;
         _databaseContext = databaseContext;
+        
+        IncludeReply = true;
     }
 
     public Dictionary<int, ShardedSingleNodeBatchCommand> GetCommands(ShardedBatchBehavior behavior, IndexBatchOptions indexBatchOptions, ReplicationBatchOptions replicationBatchOptions)

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -287,16 +287,19 @@ namespace Raven.Server.Web
 
         public virtual long? GetLongFromHeaders(string name)
         {
-            var headers = HttpContext.Request.Headers[name];
+            HttpContext.Request.Headers.TryGetValue(name, out var headers);
             if (headers.Count == 0)
                 return null;
 
-            var raw = headers[0][0] == '\"'
-                ? headers[0].AsSpan().Slice(1, headers[0].Length - 2)
-                : headers[0].AsSpan();
+            var header = headers[0];
+            if (header == null)
+                return null;
+
+            var raw = header.AsSpan();
+            if (raw[0] == '\"')
+                raw = raw.Slice(1, raw.Length - 2);
 
             var success = long.TryParse(raw, out var result);
-
             if (success)
                 return result;
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21850

### Additional description
Patching requires parsing of the script, by moving the parsing outside of the critical path, improves the throughput of patching operations by minimizing the time within a write lock. 


### Type of change
- Optimization

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change