### PR TITLE
RavenDB-21936 Fixing the allocation size for a counter group name when purging counter tombstones

### DIFF
--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -2055,8 +2055,12 @@ namespace Raven.Server.Documents
                             table.DeleteByKey(counterGroupKey);
 
                             names.GetPropertyByIndex(1, ref prop);
-                            using var newScope = context.Allocator.Allocate(CounterKeysSlice.Size + 1 /* separator */  + 1 /* replace the current name with next one in counters group */, out ByteString newCounterKey);
+                            using var newScope = context.Allocator.Allocate(documentKeyPrefix.Size /* it includes the separator already */ + prop.Name.Size /* replace the current name with next one in counters group */, out ByteString newCounterKey);
                             documentKeyPrefix.CopyTo(newCounterKey.Ptr);
+
+                            Debug.Assert(documentKeyPrefix.Size + prop.Name.Size < newCounterKey.Size,
+                                $"documentKeyPrefix.Size ({documentKeyPrefix.Size}) + prop.Name.Size ({prop.Name.Size}) < newCounterKey.Size ({newCounterKey.Size})");
+
                             Memory.Copy(newCounterKey.Ptr + documentKeyPrefix.Size, prop.Name.Buffer, prop.Name.Size);
                             Slice.From(context.Allocator, newCounterKey.Ptr, documentKeyPrefix.Size + prop.Name.Size, out counterGroupKey);
                         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21936/Tombtone-cleaner-gets-stuck-because-of-ThrowInvalidAttemptToRemoveValueFromIndexAndNotFindingIt

https://issues.hibernatingrhinos.com/issue/RavenDB-21924

### Additional description

The problem was incorrect calculation of the size to allocate when creating a new `newCounterKey`. This key is going to be a new `counterGroupKey` after the deletion of first item from the group.

This issue caused that we were overwriting next allocation / segment in `ByteStringContext` allocation. In this specific case it was a key (`Slice`) of `Transaction._globalFixedSizeTree` dictonary. This resulted in inability to find `"AllCounterGroupsEtags"` index tree hence `ThrowInvalidAttemptToRemoveValueFromIndexAndNotFindingIt()` was thrown.

This issue can cause any corruption and it's very likely it caused the replication problem too: https://issues.hibernatingrhinos.com/issue/RavenDB-21924

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
