### PR TITLE
RavenDB-19922 - cluster observer should decide which node should perform the backup

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -480,6 +480,11 @@ namespace Raven.Client.ServerWide
             if (lastResponsibleNode != null)
                 return lastResponsibleNode;
 
+            return WhoseTaskIsIt(task);
+        }
+
+        internal string WhoseTaskIsIt(IDatabaseTask task)
+        {
             var topology = new List<string>(Members);
             topology.AddRange(Promotables);
             topology.AddRange(Rehabs);

--- a/src/Raven.Server/Config/Categories/BackupConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BackupConfiguration.cs
@@ -6,7 +6,6 @@ using System.IO.Compression;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Documents.Smuggler;
 using Raven.Server.Config.Attributes;
 using Raven.Server.Config.Settings;
 using Raven.Server.ServerWide;
@@ -84,6 +83,12 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(CompressionLevel.Fastest)]
         [ConfigurationEntry("Backup.Snapshot.Compression.Level", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public CompressionLevel SnapshotCompressionLevel { get; set; }
+
+        [Description("Number of seconds, after which we will switch to a new responsible node for backup.")]
+        [DefaultValue(30 * 60)]
+        [TimeUnit(TimeUnit.Seconds)]
+        [ConfigurationEntry("Backup.MoveToNewResponsibleNodeGracePeriodInSec", ConfigurationEntryScope.ServerWideOnly)]
+        public TimeSetting MoveToNewResponsibleNodeGracePeriod { get; set; }
 
         public override void Initialize(IConfigurationRoot settings, HashSet<string> settingsNames, IConfigurationRoot serverWideSettings, HashSet<string> serverWideSettingsNames, ResourceType type, string resourceName)
         {

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Nito.AsyncEx;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;
@@ -28,7 +27,6 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server.Threading;
-using Sparrow.Threading;
 using Sparrow.Utils;
 using Voron.Exceptions;
 using Voron.Util.Settings;
@@ -1365,7 +1363,7 @@ namespace Raven.Server.Documents
                         case IdleDatabaseActivityType.UpdateBackupStatusOnly:
                             PeriodicBackupStatus backupStatus;
 
-                            using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                            using (_serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                             using (context.OpenReadTransaction())
                                 backupStatus = BackupUtils.GetBackupStatusFromCluster(_serverStore, context, databaseName, nextIdleDatabaseActivity.TaskId);
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1649,7 +1649,7 @@ namespace Raven.Server.Documents
                     DatabaseShutdown.ThrowIfCancellationRequested();
                     SubscriptionStorage?.HandleDatabaseRecordChange(record);
                     EtlLoader?.HandleDatabaseValueChanged(record);
-                    PeriodicBackupRunner?.HandleDatabaseValueChanged(type, changeState);
+                    PeriodicBackupRunner?.HandleDatabaseValueChanged(type, record, changeState);
 
                     LastValueChangeIndex = index;
                 }

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -295,7 +295,7 @@ namespace Raven.Server.Documents.ETL
                     continue;
 
                 var processState = GetProcessState(config.Transforms, _database, config.Name);
-                var whoseTaskIsIt = BackupUtils.WhoseTaskIsIt(_serverStore, _databaseRecord.Topology, config, processState, _database.NotificationCenter);
+                var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, _databaseRecord.Topology, config, processState, _database.NotificationCenter);
                 if (whoseTaskIsIt != _serverStore.NodeTag)
                     continue;
 
@@ -462,7 +462,7 @@ namespace Raven.Server.Documents.ETL
             where T : EtlConfiguration<TConnectionString>
         {
             var processState = GetProcessState(etlTask.Transforms, _database, etlTask.Name);
-            var whoseTaskIsIt = BackupUtils.WhoseTaskIsIt(_serverStore, record.Topology, etlTask, processState, _database.NotificationCenter);
+            var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, record.Topology, etlTask, processState, _database.NotificationCenter);
 
             responsibleNodes[etlTask.Name] = whoseTaskIsIt;
 

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForUpdateExternalReplication.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForUpdateExternalReplication.cs
@@ -3,6 +3,7 @@ using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
@@ -22,7 +23,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
             {
                 var topology = RequestHandler.ServerStore.Cluster.ReadDatabaseTopology(context, databaseName);
                 var taskStatus = ReplicationLoader.GetExternalReplicationState(RequestHandler.ServerStore, databaseName, watcher.TaskId);
-                responseJson[nameof(OngoingTask.ResponsibleNode)] = RequestHandler.ServerStore.WhoseTaskIsIt(topology, watcher, taskStatus);
+                responseJson[nameof(OngoingTask.ResponsibleNode)] = OngoingTasksUtils.WhoseTaskIsIt(ServerStore, topology, watcher, taskStatus, RequestHandler.Database.NotificationCenter);
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/PullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/PullReplicationHandlerProcessorForUpdatePullReplicationOnSinkNode.cs
@@ -3,6 +3,7 @@ using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
@@ -27,7 +28,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
             using (context.OpenReadTransaction())
             {
                 var topology = RequestHandler.ServerStore.Cluster.ReadDatabaseTopology(context, databaseName);
-                responseJson[nameof(OngoingTask.ResponsibleNode)] = RequestHandler.ServerStore.WhoseTaskIsIt(topology, pullReplication, null);
+                responseJson[nameof(OngoingTask.ResponsibleNode)] = OngoingTasksUtils.WhoseTaskIsIt(ServerStore, topology, pullReplication, taskStatus: null, RequestHandler.Database.NotificationCenter);
             }
         }
     }

--- a/src/Raven.Server/Documents/OngoingTasks/AbstractOngoingTasks.cs
+++ b/src/Raven.Server/Documents/OngoingTasks/AbstractOngoingTasks.cs
@@ -48,7 +48,7 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
             yield break;
 
         foreach (var backupConfiguration in databaseRecord.PeriodicBackups)
-            yield return CreateBackupTaskInfo(clusterTopology, databaseRecord, backupConfiguration);
+            yield return CreateBackupTaskInfo(clusterTopology, backupConfiguration);
     }
 
     private IEnumerable<OngoingTaskRavenEtl> GetRavenEtlTasks(ClusterTopology clusterTopology, DatabaseRecord databaseRecord)
@@ -195,7 +195,7 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
                 if (backupConfiguration == null)
                     return null;
 
-                return CreateBackupTaskInfo(clusterTopology, databaseRecord, backupConfiguration);
+                return CreateBackupTaskInfo(clusterTopology, backupConfiguration);
 
             case OngoingTaskType.SqlEtl:
 
@@ -282,7 +282,7 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
     protected abstract (string Url, OngoingTaskConnectionStatus Status) GetReplicationTaskConnectionStatus<T>(DatabaseTopology databaseTopology, ClusterTopology clusterTopology, T replication, Dictionary<string, RavenConnectionString> connectionStrings, out string responsibleNodeTag, out RavenConnectionString connection)
         where T : ExternalReplicationBase;
 
-    protected abstract PeriodicBackupStatus GetBackupStatus(long taskId, DatabaseRecord databaseRecord, PeriodicBackupConfiguration backupConfiguration, out string responsibleNodeTag, out NextBackup nextBackup, out RunningBackup onGoingBackup, out bool isEncrypted);
+    protected abstract PeriodicBackupStatus GetBackupStatus(long taskId, PeriodicBackupConfiguration backupConfiguration, out string responsibleNodeTag, out NextBackup nextBackup, out RunningBackup onGoingBackup, out bool isEncrypted);
 
     private OngoingTaskReplication CreateExternalReplicationTaskInfo(ClusterTopology clusterTopology, DatabaseRecord databaseRecord, ExternalReplication watcher)
     {
@@ -316,9 +316,9 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
         return OngoingTaskSubscription.From(subscriptionState, connectionStatus, clusterTopology, responsibleNodeTag);
     }
 
-    private OngoingTaskBackup CreateBackupTaskInfo(ClusterTopology clusterTopology, DatabaseRecord databaseRecord, PeriodicBackupConfiguration backupConfiguration)
+    private OngoingTaskBackup CreateBackupTaskInfo(ClusterTopology clusterTopology, PeriodicBackupConfiguration backupConfiguration)
     {
-        var backupStatus = GetBackupStatus(backupConfiguration.TaskId, databaseRecord, backupConfiguration, out var responsibleNodeTag, out var nextBackup,
+        var backupStatus = GetBackupStatus(backupConfiguration.TaskId, backupConfiguration, out var responsibleNodeTag, out var nextBackup,
             out var onGoingBackup, out var isEncrypted);
         var backupDestinations = backupConfiguration.GetFullBackupDestinations();
 

--- a/src/Raven.Server/Documents/PeriodicBackup/ResponsibleNodeForBackup.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/ResponsibleNodeForBackup.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.ServerWide;
+
+namespace Raven.Server.Documents.PeriodicBackup;
+
+public abstract class ResponsibleNodeForBackup
+{
+    protected ResponsibleNodeForBackup(string nodeTag, string taskName)
+    {
+        NodeTag = nodeTag;
+        TaskName = taskName;
+    }
+
+    public string NodeTag { get; }
+
+    public string TaskName { get; }
+
+    public abstract ChosenNodeReason Reason { get; }
+
+    public abstract string ReasonForDecisionLog { get; }
+
+    public abstract bool ShouldLog { get; }
+
+    public enum ChosenNodeReason
+    {
+        SameResponsibleNode,
+        SameResponsibleNodeDueToResourceLimitations,
+        SameResponsibleNodeDueToMissingHighlyAvailableTasks,
+        MentorNode,
+        PinnedMentorNode,
+        NonExistingResponsibleNode,
+        CurrentResponsibleNodeRemovedFromTopology,
+        CurrentResponsibleNodeNotResponding
+    }
+}
+
+public abstract class ResponsibleNodeForBackupWithLimitedLogging : ResponsibleNodeForBackup
+{
+    private readonly long _taskId;
+    private readonly Dictionary<long, ChosenNodeReason> _lastChosenNodeReasonPerTask;
+
+    protected ResponsibleNodeForBackupWithLimitedLogging(string nodeTag, PeriodicBackupConfiguration configuration, Dictionary<long, ChosenNodeReason> lastChosenNodeReasonPerTask) : base(nodeTag, configuration.Name)
+    {
+        _taskId = configuration.TaskId;
+        _lastChosenNodeReasonPerTask = lastChosenNodeReasonPerTask;
+    }
+
+    public override bool ShouldLog
+    {
+        get
+        {
+            if (_lastChosenNodeReasonPerTask.TryGetValue(_taskId, out var chosenNodeReason)
+                && chosenNodeReason == Reason)
+            {
+                // we want to log this only once
+                return false;
+            }
+
+            return true;
+        }
+    }
+}
+
+public class MentorNode : ResponsibleNodeForBackup
+{
+    public MentorNode(string nodeTag, string taskName) : base(nodeTag, taskName)
+    {
+    }
+
+    public override ChosenNodeReason Reason => ChosenNodeReason.MentorNode;
+
+    public override string ReasonForDecisionLog => $"Node '{NodeTag}' was selected because it's the mentor node for the backup task '{TaskName}'";
+
+    public override bool ShouldLog => true;
+}
+
+public class PinnedMentorNode : ResponsibleNodeForBackup
+{
+    public PinnedMentorNode(string nodeTag, string taskName) : base(nodeTag, taskName)
+    {
+    }
+
+    public override ChosenNodeReason Reason => ChosenNodeReason.PinnedMentorNode;
+
+    public override string ReasonForDecisionLog => $"Node '{NodeTag}' was selected because it's the pinned mentor node for the backup task '{TaskName}'";
+
+    public override bool ShouldLog => true;
+}
+
+public class NonExistingResponsibleNode : ResponsibleNodeForBackup
+{
+    public NonExistingResponsibleNode(string nodeTag, string taskName) : base(nodeTag, taskName)
+    {
+    }
+
+    public override ChosenNodeReason Reason => ChosenNodeReason.NonExistingResponsibleNode;
+
+    public override string ReasonForDecisionLog => $"No responsible node for backup currently exists for backup task '{TaskName}', setting it to '{NodeTag}'";
+
+    public override bool ShouldLog => true;
+}
+
+public class CurrentResponsibleNodeRemovedFromTopology : ResponsibleNodeForBackup
+{
+    private readonly string _currentResponsibleNode;
+
+    public CurrentResponsibleNodeRemovedFromTopology(string nodeTag, string taskName, string currentResponsibleNode) : base(nodeTag, taskName)
+    {
+        _currentResponsibleNode = currentResponsibleNode;
+    }
+
+    public override ChosenNodeReason Reason => ChosenNodeReason.CurrentResponsibleNodeRemovedFromTopology;
+
+    public override string ReasonForDecisionLog => $"Node '{_currentResponsibleNode}' has been removed from topology. Node '{NodeTag}' will now be responsible for the backup task '{TaskName}'";
+
+    public override bool ShouldLog => true;
+}
+
+public class SameResponsibleNode : ResponsibleNodeForBackup
+{
+    public SameResponsibleNode(string nodeTag, string taskName) : base(nodeTag, taskName)
+    {
+    }
+
+    public override ChosenNodeReason Reason => ChosenNodeReason.SameResponsibleNode;
+
+    public override string ReasonForDecisionLog => null;
+
+    public override bool ShouldLog => false;
+}
+
+public class SameResponsibleNodeDueToResourceLimitations : ResponsibleNodeForBackupWithLimitedLogging
+{
+    private readonly DatabasePromotionStatus _promotionStatus;
+
+    public SameResponsibleNodeDueToResourceLimitations(string lastResponsibleNode, PeriodicBackupConfiguration configuration, Dictionary<long, ChosenNodeReason> lastChosenNodeReasonPerTask, DatabasePromotionStatus promotionStatus) : base(lastResponsibleNode, configuration, lastChosenNodeReasonPerTask)
+    {
+        _promotionStatus = promotionStatus;
+    }
+
+    public override ChosenNodeReason Reason => ChosenNodeReason.SameResponsibleNodeDueToResourceLimitations;
+
+    public override string ReasonForDecisionLog => $"Node '{NodeTag}' is still responsible for the backup task '{TaskName}' although it's {GetReasonFromPromotionStatus()}";
+
+    private string GetReasonFromPromotionStatus()
+    {
+        switch (_promotionStatus)
+        {
+            case DatabasePromotionStatus.OutOfCpuCredits:
+                return "out of CPU credits";
+            case DatabasePromotionStatus.EarlyOutOfMemory:
+                return "in an early out of memory state";
+            case DatabasePromotionStatus.HighDirtyMemory:
+                return "in high dirty memory state";
+            default:
+                throw new ArgumentOutOfRangeException($"{nameof(_promotionStatus)}", $"Unhandled case of {_promotionStatus}");
+        }
+    }
+}
+
+public class SameResponsibleNodeDueToMissingHighlyAvailableTasks : ResponsibleNodeForBackupWithLimitedLogging
+{
+    public SameResponsibleNodeDueToMissingHighlyAvailableTasks(string nodeTag, PeriodicBackupConfiguration configuration, Dictionary<long, ChosenNodeReason> lastChosenNodeReasonPerTask) : base(nodeTag, configuration, lastChosenNodeReasonPerTask)
+    {
+    }
+
+    public override ChosenNodeReason Reason => ChosenNodeReason.SameResponsibleNodeDueToMissingHighlyAvailableTasks;
+
+    public override string ReasonForDecisionLog => $"Node '{NodeTag}' is still responsible for the backup task '{TaskName}' because the license doesn't include the highly available tasks feature";
+}
+
+public class CurrentResponsibleNodeNotResponding : ResponsibleNodeForBackup
+{
+    private readonly string _currentResponsibleNode;
+    private readonly TimeSpan _moveToNewResponsibleNodeGracePeriod;
+
+    public CurrentResponsibleNodeNotResponding(string nodeTag, string taskName, string currentResponsibleNode, TimeSpan moveToNewResponsibleNodeGracePeriod) : base(nodeTag, taskName)
+    {
+        _currentResponsibleNode = currentResponsibleNode;
+        _moveToNewResponsibleNodeGracePeriod = moveToNewResponsibleNodeGracePeriod;
+    }
+
+    public override ChosenNodeReason Reason => ChosenNodeReason.CurrentResponsibleNodeNotResponding;
+
+    public override string ReasonForDecisionLog => $"Node '{_currentResponsibleNode}' was in rehab state for {_moveToNewResponsibleNodeGracePeriod}. " +
+                                                   $"Node '{NodeTag}' will now be responsible for the backup task '{TaskName}'";
+
+    public override bool ShouldLog => true;
+}

--- a/src/Raven.Server/Documents/QueueSink/QueueSinkLoader.cs
+++ b/src/Raven.Server/Documents/QueueSink/QueueSinkLoader.cs
@@ -128,8 +128,7 @@ public class QueueSinkLoader : IDisposable
                 continue;
 
             var processState = GetProcessState(config.Scripts, _database, config.Name);
-            var whoseTaskIsIt = BackupUtils.WhoseTaskIsIt(_serverStore, _databaseRecord.Topology, config, processState,
-                _database.NotificationCenter);
+            var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, _databaseRecord.Topology, config, processState, _database.NotificationCenter);
             if (whoseTaskIsIt != _serverStore.NodeTag)
                 continue;
 
@@ -187,8 +186,7 @@ public class QueueSinkLoader : IDisposable
         where T : QueueSinkConfiguration
     {
         var processState = GetProcessState(queueSinkTask.Scripts, _database, queueSinkTask.Name);
-        var whoseTaskIsIt = BackupUtils.WhoseTaskIsIt(_serverStore, record.Topology, queueSinkTask, processState,
-            _database.NotificationCenter);
+        var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, record.Topology, queueSinkTask, processState, _database.NotificationCenter);
 
         responsibleNodes[queueSinkTask.Name] = whoseTaskIsIt;
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -940,7 +940,7 @@ namespace Raven.Server.Documents.Replication
                 return false;
 
             var taskStatus = GetExternalReplicationState(_server, Database.Name, task.TaskId);
-            var whoseTaskIsIt = Server.WhoseTaskIsIt(topology, task, taskStatus);
+            var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(Server, topology, task, taskStatus, Database.NotificationCenter);
             return whoseTaskIsIt == _server.NodeTag;
         }
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedOngoingTasksHandlerProcessorForUpdateExternalReplication.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Replication/ShardedOngoingTasksHandlerProcessorForUpdateExternalReplication.cs
@@ -6,6 +6,7 @@ using Raven.Server.Documents.Handlers.Processors.OngoingTasks;
 using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -25,7 +26,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Replication
                 throw new InvalidOperationException($"The database record '{RequestHandler.DatabaseName}' doesn't contain topology.");
 
             var taskStatus = ReplicationLoader.GetExternalReplicationState(RequestHandler.ServerStore, RequestHandler.DatabaseName, watcher.TaskId);
-            responseJson[nameof(OngoingTask.ResponsibleNode)] = RequestHandler.ServerStore.WhoseTaskIsIt(topology, watcher, taskStatus);
+            responseJson[nameof(OngoingTask.ResponsibleNode)] = OngoingTasksUtils.WhoseTaskIsIt(ServerStore, topology, watcher, taskStatus, ServerStore.NotificationCenter);
         }
 
         protected override void OnBeforeUpdateConfiguration(ref BlittableJsonReaderObject configuration, JsonOperationContext context)

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.OngoingTasks.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.OngoingTasks.cs
@@ -63,7 +63,7 @@ public partial class ShardedDatabaseContext
             return (null, OngoingTaskConnectionStatus.None);
         }
 
-        protected override PeriodicBackupStatus GetBackupStatus(long taskId, DatabaseRecord databaseRecord, PeriodicBackupConfiguration backupConfiguration, out string responsibleNodeTag,
+        protected override PeriodicBackupStatus GetBackupStatus(long taskId, PeriodicBackupConfiguration backupConfiguration, out string responsibleNodeTag,
             out NextBackup nextBackup, out RunningBackup onGoingBackup, out bool isEncrypted)
         {
             nextBackup = null;

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseOldestBackup.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseOldestBackup.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
 
         private static TimeSpan GetTimeSinceOldestBackup(ServerStore serverStore)
         {
-            using (serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
                 var databaseNames = serverStore.Cluster.GetDatabaseNames(context);
@@ -59,7 +59,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
             return now - oldestBackup;
         }
 
-        private static DateTime? GetLastBackup(TransactionOperationContext context, ServerStore serverStore, string databaseName)
+        private static DateTime? GetLastBackup(ClusterOperationContext context, ServerStore serverStore, string databaseName)
         {
             using (var databaseRecord = serverStore.Cluster.ReadRawDatabaseRecord(context, databaseName, out _))
             {

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -182,7 +182,8 @@ namespace Raven.Server.ServerWide
             [nameof(RemoveQueueSinkProcessStateCommand)] = 60_000,
             [nameof(UpdateQueueSinkProcessStateCommand)] = 60_000,
             
-            [nameof(EditDataArchivalCommand)] = 60_000
+            [nameof(EditDataArchivalCommand)] = 60_000,
+            [nameof(UpdateResponsibleNodeForTasksCommand)] = UpdateResponsibleNodeForTasksCommand.CommandVersion,
         };
 
         public bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -589,6 +589,10 @@ namespace Raven.Server.ServerWide
                         ToggleDatabasesState(cmd, context, type, index);
                         break;
 
+                    case nameof(UpdateResponsibleNodeForTasksCommand):
+                        UpdateResponsibleNodeForTasks(cmd, context, type, index);
+                        break;
+
                     case nameof(PutServerWideBackupConfigurationCommand):
                         AssertServerWideFor(serverStore, LicenseAttribute.ServerWideBackups);
 
@@ -4137,6 +4141,57 @@ namespace Raven.Server.ServerWide
 
             var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
             ApplyDatabaseRecordUpdates(toUpdate, type, index, items, context);
+        }
+
+        private void UpdateResponsibleNodeForTasks(BlittableJsonReaderObject cmd, ClusterOperationContext context, string type, long index)
+        {
+            var command = (UpdateResponsibleNodeForTasksCommand)JsonDeserializationCluster.Commands[type](cmd);
+            if (command.Value == null)
+                throw new RachisInvalidOperationException($"{nameof(UpdateResponsibleNodeForTasksCommand.Parameters)} is null for command type: {type}");
+
+            if (command.Value.ResponsibleNodePerDatabase == null)
+                throw new RachisInvalidOperationException($"{nameof(ToggleDatabasesStateCommand.Parameters.DatabaseNames)} is null for command type: {type}");
+
+            var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
+            Exception exception = null;
+
+
+            try
+            {
+                var actions = new List<Func<Task>>();
+
+                foreach (var keyValue in command.Value.ResponsibleNodePerDatabase)
+                {
+                    var databaseName = keyValue.Key;
+
+                    foreach (var responsibleNodeInfo in keyValue.Value)
+                    {
+                        var itemKey = ResponsibleNodeInfo.GenerateItemName(databaseName, responsibleNodeInfo.TaskId);
+
+                        using (Slice.From(context.Allocator, itemKey, out Slice valueName))
+                        using (Slice.From(context.Allocator, itemKey.ToLowerInvariant(), out Slice valueNameLowered))
+                        using (var value = context.ReadObject(responsibleNodeInfo.ToJson(), itemKey))
+                        {
+                            UpdateValue(index, items, valueNameLowered, valueName, value);
+                        }
+                    }
+
+                    actions.Add(() =>
+                        Changes.OnDatabaseChanges(databaseName, index, type, DatabasesLandlord.ClusterDatabaseChangeType.ValueChanged, null));
+                }
+
+                ExecuteManyOnDispose(context, index, type, actions);
+
+            }
+            catch (Exception e)
+            {
+                exception = e;
+                throw;
+            }
+            finally
+            {
+                LogCommand(type, index, exception, command);
+            }
         }
 
         private void UpdateDatabasesWithServerWideBackupConfiguration(ClusterOperationContext context, string type, ServerWideBackupConfiguration serverWideBackupConfiguration, long index)

--- a/src/Raven.Server/ServerWide/Commands/DeleteOngoingTaskCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteOngoingTaskCommand.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Diagnostics;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
+using Raven.Server.ServerWide.Commands.PeriodicBackup;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
@@ -28,20 +30,30 @@ namespace Raven.Server.ServerWide.Commands
             TaskType = taskType;
         }
 
-        private string _taskIdToDelete, _hubNameToDelete;
+        private long? _backupTaskIdToDelete;
+        private string _hubNameToDelete;
 
         public override void AfterDatabaseRecordUpdate(ClusterOperationContext ctx, Table items, Logger clusterAuditLog)
         {
             switch (TaskType)
             {
                 case OngoingTaskType.Backup:
-                    if (_taskIdToDelete == null)
+                    if (_backupTaskIdToDelete == null)
                         return;
-                    var itemKey = _taskIdToDelete;
-                    using (Slice.From(ctx.Allocator, itemKey, out Slice _))
-                    using (Slice.From(ctx.Allocator, itemKey.ToLowerInvariant(), out Slice valueNameToDeleteLowered))
+
+                    var responsibleNodeKey = ResponsibleNodeInfo.GenerateItemName(DatabaseName, _backupTaskIdToDelete.Value);
+                    Delete(responsibleNodeKey);
+
+                    var backupStatusKey = PeriodicBackupStatus.GenerateItemName(DatabaseName, _backupTaskIdToDelete.Value);
+                    Delete(backupStatusKey);
+
+                    void Delete(string key)
                     {
-                        items.DeleteByKey(valueNameToDeleteLowered);
+                        using (Slice.From(ctx.Allocator, key, out Slice _))
+                        using (Slice.From(ctx.Allocator, key.ToLowerInvariant(), out Slice valueNameToDeleteLowered))
+                        {
+                            items.DeleteByKey(valueNameToDeleteLowered);
+                        }
                     }
 
                     break;
@@ -96,7 +108,7 @@ namespace Raven.Server.ServerWide.Commands
                     break;
                 case OngoingTaskType.Backup:
                     record.DeletePeriodicBackupConfiguration(TaskId);
-                    _taskIdToDelete = TaskId.ToString();
+                    _backupTaskIdToDelete = TaskId;
                     break;
 
                 case OngoingTaskType.SqlEtl:

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdateResponsibleNodeForTasksCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdateResponsibleNodeForTasksCommand.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.PeriodicBackup;
+
+public class UpdateResponsibleNodeForTasksCommand : UpdateValueCommand<UpdateResponsibleNodeForTasksCommand.Parameters>
+{
+    public const int CommandVersion = 60_001;
+
+    // ReSharper disable once UnusedMember.Local
+    private UpdateResponsibleNodeForTasksCommand()
+    {
+        // for deserialization
+    }
+
+    public UpdateResponsibleNodeForTasksCommand(Parameters parameters, string uniqueRequestId) : base(uniqueRequestId)
+    {
+        Value = parameters;
+    }
+
+    public override object ValueToJson()
+    {
+        return Value.ToJson();
+    }
+
+    public override BlittableJsonReaderObject GetUpdatedValue(JsonOperationContext context, BlittableJsonReaderObject previousValue, long index)
+    {
+        return null;
+    }
+
+    public class Parameters : IDynamicJson
+    {
+        public Dictionary<string, List<ResponsibleNodeInfo>> ResponsibleNodePerDatabase { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            var djv = new DynamicJsonValue();
+
+            foreach (var keyValue in ResponsibleNodePerDatabase)
+            {
+                var list = new DynamicJsonArray();
+                foreach (var responsibleNodeInfo in keyValue.Value)
+                {
+                    list.Add(responsibleNodeInfo.ToJson());
+                }
+
+                djv[keyValue.Key] = list;
+            }
+
+            return new DynamicJsonValue
+            {
+                [nameof(ResponsibleNodePerDatabase)] = djv
+            };
+        }
+    }
+}
+
+public class ResponsibleNodeInfo : IDynamicJson
+{
+    public long TaskId { get; set; }
+
+    public string ResponsibleNode { get; set; }
+
+    public DateTime? NotSuitableForTaskSince { get; set; }
+
+    public static string GenerateItemName(string databaseName, long taskId)
+    {
+        return $"{GetPrefix(databaseName)}{taskId}";
+    }
+
+    public static string GetPrefix(string databaseName)
+    {
+        return $"values/{databaseName}/responsible-node/";
+    }
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(TaskId)] = TaskId,
+            [nameof(ResponsibleNode)] = ResponsibleNode,
+            [nameof(NotSuitableForTaskSince)] = NotSuitableForTaskSince
+        };
+    }
+}

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -285,6 +285,7 @@ namespace Raven.Server.ServerWide
             [nameof(UpdateQueueSinkCommand)] = GenerateJsonDeserializationRoutine<UpdateQueueSinkCommand>(),
             [nameof(UpdateQueueSinkProcessStateCommand)] = GenerateJsonDeserializationRoutine<UpdateQueueSinkProcessStateCommand>(),
             [nameof(RemoveQueueSinkProcessStateCommand)] = GenerateJsonDeserializationRoutine<RemoveQueueSinkProcessStateCommand>(),
+            [nameof(UpdateResponsibleNodeForTasksCommand)] = GenerateJsonDeserializationRoutine<UpdateResponsibleNodeForTasksCommand>()
         };
     }
 }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.Backup.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.Backup.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.ServerWide;
+using Raven.Server.Config;
+using Raven.Server.Config.Settings;
+using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Commands.PeriodicBackup;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+
+namespace Raven.Server.ServerWide.Maintenance;
+
+internal partial class ClusterObserver
+{
+    private readonly Dictionary<long, ResponsibleNodeForBackup.ChosenNodeReason> _lastChosenNodeReasonPerTask = new();
+
+    private List<ResponsibleNodeInfo> GetResponsibleNodesForBackupTasks(Leader currentLeader, RawDatabaseRecord rawRecord, 
+        string databaseName, DatabaseTopology topology, long observerIteration, ClusterOperationContext context)
+    {
+        // we must verify that all connected nodes are supporting the UpdateResponsibleNodeForTasksCommand command
+        foreach (var version in currentLeader.PeersVersion.Values)
+        {
+            if (version < UpdateResponsibleNodeForTasksCommand.CommandVersion)
+            {
+                // the command isn't supported
+                return null;
+            }
+        }
+
+        var moveToNewResponsibleNodeGracePeriodConfig = (TimeSetting)RavenConfiguration.GetValue(x => x.Backup.MoveToNewResponsibleNodeGracePeriod, _server.Configuration, rawRecord.Settings);
+        var moveToNewResponsibleNodeGracePeriod = moveToNewResponsibleNodeGracePeriodConfig.AsTimeSpan;
+        List<ResponsibleNodeInfo> responsibleNodeCommands = null;
+
+        foreach (var configuration in rawRecord.PeriodicBackups)
+        {
+            var responsibleNodeInfo = GetResponsibleNodeInfo(databaseName, configuration, topology, observerIteration, moveToNewResponsibleNodeGracePeriod, context);
+            if (responsibleNodeInfo == null)
+                continue;
+
+            responsibleNodeCommands ??= new List<ResponsibleNodeInfo>();
+            responsibleNodeCommands.Add(responsibleNodeInfo);
+        }
+
+        return responsibleNodeCommands;
+    }
+
+    private ResponsibleNodeInfo GetResponsibleNodeInfo(
+            string databaseName,
+            PeriodicBackupConfiguration configuration,
+            DatabaseTopology topology,
+            long observerIteration,
+            TimeSpan moveToNewResponsibleNodeGracePeriod,
+            ClusterOperationContext context)
+    {
+        var responsibleNodeBlittable = BackupUtils.GetResponsibleNodeInfoFromCluster(_server, context, databaseName, configuration.TaskId);
+        string currentResponsibleNode = null;
+        responsibleNodeBlittable?.TryGet(nameof(ResponsibleNodeInfo.ResponsibleNode), out currentResponsibleNode);
+
+        var newResponsibleNode = GetResponsibleNodeForBackup(databaseName, configuration, topology, moveToNewResponsibleNodeGracePeriod, context, currentResponsibleNode);
+        if (newResponsibleNode == null)
+        {
+            // didn't find a suitable node for backup
+            return null;
+        }
+
+        DateTime? notSuitableForTaskSince = null;
+        responsibleNodeBlittable?.TryGet(nameof(ResponsibleNodeInfo.NotSuitableForTaskSince), out notSuitableForTaskSince);
+
+        switch (newResponsibleNode.Reason)
+        {
+            case ResponsibleNodeForBackup.ChosenNodeReason.SameResponsibleNode:
+            case ResponsibleNodeForBackup.ChosenNodeReason.SameResponsibleNodeDueToResourceLimitations:
+            case ResponsibleNodeForBackup.ChosenNodeReason.SameResponsibleNodeDueToMissingHighlyAvailableTasks:
+                if (currentResponsibleNode == null)
+                {
+                    // backward compatibility - missing responsible node in the cluster storage
+                    return new ResponsibleNodeInfo
+                    {
+                        TaskId = configuration.TaskId,
+                        ResponsibleNode = newResponsibleNode.NodeTag
+                    };
+                }
+
+                if (notSuitableForTaskSince != null)
+                {
+                    // we need to remove the NotSuitableForTaskSince since the node is suitable for backup
+
+                    var reason = $"Node '{currentResponsibleNode}' was in rehab for {DateTime.UtcNow - notSuitableForTaskSince}. " +
+                                 $"Since it's now in a member state, the backup task '{configuration.Name}' will continue to run on that node";
+                    _observerLogger.AddToDecisionLog(databaseName, reason, observerIteration);
+
+                    return new ResponsibleNodeInfo
+                    {
+                        TaskId = configuration.TaskId,
+                        ResponsibleNode = newResponsibleNode.NodeTag
+                    };
+                }
+
+                AddToDecisionLog(newResponsibleNode, configuration.TaskId, databaseName, observerIteration);
+
+                // it's the same responsible node for backup, noop
+                return null;
+
+            case ResponsibleNodeForBackup.ChosenNodeReason.MentorNode:
+            case ResponsibleNodeForBackup.ChosenNodeReason.PinnedMentorNode:
+            case ResponsibleNodeForBackup.ChosenNodeReason.NonExistingResponsibleNode:
+            case ResponsibleNodeForBackup.ChosenNodeReason.CurrentResponsibleNodeRemovedFromTopology:
+                AddToDecisionLog(newResponsibleNode, configuration.TaskId, databaseName, observerIteration);
+                return new ResponsibleNodeInfo
+                {
+                    TaskId = configuration.TaskId,
+                    ResponsibleNode = newResponsibleNode.NodeTag
+                };
+
+            case ResponsibleNodeForBackup.ChosenNodeReason.CurrentResponsibleNodeNotResponding:
+                if (notSuitableForTaskSince == null)
+                {
+                    // it's the first time that we identify that the node isn't suitable for backup
+                    var reason = $"Node '{currentResponsibleNode}' is currently in rehab state. " +
+                                 $"The backup task '{configuration.Name}' will be moved to another node at: {DateTime.UtcNow + moveToNewResponsibleNodeGracePeriod} (UTC)";
+                    _observerLogger.AddToDecisionLog(databaseName, reason, observerIteration);
+
+                    return new ResponsibleNodeInfo
+                    {
+                        TaskId = configuration.TaskId,
+                        ResponsibleNode = currentResponsibleNode,
+                        NotSuitableForTaskSince = DateTime.UtcNow
+                    };
+                }
+
+                if (DateTime.UtcNow - notSuitableForTaskSince.Value < moveToNewResponsibleNodeGracePeriod)
+                {
+                    // grace period before moving the task to another node
+                    return null;
+                }
+
+                AddToDecisionLog(newResponsibleNode, configuration.TaskId, databaseName, observerIteration);
+                return new ResponsibleNodeInfo
+                {
+                    TaskId = configuration.TaskId,
+                    ResponsibleNode = newResponsibleNode.NodeTag
+                };
+
+            default:
+                throw new ArgumentOutOfRangeException($"{nameof(newResponsibleNode.Reason)}", $"Unknown chosen node reason {newResponsibleNode.Reason}");
+        }
+    }
+
+    private ResponsibleNodeForBackup GetResponsibleNodeForBackup(
+        string databaseName,
+        PeriodicBackupConfiguration configuration,
+        DatabaseTopology topology,
+        TimeSpan moveToNewResponsibleNodeGracePeriod,
+        ClusterOperationContext context,
+        string currentResponsibleNode)
+    {
+        var lastResponsibleNode = currentResponsibleNode ??
+                                  // backward compatibility - will continue running the backup on the last node that ran the backup
+                                  BackupUtils.GetBackupStatusFromCluster(_server, context, databaseName, configuration.TaskId)?.NodeTag;
+
+        var mentorNode = configuration.GetMentorNode();
+        if (mentorNode != null)
+        {
+            if (topology.AllNodes.Contains(mentorNode) && configuration.IsPinnedToMentorNode())
+            {
+                if (string.Equals(mentorNode, lastResponsibleNode))
+                    return new SameResponsibleNode(lastResponsibleNode, configuration.Name);
+
+                return new PinnedMentorNode(mentorNode, configuration.Name);
+            }
+
+            if (topology.Members.Contains(mentorNode))
+            {
+                if (string.Equals(mentorNode, lastResponsibleNode))
+                    return new SameResponsibleNode(lastResponsibleNode, configuration.Name);
+
+                return new MentorNode(mentorNode, configuration.Name);
+            }
+        }
+
+        if (lastResponsibleNode == null)
+        {
+            // we don't have a responsible node for the backup
+            var newNode = topology.WhoseTaskIsIt(configuration);
+            return new NonExistingResponsibleNode(newNode, configuration.Name);
+        }
+
+        if (topology.Members.Contains(lastResponsibleNode))
+        {
+            // this is the same node that we had before
+            return new SameResponsibleNode(lastResponsibleNode, configuration.Name);
+        }
+
+        if (topology.AllNodes.Contains(lastResponsibleNode) == false)
+        {
+            // the responsible node for the backup is not in the topology anymore
+            var newNode = topology.WhoseTaskIsIt(configuration);
+            return new CurrentResponsibleNodeRemovedFromTopology(newNode, configuration.Name, lastResponsibleNode);
+        }
+
+        if (topology.Rehabs.Contains(lastResponsibleNode) &&
+            topology.PromotablesStatus.TryGetValue(lastResponsibleNode, out var status) &&
+            (status == DatabasePromotionStatus.OutOfCpuCredits ||
+             status == DatabasePromotionStatus.EarlyOutOfMemory ||
+             status == DatabasePromotionStatus.HighDirtyMemory))
+        {
+            // avoid moving backup tasks when the machine is out of CPU credits or out of memory
+            return new SameResponsibleNodeDueToResourceLimitations(lastResponsibleNode, configuration, _lastChosenNodeReasonPerTask, status);
+        }
+
+        if (_server.LicenseManager.HasHighlyAvailableTasks() == false)
+        {
+            // can't redistribute, keep it on the original node
+            OngoingTasksUtils.RaiseAlertIfNecessary(topology, configuration, lastResponsibleNode, _server, _server.NotificationCenter);
+            return new SameResponsibleNodeDueToMissingHighlyAvailableTasks(lastResponsibleNode, configuration, _lastChosenNodeReasonPerTask);
+        }
+
+        // find a new responsible node
+        var newResponsibleNode = topology.WhoseTaskIsIt(configuration);
+        if (newResponsibleNode == null)
+            return null;
+
+        return new CurrentResponsibleNodeNotResponding(newResponsibleNode, configuration.Name,lastResponsibleNode, moveToNewResponsibleNodeGracePeriod);
+    }
+
+    private void AddToDecisionLog(ResponsibleNodeForBackup nodeForBackup, long taskId, string database, long observerIteration)
+    {
+        if (nodeForBackup.ShouldLog == false)
+            return;
+
+        _lastChosenNodeReasonPerTask[taskId] = nodeForBackup.Reason;
+
+        Debug.Assert(nodeForBackup.ReasonForDecisionLog != null);
+
+        _observerLogger.AddToDecisionLog(database, nodeForBackup.ReasonForDecisionLog, observerIteration);
+    }
+}

--- a/src/Raven.Server/Utils/OngoingTasksUtils.cs
+++ b/src/Raven.Server/Utils/OngoingTasksUtils.cs
@@ -1,0 +1,67 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.ServerWide;
+using Raven.Server.Commercial;
+using Raven.Server.NotificationCenter;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.Utils;
+
+internal static class OngoingTasksUtils
+{
+    internal static string WhoseTaskIsIt(
+        ServerStore serverStore,
+        DatabaseTopology databaseTopology,
+        IDatabaseTask configuration,
+        IDatabaseTaskStatus taskStatus,
+        AbstractNotificationCenter notificationCenter)
+    {
+        Debug.Assert(taskStatus is not PeriodicBackupStatus);
+
+        var whoseTaskIsIt = databaseTopology.WhoseTaskIsIt(
+            serverStore.Engine.CurrentState, configuration,
+            getLastResponsibleNode:
+            () =>
+            {
+                var lastResponsibleNode = taskStatus?.NodeTag;
+                if (lastResponsibleNode == null)
+                {
+                    // first time this task is assigned
+                    return null;
+                }
+
+                if (databaseTopology.AllNodes.Contains(lastResponsibleNode) == false)
+                {
+                    // the topology doesn't include the last responsible node anymore
+                    // we'll choose a different one
+                    return null;
+                }
+
+                if (serverStore.LicenseManager.HasHighlyAvailableTasks() == false)
+                {
+                    // can't redistribute, keep it on the original node
+                    RaiseAlertIfNecessary(databaseTopology, configuration, lastResponsibleNode, serverStore, notificationCenter);
+                    return lastResponsibleNode;
+                }
+
+                return null;
+            });
+
+        return whoseTaskIsIt;
+    }
+
+    internal static void RaiseAlertIfNecessary(DatabaseTopology databaseTopology, IDatabaseTask configuration, string lastResponsibleNode,
+        ServerStore serverStore, AbstractNotificationCenter notificationCenter)
+    {
+        // raise alert if redistribution is necessary
+        if (notificationCenter != null &&
+            databaseTopology.Count > 1 &&
+            serverStore.NodeTag != lastResponsibleNode &&
+            databaseTopology.Members.Contains(lastResponsibleNode) == false)
+        {
+            var alert = LicenseManager.CreateHighlyAvailableTasksAlert(databaseTopology, configuration, lastResponsibleNode);
+            notificationCenter.Add(alert);
+        }
+    }
+}

--- a/src/Raven.Server/Web/System/Processors/Databases/AbstractDatabasesHandlerProcessorForAllowedDatabases.cs
+++ b/src/Raven.Server/Web/System/Processors/Databases/AbstractDatabasesHandlerProcessorForAllowedDatabases.cs
@@ -39,7 +39,7 @@ internal abstract class AbstractDatabasesHandlerProcessorForAllowedDatabases<TRe
         return RequestHandler.ServerStore.ClusterRequestExecutor.ExecuteAsync(command, context, token: token.Token);
     }
 
-    protected static BackupInfo GetBackupInfo(string databaseName, RawDatabaseRecord record, DocumentDatabase database, ServerStore serverStore, TransactionOperationContext context)
+    protected static BackupInfo GetBackupInfo(string databaseName, RawDatabaseRecord record, DocumentDatabase database, ServerStore serverStore, ClusterOperationContext context)
     {
         if (database == null)
         {
@@ -96,7 +96,7 @@ internal abstract class AbstractDatabasesHandlerProcessorForAllowedDatabases<TRe
         return record.StudioConfiguration.Environment;
     }
 
-    protected async IAsyncEnumerable<RawDatabaseRecord> GetAllowedDatabaseRecordsAsync(string name, TransactionOperationContext context, int start, int pageSize)
+    protected async IAsyncEnumerable<RawDatabaseRecord> GetAllowedDatabaseRecordsAsync(string name, ClusterOperationContext context, int start, int pageSize)
     {
         IEnumerable<RawDatabaseRecord> items;
         if (name != null)

--- a/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGet.cs
@@ -51,7 +51,7 @@ internal sealed class DatabasesHandlerProcessorForGet : AbstractDatabasesHandler
 
     protected override async ValueTask HandleCurrentNodeAsync()
     {
-        using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+        using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
         using (context.OpenReadTransaction())
         {
             var name = GetName();
@@ -89,7 +89,7 @@ internal sealed class DatabasesHandlerProcessorForGet : AbstractDatabasesHandler
         }
     }
 
-    internal static void FillNodesTopology(ref NodesTopology nodesTopology, DatabaseTopology topology, RawDatabaseRecord databaseRecord, TransactionOperationContext context, ServerStore serverStore, HttpContext httpContext)
+    internal static void FillNodesTopology(ref NodesTopology nodesTopology, DatabaseTopology topology, RawDatabaseRecord databaseRecord, ClusterOperationContext context, ServerStore serverStore, HttpContext httpContext)
     {
         if (topology == null)
             return;
@@ -143,7 +143,7 @@ internal sealed class DatabasesHandlerProcessorForGet : AbstractDatabasesHandler
     }
 
     private void WriteDatabaseInfo(string databaseName, RawDatabaseRecord rawDatabaseRecord,
-        TransactionOperationContext context, AbstractBlittableJsonTextWriter writer)
+        ClusterOperationContext context, AbstractBlittableJsonTextWriter writer)
     {
         NodesTopology nodesTopology = new();
 

--- a/src/Raven.Server/Web/System/Processors/Studio/StudioDatabasesHandlerForGetDatabases.cs
+++ b/src/Raven.Server/Web/System/Processors/Studio/StudioDatabasesHandlerForGetDatabases.cs
@@ -27,7 +27,7 @@ internal sealed class StudioDatabasesHandlerForGetDatabases : AbstractDatabasesH
 
     protected override async ValueTask HandleCurrentNodeAsync()
     {
-        using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+        using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
         using (context.OpenReadTransaction())
         {
             var name = GetName();
@@ -48,7 +48,7 @@ internal sealed class StudioDatabasesHandlerForGetDatabases : AbstractDatabasesH
                 {
                     var databaseName = record.DatabaseName;
 
-                    WriteStudioDatabaseInfo(databaseName, record, context, w);
+                    WriteStudioDatabaseInfo(record, context, w);
                 });
 
                 writer.WriteEndObject();
@@ -58,7 +58,7 @@ internal sealed class StudioDatabasesHandlerForGetDatabases : AbstractDatabasesH
 
     protected override ValueTask<RavenCommand<StudioDatabasesInfo>> CreateCommandForNodeAsync(string nodeTag, JsonOperationContext context) => throw new NotSupportedException();
 
-    private void WriteStudioDatabaseInfo(string databaseName, RawDatabaseRecord record, TransactionOperationContext context, AbstractBlittableJsonTextWriter writer)
+    private void WriteStudioDatabaseInfo(RawDatabaseRecord record, ClusterOperationContext context, AbstractBlittableJsonTextWriter writer)
     {
         var studioEnvironment = GetStudioEnvironment(record);
         var info = StudioDatabaseInfo.From(record, studioEnvironment, context, ServerStore, HttpContext);
@@ -127,7 +127,7 @@ internal sealed class StudioDatabasesHandlerForGetDatabases : AbstractDatabasesH
             };
         }
 
-        public static StudioDatabaseInfo From([NotNull] RawDatabaseRecord record, StudioConfiguration.StudioEnvironment studioEnvironment, [NotNull] TransactionOperationContext context, [NotNull] ServerStore serverStore, [NotNull] HttpContext httpContext)
+        public static StudioDatabaseInfo From([NotNull] RawDatabaseRecord record, StudioConfiguration.StudioEnvironment studioEnvironment, [NotNull] ClusterOperationContext context, [NotNull] ServerStore serverStore, [NotNull] HttpContext httpContext)
         {
             if (record == null)
                 throw new ArgumentNullException(nameof(record));
@@ -193,7 +193,7 @@ internal sealed class StudioDatabasesHandlerForGetDatabases : AbstractDatabasesH
                 return result;
             }
 
-            public static ShardingInfo From([NotNull] RawDatabaseRecord record, [NotNull] TransactionOperationContext context, [NotNull] ServerStore serverStore, [NotNull] HttpContext httpContext)
+            public static ShardingInfo From([NotNull] RawDatabaseRecord record, [NotNull] ClusterOperationContext context, [NotNull] ServerStore serverStore, [NotNull] HttpContext httpContext)
             {
                 if (record == null)
                     throw new ArgumentNullException(nameof(record));

--- a/src/Raven.Server/Web/System/Processors/Studio/StudioDatabasesHandlerForGetDatabasesState.cs
+++ b/src/Raven.Server/Web/System/Processors/Studio/StudioDatabasesHandlerForGetDatabasesState.cs
@@ -34,7 +34,7 @@ internal sealed class StudioDatabasesHandlerForGetDatabasesState : AbstractDatab
 
     protected override async ValueTask HandleCurrentNodeAsync()
     {
-        using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+        using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
         using (context.OpenReadTransaction())
         {
             var name = GetName();
@@ -123,7 +123,7 @@ internal sealed class StudioDatabasesHandlerForGetDatabasesState : AbstractDatab
         }
     }
 
-    private void WriteStudioDatabaseState(string databaseName, RawDatabaseRecord record, TransactionOperationContext context, AbstractBlittableJsonTextWriter writer)
+    private void WriteStudioDatabaseState(string databaseName, RawDatabaseRecord record, ClusterOperationContext context, AbstractBlittableJsonTextWriter writer)
     {
         try
         {

--- a/test/FastTests/Issues/RavenDB-11424.cs
+++ b/test/FastTests/Issues/RavenDB-11424.cs
@@ -23,6 +23,7 @@ namespace FastTests.Issues
             {
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 3 */3 * *");
                 var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                Backup.WaitForResponsibleNodeUpdate(Server.ServerStore, store.Database, result.TaskId);
 
                 var periodicBackupRunner = (await Databases.GetDocumentDatabaseInstanceFor(store)).PeriodicBackupRunner;
                 var backups = periodicBackupRunner.PeriodicBackups;

--- a/test/FastTests/Issues/RavenDB-11424.cs
+++ b/test/FastTests/Issues/RavenDB-11424.cs
@@ -47,6 +47,8 @@ namespace FastTests.Issues
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 3 */3 * *");
                 var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
+                Sharding.Backup.WaitForResponsibleNodeUpdate(Server.ServerStore, store.Database, result.TaskId);
+
                 var timers = new Dictionary<int, Timer>();
                 await foreach (var shard in Sharding.GetShardsDocumentDatabaseInstancesFor(store.Database))
                 {

--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -292,6 +292,7 @@ namespace RachisTests.DatabaseCluster
             {
                 var config = new PeriodicBackupConfiguration { LocalSettings = new LocalSettings { FolderPath = backupPath }, IncrementalBackupFrequency = "0 0 */12 * *" };
                 var backupTaskId = (await source.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+                Backup.WaitForResponsibleNodeUpdate(Server.ServerStore, source.Database, backupTaskId);
 
                 using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
@@ -421,6 +422,7 @@ namespace RachisTests.DatabaseCluster
             {
                 var config = new PeriodicBackupConfiguration { LocalSettings = new LocalSettings { FolderPath = backupPath }, IncrementalBackupFrequency = "0 0 */12 * *" };
                 var backupTaskId = (await source.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+                Backup.WaitForResponsibleNodeUpdate(Server.ServerStore, source.Database, backupTaskId);
 
                 using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
@@ -482,6 +484,7 @@ namespace RachisTests.DatabaseCluster
             {
                 var config = new PeriodicBackupConfiguration { LocalSettings = new LocalSettings { FolderPath = backupPath }, IncrementalBackupFrequency = "0 0 */12 * *" };
                 var backupTaskId = (await source.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+                Backup.WaitForResponsibleNodeUpdate(Server.ServerStore, source.Database, backupTaskId);
 
                 using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {

--- a/test/SlowTests/Issues/RavenDB-13553.cs
+++ b/test/SlowTests/Issues/RavenDB-13553.cs
@@ -44,6 +44,8 @@ namespace SlowTests.Issues
                 operation = new UpdatePeriodicBackupOperation(config);
                 await store.Maintenance.SendAsync(operation);
 
+                Backup.WaitForResponsibleNodeUpdate(Server.ServerStore, store.Database, result.TaskId);
+
                 var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store);
                 documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateFailedBackup = true;
 
@@ -63,9 +65,10 @@ namespace SlowTests.Issues
 
                 var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                 var status = documentDatabase.PeriodicBackupRunner.GetBackupStatus(config.TaskId);
-                var nextBackupDetails = documentDatabase.PeriodicBackupRunner.GetNextBackupDetails(record, record.PeriodicBackups.First(), status, Server.ServerStore.NodeTag);
+                var nextBackupDetails = documentDatabase.PeriodicBackupRunner.GetNextBackupDetails(record.PeriodicBackups.First(), status, out var responsibleNode);
                 
                 Assert.True(nextBackupDetails.IsFull);
+                Assert.Equal("A", responsibleNode);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-18442.cs
+++ b/test/SlowTests/Issues/RavenDB-18442.cs
@@ -50,6 +50,7 @@ namespace SlowTests.Issues
             // Backup Config
             var config = Backup.CreateBackupConfiguration(backupPath, mentorNode: firstServer.ServerStore.NodeTag);
             var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+            Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, result.TaskId);
 
             // Turn Database offline in second server.
             Assert.Equal(1, WaitForValue(() => secondServer.ServerStore.IdleDatabases.Count, 1, timeout: 60000, interval: 1000)); //wait for db to be idle

--- a/test/SlowTests/Issues/RavenDB-19922.cs
+++ b/test/SlowTests/Issues/RavenDB-19922.cs
@@ -1,0 +1,393 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19922 : ClusterTestBase
+    {
+        public RavenDB_19922(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task ResponsibleNodeForBackup_MentorNode()
+        {
+            DoNotReuseServer();
+
+            const int clusterSize = 3;
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var databaseName = GetDatabaseName();
+
+            var settings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "0",
+                [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1"
+            };
+
+            var (nodes, leaderServer) = await CreateRaftCluster(clusterSize, customSettings: settings, watcherCluster: true);
+            await CreateDatabaseInCluster(databaseName, clusterSize, leaderServer.WebUrl);
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { leaderServer.WebUrl },
+                Conventions = new DocumentConventions { DisableTopologyUpdates = true },
+                Database = databaseName
+            })
+            {
+                var mentorNode = Servers.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: mentorNode.ServerStore.NodeTag, name: "backup");
+
+                long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
+
+                var database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                var tag1 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+
+                CheckDecisionLog(leaderServer, new MentorNode(tag1, config.Name).ReasonForDecisionLog);
+
+                var disposedServer = Servers.First(s => s.ServerStore.NodeTag == tag1);
+
+                await DisposeServerAndWaitForFinishOfDisposalAsync(disposedServer);
+
+                string tag2 = "";
+                await WaitForValueAsync(async () =>
+                {
+                    database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    tag2 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                    return tag1.Equals(tag2);
+                }, false);
+
+                Assert.Equal(tag1, tag2);
+
+                CheckDecisionLog(leaderServer, $"Node '{tag1}' is currently in rehab state. The backup task '{config.Name}' will be moved to another node");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task ResponsibleNodeForBackup_CurrentResponsibleNodeNotResponding()
+        {
+            DoNotReuseServer();
+
+            const int clusterSize = 3;
+            string tag2 = "";
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var databaseName = GetDatabaseName();
+
+            var settings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "0",
+                [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
+                [RavenConfiguration.GetKey(x => x.Backup.MoveToNewResponsibleNodeGracePeriod)] = "1"
+            };
+
+            var (nodes, leaderServer) = await CreateRaftCluster(clusterSize, customSettings: settings);
+            await CreateDatabaseInCluster(databaseName, clusterSize, leaderServer.WebUrl);
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { leaderServer.WebUrl },
+                Conventions = new DocumentConventions { DisableTopologyUpdates = true },
+                Database = databaseName
+            })
+            {
+                var mentorNode = Servers.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: mentorNode.ServerStore.NodeTag, name: "backup");
+                long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
+
+                var database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                var tag1 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+
+                CheckDecisionLog(leaderServer, new MentorNode(tag1, config.Name).ReasonForDecisionLog);
+
+                var disposedServer = Servers.First(s => s.ServerStore.NodeTag == tag1);
+                var result = await DisposeServerAndWaitForFinishOfDisposalAsync(disposedServer);
+                nodes.Remove(disposedServer);
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId);
+                //Wait for new responsible node
+                await WaitForValueAsync(async () =>
+                {
+                    database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    tag2 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                    return tag1.Equals(tag2);
+                }, false);
+                Assert.NotEqual(tag1, tag2);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId);
+
+                CheckDecisionLog(leaderServer, new CurrentResponsibleNodeNotResponding(tag2, config.Name, tag1, TimeSpan.FromSeconds(1)).ReasonForDecisionLog);
+
+                settings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url;
+                nodes.Add(GetNewServer(new ServerCreationOptions
+                {
+                    DeletePrevious = false,
+                    RunInMemory = false,
+                    DataDirectory = result.DataDirectory,
+                    CustomSettings = settings
+                }));
+                var val = await WaitForValueAsync(async () => await GetMembersCount(store), clusterSize);
+                Assert.Equal(clusterSize, val);
+
+                await WaitForValueAsync(async () =>
+                {
+                    database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    tag2 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                    return tag1.Equals(tag2);
+                }, true);
+
+                Assert.Equal(tag1, tag2);
+
+                CheckDecisionLog(leaderServer, new MentorNode(tag1, config.Name).ReasonForDecisionLog);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task ResponsibleNodeForBackup_PinnedMentorNode()
+        {
+            DoNotReuseServer();
+
+            const int clusterSize = 3;
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var databaseName = GetDatabaseName();
+
+            var settings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "0",
+                [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
+                [RavenConfiguration.GetKey(x => x.Backup.MoveToNewResponsibleNodeGracePeriod)] = "1"
+            };
+
+            var (nodes, leaderServer) = await CreateRaftCluster(clusterSize, customSettings: settings);
+            await CreateDatabaseInCluster(databaseName, clusterSize, leaderServer.WebUrl);
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { leaderServer.WebUrl },
+                Conventions = new DocumentConventions { DisableTopologyUpdates = true },
+                Database = databaseName
+            })
+            {
+                var mentorNode = Servers.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: mentorNode.ServerStore.NodeTag, name: "backup", pinToMentorNode: true);
+                long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
+
+                var database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                var tag1 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+
+                CheckDecisionLog(leaderServer, new PinnedMentorNode(tag1, config.Name).ReasonForDecisionLog);
+
+                var disposedServer = Servers.First(s => s.ServerStore.NodeTag == tag1);
+                nodes.Remove(disposedServer);
+                var result = await DisposeServerAndWaitForFinishOfDisposalAsync(disposedServer);
+
+                string tag2 = "";
+                await WaitForValueAsync(async () =>
+                {
+                    database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    tag2 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                    return tag1.Equals(tag2);
+                }, false);
+
+                Assert.Equal(tag1, tag2);
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId);
+
+                settings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url;
+                nodes.Add(GetNewServer(new ServerCreationOptions
+                {
+                    DeletePrevious = false,
+                    RunInMemory = false,
+                    DataDirectory = result.DataDirectory,
+                    CustomSettings = settings
+                }));
+                var val = await WaitForValueAsync(async () => await GetMembersCount(store), clusterSize);
+                Assert.Equal(clusterSize, val);
+
+                await WaitForValueAsync(async () =>
+                {
+                    database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    tag2 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                    return tag1.Equals(tag2);
+                }, true);
+
+                Assert.Equal(tag1, tag2);
+
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task ResponsibleNodeForBackup_CurrentResponsibleNodeRemovedFromTopology()
+        {
+            DoNotReuseServer();
+
+            const int clusterSize = 3;
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var databaseName = GetDatabaseName();
+
+            var settings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "0",
+                [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
+                [RavenConfiguration.GetKey(x => x.Backup.MoveToNewResponsibleNodeGracePeriod)] = "1"
+            };
+
+            var (nodes, leaderServer) = await CreateRaftCluster(clusterSize, customSettings: settings);
+            await CreateDatabaseInCluster(databaseName, clusterSize, leaderServer.WebUrl);
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { leaderServer.WebUrl },
+                Conventions = new DocumentConventions { DisableTopologyUpdates = true },
+                Database = databaseName
+            })
+            {
+                var mentorNode = Servers.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: mentorNode.ServerStore.NodeTag, name: "backup");
+                long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
+
+                var database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                var tag1 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                CheckDecisionLog(leaderServer, new MentorNode(tag1, config.Name).ReasonForDecisionLog);
+
+                var removedNode = Servers.First(s => s.ServerStore.NodeTag == tag1);
+
+                await ActionWithLeader(l => l.ServerStore.RemoveFromClusterAsync(removedNode.ServerStore.NodeTag));
+
+                string tag2 = "";
+                await WaitForValueAsync(async () =>
+                {
+                    database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                    tag2 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+                    return tag1.Equals(tag2);
+                }, false);
+
+                Assert.NotEqual(tag1, tag2);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId);
+
+                CheckDecisionLog(leaderServer, new CurrentResponsibleNodeRemovedFromTopology(tag2, config.Name, tag1).ReasonForDecisionLog);
+
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task ResponsibleNodeForBackup_NonExistingResponsibleNode()
+        {
+            DoNotReuseServer();
+
+            const int clusterSize = 3;
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var databaseName = GetDatabaseName();
+
+            var settings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
+                [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "0",
+                [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1"
+            };
+
+            var (nodes, leaderServer) = await CreateRaftCluster(clusterSize, customSettings: settings, watcherCluster: true);
+            await CreateDatabaseInCluster(databaseName, clusterSize, leaderServer.WebUrl);
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { leaderServer.WebUrl },
+                Conventions = new DocumentConventions { DisableTopologyUpdates = true },
+                Database = databaseName
+            })
+            {
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", name: "backup");
+
+                long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
+
+                var database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                var tag1 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
+
+                CheckDecisionLog(leaderServer, new NonExistingResponsibleNode(tag1, config.Name).ReasonForDecisionLog);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task Delete_Backup_Task_Values_After_Task_Deletion()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "oren" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                store.Maintenance.Send(new DeleteOngoingTaskOperation(backupTaskId, OngoingTaskType.Backup));
+
+                using (Server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var responsibleNodeInfo = Raven.Server.Utils.BackupUtils.GetResponsibleNodeInfoFromCluster(Server.ServerStore, context, store.Database, backupTaskId);
+                    Assert.Null(responsibleNodeInfo);
+
+                    var backupStatus = Raven.Server.Utils.BackupUtils.GetBackupStatusFromCluster(Server.ServerStore, context, store.Database, backupTaskId);
+                    Assert.Null(backupStatus);
+                }
+            }
+        }
+
+        protected static async Task<int> GetMembersCount(IDocumentStore store, string databaseName = null)
+        {
+            var res = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName ?? store.Database));
+            if (res == null)
+            {
+                return -1;
+            }
+            return res.Topology.Members.Count;
+        }
+
+        private static void CheckDecisionLog(RavenServer leaderServer, string reasonForDecisionLog)
+        {
+            var dbDecisions = leaderServer.ServerStore.Observer.ReadDecisionsForDatabase();
+            bool equals = dbDecisions.List.Any(x => x.ToString().Contains(reasonForDecisionLog, StringComparison.OrdinalIgnoreCase));
+            Assert.True(equals, reasonForDecisionLog);
+        }
+
+        private async Task<long> InitializeBackup(DocumentStore store, int clusterSize, RavenServer leaderServer, List<RavenServer> nodes, PeriodicBackupConfiguration config)
+        {
+            store.Initialize();
+            await Backup.FillClusterDatabaseWithRandomDataAsync(databaseSizeInMb: 10, store, clusterSize);
+
+            var database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+            Assert.NotNull(database);
+
+            var taskId = await Backup.UpdateConfigAndRunBackupAsync(leaderServer, config, store, opStatus: OperationStatus.InProgress);
+
+            Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId);
+
+            await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+            return taskId;
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/Counters/CountersTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/Counters/CountersTombstoneCleaner.cs
@@ -248,7 +248,7 @@ namespace SlowTests.Server.Documents.Counters
             {
                 var backupPath = NewDataPath(suffix: "BackupFolder");
                 var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "0 0 1 1 *");
-                var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                var taskId = await Backup.UpdateConfigAsync(Server, config, store);
 
                 using (var session = store.OpenSession())
                 {
@@ -295,7 +295,7 @@ namespace SlowTests.Server.Documents.Counters
                 }
                 Assert.True(c > 0);
 
-                await Backup.RunBackupInClusterAsync(store, result.TaskId, isFullBackup: true);
+                await Backup.RunBackupInClusterAsync(store, taskId, isFullBackup: true);
                 await cleaner.ExecuteCleanup();
 
                 c = 0;

--- a/test/SlowTests/Server/Documents/Counters/CountersTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/Counters/CountersTombstoneCleaner.cs
@@ -248,7 +248,9 @@ namespace SlowTests.Server.Documents.Counters
             {
                 var backupPath = NewDataPath(suffix: "BackupFolder");
                 var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "0 0 1 1 *");
-                var taskId = await Backup.UpdateConfigAsync(Server, config, store);
+                var taskId = options.DatabaseMode == RavenDatabaseMode.Single
+                    ? await Backup.UpdateConfigAsync(Server, config, store)
+                    : await Sharding.Backup.UpdateConfigAsync(Server, config, store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -490,12 +490,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     IncrementalBackupFrequency = "0 2 * * 1"
                 };
 
-                await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(serverWideBackupConfiguration1));
-                await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(serverWideBackupConfiguration2));
-
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var backup = record.PeriodicBackups.First();
-                var backupTaskId = backup.TaskId;
+                var backupTaskId = await Backup.UpdateServerWideConfigAsync(Server, serverWideBackupConfiguration1, store);
+                await Backup.UpdateServerWideConfigAsync(Server, serverWideBackupConfiguration2, store);
 
                 await store.Maintenance.SendAsync(new StartBackupOperation(true, backupTaskId));
 
@@ -601,7 +597,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         throw new ArgumentOutOfRangeException(nameof(encryptionMode), encryptionMode, null);
                 }
 
-                await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(serverWideBackupConfiguration));
+                var backupTaskId = await Backup.UpdateServerWideConfigAsync(Server, serverWideBackupConfiguration, store);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -611,10 +607,6 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     }, "users/1");
                     await session.SaveChangesAsync();
                 }
-
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var backup = record.PeriodicBackups.First();
-                var backupTaskId = backup.TaskId;
 
                 await store.Maintenance.SendAsync(new StartBackupOperation(true, backupTaskId));
 
@@ -959,11 +951,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     }
                 };
 
-                await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(serverWideBackupConfiguration));
-
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var backup = record.PeriodicBackups.First();
-                var backupTaskId = backup.TaskId;
+                var backupTaskId = await Backup.UpdateServerWideConfigAsync(Server, serverWideBackupConfiguration, store);
 
                 await store.Maintenance.SendAsync(new StartBackupOperation(true, backupTaskId));
 

--- a/test/SlowTests/Server/Documents/Replication/ServerWideReplication.cs
+++ b/test/SlowTests/Server/Documents/Replication/ServerWideReplication.cs
@@ -363,11 +363,7 @@ namespace SlowTests.Server.Documents.Replication
                     }
                 };
 
-                await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(serverWideBackupConfiguration));
-
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var backup = record.PeriodicBackups.First();
-                var backupTaskId = backup.TaskId;
+                var backupTaskId = await Backup.UpdateServerWideConfigAsync(Server, serverWideBackupConfiguration, store);
 
                 await store.Maintenance.SendAsync(new StartBackupOperation(true, backupTaskId));
 
@@ -474,11 +470,7 @@ namespace SlowTests.Server.Documents.Replication
                     }
                 };
 
-                await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(serverWideBackupConfiguration));
-
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var backup = record.PeriodicBackups.First();
-                var backupTaskId = backup.TaskId;
+                var backupTaskId = await Backup.UpdateServerWideConfigAsync(Server, serverWideBackupConfiguration, store);
 
                 await store.Maintenance.SendAsync(new StartBackupOperation(true, backupTaskId));
 

--- a/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
@@ -208,7 +208,9 @@ namespace SlowTests.Server.Documents.TimeSeries
             {
                 var backupPath = NewDataPath(suffix: "BackupFolder");
                 var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "0 0 1 1 *");
-                var taskId = await Backup.UpdateConfigAsync(Server, config, store);
+                var taskId = options.DatabaseMode == RavenDatabaseMode.Single 
+                    ? await Backup.UpdateConfigAsync(Server, config, store)
+                    : await Sharding.Backup.UpdateConfigAsync(Server, config, store);
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
+++ b/test/SlowTests/Server/Documents/TimeSeries/TimeSeriesTombstoneCleaner.cs
@@ -208,7 +208,7 @@ namespace SlowTests.Server.Documents.TimeSeries
             {
                 var backupPath = NewDataPath(suffix: "BackupFolder");
                 var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "0 0 1 1 *");
-                var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                var taskId = await Backup.UpdateConfigAsync(Server, config, store);
 
                 using (var session = store.OpenSession())
                 {
@@ -264,7 +264,7 @@ namespace SlowTests.Server.Documents.TimeSeries
                 }
                 Assert.True(c > 0);
 
-                await Backup.RunBackupInClusterAsync(store, result.TaskId, isFullBackup: true);
+                await Backup.RunBackupInClusterAsync(store, taskId, isFullBackup: true);
                 await cleaner.ExecuteCleanup();
 
                 c = 0;

--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -99,7 +99,14 @@ namespace SlowTests.Server.Replication
                 var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "0 0 1 1 *");
                 var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
-                Backup.WaitForResponsibleNodeUpdateInCluster(store, cluster.Nodes, result.TaskId);
+                if (options.DatabaseMode == RavenDatabaseMode.Single)
+                {
+                    Backup.WaitForResponsibleNodeUpdateInCluster(store, cluster.Nodes, result.TaskId);
+                }
+                else
+                {
+                    Sharding.Backup.WaitForResponsibleNodeUpdateInCluster(store, cluster.Nodes, result.TaskId);
+                }
 
                 using (var session = store.OpenSession())
                 {

--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -99,6 +99,8 @@ namespace SlowTests.Server.Replication
                 var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "0 0 1 1 *");
                 var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, cluster.Nodes, result.TaskId);
+
                 using (var session = store.OpenSession())
                 {
                     session.Store(new User { Name = "Karmel" }, "foo/bar");

--- a/test/SlowTests/Server/Replication/ReplicationRevisionsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationRevisionsTests.cs
@@ -141,7 +141,7 @@ namespace SlowTests.Server.Replication
                 }
 
                 var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "0 * * * *", mentorNode: secondNode.ServerStore.NodeTag);
-                var backupTaskId = await Backup.CreateAndRunBackupInClusterAsync(config, store, isFullBackup: true);
+                var backupTaskId = await Backup.CreateAndRunBackupInClusterAsync(config, store, nodes, isFullBackup: true);
 
                 await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, true, firstNodeTag));
                 await WaitAndAssertForValueAsync(async () =>

--- a/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
+++ b/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
@@ -339,6 +339,7 @@ namespace SlowTests.Sharding.Backup
 
                 var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
                 var backupTaskId = result.TaskId;
+                Sharding.Backup.WaitForResponsibleNodeUpdate(Server.ServerStore, store.Database, backupTaskId);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -526,6 +527,8 @@ namespace SlowTests.Sharding.Backup
 
                 var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
                 var backupTaskId = result.TaskId;
+
+                Sharding.Backup.WaitForResponsibleNodeUpdateInCluster(store, cluster.Nodes, backupTaskId);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Sharding/Backup/SnapshotBackupTests.cs
+++ b/test/SlowTests/Sharding/Backup/SnapshotBackupTests.cs
@@ -27,7 +27,7 @@ public class SnapshotBackupTests : RavenTestBase
                     {
                         FolderPath = NewDataPath()
                     }
-                }, store);
+                }, store, nodes: null);
             });
         }
     }

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
@@ -1485,8 +1485,17 @@ namespace SlowTests.Sharding.Subscriptions
                 Assert.Equal(3, states.Count);
 
                 var config = Backup.CreateBackupConfiguration(backupPath);
-                var result = await store1.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
-                var backupTaskId = result.TaskId;
+
+                long backupTaskId;
+                if (fromSharded)
+                {
+                    backupTaskId = await Sharding.Backup.UpdateConfigAsync(Server, config, store1);
+                }
+                else
+                {
+                    backupTaskId = await Backup.UpdateConfigAsync(Server, config, store1);
+                }
+
                 var op = await store1.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: true, backupTaskId));
                 await op.WaitForCompletionAsync(_reasonableWaitTime);
                 // restore the database with a different name

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-            const int numberToTolerate = 4627;
+            const int numberToTolerate = 4624;
 
             if (array.Length == numberToTolerate)
                 return;

--- a/test/StressTests/Server/Documents/PeriodicBackup/PeriodicBackupTestsStress.cs
+++ b/test/StressTests/Server/Documents/PeriodicBackup/PeriodicBackupTestsStress.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using Raven.Client.Documents;
-using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Client.Util;
 using Raven.Server;
+using Raven.Server.ServerWide.Commands.PeriodicBackup;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -25,13 +22,15 @@ namespace StressTests.Server.Documents.PeriodicBackup
         }
 
         [Fact, Trait("Category", "Smuggler")]
-        public async Task FirstBackupWithClusterDownStatusShouldRearrangeTheTimer()
+        public async Task WillRunBackupAfterGettingMissingResponsibleNode()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
+
             using (var store = GetDocumentStore(new Options { DeleteDatabaseOnDispose = true, Path = NewDataPath() }))
             {
+                var gotMissingResponsibleNode = false;
                 var documentDatabase = await GetDatabase(store.Database);
-                documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateClusterDownStatus = true;
+                documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnMissingResponsibleNode = () => gotMissingResponsibleNode = true;
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -42,9 +41,10 @@ namespace StressTests.Server.Documents.PeriodicBackup
                 var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "* * * * *");
                 var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
                 var periodicBackupTaskId = result.TaskId;
-                var val = WaitForValue(() => documentDatabase.PeriodicBackupRunner._forTestingPurposes.ClusterDownStatusSimulated, true, timeout: 66666, interval: 333);
-                Assert.True(val, "Failed to simulate ClusterDown Status");
-                documentDatabase.PeriodicBackupRunner._forTestingPurposes = null;
+
+                var val = WaitForValue(() => gotMissingResponsibleNode, true, timeout: 66666, interval: 333);
+                Assert.True(val, "Didn't get a missing responsible node status");
+
                 var getPeriodicBackupStatus = new GetPeriodicBackupStatusOperation(periodicBackupTaskId);
                 val = WaitForValue(() => store.Maintenance.Send(getPeriodicBackupStatus).Status?.LastFullBackup != null, true, timeout: 66666, interval: 333);
                 Assert.True(val, "Failed to complete the backup in time");
@@ -83,6 +83,8 @@ namespace StressTests.Server.Documents.PeriodicBackup
                 var taskId = backups1.First().TaskId;
                 var responsibleDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 Assert.NotNull(responsibleDatabase);
+                Backup.WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, taskId);
+
                 var tag = responsibleDatabase.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
                 Assert.Equal(server.ServerStore.NodeTag, tag);
 

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -11,16 +11,18 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Documents;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Sparrow.Json;
 using Xunit;
-using BackupUtils = Raven.Server.Utils.BackupUtils;
 
 namespace FastTests
 {
@@ -84,8 +86,44 @@ namespace FastTests
             public async Task<long> UpdateConfigAndRunBackupAsync(RavenServer server, PeriodicBackupConfiguration config, IDocumentStore store, bool isFullBackup = true, OperationStatus opStatus = OperationStatus.Completed, int? timeout = default)
             {
                 var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+                WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, result.TaskId);
+
                 await RunBackupAsync(server, result.TaskId, store, isFullBackup, opStatus, timeout);
                 return result.TaskId;
+            }
+
+            public async Task<long> UpdateConfigAsync(RavenServer server, PeriodicBackupConfiguration config, DocumentStore store)
+            {
+                var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+                WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, result.TaskId);
+
+                return result.TaskId;
+            }
+            
+            public async Task<long> UpdateServerWideConfigAsync(RavenServer server, ServerWideBackupConfiguration config, DocumentStore store)
+            {
+                await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(config));
+
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                var backup = record.PeriodicBackups.First();
+                var backupTaskId = backup.TaskId;
+
+                WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, backupTaskId);
+
+                return backupTaskId;
+            }
+
+            public void WaitForResponsibleNodeUpdate(ServerStore serverStore, string databaseName, long taskId, string differentThan = null)
+            {
+                var value = WaitForValue(() =>
+                {
+                    var responsibleNode = BackupUtils.GetResponsibleNodeTag(serverStore, databaseName, taskId);
+                    return responsibleNode != differentThan;
+                }, true);
+
+                Assert.True(value);
             }
 
             /// <summary>
@@ -141,14 +179,15 @@ namespace FastTests
 
             public PeriodicBackupConfiguration CreateBackupConfiguration(string backupPath = null, BackupType backupType = BackupType.Backup, bool disabled = false, string fullBackupFrequency = "0 0 1 1 *",
                 string incrementalBackupFrequency = null, long? taskId = null, string mentorNode = null, BackupEncryptionSettings backupEncryptionSettings = null, AzureSettings azureSettings = null,
-                GoogleCloudSettings googleCloudSettings = null, S3Settings s3Settings = null, FtpSettings ftpSettings = null, RetentionPolicy retentionPolicy = null, string name = null, BackupUploadMode backupUploadMode = BackupUploadMode.Default)
+                GoogleCloudSettings googleCloudSettings = null, S3Settings s3Settings = null, FtpSettings ftpSettings = null, RetentionPolicy retentionPolicy = null, string name = null, BackupUploadMode backupUploadMode = BackupUploadMode.Default, bool pinToMentorNode = false)
             {
                 var config = new PeriodicBackupConfiguration()
                 {
                     BackupType = backupType,
                     FullBackupFrequency = fullBackupFrequency,
                     Disabled = disabled,
-                    BackupUploadMode = backupUploadMode
+                    BackupUploadMode = backupUploadMode,
+                    PinToMentorNode = pinToMentorNode
                 };
 
                 if (taskId.HasValue)
@@ -177,39 +216,41 @@ namespace FastTests
                 return config;
             }
 
-            public async Task<string> GetBackupResponsibleNode(RavenServer server, long taskId, string databaseName, bool keepTaskOnOriginalMemberNode = false)
+            public string GetBackupResponsibleNode(RavenServer server, long taskId, string databaseName, bool keepTaskOnOriginalMemberNode = false)
             {
-                using (server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (context.OpenReadTransaction())
-                {
-                    var db = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName).ConfigureAwait(false);
-                    var rawRecord = server.ServerStore.Cluster.ReadRawDatabaseRecord(context, databaseName);
-                    var pbConfig = rawRecord.GetPeriodicBackupConfiguration(taskId);
-                    var backupStatus = db.PeriodicBackupRunner.GetBackupStatus(taskId);
-                    var node = BackupUtils.WhoseTaskIsIt(server.ServerStore, rawRecord.Topology, pbConfig, backupStatus, db.NotificationCenter, keepTaskOnOriginalMemberNode);
-
-                    return node;
-                }
+                var node = BackupUtils.GetResponsibleNodeTag(server.ServerStore, databaseName, taskId);
+                return node;
             }
 
             /// <summary>
             /// Create and run backup with provided task id in cluster.
             /// </summary>
             /// <returns>TaskId</returns>
-            public long CreateAndRunBackupInCluster(PeriodicBackupConfiguration config, IDocumentStore store, bool isFullBackup = true, OperationStatus opStatus = OperationStatus.Completed, int? timeout = default)
+            public long CreateAndRunBackupInCluster(PeriodicBackupConfiguration config, IDocumentStore store, List<RavenServer> nodes, bool isFullBackup = true, OperationStatus opStatus = OperationStatus.Completed, int? timeout = default)
             {
-                return AsyncHelpers.RunSync(() => CreateAndRunBackupInClusterAsync(config, store, isFullBackup, opStatus, timeout));
+                return AsyncHelpers.RunSync(() => CreateAndRunBackupInClusterAsync(config, store, nodes, isFullBackup, opStatus, timeout));
             }
 
             /// <summary>
             /// Create and run backup with provided task id in cluster.
             /// </summary>
             /// <returns>TaskId</returns>
-            public async Task<long> CreateAndRunBackupInClusterAsync(PeriodicBackupConfiguration config, IDocumentStore store, bool isFullBackup = true, OperationStatus opStatus = OperationStatus.Completed, int? timeout = default)
+            public async Task<long> CreateAndRunBackupInClusterAsync(PeriodicBackupConfiguration config, IDocumentStore store, List<RavenServer> nodes, bool isFullBackup = true, OperationStatus opStatus = OperationStatus.Completed, int? timeout = default)
             {
                 var backupTaskId = (await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+
+                WaitForResponsibleNodeUpdateInCluster(store, nodes, backupTaskId);
+
                 await RunBackupInClusterAsync(store, backupTaskId, isFullBackup, opStatus, timeout);
                 return backupTaskId;
+            }
+
+            public void WaitForResponsibleNodeUpdateInCluster(IDocumentStore store, List<RavenServer> nodes, long backupTaskId)
+            {
+                foreach (var server in nodes)
+                {
+                    WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, backupTaskId);
+                }
             }
 
             /// <summary>

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -96,7 +96,7 @@ namespace FastTests
             public async Task<long> UpdateConfigAsync(RavenServer server, PeriodicBackupConfiguration config, DocumentStore store)
             {
                 var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
-
+                
                 WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, result.TaskId);
 
                 return result.TaskId;

--- a/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
@@ -19,7 +19,9 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
 using Raven.Server;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -354,6 +356,35 @@ public partial class RavenTestBase
             await RunBackupAsync(store.Database, result.TaskId, isFullBackup, servers);
 
             return result.TaskId;
+        }
+
+        public void WaitForResponsibleNodeUpdate(ServerStore serverStore, string databaseName, long taskId, string differentThan = null)
+        {
+            using (serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                using (var rawRecord = serverStore.Engine.StateMachine.ReadRawDatabaseRecord(context, databaseName, out _))
+                {
+                    foreach (var (name, _) in rawRecord.Topologies)
+                    {
+                        var value = WaitForValue(() =>
+                        {
+                            var responsibleNode = BackupUtils.GetResponsibleNodeTag(serverStore, name, taskId);
+                            return responsibleNode != differentThan;
+                        }, true);
+
+                        Assert.True(value);
+                    }
+                }
+            }
+        }
+
+        public void WaitForResponsibleNodeUpdateInCluster(IDocumentStore store, List<RavenServer> nodes, long backupTaskId)
+        {
+            foreach (var server in nodes)
+            {
+                WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, backupTaskId);
+            }
         }
 
         public async Task RunBackupAsync(string database, long taskId, bool isFullBackup, List<RavenServer> servers = null)

--- a/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
@@ -358,6 +358,15 @@ public partial class RavenTestBase
             return result.TaskId;
         }
 
+        public async Task<long> UpdateConfigAsync(RavenServer server, PeriodicBackupConfiguration config, DocumentStore store)
+        {
+            var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+            WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, result.TaskId);
+
+            return result.TaskId;
+        }
+
         public void WaitForResponsibleNodeUpdate(ServerStore serverStore, string databaseName, long taskId, string differentThan = null)
         {
             using (serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19922/Cluster-does-not-care-if-theres-a-backup-running-already-and-starts-one-on-another-node

### Additional description

Change the way we decide on which node should perform the backup.
- Only the cluster observer will decide which node will be responsible for backup. The state will be saved in the cluster.
- Grace period before moving the backup if the currently responsible node is in rehab state (configurable - default: 30 minutes).
- Updating the cluster observer log with the decisions that we make.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
