### PR TITLE
RavenDB-22000 Ensure flushing occurs when the timeout is imminent

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -662,9 +662,12 @@ namespace Raven.Client.Documents.BulkInsert
 
         private async Task FlushIfNeeded(bool force = false)
         {
-            var flushed = await _writer.FlushIfNeeded(force).ConfigureAwait(false);
-            if (flushed)
+            if (DateTime.UtcNow.Ticks - _lastWriteToStream.Ticks < _heartbeatCheckInterval.Ticks)
+            {
                 _lastWriteToStream = DateTime.UtcNow;
+                force = true;
+            }
+            await _writer.FlushIfNeeded(force).ConfigureAwait(false);
         }
 
         public readonly struct CountersBulkInsert

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -98,9 +98,9 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
             _memoryBuffer = _backgroundMemoryBuffer;
             _backgroundMemoryBuffer = tmpBuffer;
 
-            _asyncWrite = WriteToStreamAsync(tmp, _requestBodyStream, tmpBuffer, _isInitialWrite);
+            _asyncWrite = WriteToStreamAsync(tmp, _requestBodyStream, tmpBuffer, _isInitialWrite || force);
             _isInitialWrite = false;
-            return true;
+            return _isInitialWrite || force;
         }
 
         return false;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22000

### Additional description

We lack visibility into when flushing occurs.
It's necessary to ensure that we trigger a flush when the timeout is imminent.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
