### PR TITLE
RavenDB-22008 - Use SemaphoreSlim instead of a blocking Monitor.TryEnter

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents
                     switch (changeType)
                     {
                         case ClusterDatabaseChangeType.RecordChanged:
-                            database.StateChanged(index);
+                            await database.StateChanged(index);
                             if (type == ClusterStateMachine.SnapshotInstalled)
                             {
                                 database.NotifyOnPendingClusterTransaction(index, changeType);
@@ -171,7 +171,7 @@ namespace Raven.Server.Documents
                             break;
 
                         case ClusterDatabaseChangeType.ValueChanged:
-                            database.ValueChanged(index, type, changeState);
+                            await database.ValueChanged(index, type, changeState);
                             break;
 
                         case ClusterDatabaseChangeType.PendingClusterTransactions:

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -163,7 +163,7 @@ namespace Raven.Server.Documents
                     switch (changeType)
                     {
                         case ClusterDatabaseChangeType.RecordChanged:
-                            await database.StateChanged(index);
+                            await database.StateChangedAsync(index);
                             if (type == ClusterStateMachine.SnapshotInstalled)
                             {
                                 database.NotifyOnPendingClusterTransaction(index, changeType);
@@ -171,7 +171,7 @@ namespace Raven.Server.Documents
                             break;
 
                         case ClusterDatabaseChangeType.ValueChanged:
-                            await database.ValueChanged(index, type, changeState);
+                            await database.ValueChangedAsync(index, type, changeState);
                             break;
 
                         case ClusterDatabaseChangeType.PendingClusterTransactions:

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -302,7 +302,7 @@ namespace Raven.Server.Documents
 
                 _addToInitLog("Initializing DocumentStorage");
                 DocumentsStorage.Initialize((options & InitializeOptions.GenerateNewDatabaseId) == InitializeOptions.GenerateNewDatabaseId);
-               
+
                 _addToInitLog("Initializing ConfigurationStorage");
                 ConfigurationStorage.Initialize();
 
@@ -651,17 +651,17 @@ namespace Raven.Server.Documents
                 _lastCompletedClusterTransaction = _nextClusterCommand.Value - 1;
             }
             catch (Exception e)
-                {
+            {
                 // nothing we can do
                 if (_logger.IsInfoEnabled)
-                    {
+                {
                     _logger.Info($"Failed to notify about transaction completion for database '{Name}'.", e);
-                    }
+                }
             }
         }
 
         private void OnClusterTransactionCompletion(ClusterTransactionCommand.SingleClusterDatabaseCommand command, Exception exception)
-                    {
+        {
             try
             {
                 var index = command.Index;
@@ -809,6 +809,9 @@ namespace Raven.Server.Documents
                 _clusterLocker.Wait();
                 ForTestingPurposes?.DisposeLog?.Invoke(Name, "Acquired cluster lock");
             }
+
+            ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposing the cluster locker");
+            exceptionAggregator.Execute(() => _clusterLocker.Dispose());
 
             var indexStoreTask = _indexStoreTask;
             if (indexStoreTask != null)
@@ -1532,7 +1535,7 @@ namespace Raven.Server.Documents
                 case nameof(UpdateResponsibleNodeForTasksCommand):
                 case nameof(DelayBackupCommand):
                     // both commands cannot be skipped and must be executed
-                return false;
+                    return false;
             }
 
             if (LastValueChangeIndex > index)

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -368,18 +368,19 @@ namespace Raven.Server.Documents
                     Interlocked.Exchange(ref LastCompletedClusterTransactionIndex, lastCompletedClusterTransactionIndex);
                 }
 
-                ThreadPool.QueueUserWorkItem(_ =>
+                _ = Task.Run(async () =>
                 {
                     try
                     {
-                        NotifyFeaturesAboutStateChangeAsync(record, index).GetAwaiter().GetResult();
+                        await NotifyFeaturesAboutStateChangeAsync(record, index);
                         RachisLogIndexNotifications.NotifyListenersAbout(index, null);
                     }
                     catch (Exception e)
                     {
                         RachisLogIndexNotifications.NotifyListenersAbout(index, e);
                     }
-                }, null);
+                });
+
                 var clusterTransactionThreadName = ThreadNames.GetNameToUse(ThreadNames.ForClusterTransactions($"Cluster Transaction Thread {Name}", Name));
                 _clusterTransactionsThread = PoolOfThreads.GlobalRavenThreadPool.LongRunning(x =>
                 {
@@ -650,17 +651,17 @@ namespace Raven.Server.Documents
                 _lastCompletedClusterTransaction = _nextClusterCommand.Value - 1;
             }
             catch (Exception e)
-            {
+                {
                 // nothing we can do
                 if (_logger.IsInfoEnabled)
-                {
+                    {
                     _logger.Info($"Failed to notify about transaction completion for database '{Name}'.", e);
-                }
+                    }
             }
         }
 
         private void OnClusterTransactionCompletion(ClusterTransactionCommand.SingleClusterDatabaseCommand command, Exception exception)
-        {
+                    {
             try
             {
                 var index = command.Index;
@@ -1531,7 +1532,7 @@ namespace Raven.Server.Documents
                 case nameof(UpdateResponsibleNodeForTasksCommand):
                 case nameof(DelayBackupCommand):
                     // both commands cannot be skipped and must be executed
-                    return false;
+                return false;
             }
 
             if (LastValueChangeIndex > index)

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -372,7 +372,7 @@ namespace Raven.Server.Documents
                 {
                     try
                     {
-                        NotifyFeaturesAboutStateChange(record, index).GetAwaiter().GetResult();
+                        NotifyFeaturesAboutStateChangeAsync(record, index).GetAwaiter().GetResult();
                         RachisLogIndexNotifications.NotifyListenersAbout(index, null);
                     }
                     catch (Exception e)
@@ -1330,14 +1330,14 @@ namespace Raven.Server.Documents
         /// </summary>
         public event Action<DatabaseRecord> DatabaseRecordChanged;
 
-        public async Task ValueChanged(long index, string type, object changeState)
+        public async ValueTask ValueChangedAsync(long index, string type, object changeState)
         {
             try
             {
                 if (_databaseShutdown.IsCancellationRequested)
                     ThrowDatabaseShutdown();
 
-                await NotifyFeaturesAboutValueChange(index, type, changeState);
+                await NotifyFeaturesAboutValueChangeAsync(index, type, changeState);
                 RachisLogIndexNotifications.NotifyListenersAbout(index, null);
             }
             catch (Exception e)
@@ -1351,7 +1351,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public async Task StateChanged(long index)
+        public async ValueTask StateChangedAsync(long index)
         {
             try
             {
@@ -1374,7 +1374,7 @@ namespace Raven.Server.Documents
                     : Constants.Identities.DefaultSeparator;
                 StudioConfiguration = record.Studio;
 
-                await NotifyFeaturesAboutStateChange(record, index);
+                await NotifyFeaturesAboutStateChangeAsync(record, index);
 
                 RachisLogIndexNotifications.NotifyListenersAbout(index, null);
             }
@@ -1397,7 +1397,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        private async Task NotifyFeaturesAboutStateChange(DatabaseRecord record, long index)
+        private async ValueTask NotifyFeaturesAboutStateChangeAsync(DatabaseRecord record, long index)
         {
             if (CanSkipDatabaseRecordChange(record.DatabaseName, index))
                 return;
@@ -1545,7 +1545,7 @@ namespace Raven.Server.Documents
             return false;
         }
 
-        private async Task NotifyFeaturesAboutValueChange(long index, string type, object changeState)
+        private async ValueTask NotifyFeaturesAboutValueChangeAsync(long index, string type, object changeState)
         {
             if (CanSkipValueChange(index, type))
                 return;
@@ -1587,7 +1587,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public async Task RefreshFeatures()
+        public ValueTask RefreshFeaturesAsync()
         {
             if (_databaseShutdown.IsCancellationRequested)
                 ThrowDatabaseShutdown();
@@ -1599,7 +1599,8 @@ namespace Raven.Server.Documents
             {
                 record = _serverStore.Cluster.ReadDatabase(context, Name, out index);
             }
-            await NotifyFeaturesAboutStateChange(record, index);
+
+            return NotifyFeaturesAboutStateChangeAsync(record, index);
         }
 
         private void InitializeFromDatabaseRecord(DatabaseRecord record)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1037,7 +1037,7 @@ namespace Raven.Server.ServerWide
                 try
                 {
                     var database = await completedTask;
-                    database.RefreshFeatures();
+                    await database.RefreshFeatures();
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1037,7 +1037,7 @@ namespace Raven.Server.ServerWide
                 try
                 {
                     var database = await completedTask;
-                    await database.RefreshFeatures();
+                    await database.RefreshFeaturesAsync();
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22008/Large-amount-of-threads-are-waiting-on-NotifyFeaturesAboutValueChange

### Additional description

Because of a bug that is described here: https://github.com/ravendb/ravendb/pull/18057, we might get into a state where the `_clusterLocker` is taken for a long time. This will cause us to wait here:
https://github.com/ravendb/ravendb/blob/97cd7752ebf37df3080b5ee3fc33cf3a26ac11c1/src/Raven.Server/Documents/DocumentDatabase.cs#L1636

When we have a lot of `ValueChanged` updates we'll have a lot of blocked thread pool threads which causes an overall system slowdown.

I tested another implementation that requires more changes but it has roughly the same performance as this one (using a `TaskCompletionSource` - @ayende).

Tested it by updating the subscription state manually which triggers a `ValueChanged` event and acquiring the `_clusterLock` in `NotifyFeaturesAboutStateChange` for 3 minutes.
The number of thread pool threads rose by +500 and simple query requests on an empty database took ~2sec.
This doesn't happen with the new implementation.

Generating the `AcknowledgeSubscriptionBatchCommand` commands in a test.

```
var subsId = await store.Subscriptions.CreateAsync(subscriptionCreationParams);

string prevValue = null;
var count = 0;
var database = await GetDatabase(Server, store.Database);

while (true)
{
    var command = new AcknowledgeSubscriptionBatchCommand(store.Database, RaftIdGenerator.NewId())
    {
        ChangeVector = $"A:{++count}-V9af9ZE2rUC6A65xy9dt9Q",
        NodeTag = Server.ServerStore.NodeTag,
        HasHighlyAvailableTasks = Server.ServerStore.LicenseManager.HasHighlyAvailableTasks(),
        SubscriptionName = subsId,
        LastTimeServerMadeProgressWithDocuments = DateTime.UtcNow,
        LastKnownSubscriptionChangeVector = prevValue,
        DatabaseName = store.Database,
    };

    var index = await Server.ServerStore.SendToLeaderAsync(command);
    prevValue = command.ChangeVector;
}
```

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
