### PR TITLE
RavenDB-21995 Handle wildcard as Corax search term

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -107,7 +107,8 @@ namespace Corax
             {
                 TermMatch = 0,
                 StartsWith = 1,
-                EndsWith = 2,
+                EndsWith = 1 << 1,
+                Exists = 1 << 2,
                 Contains = StartsWith | EndsWith
             }
 

--- a/test/SlowTests/Issues/RavenDB_21995.cs
+++ b/test/SlowTests/Issues/RavenDB_21995.cs
@@ -1,0 +1,111 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21995 : RavenTestBase
+{
+    public RavenDB_21995(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public async Task TestWildcardAsSearchTerm()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                var customer1 = new Customer() { Name = "CoolName" };
+                var customer2 = new Customer() { Name = "Something*Something" };
+
+                await session.StoreAsync(customer1);
+                await session.StoreAsync(customer2);
+
+                await session.SaveChangesAsync();
+
+                var luceneIndex = new LuceneIndex();
+                var coraxIndex = new CoraxIndex();
+                
+                await luceneIndex.ExecuteAsync(store);
+                await coraxIndex.ExecuteAsync(store);
+
+                await Indexes.WaitForIndexingAsync(store);
+
+                var userListLucene = await session.Query<Customer>(luceneIndex.IndexName)
+                    .Search(x => x.Name, "*")
+                    .ToListAsync();
+                
+                var userListCorax = await session.Query<Customer>(coraxIndex.IndexName)
+                    .Search(x => x.Name, "*")
+                    .ToListAsync();
+                
+                Assert.Equal(2, userListLucene.Count);
+                Assert.Equal(2, userListCorax.Count);
+                
+                var userListLuceneDoubleWildcard = await session.Query<Customer>(luceneIndex.IndexName)
+                    .Search(x => x.Name, "**")
+                    .ToListAsync();
+                
+                var userListCoraxDoubleWildcard = await session.Query<Customer>(coraxIndex.IndexName)
+                    .Search(x => x.Name, "**")
+                    .ToListAsync();
+                
+                Assert.Equal(2, userListLuceneDoubleWildcard.Count);
+                Assert.Equal(2, userListCoraxDoubleWildcard.Count);
+                
+                var userListLuceneTripleWildcard = await session.Query<Customer>(luceneIndex.IndexName)
+                    .Search(x => x.Name, "***")
+                    .ToListAsync();
+                
+                var userListCoraxTripleWildcard = await session.Query<Customer>(coraxIndex.IndexName)
+                    .Search(x => x.Name, "***")
+                    .ToListAsync();
+                
+                Assert.Equal(2, userListLuceneTripleWildcard.Count);
+                Assert.Equal(2, userListCoraxTripleWildcard.Count);
+            }
+        }
+    }
+
+    private class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    private class LuceneIndex : AbstractIndexCreationTask<Customer>
+    {
+        public LuceneIndex()
+        {
+            Map = customers => from customer in customers
+                select new
+                {
+                    customer.Name
+                };
+            
+            Index(x => x.Name, FieldIndexing.Search);
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Lucene;
+        }
+    }
+    
+    private class CoraxIndex : AbstractIndexCreationTask<Customer>
+    {
+        public CoraxIndex()
+        {
+            Map = customers => from customer in customers
+                select new
+                {
+                    customer.Name
+                };
+            
+            Index(x => x.Name, FieldIndexing.Search);
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_21995.cs
+++ b/test/SlowTests/Issues/RavenDB_21995.cs
@@ -15,10 +15,11 @@ public class RavenDB_21995 : RavenTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
-    public async Task TestWildcardAsSearchTerm()
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task TestWildcardAsSearchTerm(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenAsyncSession())
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21995/Corax-query-using-searchEmail-throws

### Additional description

We want to use `ExistsQuery` in case of search term consisting only of wildcards in Corax. Using more than one wildcard characters (e.g. `***`) as search term should match Lucene behavior, so we also use `ExistsQuery` in this case.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
