### PR TITLE
RavenDB-21871 Support for nullable numeric values inside `InQuery`.

### DIFF
--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -242,7 +242,8 @@ namespace Raven.Server.Documents.Queries
             {
                 case LuceneTermType.Double:
                 case LuceneTermType.Long:
-                    return value;
+                    // In the case of a nullable numeric value, we have to match it via NULL_VALUE.
+                    return value ?? Constants.Documents.Indexing.Fields.NullValue;
                 default:
                     {
                         if (value == null)

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6440;
+            const int numberToTolerate = 6439;
             if (array.Length == numberToTolerate)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21871

### Additional description

We expected all items to be the same type as first one, since we store nulls as `NULL_VALUE` in Lucene we've to add path to return this term when numeric is null.

### Type of change

- Bug fix

### How risky is the change?

- Moderate 


### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works


### Testing by RavenDB QA team
x
- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
