### PR TITLE
RavenDB-21950 Throw if microsoft logs configured by http request

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -236,7 +236,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                 if (parameters.TryGet("Configuration", out BlittableJsonReaderObject microsoftConfig) == false)
                     throw new InvalidOperationException($"The request body doesn't contain required 'Configuration' property - {parameters}");
 
-                provider.Configuration.ReadConfiguration(microsoftConfig, reset);
+                provider.Configuration.ReadConfigurationOrThrow(microsoftConfig, reset);
                 provider.ApplyConfiguration();
 
                 if (parameters.TryGet("Persist", out bool persist) && persist)

--- a/src/Raven.Server/Utils/MicrosoftLogging/MicrosoftLoggingConfiguration.cs
+++ b/src/Raven.Server/Utils/MicrosoftLogging/MicrosoftLoggingConfiguration.cs
@@ -116,7 +116,7 @@ public class MicrosoftLoggingConfiguration : IEnumerable<(string Category, LogLe
         if (reset)
             _configuration.Clear();
 
-        ReadConfiguration(blitConfiguration, null);
+        ReadConfiguration(blitConfiguration, rootCategory: null);
     }
 
     private void ReadConfiguration(BlittableJsonReaderObject jConfiguration, string rootCategory)

--- a/src/Raven.Server/Utils/MicrosoftLogging/MicrosoftLoggingConfiguration.cs
+++ b/src/Raven.Server/Utils/MicrosoftLogging/MicrosoftLoggingConfiguration.cs
@@ -111,22 +111,12 @@ public class MicrosoftLoggingConfiguration : IEnumerable<(string Category, LogLe
         }
     }
 
-    public void ReadConfiguration(BlittableJsonReaderObject blitConfiguration, bool reset = true)
+    public void ReadConfigurationOrThrow(BlittableJsonReaderObject blitConfiguration, bool reset = true)
     {
-        try
-        {
-            if (reset)
-                _configuration.Clear();
+        if (reset)
+            _configuration.Clear();
 
-            ReadConfiguration(blitConfiguration, null);
-
-            //If the code run on server startup the notification center is not initialized 
-            _ = _notificationCenter.InitializeTask.ContinueWith(task => task.Result.Dismiss(_notificationId));
-        }
-        catch (Exception e)
-        {
-            HandleReadConfigurationFailure(blitConfiguration, e);
-        }
+        ReadConfiguration(blitConfiguration, null);
     }
 
     private void ReadConfiguration(BlittableJsonReaderObject jConfiguration, string rootCategory)

--- a/test/SlowTests/SparrowTests/MicrosoftLogTests.cs
+++ b/test/SlowTests/SparrowTests/MicrosoftLogTests.cs
@@ -15,6 +15,7 @@ using Raven.Server.Utils.MicrosoftLogging;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -50,7 +51,7 @@ public class MicrosoftLogTests : RavenTestBase
         await Test(Predicate);
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Logging)]
     public async Task EnableMicrosoftLogs_WhenEnabledAndConfigurationFileDoesNotExist_ShouldNotLogMicrosoftLogs()
     {
         _serverFactory = () =>
@@ -72,7 +73,7 @@ public class MicrosoftLogTests : RavenTestBase
         await Test(Predicate);
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.Logging)]
     public async Task EnableMicrosoftLogs_WhenEnabledAndConfigureDefaultToInformation_ShouldLogMinimumInformationLevel()
     {
         var configurationFile = await CreateConfigurationFileAsync($@"
@@ -143,7 +144,7 @@ public class MicrosoftLogTests : RavenTestBase
     }
 
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Logging)]
     public async Task MicrosoftLoggerProvider_WhenDefineNestedCategory_ShouldHandleAsRootProp()
     {
         var loggingSource = new LoggingSource(LogMode.None, "", "", TimeSpan.Zero, 0);
@@ -169,7 +170,7 @@ public class MicrosoftLogTests : RavenTestBase
         Assert.Contains(configuration, x => x is { Category: "Key1.Key2", LogLevel: LogLevel.Error });
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Logging)]
     public async Task MicrosoftLoggerProvider_WhenErrorConfiguration_ShouldNotThrow()
     {
         var loggingSource = new LoggingSource(LogMode.None, "", "", TimeSpan.Zero, 0);
@@ -223,7 +224,7 @@ public class MicrosoftLogTests : RavenTestBase
         }
     }
     
-    [Fact]
+    [RavenFact(RavenTestCategory.Logging)]
     public async Task MicrosoftLoggerProvider_WhenDisable_AllLogsLogLevelShouldBeNone()
     {
         var path = NewDataPath(forceCreateDir: true);
@@ -259,7 +260,7 @@ public class MicrosoftLogTests : RavenTestBase
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Logging)]
     public async Task ConfigureMicrosoftLogs_WhenLogLevelIsInvalid_ShouldThrow()
     {
         using var store = GetDocumentStore();

--- a/test/SlowTests/SparrowTests/MicrosoftLogTests.cs
+++ b/test/SlowTests/SparrowTests/MicrosoftLogTests.cs
@@ -40,7 +40,7 @@ public class MicrosoftLogTests : RavenTestBase
             : base.GetNewServer(options, caller);
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Logging)]
     public async Task EnableMicrosoftLogs_WhenDisabled_ShouldNotLogMicrosoftLogs()
     {
         bool Predicate(string m)

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6439;
+            const int numberToTolerate = 6433;
             if (array.Length == numberToTolerate)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21950

### Additional description
On RavenDB startup we don't want to throw if the Microsoft configuration were set incorrectly.
The behavior is to only log and alert about it.
But if the user tries to configure the Microsoft log by requesting a HTTP request he should get an error on failing.
The current behavior is a silent failure and the user has no indication of that except for the log/alert.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
