### PR TITLE
RavenDB-21989 - don't materialize the database record in HandleClusterDatabaseChanged

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1511,8 +1511,14 @@ namespace Raven.Server.Documents
             return false;
         }
 
-        private bool CanSkipValueChange(long index)
+        private bool CanSkipValueChange(long index, object changeState)
         {
+            if (changeState != null)
+            {
+                // must set a specific state
+                return false;
+            }
+
             if (LastValueChangeIndex > index)
             {
                 // index and LastDatabaseRecordIndex could have equal values when we transit from/to passive and want to update the tasks.
@@ -1526,7 +1532,7 @@ namespace Raven.Server.Documents
 
         private void NotifyFeaturesAboutValueChange(long index, string type, object changeState)
         {
-            if (CanSkipValueChange(index))
+            if (CanSkipValueChange(index, changeState))
                 return;
 
             var taken = false;
@@ -1536,7 +1542,7 @@ namespace Raven.Server.Documents
 
                 try
                 {
-                    if (CanSkipValueChange(index))
+                    if (CanSkipValueChange(index, changeState))
                         return;
 
                     if (DatabaseShutdown.IsCancellationRequested)

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -796,14 +796,14 @@ namespace Raven.Server.Documents.ETL
             return reason;
         }
 
-        public void HandleDatabaseValueChanged(string databaseName)
+        public void HandleDatabaseValueChanged()
         {
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
             {
                 foreach (var process in _processes)
                 {
-                    var state = _serverStore.Cluster.Read(context, EtlProcessState.GenerateItemName(databaseName, process.ConfigurationName, process.TransformationName));
+                    var state = _serverStore.Cluster.Read(context, EtlProcessState.GenerateItemName(_database.Name, process.ConfigurationName, process.TransformationName));
 
                     if (state == null)
                     {

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -796,14 +796,14 @@ namespace Raven.Server.Documents.ETL
             return reason;
         }
 
-        public void HandleDatabaseValueChanged(DatabaseRecord record)
+        public void HandleDatabaseValueChanged(string databaseName)
         {
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
             {
                 foreach (var process in _processes)
                 {
-                    var state = _serverStore.Cluster.Read(context, EtlProcessState.GenerateItemName(record.DatabaseName, process.ConfigurationName, process.TransformationName));
+                    var state = _serverStore.Cluster.Read(context, EtlProcessState.GenerateItemName(databaseName, process.ConfigurationName, process.TransformationName));
 
                     if (state == null)
                     {

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -1044,12 +1044,12 @@ namespace Raven.Server.Documents.PeriodicBackup
             return dict;
         }
 
-        public void HandleDatabaseValueChanged(string type, List<PeriodicBackupConfiguration> configurations, object changeState)
+        public void HandleDatabaseValueChanged(string type, RawDatabaseRecord record, object changeState)
         {
             switch (type)
             {
                 case nameof(UpdateResponsibleNodeForTasksCommand):
-                    UpdateConfigurations(configurations);
+                    UpdateConfigurations(record.PeriodicBackups);
                     break;
 
                 case nameof(DelayBackupCommand):

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -657,12 +657,12 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
         }
 
-        public void UpdateConfigurations(DatabaseRecord databaseRecord)
+        public void UpdateConfigurations(List<PeriodicBackupConfiguration> configurations)
         {
             if (_disposed)
                 return;
 
-            if (databaseRecord.PeriodicBackups == null)
+            if (configurations == null)
             {
                 foreach (var periodicBackup in _periodicBackups)
                 {
@@ -673,7 +673,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
 
             var allBackupTaskIds = new List<long>();
-            foreach (var periodicBackupConfiguration in databaseRecord.PeriodicBackups)
+            foreach (var periodicBackupConfiguration in configurations)
             {
                 var newBackupTaskId = periodicBackupConfiguration.TaskId;
                 allBackupTaskIds.Add(newBackupTaskId);
@@ -1044,12 +1044,12 @@ namespace Raven.Server.Documents.PeriodicBackup
             return dict;
         }
 
-        public void HandleDatabaseValueChanged(string type, DatabaseRecord record, object changeState)
+        public void HandleDatabaseValueChanged(string type, List<PeriodicBackupConfiguration> configurations, object changeState)
         {
             switch (type)
             {
                 case nameof(UpdateResponsibleNodeForTasksCommand):
-                    UpdateConfigurations(record);
+                    UpdateConfigurations(configurations);
                     break;
 
                 case nameof(DelayBackupCommand):

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -675,7 +675,7 @@ namespace Raven.Server.Documents.Subscriptions
             return subscriptionData;
         }
 
-        public void HandleDatabaseRecordChange(string databaseName, DatabaseTopology topology)
+        public void HandleDatabaseRecordChange(DatabaseTopology topology)
         {
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
@@ -687,7 +687,7 @@ namespace Raven.Server.Documents.Subscriptions
                     if (subscriptionName == null)
                         continue;
 
-                    var subscriptionBlittable = _serverStore.Cluster.Read(context, SubscriptionState.GenerateSubscriptionItemKeyName(databaseName, subscriptionName));
+                    var subscriptionBlittable = _serverStore.Cluster.Read(context, SubscriptionState.GenerateSubscriptionItemKeyName(_db.Name, subscriptionName));
                     if (subscriptionBlittable == null)
                     {
                         DeleteAndSetException(subscriptionStateKvp.Key, new SubscriptionDoesNotExistException($"The subscription {subscriptionName} had been deleted"));

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -675,7 +675,7 @@ namespace Raven.Server.Documents.Subscriptions
             return subscriptionData;
         }
 
-        public void HandleDatabaseRecordChange(DatabaseRecord databaseRecord)
+        public void HandleDatabaseRecordChange(string databaseName, DatabaseTopology topology)
         {
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
@@ -687,7 +687,7 @@ namespace Raven.Server.Documents.Subscriptions
                     if (subscriptionName == null)
                         continue;
 
-                    var subscriptionBlittable = _serverStore.Cluster.Read(context, SubscriptionState.GenerateSubscriptionItemKeyName(databaseRecord.DatabaseName, subscriptionName));
+                    var subscriptionBlittable = _serverStore.Cluster.Read(context, SubscriptionState.GenerateSubscriptionItemKeyName(databaseName, subscriptionName));
                     if (subscriptionBlittable == null)
                     {
                         DeleteAndSetException(subscriptionStateKvp.Key, new SubscriptionDoesNotExistException($"The subscription {subscriptionName} had been deleted"));
@@ -720,7 +720,7 @@ namespace Raven.Server.Documents.Subscriptions
                         continue;
                     }
 
-                    var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, databaseRecord.Topology, subscriptionState, subscriptionState, _db.NotificationCenter);
+                    var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, topology, subscriptionState, subscriptionState, _db.NotificationCenter);
                     if (whoseTaskIsIt != _serverStore.NodeTag)
                     {
                         DropSubscriptionConnections(subscriptionStateKvp.Key,

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2854,7 +2854,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(server.ServerStore.NodeTag, tag);
 
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = true;
-                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
                     tcs.SetResult(null);
 
                     responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
@@ -2922,7 +2922,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(server.ServerStore.NodeTag, tag);
 
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateDisableNodeStatus_UpdateConfigurations = true;
-                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
                     tcs.SetResult(null);
 
                     responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
@@ -3543,10 +3543,10 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(server.ServerStore.NodeTag, tag);
 
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = true;
-                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = false;
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByCurrentNode_UpdateConfigurations = true;
-                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
                     tcs.SetResult(null);
 
                     responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;

--- a/test/StressTests/Server/Documents/PeriodicBackup/PeriodicBackupTestsStress.cs
+++ b/test/StressTests/Server/Documents/PeriodicBackup/PeriodicBackupTestsStress.cs
@@ -97,7 +97,7 @@ namespace StressTests.Server.Documents.PeriodicBackup
                                   "so when the task status is back to be ActiveByCurrentNode, UpdateConfigurations will be able to reassign the backup timer");
 
                 responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
-                responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
                 var getPeriodicBackupStatus = new GetPeriodicBackupStatusOperation(taskId);
 
                 val = WaitForValue(() => store.Maintenance.Send(getPeriodicBackupStatus).Status?.LastFullBackup != null, true, timeout: 66666, interval: 444);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21989/Materialized-database-record-in-HandleClusterDatabaseChanged

### Additional description

Don't materialize the database record in `HandleClusterDatabaseChanged`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
