### PR TITLE
RavenDB-7070 - skip logging of queries that allocate less than 32MB

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
     {
         protected readonly QueryBuilderFactories QueryBuilderFactories;
         private readonly MemoryInfo _memoryInfo;
-        private static readonly long ThresholdForMemoryUsageLoggingInBytes = new Size(32, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes);
+        private static readonly long ThresholdForMemoryUsageLoggingInBytes = new Size(512, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes);
 
         protected IndexReadOperationBase(Index index, Logger logger, QueryBuilderFactories queryBuilderFactories, IndexQueryServerSide query) : base(index, logger)
         {
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
             Func<string, SpatialField> getSpatialField, bool ignoreLimit, CancellationToken token);
 
         public abstract IEnumerable<string> DynamicEntriesFields(HashSet<string> staticFields);
-        
+
         public override void Dispose()
         {
             if ((_logger.IsInfoEnabled || (_logger.IsOperationsEnabled && _index.IsLowMemory)) &&
@@ -93,7 +93,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
                 }
             }
         }
-        
+
         public struct QueryResult
         {
             public Document Result;

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
@@ -19,6 +19,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
     {
         protected readonly QueryBuilderFactories QueryBuilderFactories;
         private readonly MemoryInfo _memoryInfo;
+        private static readonly long ThresholdForMemoryUsageLoggingInBytes = new Size(32, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes);
 
         protected IndexReadOperationBase(Index index, Logger logger, QueryBuilderFactories queryBuilderFactories, IndexQueryServerSide query) : base(index, logger)
         {
@@ -70,8 +71,14 @@ namespace Raven.Server.Documents.Indexes.Persistence
                 var mangedDiff = GC.GetAllocatedBytesForCurrentThread() - _memoryInfo.AllocatedManagedBefore;
                 var unmanagedDiff = Math.Max(0, NativeMemory.ThreadAllocations.Value.TotalAllocated - _memoryInfo.AllocatedUnmanagedBefore);
 
+                if (_logger.IsOperationsEnabled && mangedDiff < ThresholdForMemoryUsageLoggingInBytes && unmanagedDiff < ThresholdForMemoryUsageLoggingInBytes)
+                {
+                    // we don't want to spam the logs when we are in a low memory state and operations logs are enabled
+                    return;
+                }
+
                 var msg = $"Query for index `{_indexName}` for query: `{_memoryInfo.Query}`, " +
-                          $"Page size: {_memoryInfo.PageSize:#,#;;0}, " +
+                          $"page size: {_memoryInfo.PageSize:#,#;;0}, " +
                           $"allocated managed: {new Size(mangedDiff, SizeUnit.Bytes)}, " +
                           $"allocated unmanaged: {new Size(unmanagedDiff, SizeUnit.Bytes)}, " +
                           $"managed thread id: {_memoryInfo.ManagedThreadId}";


### PR DESCRIPTION
### Issue link


### Additional description

Skip logging of queries that allocate less than 32MB

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
