### PR TITLE
RavenDB-21174 & RavenDB-21468: Addressing known sources of lock convoys.

### DIFF
--- a/src/Sparrow/Json/PerCoreStatic.cs
+++ b/src/Sparrow/Json/PerCoreStatic.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Sparrow.Utils;
+
+namespace Sparrow.Json
+{
+    public sealed class PerCoreStatic<T> where T : class
+    {
+        private readonly T[] _perCoreArrays;
+
+        public PerCoreStatic(Func<T> creationFunc)
+        {
+            _perCoreArrays = new T[Environment.ProcessorCount];
+            for (int i = 0; i < _perCoreArrays.Length; i++)
+                _perCoreArrays[i] = creationFunc();
+        }
+
+        public T Get()
+        {
+            return _perCoreArrays[CurrentProcessorIdHelper.GetCurrentProcessorId() % _perCoreArrays.Length];
+        }
+    }
+}

--- a/src/Voron/Data/CompactTrees/CompactKey.cs
+++ b/src/Voron/Data/CompactTrees/CompactKey.cs
@@ -3,9 +3,9 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 using System.Text;
 using Sparrow.Binary;
+using Sparrow.Json;
 using Sparrow.Server;
 using Voron.Exceptions;
 using Voron.Global;
@@ -20,8 +20,7 @@ public sealed unsafe class CompactKey : IDisposable
 {
     public static readonly CompactKey NullInstance = new();
 
-    [ThreadStatic]
-    private static ArrayPool<byte> StoragePool;
+    private static readonly PerCoreStatic<ArrayPool<byte>> StoragePool = new (ArrayPool<byte>.Create);
 
     private LowLevelTransaction _owner;
 
@@ -75,9 +74,7 @@ public sealed unsafe class CompactKey : IDisposable
         _currentIdx = 0;
         MaxLength = 0;
 
-        StoragePool ??= ArrayPool<byte>.Create();
-
-        _storage = StoragePool.Rent(2 * Constants.CompactTree.MaximumKeySize);
+        _storage = StoragePool.Get().Rent(2 * Constants.CompactTree.MaximumKeySize);
     }
 
     public void Reset()
@@ -87,7 +84,7 @@ public sealed unsafe class CompactKey : IDisposable
 
         _owner = null;
 
-        StoragePool.Return(_storage);
+        StoragePool.Get().Return(_storage);
         _storage = null;
     }
 
@@ -226,10 +223,11 @@ public sealed unsafe class CompactKey : IDisposable
         // Request more memory, copy the content and return it.
         maxSize = Math.Max(maxSize, _storage.Length) * 2;
 
-        var storage = StoragePool.Rent(maxSize);
+        var storagePool = StoragePool.Get();
+        var storage = storagePool.Rent(maxSize);
         _storage.AsSpan(0, _currentIdx).CopyTo(storage.AsSpan());
-        
-        StoragePool.Return(_storage); // Return old to pool.
+
+        storagePool.Return(_storage); // Return old to pool.
         _storage = storage; // Update the new references.
     }
 

--- a/src/Voron/Data/CompactTrees/CompactKey.cs
+++ b/src/Voron/Data/CompactTrees/CompactKey.cs
@@ -19,20 +19,30 @@ namespace Voron.Data.CompactTrees;
 public sealed unsafe class CompactKey : IDisposable
 {
     public static readonly CompactKey NullInstance = new();
-    
-    private static readonly ArrayPool<byte> StoragePool = ArrayPool<byte>.Shared;
-    private static readonly ArrayPool<long> KeyMappingPool = ArrayPool<long>.Shared;
+
+    [ThreadStatic]
+    private static ArrayPool<byte> StoragePool;
 
     private LowLevelTransaction _owner;
 
     private const int MappingTableSize = 64;
     private const int MappingTableMask = MappingTableSize - 1;
 
-    private long[] _keyMappingCache;
-    private ref long KeyMappingCache(int i) => ref _keyMappingCache[i];
-    private ref long KeyMappingCacheIndex(int i) => ref _keyMappingCache[MappingTableSize + i];
+    private struct KeyMappingCache
+    {
+        private fixed long _keyMappingCache[MappingTableSize * 2];
 
+        public long GetMap(int i) => _keyMappingCache[i];
+        public long GetIndex(int i) => _keyMappingCache[MappingTableSize + i];
 
+        public void Set(int i, long map, long index)
+        {
+            _keyMappingCache[i] = map;
+            _keyMappingCache[MappingTableSize + i] = index;
+        }
+    }
+
+    private KeyMappingCache _keyMappingCache;
     private byte[] _storage;
 
     // The storage data will be used in an arena fashion. If there is no enough, we just create a bigger one and
@@ -65,22 +75,20 @@ public sealed unsafe class CompactKey : IDisposable
         _currentIdx = 0;
         MaxLength = 0;
 
+        StoragePool ??= ArrayPool<byte>.Create();
+
         _storage = StoragePool.Rent(2 * Constants.CompactTree.MaximumKeySize);
-        _keyMappingCache = KeyMappingPool.Rent(2 * MappingTableMask);
     }
 
     public void Reset()
     {
-        if (_storage is null || _keyMappingCache is null)
+        if (_storage is null)
             throw new InvalidOperationException("The key has not been initialized before calling reset.");
 
         _owner = null;
 
         StoragePool.Return(_storage);
         _storage = null;
-
-        KeyMappingPool.Return(_keyMappingCache);
-        _keyMappingCache = null;
     }
 
     public bool IsValid => Dictionary > 0;
@@ -108,8 +116,7 @@ public sealed unsafe class CompactKey : IDisposable
 
             // We look for an appropriate place to put this key
             int buckedIdx = SelectBucketForWrite();
-            KeyMappingCache(buckedIdx) = dictionaryId;
-            KeyMappingCacheIndex(buckedIdx) = _currentIdx;
+            _keyMappingCache.Set(buckedIdx, dictionaryId, _currentIdx);
 
             var dictionary = _owner.GetEncodingDictionary(dictionaryId);
             int maxSize = dictionary.GetMaxEncodingBytes(decodedKey.Length) + 4;
@@ -146,12 +153,12 @@ public sealed unsafe class CompactKey : IDisposable
             }
             else
             {
-                startIdx = (int)KeyMappingCacheIndex(bucketIdx);
+                startIdx = (int)_keyMappingCache.GetIndex(bucketIdx);
             }
 
             // Because we are decoding for the current dictionary, we will update the lazy index to avoid searching again next time. 
             if (Dictionary == dictionaryId)
-                _currentKeyIdx = (int)KeyMappingCacheIndex(bucketIdx);
+                _currentKeyIdx = (int)_keyMappingCache.GetIndex(bucketIdx);
         }
 
 
@@ -166,11 +173,11 @@ public sealed unsafe class CompactKey : IDisposable
 
         long currentDictionary = Dictionary;
         int currentKeyIdx = _currentKeyIdx;
-        if (currentKeyIdx == Invalid && KeyMappingCache(0) != 0)
+        if (currentKeyIdx == Invalid && _keyMappingCache.GetMap(0) != 0)
         {
             // We don't have any decoded version, so we pick the first one and do it. 
-            currentDictionary = KeyMappingCache(0);
-            currentKeyIdx = (int)KeyMappingCacheIndex(0);
+            currentDictionary = _keyMappingCache.GetMap(0);
+            currentKeyIdx = (int)_keyMappingCache.GetIndex(0);
         }
 
         Debug.Assert(currentKeyIdx != Invalid);
@@ -272,8 +279,7 @@ public sealed unsafe class CompactKey : IDisposable
         Dictionary = dictionaryId;
 
         int bucketIdx = SelectBucketForWrite();
-        KeyMappingCache(bucketIdx) = dictionaryId;
-        KeyMappingCacheIndex(bucketIdx) = _currentKeyIdx;
+        _keyMappingCache.Set(bucketIdx, dictionaryId, _currentKeyIdx);
 
         // We write the size and the key. 
         Unsafe.WriteUnaligned(ref _storage[0], keyLengthInBits);
@@ -294,7 +300,7 @@ public sealed unsafe class CompactKey : IDisposable
         int elementIdx = Math.Min(_lastKeyMappingItem, MappingTableSize - 1);
         while (elementIdx >= 0)
         {
-            long currentDictionary = _keyMappingCache[elementIdx];
+            long currentDictionary = _keyMappingCache.GetMap(elementIdx);
             if (currentDictionary == dictionaryId)
                 return elementIdx;
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1527,8 +1527,6 @@ namespace Voron
         public unsafe void ValidatePageChecksum(long pageNumber, PageHeader* current)
         {
             var index = pageNumber / (8 * sizeof(long));
-            var bitIndex = (int)(pageNumber % (8 * sizeof(long)));
-            var bitToSet = 1L << bitIndex;
 
             // If the page is beyond the initial size of the file we don't validate it. 
             // We assume that it is valid since we wrote it in this run.
@@ -1536,14 +1534,17 @@ namespace Voron
             if (index >= _validPages.Length)
                 return;
 
-            long old = _validPages[index];
-            if ((old & bitToSet) != 0)
+            var bitIndex = (int)(pageNumber % (8 * sizeof(long)));
+            var bitToSet = 1L << bitIndex;
+
+            ref long pageBucket = ref _validPages[index];
+            if ((pageBucket & bitToSet) != 0)
                 return;
 
-            UnlikelyValidatePage(pageNumber, current, index, old, bitToSet);
+            UnlikelyValidatePage(pageNumber, current, ref pageBucket, bitToSet);
         }
 
-        private unsafe void UnlikelyValidatePage(long pageNumber, PageHeader* current, long index, long old, long bitToSet)
+        private unsafe void UnlikelyValidatePage(long pageNumber, PageHeader* current, ref long bucket, long bitToSet)
         {
             // No need to call EnsureMapped here. ValidatePageChecksum is only called for pages in the datafile, 
             // which we already got using AcquirePagePointerWithOverflowHandling()
@@ -1559,11 +1560,10 @@ namespace Voron
             {
                 // PERF: This code used to have a spin-wait. While it makes sense where threads are competing on tight loops for
                 // for resources, the spin-wait here serves no purpose as the thread is going to bail out immediately after completion.
-                long modified = Interlocked.CompareExchange(ref _validPages[index], old | bitToSet, old);
-                if (modified == old || (modified & bitToSet) != 0)
+                long old = bucket;
+                long modified = Interlocked.CompareExchange(ref bucket, old | bitToSet, old);
+                if (modified == old || (bucket & bitToSet) != 0)
                     break;
-
-                old = modified;
             }
         }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21174
https://issues.hibernatingrhinos.com/issue/RavenDB-21468

### Additional description
Known sources for lock convoys are been addressed to avoid contention as much as possible.

### Type of change
- Optimization

### How risky is the change?
- Low 

### Backward compatibility
- Non breaking change