### PR TITLE
RavenDB-21811 - Cluster wide slower performance in 6.0

### DIFF
--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -385,7 +385,7 @@ namespace Raven.Server.Rachis
                                     continue; // instead of waiting, we have new entries, start immediately
 
                                 if (_engine.GetLastCommitIndex(context) != myLastCommittedIndex)
-                                    continue;
+                                    continue; // there is a new committed command, continue to let the leader know immediately
                             }
 
                             // either we have new entries to send, or we waited for long enough 

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -253,6 +253,7 @@ namespace Raven.Server.Rachis
                         var readWatcher = Stopwatch.StartNew();
                         while (_leader.Running && _running)
                         {
+                            var myLastCommittedIndex = 0L;
                             entries.Clear();
                             _engine.ValidateTerm(_term);
 
@@ -289,6 +290,8 @@ namespace Raven.Server.Rachis
                                             TimeAsLeader = _leader.LeaderShipDuration,
                                             MinCommandVersion = ClusterCommandsVersionManager.CurrentClusterMinimalVersion
                                         };
+
+                                        myLastCommittedIndex = appendEntries.LeaderCommit;
                                     }
                                 }
 
@@ -380,6 +383,9 @@ namespace Raven.Server.Rachis
                             {
                                 if (_engine.GetLastEntryIndex(context) != _followerMatchIndex)
                                     continue; // instead of waiting, we have new entries, start immediately
+
+                                if (_engine.GetLastCommitIndex(context) != myLastCommittedIndex)
+                                    continue;
                             }
 
                             // either we have new entries to send, or we waited for long enough 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21811

### Additional description

Added check of last committed index to avoid waiting the timeout for new entries when there are new committed commands.

### Type of change

- Optimization

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- It has been verified by manual testing

### Testing by RavenDB QA team

- Has been run by QA

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
