### PR TITLE
RavenDB-21541 - fix task connection status when getting subscription ongoing task by name

### DIFF
--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -1355,7 +1355,7 @@ namespace Raven.Server.Web.System
                             {
                                 connectionStatus = OngoingTaskConnectionStatus.NotOnThisNode;
                             }
-                            else if (Database.SubscriptionStorage.TryGetRunningSubscriptionConnectionsState(key, out var connectionsState))
+                            else if (Database.SubscriptionStorage.TryGetRunningSubscriptionConnectionsState(subscriptionState.SubscriptionId, out var connectionsState))
                             {
                                 connectionStatus = connectionsState.IsSubscriptionActive() ? OngoingTaskConnectionStatus.Active : OngoingTaskConnectionStatus.NotActive;
                             }

--- a/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/FastTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Documents.Subscriptions;
@@ -1174,6 +1175,44 @@ namespace FastTests.Client.Subscriptions
 
                     throw new TimeoutException($"No batch received for {timeout}");
                 }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscription_GetOngoingTaskInfoOperation_ShouldReturnCorrentTaskStatus()
+        {
+            using var store = GetDocumentStore();
+
+            var entity = new User();
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+            }
+
+            var name = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions<User>());
+
+            var state = await store.Subscriptions.GetSubscriptionStateAsync(name);
+            await using (var sub = store.Subscriptions.GetSubscriptionWorker<ProjectionObject>(name))
+            {
+                var mre = new AsyncManualResetEvent();
+                var subscriptionTask = sub.Run(batch =>
+                {
+                    mre.Set();
+                });
+                var timeout = TimeSpan.FromSeconds(30);
+                Assert.True(await mre.WaitAsync(timeout));
+                var taskInfoById = store.Maintenance.Send(new GetOngoingTaskInfoOperation(state.SubscriptionId, OngoingTaskType.Subscription));
+                Assert.NotNull(taskInfoById);
+                Assert.Equal(OngoingTaskState.Enabled, taskInfoById.TaskState);
+                Assert.Equal(OngoingTaskType.Subscription, taskInfoById.TaskType);
+                Assert.Equal(OngoingTaskConnectionStatus.Active, taskInfoById.TaskConnectionStatus);
+
+                var taskInfoByName = store.Maintenance.Send(new GetOngoingTaskInfoOperation(state.SubscriptionName, OngoingTaskType.Subscription));
+                Assert.NotNull(taskInfoByName);
+                Assert.Equal(taskInfoById.TaskState, taskInfoByName.TaskState);
+                Assert.Equal(taskInfoById.TaskType, taskInfoByName.TaskType);
+                Assert.Equal(taskInfoById.TaskConnectionStatus, taskInfoByName.TaskConnectionStatus);
             }
         }
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21541

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
