### PR TITLE
RavenDB-21945 Temporarily disable windows disk stats

### DIFF
--- a/src/Sparrow.Server/Utils/DiskUtils.cs
+++ b/src/Sparrow.Server/Utils/DiskUtils.cs
@@ -250,9 +250,7 @@ namespace Sparrow.Server.Utils
 #pragma warning disable CA1416
             return PlatformDetails.RunningOnLinux
                 ? new LinuxDiskStatsGetter(minInterval)
-                : PlatformDetails.RunningOnWindows ?
-                        new WindowsDiskStatsGetter(minInterval)
-                        : new NotImplementedDiskStatsGetter();
+                : new NotImplementedDiskStatsGetter();
 #pragma warning restore CA1416
         }
 

--- a/test/SlowTests/Monitoring/DiskStatsGetterTest.cs
+++ b/test/SlowTests/Monitoring/DiskStatsGetterTest.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Monitoring
             await DiskStats_WhenGet_ShouldBeLessThenTwoSimpleGet(diskStatsGetter);
         }
         
-        [NightlyBuildMultiplatformFact(RavenPlatform.Windows)]
+        [NightlyBuildMultiplatformFact(RavenPlatform.Windows, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-21945")]
         public async Task WindowsDiskStats_WhenGet_ShouldBeLessThenTwoSimpleGet()
         {
 #pragma warning disable CA1416


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-21945

### Additional description
I disabled the windows disk stats until we fix the issue
https://issues.hibernatingrhinos.com/issue/RavenDB-21945/Fix-The-process-cannot-access-the-file-because-it-is-being-used-by-another-process.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Windows.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Not relevant
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
