### PR TITLE
RavenDB-22008 - Use SemaphoreSlim instead of a blocking Monitor.TryEnter

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -281,7 +281,7 @@ namespace Raven.Server.Documents
                     break;
 
                 case ClusterDatabaseChangeType.ValueChanged:
-                    database.ValueChanged(index, type, changeState);
+                    await database.ValueChanged(index, type, changeState);
                     break;
 
                 case ClusterDatabaseChangeType.PendingClusterTransactions:

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -157,7 +157,7 @@ namespace Raven.Server.Documents
                                 // we need to update this upon any shard topology change
                                 // and upon migration completion
                                 var databaseContext = GetOrAddShardedDatabaseContext(databaseName, rawRecord);
-                                await databaseContext.UpdateDatabaseRecord(rawRecord, index);
+                                await databaseContext.UpdateDatabaseRecordAsync(rawRecord, index);
                             }
                             else
                             {
@@ -273,7 +273,7 @@ namespace Raven.Server.Documents
             switch (changeType)
             {
                 case ClusterDatabaseChangeType.RecordChanged:
-                    await database.StateChanged(index);
+                    await database.StateChangedAsync(index);
                     if (type == ClusterStateMachine.SnapshotInstalled)
                     {
                         database.NotifyOnPendingClusterTransaction(index, changeType);
@@ -281,7 +281,7 @@ namespace Raven.Server.Documents
                     break;
 
                 case ClusterDatabaseChangeType.ValueChanged:
-                    await database.ValueChanged(index, type, changeState);
+                    await database.ValueChangedAsync(index, type, changeState);
                     break;
 
                 case ClusterDatabaseChangeType.PendingClusterTransactions:
@@ -1519,7 +1519,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public static async ValueTask NotifyFeaturesAboutStateChange(DatabaseRecord record, long index, StateChange state)
+        public static async ValueTask NotifyFeaturesAboutStateChangeAsync(DatabaseRecord record, long index, StateChange state)
         {
             if (CanSkipDatabaseRecordChange())
                 return;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -938,6 +938,9 @@ namespace Raven.Server.Documents
                 ForTestingPurposes?.DisposeLog?.Invoke(Name, "Acquired cluster lock");
             }
 
+            ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposing the cluster locker");
+            exceptionAggregator.Execute(() => _clusterLocker.Dispose());
+
             var indexStoreTask = _indexStoreTask;
             if (indexStoreTask != null)
             {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -450,7 +450,7 @@ namespace Raven.Server.Documents
                 {
                     try
                     {
-                        await DatabasesLandlord.NotifyFeaturesAboutStateChange(record, index, _databaseStateChange);
+                        await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _databaseStateChange);
                         RachisLogIndexNotifications.NotifyListenersAbout(index, null);
                     }
                     catch (Exception e)
@@ -1485,15 +1485,14 @@ namespace Raven.Server.Documents
         /// </summary>
         public event Action<DatabaseRecord> DatabaseRecordChanged;
 
-        public async ValueTask ValueChanged(long index, string type, object changeState)
+        public async ValueTask ValueChangedAsync(long index, string type, object changeState)
         {
             try
             {
                 if (_databaseShutdown.IsCancellationRequested)
                     ThrowDatabaseShutdown();
 
-                NotifyFeaturesAboutValueChange(record, index, type, changeState);
-                await NotifyFeaturesAboutValueChange(index, type, changeState);
+                await NotifyFeaturesAboutValueChangeAsync(index, type, changeState);
                 RachisLogIndexNotifications.NotifyListenersAbout(index, null);
             }
             catch (Exception e)
@@ -1507,7 +1506,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public async ValueTask StateChanged(long index)
+        public async ValueTask StateChangedAsync(long index)
         {
             try
             {
@@ -1553,7 +1552,7 @@ namespace Raven.Server.Documents
 
                 ServerStore.DatabasesLandlord.ForTestingPurposes?.DelayNotifyFeaturesAboutStateChange?.Invoke();
 
-                await DatabasesLandlord.NotifyFeaturesAboutStateChange(record, index, _databaseStateChange);
+                await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _databaseStateChange);
 
                 RachisLogIndexNotifications.NotifyListenersAbout(index, null);
             }
@@ -1628,7 +1627,7 @@ namespace Raven.Server.Documents
             return false;
         }
 
-        private async ValueTask NotifyFeaturesAboutValueChange(long index, string type, object changeState)
+        private async ValueTask NotifyFeaturesAboutValueChangeAsync(long index, string type, object changeState)
         {
             if (CanSkipValueChange(index, type))
                 return;
@@ -1665,7 +1664,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public ValueTask RefreshFeatures()
+        public ValueTask RefreshFeaturesAsync()
         {
             if (_databaseShutdown.IsCancellationRequested)
                 ThrowDatabaseShutdown();
@@ -1678,7 +1677,7 @@ namespace Raven.Server.Documents
                 record = _serverStore.Cluster.ReadDatabase(context, Name, out index);
             }
 
-            return DatabasesLandlord.NotifyFeaturesAboutStateChange(record, index, _databaseStateChange);
+            return DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _databaseStateChange);
         }
 
         private void InitializeFromDatabaseRecord(DatabaseRecord record)

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -100,11 +100,11 @@ namespace Raven.Server.Documents.Sharding
 
         public IDisposable AllocateOperationContext(out JsonOperationContext context) => ServerStore.ContextPool.AllocateOperationContext(out context);
 
-        public async ValueTask UpdateDatabaseRecord(DatabaseRecord record, long index)
+        public async ValueTask UpdateDatabaseRecordAsync(DatabaseRecord record, long index)
         {
             try
             {
-                await DatabasesLandlord.NotifyFeaturesAboutStateChange(record, index, _orchestratorStateChange);
+                await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _orchestratorStateChange);
                 RachisLogIndexNotifications.NotifyListenersAbout(index, e: null);
             }
             catch (Exception e)
@@ -184,7 +184,7 @@ namespace Raven.Server.Documents.Sharding
             AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, _record);
         }
 
-        public async ValueTask UpdateUrls(long index) => await DatabasesLandlord.NotifyFeaturesAboutStateChange(_record, index, _urlUpdateStateChange);
+        public async ValueTask UpdateUrlsAsync(long index) => await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(_record, index, _urlUpdateStateChange);
 
         public string DatabaseName => _record.DatabaseName;
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Http;
@@ -99,11 +100,11 @@ namespace Raven.Server.Documents.Sharding
 
         public IDisposable AllocateOperationContext(out JsonOperationContext context) => ServerStore.ContextPool.AllocateOperationContext(out context);
 
-        public void UpdateDatabaseRecord(DatabaseRecord record, long index)
+        public async ValueTask UpdateDatabaseRecord(DatabaseRecord record, long index)
         {
             try
             {
-                DatabasesLandlord.NotifyFeaturesAboutStateChange(record, index, _orchestratorStateChange);
+                await DatabasesLandlord.NotifyFeaturesAboutStateChange(record, index, _orchestratorStateChange);
                 RachisLogIndexNotifications.NotifyListenersAbout(index, e: null);
             }
             catch (Exception e)
@@ -183,7 +184,7 @@ namespace Raven.Server.Documents.Sharding
             AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, _record);
         }
 
-        public void UpdateUrls(long index) => DatabasesLandlord.NotifyFeaturesAboutStateChange(_record, index, _urlUpdateStateChange);
+        public async ValueTask UpdateUrls(long index) => await DatabasesLandlord.NotifyFeaturesAboutStateChange(_record, index, _urlUpdateStateChange);
 
         public string DatabaseName => _record.DatabaseName;
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1126,7 +1126,7 @@ namespace Raven.Server.ServerWide
                 try
                 {
                     var database = await completedTask;
-                    await database.RefreshFeatures();
+                    await database.RefreshFeaturesAsync();
                 }
                 catch (Exception e)
                 {
@@ -1336,7 +1336,7 @@ namespace Raven.Server.ServerWide
                         if (orchestrator.IsCompletedSuccessfully == false)
                             continue;
 
-                        await orchestrator.Result.UpdateUrls(index);
+                        await orchestrator.Result.UpdateUrlsAsync(index);
                     }
 
                     break;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1126,7 +1126,7 @@ namespace Raven.Server.ServerWide
                 try
                 {
                     var database = await completedTask;
-                    database.RefreshFeatures();
+                    await database.RefreshFeatures();
                 }
                 catch (Exception e)
                 {
@@ -1336,7 +1336,7 @@ namespace Raven.Server.ServerWide
                         if (orchestrator.IsCompletedSuccessfully == false)
                             continue;
 
-                        orchestrator.Result.UpdateUrls(index);
+                        await orchestrator.Result.UpdateUrls(index);
                     }
 
                     break;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22008/Large-amount-of-threads-are-waiting-on-NotifyFeaturesAboutValueChange

### Additional description

https://github.com/ravendb/ravendb/pull/18059

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
