### PR TITLE
RavenDB-22008 - stop the removed ETL tasks in an async fashion

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -672,6 +672,9 @@ namespace Raven.Server.Documents.ETL
 
             LoadProcesses(record, myRavenEtl, mySqlEtl, myOlapEtl, myElasticSearchEtl, myQueueEtl, toRemove.SelectMany(x => x.Value).ToList());
 
+            if (toRemove.Count == 0)
+                return;
+
             ThreadPool.QueueUserWorkItem(_ =>
             {
                 Parallel.ForEach(toRemove, x =>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22008/Large-amount-of-threads-are-waiting-on-NotifyFeaturesAboutValueChange

### Additional description

Executing the `HandleDatabaseRecordChange` operation occurs within the context of the `_clusterLock` in the `DocumentDatabase`. It is important to note that we make the assumption that all operations are of short duration. However, if a task is either removed or not managed by the current node, it will be promptly removed.
After that, we can stop the running ETL task thread and this might take some time. To mitigate potential delays, we can do it in an async fashion.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
