### PR TITLE
RavenDB-17788 - SlowTests.Client.TimeSeries.Policies.TimeSeriesConfig…

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1234,7 +1234,7 @@ namespace Raven.Server.Documents.Replication
                                 };
                                 var removedChangeVector = tss.DeleteTimestampRange(context, deletionRangeRequest, rcvdChangeVector, updateMetadata: false);
                                 if (removedChangeVector != null)
-                                    context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(removedChangeVector, rcvdChangeVector);
+                                    context.LastDatabaseChangeVector = ChangeVectorUtils.MergeVectors(removedChangeVector, context.LastDatabaseChangeVector);
 
                                 break;
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -437,9 +437,10 @@ namespace Raven.Server.Documents.TimeSeries
 
                         if (canDeleteEntireSegment && readOnlySegment.NumberOfLiveEntries > 1)
                         {
-                            deleted = readOnlySegment.NumberOfLiveEntries;
-                            holder.AddNewValue(baseline, new double[numberOfValues], Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
-                            holder.AddNewValue(readOnlySegment.GetLastTimestamp(baseline), new double[numberOfValues], Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
+                            deleted += readOnlySegment.NumberOfLiveEntries;
+                            Span<double> emptyValues = stackalloc double[numberOfValues];
+                            holder.AddNewValue(baseline, emptyValues, Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
+                            holder.AddNewValue(end, emptyValues, Slices.Empty.AsSpan(), ref newSegment, TimeSeriesValuesSegment.Dead);
                             holder.AppendDeadSegment(newSegment);
                             if (updateMetadata)
                             {
@@ -448,6 +449,7 @@ namespace Raven.Server.Documents.TimeSeries
                                 RemoveTimeSeriesNameFromMetadata(context, slicer.DocId, slicer.Name);
                             }
 
+                            changeVector = holder.ChangeVector;
                             return true;
                         }
 


### PR DESCRIPTION
…urationTests.FullRetentionAndRollupInACluster

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17788/SlowTests.Client.TimeSeries.Policies.TimeSeriesConfigurationTests.FullRetentionAndRollupInACluster

### Additional description

On failure, the replication stops due to an exception thrown from `UpdateGlobalReplicationInfoBeforeCommit.SetDatabaseChangeVector.ThrowOnNotUpdatedChangeVector()` where the `ChangeVectorUtils.GetConflictStatus == Coflict`. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
