### PR TITLE
RavenDB-20843 - 2 attachments with identical names on one document

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1632,7 +1632,9 @@ namespace Raven.Server.Smuggler.Documents
                         continue;
                     }
 
-                    PutAttachments(context, document, isRevision: false, out _);
+                    PutAttachments(context, document, isRevision: false, out bool updateDocumentMetadata);
+                    if (updateDocumentMetadata)
+                        document.NonPersistentFlags |= NonPersistentDocumentFlags.ResolveAttachmentsConflict;
 
                     newEtag = _database.DocumentsStorage.GenerateNextEtag();
                     document.ChangeVector = _database.DocumentsStorage.GetNewChangeVector(context, newEtag);
@@ -1699,6 +1701,7 @@ namespace Raven.Server.Smuggler.Documents
                     metadata.TryGet(Client.Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments) == false)
                     return;
 
+                var type = (document.Flags & DocumentFlags.Revision) == DocumentFlags.Revision ? AttachmentType.Revision : AttachmentType.Document;
                 var attachmentsStorage = _database.DocumentsStorage.AttachmentsStorage;
                 foreach (BlittableJsonReaderObject attachment in attachments)
                 {
@@ -1707,23 +1710,24 @@ namespace Raven.Server.Smuggler.Documents
                     if (attachment.TryGet(nameof(AttachmentName.Name), out LazyStringValue name) == false ||
                         attachment.TryGet(nameof(AttachmentName.ContentType), out LazyStringValue contentType) == false ||
                         attachment.TryGet(nameof(AttachmentName.Hash), out LazyStringValue hash) == false)
-                        throw new ArgumentException($"The attachment info in missing a mandatory value: {attachment}");
+                        throw new ArgumentException($"The attachment info is missing a mandatory value: {attachment}");
 
-                    var cv = Slices.Empty;
-                    var type = (document.Flags & DocumentFlags.Revision) == DocumentFlags.Revision ? AttachmentType.Revision : AttachmentType.Document;
-
-                    if (isRevision == false && attachmentsStorage.AttachmentExists(context, hash) == false)
+                    if (isRevision == false)
                     {
-                        _documentIdsOfMissingAttachments.Add(document.Id);
+                        if (attachmentsStorage.AttachmentExists(context, hash) == false)
+                            _documentIdsOfMissingAttachments.Add(document.Id);
+
+                        attachmentsStorage.PutAttachmentFromSmuggler(context, document.Id, name, contentType, hash);
+                        continue;
                     }
 
                     using (DocumentIdWorker.GetSliceFromId(_context, document.Id, out Slice lowerDocumentId))
                     using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(_context, name, out Slice lowerName, out Slice nameSlice))
                     using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(_context, contentType, out Slice lowerContentType, out Slice contentTypeSlice))
                     using (Slice.External(_context.Allocator, hash, out Slice base64Hash))
-                    using (type == AttachmentType.Revision ? Slice.From(_context.Allocator, document.ChangeVector, out cv) : (IDisposable)null)
+                    using (Slice.From(_context.Allocator, document.ChangeVector, out Slice cv))
                     using (attachmentsStorage.GetAttachmentKey(_context, lowerDocumentId.Content.Ptr, lowerDocumentId.Size, lowerName.Content.Ptr, lowerName.Size,
-                        base64Hash, lowerContentType.Content.Ptr, lowerContentType.Size, type, cv, out Slice keySlice))
+                               base64Hash, lowerContentType.Content.Ptr, lowerContentType.Size, type, cv, out Slice keySlice))
                     {
                         attachmentsStorage.PutDirect(context, keySlice, nameSlice, contentTypeSlice, base64Hash);
                     }

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1717,7 +1717,7 @@ namespace Raven.Server.Smuggler.Documents
                         if (attachmentsStorage.AttachmentExists(context, hash) == false)
                             _documentIdsOfMissingAttachments.Add(document.Id);
 
-                        attachmentsStorage.PutAttachmentFromSmuggler(context, document.Id, name, contentType, hash);
+                        attachmentsStorage.PutAttachment(context, document.Id, name, contentType, hash, updateDocument: false, fromSmuggler: true);
                         continue;
                     }
 

--- a/test/SlowTests/Issues/RavenDB_20843.cs
+++ b/test/SlowTests/Issues/RavenDB_20843.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Smuggler;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20843 : ReplicationTestBase
+    {
+        public RavenDB_20843(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.BackupExportImport)]
+        public async Task AttachmentsWithSameNameShouldNotExistTwiceAfterImportFrom2Stores()
+        {
+            var file1 = GetTempFileName();
+            var file2 = GetTempFileName();
+
+            try
+            {
+                using (var store1 = GetDocumentStore())
+                using (var store2 = GetDocumentStore())
+                {
+                    using (var session = store1.OpenSession())
+                    {
+                        var user1 = new User { Name = "EGR" };
+                        session.Store(user1, "users/1");
+                        session.SaveChanges();
+                    }
+
+                    using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                    {
+                        var result = store1.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", profileStream, "image/png"));
+                        Assert.Equal("foo/bar", result.Name);
+                        Assert.Equal("users/1", result.DocumentId);
+                        Assert.Equal("image/png", result.ContentType);
+                        Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                    }
+
+                    using (var session = store2.OpenSession())
+                    {
+                        var user1 = new User { Name = "EGR" };
+                        session.Store(user1, "users/1");
+                        session.SaveChanges();
+                    }
+
+                    using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
+                    {
+                        var result = store2.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "image/png"));
+                        Assert.Equal("foo/bar", result.Name);
+                        Assert.Equal("users/1", result.DocumentId);
+                        Assert.Equal("image/png", result.ContentType);
+                        Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", result.Hash);
+                    }
+
+                    var exportOperation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file1);
+                    var exportResult = (SmugglerResult)await exportOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                    Assert.Equal(1, exportResult.Documents.ReadCount);
+                    Assert.Equal(1, exportResult.Documents.Attachments.ReadCount);
+
+                    exportOperation = await store2.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file2);
+                    exportResult = (SmugglerResult)await exportOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                    Assert.Equal(1, exportResult.Documents.ReadCount);
+                    Assert.Equal(1, exportResult.Documents.Attachments.ReadCount);
+
+                    using (var store3 = GetDocumentStore())
+                    {
+                        var importOperation = await store3.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file1);
+                        var importResult = (SmugglerResult)await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                        Assert.Equal(1, importResult.Documents.ReadCount);
+                        Assert.Equal(1, importResult.Documents.Attachments.ReadCount);
+
+                        importOperation = await store3.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file2);
+                        importResult = (SmugglerResult)await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    
+                        Assert.Equal(1, importResult.Documents.ReadCount);
+                        Assert.Equal(1, importResult.Documents.Attachments.ReadCount);
+
+                        var database3 = await GetDatabase(store3.Database);
+                        using (database3.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                        using (context.OpenReadTransaction())
+                        {
+                            using (DocumentIdWorker.GetSliceFromId(context, "users/1", out Slice docIdSlice))
+                            {
+                                var attachments = database3.DocumentsStorage.AttachmentsStorage.GetAttachmentsForDocument(context, docIdSlice).ToList();
+                                Assert.NotNull(attachments);
+                                Assert.Equal(1, attachments.Count); // we should have only one attachment here 
+                                Assert.Equal("foo/bar", attachments[0].Name);
+                                Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", attachments[0].Base64Hash.ToString());
+                            }
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                File.Delete(file1);
+                File.Delete(file2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20843/2-attachments-with-identical-names-on-one-document


### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Non breaking change

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor

- Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
