### PR TITLE
RavenDB-21833 fix setting _lastWriteToStream

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -435,7 +435,6 @@ namespace Raven.Client.Documents.BulkInsert
         {
             using (await ConcurrencyCheckAsync().ConfigureAwait(false))
             {
-                _lastWriteToStream = DateTime.UtcNow;
                 VerifyValidId(id);
 
                 await ExecuteBeforeStore().ConfigureAwait(false);
@@ -554,6 +553,7 @@ namespace Raven.Client.Documents.BulkInsert
                 _backgroundWriter = tmp;
                 _currentWriter.BaseStream.SetLength(0);
                 ((MemoryStream)tmp.BaseStream).TryGetBuffer(out var buffer);
+                _lastWriteToStream = DateTime.UtcNow;
                 _asyncWrite = WriteToRequestBodyStreamAsync(buffer);
             }
         }
@@ -856,7 +856,6 @@ namespace Raven.Client.Documents.BulkInsert
                         if (_operation._inProgressCommand == CommandType.TimeSeries)
                             TimeSeriesBulkInsertBase.ThrowAlreadyRunningTimeSeries();
 
-                        _operation._lastWriteToStream = DateTime.UtcNow;
                         var isFirst = _id == null;
                         if (isFirst || _id.Equals(id, StringComparison.OrdinalIgnoreCase) == false)
                         {
@@ -956,7 +955,6 @@ namespace Raven.Client.Documents.BulkInsert
                 {
                     try
                     {
-                        _operation._lastWriteToStream = DateTime.UtcNow;
                         await _operation.ExecuteBeforeStore().ConfigureAwait(false);
 
                         if (_first)
@@ -1151,7 +1149,6 @@ namespace Raven.Client.Documents.BulkInsert
                 {
                     try
                     {
-                        _operation._lastWriteToStream = DateTime.UtcNow;
                         _operation.EndPreviousCommandIfNeeded();
 
                         await _operation.ExecuteBeforeStore().ConfigureAwait(false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21833

### Additional description

The issue occurs from incorrect setting _lastWriteToStream . It should only be updated when writing to the Request Body Stream. The root cause of the problem was the misalignment in timing, leading to the server prematurely closing the stream due to a read timeout.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
