### PR TITLE
RavenDB-21921 starting from .NET 8 SDK the --self-contained is a mandatory parameter

### DIFF
--- a/scripts/buildProjects.ps1
+++ b/scripts/buildProjects.ps1
@@ -132,6 +132,7 @@ function BuildTool ( $toolName, $srcDir, $outDir, $target, $trim ) {
     $configuration = if ($debug) { 'Debug' } else { 'Release' }
     $commandArgs += @( "--configuration", $configuration )
     $commandArgs += $( "--runtime", "$($target.Runtime)" )
+    $commandArgs += $( "--self-contained", "true" )
     $commandArgs += "$srcDir"
 
     if ([string]::IsNullOrEmpty($target.Arch) -eq $false) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21921

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
