### PR TITLE
RavenDB-21860 improve cluster-wide tx performance

### DIFF
--- a/src/Raven.Client/Extensions/TaskExtensions.cs
+++ b/src/Raven.Client/Extensions/TaskExtensions.cs
@@ -38,7 +38,7 @@ namespace Raven.Client.Extensions
 
         public static async Task<bool> WaitWithTimeout(this Task task, TimeSpan? timeout)
         {
-            if (timeout == null)
+            if (timeout == null || timeout == Timeout.InfiniteTimeSpan)
             {
                 await task.ConfigureAwait(false);
                 return true;

--- a/src/Raven.Server/Documents/ClusterTransactionWaiter.cs
+++ b/src/Raven.Server/Documents/ClusterTransactionWaiter.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Documents
             Database.RachisLogIndexNotifications.NotifyListenersAbout(index, null);
             if (_results.TryGetValue(id, out var task))
             {
-                task.SetResult(result);
+                task.TrySetResult(result);
             }
         }
 
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents
             Database.RachisLogIndexNotifications.NotifyListenersAbout(index, e);
             if (_results.TryGetValue(id, out var task))
             {
-                task.SetException(e);
+                task.TrySetException(e);
             }
         }
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -658,9 +658,9 @@ namespace Raven.Server.Documents
             catch (Exception e)
             {
                 // nothing we can do
-                if (_logger.IsInfoEnabled)
+                if (_logger.IsOperationsEnabled)
                 {
-                    _logger.Info($"Failed to notify about transaction completion for database '{Name}'.", e);
+                    _logger.Operations($"Failed to notify about transaction completion for database '{Name}'.", e);
                 }
             }
         }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -389,7 +389,7 @@ namespace Raven.Server.Documents
                     }
                     catch (Exception e)
                     {
-                        if (_logger.IsInfoEnabled)
+                        if (_logger.IsOperationsEnabled)
                         {
                             _logger.Info("An unhandled exception closed the cluster transaction task", e);
                         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2101,7 +2101,7 @@ namespace Raven.Server.Documents
                     {
                         if (flags.Contain(DocumentFlags.FromClusterTransaction) == false)
                         {
-                            Debug.Assert(false, $"flags must set FromClusterTransaction for the change vector: {changeVector}");
+                            Debug.Assert(false, $"flags: '{flags}' must set FromClusterTransaction for the change vector: {changeVector}");
                         }
                     }
                     break;

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -666,7 +666,6 @@ namespace Raven.Server.Documents.Handlers
                                             }
                                         }
 
-                                        //var document = cmd.Document.Clone(context);
                                         var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, cmd.Document, changeVector: changeVector,
                                             flags: DocumentFlags.FromClusterTransaction);
                                         context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, cmd.Document.Size);

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Net.Http.Headers;
@@ -639,7 +640,7 @@ namespace Raven.Server.Documents.Handlers
 
                     if (commands != null)
                     {
-                        foreach (BlittableJsonReaderObject blittableCommand in commands)
+                        foreach (var cmd in commands)
                         {
                             count++;
                             var changeVector = $"{ChangeVectorParser.RaftTag}:{count}-{Database.DatabaseGroupId}";
@@ -647,7 +648,6 @@ namespace Raven.Server.Documents.Handlers
                             {
                                 changeVector += $",{ChangeVectorParser.TrxnTag}:{command.Index}-{Database.ClusterTransactionId}";
                             }
-                            var cmd = JsonDeserializationServer.ClusterTransactionDataCommand(blittableCommand);
 
                             switch (cmd.Type)
                             {
@@ -666,10 +666,10 @@ namespace Raven.Server.Documents.Handlers
                                             }
                                         }
 
-                                        var document = cmd.Document.Clone(context);
-                                        var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, document, changeVector: changeVector,
+                                        //var document = cmd.Document.Clone(context);
+                                        var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, cmd.Document, changeVector: changeVector,
                                             flags: DocumentFlags.FromClusterTransaction);
-                                        context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, document.Size);
+                                        context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, cmd.Document.Size);
                                         AddPutResult(putResult);
                                     }
                                     else

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -832,7 +832,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     if (executed.Count == 0)
                         break;
 
-                    totalExecutedCommands += executed.Sum(x => x.Commands.Length);
+                    totalExecutedCommands += executed.Sum(x => x.Commands.Count);
                     result.AddInfo($"Executed {totalExecutedCommands:#,#;;0} cluster transaction commands.");
                     onProgress.Invoke(result.Progress);
                 }

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -713,6 +713,8 @@ namespace Raven.Server.Rachis
 
             public void Dispose()
             {
+                Command.Raw?.Dispose();
+                Command.Raw = null;
                 BlittableResultWriter?.Dispose();
                 _ctxReturn?.Dispose();
             }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -313,7 +313,7 @@ namespace Raven.Server.Rachis
 
         public Action<ClusterOperationContext> SwitchToSingleLeaderAction;
 
-        public Action<ClusterOperationContext, Leader.RachisMergedCommand> BeforeAppendToRaftLog;
+        public Action<ClusterOperationContext, RachisMergedCommand> BeforeAppendToRaftLog;
 
         private string _tag;
         private string _clusterId;
@@ -1846,7 +1846,7 @@ namespace Raven.Server.Rachis
 
         public async Task WaitForCommitIndexChange(CommitIndexModification modification, long value, TimeSpan? timeout = null, CancellationToken token = default)
         {
-            var timeoutTask = TimeoutManager.WaitFor(timeout ?? OperationTimeout, token);
+            var timeoutTask = TimeoutManager.WaitFor(timeout ?? OperationTimeout);
             while (timeoutTask.IsCompleted == false)
             {
                 token.ThrowIfCancellationRequested();
@@ -2313,7 +2313,7 @@ namespace Raven.Server.Rachis
         private readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();
         private int _heartbeatWaitersCounter;
 
-        public void InvokeBeforeAppendToRaftLog(ClusterOperationContext context, Leader.RachisMergedCommand cmd)
+        public void InvokeBeforeAppendToRaftLog(ClusterOperationContext context, RachisMergedCommand cmd)
         {
             BeforeAppendToRaftLog?.Invoke(context, cmd);
         }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -313,7 +313,7 @@ namespace Raven.Server.Rachis
 
         public Action<ClusterOperationContext> SwitchToSingleLeaderAction;
 
-        public Action<ClusterOperationContext, CommandBase> BeforeAppendToRaftLog;
+        public Action<ClusterOperationContext, Leader.RachisMergedCommand> BeforeAppendToRaftLog;
 
         private string _tag;
         private string _clusterId;
@@ -2313,7 +2313,7 @@ namespace Raven.Server.Rachis
         private readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();
         private int _heartbeatWaitersCounter;
 
-        public void InvokeBeforeAppendToRaftLog(ClusterOperationContext context, CommandBase cmd)
+        public void InvokeBeforeAppendToRaftLog(ClusterOperationContext context, Leader.RachisMergedCommand cmd)
         {
             BeforeAppendToRaftLog?.Invoke(context, cmd);
         }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1844,9 +1844,9 @@ namespace Raven.Server.Rachis
             context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += _ => TaskExecutor.CompleteAndReplace(ref _commitIndexChanged);
         }
 
-        public async Task WaitForCommitIndexChange(CommitIndexModification modification, long value, CancellationToken token = default)
+        public async Task WaitForCommitIndexChange(CommitIndexModification modification, long value, TimeSpan? timeout = null, CancellationToken token = default)
         {
-            var timeoutTask = TimeoutManager.WaitFor(OperationTimeout, token);
+            var timeoutTask = TimeoutManager.WaitFor(timeout ?? OperationTimeout, token);
             while (timeoutTask.IsCompleted == false)
             {
                 token.ThrowIfCancellationRequested();

--- a/src/Raven.Server/Rachis/RachisMergedCommand.cs
+++ b/src/Raven.Server/Rachis/RachisMergedCommand.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading.Tasks;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Threading;
+
+namespace Raven.Server.Rachis;
+
+public class RachisMergedCommand : IDisposable
+{
+    private readonly ClusterContextPool _pool;
+    private IDisposable _ctxReturn;
+
+    public CommandBase Command;
+    public TaskCompletionSource<Task<(long Index, object Result)>> Tcs = new TaskCompletionSource<Task<(long Index, object Result)>>(TaskCreationOptions.RunContinuationsAsynchronously);
+    public readonly MultipleUseFlag Consumed = new MultipleUseFlag();
+    public BlittableResultWriter BlittableResultWriter { get; private set; }
+    public BlittableJsonReaderObject Raw;
+    public RachisMergedCommand(ClusterContextPool pool, CommandBase command)
+    {
+        _pool = pool;
+        Command = command;
+    }
+
+    public void Initialize()
+    {
+        BlittableResultWriter = Command is IBlittableResultCommand crCommand ? new BlittableResultWriter(crCommand.WriteResult) : null;
+
+        // prepare the command outside the write lock.
+        _ctxReturn = _pool.AllocateOperationContext(out JsonOperationContext context);
+        var djv = Command.ToJson(context);
+        Raw = context.ReadObject(djv, "prepare-raw-command");
+    }
+
+    public async Task<(long Index, object Result)> Result()
+    {
+        var inner = await Tcs.Task;
+        var r = await inner;
+        return BlittableResultWriter == null ? r : (r.Index, BlittableResultWriter.Result);
+    } 
+
+    public void Dispose()
+    {
+        Raw?.Dispose();
+        Raw = null;
+        BlittableResultWriter?.Dispose();
+        _ctxReturn?.Dispose();
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -602,7 +602,7 @@ namespace Raven.Server.ServerWide.Commands
             foreach (BlittableJsonReaderObject blittableCommand in array)
             {
                 var cmd = JsonDeserializationServer.ClusterTransactionDataCommand(blittableCommand);
-                cmd.Document = cmd.Document.CloneOnTheSameContext(); // we need to get it out of the array
+                cmd.Document = cmd.Document?.CloneOnTheSameContext(); // we need to get it out of the array outside the write tx
                 databaseCommands.Add(cmd);
             }
 

--- a/src/Raven.Server/ServerWide/Commands/CommandBase.cs
+++ b/src/Raven.Server/ServerWide/Commands/CommandBase.cs
@@ -32,6 +32,8 @@ namespace Raven.Server.ServerWide.Commands
         // if (null) value is passed, it will be treated as a bug. (will throw an exception only in Debug builds to support old clients)
         public string UniqueRequestId;
 
+        public BlittableJsonReaderObject Raw;
+
         protected CommandBase() { }
 
         protected CommandBase(string uniqueRequestId)
@@ -46,10 +48,25 @@ namespace Raven.Server.ServerWide.Commands
                 throw new RachisApplyException("Command must contain 'Type' field.");
             }
 
+            if (type == nameof(ClusterTransactionCommand))
+            {
+                // we optimize here the case of cluster wide tx
+                // since we do not use anything other from the inner properties of the command in this code path
+                
+                var command = new ClusterTransactionCommand { Raw = json };
+                
+                json.TryGet(nameof(UniqueRequestId), out command.UniqueRequestId);
+                json.TryGet(nameof(Timeout), out command.Timeout);
+
+                return command;
+            }
+
             if (JsonDeserializationCluster.Commands.TryGetValue(type, out Func<BlittableJsonReaderObject, CommandBase> deserializer) == false)
                 throw new InvalidOperationException($"There is not deserializer for '{type}' command.");
 
-            return deserializer(json);
+            var r = deserializer(json);
+            r.Raw = json;
+            return r;
         }
 
         public virtual void VerifyCanExecuteCommand(ServerStore store, TransactionOperationContext context, bool isClusterAdmin)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -885,14 +885,15 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        private void BeforeAppendToRaftLog(ClusterOperationContext ctx, CommandBase cmd)
+        private void BeforeAppendToRaftLog(ClusterOperationContext ctx, Leader.RachisMergedCommand rachisMergedCommand)
         {
-            switch (cmd)
+            switch (rachisMergedCommand.Command)
             {
                 case AddDatabaseCommand addDatabase:
                     if (addDatabase.Record.Topology.Count == 0)
                     {
                         AssignNodesToDatabase(GetClusterTopology(ctx), addDatabase.Record);
+                        rachisMergedCommand.CommandAsJson = ctx.ReadObject(rachisMergedCommand.Command.ToJson(ctx), "topology-modified");
                     }
                     Debug.Assert(addDatabase.Record.Topology.Count != 0, "Empty topology after AssignNodesToDatabase");
                     break;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3014,6 +3014,7 @@ namespace Raven.Server.ServerWide
             }
         }
 
+        // TODO: We need always to link the token with the request abort token
         public async Task<(long Index, object Result)> SendToLeaderAsync(CommandBase cmd, CancellationToken? token = null)
         {
             using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -828,7 +828,6 @@ namespace Raven.Server.ServerWide
             CheckSwapOrPageFileAndRaiseNotification();
 
             _engine = new RachisConsensus<ClusterStateMachine>(this);
-            _engine.BeforeAppendToRaftLog = BeforeAppendToRaftLog;
 
             var myUrl = GetNodeHttpServerUrl();
             _engine.Initialize(_env, Configuration, clusterChanges, myUrl, out _lastClusterTopologyIndex);
@@ -882,21 +881,6 @@ namespace Raven.Server.ServerWide
                         "Your system has no PageFile. It is recommended to have a PageFile in order for Server to work properly",
                         AlertType.LowSwapSize,
                         NotificationSeverity.Warning));
-            }
-        }
-
-        private void BeforeAppendToRaftLog(ClusterOperationContext ctx, Leader.RachisMergedCommand rachisMergedCommand)
-        {
-            switch (rachisMergedCommand.Command)
-            {
-                case AddDatabaseCommand addDatabase:
-                    if (addDatabase.Record.Topology.Count == 0)
-                    {
-                        AssignNodesToDatabase(GetClusterTopology(ctx), addDatabase.Record);
-                        rachisMergedCommand.CommandAsJson = ctx.ReadObject(rachisMergedCommand.Command.ToJson(ctx), "topology-modified");
-                    }
-                    Debug.Assert(addDatabase.Record.Topology.Count != 0, "Empty topology after AssignNodesToDatabase");
-                    break;
             }
         }
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3030,20 +3030,20 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public async Task<(long Index, object Result)> SendToLeaderAsync(CommandBase cmd)
+        public async Task<(long Index, object Result)> SendToLeaderAsync(CommandBase cmd, CancellationToken? token = null)
         {
             using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                return await SendToLeaderAsyncInternal(context, cmd);
+                return await SendToLeaderAsyncInternal(context, cmd, token ?? _shutdownNotification.Token);
         }
 
-        private async Task<(long Index, object Result)> SendToLeaderAsyncInternal(TransactionOperationContext context, CommandBase cmd)
+        private async Task<(long Index, object Result)> SendToLeaderAsyncInternal(TransactionOperationContext context, CommandBase cmd, CancellationToken token)
         {
             //I think it is reasonable to expect timeout twice of error retry
-            var timeoutTask = TimeoutManager.WaitFor(Engine.OperationTimeout, _shutdownNotification.Token);
+            var timeoutTask = TimeoutManager.WaitFor(Engine.OperationTimeout, token);
             Exception requestException = null;
             while (true)
             {
-                _shutdownNotification.Token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
                 if (_engine.CurrentState == RachisState.Leader && _engine.CurrentLeader?.Running == true)
                 {
@@ -3071,7 +3071,7 @@ namespace Raven.Server.ServerWide
                     if (cachedLeaderTag == null)
                     {
                         await Task.WhenAny(logChange, timeoutTask);
-                        _shutdownNotification.Token.ThrowIfCancellationRequested();
+                        token.ThrowIfCancellationRequested();
 
                         if (timeoutTask.IsCompleted)
                             ThrowTimeoutException(cmd, requestException);
@@ -3079,7 +3079,7 @@ namespace Raven.Server.ServerWide
                         continue;
                     }
 
-                    var response = await SendToNodeAsync(context, cachedLeaderTag, cmd, reachedLeader);
+                    var response = await SendToNodeAsync(context, cachedLeaderTag, cmd, reachedLeader, token);
                     return (response.Index, cmd.FromRemote(response.Result));
                 }
                 catch (Exception ex)
@@ -3094,7 +3094,7 @@ namespace Raven.Server.ServerWide
                 }
 
                 await Task.WhenAny(logChange, timeoutTask);
-                _shutdownNotification.Token.ThrowIfCancellationRequested();
+                token.ThrowIfCancellationRequested();
 
                 if (timeoutTask.IsCompleted)
                 {
@@ -3116,7 +3116,8 @@ namespace Raven.Server.ServerWide
                                        $"and we timed out waiting for one after {Engine.OperationTimeout}", requestException);
         }
 
-        private async Task<(long Index, object Result)> SendToNodeAsync(TransactionOperationContext context, string engineLeaderTag, CommandBase cmd, Reference<bool> reachedLeader)
+        private async Task<(long Index, object Result)> SendToNodeAsync(TransactionOperationContext context, string engineLeaderTag, CommandBase cmd,
+            Reference<bool> reachedLeader, CancellationToken token)
         {
             var djv = cmd.ToJson(context);
             var cmdJson = context.ReadObject(djv, "raft/command");
@@ -3129,7 +3130,10 @@ namespace Raven.Server.ServerWide
                 throw new InvalidOperationException("Leader " + engineLeaderTag + " was not found in the topology members");
 
             cmdJson.TryGet("Type", out string commandType);
-            var command = new PutRaftCommand(cmdJson, _engine.Url, commandType);
+            var command = new PutRaftCommand(cmdJson, _engine.Url, commandType)
+            {
+                Timeout = cmd.Timeout
+            };
 
             var serverCertificateChanged = Interlocked.Exchange(ref _serverCertificateChanged, 0) == 1;
 
@@ -3143,7 +3147,7 @@ namespace Raven.Server.ServerWide
 
             try
             {
-                await _clusterRequestExecutor.ExecuteAsync(command, context, token: ServerShutdown);
+                await _clusterRequestExecutor.ExecuteAsync(command, context, token: token);
             }
             catch
             {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -408,8 +408,9 @@ namespace Raven.Server.Web.System
             else
             {
                 databaseRecord.Topology ??= new DatabaseTopology();
-
                 databaseRecord.Topology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
+
+                Server.ServerStore.AssignNodesToDatabase(clusterTopology, databaseRecord);
             }
 
             databaseRecord.Topology.ClusterTransactionIdBase64 ??= Guid.NewGuid().ToBase64Unpadded();

--- a/src/Sparrow.Server/AsyncManualResetEvent.cs
+++ b/src/Sparrow.Server/AsyncManualResetEvent.cs
@@ -101,7 +101,7 @@ namespace Sparrow.Server
                 if (_parent._token.IsCancellationRequested)
                     return false;
 
-                var result = await Task.WhenAny(waitAsync, TimeoutManager.WaitFor(timeout, _parent._token)).ConfigureAwait(false);
+                var result = await waitAsync.WaitFor(timeout, _parent._token).ConfigureAwait(false);
 
                 if (result.IsFaulted)
                     throw result.Exception;

--- a/src/Sparrow/Utils/TimeoutManager.cs
+++ b/src/Sparrow/Utils/TimeoutManager.cs
@@ -112,6 +112,35 @@ namespace Sparrow.Utils
             return value;
         }
 
+        public static async Task<Task> WaitFor(this Task outer, TimeSpan duration, CancellationToken token = default)
+        {
+            if (duration == TimeSpan.Zero)
+                return Task.CompletedTask;
+
+            if (token.IsCancellationRequested)
+            {
+                return Task.CompletedTask;
+            }
+
+            Task task;
+            // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
+            if (duration != Timeout.InfiniteTimeSpan)
+                task = WaitForInternal(duration, token);
+            else
+                task = InfiniteTask;
+            
+            if (token == CancellationToken.None || token.CanBeCanceled == false)
+            {
+                return await Task.WhenAny(outer, task).ConfigureAwait(false);
+            }
+            
+            var onCancel = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (token.Register(tcs => onCancel.TrySetCanceled(), onCancel))
+            {
+                return await Task.WhenAny(outer, task, onCancel.Task).ConfigureAwait(false);
+            }
+        }
+
         public static async Task WaitFor(TimeSpan duration, CancellationToken token = default)
         {
             if (duration == TimeSpan.Zero)
@@ -136,6 +165,12 @@ namespace Sparrow.Utils
             }
 
             var onCancel = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (task == InfiniteTask)
+            {
+                await onCancel.Task.ConfigureAwait(false);
+                return;
+            }
+
             using (token.Register(tcs => onCancel.TrySetCanceled(), onCancel))
             {
                 await Task.WhenAny(task, onCancel.Task).ConfigureAwait(false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21860

### Additional description

- use Http token instead of the operational 15s timeout, this would cause to spam even more requests when the timeout was reached.
- Clone the document outside of the write-tx, since it can be very costly to clone a large document especially if it contain an array with many elements.
- Avoid this cloning when the database execute the transaction
- Avoid this cloning when the leader is getting the command from a follower.
- Avoid leaking token registration callback when we wait for an infinite task.

Tested on our cloud with P10 cluster (sample size is 10)
![good-optimizations](https://github.com/ravendb/ravendb/assets/6377808/90952380-ef4a-4ecd-b991-b807f33f1242)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. 
The format over the wire as well as the persistent format were not changed.
- [x] Breaking change - minor? 
Cluster tx with not throw on timeout after 15s (operational timeout), but instead are linked with the Http request token. Same as the normal tx.
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
