### PR TITLE
RavenDB-21088 Failed to load the storage report

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -317,5 +317,12 @@ namespace Raven.Server.Documents.Handlers.Debugging
             writer.WriteEndArray();
             writer.WriteEndObject();
         }
+
+        [RavenAction("/databases/*/debug/storage/environment/scratch-buffer-info", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        public async Task ScratchBufferPoolInfoReport()
+        {
+            using (var processor = new StorageHandlerProcessorForGetScratchBufferReport(this))
+                await processor.ExecuteAsync();
+        }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentPages.cs
@@ -9,8 +9,11 @@ using JetBrains.Annotations;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Web.Http;
+using Sparrow.Json.Parsing;
+using Voron;
 using Voron.Data.Containers;
 using Voron.Data.PostingLists;
+using Voron.Impl;
 
 namespace Raven.Server.Documents.Handlers.Processors.Debugging;
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentReport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentReport.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Voron;
 using Voron.Debugging;
+using Voron.Impl;
 
 namespace Raven.Server.Documents.Handlers.Processors.Debugging;
 
@@ -41,21 +43,7 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentReport : AbstractS
         {
             await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
             {
-                writer.WriteStartObject();
-
-                writer.WritePropertyName("Name");
-                writer.WriteString(env.Name);
-                writer.WriteComma();
-
-                writer.WritePropertyName("Type");
-                writer.WriteString(env.Type.ToString());
-                writer.WriteComma();
-
-                var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(GetDetailedReport(env, details));
-                writer.WritePropertyName("Report");
-                writer.WriteObject(context.ReadObject(djv, env.Name));
-
-                writer.WriteEndObject();
+                WriteReport(writer, name, new List<StorageEnvironmentWithType>() { env }, context, details);
             }
         }
     }
@@ -74,5 +62,10 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentReport : AbstractS
 
         var index = RequestHandler.Database.IndexStore.GetIndex(environment.Name);
         return index.GenerateStorageReport(details);
+    }
+
+    protected override DynamicJsonValue GetJsonReport(StorageEnvironmentWithType env, LowLevelTransaction lowTx, bool de)
+    {
+        return (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(GetDetailedReport(env, de));
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetScratchBufferReport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetScratchBufferReport.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Server.Web.Http;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Voron;
+using Voron.Impl;
+
+namespace Raven.Server.Documents.Handlers.Processors.Debugging
+{
+    internal sealed class StorageHandlerProcessorForGetScratchBufferReport : AbstractStorageHandlerProcessorForGetEnvironmentReport<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public StorageHandlerProcessorForGetScratchBufferReport([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => true;
+
+        protected override async ValueTask HandleCurrentNodeAsync()
+        {
+            var name = GetName();
+            var typeAsString = RequestHandler.GetStringQueryString("type", false);
+
+            IEnumerable<StorageEnvironmentWithType> envs;
+
+            if (typeAsString != null)
+            {
+                if (Enum.TryParse(typeAsString, out StorageEnvironmentWithType.StorageEnvironmentType type) == false)
+                    throw new InvalidOperationException("Query string value 'type' is not a valid environment type: " + typeAsString);
+                var db = RequestHandler.Database.GetAllStoragesEnvironment()
+                    .FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase) && x.Type == type);
+                envs = db == null ? null : new List<StorageEnvironmentWithType>() { db };
+            }
+            else
+            {
+                envs = RequestHandler.Database.GetAllStoragesEnvironment();
+            }
+
+            if (envs == null)
+            {
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                return;
+            }
+
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+                {
+                    WriteReport(writer, name, envs, context);
+                }
+            }
+        }
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
+
+        protected override DynamicJsonValue GetJsonReport(StorageEnvironmentWithType env, LowLevelTransaction lowTx, bool de)
+        {
+            //Opening a write transaction to avoid concurrency problems (Issue #21088)
+            var sc = env.Environment.ScratchBufferPool.InfoForDebug(env.Environment.PossibleOldestReadTransaction(lowTx));
+            return (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(sc);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Debugging/ShardedStorageHandlerProcessorForGetScratchBufferReport.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Debugging/ShardedStorageHandlerProcessorForGetScratchBufferReport.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.ServerWide;
+using Raven.Server.Web.Http;
+
+using Raven.Server.Documents.Handlers.Processors.Debugging;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Debugging
+{
+    internal sealed class ShardedStorageHandlerProcessorForGetScratchBufferReport : AbstractStorageHandlerProcessorForGetEnvironmentReport<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    {
+        public ShardedStorageHandlerProcessorForGetScratchBufferReport([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override bool SupportsCurrentNode => false;
+
+        protected override ValueTask HandleCurrentNodeAsync() => throw new NotSupportedException();
+
+        protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token)
+        {
+            var shardNumber = GetShardNumber();
+
+            return RequestHandler.ShardExecutor.ExecuteSingleShardAsync(command, shardNumber, token.Token);
+        }
+    }
+}

--- a/src/Raven.Server/Web/System/AdminStorageHandler.cs
+++ b/src/Raven.Server/Web/System/AdminStorageHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -30,6 +31,38 @@ namespace Raven.Server.Web.System
                 using (var tx = env.ReadTransaction())
                 {
                     var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(env.GenerateDetailedReport(tx, details));
+                    writer.WritePropertyName("Report");
+                    writer.WriteObject(context.ReadObject(djv, "System"));
+                }
+
+                writer.WriteEndObject();
+            }
+        }
+
+        [RavenAction("/admin/debug/storage/environment/scratch-buffer-info", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = false)]
+        public async Task SystemScratchBufferPoolInfoReport()
+        {
+            var env = ServerStore._env;
+
+            using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("Environment");
+                writer.WriteString("Server");
+                writer.WriteComma();
+
+                writer.WritePropertyName("Type");
+                writer.WriteString(nameof(StorageEnvironmentWithType.StorageEnvironmentType.System));
+                writer.WriteComma();
+
+                using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                using (var tx = env.ReadTransaction())
+                using (ctx.OpenWriteTransaction())
+                {
+                    //Opening a write transaction to avoid concurrency problems (Issue #21088)
+                    var sc = env.ScratchBufferPool.InfoForDebug(env.PossibleOldestReadTransaction(tx.LowLevelTransaction));
+                    var djv = (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(sc);
                     writer.WritePropertyName("Report");
                     writer.WriteObject(context.ReadObject(djv, "System"));
                 }

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -273,7 +273,6 @@ namespace Voron.Debugging
                 Tables = tables,
                 Journals = journals,
                 PreAllocatedBuffers = preAllocatedBuffers,
-                ScratchBufferPoolInfo = input.ScratchBufferPoolInfo,
                 TempBuffers = tempBuffers,
                 TotalEncryptionBufferSize = input.TotalEncryptionBufferSize.ToString()
             };

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1333,7 +1333,6 @@ namespace Voron
                 NumericLookups = new(),
                 TextualLookups = new(),
                 IncludeDetails = includeDetails,
-                ScratchBufferPoolInfo = _scratchBufferPool.InfoForDebug(PossibleOldestReadTransaction(tx.LowLevelTransaction)),
                 TempPath = Options.TempPath,
                 JournalPath = (Options as StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions)?.JournalPath,
                 TotalEncryptionBufferSize = totalCryptoBufferSize,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-21088

### Additional description

_allocatedPages dictionary was modified while we were iterating it.
Now there is a new endpoint for ScratchBufferPoolInfo , and we open a write transaction to avoid concurrency problem

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
