### PR TITLE
RavenDB-22027 avoid concurrent context usage on revisions restore

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -437,7 +437,7 @@ namespace Raven.Server.Documents.Revisions
                 if (table.VerifyKeyExists(changeVectorSlice)) // we might create
                     return true;
 
-                using var revision = AddCounterAndTimeSeriesSnapshotsIfNeeded(context, id, document.CloneOnTheSameContext());
+                using var revision = AddCounterAndTimeSeriesSnapshotsIfNeeded(context, id, document.Clone(context));
 
                 flags |= DocumentFlags.Revision;
                 if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.ForceRevisionCreation))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22027

### Additional description

This fix is a work around for a known concurrent usage of a context during import/restore that affected restore of revisions.

On restore we batch few documents and send them to the tx merger _without_ waiting and in the meanwhile we collect the next batch.

So during execution of the batch we called `CloneOnTheSameContext` which requests a memory from the context. 
In the meanwhile on a different thread we might return some memory chunks back to that context here:
https://github.com/ravendb/ravendb/blob/da5b3f1c0064b8e046a7307b95ef900209dae759/src/Raven.Server/Smuggler/Documents/StreamSource.cs#L1498

The proper fix would be to register the disposable of the builder & the modifier to the command dispose, but it will be handled in a dedicated PR.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

was easily reproduced when I've added `CloneOnTheSameContext` here:
https://github.com/ravendb/ravendb/blob/da5b3f1c0064b8e046a7307b95ef900209dae759/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs#L1646

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
