### PR TITLE
RavenDB-21468: Optimization of codegen and useless operations at Blittable Json Reader

### DIFF
--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -497,16 +497,23 @@ namespace Raven.Server.Utils
             switch (value)
             {
                 case string valueAsString:
-                    return TryConvertStringValue(valueAsString, out object result) ? result : valueAsString;
+                {
+                    if (TryConvertStringValue(valueAsString, out object result))
+                        return result;
+
+                    return valueAsString;
+                }
                 case LazyCompressedStringValue compressedStringValue:
                     return ConvertLazyStringValue(compressedStringValue.ToLazyStringValue());
                 case LazyStringValue lazyStringValue:
                     return ConvertLazyStringValue(lazyStringValue);
-                case BlittableJsonReaderObject blittableJsonReaderObject 
-                    when blittableJsonReaderObject.TryGetWithoutThrowingOnError(ValuesPropertyName, out BlittableJsonReaderArray ja1):
-                    return new DynamicArray(ja1);
                 case BlittableJsonReaderObject blittableJsonReaderObject:
+                {
+                    if (blittableJsonReaderObject.TryGetWithoutThrowingOnError(ValuesPropertyName, out BlittableJsonReaderArray ja1))
+                        return new DynamicArray(ja1);
+
                     return new DynamicBlittableJson(blittableJsonReaderObject);
+                }
                 case BlittableJsonReaderArray blittableJsonReaderArray:
                     return new DynamicArray(blittableJsonReaderArray);
                 default:
@@ -607,7 +614,12 @@ namespace Raven.Server.Utils
             switch (value)
             {
                 case string valueAsString:
-                    return TryConvertStringValue(valueAsString, supportTimeOnlyDateOnly, out object result) ? result : valueAsString;
+                {
+                    if (TryConvertStringValue(valueAsString, supportTimeOnlyDateOnly, out object result))
+                        return result;
+
+                    return valueAsString;
+                }
                 case LazyCompressedStringValue compressedStringValue:
                     return ConvertLazyStringValue(compressedStringValue.ToLazyStringValue(), propertyName, supportTimeOnlyDateOnly);
                 case LazyStringValue lazyStringValue:

--- a/src/Sparrow/Json/BlittableJsonReaderBase.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Sparrow.Compression;
@@ -227,33 +227,10 @@ namespace Sparrow.Json
             return -1;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected long ReadVariableSizeLong(int pos)
         {
-            // ReadAsync out an Int64 7 bits at a time.  The high bit 
-            // of the byte when on means to continue reading more bytes.
-
-            ulong count = 0;
-            byte shift = 0;
-            byte b;
-            do
-            {
-                if (shift == 70)
-                    goto Error; // PERF: Using goto to diminish the size of the loop.
-
-                b = _mem[pos++];
-                count |= (ulong)(b & 0x7F) << shift;
-                shift += 7;
-            }
-            while ((b & 0x80) != 0);
-
-            // good handling for negative values via:
-            // http://code.google.com/apis/protocolbuffers/docs/encoding.html#types
-
-            return (long)(count >> 1) ^ -(long)(count & 1);
-
-            Error:
-            ThrowInvalidShift();
-            return -1;
+            return ZigZagEncoding.Decode<long>(_mem, out _, pos: pos);
         }
 
         [Conditional("DEBUG")]

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -958,7 +958,7 @@ namespace Sparrow.Json
                     return ReadCompressStringLazily(position);
 
                 case BlittableJsonToken.Boolean:
-                    return ReadNumber(_mem + position, 1) == 1 ? BoxedTrue : BoxedFalse;
+                    return ReadNumber(_mem + position, sizeof(byte)) == 1 ? BoxedTrue : BoxedFalse;
 
                 case BlittableJsonToken.Null:
                     return null;

--- a/src/Sparrow/Json/Parsing/JsonParserState.cs
+++ b/src/Sparrow/Json/Parsing/JsonParserState.cs
@@ -161,7 +161,7 @@ namespace Sparrow.Json.Parsing
                 // 34 => '"'  => 0010 0010
                 // 92 => '\\' => 0101 1100
 
-                if (value == 92 || value == 34 || (value >= 8 && value <= 13 && value != 11))
+                if (value == 92 || value == 34 || (value is >= 8 and <= 13 && value != 11))
                 {
                     buffer.Add(i - lastEscape);
                     lastEscape = i + 1;
@@ -184,10 +184,7 @@ namespace Sparrow.Json.Parsing
                     Buffer.MemoryCopy(from, to, (uint)sizeToCopy, (uint)sizeToCopy);
                     str[i] = (byte)'\\';
                     str[i + 1] = (byte)'u';
-                    fixed (byte* controlString = AsyncBlittableJsonTextWriter.ControlCodeEscapes[value])
-                    {
-                        Memory.Copy(str + i + 2, controlString, 4);
-                    }
+                    *(int*)(str + i + 2) = AbstractBlittableJsonTextWriter.ControlCodeEscapes[value];
                     //The original string already had one byte so we only added 5.
                     len += ControlCharacterItemSize;
                     i += ControlCharacterItemSize;

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
@@ -8,17 +8,9 @@ namespace Sparrow.Json.Parsing
 {
     public sealed unsafe class UnmanagedJsonParser : IJsonParser
     {
-        private static readonly byte[] NaN = { (byte)'N', (byte)'a', (byte)'N' };
-
-        private static readonly byte[] PositiveInfinity =
-        {
-            (byte)'I', (byte)'n', (byte)'f', (byte)'i', (byte)'n', (byte)'i', (byte)'t', (byte)'y'
-        };
-
-        private static readonly byte[] NegativeInfinity =
-        {
-            (byte)'-', (byte)'I', (byte)'n', (byte)'f', (byte)'i', (byte)'n', (byte)'i', (byte)'t', (byte)'y'
-        };
+        private static readonly byte[] NaN = "NaN"u8.ToArray();
+        private static readonly byte[] PositiveInfinity = "Infinity"u8.ToArray();
+        private static readonly byte[] NegativeInfinity = "-Infinity"u8.ToArray();
 
         public static readonly byte[] Utf8Preamble = Encoding.UTF8.GetPreamble();
 
@@ -366,7 +358,7 @@ namespace Sparrow.Json.Parsing
                 case (byte)'n':
                     {
                         _state.CurrentTokenType = JsonParserToken.Null;
-                        _expectedTokenBuffer = AsyncBlittableJsonTextWriter.NullBuffer;
+                        _expectedTokenBuffer = AbstractBlittableJsonTextWriter.NullBuffer;
                         _expectedTokenBufferPosition = 1;
                         _expectedTokenString = "null";
                         if (EnsureRestOfToken(ref pos) == false)
@@ -382,7 +374,7 @@ namespace Sparrow.Json.Parsing
                 case (byte)'t':
                     {
                         _state.CurrentTokenType = JsonParserToken.True;
-                        _expectedTokenBuffer = AsyncBlittableJsonTextWriter.TrueBuffer;
+                        _expectedTokenBuffer = AbstractBlittableJsonTextWriter.TrueBuffer;
                         _expectedTokenBufferPosition = 1;
                         _expectedTokenString = "true";
                         if (EnsureRestOfToken(ref pos) == false)
@@ -398,7 +390,7 @@ namespace Sparrow.Json.Parsing
                 case (byte)'f':
                     {
                         _state.CurrentTokenType = JsonParserToken.False;
-                        _expectedTokenBuffer = AsyncBlittableJsonTextWriter.FalseBuffer;
+                        _expectedTokenBuffer = AbstractBlittableJsonTextWriter.FalseBuffer;
                         _expectedTokenBufferPosition = 1;
                         _expectedTokenString = "false";
                         if (EnsureRestOfToken(ref pos) == false)

--- a/src/Sparrow/StringSegment.cs
+++ b/src/Sparrow/StringSegment.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Sparrow
@@ -641,14 +642,7 @@ namespace Sparrow
         /// <returns></returns>
         public static bool IsNullOrEmpty(StringSegment value)
         {
-            var res = false;
-
-            if (!value.HasValue || value.Length == 0)
-            {
-                res = true;
-            }
-
-            return res;
+            return !value.HasValue || value.Length == 0;
         }
 
         /// <summary>
@@ -660,6 +654,9 @@ namespace Sparrow
             return Value ?? string.Empty;
         }
 
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
         // Methods that do no return (i.e. throw) are not inlined
         // https://github.com/dotnet/coreclr/pull/6103
         private static void ThrowInvalidArguments(string buffer, int offset, int length)
@@ -688,6 +685,9 @@ namespace Sparrow
             }
         }
 
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
         private void ThrowInvalidArguments(int offset, int length)
         {
             throw GetInvalidArgumentsException(HasValue);
@@ -715,11 +715,17 @@ namespace Sparrow
 
         private static class ThrowHelper
         {
+#if NET6_0_OR_GREATER
+            [DoesNotReturn]
+#endif
             internal static void ThrowArgumentNullException(ExceptionArgument argument)
             {
                 throw new ArgumentNullException(GetArgumentName(argument));
             }
 
+#if NET6_0_OR_GREATER
+            [DoesNotReturn]
+#endif
             internal static void ThrowArgumentOutOfRangeException(ExceptionArgument argument, int value)
             {
                 throw new ArgumentOutOfRangeException(GetArgumentName(argument), value, "Unexpected value: " + value);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21468

### Additional description
Improvements in the codegen to remove:
- Bound checks
- Redundant calls to `.EnsureBuffer()`
- Location of static sequences.

### Type of change
- Optimization

### How risky is the change?
- Low

### Backward compatibility
- Non breaking change