### PR TITLE
RavenDB-21955 Grace period before closing JSON-preview tooltip to fac…

### DIFF
--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
@@ -27,6 +27,7 @@ class columnPreviewPlugin<T extends object> {
     private grid: virtualGrid<T>;
     private previewTimeoutHandle: number;
     private enterTooltipTimeoutHandle: number;
+    private exitTooltipTimeoutHandle: number;
     private previewVisible = false;
     private $tooltip: JQuery;
     private currentValue: any;
@@ -37,7 +38,8 @@ class columnPreviewPlugin<T extends object> {
     static localDateFormat = "YYYY-MM-DD HH:mm:ss.SSS";
 
     private static readonly delay = 500;
-    private static readonly enterTooltipDelay = 100;
+    private static readonly enterTooltipDelay = 300;
+    private static readonly exitTooltipDelay = 200;
     
     constructor() {
         _.bindAll(this, "defaultMarkupProvider");
@@ -129,12 +131,18 @@ class columnPreviewPlugin<T extends object> {
                 clearTimeout(this.enterTooltipTimeoutHandle);
                 this.enterTooltipTimeoutHandle = undefined;
             }
+            if (this.exitTooltipTimeoutHandle) {
+                clearTimeout(this.exitTooltipTimeoutHandle);
+                this.exitTooltipTimeoutHandle = undefined;
+            }
         });
 
         $(tooltipSelector).on("mouseleave", () => {
             if (this.previewVisible) {
-                this.hide();
-                this.previewVisible = false;
+                this.exitTooltipTimeoutHandle = setTimeout(() => {
+                    this.hide();
+                    this.previewVisible = false;
+                }, columnPreviewPlugin.exitTooltipDelay);
             }
         });
     }


### PR DESCRIPTION
…ilitate easier copy to clipboard

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21955 

### Additional description

Tweaking tooltips

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
