### PR TITLE
RavenDB-22031 - Raft log is not truncated in followers

### DIFF
--- a/src/Raven.Server/Rachis/Commands/LowestIndexUpdateCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/LowestIndexUpdateCommand.cs
@@ -13,17 +13,14 @@ namespace Raven.Server.Rachis.Commands;
 
 public sealed class LowestIndexUpdateCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
 {
-    private readonly Leader _leader;
-
     private readonly RachisConsensus _engine;
 
     private long _lowestIndexInEntireCluster;
 
 
-    public LowestIndexUpdateCommand([NotNull] Leader leader, [NotNull] RachisConsensus engine, long lowestIndexInEntireCluster)
+    public LowestIndexUpdateCommand([NotNull] RachisConsensus engine, long lowestIndexInEntireCluster)
     {
         _engine = engine ?? throw new ArgumentNullException(nameof(engine));
-        _leader = leader;
         _lowestIndexInEntireCluster = lowestIndexInEntireCluster;
     }
 

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -361,9 +361,9 @@ namespace Raven.Server.Rachis
 
                         if (lowestIndexInEntireCluster > lastTruncated)
                         {
-                            var cmd = new LowestIndexUpdateCommand(leader: this, engine: _engine, lowestIndexInEntireCluster: lowestIndexInEntireCluster);
+                            var cmd = new LowestIndexUpdateCommand(engine: _engine, lowestIndexInEntireCluster: lowestIndexInEntireCluster);
                             _engine.TxMerger.EnqueueSync(cmd);
-                            LowestIndexInEntireCluster = _lowestIndexInEntireCluster;
+                            LowestIndexInEntireCluster = lowestIndexInEntireCluster;
                         }
                     }
                     catch (Exception ex)

--- a/test/SlowTests/Issues/RavenDB-22031.cs
+++ b/test/SlowTests/Issues/RavenDB-22031.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Session;
+using Raven.Server;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22031 : ClusterTestBase
+{
+    public RavenDB_22031(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Cluster)]
+    public async Task RaftLogTrancateShouldWorkOnFollowers()
+    {
+        var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
+
+        using var store = GetDocumentStore(new Options
+        {
+            Server = leader, 
+            ReplicationFactor = 3
+        });
+
+        for (int i = 0; i < 10; i++)
+        {
+            var user = new User
+            {
+                Id = $"Users/{i}-A",
+                Name = $"User{i}"
+            };
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(user);
+                await session.SaveChangesAsync();
+            }
+        }
+
+        long[] min = new long[3];
+        long[] max = new long[3];
+
+        var result = await WaitForValueAsync(() =>
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                (min[i], max[i]) = GetLogEntriesRange(nodes[i]);
+            }
+
+            return min[0] == min[1] && min[1] == min[2] && 
+                            max[0] == max[1] && max[1] == max[2];
+        }, true);
+
+        Assert.True(result, $"log history ranges of the nodes are different. leader is {leader.ServerStore.NodeTag}. ranges: {GetRangesString(min, max, nodes)}");
+    }
+
+    private string GetRangesString(long[] min, long[] max, List<RavenServer> nodes)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < 3; i++)
+        {
+            sb.Append(nodes[i].ServerStore.NodeTag).Append("-[").Append(min[i]).Append(", ").Append(max[i]).Append("] ");
+        }
+
+        return sb.ToString();
+    }
+
+    private (long Min, long Max) GetLogEntriesRange(RavenServer ravenServer)
+    {
+        using(ravenServer.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+        using (context.OpenWriteTransaction())
+        {
+            return ravenServer.ServerStore.Engine.GetLogEntriesRange(context);
+        }
+    }
+
+
+    private class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22031/Raft-log-is-not-truncated

### Additional description

Raft log is not truncated in followers, which caused the log history table to not clear.
This happened due to the fact that the leader did not update the variable `LowestIndexInEntireCluster`, which caused the follower ambassador to always send the follower `LowestIndexInEntireCluster` with a value of 0.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
