### PR TITLE
RavenDB-21837: Implementation of shadow buffering with Streams

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Collections/CollectionsHandlerProcessorForGetCollectionDocuments.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Collections/CollectionsHandlerProcessorForGetCollectionDocuments.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Collections
                 long numberOfResults;
                 long totalDocumentsSizeInBytes;
 
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream(), token))
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
                     writer.WritePropertyName("Results");

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
@@ -72,7 +72,7 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
 
         HttpContext.Response.Headers[Constants.Headers.Etag] = CharExtensions.ToInvariantString(result.ResultEtag);
 
-        await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream(), token.Token))
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
         {
             await writer.WriteIndexEntriesQueryResultAsync(context, result, token.Token);
         }
@@ -170,13 +170,13 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
 
                         long numberOfResults;
                         long totalDocumentsSizeInBytes;
-                        await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream(), token.Token))
+                        await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                         {
                             result.Timings = indexQuery.Timings?.ToTimings();
 
                             (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteDocumentQueryResultAsync(context, result, metadataOnly,
                                 WriteAdditionalData(indexQuery, shouldReturnServerSideQuery), token.Token);
-                            await writer.MaybeOuterFlushAsync();
+                            await writer.MaybeFlushAsync();
                         }
 
 
@@ -274,7 +274,7 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
 
         long numberOfResults;
         long totalDocumentsSizeInBytes;
-        await using (var writer = new AsyncBlittableJsonTextWriter(operationContext, RequestHandler.ResponseBodyStream(), token.Token))
+        await using (var writer = new AsyncBlittableJsonTextWriter(operationContext, RequestHandler.ResponseBodyStream()))
         {
             (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteSuggestionQueryResultAsync(operationContext, result, token.Token);
         }
@@ -296,7 +296,7 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
         HttpContext.Response.Headers[Constants.Headers.Etag] = CharExtensions.ToInvariantString(result.ResultEtag);
 
         long numberOfResults;
-        await using (var writer = new AsyncBlittableJsonTextWriter(operationContext, RequestHandler.ResponseBodyStream(), token.Token))
+        await using (var writer = new AsyncBlittableJsonTextWriter(operationContext, RequestHandler.ResponseBodyStream()))
         {
             result.Timings = query.Timings?.ToTimings();
             numberOfResults = await writer.WriteFacetedQueryResultAsync(operationContext, result, token.Token);

--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/DatabaseQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/DatabaseQueriesHandlerProcessorForGet.cs
@@ -66,7 +66,7 @@ internal sealed class DatabaseQueriesHandlerProcessorForGet : AbstractQueriesHan
     {
         var explanations = RequestHandler.Database.QueryRunner.ExplainDynamicIndexSelection(query, out string indexName);
 
-        await using (var writer = new AsyncBlittableJsonTextWriter(queryContext.Documents, RequestHandler.ResponseBodyStream(), token.Token))
+        await using (var writer = new AsyncBlittableJsonTextWriter(queryContext.Documents, RequestHandler.ResponseBodyStream()))
         {
             writer.WriteStartObject();
             writer.WritePropertyName("IndexName");

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/StreamingHandlerProcessorForGetDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/StreamingHandlerProcessorForGetDocs.cs
@@ -83,8 +83,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
         private IStreamResultsWriter<Document> GetLoadDocumentsResultsWriter(string format, JsonOperationContext context, Stream responseBodyStream, CancellationToken token)
         {
             if (string.IsNullOrEmpty(format) == false && string.Equals(format, "jsonl", StringComparison.OrdinalIgnoreCase))
-                return new StreamJsonlResultsWriter(responseBodyStream, context, token);
-            return new StreamResultsWriter(responseBodyStream, context, token);
+                return new StreamJsonlResultsWriter(responseBodyStream, context);
+            return new StreamResultsWriter(responseBodyStream, context);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamJsonlResultsWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamJsonlResultsWriter.cs
@@ -11,10 +11,10 @@ public sealed class StreamJsonlResultsWriter : IStreamResultsWriter<Document>
     private readonly AsyncBlittableJsonTextWriter _writer;
     private readonly JsonOperationContext _context;
 
-    public StreamJsonlResultsWriter(Stream stream, JsonOperationContext context, CancellationToken token)
+    public StreamJsonlResultsWriter(Stream stream, JsonOperationContext context)
     {
         _context = context;
-        _writer = new AsyncBlittableJsonTextWriter(context, stream, token);
+        _writer = new AsyncBlittableJsonTextWriter(context, stream);
     }
     
     public ValueTask DisposeAsync()

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamResultsWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamResultsWriter.cs
@@ -13,10 +13,10 @@ public sealed class StreamResultsWriter : IStreamResultsWriter<Document>
     private bool _first = true;
     
 
-    public StreamResultsWriter(Stream stream, JsonOperationContext context, CancellationToken token)
+    public StreamResultsWriter(Stream stream, JsonOperationContext context)
     {
         _context = context;
-        _writer = new AsyncBlittableJsonTextWriter(context, stream, token);
+        _writer = new AsyncBlittableJsonTextWriter(context, stream);
     }
     
     public ValueTask DisposeAsync()

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetDocs.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetDocs.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
                     OrderDocumentsById(streams, continuationToken) : 
                     OrderDocumentsByLastModified(streams, continuationToken);
 
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream(), token.Token))
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                 {
                     writer.WriteStartObject();
 

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1884,7 +1884,7 @@ namespace Raven.Server.Json
                 writer.WritePropertyName(includeDoc.GetMetadata().GetId());
                 writer.WriteObject(includeDoc);
 
-                await writer.MaybeOuterFlushAsync();
+                await writer.MaybeFlushAsync();
             }
 
             writer.WriteEndObject();

--- a/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
+++ b/src/Raven.Server/Utils/AsyncBlittableJsonTextWriterForDebug.cs
@@ -16,11 +16,11 @@ namespace Raven.Server.Utils
         private bool _isOnlyWrite;
         private readonly AsyncBlittableJsonTextWriter _inner;
 
-        public AsyncBlittableJsonTextWriterForDebug(JsonOperationContext context, ServerStore serverStore, Stream stream, CancellationToken cancellationToken = default)
+        public AsyncBlittableJsonTextWriterForDebug(JsonOperationContext context, ServerStore serverStore, Stream stream)
         {
             _isFirst = true;
             _serverStore = serverStore;
-            _inner = new AsyncBlittableJsonTextWriter(context, stream, cancellationToken: cancellationToken);
+            _inner = new AsyncBlittableJsonTextWriter(context, stream);
         }
 
         public void WriteStartObject()

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -11,7 +11,8 @@ namespace Sparrow.Json
     public abstract unsafe class AbstractBlittableJsonTextWriter : IBlittableJsonTextWriter
     {
         protected readonly JsonOperationContext _context;
-        protected readonly Stream _stream;
+        protected Stream _stream;
+
         private const byte StartObject = (byte)'{';
         private const byte EndObject = (byte)'}';
         private const byte StartArray = (byte)'[';
@@ -70,6 +71,7 @@ namespace Sparrow.Json
         private readonly byte* _auxiliarBuffer;
         private readonly int _auxiliarBufferLength;
 
+        private protected bool _started;
         private protected int _pos;
         private readonly JsonOperationContext.MemoryBuffer.ReturnBuffer _returnBuffer;
         private readonly JsonOperationContext.MemoryBuffer.ReturnBuffer _returnAuxiliarBuffer;
@@ -85,6 +87,8 @@ namespace Sparrow.Json
             _returnAuxiliarBuffer = context.GetMemoryBuffer(32, out var buffer);
             _auxiliarBuffer = buffer.Address;
             _auxiliarBufferLength = buffer.Size;
+            
+            _started = false;
         }
 
         public int Position => _pos;
@@ -556,6 +560,7 @@ namespace Sparrow.Json
             _stream.Write(_pinnedBuffer.Memory.Memory.Span.Slice(0, _pos));
             _stream.Flush();
 
+            _started = true;
             _pos = 0;
             return true;
         }
@@ -757,8 +762,8 @@ namespace Sparrow.Json
         {
             try
             {
-                FlushInternal();
-                _stream.Flush();
+                if (FlushInternal() == false)
+                    _stream.Flush();
             }
             catch (ObjectDisposedException)
             {

--- a/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Sparrow/Json/BlittableJsonTextWriterExtensions.cs
@@ -182,7 +182,7 @@ namespace Sparrow.Json
                 first = false;
 
                 writer.WriteObject(item);
-                await writer.MaybeOuterFlushAsync().ConfigureAwait(false);
+                await writer.MaybeFlushAsync().ConfigureAwait(false);
             }
             writer.WriteEndArray();
         }
@@ -201,7 +201,7 @@ namespace Sparrow.Json
                 first = false;
 
                 writer.WriteObject(item);
-                await writer.MaybeOuterFlushAsync().ConfigureAwait(false);
+                await writer.MaybeFlushAsync().ConfigureAwait(false);
             }
             writer.WriteEndArray();
         }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21837

### Additional description
The idea behind using shadow buffering of streams is allowing to start writing to the network while we are computing the rest of the response in order to impact latency, specially when faced with big responses. 

### Type of change
- Optimization

### How risky is the change?
- Moderate

### Backward compatibility
- Non breaking change
