### PR TITLE
RavenDB-20155 - ClusterTransactionShouldBeRedirectedFromPromotableNode fails

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -391,6 +391,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     }
 
                     previous.LastSentEtag = dbReport.LastSentEtag;
+                    previous.LastCompareExchangeIndex = dbReport.LastCompareExchangeIndex;
                     previous.UpTime = dbReport.UpTime;
                     nodeReport.Report[dbName] = previous;
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20155/SlowTests.Cluster.ClusterTransactionTests.ClusterTransactionShouldBeRedirectedFromPromotableNodeoptions-DatabaseMode-Sharded

### Additional description

ClusterTransactionShouldBeRedirectedFromPromotableNode fails.
The supervisor doesnt takes the LastCompareExchangeIndex of the db reports (DatabaseStatusReport) in the current ClusterNodeStatusReport if it gets db status 'NoChange'. updating happens in 'UpdateNodeReportIfNeeded' method.
because of that, the cluster observer gets db report with outdated 'LastCompareExchangeIndex' and doesnt promote the node, so it stays promotable.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
