### PR TITLE
RavenDB-21088 Failed to load the storage report

### DIFF
--- a/src/Raven.Server/Web/System/AdminStorageHandler.cs
+++ b/src/Raven.Server/Web/System/AdminStorageHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -30,6 +31,38 @@ namespace Raven.Server.Web.System
                 using (var tx = env.ReadTransaction())
                 {
                     var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(env.GenerateDetailedReport(tx, details));
+                    writer.WritePropertyName("Report");
+                    writer.WriteObject(context.ReadObject(djv, "System"));
+                }
+
+                writer.WriteEndObject();
+            }
+        }
+
+        [RavenAction("/admin/debug/storage/environment/scratch-buffer-info", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = false)]
+        public async Task SystemScratchBufferPoolInfoReport()
+        {
+            var env = ServerStore._env;
+
+            using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("Environment");
+                writer.WriteString("Server");
+                writer.WriteComma();
+
+                writer.WritePropertyName("Type");
+                writer.WriteString(nameof(StorageEnvironmentWithType.StorageEnvironmentType.System));
+                writer.WriteComma();
+
+                using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                using (var tx = env.ReadTransaction())
+                using (ctx.OpenWriteTransaction())
+                {
+                    //Opening a write transaction to avoid concurrency problems (Issue #21088)
+                    var sc = env.ScratchBufferPool.InfoForDebug(env.PossibleOldestReadTransaction(tx.LowLevelTransaction));
+                    var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(sc);
                     writer.WritePropertyName("Report");
                     writer.WriteObject(context.ReadObject(djv, "System"));
                 }

--- a/src/Voron/Debugging/DetailedStorageReport.cs
+++ b/src/Voron/Debugging/DetailedStorageReport.cs
@@ -36,7 +36,6 @@ namespace Voron.Debugging
         public List<TreeReport> Trees { get; set; }
         public List<TableReport> Tables { get; set; }
         public PreAllocatedBuffersReport PreAllocatedBuffers { get; set; }
-        public ScratchBufferPoolInfo ScratchBufferPoolInfo { get; set; }
         public string TotalEncryptionBufferSize { get; set; }
     }
 

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -61,7 +61,6 @@ namespace Voron.Debugging
         public List<PostingList> PostingLists;
         public List<PersistentDictionaryRootHeader> PersistentDictionaries;
         public List<CompactTree> CompactTrees;
-        public ScratchBufferPoolInfo ScratchBufferPoolInfo { get; set; }
         public bool IncludeDetails { get; set; }
         public VoronPathSetting TempPath { get; set; }
         public VoronPathSetting JournalPath { get; set; }
@@ -251,7 +250,6 @@ namespace Voron.Debugging
                 Tables = tables,
                 Journals = journals,
                 PreAllocatedBuffers = preAllocatedBuffers,
-                ScratchBufferPoolInfo = input.ScratchBufferPoolInfo,
                 TempBuffers = tempBuffers,
                 TotalEncryptionBufferSize = input.TotalEncryptionBufferSize.ToString()
             };

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1115,7 +1115,6 @@ namespace Voron
                 PersistentDictionaries = new(),
                 CompactTrees = new(),
                 IncludeDetails = includeDetails,
-                ScratchBufferPoolInfo = _scratchBufferPool.InfoForDebug(PossibleOldestReadTransaction(tx.LowLevelTransaction)),
                 TempPath = Options.TempPath,
                 JournalPath = (Options as StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)?.JournalPath,
                 TotalEncryptionBufferSize = totalCryptoBufferSize,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21088

### Additional description

_allocatedPages dictionary was modified while we were iterating it. 
Now there is a new endpoint for ScratchBufferPoolInfo , and we open a write transaction to avoid concurrency problem

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Not tested

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work


- No UI work is needed
