### PR TITLE
RavenDB-19096 Aggregate CPU credits exhaustion warnings into one warning

### DIFF
--- a/src/Raven.Server/NotificationCenter/Indexing.cs
+++ b/src/Raven.Server/NotificationCenter/Indexing.cs
@@ -156,7 +156,7 @@ namespace Raven.Server.NotificationCenter
                     _isCpuExhaustionWarningAdded = true;
                 }
                 
-                if (_warningIndexOutputsPerDocumentQueue.IsEmpty && _warningReferenceDocumentLoadsQueue.IsEmpty && _mismatchedReferencesLoadWarning == null && _warningComplexFieldAutoIndexing.IsEmpty && _cpuExhaustionWarningIndexNames.Count == 0)
+                if (_warningIndexOutputsPerDocumentQueue.IsEmpty && _warningReferenceDocumentLoadsQueue.IsEmpty && _mismatchedReferencesLoadWarning == null && _warningComplexFieldAutoIndexing.IsEmpty)
                     return;
 
                 PerformanceHint indexOutputPerDocumentHint = null;

--- a/src/Raven.Server/NotificationCenter/Indexing.cs
+++ b/src/Raven.Server/NotificationCenter/Indexing.cs
@@ -251,7 +251,7 @@ namespace Raven.Server.NotificationCenter
         
         private AlertRaised GetCpuCreditsExhaustionAlert(CpuCreditsExhaustionWarning cpuCreditsExhaustionWarning)
         {
-            return AlertRaised.Create(_notificationCenter.Database, "Indexing stopped because of CPU credits exhaustion",
+            return AlertRaised.Create(_notificationCenter.Database, "Indexing paused because of CPU credits exhaustion",
                 "Indexing has been paused because the CPU credits balance is almost completely used, will be resumed when there are enough CPU credits to use.",
                 AlertType.Throttling_CpuCreditsBalance, NotificationSeverity.Warning, Source, cpuCreditsExhaustionWarning);
         }

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/CpuCreditsExhaustionWarning.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/CpuCreditsExhaustionWarning.cs
@@ -1,0 +1,36 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.NotificationCenter.Notifications.Details;
+
+public sealed class CpuCreditsExhaustionWarning : INotificationDetails
+{
+    public CpuCreditsExhaustionWarning()
+    {
+        // deserialization
+    }
+    
+    public HashSet<string> IndexNames { get; set; }
+    
+    public CpuCreditsExhaustionWarning(HashSet<string> indexNames)
+    {
+        IndexNames = indexNames;
+    }
+    
+    public DynamicJsonValue ToJson()
+    {
+        var djv = new DynamicJsonValue(GetType());
+        
+        var indexNames = new DynamicJsonArray();
+
+        foreach (var indexName in IndexNames)
+        {
+            indexNames.Add(indexName);
+        }
+        
+        djv[nameof(IndexNames)] = indexNames;
+
+        return djv;
+    }
+}

--- a/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
+++ b/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
@@ -66,6 +66,8 @@ import conflictExceededDetails
     from "viewmodels/common/notificationCenter/detailViewer/alerts/conflictExceededDetails";
 import complexFieldsAlertDetails
     from "viewmodels/common/notificationCenter/detailViewer/alerts/complexFieldsAlertDetails";
+import cpuCreditsBalanceDetails
+    from "viewmodels/common/notificationCenter/detailViewer/alerts/cpuCreditsBalanceDetails";
 interface detailsProvider {
     supportsDetailsFor(notification: abstractNotification): boolean;
     showDetailsFor(notification: abstractNotification, notificationCenter: notificationCenter): JQueryPromise<void> | void;
@@ -187,6 +189,7 @@ class notificationCenter {
             mismatchedReferenceLoadDetails,
             blockingTombstonesDetails,
             queueSinkErrorDetails,
+            cpuCreditsBalanceDetails,
             serverLimitsDetails,
             conflictExceededDetails,
             complexFieldsAlertDetails,

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/cpuCreditsBalanceDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/cpuCreditsBalanceDetails.ts
@@ -1,0 +1,71 @@
+import app = require("durandal/app");
+import abstractNotification = require("common/notifications/models/abstractNotification");
+import notificationCenter = require("common/notifications/notificationCenter");
+import virtualGridController = require("widgets/virtualGrid/virtualGridController");
+import textColumn = require("widgets/virtualGrid/columns/textColumn");
+import alert = require("common/notifications/models/alert");
+import columnPreviewPlugin = require("widgets/virtualGrid/columnPreviewPlugin");
+import abstractAlertDetails = require("viewmodels/common/notificationCenter/detailViewer/alerts/abstractAlertDetails");
+import genUtils from "common/generalUtils";
+
+interface TableItem {
+    indexName: string;
+}
+
+class cpuCreditsBalanceDetails extends abstractAlertDetails {
+    
+    view = require("views/common/notificationCenter/detailViewer/alerts/cpuCreditsBalanceDetails.html");
+
+    tableItems: TableItem[] = [];
+    private gridController = ko.observable<virtualGridController<TableItem>>();
+    private columnPreview = new columnPreviewPlugin<TableItem>();
+
+    constructor(alert: alert, notificationCenter: notificationCenter) {
+        super(alert, notificationCenter);
+
+        const details = this.alert.details() as Raven.Server.NotificationCenter.Notifications.Details.CpuCreditsExhaustionWarning;
+        this.tableItems = details.IndexNames.map(x => ({ indexName: x }));
+    }
+    
+    compositionComplete() {
+        super.compositionComplete();
+
+        const grid = this.gridController();
+        grid.headerVisible(true);
+
+        grid.init(() => this.fetcher(), () =>
+            [
+                new textColumn<TableItem>(grid, x => x.indexName, "Index Name", "95%")
+            ]);
+        
+        
+        this.columnPreview.install(".cpuCreditsBalanceDetails", ".js-cpu-credits-balance-details-tooltip",
+            (details: TableItem,
+             column: textColumn<TableItem>,
+             e: JQueryEventObject, onValue: (context: any, valueToCopy?: string) => void) => {
+                const value = column.getCellValue(details);
+                if (value) {
+                    onValue(genUtils.escapeHtml(value), value);
+                }
+            });
+    }
+    
+    private fetcher(): JQueryPromise<pagedResult<TableItem>> {
+        return $.Deferred<pagedResult<TableItem>>()
+            .resolve({
+                items: this.tableItems,
+                totalResultCount: this.tableItems.length
+            });
+    }
+    
+    static supportsDetailsFor(notification: abstractNotification) {
+        return (notification instanceof alert) 
+            && notification.alertType() === "Throttling_CpuCreditsBalance";
+    }
+
+    static showDetailsFor(alert: alert, center: notificationCenter) {
+        return app.showBootstrapDialog(new cpuCreditsBalanceDetails(alert, center));
+    }
+}
+
+export = cpuCreditsBalanceDetails;

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/cpuCreditsBalanceDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/cpuCreditsBalanceDetails.html
@@ -1,0 +1,26 @@
+<div class="modal-dialog modal-lg cpuCreditsBalanceDetails" id="js-cpu-credits-balance-details" role="document">
+    <div class="modal-content force-text-wrap-word" tabindex="-1">
+        <div class="modal-header">
+            <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                <i class="icon-cancel"></i>
+            </button>
+            <div data-bind="with: alert">
+                <h3 class="modal-title" id="myModalLabel" data-bind="text: title, attr:{ class: 'modal-title ' + headerClass() }"></h3>
+                <div class="notification-time" data-bind="text: displayDate().format('LLL')"></div>
+            </div>
+        </div>
+        <div class="modal-body">
+            <h3 data-bind="html: alert.message"></h3>
+            
+            <div>Paused indexes:</div>
+            
+            <div class="margin-bottom" style="position: relative; height: 300px">
+                <virtual-grid style="height: 300px" class="resizable flex-window" params="controller: gridController"></virtual-grid>
+            </div>
+        </div>
+        <div class="modal-footer" data-bind="compose: $root.footerPartialView">
+        </div>
+    </div>
+</div>
+<div class="tooltip json-preview js-cpu-credits-balance-details-tooltip" style="opacity: 0">
+</div>

--- a/test/SlowTests/Issues/RavenDB-19096.cs
+++ b/test/SlowTests/Issues/RavenDB-19096.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Collections;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19096 : RavenTestBase
+{
+    public RavenDB_19096(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.None)]
+    public async Task AssertIndexNamesAreAddedToCpuCreditsExhaustionNotification()
+    {
+        DoNotReuseServer();
+        
+        using (var store = GetDocumentStore())
+        {
+            var db = await GetDatabase(store.Database);
+
+            var notificationsQueue = new AsyncQueue<DynamicJsonValue>();
+
+            using (db.NotificationCenter.TrackActions(notificationsQueue, null))
+            {
+                var index1 = new DummyIndex();
+                var index2 = new OtherIndex();
+                
+                await index1.ExecuteAsync(store);
+                await index2.ExecuteAsync(store);
+                
+                await Indexes.WaitForIndexingAsync(store);
+
+                db.NotificationCenter.Indexing.AddIndexNameToCpuCreditsExhaustionWarning(index1.IndexName);
+                db.NotificationCenter.Indexing.AddIndexNameToCpuCreditsExhaustionWarning(index2.IndexName);
+                
+                db.NotificationCenter.Indexing.UpdateIndexing(null);
+                
+                Tuple<bool, DynamicJsonValue> notification;
+
+                do
+                {
+                    notification = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
+                } while (notification.Item1 && notification.Item2["Type"].ToString() != NotificationType.AlertRaised.ToString());
+
+                var cpuExhaustionWarningDetails = notification.Item2[nameof(AlertRaised.Details)] as DynamicJsonValue;
+
+                using (var ctx = JsonOperationContext.ShortTermSingleUse())
+                {
+                    var json = ctx.ReadObject(cpuExhaustionWarningDetails, "details");
+
+                    var detailsObject =
+                        DocumentConventions.DefaultForServer.Serialization.DefaultConverter.FromBlittable<CpuCreditsExhaustionWarning>(json, "cpu_exhaustion_warning_details");
+
+                    Assert.Equal(2, detailsObject.IndexNames.Count);
+                    Assert.Contains(index1.IndexName, detailsObject.IndexNames);
+                    Assert.Contains(index2.IndexName, detailsObject.IndexNames);
+                }
+                
+                db.NotificationCenter.Indexing.RemoveIndexNameFromCpuCreditsExhaustionWarning(index1.IndexName);
+                db.NotificationCenter.Indexing.RemoveIndexNameFromCpuCreditsExhaustionWarning(index2.IndexName);
+                
+                db.NotificationCenter.Indexing.UpdateIndexing(null);
+                
+                do
+                {
+                    notification = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
+                } while (notification.Item1 && notification.Item2["Type"].ToString() != NotificationType.NotificationUpdated.ToString());
+
+                Assert.Equal("NotificationUpdated/Dismissed/AlertRaised/Throttling_CpuCreditsBalance/Indexing", notification.Item2["Id"]);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public DummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new
+                {
+                    Name = dto.Name
+                };
+        }
+    }
+
+    private class OtherIndex : AbstractIndexCreationTask<Dto>
+    {
+        public OtherIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new
+                {
+                    Name = dto.Name + "ddd"
+                };
+        }
+    }
+}

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -276,6 +276,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(WarnIndexOutputsPerDocument));
             scripter.AddType(typeof(IndexingReferenceLoadWarning));
             scripter.AddType(typeof(QueueSinkErrorsDetails));
+            scripter.AddType(typeof(CpuCreditsExhaustionWarning));
             scripter.AddType(typeof(ConflictPerformanceDetails));
 
             // subscriptions


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19096/Indexing-paused-due-to-CPU-credits-exhaustion-shows-up-for-every-index-in-the-DB-cluttering-notification-center

### Additional description

We want to aggregate all indexes affected by CPU credits exhaustion into one notification.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
