### PR TITLE
RavenDB-21958 Use AlmostEquals instead of epsilon for double comparison in Corax codepaths.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -1312,7 +1312,7 @@ namespace Corax.Indexing
                         recordedTerm.Long = entries.Long.Value;
 
                         // only if the double value can not be computed by casting from long, we store it 
-                        if (entries.Double != null && Math.Abs(entries.Double.Value - recordedTerm.Long) > double.Epsilon)
+                        if (entries.Double != null && entries.Double.Value.AlmostEquals(recordedTerm.Long) == false)
                         {
                             recordedTermContainerId |= 2; // marker!
                             recordedTerm.Double = entries.Double.Value;

--- a/src/Voron/Data/Lookups/DoubleLookupKey.cs
+++ b/src/Voron/Data/Lookups/DoubleLookupKey.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.Contracts;
+using Sparrow.Extensions;
 
 namespace Voron.Data.Lookups;
 
@@ -66,7 +67,7 @@ public struct DoubleLookupKey : ILookupKey
         }
 
         var o = (DoubleLookupKey)(object)k;
-        return Math.Abs(Value - o.Value) < double.Epsilon;
+        return Value.AlmostEquals(o.Value);
     }
 
     public void OnNewKeyAddition<T>(Lookup<T> parent) where T : struct, ILookupKey


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21958
### Additional description

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
