### PR TITLE
RavenDB-21858 Cannot download the dump file generated by /admin/debug/dump endpoint

### DIFF
--- a/src/Raven.Server/Web/System/AdminDumpHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDumpHandler.cs
@@ -84,6 +84,9 @@ namespace Raven.Server.Web.System
 
             var sb = new StringBuilder($"{args} --pid {processId} --output {CommandLineArgumentEscaper.EscapeSingleArg(output)}");
 
+            if (PlatformDetails.RunningOnPosix)
+                sb.Append($" --output-owner {Environment.UserName}"); // make sure we'll be able to download the output file and delete it once HTTP request completes
+
             var startup = new ProcessStartInfo
             {
                 Arguments = sb.ToString(),

--- a/tools/Raven.Debug/CommandLineApp.cs
+++ b/tools/Raven.Debug/CommandLineApp.cs
@@ -132,6 +132,7 @@ namespace Raven.Debug
                 var pidOption = cmd.Option("--pid", "Process ID to which the tool will attach to", CommandOptionType.SingleValue);
                 var outputOption = cmd.Option("--output", "Output file path", CommandOptionType.SingleValue);
                 var typeOption = cmd.Option("--type", "Type of dump (Heap or Mini). ", CommandOptionType.SingleValue);
+                var outputOwnerOption = cmd.Option("--output-owner", "The owner of the output file (applicable only to Posix based OS)", CommandOptionType.SingleValue);
 
                 cmd.OnExecuteAsync(async (_) =>
                 {
@@ -151,10 +152,14 @@ namespace Raven.Debug
                     if (outputOption.HasValue())
                         output = outputOption.Value();
 
+                    string outputOwner = null;
+                    if (outputOwnerOption.HasValue())
+                        outputOwner = outputOwnerOption.Value();
+
                     try
                     {
                         var dumper = new Dumper();
-                        await dumper.Collect(cmd, pid, output, diag: false, type).ConfigureAwait(false);
+                        await dumper.Collect(cmd, pid, output, outputOwner, diag: false, type).ConfigureAwait(false);
                         return 0;
                     }
                     catch (Exception e)
@@ -173,6 +178,7 @@ namespace Raven.Debug
                 var outputOption = cmd.Option("--output", "Output file path", CommandOptionType.SingleValue);
                 var timeoutOption = cmd.Option("--timeout", "Give up on collecting the gcdump if it takes longer than this many seconds. The default value is. Default 30", CommandOptionType.SingleValue);
                 var verboseOption = cmd.Option("--verbose", "Output the log while collecting the gcdump.", CommandOptionType.NoValue);
+                var outputOwnerOption = cmd.Option("--output-owner", "The owner of the output file (applicable only to Posix based OS)", CommandOptionType.SingleValue);
 
                 cmd.OnExecuteAsync(async token =>
                 {
@@ -186,6 +192,10 @@ namespace Raven.Debug
                     if (outputOption.HasValue())
                         output = outputOption.Value();
 
+                    string outputOwner = null;
+                    if (outputOwnerOption.HasValue())
+                        outputOwner = outputOwnerOption.Value();
+
                     int timeout = 30;
                     if (timeoutOption.HasValue() && int.TryParse(timeoutOption.Value(), out timeout) == false)
                         return cmd.ExitWithError($"Could not parse --timeout with value '{timeoutOption.Value()}' to number.");
@@ -194,7 +204,7 @@ namespace Raven.Debug
 
                     try
                     {
-                        await GCHeapDumper.Collect(token, cmd, pid, output, timeout, verbose).ConfigureAwait(false);
+                        await GCHeapDumper.Collect(token, cmd, pid, output, outputOwner, timeout, verbose).ConfigureAwait(false);
                         return 0;
                     }
                     catch (Exception e)

--- a/tools/Raven.Debug/Dump/Dumper.cs
+++ b/tools/Raven.Debug/Dump/Dumper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.Tools.Dump
         {
         }
 
-        public async Task<int> Collect(CommandLineApplication cmd, int processId, string output, bool diag, DumpTypeOption type)
+        public async Task<int> Collect(CommandLineApplication cmd, int processId, string output, string outputOwner, bool diag, DumpTypeOption type)
         {
             if (processId == 0)
             {
@@ -66,6 +66,9 @@ namespace Microsoft.Diagnostics.Tools.Dump
 
                     // Send the command to the runtime to initiate the core dump
                     client.WriteDump(dumpType, output, diag);
+
+                    if (string.IsNullOrEmpty(outputOwner) == false)
+                        PosixFileExtensions.ChangeFileOwner(output, outputOwner);
                 }
                 else
                 {

--- a/tools/Raven.Debug/Utils/PosixFileExtensions.cs
+++ b/tools/Raven.Debug/Utils/PosixFileExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Diagnostics;
+using Sparrow.Platform;
+
+namespace Raven.Debug.Utils;
+
+public static class PosixFileExtensions
+{
+    public static void ChangeFileOwner(string fileName, string owner)
+    {
+        if (PlatformDetails.RunningOnPosix == false)
+            throw new InvalidOperationException("This method is supposed to be called only on Posix systems");
+
+        var startup = new ProcessStartInfo
+        {
+            FileName = "chown",
+            Arguments = $"{owner}:{owner} {fileName}",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = true
+        };
+
+        var process = new Process
+        {
+            StartInfo = startup,
+            EnableRaisingEvents = true
+        };
+
+        process.Start();
+        process.WaitForExit();
+
+
+        if (process.ExitCode == 0) 
+            return;
+        
+        var error = process.StandardError.ReadToEnd();
+
+        throw new InvalidOperationException($"Error changing file owner: {error}");
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21858

### Additional description

This fixes two issues:

1. The user running RavenDB process will be able to access the generated output file so it will be returned to a user
2. We'll manage to delete the output file at the end of the request (we have `HttpContext.Response.RegisterForDispose(new DeleteFile(path));` for that)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
   - Linux 
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
