### PR TITLE
RavenDB-21088 - we need to return 404 if env is missing

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -345,12 +345,13 @@ namespace Raven.Server.Documents.Handlers.Debugging
             var name = GetStringQueryString("name");
             var typeAsString = GetStringQueryString("type", false);
 
+            var envs = Database.GetAllStoragesEnvironment();
+
             if (typeAsString != null)
             {
                 if (Enum.TryParse(typeAsString, out StorageEnvironmentWithType.StorageEnvironmentType type) == false)
                     throw new InvalidOperationException("Query string value 'type' is not a valid environment type: " + typeAsString);
-                var env = Database.GetAllStoragesEnvironment()
-                    .FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase) && x.Type == type);
+                var env = envs.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase) && x.Type == type);
 
                 if (env == null)
                 {
@@ -372,7 +373,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 {
                     await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                     {
-                        WriteEnvironmentsReport(writer, name, Database.GetAllStoragesEnvironment(), context, StorageReportType.ScratchReport);
+                        WriteEnvironmentsReport(writer, name, envs, context, StorageReportType.ScratchReport);
                     }
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21088

### Additional description

Return notFound for null storageENV

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
