### PR TITLE
RavenDB-22013 - NRE in Raven.Server.ServerWide.ClusterStateMachine.AddDatabase()

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2809,6 +2809,12 @@ namespace Raven.Server.ServerWide
             if (string.IsNullOrEmpty(record.Topology.ClusterTransactionIdBase64))
                 record.Topology.ClusterTransactionIdBase64 = Guid.NewGuid().ToBase64Unpadded();
 
+            foreach (var node in record.Topology.AllNodes)
+            {
+                if (string.IsNullOrEmpty(node))
+                    throw new InvalidOperationException($"Attempting to save the database record of '{databaseName}' but one of its specified topology nodes is null.");
+            }
+
             record.Topology.Stamp ??= new LeaderStamp();
             record.Topology.Stamp.Term = _engine.CurrentTerm;
             record.Topology.Stamp.LeadersTicks = _engine.CurrentLeader?.LeaderShipDuration ?? 0;

--- a/test/SlowTests/Issues/RavenDB_22013.cs
+++ b/test/SlowTests/Issues/RavenDB_22013.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22013 : RavenTestBase
+    {
+        public RavenDB_22013(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.None)]
+        public async Task ValidateNodesNotNullInDatabaseRecordBeforeSavingRecordClusterWide()
+        {
+            var databaseName = GetDatabaseName();
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                context.OpenReadTransaction();
+
+                var databaseRecord = new DatabaseRecord(databaseName);
+                databaseRecord.Topology = new DatabaseTopology()
+                {
+                    Members = new List<string>() { null }
+                };
+                await Server.ServerStore.EnsureNotPassiveAsync();
+
+                var error = await Assert.ThrowsAnyAsync<InvalidOperationException>(async () =>
+                {
+                    var (etag, _) = await Server.ServerStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null, Guid.NewGuid().ToString());
+                    await Server.ServerStore.Cluster.WaitForIndexNotification(etag);
+                });
+                Assert.Contains("but one of its specified topology nodes is null", error.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22013

### Additional description

Following https://github.com/ravendb/ravendb/pull/18084
There was a path which allowed for `AddDatabaseCommand` to be sent with a `null` node in the database record's topology, which later failed upon deserialization on the other nodes. Added validation before sending the command.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
