### PR TITLE
RavenDB-21960 Add server endpoint to expose indexes metadata

### DIFF
--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -1169,6 +1169,45 @@ namespace Raven.Server.Documents.Handlers
 
         private static readonly int DefaultInputSizeForTestingJavaScriptIndex = 10;
 
+        [RavenAction("/databases/*/indexes/debug/metadata", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
+        public async Task Metadata()
+        {
+            using (var context = QueryOperationContext.Allocate(Database, needsServerContext: true))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context.Documents, ServerStore, ResponseBodyStream()))
+            {
+                var indexMetadata = GetIndexesToReportOn()
+                    .OrderBy(x => x.Name)
+                    .Select(x =>
+                    {
+                        var timeFields = x._indexStorage.ReadIndexTimeFields();
+                        var hasTimeFields = timeFields.Count > 0;
+
+                        return new DynamicJsonValue
+                        {
+                            [nameof(x.Name)] = x.Name,
+                            [nameof(x.Definition.Version)] = x.Definition.Version,
+                            [nameof(x.Type)] = x.Type,
+                            [nameof(x.Definition.State)] = x.Definition.State,
+                            [nameof(x.Definition.LockMode)] = x.Definition.LockMode,
+                            [nameof(x.SourceType)] = x.SourceType,
+                            [nameof(x.Definition.Priority)] = x.Definition.Priority,
+                            [nameof(x.SearchEngineType)] = x.SearchEngineType,
+                            [nameof(x.Definition.HasDynamicFields)] = x.Definition.HasDynamicFields,
+                            [nameof(x.Definition.HasCompareExchange)] = x.Definition.HasCompareExchange,
+                            ["HasTimeFields"] = hasTimeFields,
+                            ["TimeFields"] = timeFields
+                        };
+                    }).ToArray();
+                
+                writer.WriteStartObject();
+
+                writer.WriteArray(context.Documents, "Results", indexMetadata, 
+                    (w, c, metadata) => c.Write(w, metadata));
+
+                writer.WriteEndObject();
+            }
+        }
+
         private IEnumerable<Index> GetIndexesToReportOn()
         {
             IEnumerable<Index> indexes;

--- a/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationDebugPackageInfoTests.cs
@@ -55,7 +55,7 @@ namespace SlowTests.Authentication
         {
             var shouldContain = new[]
             {
-                "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "io-metrics.json", "perf-metrics.json",
+                "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "indexes.metadata.json", "io-metrics.json", "perf-metrics.json",
                 "replication.outgoing-failures.json", "replication.incoming-last-activity-time.json", "replication.incoming-rejection-info.json",
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
                 "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json",
@@ -73,7 +73,7 @@ namespace SlowTests.Authentication
         {
             var shouldContain = new[]
             {
-                "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "io-metrics.json", "perf-metrics.json",
+                "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "indexes.metadata.json", "io-metrics.json", "perf-metrics.json",
                 "replication.outgoing-failures.json", "replication.incoming-last-activity-time.json", "replication.incoming-rejection-info.json",
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
                 "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json", 
@@ -91,7 +91,7 @@ namespace SlowTests.Authentication
         {
             var shouldContain = new[]
             {
-                "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "io-metrics.json", "perf-metrics.json",
+                "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "indexes.metadata.json", "io-metrics.json", "perf-metrics.json",
                 "replication.outgoing-failures.json", "replication.incoming-last-activity-time.json", "replication.incoming-rejection-info.json",
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
                 "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json", 
@@ -110,7 +110,7 @@ namespace SlowTests.Authentication
         {
             var shouldContain = new[]
             {
-                "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "io-metrics.json", "perf-metrics.json",
+                "tasks.json", "indexes.json", "indexes.stats.json", "indexes.errors.json", "indexes.metadata.json", "io-metrics.json", "perf-metrics.json",
                 "replication.outgoing-failures.json", "replication.incoming-last-activity-time.json", "replication.incoming-rejection-info.json",
                 "replication.outgoing-reconnect-queue.json", "stats.json", "subscriptions.json", "tcp.json", "documents.huge.json", "identities.json",
                 "queries.running.json", "queries.cache.list.json", "script-runners.json", "storage.report.json", 

--- a/test/SlowTests/Issues/RavenDB-21960.cs
+++ b/test/SlowTests/Issues/RavenDB-21960.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Http;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21960 : RavenTestBase
+{
+    public RavenDB_21960(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public async Task CheckIndexesDebugMetadataEndpoint()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var o1 = new Order() { OrderedAt = new DateTime(2024, 1, 17, 15, 0, 0) };
+                
+                session.Store(o1);
+                session.SaveChanges();
+
+                var index = new DummyIndex();
+                await index.ExecuteAsync(store);
+
+                var otherIndex = new OtherDummyIndex();
+                await otherIndex.ExecuteAsync(store);
+                
+                Indexes.WaitForIndexing(store);
+
+                using (var commands = store.Commands())
+                {
+                    var cmd = new IndexMetadataCommand();
+                    await commands.ExecuteAsync(cmd);
+
+                    var res = cmd.Result as BlittableJsonReaderObject;
+                    
+                    Assert.NotNull(res);
+                    
+                    res.TryGet("Results", out BlittableJsonReaderArray indexMetadataArray);
+                    
+                    Assert.Equal(2, indexMetadataArray.Length);
+
+                    // First index
+
+                    var firstIndex = (BlittableJsonReaderObject)indexMetadataArray[0];
+
+                    Assert.Equal("DummyIndex", firstIndex["Name"]);
+                    Assert.Equal(IndexType.JavaScriptMap.ToString(), firstIndex["Type"]);
+                    Assert.Equal(IndexState.Normal.ToString(), firstIndex["State"]);
+                    Assert.Equal(IndexLockMode.Unlock.ToString(), firstIndex["LockMode"]);
+                    Assert.Equal(IndexSourceType.Documents.ToString(), firstIndex["SourceType"]);
+                    Assert.Equal(IndexPriority.Normal.ToString(), firstIndex["Priority"]);
+                    Assert.Equal(SearchEngineType.Lucene.ToString(), firstIndex["SearchEngineType"]);
+                    Assert.Equal(false, firstIndex["HasDynamicFields"]);
+                    Assert.Equal(false, firstIndex["HasCompareExchange"]);
+                    Assert.Equal(true, firstIndex["HasTimeFields"]);
+                    Assert.Equal("OrderedAt", ((BlittableJsonReaderArray)firstIndex["TimeFields"])[0]);
+
+                    var db = await GetDatabase(store.Database);
+                    
+                    var indexInstance = db.IndexStore.GetIndex(index.IndexName);
+
+                    Assert.Equal(indexInstance.Definition.Version, firstIndex["Version"]);
+
+                    //// Second index
+
+                    var secondIndex = (BlittableJsonReaderObject)indexMetadataArray[1];
+
+                    Assert.Equal("OtherDummyIndex", secondIndex["Name"]);
+                    Assert.Equal(IndexType.Map.ToString(), secondIndex["Type"]);
+                    Assert.Equal(IndexState.Normal.ToString(), secondIndex["State"]);
+                    Assert.Equal(IndexLockMode.Unlock.ToString(), secondIndex["LockMode"]);
+                    Assert.Equal(IndexSourceType.Documents.ToString(), secondIndex["SourceType"]);
+                    Assert.Equal(IndexPriority.Normal.ToString(), secondIndex["Priority"]);
+                    Assert.Equal(SearchEngineType.Corax.ToString(), secondIndex["SearchEngineType"]);
+                    Assert.Equal(false, secondIndex["HasDynamicFields"]);
+                    Assert.Equal(false, secondIndex["HasCompareExchange"]);
+                    Assert.Equal(false, secondIndex["HasTimeFields"]);
+                    Assert.Equal(0, ((BlittableJsonReaderArray)secondIndex["TimeFields"]).Length);
+
+                    var otherIndexInstance = db.IndexStore.GetIndex(otherIndex.IndexName);
+
+                    Assert.Equal(otherIndexInstance.Definition.Version, secondIndex["Version"]);
+                }
+            }
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task CheckIndexesDebugMetadataEndpointWithNameParameter()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var o1 = new Order() { OrderedAt = new DateTime(2024, 1, 17, 15, 0, 0) };
+                
+                session.Store(o1);
+                session.SaveChanges();
+
+                var index = new DummyIndex();
+                await index.ExecuteAsync(store);
+
+                var otherIndex = new OtherDummyIndex();
+                await otherIndex.ExecuteAsync(store);
+                
+                Indexes.WaitForIndexing(store);
+
+                using (var commands = store.Commands())
+                {
+                    var cmd = new IndexMetadataCommand(otherIndex.IndexName);
+                    await commands.ExecuteAsync(cmd);
+
+                    var res = cmd.Result as BlittableJsonReaderObject;
+                    
+                    Assert.NotNull(res);
+                    
+                    res.TryGet("Results", out BlittableJsonReaderArray indexMetadataArray);
+
+                    Assert.Equal(1, indexMetadataArray.Length);
+
+                    var metadata = (BlittableJsonReaderObject)indexMetadataArray[0];
+
+                    Assert.Equal("OtherDummyIndex", metadata["Name"]);
+                    Assert.Equal(IndexType.Map.ToString(), metadata["Type"]);
+                    Assert.Equal(IndexState.Normal.ToString(), metadata["State"]);
+                    Assert.Equal(IndexLockMode.Unlock.ToString(), metadata["LockMode"]);
+                    Assert.Equal(IndexSourceType.Documents.ToString(), metadata["SourceType"]);
+                    Assert.Equal(IndexPriority.Normal.ToString(), metadata["Priority"]);
+                    Assert.Equal(SearchEngineType.Corax.ToString(), metadata["SearchEngineType"]);
+                    Assert.Equal(false, metadata["HasDynamicFields"]);
+                    Assert.Equal(false, metadata["HasCompareExchange"]);
+                    Assert.Equal(false, metadata["HasTimeFields"]);
+                    Assert.Equal(0, ((BlittableJsonReaderArray)metadata["TimeFields"]).Length);
+
+                    var db = await GetDatabase(store.Database);
+
+                    var otherIndexInstance = db.IndexStore.GetIndex(otherIndex.IndexName);
+
+                    Assert.Equal(otherIndexInstance.Definition.Version, metadata["Version"]);
+                }
+            }
+        }
+    }
+
+    private class Order
+    {
+        public DateTime OrderedAt { get; set; }
+    }
+    
+    private class DummyIndex : AbstractJavaScriptIndexCreationTask
+    {
+        public DummyIndex()
+        {
+            Maps = new HashSet<string>
+            {
+                @"map('Orders', function (order){ 
+                    return { 
+                        OrderedAt: order.OrderedAt
+                    };
+                })",
+            };
+        }
+    }
+    
+    private class OtherDummyIndex : AbstractIndexCreationTask<Order>
+    {
+        public OtherDummyIndex()
+        {
+            Map = orders => from order in orders
+                select new
+                {
+                    Whatever = "abc"
+                };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+    
+    private class IndexMetadataCommand : RavenCommand<object>
+    {
+        private readonly string _indexName;
+        public IndexMetadataCommand(string indexName = null)
+        {
+            _indexName = indexName;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            if (_indexName == null)
+                url = $"{node.Url}/databases/{node.Database}/indexes/debug/metadata";
+            else
+                url = $"{node.Url}/databases/{node.Database}/indexes/debug/metadata?name={_indexName}";
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = response;
+        }
+
+        public override bool IsReadRequest => true;
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21960/Add-server-endpoint-to-expose-indexes-metadata

### Additional description

Exposing some additional index information, e.g. its TimeFields

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
