### PR TITLE
RavenDB-20628 - Handle failover on cluster transaction (5.4)

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -51,6 +51,7 @@ using Sparrow.Server;
 using Sparrow.Server.Meters;
 using Sparrow.Server.Utils;
 using Sparrow.Threading;
+using Sparrow.Utils;
 using Voron;
 using Voron.Data.Tables;
 using Voron.Exceptions;
@@ -360,6 +361,13 @@ namespace Raven.Server.Documents
 
                 _serverStore.StorageSpaceMonitor.Subscribe(this);
 
+                using (DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var lastCompletedClusterTransactionIndex = DocumentsStorage.ReadLastCompletedClusterTransactionIndex(ctx.Transaction.InnerTransaction);
+                    Interlocked.Exchange(ref LastCompletedClusterTransactionIndex, lastCompletedClusterTransactionIndex);
+                }
+
                 ThreadPool.QueueUserWorkItem(_ =>
                 {
                     try
@@ -450,6 +458,8 @@ namespace Raven.Server.Documents
         private long? _nextClusterCommand;
         private long _lastCompletedClusterTransaction;
         public long LastCompletedClusterTransaction => _lastCompletedClusterTransaction;
+
+        public long LastCompletedClusterTransactionIndex;
         public bool IsEncrypted => MasterKey != null;
 
         private PoolOfThreads.LongRunningWork _clusterTransactionsThread;
@@ -574,7 +584,7 @@ namespace Raven.Server.Documents
                     if (command.Processed)
                         continue;
 
-                    ClusterTransactionWaiter.SetException(command.Options.TaskId, command.Index, exception);
+                    OnClusterTransactionCompletion(command, exception);
                 }
             }
             finally
@@ -605,7 +615,7 @@ namespace Raven.Server.Documents
                 }
                 catch (Exception e) when (_databaseShutdown.IsCancellationRequested == false)
                 {
-                    OnClusterTransactionCompletion(command, mergedCommand, exception: e);
+                    OnClusterTransactionCompletion(command, exception: e);
                     NotificationCenter.Add(AlertRaised.Create(
                         Name,
                         "Cluster transaction failed to execute",
@@ -625,35 +635,38 @@ namespace Raven.Server.Documents
             }
         }
 
-        private void OnClusterTransactionCompletion(ClusterTransactionCommand.SingleClusterDatabaseCommand command,
-            BatchHandler.ClusterTransactionMergedCommand mergedCommands, Exception exception = null)
+        private void OnClusterTransactionCompletion(ClusterTransactionCommand.SingleClusterDatabaseCommand command, BatchHandler.ClusterTransactionMergedCommand mergedCommands)
         {
             try
             {
                 var index = command.Index;
                 var options = mergedCommands.Options[index];
-                if (exception == null)
+
+                ClusterTransactionWaiter.TrySetResult(options.TaskId, index, mergedCommands.ModifiedCollections);
+
+                ThreadingHelper.InterlockedExchangeMax(ref LastCompletedClusterTransactionIndex, index);
+
+                _nextClusterCommand = command.PreviousCount + command.Commands.Length;
+                _lastCompletedClusterTransaction = _nextClusterCommand.Value - 1;
+            }
+            catch (Exception e)
+            {
+                // nothing we can do
+                if (_logger.IsInfoEnabled)
                 {
-                    Task indexTask = null;
-                    if (options.WaitForIndexesTimeout != null)
-                    {
-                        indexTask = BatchHandler.WaitForIndexesAsync(DocumentsStorage.ContextPool, this, options.WaitForIndexesTimeout.Value,
-                            options.SpecifiedIndexesQueryString, options.WaitForIndexThrow,
-                            mergedCommands.LastDocumentEtag, mergedCommands.LastTombstoneEtag, mergedCommands.ModifiedCollections);
-                    }
-
-                    var result = new BatchHandler.ClusterTransactionCompletionResult
-                    {
-                        Array = mergedCommands.Replies[index],
-                        IndexTask = indexTask,
-                    };
-                    ClusterTransactionWaiter.SetResult(options.TaskId, index, result);
-                    _nextClusterCommand = command.PreviousCount + command.Commands.Length;
-                    _lastCompletedClusterTransaction = _nextClusterCommand.Value - 1;
-                    return;
+                    _logger.Info($"Failed to notify about transaction completion for database '{Name}'.", e);
                 }
+            }
+        }
 
-                ClusterTransactionWaiter.SetException(options.TaskId, index, exception);
+        private void OnClusterTransactionCompletion(ClusterTransactionCommand.SingleClusterDatabaseCommand command, Exception exception)
+        {
+            try
+            {
+                var index = command.Index;
+                var options = command.Options;
+
+                ClusterTransactionWaiter.TrySetException(options.TaskId, index, exception);
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -46,6 +46,7 @@ namespace Raven.Server.Documents
         private static readonly Slice LastReplicatedEtagsSlice;
         private static readonly Slice EtagsSlice;
         private static readonly Slice LastEtagSlice;
+        private static readonly Slice LastCompletedClusterTransactionIndexSlice;
         private static readonly Slice GlobalTreeSlice;
         private static readonly Slice GlobalChangeVectorSlice;
         private static readonly Slice GlobalFullChangeVectorSlice;
@@ -116,6 +117,7 @@ namespace Raven.Server.Documents
                 Slice.From(ctx, CollectionName.GetTablePrefix(CollectionTableType.Tombstones), ByteStringType.Immutable, out TombstonesPrefix);
                 Slice.From(ctx, "DeletedEtags", ByteStringType.Immutable, out DeletedEtagsSlice);
                 Slice.From(ctx, "LastReplicatedEtags", ByteStringType.Immutable, out LastReplicatedEtagsSlice);
+                Slice.From(ctx, "LastCompletedClusterTransactionIndex", ByteStringType.Immutable, out LastCompletedClusterTransactionIndexSlice);
                 Slice.From(ctx, "GlobalTree", ByteStringType.Immutable, out GlobalTreeSlice);
                 Slice.From(ctx, "GlobalChangeVector", ByteStringType.Immutable, out GlobalChangeVectorSlice);
                 Slice.From(ctx, "GlobalFullChangeVector", ByteStringType.Immutable, out GlobalFullChangeVectorSlice);
@@ -723,6 +725,30 @@ namespace Raven.Server.Documents
                 lastEtag = lastTimeSeriesEtag;
 
             return lastEtag;
+        }
+        public static long ReadLastCompletedClusterTransactionIndex(Transaction tx)
+        {
+            if (tx == null)
+                throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
+            var tree = tx.ReadTree(GlobalTreeSlice);
+            if (tree == null)
+            {
+                return 0;
+            }
+            var readResult = tree.Read(LastCompletedClusterTransactionIndexSlice);
+            if (readResult == null)
+            {
+                return 0;
+            }
+
+            return readResult.Reader.ReadLittleEndianInt64();
+        }
+
+        public void SetLastCompletedClusterTransactionIndex(DocumentsOperationContext context, long index)
+        {
+            var tree = context.Transaction.InnerTransaction.CreateTree(GlobalTreeSlice);
+            using (Slice.External(context.Allocator, (byte*)&index, sizeof(long), out Slice indexSlice))
+                tree.Add(LastCompletedClusterTransactionIndexSlice, indexSlice);
         }
 
         public IEnumerable<Document> GetDocumentsStartingWith(DocumentsOperationContext context, string idPrefix, string startAfterId,

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task BulkDocs()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            using (var token = CreateHttpRequestBoundOperationToken())
+            using (var token = new OperationCancelToken(ServerStore.ServerShutdown, HttpContext.RequestAborted))
             using (var command = new MergedBatchCommand(Database))
             {
                 var contentType = HttpContext.Request.ContentType;

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -5,8 +5,10 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Changes;
@@ -14,12 +16,15 @@ using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents;
+using Raven.Client.Extensions;
 using Raven.Client.Json;
+using Raven.Client.ServerWide;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.PeriodicBackup;
@@ -34,10 +39,12 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler;
 using Raven.Server.TrafficWatch;
 using Raven.Server.Utils;
+using Raven.Server.Web;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron;
+using static Raven.Server.ServerWide.Commands.ClusterTransactionCommand;
 using Constants = Raven.Client.Constants;
 using Index = Raven.Server.Documents.Indexes.Index;
 
@@ -51,6 +58,7 @@ namespace Raven.Server.Documents.Handlers
         public async Task BulkDocs()
         {
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (var token = CreateHttpRequestBoundOperationToken())
             using (var command = new MergedBatchCommand(Database))
             {
                 var contentType = HttpContext.Request.ContentType;
@@ -59,12 +67,12 @@ namespace Raven.Server.Documents.Handlers
                     if (contentType == null ||
                         contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
                     {
-                        await BatchRequestParser.BuildCommandsAsync(context, command, RequestBodyStream(), Database, ServerStore);
+                        await BatchRequestParser.BuildCommandsAsync(context, command, RequestBodyStream(), Database, ServerStore, token.Token);
                     }
                     else if (contentType.StartsWith("multipart/mixed", StringComparison.OrdinalIgnoreCase) ||
                              contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
                     {
-                        await ParseMultipart(context, command);
+                        await ParseMultipart(context, command, token.Token);
                     }
                     else
                         ThrowNotSupportedType(contentType);
@@ -88,20 +96,9 @@ namespace Raven.Server.Documents.Handlers
 
                 if (command.IsClusterTransaction)
                 {
-                    ValidateCommandForClusterWideTransaction(command, disableAtomicDocumentWrites);
+                    await HandleClusterTransaction(context, command, disableAtomicDocumentWrites, specifiedIndexesQueryString, waitForIndexesTimeout, waitForIndexThrow,
+                        token.Token);
 
-                    using (Database.ClusterTransactionWaiter.CreateTask(out var taskId))
-                    {
-                        // Since this is a cluster transaction we are not going to wait for the write assurance of the replication.
-                        // Because in any case the user will get a raft index to wait upon on his next request.
-                        var options = new ClusterTransactionCommand.ClusterTransactionOptions(taskId, disableAtomicDocumentWrites, ClusterCommandsVersionManager.CurrentClusterMinimalVersion)
-                        {
-                            WaitForIndexesTimeout = waitForIndexesTimeout,
-                            WaitForIndexThrow = waitForIndexThrow,
-                            SpecifiedIndexesQueryString = specifiedIndexesQueryString.Count > 0 ? specifiedIndexesQueryString.ToList() : null,
-                        };
-                        await HandleClusterTransaction(context, command, options);
-                    }
                     return;
                 }
 
@@ -130,7 +127,7 @@ namespace Raven.Server.Documents.Handlers
                 if (waitForIndexesTimeout != null)
                 {
                     long lastEtag = ChangeVectorUtils.GetEtagById(command.LastChangeVector, Database.DbBase64Id);
-                    await WaitForIndexesAsync(ContextPool, Database, waitForIndexesTimeout.Value, specifiedIndexesQueryString.ToList(), waitForIndexThrow,
+                    await WaitForIndexesAsync(Database, waitForIndexesTimeout.Value, specifiedIndexesQueryString.ToList(), waitForIndexThrow,
                         lastEtag, command.LastTombstoneEtag, command.ModifiedCollections);
                 }
 
@@ -162,9 +159,12 @@ namespace Raven.Server.Documents.Handlers
             }
         }
 
-        private static void ValidateCommandForClusterWideTransaction(MergedBatchCommand command, bool disableAtomicDocumentWrites)
+        private void ValidateCommandForClusterWideTransaction(ArraySegment<BatchRequestParser.CommandData> parsedCommands, DatabaseTopology databaseTopology, bool disableAtomicDocumentWrites)
         {
-            foreach (var commandData in command.ParsedCommands)
+            if (databaseTopology.Promotables.Contains(ServerStore.NodeTag))
+                throw new DatabaseNotRelevantException("Cluster transaction can't be handled by a promotable node.");
+
+            foreach (var commandData in parsedCommands)
             {
                 switch (commandData.Type)
                 {
@@ -228,63 +228,46 @@ namespace Raven.Server.Documents.Handlers
             AddStringToHttpContext(sb.ToString(), TrafficWatchChangeType.BulkDocs);
         }
 
-        private async Task HandleClusterTransaction(DocumentsOperationContext context, MergedBatchCommand command, ClusterTransactionCommand.ClusterTransactionOptions options)
+        public async Task HandleClusterTransaction(JsonOperationContext context, MergedBatchCommand command, 
+            bool disableAtomicDocumentWrites, StringValues specifiedIndexesQueryString, TimeSpan? waitForIndexesTimeout, bool waitForIndexThrow,
+            CancellationToken token)
         {
-            var raftRequestId = GetRaftRequestIdFromQuery();
+            var parsedCommands = command.ParsedCommands;
             var topology = ServerStore.LoadDatabaseTopology(Database.Name);
 
-            if (topology.Promotables.Contains(ServerStore.NodeTag))
-                throw new DatabaseNotRelevantException("Cluster transaction can't be handled by a promotable node.");
+            ValidateCommandForClusterWideTransaction(parsedCommands, topology, disableAtomicDocumentWrites);
+
+
+            var raftRequestId = GetRaftRequestIdFromQuery();
+
+            var options =
+                new ClusterTransactionOptions(taskId: raftRequestId, disableAtomicDocumentWrites,
+                    ClusterCommandsVersionManager.CurrentClusterMinimalVersion)
+                {
+                    WaitForIndexesTimeout = waitForIndexesTimeout,
+                    WaitForIndexThrow = waitForIndexThrow,
+                    SpecifiedIndexesQueryString = specifiedIndexesQueryString.Count > 0 ? specifiedIndexesQueryString.ToList() : null
+                };
+
 
             var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, Database.IdentityPartsSeparator, topology, command.ParsedCommands, options, raftRequestId);
-            var result = await ServerStore.SendToLeaderAsync(clusterTransactionCommand);
+            DynamicJsonArray array;
+            long index;
 
-            if (result.Result is List<ClusterTransactionCommand.ClusterTransactionErrorInfo> errors)
+            using (Database.ClusterTransactionWaiter.CreateTask(id: options.TaskId, out var tcs))
+            await using (token.Register(() => tcs.TrySetCanceled()))
             {
-                HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;
-                throw new ClusterTransactionConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
-                {
-                    ConcurrencyViolations = errors.Select(e => e.Violation).ToArray()
-                };
-            }
-
-            // wait for the command to be applied on this node
-            await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, result.Index);
-
-            var array = new DynamicJsonArray();
-            if (clusterTransactionCommand.DatabaseCommandsCount > 0)
-            {
-                try
-                {
-                    ClusterTransactionCompletionResult reply;
-                    using (var cts = CreateHttpRequestBoundTimeLimitedOperationToken(ServerStore.Engine.OperationTimeout))
-                    {
-                        reply = (ClusterTransactionCompletionResult)await Database.ClusterTransactionWaiter.WaitForResults(options.TaskId, cts.Token);
-                    }
-
-                    if (reply.IndexTask != null)
-                    {
-                        await reply.IndexTask;
-                    }
-
-                    array = reply.Array;
-                }
-                catch (Exception e)
-                {
-                    if (Database.IsShutdownRequested())
-                        Database.ThrowDatabaseShutdown(e);
-
-                    throw;
-                }
+                (index, object result) = await ServerStore.SendToLeaderAsync(clusterTransactionCommand);
+                array = await GetClusterTransactionDatabaseCommandsResults(result, clusterTransactionCommand.DatabaseCommandsCount, index, options, onDatabaseCompletionTask: tcs.Task, token);
             }
 
             foreach (var clusterCommands in clusterTransactionCommand.ClusterCommands)
             {
                 array.Add(new DynamicJsonValue
                 {
-                    ["Type"] = clusterCommands.Type,
-                    ["Key"] = clusterCommands.Id,
-                    ["Index"] = result.Index
+                    [nameof(ICommandData.Type)] = clusterCommands.Type,
+                    [nameof(ICompareExchangeValue.Key)] = clusterCommands.Id,
+                    [nameof(ICompareExchangeValue.Index)] = index
                 });
             }
 
@@ -294,17 +277,72 @@ namespace Raven.Server.Documents.Handlers
                 context.Write(writer, new DynamicJsonValue
                 {
                     [nameof(BatchCommandResult.Results)] = array,
-                    [nameof(BatchCommandResult.TransactionIndex)] = result.Index
+                    [nameof(BatchCommandResult.TransactionIndex)] = index
                 });
             }
         }
+
+        private async Task<DynamicJsonArray> GetClusterTransactionDatabaseCommandsResults(object result, long databaseCommandsCount, long index, ClusterTransactionOptions options, Task<HashSet<string>> onDatabaseCompletionTask, CancellationToken token)
+        {
+            if (result is List<ClusterTransactionErrorInfo> errors)
+                ThrowClusterTransactionConcurrencyException(errors);
+
+            if (databaseCommandsCount == 0)
+                return new DynamicJsonArray();
+
+            ServerStore.ForTestingPurposes?.AfterCommitInClusterTransaction?.Invoke();
+
+            if (result is ClusterTransactionResult clusterTxResult)
+            {
+                await WaitForDatabaseCompletion(onDatabaseCompletionTask, index, options, token);
+                return clusterTxResult.GeneratedResult;
+            }
+
+            throw new InvalidOperationException(
+                "Cluster-transaction was succeeded, but Leader is outdated and its results are inaccessible (the command has been already deleted from the history log).  We recommend you to update all nodes in the cluster to the last stable version.");
+        }
+
+        private void ThrowClusterTransactionConcurrencyException(List<ClusterTransactionErrorInfo> errors)
+        {
+            HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;
+            throw new ClusterTransactionConcurrencyException($"Failed to execute cluster transaction due to the following issues: {string.Join(Environment.NewLine, errors.Select(e => e.Message))}")
+            {
+                ConcurrencyViolations = errors.Select(e => e.Violation).ToArray()
+            };
+        }
+
+        private async Task WaitForDatabaseCompletion(Task<HashSet<string>> onDatabaseCompletionTask, long index, ClusterTransactionOptions options, CancellationToken token)
+        {
+            var lastCompleted = Interlocked.Read(ref Database.LastCompletedClusterTransactionIndex);
+            HashSet<string> modifiedCollections = null;
+            if (lastCompleted < index)
+                modifiedCollections = await onDatabaseCompletionTask; // already registered to the token
+
+            if (options.WaitForIndexesTimeout.HasValue)
+            {
+                long lastDocumentEtag, lastTombstoneEtag;
+
+                using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenReadTransaction())
+                {
+                    lastDocumentEtag = DocumentsStorage.ReadLastDocumentEtag(tx.InnerTransaction);
+                    lastTombstoneEtag = DocumentsStorage.ReadLastTombstoneEtag(tx.InnerTransaction);
+                    modifiedCollections ??= Database.DocumentsStorage.GetCollections(context).Select(c => c.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+                }
+
+                await WaitForIndexesAsync(Database, options.WaitForIndexesTimeout.Value,
+                    options.SpecifiedIndexesQueryString, options.WaitForIndexThrow,
+                    lastDocumentEtag, lastTombstoneEtag, modifiedCollections, token);
+            }
+        }
+
 
         private static void ThrowNotSupportedType(string contentType)
         {
             throw new InvalidOperationException($"The requested Content type '{contentType}' is not supported. Use 'application/json' or 'multipart/mixed'.");
         }
 
-        private async Task ParseMultipart(DocumentsOperationContext context, MergedBatchCommand command)
+        private async Task ParseMultipart(DocumentsOperationContext context, MergedBatchCommand command, CancellationToken token)
         {
             var boundary = MultipartRequestHelper.GetBoundary(
                 MediaTypeHeaderValue.Parse(HttpContext.Request.ContentType),
@@ -312,14 +350,14 @@ namespace Raven.Server.Documents.Handlers
             var reader = new MultipartReader(boundary, RequestBodyStream());
             for (var i = 0; i < int.MaxValue; i++)
             {
-                var section = await reader.ReadNextSectionAsync().ConfigureAwait(false);
+                var section = await reader.ReadNextSectionAsync(token).ConfigureAwait(false);
                 if (section == null)
                     break;
 
                 var bodyStream = GetBodyStream(section);
                 if (i == 0)
                 {
-                    await BatchRequestParser.BuildCommandsAsync(context, command, bodyStream, Database, ServerStore);
+                    await BatchRequestParser.BuildCommandsAsync(context, command, bodyStream, Database, ServerStore, token);
                     continue;
                 }
 
@@ -333,8 +371,8 @@ namespace Raven.Server.Documents.Handlers
                 {
                     Stream = command.AttachmentStreamsTempFile.StartNewStream()
                 };
-                attachmentStream.Hash = await AttachmentsStorageHelper.CopyStreamToFileAndCalculateHash(context, bodyStream, attachmentStream.Stream, Database.DatabaseShutdown);
-                await attachmentStream.Stream.FlushAsync();
+                attachmentStream.Hash = await AttachmentsStorageHelper.CopyStreamToFileAndCalculateHash(context, bodyStream, attachmentStream.Stream, token);
+                await attachmentStream.Stream.FlushAsync(token);
                 command.AttachmentStreams.Add(attachmentStream);
             }
         }
@@ -371,9 +409,9 @@ namespace Raven.Server.Documents.Handlers
             }
         }
 
-        public static async Task WaitForIndexesAsync(DocumentsContextPool contextPool, DocumentDatabase database, TimeSpan timeout,
+        public static async Task WaitForIndexesAsync(DocumentDatabase database, TimeSpan timeout,
             List<string> specifiedIndexesQueryString, bool throwOnTimeout,
-            long lastDocumentEtag, long lastTombstoneEtag, HashSet<string> modifiedCollections)
+            long lastDocumentEtag, long lastTombstoneEtag, HashSet<string> modifiedCollections, CancellationToken token = default)
         {
             // waitForIndexesTimeout=timespan & waitForIndexThrow=false (default true)
             // waitForSpecificIndex=specific index1 & waitForSpecificIndex=specific index 2
@@ -427,7 +465,7 @@ namespace Raven.Server.Documents.Handlers
 
                         hadStaleIndexes = true;
 
-                        await waitForIndexItem.WaitForIndexing.WaitForIndexingAsync(waitForIndexItem.IndexBatchAwaiter);
+                        await waitForIndexItem.WaitForIndexing.WaitForIndexingAsync(waitForIndexItem.IndexBatchAwaiter).WithCancellation(token);
 
                         if (waitForIndexItem.WaitForIndexing.TimeoutExceeded)
                         {
@@ -490,7 +528,7 @@ namespace Raven.Server.Documents.Handlers
         {
             var indexesToCheck = new List<Index>();
 
-            if (specifiedIndexesQueryString.Count > 0)
+            if (specifiedIndexesQueryString is { Count: > 0 })
             {
                 var specificIndexes = specifiedIndexesQueryString.ToHashSet();
                 foreach (var index in database.IndexStore.GetIndexes())
@@ -621,6 +659,8 @@ namespace Raven.Server.Documents.Handlers
                 Replies.Clear();
                 Options.Clear();
 
+                long lastIndexInBatch = 0L;
+
                 foreach (var command in _batch)
                 {
                     Replies.Add(command.Index, new DynamicJsonArray());
@@ -640,11 +680,7 @@ namespace Raven.Server.Documents.Handlers
                         foreach (BlittableJsonReaderObject blittableCommand in commands)
                         {
                             count++;
-                            var changeVector = $"{ChangeVectorParser.RaftTag}:{count}-{Database.DatabaseGroupId}";
-                            if (options.DisableAtomicDocumentWrites == false)
-                            {
-                                changeVector += $",{ChangeVectorParser.TrxnTag}:{command.Index}-{Database.ClusterTransactionId}";
-                            }
+                            var changeVector = ChangeVectorUtils.GetClusterWideChangeVector(Database.DatabaseGroupId, count, options.DisableAtomicDocumentWrites == false, command.Index, Database.ClusterTransactionId);
                             var cmd = JsonDeserializationServer.ClusterTransactionDataCommand(blittableCommand);
 
                             switch (cmd.Type)
@@ -768,7 +804,14 @@ namespace Raven.Server.Documents.Handlers
                     {
                         context.LastDatabaseChangeVector = updatedChangeVector.ChangeVector;
                     }
+
+                    lastIndexInBatch = long.Max(lastIndexInBatch, command.Index);
                 }
+
+                // set last cluster transaction index (persistent)
+                var lastClusterTxIndex = DocumentsStorage.ReadLastCompletedClusterTransactionIndex(context.Transaction.InnerTransaction);
+                if (lastIndexInBatch > lastClusterTxIndex)
+                    Database.DocumentsStorage.SetLastCompletedClusterTransactionIndex(context, lastIndexInBatch);
 
                 return Reply.Count;
             }

--- a/src/Raven.Server/ServerWide/ClusterTransactionResult.cs
+++ b/src/Raven.Server/ServerWide/ClusterTransactionResult.cs
@@ -1,0 +1,16 @@
+﻿using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide;
+public class ClusterTransactionResult : IDynamicJsonValueConvertible
+{
+    public DynamicJsonArray GeneratedResult { get; set; }
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(GeneratedResult)] = GeneratedResult,
+        };
+    }
+}

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Analysis;
@@ -139,6 +140,11 @@ namespace Raven.Server.ServerWide
 
                 return _topology;
             }
+        }
+
+        public string GetClusterTransactionId()
+        {
+            return _materializedRecord != null ? _materializedRecord.Topology.ClusterTransactionIdBase64 : Topology.ClusterTransactionIdBase64;
         }
 
         private DatabaseStateStatus? _databaseState;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3640,6 +3640,7 @@ namespace Raven.Server.ServerWide
             internal bool StopIndex;
             internal Action<CompareExchangeCommandBase> ModifyCompareExchangeTimeout;
             internal Action RestoreDatabaseAfterSavingDatabaseRecord;
+            internal Action AfterCommitInClusterTransaction;
         }
         
         public readonly MemoryCache QueryClauseCache;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -729,7 +729,7 @@ namespace Raven.Server.Smuggler.Documents
                     var parsedCommands = _clusterTransactionCommands.GetArraySegment();
 
                     var raftRequestId = RaftIdGenerator.NewId();
-                    var options = new ClusterTransactionCommand.ClusterTransactionOptions(string.Empty, disableAtomicDocumentWrites: false,
+                    var options = new ClusterTransactionCommand.ClusterTransactionOptions(taskId: raftRequestId, disableAtomicDocumentWrites: false,
                         ClusterCommandsVersionManager.CurrentClusterMinimalVersion);
                     var topology = _database.ServerStore.LoadDatabaseTopology(_database.Name);
 

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -398,5 +398,20 @@ namespace Raven.Server.Utils
 
             return newChangeVector.SerializeVector();
         }
+
+        public static string GetClusterWideChangeVector(string databaseId, long prevCount, bool addTrxAddition, long index, string clusterTransactionId)
+        {
+            var stringBuilder = new StringBuilder(ChangeVectorParser.RaftTag)
+                .Append(':').Append(prevCount)
+                .Append('-').Append(databaseId);
+            if (addTrxAddition)
+            {
+                stringBuilder
+                    .Append(',').Append(ChangeVectorParser.TrxnTag)
+                    .Append(':').Append(index)
+                    .Append('-').Append(clusterTransactionId);
+            }
+            return stringBuilder.ToString();
+        }
     }
 }

--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -41,7 +41,8 @@ namespace InterversionTests
             return base.GetNewServer(options, caller);
         }
 
-        protected async Task<List<ProcessNode>> CreateCluster(string[] peers, IDictionary<string, string> customSettings = null, X509Certificate2 certificate = null)
+        protected async Task<List<ProcessNode>> CreateCluster(string[] peers, X509Certificate2 certificate = null
+            , bool watcherCluster = false)
         {
             var processes = new List<ProcessNode>();
             foreach (var peer in peers)
@@ -49,28 +50,31 @@ namespace InterversionTests
                 processes.Add(await GetServerAsync(peer));
             }
 
-            var chosenOne = processes[0];
+            var leader = processes[0];
 
-            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(chosenOne.Url, certificate, DocumentConventions.DefaultForServer))
+            using (var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(leader.Url, certificate, DocumentConventions.DefaultForServer))
             using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
                 foreach (var processNode in processes)
                 {
-                    if (processNode == chosenOne)
+                    if (processNode == leader)
                         continue;
 
-                    var addCommand = new AddClusterNodeCommand(processNode.Url);
+                    var addCommand = new AddClusterNodeCommand(processNode.Url, watcher: watcherCluster);
                     await requestExecutor.ExecuteAsync(addCommand, context);
                 }
 
+                var result = watcherCluster ? (1, peers.Length - 1) : (peers.Length, 0);
                 var clusterCreated = await WaitForValueAsync(async () =>
                 {
                     var clusterTopology = new GetClusterTopologyCommand();
                     await requestExecutor.ExecuteAsync(clusterTopology, context);
-                    return clusterTopology.Result.Topology.Members.Count;
-                }, peers.Length);
+                    var clusterTopology1 = clusterTopology.Result.Topology;
 
-                Assert.True(clusterCreated == peers.Length, "Failed to create initial cluster");
+                    return (clusterTopology1.Members.Count, clusterTopology1.Watchers.Count);
+                }, result);
+
+                Assert.True(clusterCreated == result, "Failed to create initial cluster");
             }
 
             return processes;
@@ -218,9 +222,9 @@ namespace InterversionTests
             }), stores);
         }
 
-        protected static async Task<string> CreateDatabase(IDocumentStore store, int replicationFactor = 1, [CallerMemberName] string dbName = null)
+        protected static async Task<string> CreateDatabase(IDocumentStore store, int replicationFactor = 1, [CallerMemberName] string dbName = null, DatabaseRecord record = null)
         {
-            var doc = new DatabaseRecord(dbName)
+            var doc = record ?? new DatabaseRecord(dbName)
             {
                 Settings =
                 {

--- a/test/InterversionTests/RavenDB-20628-backward-compatibility.cs
+++ b/test/InterversionTests/RavenDB-20628-backward-compatibility.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
+using Raven.Client.Http;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Commands;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Tests.Infrastructure.InterversionTest;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace InterversionTests
+{
+    public class RavenDB_20628_backward_compatibility : MixedClusterTestBase
+    {
+        public RavenDB_20628_backward_compatibility(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [MultiplatformTheory(RavenPlatform.Windows | RavenPlatform.Linux)]
+        [InlineData("5.4.107")]
+        [InlineData("5.4.109")]
+        public async Task UpgradeLeaderToLatest(string latest)
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+
+            var initialVersions = new[] { latest, latest };
+
+            var nodes = await CreateCluster(initialVersions, watcherCluster: true);
+            var database = GetDatabaseName();
+            var result = await GetStores(database, nodes);
+            var leaderUrl = await GetLeaderUrl(result.Stores[0]);
+            var leaderProc = nodes.Single(n => n.Url == leaderUrl);
+            var followerUrl = nodes.Single(n => n.Url != leaderUrl).Url;
+
+            using (result.Disposable)
+            {
+                var stores = result.Stores;
+                await CreateDatabase(stores[0], replicationFactor: nodes.Count, dbName: database, record: new DatabaseRecord(database));
+
+                await UpgradeServerAsync("current", leaderProc);
+
+                using var followerStore = new DocumentStore()
+                {
+                    Urls = new[] { followerUrl },
+                    Conventions =
+                    {
+                        DisableTopologyUpdates = true
+                    }
+                }.Initialize();
+
+                var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+
+                using (var session = followerStore.OpenAsyncSession(new SessionOptions
+                {
+                    Database = database,
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    await session.StoreAsync(user1);
+                    await session.SaveChangesAsync();
+                }
+            }
+        }
+
+        [MultiplatformTheory(RavenPlatform.Windows | RavenPlatform.Linux)]
+        [InlineData("5.4.107")]
+        [InlineData("5.4.109")]
+        public async Task UpgradeFollowerToLatest(string latest)
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+
+            var initialVersions = new[] { latest, latest };
+
+            var nodes = await CreateCluster(initialVersions, watcherCluster: true);
+            var database = GetDatabaseName();
+            var result = await GetStores(database, nodes);
+            var leaderUrl = await GetLeaderUrl(result.Stores[0]);
+            var followerProc = nodes.Single(n => n.Url != leaderUrl);
+            var followerUrl = followerProc.Url;
+
+            using (result.Disposable)
+            {
+                var stores = result.Stores;
+                await CreateDatabase(stores[0], replicationFactor: nodes.Count, dbName: database, record: new DatabaseRecord(database));
+                await UpgradeServerAsync("current", followerProc);
+
+                using var followerStore = new DocumentStore()
+                {
+                    Urls = new[] { followerUrl },
+                    Conventions =
+                    {
+                        DisableTopologyUpdates = true
+                    }
+                }.Initialize();
+
+                var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+
+                using (var session = followerStore.OpenAsyncSession(new SessionOptions
+                {
+                    Database = database,
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    await session.StoreAsync(user1);
+                    var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await session.SaveChangesAsync());
+                    Assert.True(e.InnerException is InvalidOperationException);
+                }
+            }
+        }
+
+        private async Task<string> GetLeaderUrl(IDocumentStore store)
+        {
+            var clusterTopology = await store.Maintenance.Server.SendAsync(new GetClusterTopologyOperation());
+            var leaderTag = clusterTopology.Leader;
+            var leaderUrl = clusterTopology.Topology.Members[leaderTag];
+            return leaderUrl;
+        }
+
+        private class GetClusterTopologyOperation : IServerOperation<ClusterTopologyResponse>
+        {
+            public GetClusterTopologyOperation()
+            {
+            }
+
+            public RavenCommand<ClusterTopologyResponse> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new GetClusterTopologyCommand();
+            }
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+    }
+}

--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -52,8 +52,13 @@ namespace RachisTests.DatabaseCluster
                 await session.SaveChangesAsync();
             }
 
-            var result = await store.Operations.SendAsync(new GetCompareExchangeValuesOperation<TestObj>(""));
-            Assert.Single(result);
+            Dictionary<string, CompareExchangeValue<TestObj>> result = null;
+            await AssertWaitForValueAsync(async () =>
+            {
+                result = await store.Operations.SendAsync(new GetCompareExchangeValuesOperation<TestObj>(""));
+                return result.Count;
+            }, 1);
+
             Assert.EndsWith(entity.Id, result.Single().Key, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Esprima.Ast;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Raven.Server;
+using Raven.Server.Rachis;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_20628 : ClusterTestBase
+    {
+        public RavenDB_20628(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Cluster)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ClusterTransaction_Should_Work_After_Commit_And_Failover(Options options)
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
+
+            options.Server = leader;
+            options.ReplicationFactor = nodes.Count;
+            using var store = GetDocumentStore(options);
+
+            ApplyFailoverAfterCommit(nodes);
+
+            var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(user1);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var users1onSession = await session.LoadAsync<User>(user1.Id);
+                Assert.Equal(users1onSession.Name, "Alice");
+            }
+
+        }
+
+        [RavenTheory(RavenTestCategory.Cluster)]
+        [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ClusterTransaction_WithMultipleCommands_Should_Work_After_Commit_And_Failover(Options options, bool waitForIndexes)
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
+
+            options.Server = leader;
+            options.ReplicationFactor = nodes.Count;
+            using var store = GetDocumentStore(options);
+
+            ApplyFailoverAfterCommit(nodes);
+
+            var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+            var user2 = new User() { Id = "Users/2-A", Name = "Bob" };
+            var company3 = new Company() { Id = "Companies/3-A", Name = "Alice" };
+            var post4 = new Post() { Id = "Posts/4-A", Title = "Alice" };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.StoreAsync(company3);
+                await session.StoreAsync(post4);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                if (waitForIndexes)
+                    session.Advanced.WaitForIndexesAfterSaveChanges();
+
+                (await session.LoadAsync<User>(user1.Id)).Name = "Bob";
+                await session.StoreAsync(user2);
+                session.Delete(company3.Id);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var users1onSession = await session.LoadAsync<User>(user1.Id);
+                Assert.Equal(users1onSession.Name, "Bob");
+
+                var users2onSession = await session.LoadAsync<User>(user2.Id);
+                Assert.Equal(users2onSession.Name, "Bob");
+
+                var users3onSession = await session.LoadAsync<User>(company3.Id);
+                Assert.Null(users3onSession);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Cluster)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ClusterTransaction_WithMultipleCommands_Should_Work_After_Commit_And_Failover_UseResults(Options options)
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 2, watcherCluster: true);
+
+            options.Server = leader;
+            options.ReplicationFactor = nodes.Count;
+            using var store = GetDocumentStore(options);
+
+            ApplyFailoverAfterCommit(nodes);
+
+            var user1 = new User() { Id = "Users/1-A", Name = "Alice" };
+            var user2 = new User() { Id = "Users/2-A", Name = "Bob" };
+            var user3 = new User() { Id = "Users/3-A", Name = "Alice" };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.StoreAsync(user3);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var users1onSession = await session.LoadAsync<User>(user1.Id);
+                users1onSession.Name = "Bob";
+                await session.StoreAsync(user2);
+                session.Delete(user3.Id);
+                await session.SaveChangesAsync();
+
+                users1onSession.Name = "Shahar";
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var users1onSession = await session.LoadAsync<User>(user1.Id);
+                Assert.Equal(users1onSession.Name, "Shahar");
+
+                var users2onSession = await session.LoadAsync<User>(user2.Id);
+                Assert.Equal(users2onSession.Name, "Bob");
+
+                var users3onSession = await session.LoadAsync<User>(user3.Id);
+                Assert.Null(users3onSession);
+            }
+        }
+
+        private void ApplyFailoverAfterCommit(List<RavenServer> nodes)
+        {
+            int failover = 0;
+            foreach (var server in nodes)
+            {
+                server.ServerStore.ForTestingPurposesOnly().AfterCommitInClusterTransaction = () =>
+                {
+                    if (Interlocked.CompareExchange(ref failover, 1, 0) == 0)
+                        throw new TimeoutException("Fake server fail that cause failover"); // for failover in node A
+                };
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20628/Cluster-wide-transaction-throw-TaskCanceledException-when-fails-on-timeout

### Additional description

merge this one to 5.4:
https://github.com/ravendb/ravendb/pull/17871

Cluster wide transaction : throw `TaskCanceledException` when fails on timeout (happens in failover) - 6.0
The scenario:
The client sends the request to node A, it finishes performing the cluster transaction, then it fails.
Now client sends the same request to node B (as part of the failover) but it throws `TaskCanceledException`.

### Type of change

- Bug fix

### How risky is the change?

- Low 

### Backward compatibility

- Not relevant

### Is it platform specific issue?

- No

### Documentation update

- No documentation update is needed 

### Testing 

- Tests have been added that prove the fix is effective or that the feature works

### Is there any existing behavior change of other features due to this change?

- No

### UI work

- No UI work is needed
