### PR TITLE
RavenDB-7070 - update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ src/Raven.Studio/junit.xml
 
 test/FastTests/Databases/
 /test/Tryouts/Logs
+/test/Tryouts/Properties/launchSettings.json
 /test/FastTests/Logs
 /test/SlowTests/test-timings.xml
 


### PR DESCRIPTION
when running tryouts with wsl `launchSettings.json` might contrain env variables (such license)