### PR TITLE
RavenDB-22010 - Wrong count of dedicated threads

### DIFF
--- a/src/Raven.Server/Dashboard/ThreadsInfo.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfo.cs
@@ -23,6 +23,8 @@ namespace Raven.Server.Dashboard
 
         public long ThreadsCount => List.Count;
 
+        public int DedicatedThreadsCount { get; set; }
+
         public ThreadsInfo(int? take)
         {
             _take = take;
@@ -55,6 +57,7 @@ namespace Raven.Server.Dashboard
                 [nameof(ProcessCpuUsage)] = ProcessCpuUsage,
                 [nameof(ActiveCores)] = ActiveCores,
                 [nameof(ThreadsCount)] = ThreadsCount,
+                [nameof(DedicatedThreadsCount)] = DedicatedThreadsCount,
                 [nameof(List)] = new DynamicJsonArray(List.Take(_take ?? int.MaxValue).Select(x => x.ToJson()))
             };
         }

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -99,6 +99,7 @@ namespace Raven.Server.Utils
                             int? managedThreadId = null;
                             string threadName = null;
                             long? unmanagedAllocations = null;
+
                             if (threadAllocations.TryGetValue((ulong)thread.Id, out var threadStats))
                             {
                                 managedThreadId = threadStats.ManagedThreadId;
@@ -106,6 +107,7 @@ namespace Raven.Server.Utils
                                 if (ThreadNames.FullThreadNames.TryGetValue(managedThreadId.Value, out var fullThreadName))
                                 {
                                     threadName = fullThreadName;
+                                    threadsInfo.DedicatedThreadsCount++;
                                 }
                                 else
                                 {

--- a/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
@@ -26,7 +26,7 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
     isConnectedToWebSocket: KnockoutComputed<boolean>;
     
     threadsCount: KnockoutComputed<number>;
-    dedicatedThreadsCount: KnockoutComputed<number>;
+    dedicatedThreadsCount = ko.observable<number>(0);
     machineCpuUsage = ko.observable<number>(0);
     serverCpuUsage = ko.observable<number>(0);
 
@@ -44,15 +44,6 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
             
             if (data) {
                 return data.length;
-            }
-            return 0;
-        });
-        
-        this.dedicatedThreadsCount = ko.pureComputed(() => {
-            const data = this.filteredData();
-            
-            if (data) {
-                return data.filter(x => x.Name !== "Unknown" && x.Name !== "Unmanaged Thread").length;
             }
             return 0;
         });
@@ -170,8 +161,9 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
         this.allData(data.List);
         this.machineCpuUsage(data.CpuUsage);
         this.serverCpuUsage(data.ProcessCpuUsage);
-        
-                this.filterEntries();
+        this.dedicatedThreadsCount(data.DedicatedThreadsCount);
+
+        this.filterEntries();
         
         this.gridController().reset(false);
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22010/Wrong-count-of-dedicated-threads-count

### Additional description

Wrong count of dedicated threads.
It looks like the dotnet framework started naming threads, we need to count the dedicated threads on the server.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
