### PR TITLE
RavenDB-22013 - NRE in Raven.Server.ServerWide.ClusterStateMachine.AddDatabase()

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
         public RestoreFromLocal(RestoreBackupConfiguration restoreConfiguration)
         {
-            if (restoreConfiguration.ShardRestoreSettings?.Shards.Count > 0)
+            if (restoreConfiguration.ShardRestoreSettings != null)
                 return;
 
             if (string.IsNullOrWhiteSpace(restoreConfiguration.BackupLocation))

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3037,12 +3037,6 @@ namespace Raven.Server.ServerWide
                 if (string.IsNullOrEmpty(topology.ClusterTransactionIdBase64))
                     topology.ClusterTransactionIdBase64 = Guid.NewGuid().ToBase64Unpadded();
 
-                foreach (var node in topology.AllNodes)
-                {
-                    if (string.IsNullOrEmpty(node))
-                        throw new InvalidOperationException($"Attempting to save the database record of '{databaseName}' but one of its specified topology nodes is null.");
-                }
-
                 topology.Stamp ??= new LeaderStamp();
                 topology.Stamp.Term = engine.CurrentTerm;
                 topology.Stamp.LeadersTicks = engine.CurrentLeader?.LeaderShipDuration ?? 0;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3025,6 +3025,12 @@ namespace Raven.Server.ServerWide
             {
                 Debug.Assert(topology != null);
 
+                foreach (var node in topology.AllNodes)
+                {
+                    if (string.IsNullOrEmpty(node))
+                        throw new InvalidOperationException($"Attempting to save the database record of '{databaseName}' but one of its specified topology nodes is null.");
+                }
+
                 if (string.IsNullOrEmpty(topology.DatabaseTopologyIdBase64))
                     topology.DatabaseTopologyIdBase64 = Guid.NewGuid().ToBase64Unpadded();
 

--- a/test/SlowTests/Issues/RavenDB_22013.cs
+++ b/test/SlowTests/Issues/RavenDB_22013.cs
@@ -17,28 +17,24 @@ namespace SlowTests.Issues
         {
         }
 
-        [RavenFact(RavenTestCategory.None)]
+        [RavenFact(RavenTestCategory.Cluster)]
         public async Task ValidateNodesNotNullInDatabaseRecordBeforeSavingRecordClusterWide()
         {
             var databaseName = GetDatabaseName();
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            
+            var databaseRecord = new DatabaseRecord(databaseName);
+            databaseRecord.Topology = new DatabaseTopology()
             {
-                context.OpenReadTransaction();
+                Members = new List<string>() { null }
+            };
+            await Server.ServerStore.EnsureNotPassiveAsync();
 
-                var databaseRecord = new DatabaseRecord(databaseName);
-                databaseRecord.Topology = new DatabaseTopology()
-                {
-                    Members = new List<string>() { null }
-                };
-                await Server.ServerStore.EnsureNotPassiveAsync();
-
-                var error = await Assert.ThrowsAnyAsync<InvalidOperationException>(async () =>
-                {
-                    var (etag, _) = await Server.ServerStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null, Guid.NewGuid().ToString());
-                    await Server.ServerStore.Cluster.WaitForIndexNotification(etag);
-                });
-                Assert.Contains("but one of its specified topology nodes is null", error.Message);
-            }
+            var error = await Assert.ThrowsAnyAsync<InvalidOperationException>(async () =>
+            {
+                var (etag, _) = await Server.ServerStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null, Guid.NewGuid().ToString());
+                await Server.ServerStore.Cluster.WaitForIndexNotification(etag);
+            });
+            Assert.Contains("but one of its specified topology nodes is null", error.Message);
         }
 
         [RavenFact(RavenTestCategory.Sharding)]

--- a/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
@@ -161,7 +161,8 @@ public partial class RavenTestBase
                 throw new ArgumentException($"Missing shard number after $ sign in backup path {path}. Expected a number but got '{path[shardIndexPosition]}'");
 
             int shardNumberLength = 1;
-            while (char.IsDigit(path[shardIndexPosition + shardNumberLength]))
+            while (shardIndexPosition + shardNumberLength < path.Length &&
+                   char.IsDigit(path[shardIndexPosition + shardNumberLength]))
                 shardNumberLength++;
 
             return int.Parse(path.Substring(shardIndexPosition, shardNumberLength));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22013

### Additional description

We were able to send a request with a restore configuration that contained a shard topology with `null` as one of the nodes. The null was passed on to the new database record and later was sent to the leader as part of an `AddDatabaseCommand`. The command failed in the CSM upon deserializtion of the database record (couldn't convert the null) and kept retrying and failing.

Added validation to the topology nodes in the configuration received from client and a few other extra validations.
This PR as well as a seperate one for v5.4 also includes:
Added the null check in topology inside the more general `WriteDatabaseRecordAsync`, before the record is sent to the leader.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
