### PR TITLE
RavenDB-22005 Attempt to fix .RavenDB_18059.RaceConditionBetweenFullBackupAndUpdateDatabaseStateAfterSync(compressionAlgorithm: Zstd) test

### DIFF
--- a/test/SlowTests/Voron/Issues/RavenDB_18059.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_18059.cs
@@ -55,26 +55,34 @@ public class RavenDB_18059 : StorageTest
 
         var voronDataDir = new VoronPathSetting(DataDir);
 
+        Thread syncOperationThread = null;
+        bool syncResult = false;
+
         Env.ForTestingPurposesOnly().ActionToCallDuringFullBackupRighAfterCopyHeaders += () =>
         {
             // here we remove 0000000000000000000.journal file while during backup we'll try to backup it
 
-            Thread syncOperation = new Thread(() =>
+            syncOperationThread = new Thread(() =>
             {
                 using (var operation = new WriteAheadJournal.JournalApplicator.SyncOperation(Env.Journal.Applicator))
                 {
-                    var syncResult = operation.SyncDataFile();
-
-                    Assert.True(syncResult);
+                    syncResult = operation.SyncDataFile();
                 }
             });
 
-            syncOperation.Start();
+            syncOperationThread.Start();
 
-            Assert.False(syncOperation.Join(TimeSpan.FromSeconds(5)));
+            // ActionToCallDuringFullBackupRighAfterCopyHeaders() is called under the flushing lock
+            // the sync operation is trying to get the same lock
+            // it means that as long as we wait here the lock won't be released so the thread won't be terminated
+            Assert.False(syncOperationThread.Join(TimeSpan.FromSeconds(5))); 
         };
 
         BackupMethods.Full.ToFile(Env, voronDataDir.Combine("voron-test.backup"), compressionAlgorithm);
+
+        Assert.True(syncOperationThread.Join(TimeSpan.FromMinutes(1))); // let's wait for the sync operation thread to complete
+
+        Assert.True(syncResult); // at this point we should be after the successful sync 
 
         BackupMethods.Full.Restore(voronDataDir.Combine("voron-test.backup"), voronDataDir.Combine("backup-test.data"));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22005

### Additional description

- the test was added in https://github.com/ravendb/ravendb/pull/13787
- moving `Assert.True()` outside the thread so we won't get `UnhandledException occurred` if the assertion fails
- added the wait for the sync operation thread to complete before continuing the restore

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
