### PR TITLE
RavenDB-21968 Use `WaitForValue` since `IndexState` could not be persisted on disk yet.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-14323.cs
+++ b/test/SlowTests/Issues/RavenDB-14323.cs
@@ -127,9 +127,9 @@ namespace SlowTests.Issues
                     return stats.IsInvalidIndex;
                 }, TimeSpan.FromSeconds(10))); //precaution
 
-                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+                WaitForValue(() => store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName)).State, IndexState.Error);
 
-                Assert.True(indexStats.IsInvalidIndex);
+                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
                 Assert.Equal(IndexState.Error, indexStats.State);
 
                 Assert.Equal(numberOfReferencedDocuments, indexStats.MapAttempts);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21968

### Additional description
Use `WaitForValue` since `IndexState` could not be persisted on disk yet.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
