### PR TITLE
RavenDB-21989 - don't materialize the database record in HandleClusterDatabaseChanged

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -798,9 +798,9 @@ namespace Raven.Server.Documents.ETL
             return reason;
         }
 
-        public void HandleDatabaseValueChanged(DatabaseRecord record)
+        public void HandleDatabaseValueChanged()
         {
-            var dbName = ShardHelper.ToDatabaseName(record.DatabaseName);
+            var dbName = ShardHelper.ToDatabaseName(_database.Name);
 
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Subscriptions.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Subscriptions.cs
@@ -54,9 +54,9 @@ public partial class ShardedDatabaseContext
             return false;
         }
 
-        public void Update(RawDatabaseRecord databaseRecord)
+        public void Update()
         {
-            HandleDatabaseRecordChange(databaseRecord);
+            HandleDatabaseRecordChange();
         }
 
         public override bool DropSingleSubscriptionConnection(long subscriptionId, string workerId, SubscriptionException ex)

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -149,7 +149,7 @@ namespace Raven.Server.Documents.Sharding
 
             Indexes.Update(record, index);
 
-            SubscriptionsStorage.Update(record);
+            SubscriptionsStorage.Update();
 
             Interlocked.Exchange(ref _record, record);
         }

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
@@ -232,7 +232,7 @@ public abstract class AbstractSubscriptionStorage<TState> : AbstractSubscription
         return count;
     }
 
-    public virtual void HandleDatabaseRecordChange(DatabaseRecord databaseRecord)
+    public virtual void HandleDatabaseRecordChange()
     {
         using (_serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
         using (context.OpenReadTransaction())

--- a/src/Raven.Server/Documents/Subscriptions/Sharding/ShardSubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Sharding/ShardSubscriptionStorage.cs
@@ -20,7 +20,7 @@ public sealed class ShardSubscriptionStorage : SubscriptionStorage
         _shardNumber = ShardHelper.GetShardNumberFromDatabaseName(_shardName);
     }
 
-    public override void HandleDatabaseRecordChange(DatabaseRecord databaseRecord)
+    public override void HandleDatabaseRecordChange()
     {
         using (_serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
         using (context.OpenReadTransaction())

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2865,7 +2865,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(server.ServerStore.NodeTag, tag);
 
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = true;
-                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
                     tcs.SetResult(null);
 
                     responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
@@ -2933,7 +2933,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(server.ServerStore.NodeTag, tag);
 
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateDisableNodeStatus_UpdateConfigurations = true;
-                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
                     tcs.SetResult(null);
 
                     responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
@@ -3556,10 +3556,10 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(server.ServerStore.NodeTag, tag);
 
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = true;
-                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = false;
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByCurrentNode_UpdateConfigurations = true;
-                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                    responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
                     tcs.SetResult(null);
 
                     responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;

--- a/test/StressTests/Server/Documents/PeriodicBackup/PeriodicBackupTestsStress.cs
+++ b/test/StressTests/Server/Documents/PeriodicBackup/PeriodicBackupTestsStress.cs
@@ -97,7 +97,7 @@ namespace StressTests.Server.Documents.PeriodicBackup
                                   "so when the task status is back to be ActiveByCurrentNode, UpdateConfigurations will be able to reassign the backup timer");
 
                 responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
-                responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1);
+                responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
                 var getPeriodicBackupStatus = new GetPeriodicBackupStatusOperation(taskId);
 
                 val = WaitForValue(() => store.Maintenance.Send(getPeriodicBackupStatus).Status?.LastFullBackup != null, true, timeout: 66666, interval: 444);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21989/Materialized-database-record-in-HandleClusterDatabaseChanged

### Additional description

Don't materialize the database record in `HandleClusterDatabaseChanged`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
