### PR TITLE
RavenDB-21888 We are not able to detect the leak of HttpCacheItem based on the finalizer.

### DIFF
--- a/src/Raven.Client/Http/HttpCache.cs
+++ b/src/Raven.Client/Http/HttpCache.cs
@@ -93,8 +93,6 @@ namespace Raven.Client.Http
                 }
                 Allocation = null;
 
-                GC.SuppressFinalize(this);
-
                 if (Logger.IsInfoEnabled)
                 {
                     Logger.Info($"Released item from cache. Total cache size: {Cache._totalSize}");
@@ -118,18 +116,6 @@ namespace Raven.Client.Http
             {
                 ReleaseRefInternal();
             }
-#if !RELEASE
-            ~HttpCacheItem()
-            {
-                Allocation = null;
-
-                // Hitting this on DEBUG and/or VALIDATE and getting a higher number than 0 means we have a leak.
-                // On release we will leak, but wont crash. 
-                if (_usages > 0)
-                    throw new LowMemoryException("Detected a leak on HttpCache when running the finalizer. See: https://issues.hibernatingrhinos.com/issue/RavenDB-9737");
-
-            }
-#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Those items are supposed to be disposed on the disposal of a request executor. We already have the finalizer defined in RequestExecutor. The order of finalizers isn't guaranteed and we've confimed that the finalizer of HttpCacheItem might be called before the finalizer of RequestExecutor.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21888

### Additional description

All details are in comment https://issues.hibernatingrhinos.com/issue/RavenDB-21888/Finalizer-of-RequestExecutor-is-never-called-because-of-updateTopologyTimer#focus=Comments-67-1047971.0-0

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility


- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing by Contributor


- It has been verified by manual testing

### Testing by RavenDB QA team


- No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
