### PR TITLE
RavenDB-21938 : fix flaky test

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Raven/BasicRavenEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/BasicRavenEtlTests.cs
@@ -123,10 +123,10 @@ namespace SlowTests.Server.Documents.ETL.Raven
                 {
                     using (var session = dest.OpenSession())
                     {
-                        var user = session.Load<User>("users/1-A,Chicago");
-                        return user != null;
+                        var docs = session.Advanced.LoadStartingWith<User>("users/1-A");
+                        return docs.Length;
                     }
-                }, true);
+                }, expectedVal: 2);
 
                 string secondaryId; 
                 using (var session = dest.OpenSession())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21938/SlowTests.Server.Documents.ETL.Raven.BasicRavenEtlTests.WithDocumentPrefix

### Additional description

 need to wait for both transformations to reach destination


### Type of change

- Tests stabilization

### How risky is the change?

- Low 

