### PR TITLE
RavenDB-21790 Enabling `stats` in the console turns off Logging Thread

### DIFF
--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -352,11 +352,7 @@ namespace Raven.Server.Utils.Cli
             Console.ResetColor();
 
             LoggingSource.Instance.DisableConsoleLogging();
-            var prevLogMode = LoggingSource.Instance.LogMode;
-            SetupLogMode(LogMode.None, cli._server.Configuration.Logs);
             Program.WriteServerStatsAndWaitForEsc(cli._server);
-            SetupLogMode(prevLogMode, cli._server.Configuration.Logs);
-            Console.WriteLine($"LogMode set back to {prevLogMode}.");
             return true;
         }
 
@@ -418,11 +414,7 @@ namespace Raven.Server.Utils.Cli
             Console.ResetColor();
 
             LoggingSource.Instance.DisableConsoleLogging();
-            var prevLogMode = LoggingSource.Instance.LogMode;
-            SetupLogMode(LogMode.None, cli._server.Configuration.Logs);
             Program.WriteThreadsInfoAndWaitForEsc(cli._server, maxTopThreads, updateIntervalInMs, cpuUsageThreshold);
-            SetupLogMode(prevLogMode, cli._server.Configuration.Logs);
-            Console.WriteLine($"LogMode set back to {prevLogMode}.");
             return true;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21790

### Additional description

We where changing log mode to none while stats and TopThreads was tunning

_Please delete below the options that are not relevant_

### Type of change

- Bug fix

### How risky is the change?

- Low 


### Backward compatibility

- Non breaking change


### Is it platform specific issue?


- No

### Documentation update


- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?


- No

### UI work


- No UI work is needed
