### PR TITLE
RavenDB-20836 : flaky test adjustments

### DIFF
--- a/test/SlowTests/Server/Documents/OngoingTasks/PinOnGoingTaskToMentorNode.cs
+++ b/test/SlowTests/Server/Documents/OngoingTasks/PinOnGoingTaskToMentorNode.cs
@@ -262,7 +262,8 @@ public class PinOnGoingTaskToMentorNode : ReplicationTestBase
                 return ongoingTask.ResponsibleNode.NodeTag != responsibleNodeNodeTag;
             }, true);
 
-            Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "Joe Doe2"));
+            Assert.True(WaitForDocument<User>(dest, "users/2", u => u.Name == "Joe Doe2", timeout: 30_000), 
+                userMessage: await Etl.GetEtlDebugInfo(src.Database, server: srcRaft.Nodes.Single(s => s.ServerStore.NodeTag == ongoingTask.ResponsibleNode.NodeTag)));
         }
     }
 

--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -33,6 +33,7 @@ using Raven.Server.Documents;
 using System.Text;
 using Newtonsoft.Json;
 using Raven.Client.Util;
+using Raven.Server;
 using Tests.Infrastructure;
 
 namespace FastTests
@@ -321,16 +322,16 @@ namespace FastTests
                 return await _parent.GetDocumentDatabaseInstanceFor(store, databaseName);
             }
 
-            public async Task<string> GetEtlDebugInfo(string database, TimeSpan timeout, RavenDatabaseMode databaseMode = RavenDatabaseMode.Single)
+            public async Task<string> GetEtlDebugInfo(string database, TimeSpan? timeout = null, RavenDatabaseMode databaseMode = RavenDatabaseMode.Single, RavenServer server = null)
             {
                 IEnumerable<DocumentDatabase> databases = databaseMode switch
                 {
-                    RavenDatabaseMode.Single => new[] { await _parent.GetDatabase(database) },
-                    RavenDatabaseMode.Sharded => await _parent.Sharding.GetShardsDocumentDatabaseInstancesFor(database).ToListAsync(),
+                    RavenDatabaseMode.Single => new[] { await GetDatabase(server ?? _parent.Server, database) },
+                    RavenDatabaseMode.Sharded => await _parent.Sharding.GetShardsDocumentDatabaseInstancesFor(database, server == null ? null : [server]).ToListAsync(),
                     _ => throw new ArgumentOutOfRangeException(nameof(databaseMode), databaseMode, null)
                 };
 
-                var sb = new StringBuilder($"ETL did not finish in {timeout.TotalSeconds} seconds.");
+                var sb = new StringBuilder($"ETL did not finish in {timeout?.TotalSeconds ?? 30} seconds.");
 
                 foreach (var documentDatabase in databases)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20836/SlowTests.Server.Documents.OngoingTasks.PinOnGoingTaskToMentorNode.CanFailOverWhenRemovingMentorNodeEtl

### Additional description

increase timeout, add debug info

### Type of change

- Tests stabilization

### How risky is the change?

- Low 
