### PR TITLE
RavenDB-19922 - change to MoveToNewResponsibleNodeGracePeriodInMin

### DIFF
--- a/src/Raven.Server/Config/Categories/BackupConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/BackupConfiguration.cs
@@ -84,10 +84,10 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Backup.Snapshot.Compression.Level", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public CompressionLevel SnapshotCompressionLevel { get; set; }
 
-        [Description("Number of seconds, after which we will switch to a new responsible node for backup.")]
-        [DefaultValue(30 * 60)]
-        [TimeUnit(TimeUnit.Seconds)]
-        [ConfigurationEntry("Backup.MoveToNewResponsibleNodeGracePeriodInSec", ConfigurationEntryScope.ServerWideOnly)]
+        [Description("Number of minutes, after which we will switch to a new responsible node for backup.")]
+        [DefaultValue(30)]
+        [TimeUnit(TimeUnit.Minutes)]
+        [ConfigurationEntry("Backup.MoveToNewResponsibleNodeGracePeriodInMin", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting MoveToNewResponsibleNodeGracePeriod { get; set; }
 
         public override void Initialize(IConfigurationRoot settings, HashSet<string> settingsNames, IConfigurationRoot serverWideSettings, HashSet<string> serverWideSettingsNames, ResourceType type, string resourceName)

--- a/test/SlowTests/Issues/RavenDB-19922.cs
+++ b/test/SlowTests/Issues/RavenDB-19922.cs
@@ -95,7 +95,7 @@ namespace SlowTests.Issues
                 [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
                 [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "0",
                 [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
-                [RavenConfiguration.GetKey(x => x.Backup.MoveToNewResponsibleNodeGracePeriod)] = "1"
+                [RavenConfiguration.GetKey(x => x.Backup.MoveToNewResponsibleNodeGracePeriod)] = "0"
             };
 
             var (nodes, leaderServer) = await CreateRaftCluster(clusterSize, customSettings: settings);
@@ -132,7 +132,7 @@ namespace SlowTests.Issues
 
                 Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId);
 
-                CheckDecisionLog(leaderServer, new CurrentResponsibleNodeNotResponding(tag2, config.Name, tag1,TimeSpan.FromSeconds(1)).ReasonForDecisionLog);
+                CheckDecisionLog(leaderServer, new CurrentResponsibleNodeNotResponding(tag2, config.Name, tag1,TimeSpan.FromMinutes(0)).ReasonForDecisionLog);
 
                 settings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url;
                 nodes.Add(GetNewServer(new ServerCreationOptions
@@ -173,7 +173,7 @@ namespace SlowTests.Issues
                 [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
                 [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "0",
                 [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
-                [RavenConfiguration.GetKey(x => x.Backup.MoveToNewResponsibleNodeGracePeriod)] = "1"
+                [RavenConfiguration.GetKey(x => x.Backup.MoveToNewResponsibleNodeGracePeriod)] = "0"
             };
 
             var (nodes, leaderServer) = await CreateRaftCluster(clusterSize, customSettings: settings);
@@ -248,7 +248,7 @@ namespace SlowTests.Issues
                 [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
                 [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "0",
                 [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
-                [RavenConfiguration.GetKey(x => x.Backup.MoveToNewResponsibleNodeGracePeriod)] = "1"
+                [RavenConfiguration.GetKey(x => x.Backup.MoveToNewResponsibleNodeGracePeriod)] = "0"
             };
 
             var (nodes, leaderServer) = await CreateRaftCluster(clusterSize, customSettings: settings);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19922/Cluster-does-not-care-if-theres-a-backup-running-already-and-starts-one-on-another-node

### Additional description

Change the configuration option from seconds to minutes.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
