### PR TITLE
RavenDB-21920 - Enforce uniqueness of Queue Sink task names

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -465,6 +465,8 @@ namespace Raven.Client.ServerWide
                 throw new InvalidOperationException($"Can't use task name '{taskName}', there is already a Periodic Backup task with that name");
             if (QueueEtls.Any(x => x.Name.Equals(taskName, StringComparison.OrdinalIgnoreCase)))
                 throw new InvalidOperationException($"Can't use task name '{taskName}', there is already a Queue ETL task with that name");
+            if (QueueSinks.Any(x => x.Name.Equals(taskName, StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"Can't use task name '{taskName}', there is already a Queue Sink task with that name");
         }
 
         internal string EnsureUniqueTaskName(string defaultTaskName)

--- a/test/SlowTests/Server/Documents/QueueSink/RabbitMqSinkTests.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/RabbitMqSinkTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
 using RabbitMQ.Client;
-using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Client.Documents.Operations.QueueSink;
 using Tests.Infrastructure;
@@ -213,7 +212,7 @@ public class RabbitMqSinkTests : QueueSinkTestBase
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Sinks)]
     public void Error_if_script_is_empty()
     {
         var config = new QueueSinkConfiguration

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-            const int numberToTolerate = 4632;
+            const int numberToTolerate = 4627;
 
             if (array.Length == numberToTolerate)
                 return;

--- a/test/Tests.Infrastructure/RavenTestCategory.cs
+++ b/test/Tests.Infrastructure/RavenTestCategory.cs
@@ -60,5 +60,6 @@ public enum RavenTestCategory : long
     Interversion = 1L << 44,
     Security = 1L << 45,
     Core = 1L << 46,
-    Intrinsics = 1L << 47
+    Intrinsics = 1L << 47,
+    Sinks = 1L << 48
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21920

### Additional description

Enforce uniqueness of Queue Sink task names.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing