### PR TITLE
RavenDB-21879 Throw meaningful exception when trying to use default HiLo with existing custom one

### DIFF
--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Changes;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Identity;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Session;
@@ -44,7 +45,7 @@ namespace Raven.Client.Documents
 
         private string _identifier;
 
-        public override IHiLoIdGenerator HiLoIdGenerator => _asyncMultiDbHiLo;
+        public override IHiLoIdGenerator HiLoIdGenerator => _asyncMultiDbHiLo ?? throw new InvalidOperationException($"Overwriting {nameof(DocumentConventions.AsyncDocumentIdGenerator)} convention does not allow usage of default HiLo generator, you should use your own one.");
 
         /// <summary>
         /// Gets or sets the identifier for this store.

--- a/test/SlowTests/Issues/RavenDB-21879.cs
+++ b/test/SlowTests/Issues/RavenDB-21879.cs
@@ -127,7 +127,7 @@ public class RavenDB_21879 : RavenTestBase
         }
     }
 
-    public class Dto
+    private class Dto
     {
         public string Id { get; set; }
         public string Name { get; set; }

--- a/test/SlowTests/Issues/RavenDB-21879.cs
+++ b/test/SlowTests/Issues/RavenDB-21879.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Identity;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21879 : RavenTestBase
+{
+    public RavenDB_21879(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class SingleNodeAsyncMultiDatabaseHiLoIdGenerator : AsyncMultiDatabaseHiLoIdGenerator
+    {
+        public SingleNodeAsyncMultiDatabaseHiLoIdGenerator(DocumentStore store) : base(store)
+        {
+        }
+
+        public override AsyncMultiTypeHiLoIdGenerator GenerateAsyncMultiTypeHiLoFunc(string dbName)
+        {
+            return new SingleNodeAsyncMultiTypeHiLoIdGenerator(Store, dbName);
+        }
+
+        private class SingleNodeAsyncMultiTypeHiLoIdGenerator : AsyncMultiTypeHiLoIdGenerator
+        {
+            public SingleNodeAsyncMultiTypeHiLoIdGenerator(DocumentStore store, string dbName) : base(store, dbName)
+            {
+            }
+
+            protected override AsyncHiLoIdGenerator CreateGeneratorFor(string tag)
+            {
+                return new SingleNodeAsyncHiLoIdGenerator(tag, Store, DbName, Conventions.IdentityPartsSeparator);
+            }
+
+            private class SingleNodeAsyncHiLoIdGenerator : AsyncHiLoIdGenerator
+            {
+                public SingleNodeAsyncHiLoIdGenerator(string tag, DocumentStore store, string dbName, char identityPartsSeparator) : base(tag, store, dbName,
+                    identityPartsSeparator)
+                {
+                }
+                
+                [Obsolete("Will be removed in next major version of the product. Use the GetDocumentIdFromId(NextId) overload.")]
+                protected override string GetDocumentIdFromId(long nextId)
+                {
+                    return $"{Prefix}{nextId}";
+                }
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Configuration)]
+    public async Task CustomHiloIdGeneration()
+    {
+        SingleNodeAsyncMultiDatabaseHiLoIdGenerator customHiloIdGenerator = null;
+        
+        var options = new Options()
+        {
+            ModifyDocumentStore = documentStore =>
+            {
+                customHiloIdGenerator = new SingleNodeAsyncMultiDatabaseHiLoIdGenerator(documentStore);
+
+                documentStore.Conventions.AsyncDocumentIdGenerator = customHiloIdGenerator.GenerateDocumentIdAsync;
+            }
+        };
+        
+        using (var store = GetDocumentStore(options))
+        { 
+            var idForDto = await customHiloIdGenerator.GenerateNextIdForAsync(null, typeof(Dto));
+
+            Assert.Equal(1, idForDto);
+            
+            var dto = new Dto() { Name = "CoolName" };
+
+            var fullIdForDto = await customHiloIdGenerator.GenerateDocumentIdAsync(null, dto);
+            
+            Assert.Equal("dtos/33", fullIdForDto);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Configuration)]
+    public async Task UsingDefaultHiLoGeneratorWithExistingCustomOneShouldThrow()
+    {
+        SingleNodeAsyncMultiDatabaseHiLoIdGenerator customHiloIdGenerator = null;
+
+        var options = new Options()
+        {
+            ModifyDocumentStore = documentStore =>
+            {
+                customHiloIdGenerator = new SingleNodeAsyncMultiDatabaseHiLoIdGenerator(documentStore);
+
+                documentStore.Conventions.AsyncDocumentIdGenerator = customHiloIdGenerator.GenerateDocumentIdAsync;
+            }
+        };
+
+        using (var store = GetDocumentStore(options))
+        {
+            var e1 = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                var nextId = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, typeof(Dto));
+            });
+
+            Assert.Contains($"Overwriting {nameof(DocumentConventions.AsyncDocumentIdGenerator)} convention does not allow usage of default HiLo generator, you should use your own one.", e1.Message);
+            
+            var e2 = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                var dto = new Dto() { Name = "CoolName" };
+                var nextFullId = await store.HiLoIdGenerator.GenerateDocumentIdAsync(null, dto);
+            });
+            
+            Assert.Contains($"Overwriting {nameof(DocumentConventions.AsyncDocumentIdGenerator)} convention does not allow usage of default HiLo generator, you should use your own one.", e2.Message);
+            
+            var dto = new Dto() { Name = "CoolName" };
+            
+            using (var session = store.OpenSession())
+            {
+                session.Store(dto);
+                session.SaveChanges();
+            }
+            
+            Assert.Equal("dtos/1", dto.Id);
+        }
+    }
+
+    public class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21879/CustomHiLoIdGenerator-and-DocumentStore.HiLoIdGenerator

### Additional description

If user overrides `AsyncDocumentIdGenerator` document convention, we want to throw a meaningful exception when they attempt to use Raven default generator to generate a HiLo id directly through it.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
