### PR TITLE
RavenDB-21920 - enforce uniqueness of Queue ETL task names

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -407,6 +407,8 @@ namespace Raven.Client.ServerWide
                 throw new InvalidOperationException($"Can't use task name '{taskName}', there is already an OLAP ETL task with that name");
             if (PeriodicBackups.Any(x => x.Name.Equals(taskName, StringComparison.OrdinalIgnoreCase)))
                 throw new InvalidOperationException($"Can't use task name '{taskName}', there is already a Periodic Backup task with that name");
+            if (QueueEtls.Any(x => x.Name.Equals(taskName, StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"Can't use task name '{taskName}', there is already a Queue ETL task with that name");
         }
 
         internal string EnsureUniqueTaskName(string defaultTaskName)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21920/Can-define-non-unique-queue-etl-task-name

### Additional description

Enforce uniqueness of Queue ETL task names.

### Type of change

- Bug fix

### How risky is the change?

- Low 