### PR TITLE
RavenDB-21888 Introducing WeakReferencingTimer for usages where timer callbacks are referencing objects that are supposed to be finalized by GC

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -99,7 +99,7 @@ namespace Raven.Client.Http
 
         public IReadOnlyList<ServerNode> TopologyNodes => _nodeSelector?.Topology.Nodes;
 
-        private Timer _updateTopologyTimer;
+        private WeakReferencingTimer _updateTopologyTimer;
 
         protected internal NodeSelector _nodeSelector;
 
@@ -889,7 +889,7 @@ namespace Raven.Client.Http
                 if (_updateTopologyTimer != null)
                     return;
 
-                _updateTopologyTimer = new Timer(UpdateTopologyCallback, null, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
+                _updateTopologyTimer = new WeakReferencingTimer(UpdateTopologyCallback, null, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
             }
         }
 
@@ -2235,7 +2235,7 @@ namespace Raven.Client.Http
             private readonly RequestExecutor _requestExecutor;
             public readonly int NodeIndex;
             public readonly ServerNode Node;
-            private Timer _timer;
+            private WeakReferencingTimer _timer;
 
             public NodeStatus(RequestExecutor requestExecutor, int nodeIndex, ServerNode node)
             {
@@ -2256,7 +2256,7 @@ namespace Raven.Client.Http
 
             public void StartTimer()
             {
-                _timer = new Timer(TimerCallback, null, _timerPeriod, Timeout.InfiniteTimeSpan);
+                _timer = new WeakReferencingTimer(TimerCallback, null, _timerPeriod, Timeout.InfiniteTimeSpan);
             }
 
             private void TimerCallback(object state)

--- a/src/Raven.Client/Util/WeakReferencingTimer.cs
+++ b/src/Raven.Client/Util/WeakReferencingTimer.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Threading;
+
+namespace Raven.Client.Util;
+
+internal class WeakReferencingTimer : IDisposable
+{
+    internal delegate void WeakReferencingTimerCallback(object state);
+
+    private readonly Timer _timer;
+
+    public WeakReferencingTimer(WeakReferencingTimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
+    {
+        if (callback == null)
+            throw new ArgumentNullException(nameof(callback));
+
+        var internalTimerState = new TimerState
+        {
+            State = state is not null ? new WeakReference<object>(state) : null,
+            Callback = new WeakReference<WeakReferencingTimerCallback>(callback)
+        };
+
+        _timer = new Timer(StaticCallback, internalTimerState, dueTime, period);
+
+        internalTimerState.Timer = _timer;
+    }
+
+    private static void StaticCallback(object state)
+    {
+        var timerState = (TimerState)state;
+        object stateObj = null;
+
+        if (timerState.State is not null && timerState.State.TryGetTarget(out stateObj) == false)
+        {
+            timerState.Timer.Dispose();
+            return;
+        }
+
+        if (timerState.Callback.TryGetTarget(out var callback) == false)
+        {
+            timerState.Timer.Dispose();
+            return;
+        }
+
+        callback(stateObj);
+    }
+
+    private class TimerState
+    {
+        public WeakReference<object> State;
+        public WeakReference<WeakReferencingTimerCallback> Callback;
+        public Timer Timer;
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+    }
+
+    public void Change(TimeSpan dueTime, TimeSpan period)
+    {
+        _timer?.Change(dueTime, period);
+    }
+}

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -1203,7 +1203,7 @@ namespace RachisTests.DatabaseCluster
                 Assert.True(selectorNodes.All(x => x.ServerRole == ServerNode.Role.Member));
 
                 //artificially call the timer func
-                re.UpdateTopologyCallback(null);
+                RequestExecutor.UpdateTopologyCallback(re);
 
                 //we expect a failover and an updated request executor
                 await WaitAndAssertForValueAsync(() =>


### PR DESCRIPTION
This applies to RequestExecutor and also similar approach was already implemented for the bulk insert heartbeat timer.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21888/

### Additional description

Under the covers we'll user WeakReference to ensure that timer callbacks won't reference actual objects so GC will be able to collect them.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
