### PR TITLE
RavenDB-21934 - Enforce revisions configuration is skipping on docs

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1905,25 +1905,23 @@ namespace Raven.Server.Documents.Revisions
 
         private IEnumerable<TableValueHolder> GetRevisionsTable(DocumentsOperationContext context, string collection, long lastScannedEtag)
         {
-            IEnumerable<TableValueHolder> table = null;
-
             if (collection == null)
             {
                 var revisions = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
-                table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], lastScannedEtag);
+                return revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], lastScannedEtag);
             }
             else
             {
                 var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false) ?? new CollectionName(collection);
                 var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
                 var revisions = context.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
-                if (revisions != null) // there is no revisions for that collection
+                if (revisions != null) // there are existing revisions for that collection
                 {
-                    table = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
+                    return revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
                 }
             }
 
-            return table;
+            return null;
         }
 
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1910,15 +1910,13 @@ namespace Raven.Server.Documents.Revisions
                 var revisions = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
                 return revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], lastScannedEtag);
             }
-            else
+
+            var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false) ?? new CollectionName(collection);
+            var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
+            var collectionRevisions = context.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
+            if (collectionRevisions != null) // there are existing revisions for that collection
             {
-                var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false) ?? new CollectionName(collection);
-                var tableName = collectionName.GetTableName(CollectionTableType.Revisions);
-                var revisions = context.Transaction.InnerTransaction.OpenTable(RevisionsSchema, tableName);
-                if (revisions != null) // there are existing revisions for that collection
-                {
-                    return revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
-                }
+                return collectionRevisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], lastScannedEtag);
             }
 
             return null;

--- a/src/Raven.Server/Documents/TransactionCommands/EnforceRevisionConfigurationCommand.cs
+++ b/src/Raven.Server/Documents/TransactionCommands/EnforceRevisionConfigurationCommand.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.TransactionCommands
                 _token.ThrowIfCancellationRequested();
                 _result.RemovedRevisions += (int)_revisionsStorage.EnforceConfigurationFor(context, id, _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration == false, out var moreWork);
 
-                if(moreWork == false)
+                if (moreWork == false)
                     idsToRemove.Add(id);
             }
 

--- a/src/Raven.Server/Documents/TransactionCommands/EnforceRevisionConfigurationCommand.cs
+++ b/src/Raven.Server/Documents/TransactionCommands/EnforceRevisionConfigurationCommand.cs
@@ -26,14 +26,24 @@ namespace Raven.Server.Documents.TransactionCommands
     
         protected override long ExecuteCmd(DocumentsOperationContext context)
         {
-            MoreWork = false;
+            var idsToRemove = new List<string>();
             foreach (var id in _ids)
             {
                 _token.ThrowIfCancellationRequested();
-                _result.RemovedRevisions += (int)_revisionsStorage.EnforceConfigurationFor(context, id, _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration == false, ref MoreWork);
+                _result.RemovedRevisions += (int)_revisionsStorage.EnforceConfigurationFor(context, id, _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration == false, out var moreWork);
+
+                if(moreWork == false)
+                    idsToRemove.Add(id);
             }
-    
-            return _ids.Count;
+
+            foreach (var id in idsToRemove)
+            {
+                _ids.Remove(id);
+            }
+
+            MoreWork = _ids.Count > 0;
+
+            return idsToRemove.Count;
         }
     
         public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)

--- a/test/SlowTests/Issues/RavenDB-21934.cs
+++ b/test/SlowTests/Issues/RavenDB-21934.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.ServerWide;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using static SlowTests.RavenDB_20425;
+
+namespace SlowTests.Issues;
+public class RavenDB_21934 : RavenTestBase
+{
+    public RavenDB_21934(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Revisions)]
+    public async Task EnforceRevisionsConfigurationShouldntSkipDocs()
+    {
+        using var store = GetDocumentStore();
+
+        var collections = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Companies",
+            "Users"
+        };
+
+        var configuration = new RevisionsConfiguration
+        {
+            Default = new RevisionsCollectionConfiguration
+            {
+                Disabled = false,
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        // 1026 users
+        for (int i = 0; i < 1026; i++)
+        {
+            var user = new User { Id = $"Users/{i}", Name = "user" };
+            await StoreRevisionsAsync(store, user);
+        }
+
+        // 1028 companies
+        for (int i = 0; i < 1028; i++)
+        {
+            var company = new Company { Id = $"Companies/{i}", Name = "company" };
+            await StoreRevisionsAsync(store, company);
+        }
+
+        configuration = new RevisionsConfiguration
+        {
+            Default = new RevisionsCollectionConfiguration
+            {
+                Disabled = false,
+                MinimumRevisionsToKeep = 2
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+        using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, true, collections, token: token);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var company1Count = await session.Advanced.Revisions.GetCountForAsync("Companies/1");
+            Assert.Equal(2, company1Count);
+            var company2Count = await session.Advanced.Revisions.GetCountForAsync("Companies/2");
+            Assert.Equal(2, company2Count);
+        }
+
+    }
+
+    private static async Task StoreRevisionsAsync(IDocumentStore store, IEntity o)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                o.Name += i;
+                await session.StoreAsync(o);
+                await session.SaveChangesAsync();
+            }
+        }
+    }
+
+    private class User : IEntity
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class Company : IEntity
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private interface IEntity
+    {
+        string Id { get; set; }
+        string Name { get; set; }
+    }
+}
+


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21934/Enforce-configuration-in-5.4.113-cancelling

### Additional description

Enforce revisions configuration is skipping on docs when passing multiple collections

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
