### PR TITLE
RavenDB-17793 : Prefixed Sharding

### DIFF
--- a/src/Raven.Client/ServerWide/Sharding/AddPrefixedShardingSettingOperation.cs
+++ b/src/Raven.Client/ServerWide/Sharding/AddPrefixedShardingSettingOperation.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Client.ServerWide.Sharding
+{
+    public sealed class AddPrefixedShardingSettingOperation : IMaintenanceOperation
+    {
+        private readonly PrefixedShardingSetting _setting;
+
+        public AddPrefixedShardingSettingOperation(PrefixedShardingSetting setting)
+        {
+            _setting = setting ?? throw new ArgumentNullException(nameof(setting));
+        }
+
+        public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
+        {
+            return new AddPrefixedShardingSettingCommand(conventions, _setting);
+        }
+
+        private sealed class AddPrefixedShardingSettingCommand : PrefixedShardingCommand
+        {
+            protected override PrefixedCommandType CommandType => PrefixedCommandType.Add;
+
+            public AddPrefixedShardingSettingCommand(DocumentConventions conventions, PrefixedShardingSetting setting) : base(conventions, setting)
+            {
+            }
+        }
+    }
+}

--- a/src/Raven.Client/ServerWide/Sharding/DeletePrefixedShardingSettingOperation.cs
+++ b/src/Raven.Client/ServerWide/Sharding/DeletePrefixedShardingSettingOperation.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Client.ServerWide.Sharding
+{
+    public sealed class DeletePrefixedShardingSettingOperation : IMaintenanceOperation
+    {
+        private readonly string _prefix;
+
+        public DeletePrefixedShardingSettingOperation(string prefix)
+        {
+            if (string.IsNullOrEmpty(prefix))
+                throw new ArgumentNullException(nameof(prefix));
+
+            _prefix = prefix;
+        }
+
+        public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
+        {
+            return new DeletePrefixedShardingSettingCommand(conventions, new PrefixedShardingSetting
+            {
+                Prefix = _prefix
+            });
+        }
+
+        private sealed class DeletePrefixedShardingSettingCommand : PrefixedShardingCommand
+        {
+            protected override PrefixedCommandType CommandType => PrefixedCommandType.Delete;
+
+            public DeletePrefixedShardingSettingCommand(DocumentConventions conventions, PrefixedShardingSetting setting) : base(conventions, setting)
+            {
+            }
+        }
+    }
+}

--- a/src/Raven.Client/ServerWide/Sharding/PrefixedShardingCommand.cs
+++ b/src/Raven.Client/ServerWide/Sharding/PrefixedShardingCommand.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Util;
+using Sparrow.Json;
+
+namespace Raven.Client.ServerWide.Sharding
+{
+    internal abstract class PrefixedShardingCommand : RavenCommand, IRaftCommand
+    {
+        private readonly DocumentConventions _conventions;
+        private readonly PrefixedShardingSetting _setting;
+
+        protected abstract PrefixedCommandType CommandType { get; }
+
+        protected PrefixedShardingCommand(DocumentConventions conventions, PrefixedShardingSetting setting)
+        {
+            _conventions = conventions;
+            _setting = setting;
+        }
+
+        public override bool IsReadRequest => false;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/admin/sharding/prefixed";
+
+            return new HttpRequestMessage
+            {
+                Method = CommandType switch
+                {
+                    PrefixedCommandType.Add => HttpMethod.Put,
+                    PrefixedCommandType.Delete => HttpMethod.Delete,
+                    PrefixedCommandType.Update => HttpMethod.Post,
+                    _ => throw new ArgumentOutOfRangeException()
+                },
+                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream,
+                    DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_setting, ctx)).ConfigureAwait(false), _conventions)
+            };
+        }
+
+        public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
+    }
+
+    internal enum PrefixedCommandType
+    {
+        Add = 1,
+        Delete = 2,
+        Update = 3
+    }
+}

--- a/src/Raven.Client/ServerWide/Sharding/PrefixedShardingSetting.cs
+++ b/src/Raven.Client/ServerWide/Sharding/PrefixedShardingSetting.cs
@@ -11,6 +11,15 @@ public sealed class PrefixedShardingSetting
 
     private byte[] _prefixBytesLowerCase;
 
+    public PrefixedShardingSetting()
+    {
+    }
+
+    public PrefixedShardingSetting(string prefix)
+    {
+        Prefix = prefix;
+    }
+
     internal byte[] PrefixBytesLowerCase => _prefixBytesLowerCase ??= Encoding.UTF8.GetBytes(Prefix.ToLower());
 
     public List<int> Shards { get; set; }

--- a/src/Raven.Client/ServerWide/Sharding/ShardingConfiguration.cs
+++ b/src/Raven.Client/ServerWide/Sharding/ShardingConfiguration.cs
@@ -44,4 +44,17 @@ public sealed class ShardingConfiguration
 
         return false;
     }
+
+    internal bool DoesShardHavePrefixes(int shardNumber) => DoesShardHavePrefixes(Prefixed, shardNumber);
+
+    internal static bool DoesShardHavePrefixes(List<PrefixedShardingSetting> prefixes, int shardNumber)
+    {
+        foreach (var setting in prefixes)
+        {
+            if (setting.Shards.Contains(shardNumber))
+                return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Raven.Client/ServerWide/Sharding/UpdatePrefixedShardingSettingOperation.cs
+++ b/src/Raven.Client/ServerWide/Sharding/UpdatePrefixedShardingSettingOperation.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Sparrow.Json;
+
+namespace Raven.Client.ServerWide.Sharding
+{
+    public sealed class UpdatePrefixedShardingSettingOperation : IMaintenanceOperation
+    {
+        private readonly PrefixedShardingSetting _setting;
+
+        public UpdatePrefixedShardingSettingOperation(PrefixedShardingSetting setting)
+        {
+            _setting = setting ?? throw new ArgumentNullException(nameof(setting));
+        }
+
+        public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
+        {
+            return new UpdatePrefixedShardingSettingCommand(conventions, _setting);
+        }
+
+        private sealed class UpdatePrefixedShardingSettingCommand : PrefixedShardingCommand
+        {
+            public UpdatePrefixedShardingSettingCommand(DocumentConventions conventions, PrefixedShardingSetting setting) : base(conventions, setting)
+            {
+            }
+
+            protected override PrefixedCommandType CommandType => PrefixedCommandType.Update;
+
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminShardingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminShardingHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net;
 using System.Threading.Tasks;
-using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Routing;
 using Raven.Server.Utils;
@@ -26,19 +25,19 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/databases/*/admin/sharding/prefixed", "PUT", AuthorizationStatus.DatabaseAdmin)]
         public Task AddPrefixedShardingSetting()
         {
-            throw new NotSupportedInShardingException("This operation is not available from a specific shard");
+            throw new NotSupportedException("This operation is not available from a specific shard");
         }
 
         [RavenAction("/databases/*/admin/sharding/prefixed", "DELETE", AuthorizationStatus.DatabaseAdmin)]
         public Task DeletePrefixedShardingSetting()
         {
-            throw new NotSupportedInShardingException("This operation is not available from a specific shard");
+            throw new NotSupportedException("This operation is not available from a specific shard");
         }
 
         [RavenAction("/databases/*/admin/sharding/prefixed", "POST", AuthorizationStatus.DatabaseAdmin)]
         public Task UpdatePrefixedShardingSetting()
         {
-            throw new NotSupportedInShardingException("This operation is not available from a specific shard");
+            throw new NotSupportedException("This operation is not available from a specific shard");
         }
 
         private void ValidateShardDatabaseName()

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminShardingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminShardingHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Threading.Tasks;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Routing;
 using Raven.Server.Utils;
@@ -20,6 +21,24 @@ namespace Raven.Server.Documents.Handlers.Admin
             await database.DocumentsMigrator.ExecuteMoveDocumentsAsync();
 
             HttpContext.Response.StatusCode = (int)HttpStatusCode.NoContent;
+        }
+
+        [RavenAction("/databases/*/admin/sharding/prefixed", "PUT", AuthorizationStatus.DatabaseAdmin)]
+        public Task AddPrefixedShardingSetting()
+        {
+            throw new NotSupportedInShardingException("This operation is not available from a specific shard");
+        }
+
+        [RavenAction("/databases/*/admin/sharding/prefixed", "DELETE", AuthorizationStatus.DatabaseAdmin)]
+        public Task DeletePrefixedShardingSetting()
+        {
+            throw new NotSupportedInShardingException("This operation is not available from a specific shard");
+        }
+
+        [RavenAction("/databases/*/admin/sharding/prefixed", "POST", AuthorizationStatus.DatabaseAdmin)]
+        public Task UpdatePrefixedShardingSetting()
+        {
+            throw new NotSupportedInShardingException("This operation is not available from a specific shard");
         }
 
         private void ValidateShardDatabaseName()

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/ShardedAdminShardingHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/ShardedAdminShardingHandler.cs
@@ -1,6 +1,22 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Documents.Sharding.Handlers.Processors;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands.Sharding;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.ServerWide.Sharding;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using ShardingConfiguration = Raven.Client.ServerWide.Sharding.ShardingConfiguration;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Admin
 {
@@ -12,6 +28,183 @@ namespace Raven.Server.Documents.Sharding.Handlers.Admin
             using (var processor = new NotSupportedInShardingProcessor(this, $"Database '{DatabaseName}' is a sharded database and does not support documents migration operation. " +
                                                                              "This operation is available only from a specific shard"))
                 await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/sharding/prefixed", "PUT")]
+        public async Task AddPrefixedShardingSetting()
+        {
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                var json = await context.ReadForMemoryAsync(RequestBodyStream(), GetType().Name);
+                var setting = JsonDeserializationCluster.PrefixedShardingSetting(json);
+                var shardingConfiguration = ServerStore.Cluster.ReadShardingConfiguration(DatabaseName);
+
+                ShardingStore.AssertValidPrefix(setting, shardingConfiguration);
+
+                var exists = shardingConfiguration.Prefixed.BinarySearch(setting, PrefixedSettingComparer.Instance) >= 0;
+                if (exists)
+                    throw new InvalidOperationException(
+                        $"Prefix '{setting.Prefix}' already exists in {nameof(ShardingConfiguration)}.{nameof(ShardingConfiguration.Prefixed)}. Please use '{nameof(UpdatePrefixedShardingSettingOperation)}' operation.");
+
+                string[] urls;
+                using (context.OpenReadTransaction())
+                {
+                    var clusterTopology = ServerStore.GetClusterTopology(context);
+                    urls = shardingConfiguration.Orchestrator.Topology.Members.Select(clusterTopology.GetUrlFromTag).ToArray();
+                }
+
+                if (await AssertNoDocumentsStartingWith(context, setting.Prefix, urls) == false)
+                    throw new InvalidOperationException(
+                        $"Cannot add prefix '{setting.Prefix}' to {nameof(ShardingConfiguration)}.{nameof(ShardingConfiguration.Prefixed)}. " +
+                        $"There are existing documents in database '{DatabaseName}' that start with '{setting.Prefix}'. " +
+                        "In order to define sharding by prefix, you cannot have any documents in the database that starts with this prefix.");
+
+                var cmd = new AddPrefixedShardingSettingCommand(setting, DatabaseName, GetRaftRequestIdFromQuery());
+                var (raftIndex, _) = await ServerStore.SendToLeaderAsync(cmd);
+
+                await DatabaseContext.ServerStore.WaitForExecutionOnRelevantNodesAsync(context, shardingConfiguration.Orchestrator.Topology.Members, raftIndex);
+
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.NoContent;
+            }
+        }
+
+        [RavenShardedAction("/databases/*/admin/sharding/prefixed", "DELETE")]
+        public async Task DeletePrefixedShardingSetting()
+        {
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context)) 
+            {
+                var json = await context.ReadForMemoryAsync(RequestBodyStream(), GetType().Name);
+                var setting = JsonDeserializationCluster.PrefixedShardingSetting(json);
+
+                var shardingConfiguration = ServerStore.Cluster.ReadShardingConfiguration(DatabaseName);
+                bool found = shardingConfiguration.Prefixed.BinarySearch(setting, PrefixedSettingComparer.Instance) >= 0; 
+                if (found == false)
+                    throw new InvalidDataException($"Prefix '{setting.Prefix}' wasn't found in sharding configuration");
+
+                string[] urls;
+                using (context.OpenReadTransaction())
+                {
+                    var clusterTopology = ServerStore.GetClusterTopology(context);
+                    urls = shardingConfiguration.Orchestrator.Topology.Members.Select(clusterTopology.GetUrlFromTag).ToArray();
+                }
+
+                if (await AssertNoDocumentsStartingWith(context, setting.Prefix, urls) == false)
+                    throw new InvalidOperationException(
+                        $"Cannot remove prefix '{setting.Prefix}' from {nameof(ShardingConfiguration)}.{nameof(ShardingConfiguration.Prefixed)}. " +
+                        $"There are existing documents in database '{DatabaseName}' that start with '{setting.Prefix}'. " +
+                        "In order to remove a sharding by prefix setting, you cannot have any documents in the database that starts with this prefix.");
+
+                var cmd = new DeletePrefixedShardingSettingCommand(setting, DatabaseName, GetRaftRequestIdFromQuery());
+                var (raftIndex, _) = await ServerStore.SendToLeaderAsync(cmd);
+
+                await DatabaseContext.ServerStore.WaitForExecutionOnRelevantNodesAsync(context, shardingConfiguration.Orchestrator.Topology.Members, raftIndex);
+
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.NoContent;
+            }
+        }
+
+        [RavenShardedAction("/databases/*/admin/sharding/prefixed", "POST")]
+        public async Task UpdatePrefixedShardingSetting()
+        {
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                var json = await context.ReadForMemoryAsync(RequestBodyStream(), GetType().Name);
+                var setting = JsonDeserializationCluster.PrefixedShardingSetting(json);
+
+                var shardingConfiguration = ServerStore.Cluster.ReadShardingConfiguration(DatabaseName);
+
+                var location = shardingConfiguration.Prefixed.BinarySearch(setting, PrefixedSettingComparer.Instance);
+                if (location < 0)
+                    throw new InvalidDataException($"Prefix '{setting.Prefix}' wasn't found in sharding configuration");
+
+                var oldSetting = shardingConfiguration.Prefixed[location];
+                AssertValidShardsDistribution(oldSetting, setting, shardingConfiguration);
+
+                var cmd = new UpdatePrefixedShardingSettingCommand(setting, DatabaseName, GetRaftRequestIdFromQuery());
+                var (raftIndex, _) = await ServerStore.SendToLeaderAsync(cmd);
+
+                await DatabaseContext.ServerStore.WaitForExecutionOnRelevantNodesAsync(context, shardingConfiguration.Orchestrator.Topology.Members, raftIndex);
+
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.NoContent;
+            }
+        }
+
+        private static void AssertValidShardsDistribution(PrefixedShardingSetting oldSetting, PrefixedShardingSetting updatedSetting, ShardingConfiguration configuration)
+        {
+            var removedShards = oldSetting.Shards;
+
+            foreach (var shard in updatedSetting.Shards)
+            {
+                if (oldSetting.Shards.Contains(shard))
+                    removedShards.Remove(shard);
+                else if (configuration.Shards.ContainsKey(shard) == false)
+                    throw new InvalidDataException($"Cannot assign shard number {shard} to prefix {updatedSetting.Prefix}, " +
+                                                   $"there's no shard '{shard}' in sharding topology!");
+            }
+
+            if (removedShards.Count <= 0) 
+                return;
+
+            // check that there are no bucket ranges mapped to these shards
+
+            int index;
+            bool found = false;
+            var prefixBucketRangeStart = oldSetting.BucketRangeStart;
+
+            for (index = 0; index < configuration.BucketRanges.Count; index++)
+            {
+                var range = configuration.BucketRanges[index];
+                if (range.BucketRangeStart < prefixBucketRangeStart)
+                    continue;
+
+                if (range.BucketRangeStart == prefixBucketRangeStart)
+                    found = true;
+
+                break;
+            }
+
+            if (found == false) 
+                return;
+
+            var shards = new List<int>
+            {
+                configuration.BucketRanges[index++].ShardNumber
+            };
+
+            var nextPrefixedRangeStart = prefixBucketRangeStart + ShardHelper.NumberOfBuckets;
+            for (; index < configuration.BucketRanges.Count; index++)
+            {
+                var range = configuration.BucketRanges[index];
+                if (range.BucketRangeStart < nextPrefixedRangeStart)
+                {
+                    shards.Add(range.ShardNumber);
+                    continue;
+                }
+
+                break;
+            }
+
+            foreach (var shard in removedShards)
+            {
+                if (shards.Contains(shard))
+                    throw new InvalidOperationException(
+                        $"Cannot remove shard {shard} from '{updatedSetting.Prefix}' settings in {nameof(ShardingConfiguration)}.{nameof(ShardingConfiguration.Prefixed)}. " +
+                        $"There are bucket ranges mapped to this shard. " +
+                        "In order to remove a shard from a Prefixed setting, first you need to migrate all its buckets to another shard.");
+
+            }
+        }
+
+        private async Task<bool> AssertNoDocumentsStartingWith(JsonOperationContext context, string prefix, string[] urls, string database = null)
+        {
+            using (var requestExecutor = RequestExecutor.CreateForServer(urls, database ?? DatabaseName, ServerStore.Server.Certificate.Certificate, DocumentConventions.DefaultForServer))
+            {
+                var command = new GetDocumentsCommand(requestExecutor.Conventions, startWith: prefix,
+                    startAfter: null, matches: null, exclude: null, start: 0, pageSize: 1, metadataOnly: false);
+
+                await requestExecutor.ExecuteAsync(command, context, sessionInfo: null);
+                return command.Result.Results.Length == 0;
+            }
         }
     }
 }

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -181,9 +181,14 @@ namespace Raven.Server.ServerWide
             [nameof(UpdateQueueSinkCommand)] = 60_000,
             [nameof(RemoveQueueSinkProcessStateCommand)] = 60_000,
             [nameof(UpdateQueueSinkProcessStateCommand)] = 60_000,
-            
+
             [nameof(EditDataArchivalCommand)] = 60_000,
+
             [nameof(UpdateResponsibleNodeForTasksCommand)] = UpdateResponsibleNodeForTasksCommand.CommandVersion,
+            [nameof(AddPrefixedShardingSettingCommand)] = 61_000,
+            [nameof(DeletePrefixedShardingSettingCommand)] = 61_000,
+            [nameof(UpdatePrefixedShardingSettingCommand)] = 61_000
+
         };
 
         public bool CanPutCommand(string command)

--- a/src/Raven.Server/ServerWide/Commands/Sharding/AddPrefixedShardingSettingCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/AddPrefixedShardingSettingCommand.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Server.ServerWide.Sharding;
+using Raven.Server.Utils;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.Sharding
+{
+    public sealed class AddPrefixedShardingSettingCommand : UpdateDatabaseCommand
+    {
+        public PrefixedShardingSetting Setting;
+
+        public AddPrefixedShardingSettingCommand()
+        {
+        }
+
+        public AddPrefixedShardingSettingCommand(PrefixedShardingSetting setting, string database, string raftId) : base(database, raftId)
+        {
+            Setting = setting;
+        }
+
+        public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
+        {
+            record.Sharding.Prefixed ??= new List<PrefixedShardingSetting>();
+            Setting.BucketRangeStart = GetNextPrefixedBucketRangeStart(record.Sharding.Prefixed);
+
+            var rangeStart = Setting.BucketRangeStart;
+            var shards = Setting.Shards;
+            var step = ShardHelper.NumberOfBuckets / shards.Count;
+
+            foreach (var shardNumber in shards.OrderBy(x => x))
+            {
+                record.Sharding.BucketRanges.Add(new ShardBucketRange
+                {
+                    ShardNumber = shardNumber,
+                    BucketRangeStart = rangeStart
+                });
+                rangeStart += step;
+            }
+
+            var index = record.Sharding.Prefixed.BinarySearch(Setting, PrefixedSettingComparer.Instance);
+            record.Sharding.Prefixed.Insert(~index, Setting);
+        }
+
+        private static int GetNextPrefixedBucketRangeStart(IEnumerable<PrefixedShardingSetting> prefixes)
+        {
+            var prefixesByRangeStart = prefixes.OrderBy(x => x.BucketRangeStart).ToList();
+            if (prefixesByRangeStart.Count == 0)
+                return ShardHelper.NumberOfBuckets;
+
+            for (int i = 0; i < prefixesByRangeStart.Count; i++)
+            {
+                var currentRangeStart = prefixesByRangeStart[i].BucketRangeStart;
+                var nextRangeStart = i + 1 < prefixesByRangeStart.Count 
+                    ? prefixesByRangeStart[i + 1].BucketRangeStart 
+                    : int.MaxValue;
+
+                var expectedNext = currentRangeStart + ShardHelper.NumberOfBuckets;
+                if (expectedNext < nextRangeStart)
+                {
+                    // found gap
+                    return expectedNext;
+                }
+            }
+
+            return prefixesByRangeStart[^1].BucketRangeStart + ShardHelper.NumberOfBuckets;
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            json[nameof(Setting)] = Setting.ToJson();
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/Sharding/CreateNewShardCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/CreateNewShardCommand.cs
@@ -34,7 +34,6 @@ namespace Raven.Server.ServerWide.Commands.Sharding
 
             if (record.Sharding.Shards.ContainsKey(ShardNumber))
                 throw new RachisApplyException($"Cannot add new shard {ShardNumber} to the database {DatabaseName} because it already exists.");
-
             record.Sharding.Shards.Add(ShardNumber, Topology);
         }
 

--- a/src/Raven.Server/ServerWide/Commands/Sharding/DeletePrefixedShardingSettingCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/DeletePrefixedShardingSettingCommand.cs
@@ -1,0 +1,59 @@
+﻿using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Sharding;
+using Raven.Server.Utils;  
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.Sharding
+{
+    public sealed class DeletePrefixedShardingSettingCommand : UpdateDatabaseCommand
+    {
+        public PrefixedShardingSetting Setting;
+
+        public DeletePrefixedShardingSettingCommand()
+        {
+        }
+
+        public DeletePrefixedShardingSettingCommand(PrefixedShardingSetting setting, string database, string raftId) : base(database, raftId)
+        {
+            Setting = setting;
+        }
+
+        public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
+        {
+            int prefixIndex = record.Sharding.Prefixed.BinarySearch(Setting, PrefixedSettingComparer.Instance);
+            if (prefixIndex < 0)
+                throw new RachisApplyException($"Prefixed setting '{Setting.Prefix}' was not found in sharding configuration");
+
+            var prefixRangeStart = record.Sharding.Prefixed[prefixIndex].BucketRangeStart;
+            var nextPrefixRangeStart = prefixRangeStart + ShardHelper.NumberOfBuckets;
+
+            record.Sharding.Prefixed.RemoveAt(prefixIndex);
+
+            var numberOfRangesToRemove = 0;
+            var firstRangeIndex = 0;
+            for (int i = 0; i < record.Sharding.BucketRanges.Count; i++)
+            {
+                var range = record.Sharding.BucketRanges[i];
+                if (range.BucketRangeStart < prefixRangeStart)
+                    continue;
+
+                if (range.BucketRangeStart == prefixRangeStart)
+                    firstRangeIndex = i;
+
+                else if (range.BucketRangeStart >= nextPrefixRangeStart)
+                    break;
+
+                numberOfRangesToRemove++;
+            }
+
+            record.Sharding.BucketRanges.RemoveRange(firstRangeIndex, numberOfRangesToRemove);
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            json[nameof(Setting)] = Setting.ToJson();
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
@@ -5,6 +5,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.ServerWide.Sharding;
 using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
@@ -18,6 +19,7 @@ namespace Raven.Server.ServerWide.Commands.Sharding
         public int? SourceShard;
         public int DestinationShard;
         public int Bucket;
+        public string Prefix;
 
         private ShardBucketMigration _migration;
 
@@ -25,13 +27,14 @@ namespace Raven.Server.ServerWide.Commands.Sharding
         {
         }
 
-        public StartBucketMigrationCommand(int bucket, int destShard, string database, string raftId) : base(database, raftId)
+        public StartBucketMigrationCommand(int bucket, int destShard, string database, string prefix, string raftId) : base(database, raftId)
         {
             Bucket = bucket;
             DestinationShard = destShard;
+            Prefix = prefix;
         }
 
-        public StartBucketMigrationCommand(int bucket, int sourceShard, int destShard, string database, string raftId) : this(bucket, destShard, database, raftId)
+        public StartBucketMigrationCommand(int bucket, int sourceShard, int destShard, string database, string raftId) : this(bucket, destShard, database, prefix: null, raftId)
         {
             SourceShard = sourceShard;
         }
@@ -55,8 +58,7 @@ namespace Raven.Server.ServerWide.Commands.Sharding
                 }
             }
 
-            if (record.Sharding.Shards.ContainsKey(DestinationShard) == false)
-                throw new RachisApplyException($"Destination shard {DestinationShard} doesn't exists");
+            AssertDestinationShardExists(record.Sharding);
 
             _migration = new ShardBucketMigration
             {
@@ -114,11 +116,30 @@ namespace Raven.Server.ServerWide.Commands.Sharding
             }
         }
 
+        private void AssertDestinationShardExists(ShardingConfiguration shardingConfiguration)
+        {
+            if (shardingConfiguration.Shards.ContainsKey(DestinationShard) == false)
+                throw new RachisApplyException($"Database '{DatabaseName}' : Failed to start migration of bucket '{Bucket}'. Destination shard {DestinationShard} doesn't exist");
+
+            if (string.IsNullOrEmpty(Prefix)) 
+                return;
+
+            // prefixed bucket range
+            var index = shardingConfiguration.Prefixed.BinarySearch(new PrefixedShardingSetting(Prefix), PrefixedSettingComparer.Instance);
+            if (index < 0)
+                throw new RachisApplyException($"Database '{DatabaseName}' : Failed to start migration of bucket '{Bucket}'. Prefix {Prefix} doesn't exist");
+
+            var shards = shardingConfiguration.Prefixed[index].Shards;
+            if (shards == null || shards.Contains(DestinationShard) == false)
+                throw new RachisApplyException($"Database '{DatabaseName}' : Failed to start migration of bucket '{Bucket}'. Destination shard {DestinationShard} doesn't exist");
+        }
+
         public override void FillJson(DynamicJsonValue json)
         {
             json[nameof(SourceShard)] = SourceShard;
             json[nameof(DestinationShard)] = DestinationShard;
             json[nameof(Bucket)] = Bucket;
+            json[nameof(Prefix)] = Prefix;
         }
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/Sharding/UpdatePrefixedShardingSettingCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/UpdatePrefixedShardingSettingCommand.cs
@@ -1,0 +1,37 @@
+﻿using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Sharding;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands.Sharding
+{
+    public sealed class UpdatePrefixedShardingSettingCommand : UpdateDatabaseCommand
+    {
+        public PrefixedShardingSetting Setting;
+
+        public UpdatePrefixedShardingSettingCommand()
+        {
+        }
+
+        public UpdatePrefixedShardingSettingCommand(PrefixedShardingSetting setting, string database, string raftId) : base(database, raftId)
+        {
+            Setting = setting;
+        }
+
+        public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
+        {
+            var location = record.Sharding.Prefixed.BinarySearch(Setting, PrefixedSettingComparer.Instance);
+            if (location < 0)
+                throw new RachisApplyException($"Prefixed setting '{Setting.Prefix}' was not found in sharding configuration");
+
+            var oldSetting = record.Sharding.Prefixed[location];
+            oldSetting.Shards = Setting.Shards;
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            json[nameof(Setting)] = Setting.ToJson();
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -76,6 +76,8 @@ namespace Raven.Server.ServerWide
 
         public static readonly Func<BlittableJsonReaderObject, ServerWideBackupConfiguration> ServerWideBackupConfiguration = GenerateJsonDeserializationRoutine<ServerWideBackupConfiguration>();
 
+        public static readonly Func<BlittableJsonReaderObject, PrefixedShardingSetting> PrefixedShardingSetting = GenerateJsonDeserializationRoutine<PrefixedShardingSetting>();
+
         public static readonly Func<BlittableJsonReaderObject, ServerWideExternalReplication> ServerWideExternalReplication = GenerateJsonDeserializationRoutine<ServerWideExternalReplication>();
 
         public static readonly Func<BlittableJsonReaderObject, ExternalReplicationState> ExternalReplicationState = GenerateJsonDeserializationRoutine<ExternalReplicationState>();
@@ -285,7 +287,10 @@ namespace Raven.Server.ServerWide
             [nameof(UpdateQueueSinkCommand)] = GenerateJsonDeserializationRoutine<UpdateQueueSinkCommand>(),
             [nameof(UpdateQueueSinkProcessStateCommand)] = GenerateJsonDeserializationRoutine<UpdateQueueSinkProcessStateCommand>(),
             [nameof(RemoveQueueSinkProcessStateCommand)] = GenerateJsonDeserializationRoutine<RemoveQueueSinkProcessStateCommand>(),
-            [nameof(UpdateResponsibleNodeForTasksCommand)] = GenerateJsonDeserializationRoutine<UpdateResponsibleNodeForTasksCommand>()
+            [nameof(UpdateResponsibleNodeForTasksCommand)] = GenerateJsonDeserializationRoutine<UpdateResponsibleNodeForTasksCommand>(),
+            [nameof(AddPrefixedShardingSettingCommand)] = GenerateJsonDeserializationRoutine<AddPrefixedShardingSettingCommand>(),
+            [nameof(DeletePrefixedShardingSettingCommand)] = GenerateJsonDeserializationRoutine<DeletePrefixedShardingSettingCommand>(),
+            [nameof(UpdatePrefixedShardingSettingCommand)] = GenerateJsonDeserializationRoutine<UpdatePrefixedShardingSettingCommand>()
         };
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3010,12 +3010,7 @@ namespace Raven.Server.ServerWide
                         throw new ConcurrencyException($"Database '{databaseName}' already exists!");
                 }
 
-                DatabaseHelper.FillDatabaseTopology(this, context, databaseName, record, replicationFactor, index);
-
-                if (record.IsSharded)
-                {
-                    await Sharding.UpdatePrefixedShardingIfNeeded(context, record);
-                }
+                DatabaseHelper.FillDatabaseTopology(this, context, databaseName, record, replicationFactor, index, isRestore);
             }
 
             var addDatabaseCommand = new AddDatabaseCommand(raftRequestId)

--- a/src/Raven.Server/ServerWide/Sharding/PrefixSettingComparer.cs
+++ b/src/Raven.Server/ServerWide/Sharding/PrefixSettingComparer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Client.ServerWide.Sharding;
+
+namespace Raven.Server.ServerWide.Sharding
+{
+    public class PrefixedSettingComparer : IComparer<PrefixedShardingSetting>
+    {
+        private PrefixedSettingComparer()
+        {
+        }
+
+        public static readonly PrefixedSettingComparer Instance = new();
+
+        public int Compare(PrefixedShardingSetting x, PrefixedShardingSetting y)
+        {
+            // compare prefixes in descending order 
+            return string.Compare(y?.Prefix, x?.Prefix, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+}

--- a/src/Raven.Server/ServerWide/Sharding/RawShardingConfiguration.cs
+++ b/src/Raven.Server/ServerWide/Sharding/RawShardingConfiguration.cs
@@ -230,4 +230,6 @@ public sealed class RawShardingConfiguration
     }
 
     public bool DoesShardHaveBuckets(int shardNumber) => ShardingConfiguration.DoesShardHaveBuckets(BucketRanges, shardNumber);
+
+    public bool DoesShardHavePrefixes(int shardNumber) => ShardingConfiguration.DoesShardHavePrefixes(Prefixed, shardNumber);
 }

--- a/src/Raven.Server/Utils/ShardHelper.cs
+++ b/src/Raven.Server/Utils/ShardHelper.cs
@@ -142,8 +142,6 @@ namespace Raven.Server.Utils
 
         public static int GetShardNumberFor(ShardingConfiguration configuration, int bucket) => FindBucketShard(configuration.BucketRanges, bucket);
 
-        public static int GetShardNumberFor(RawShardingConfiguration configuration, int bucket) => FindBucketShard(configuration.BucketRanges, bucket);
-
         public static int GetShardNumberFor(ShardingConfiguration configuration, ByteStringContext allocator, string id) => GetShardNumberAndBucketFor(configuration, allocator, id).ShardNumber;
 
         public static int GetShardNumberFor(ShardingConfiguration configuration, ByteStringContext allocator, LazyStringValue id) => GetShardNumberAndBucketFor(configuration, allocator, id).ShardNumber;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -626,10 +626,15 @@ namespace Raven.Server.Web.System
                                         throw new InvalidOperationException($"Database '{databaseName}' doesn't reside on node '{node}' so it can't be deleted from it");
                                     }
 
-                                    if (isShard && topology.ReplicationFactor == 1 && rawRecord.Sharding.DoesShardHaveBuckets(shardNumber))
+                                    if (isShard && topology.ReplicationFactor == 1)
                                     {
-                                        throw new InvalidOperationException(
-                                            $"Database {databaseName} cannot be deleted because it is the last copy of shard {shardNumber} and it contains data that has not been migrated.");
+                                        if (rawRecord.Sharding.DoesShardHaveBuckets(shardNumber))
+                                            throw new InvalidOperationException(
+                                                $"Database {databaseName} cannot be deleted because it is the last copy of shard {shardNumber} and it contains data that has not been migrated.");
+                                        if (rawRecord.Sharding.DoesShardHavePrefixes(shardNumber))
+                                            throw new InvalidOperationException(
+                                                $"Database {databaseName} cannot be deleted because it is the last copy of shard {shardNumber} and there are prefixes settings for this shard. " +
+                                                $"In order to delete shard {shardNumber} from database {databaseName} you need to remove shard {shardNumber} from all prefixes settings in DatabaseRecord.Sharding.Prefixed.");
                                     }
 
                                     pendingDeletes.Add(node);

--- a/src/Raven.Server/Web/System/DatabaseHelper.cs
+++ b/src/Raven.Server/Web/System/DatabaseHelper.cs
@@ -127,7 +127,9 @@ namespace Raven.Server.Web.System
                 record.Topology?.ValidateTopology(record.DatabaseName);
             }
         }
-        public static void FillDatabaseTopology(ServerStore server, ClusterOperationContext context, string name, DatabaseRecord record, int replicationFactor, long? index)
+
+        public static void FillDatabaseTopology(ServerStore server, ClusterOperationContext context, string name, DatabaseRecord record, int replicationFactor,
+            long? index, bool isRestore)
         {
             if (replicationFactor <= 0)
                 throw new ArgumentException("Replication factor must be greater than 0.");
@@ -147,10 +149,7 @@ namespace Raven.Server.Web.System
 
             if (record.IsSharded)
             {
-                server.Sharding.FillShardingConfiguration(record, clusterTopology, index);
-
-                if (server.Sharding.BlockPrefixedSharding && record.Sharding.Prefixed is { Count: > 0 })
-                    throw new InvalidOperationException("Cannot use prefixed sharding, this feature is currently blocked");
+                server.Sharding.FillShardingConfiguration(record, clusterTopology, index, isRestore);
 
                 if (string.IsNullOrEmpty(record.Sharding.DatabaseId))
                 {

--- a/src/Raven.Studio/typescript/commands/resources/createDatabaseCommand.ts
+++ b/src/Raven.Studio/typescript/commands/resources/createDatabaseCommand.ts
@@ -10,7 +10,8 @@ export type CreateDatabaseDto = Pick<
         Shards: Record<number, { Members?: string[] }>;
         Orchestrator: {
             Topology: Pick<Raven.Client.ServerWide.DatabaseTopology, "Members">
-        }
+        },
+        Prefixed?: Raven.Client.ServerWide.Sharding.ShardingConfiguration["Prefixed"]
     };
 };
 

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/CreateDatabaseFromBackupStepBasicInfo.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/CreateDatabaseFromBackupStepBasicInfo.tsx
@@ -34,6 +34,7 @@ export default function CreateDatabaseFromBackupStepBasicInfo() {
                         name="basicInfoStep.databaseName"
                         id="DbName"
                         placeholder="Database Name"
+                        autoComplete="off"
                     />
                 </Col>
             </Row>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/CreateDatabaseRegular.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/CreateDatabaseRegular.tsx
@@ -11,6 +11,7 @@ import StepBasicInfo from "./steps/CreateDatabaseRegularStepBasicInfo";
 import StepEncryption from "../../../../../../common/FormEncryption";
 import StepReplicationAndSharding from "./steps/CreateDatabaseRegularStepReplicationAndSharding";
 import StepNodeSelection from "./steps/CreateDatabaseRegularStepNodeSelection";
+import StepShardingPrefixes from "components/pages/resources/databases/partials/create/regular/steps/StepShardingPrefixes";
 import StepPath from "../shared/CreateDatabaseStepDataDirectory";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
@@ -59,6 +60,8 @@ export default function CreateDatabaseRegular({ closeModal, changeCreateModeToBa
                     isSharded: data.replicationAndShardingStep.isSharded,
                     isManualReplication: data.replicationAndShardingStep.isManualReplication,
                     isEncrypted: data.basicInfoStep.isEncrypted,
+                    isPrefixesForShards: data.replicationAndShardingStep.isPrefixesForShards,
+                    usedPrefixes: data.shardingPrefixesStep.prefixesForShards.map((x) => x.prefix),
                 },
                 options
             ),
@@ -232,6 +235,12 @@ function getActiveStepsList(
             isInvalid: !!errors.manualNodeSelectionStep,
         },
         {
+            id: "shardingPrefixesStep",
+            label: "Sharding Prefixes",
+            active: formValues.replicationAndShardingStep.isPrefixesForShards,
+            isInvalid: !!errors.shardingPrefixesStep,
+        },
+        {
             id: "dataDirectoryStep",
             label: "Data Directory",
             active: true,
@@ -269,6 +278,7 @@ function getStepViews(
         ),
         replicationAndShardingStep: <StepReplicationAndSharding />,
         manualNodeSelectionStep: <StepNodeSelection />,
+        shardingPrefixesStep: <StepShardingPrefixes />,
         dataDirectoryStep: (
             <StepPath
                 isBackupFolder={false}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/createDatabaseRegularDataUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/createDatabaseRegularDataUtils.ts
@@ -17,11 +17,20 @@ const getDefaultValues = (allNodeTags: string[]): FormData => {
             shardsCount: 1,
             isDynamicDistribution: false,
             isManualReplication: false,
+            isPrefixesForShards: false,
         },
         manualNodeSelectionStep: {
             // if there is only one node, it should be selected by default
             nodes: allNodeTags.length === 1 ? allNodeTags : [],
             shards: [],
+        },
+        shardingPrefixesStep: {
+            prefixesForShards: [
+                {
+                    prefix: "",
+                    shardNumbers: [],
+                },
+            ],
         },
         dataDirectoryStep: {
             isDefault: true,
@@ -71,6 +80,12 @@ function mapToDto(formValues: FormData, allNodeTags: string[]): CreateDatabaseDt
                       Members: selectedOrchestrators,
                   },
               },
+              Prefixed: formValues.replicationAndShardingStep.isPrefixesForShards
+                  ? formValues.shardingPrefixesStep.prefixesForShards.map((x) => ({
+                        Prefix: x.prefix,
+                        Shards: x.shardNumbers,
+                    }))
+                  : null,
           }
         : null;
 

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepBasicInfo.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepBasicInfo.tsx
@@ -52,6 +52,7 @@ export default function CreateDatabaseRegularStepBasicInfo() {
                         name="basicInfoStep.databaseName"
                         placeholder="Database Name"
                         id="DbName"
+                        autoComplete="off"
                     />
                 </Col>
             </Row>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepReplicationAndSharding.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepReplicationAndSharding.tsx
@@ -101,7 +101,7 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
             </Row>
 
             <Row>
-                <Col lg={{ offset: 2, size: 8 }}>
+                <Col lg={{ offset: 1, size: 10 }}>
                     <Row className="pt-2">
                         <Col sm="6" className="d-flex gap-1 align-items-center">
                             <Icon id="ReplicationInfo" icon="info" color="info" margin="m-0" /> Available nodes:{" "}
@@ -181,7 +181,7 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
                                 />
                             </Collapse>
                         </Col>
-                        <Col sm="auto">
+                        <Col sm="6">
                             <Collapse isOpen={isSharded}>
                                 <InputGroup>
                                     <InputGroupText>Number of shards</InputGroupText>
@@ -194,6 +194,19 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
                                         max="100"
                                     />
                                 </InputGroup>
+                                <FormSwitch
+                                    control={control}
+                                    name="replicationAndShardingStep.isPrefixesForShards"
+                                    color="primary"
+                                    className="mt-3"
+                                >
+                                    Add <strong>prefixes</strong> for shards
+                                    <br />
+                                    <small className="text-muted">
+                                        Manage document distribution by defining
+                                        <br />a prefix for document names
+                                    </small>
+                                </FormSwitch>
                             </Collapse>
                         </Col>
                     </Row>
@@ -224,7 +237,7 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
             </Row>
 
             <Row className="mt-4">
-                <Col>
+                <Col lg={{ offset: 1, size: 5 }}>
                     <ConditionalPopover
                         conditions={{
                             isActive: !hasDynamicNodesDistribution,
@@ -249,7 +262,7 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
                         </FormSwitch>
                     </ConditionalPopover>
                 </Col>
-                <Col>
+                <Col lg={{ size: 5 }}>
                     <ConditionalPopover
                         conditions={[
                             {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/StepShardingPrefixes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/StepShardingPrefixes.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect } from "react";
+import { CreateDatabaseRegularFormData as FormData } from "../createDatabaseRegularValidation";
+import { FieldArrayWithId, useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { Alert, Button, Table, UncontrolledTooltip } from "reactstrap";
+import { Icon } from "components/common/Icon";
+import { FormInput } from "components/common/Form";
+import { Checkbox } from "components/common/Checkbox";
+
+export default function StepShardingPrefixes() {
+    const { control, trigger } = useFormContext<FormData>();
+
+    const {
+        shardingPrefixesStep: { prefixesForShards },
+        replicationAndShardingStep: { shardsCount },
+    } = useWatch({ control });
+
+    const { fields, append, remove, update } = useFieldArray({
+        control,
+        name: "shardingPrefixesStep.prefixesForShards",
+    });
+
+    const toggleShard = (index: number, shardNumber: number) => {
+        const field = prefixesForShards[index];
+
+        const updatedShardNumbers = field.shardNumbers.includes(shardNumber)
+            ? field.shardNumbers.filter((x) => x !== shardNumber)
+            : [...field.shardNumbers, shardNumber];
+
+        update(index, {
+            prefix: field.prefix,
+            shardNumbers: updatedShardNumbers,
+        });
+        trigger(`shardingPrefixesStep.prefixesForShards.${index}.shardNumbers`);
+    };
+
+    const allShardNumbers = [...new Array(shardsCount).keys()];
+
+    return (
+        <div className="text-center">
+            <h2 className="text-center">Sharding Prefixes</h2>
+
+            <Table responsive>
+                <thead>
+                    <tr>
+                        <th></th>
+                        {allShardNumbers.map((shardNumber) => (
+                            <th key={shardNumber} className="px-0">
+                                <Icon icon="shard" color="shard" />
+                                {shardNumber}
+                            </th>
+                        ))}
+                        <th></th>
+                        <th className="px-0"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {fields.map((field, index) => (
+                        <PrefixRow
+                            key={field.id}
+                            field={field}
+                            index={index}
+                            allShardNumbers={allShardNumbers}
+                            toggleShard={toggleShard}
+                            remove={remove}
+                        />
+                    ))}
+                </tbody>
+            </Table>
+
+            <Button
+                type="button"
+                color="shard"
+                outline
+                className="rounded-pill mt-2"
+                onClick={() => append({ prefix: "", shardNumbers: [] })}
+            >
+                <Icon icon="plus" />
+                Add prefix
+            </Button>
+
+            <div className="d-flex justify-content-center mt-3">
+                <Alert color="warning">
+                    Sharding prefixes can be defined only when creating a database, and cannot be modified.
+                    <br />
+                    Make sure everything is set up correctly.
+                </Alert>
+            </div>
+        </div>
+    );
+}
+
+interface PrefixRowProps {
+    index: number;
+    field: FieldArrayWithId<FormData, "shardingPrefixesStep.prefixesForShards", "id">;
+    allShardNumbers: number[];
+    toggleShard: (index: number, shardNumber: number) => void;
+    remove: (index: number) => void;
+}
+
+function PrefixRow({ index, field, allShardNumbers, toggleShard, remove }: PrefixRowProps) {
+    const { control, formState, trigger } = useFormContext<FormData>();
+
+    const {
+        shardingPrefixesStep: { prefixesForShards },
+    } = useWatch({ control });
+
+    const prefix = prefixesForShards[index].prefix;
+
+    // Trigger validation for all fields when prefix changes (check for duplicates)
+    useEffect(() => {
+        if (!prefix) {
+            return;
+        }
+
+        trigger("shardingPrefixesStep.prefixesForShards");
+    }, [prefix, trigger]);
+
+    const shardsError = formState.errors.shardingPrefixesStep?.prefixesForShards?.[index]?.shardNumbers?.message;
+
+    return (
+        <tr>
+            <td>
+                <FormInput
+                    type="text"
+                    control={control}
+                    name={`shardingPrefixesStep.prefixesForShards.${index}.prefix`}
+                    className="form-control"
+                    placeholder="Prefix"
+                    style={{ minWidth: "100px", maxWidth: "300px" }}
+                />
+            </td>
+            {allShardNumbers.map((shardNumber) => (
+                <td key={shardNumber} className="px-0 align-middle">
+                    <Checkbox
+                        size="lg"
+                        selected={field.shardNumbers.includes(shardNumber)}
+                        toggleSelection={() => toggleShard(index, shardNumber)}
+                    />
+                </td>
+            ))}
+            <td className="px-0 align-middle">
+                {index !== 0 && (
+                    <Button type="button" color="danger" outline onClick={() => remove(index)}>
+                        <Icon icon="trash" margin="m-0" />
+                    </Button>
+                )}
+            </td>
+            <td id={"prefixShardsError" + index} className="px-0 align-middle">
+                {shardsError && (
+                    <>
+                        <Icon icon="warning" color="danger" margin="m-0" />
+                        <UncontrolledTooltip target={"prefixShardsError" + index} placement="left">
+                            {shardsError}
+                        </UncontrolledTooltip>
+                    </>
+                )}
+            </td>
+        </tr>
+    );
+}

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -70,7 +70,8 @@ namespace FastTests.Client
                 "AddDatabaseShardCommand", "GetNextServerOperationIdCommand", "KillServerOperationCommand", "ModifyDatabaseTopologyCommand", "DelayBackupCommand",
                 "PutDatabaseClientConfigurationCommand", "PutDatabaseSettingsCommand", "PutDatabaseStudioConfigurationCommand", "GetTcpInfoForReplicationCommand",
                 "AddQueueSinkCommand", "UpdateQueueSinkCommand", "ConfigureDataArchivalCommand",
-                "AdoptOrphanedRevisionsCommand"
+                "AdoptOrphanedRevisionsCommand",
+                "AddPrefixedShardingSettingCommand", "DeletePrefixedShardingSettingCommand", "UpdatePrefixedShardingSettingCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
+++ b/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
@@ -76,7 +76,6 @@ namespace SlowTests.Sharding.BucketMigration
         [RavenFact(RavenTestCategory.Sharding)]
         public async Task DocumentsMigratorShouldWork_MultipleWrongBuckets()
         {
-            Server.ServerStore.Sharding.BlockPrefixedSharding = false;
             using var store = Sharding.GetDocumentStore(new Options
             {
                 ModifyDatabaseRecord = record =>

--- a/test/SlowTests/Sharding/PrefixedSharding.cs
+++ b/test/SlowTests/Sharding/PrefixedSharding.cs
@@ -4,13 +4,16 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Sharding;
+using Raven.Client.Util;
+using Raven.Server.Documents;
 using Raven.Server.Documents.Sharding;
+using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
@@ -21,16 +24,14 @@ using Tests.Infrastructure.Entities;
 using Voron;
 using Xunit;
 using Xunit.Abstractions;
+using BucketStats = Raven.Server.Documents.Sharding.BucketStats;
 
 namespace SlowTests.Sharding;
 
-public class PrefixedSharding : RavenTestBase
+public class PrefixedSharding : ClusterTestBase
 {
     public PrefixedSharding(ITestOutputHelper output) : base(output)
     {
-        DoNotReuseServer();
-
-        Server.ServerStore.Sharding.BlockPrefixedSharding = false;
     }
 
     [RavenFact(RavenTestCategory.Sharding)]
@@ -41,24 +42,24 @@ public class PrefixedSharding : RavenTestBase
             ModifyDatabaseRecord = record =>
             {
                 record.Sharding ??= new ShardingConfiguration();
-                record.Sharding.Prefixed = new List<PrefixedShardingSetting>
-                {
+                record.Sharding.Prefixed =
+                [
                     new PrefixedShardingSetting
                     {
                         // range for 'eu/' is : 
                         // shard 0 : [1M, 2M]
-                        Prefix = "eu/",
-                        Shards = new List<int> { 0 }
+                        Prefix = "eu/", 
+                        Shards = [0]
                     },
                     new PrefixedShardingSetting
                     {
                         // range for 'asia/' is :
                         // shard 1 : [2M, 2.5M]
                         // shard 2 : [2.5M, 3M]
-                        Prefix = "asia/",
-                        Shards = new List<int> { 1, 2 }
+                        Prefix = "asia/", 
+                        Shards = [1, 2]
                     }
-                };
+                ];
             }
         });
 
@@ -101,7 +102,7 @@ public class PrefixedSharding : RavenTestBase
             }
         }
 
-        var rand = new System.Random(2022_04_19);
+        var rand = new Random(2022_04_19);
         var prefixes = new[] { "us/", "eu/", "asia/", null };
 
         int d = 0;
@@ -152,21 +153,55 @@ public class PrefixedSharding : RavenTestBase
     {
         using var store = Sharding.GetDocumentStore();
 
-        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-        var shardingConfiguration = record.Sharding;
-
-        shardingConfiguration.Prefixed ??= new List<PrefixedShardingSetting>();
-        shardingConfiguration.Prefixed.Add(new PrefixedShardingSetting
+        var task = store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
         {
             Prefix = "asia",
-            Shards = new List<int> { 1, 2 }
-        });
+            Shards = [1, 2]
+        }));
 
-        var task = store.Maintenance.Server.SendAsync(new UpdateDatabaseOperation(record, replicationFactor: 1, record.Etag));
         var e = await Assert.ThrowsAsync<RavenException>(async () => await task);
         Assert.Contains(
             "Cannot add prefix 'asia' to ShardingConfiguration.Prefixed. In order to define sharding by prefix, the prefix string must end with '/' or '-' characters",
             e.Message);
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task ShouldThrowOnPrefixSettingWithNoShards()
+    {
+        using var store = Sharding.GetDocumentStore();
+
+        await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/",
+            Shards = []
+        })));
+
+        await store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/",
+            Shards = [0]
+        }));
+          
+        Assert.Throws<RavenException>(() =>
+        {
+            using var newStore = Sharding.GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Sharding ??= new ShardingConfiguration();
+                    record.Sharding.Prefixed =
+                    [
+                        new PrefixedShardingSetting
+                        {
+                            Prefix = "users/",
+                            Shards = []
+                        }
+                    ];
+                }
+            });
+        });
+          
+
     }
 
     [RavenFact(RavenTestCategory.Sharding)]
@@ -177,14 +212,14 @@ public class PrefixedSharding : RavenTestBase
             ModifyDatabaseRecord = record =>
             {
                 record.Sharding ??= new ShardingConfiguration();
-                record.Sharding.Prefixed = new List<PrefixedShardingSetting>
-                {
+                record.Sharding.Prefixed =
+                [
                     new PrefixedShardingSetting
                     {
-                        Prefix = "eu/",
-                        Shards = new List<int> { 0 }
+                        Prefix = "eu/", 
+                        Shards = [0]
                     }
-                };
+                ];
             }
         });
 
@@ -199,16 +234,12 @@ public class PrefixedSharding : RavenTestBase
             await session.SaveChangesAsync();
         }
 
-        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-        var shardingConfiguration = record.Sharding;
-
-        shardingConfiguration.Prefixed.Add(new PrefixedShardingSetting
+        var task = store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
         {
             Prefix = "asia/",
-            Shards = new List<int> { 1, 2 }
-        });
+            Shards = [1, 2]
+        }));
 
-        var task = store.Maintenance.Server.SendAsync(new UpdateDatabaseOperation(record, replicationFactor: 1, record.Etag));
         var e = await Assert.ThrowsAsync<RavenException>(async () => await task);
         Assert.Contains(
             $"Cannot add prefix 'asia/' to ShardingConfiguration.Prefixed. There are existing documents in database '{store.Database}' that start with 'asia/'",
@@ -223,19 +254,19 @@ public class PrefixedSharding : RavenTestBase
             ModifyDatabaseRecord = record =>
             {
                 record.Sharding ??= new ShardingConfiguration();
-                record.Sharding.Prefixed = new List<PrefixedShardingSetting>
-                {
+                record.Sharding.Prefixed =
+                [
                     new PrefixedShardingSetting
                     {
-                        Prefix = "asia/",
-                        Shards = new List<int> { 0 }
+                        Prefix = "asia/", 
+                        Shards = [0]
                     },
                     new PrefixedShardingSetting
                     {
-                        Prefix = "eu/",
-                        Shards = new List<int> { 1, 2 }
+                        Prefix = "eu/", 
+                        Shards = [1, 2]
                     }
-                };
+                ];
             }
         });
 
@@ -250,12 +281,7 @@ public class PrefixedSharding : RavenTestBase
             await session.SaveChangesAsync();
         }
 
-        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-        var shardingConfiguration = record.Sharding;
-
-        shardingConfiguration.Prefixed.RemoveAt(0);
-
-        var task = store.Maintenance.Server.SendAsync(new UpdateDatabaseOperation(record, replicationFactor: 1, record.Etag));
+        var task = store.Maintenance.SendAsync(new DeletePrefixedShardingSettingOperation("asia/"));
         var e = await Assert.ThrowsAsync<RavenException>(async () => await task);
         Assert.Contains(
             $"Cannot remove prefix 'asia/' from ShardingConfiguration.Prefixed. There are existing documents in database '{store.Database}' that start with 'asia/'",
@@ -270,14 +296,14 @@ public class PrefixedSharding : RavenTestBase
             ModifyDatabaseRecord = record =>
             {
                 record.Sharding ??= new ShardingConfiguration();
-                record.Sharding.Prefixed = new List<PrefixedShardingSetting>
-                {
+                record.Sharding.Prefixed =
+                [
                     new PrefixedShardingSetting
                     {
-                        Prefix = "eu/",
-                        Shards = new List<int> { 0 }
+                        Prefix = "eu/", 
+                        Shards = [0]
                     }
-                };
+                ];
             }
         });
 
@@ -294,22 +320,31 @@ public class PrefixedSharding : RavenTestBase
 
         var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
         var shardingConfiguration = record.Sharding;
-
-        shardingConfiguration.Prefixed.Add(new PrefixedShardingSetting
-        {
-            Prefix = "asia/",
-            Shards = new List<int> { 1, 2 }
-        });
-
         Assert.Equal(4, shardingConfiguration.BucketRanges.Count);
 
-        await store.Maintenance.Server.SendAsync(new UpdateDatabaseOperation(record, replicationFactor: 1, record.Etag));
+        await store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "asia/",
+            Shards = [1, 2]
+        }));
 
         shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
 
         Assert.Equal(2, shardingConfiguration.Prefixed.Count);
         Assert.Equal(ShardHelper.NumberOfBuckets * 2, shardingConfiguration.Prefixed[1].BucketRangeStart);
         Assert.Equal(6, shardingConfiguration.BucketRanges.Count);
+
+        // check that we can add prefixes even if none were defined in database creation 
+        var newStore = Sharding.GetDocumentStore();
+        await newStore.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/",
+            Shards = [0, 2]
+        }));
+
+        shardingConfiguration = await Sharding.GetShardingConfigurationAsync(newStore);
+        Assert.Equal(1, shardingConfiguration.Prefixed.Count);
+
     }
 
     [RavenFact(RavenTestCategory.Sharding)]
@@ -320,14 +355,14 @@ public class PrefixedSharding : RavenTestBase
             ModifyDatabaseRecord = record =>
             {
                 record.Sharding ??= new ShardingConfiguration();
-                record.Sharding.Prefixed = new List<PrefixedShardingSetting>
-                {
+                record.Sharding.Prefixed =
+                [
                     new PrefixedShardingSetting
                     {
-                        Prefix = "eu/",
-                        Shards = new List<int> { 0, 1 }
+                        Prefix = "eu/", 
+                        Shards = [0, 1]
                     }
-                };
+                ];
             }
         });
 
@@ -344,12 +379,9 @@ public class PrefixedSharding : RavenTestBase
 
         var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
         var shardingConfiguration = record.Sharding;
-
-        shardingConfiguration.Prefixed.RemoveAt(0);
-
         Assert.Equal(5, shardingConfiguration.BucketRanges.Count);
 
-        await store.Maintenance.Server.SendAsync(new UpdateDatabaseOperation(record, replicationFactor: 1, record.Etag));
+        await store.Maintenance.SendAsync(new DeletePrefixedShardingSettingOperation("eu/"));
 
         shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
 
@@ -365,19 +397,19 @@ public class PrefixedSharding : RavenTestBase
             ModifyDatabaseRecord = record =>
             {
                 record.Sharding ??= new ShardingConfiguration();
-                record.Sharding.Prefixed = new List<PrefixedShardingSetting>
-                {
+                record.Sharding.Prefixed =
+                [
                     new PrefixedShardingSetting
                     {
-                        Prefix = "eu/",
-                        Shards = new List<int> { 0, 1 }
+                        Prefix = "eu/", 
+                        Shards = [0, 1]
                     },
                     new PrefixedShardingSetting
                     {
-                        Prefix = "us/",
-                        Shards = new List<int> { 1, 2 }
+                        Prefix = "us/", 
+                        Shards = [1, 2]
                     }
-                };
+                ];
             }
         });
 
@@ -391,316 +423,230 @@ public class PrefixedSharding : RavenTestBase
 
             await session.SaveChangesAsync();
         }
-
+        
         var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
         var shardingConfiguration = record.Sharding;
         Assert.Equal(7, shardingConfiguration.BucketRanges.Count);
 
         // remove 'eu/' prefix
-        shardingConfiguration.Prefixed.RemoveAt(0);
-        await store.Maintenance.Server.SendAsync(new UpdateDatabaseOperation(record, replicationFactor: 1, record.Etag));
+        await store.Maintenance.SendAsync(new DeletePrefixedShardingSettingOperation("eu/"));
 
         shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
         Assert.Equal(1, shardingConfiguration.Prefixed.Count);
         Assert.Equal(5, shardingConfiguration.BucketRanges.Count);
 
         // add a new prefix
-        record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-        shardingConfiguration = record.Sharding;
-        shardingConfiguration.Prefixed.Add(new PrefixedShardingSetting
+        await store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
         {
             Prefix = "africa/",
-            Shards = new List<int> { 0, 2 }
-        });
+            Shards = [0, 2]
+        }));
 
-        await store.Maintenance.Server.SendAsync(new UpdateDatabaseOperation(record, replicationFactor: 1, record.Etag));
         shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
         Assert.Equal(2, shardingConfiguration.Prefixed.Count);
         Assert.Equal(7, shardingConfiguration.BucketRanges.Count);
 
-        Assert.Equal(ShardHelper.NumberOfBuckets * 2, shardingConfiguration.BucketRanges[3].BucketRangeStart);
-        Assert.Equal(ShardHelper.NumberOfBuckets * 2.5, shardingConfiguration.BucketRanges[4].BucketRangeStart);
-        Assert.Equal(ShardHelper.NumberOfBuckets * 3, shardingConfiguration.BucketRanges[5].BucketRangeStart);
-        Assert.Equal(ShardHelper.NumberOfBuckets * 3.5, shardingConfiguration.BucketRanges[6].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets, shardingConfiguration.BucketRanges[3].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 1.5, shardingConfiguration.BucketRanges[4].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 2, shardingConfiguration.BucketRanges[5].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 2.5, shardingConfiguration.BucketRanges[6].BucketRangeStart);
     }
 
     [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding)]
     public async Task BackupAndRestoreShardedDatabase_ShouldPreservePrefixedSettingsAndBucketRanges()
     {
-        using (var store = Sharding.GetDocumentStore())
+        using var store = Sharding.GetDocumentStore(new Options
         {
-            var databaseRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-            databaseRecord.Sharding.Prefixed ??= new List<PrefixedShardingSetting>();
-            databaseRecord.Sharding.Prefixed.Add(new PrefixedShardingSetting
+            ModifyDatabaseRecord = databaseRecord =>
             {
-                Prefix = "users/",
-                Shards = new List<int> { 0 }
-            });
-            databaseRecord.Sharding.Prefixed.Add(new PrefixedShardingSetting
+                databaseRecord.Sharding ??= new ShardingConfiguration();
+                databaseRecord.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/", 
+                        Shards = [0]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "orders/", 
+                        Shards = [1]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "employees/", 
+                        Shards = [2]
+                    }
+                ];
+            }
+        });
+
+        var sharding = await Sharding.GetShardingConfigurationAsync(store);
+
+        Assert.Equal(6, sharding.BucketRanges.Count);
+        Assert.Equal(ShardHelper.NumberOfBuckets, sharding.BucketRanges[3].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 2, sharding.BucketRanges[4].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 3, sharding.BucketRanges[5].BucketRangeStart);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
             {
-                Prefix = "orders/",
-                Shards = new List<int> { 1 }
-            });
-            databaseRecord.Sharding.Prefixed.Add(new PrefixedShardingSetting
+                await session.StoreAsync(new User(), $"users/{i}");
+                await session.StoreAsync(new Order(), $"orders/{i}");
+                await session.StoreAsync(new Employee(), $"employees/{i}");
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            for (int i = 0; i < 10; i++)
             {
-                Prefix = "employees/",
-                Shards = new List<int> { 2 }
-            });
+                var doc = await session.LoadAsync<User>($"users/{i}");
+                Assert.NotNull(doc);
+            }
+        }
 
-            await store.Maintenance.Server.SendAsync(new UpdateDatabaseOperation(databaseRecord, replicationFactor: 1, databaseRecord.Etag));
-            var sharding = await Sharding.GetShardingConfigurationAsync(store);
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var doc = await session.LoadAsync<Order>($"orders/{i}");
+                Assert.NotNull(doc);
+            }
+        }
 
-            Assert.Equal(6, sharding.BucketRanges.Count);
-            Assert.Equal(ShardHelper.NumberOfBuckets, sharding.BucketRanges[3].BucketRangeStart);
-            Assert.Equal(ShardHelper.NumberOfBuckets * 2, sharding.BucketRanges[4].BucketRangeStart);
-            Assert.Equal(ShardHelper.NumberOfBuckets * 3, sharding.BucketRanges[5].BucketRangeStart);
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var doc = await session.LoadAsync<Employee>($"employees/{i}");
+                Assert.NotNull(doc);
+            }
+        }
 
-            using (var session = store.OpenAsyncSession())
+        var bucketStats = new Dictionary<int, List<BucketStats>>();
+        await foreach (var db in Sharding.GetShardsDocumentDatabaseInstancesFor(store))
+        {
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var stats = ShardedDocumentsStorage.GetBucketStatistics(ctx, 0, int.MaxValue).ToList();
+                Assert.Equal(10, stats.Count);
+                bucketStats[db.ShardNumber] = stats;
+            }
+        }
+
+        var waitHandles = await Sharding.Backup.WaitForBackupToComplete(store);
+        var backupPath = NewDataPath(suffix: "BackupFolder");
+        var config = Backup.CreateBackupConfiguration(backupPath);
+
+        await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store, config);
+        Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+
+        var dirs = Directory.GetDirectories(backupPath);
+        Assert.Equal(3, dirs.Length);
+
+        sharding = await Sharding.GetShardingConfigurationAsync(store);
+        var settings = Sharding.Backup.GenerateShardRestoreSettings(dirs, sharding);
+
+        // restore the database with a different name
+        var restoredDatabaseName = $"restored_database-{Guid.NewGuid()}";
+        using (Sharding.Backup.ReadOnly(backupPath))
+        using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration 
+        {
+            DatabaseName = restoredDatabaseName,
+            ShardRestoreSettings = settings
+        }, timeout: TimeSpan.FromSeconds(60)))
+        {
+            var newDatabaseRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(restoredDatabaseName));
+            Assert.Equal(3, newDatabaseRecord.Sharding.Shards.Count);
+            Assert.Equal(3, newDatabaseRecord.Sharding.Prefixed.Count);
+
+            var usersPrefixSetting = newDatabaseRecord.Sharding.Prefixed[0];
+            Assert.Equal("users/", usersPrefixSetting.Prefix);
+            Assert.Equal(1, usersPrefixSetting.Shards.Count);
+            Assert.Equal(0, usersPrefixSetting.Shards[0]);
+            Assert.Equal(ShardHelper.NumberOfBuckets, usersPrefixSetting.BucketRangeStart);
+
+            var ordersPrefixSetting = newDatabaseRecord.Sharding.Prefixed[1];
+            Assert.Equal("orders/", ordersPrefixSetting.Prefix);
+            Assert.Equal(1, ordersPrefixSetting.Shards.Count);
+            Assert.Equal(1, ordersPrefixSetting.Shards[0]);
+            Assert.Equal(ShardHelper.NumberOfBuckets * 2, ordersPrefixSetting.BucketRangeStart);
+
+            var employeesPrefixSetting = newDatabaseRecord.Sharding.Prefixed[2];
+            Assert.Equal("employees/", employeesPrefixSetting.Prefix);
+            Assert.Equal(1, employeesPrefixSetting.Shards.Count);
+            Assert.Equal(2, employeesPrefixSetting.Shards[0]);
+            Assert.Equal(ShardHelper.NumberOfBuckets * 3, employeesPrefixSetting.BucketRangeStart);
+
+            Assert.Equal(6, newDatabaseRecord.Sharding.BucketRanges.Count);
+            Assert.Equal(ShardHelper.NumberOfBuckets, newDatabaseRecord.Sharding.BucketRanges[3].BucketRangeStart);
+            Assert.Equal(ShardHelper.NumberOfBuckets * 2, newDatabaseRecord.Sharding.BucketRanges[4].BucketRangeStart);
+            Assert.Equal(ShardHelper.NumberOfBuckets * 3, newDatabaseRecord.Sharding.BucketRanges[5].BucketRangeStart);
+
+            using (var session = store.OpenAsyncSession(database: restoredDatabaseName))
             {
                 for (int i = 0; i < 10; i++)
                 {
-                    await session.StoreAsync(new User(), $"users/{i}");
-                    await session.StoreAsync(new Order(), $"orders/{i}");
-                    await session.StoreAsync(new Employee(), $"employees/{i}");
-                }
+                    var user = await session.LoadAsync<User>($"users/{i}");
+                    Assert.NotNull(user);
 
-                await session.SaveChangesAsync();
-            }
+                    var order = await session.LoadAsync<Order>($"orders/{i}");
+                    Assert.NotNull(order);
 
-            using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
-            {
-                for (int i = 0; i < 10; i++)
-                {
-                    var doc = await session.LoadAsync<User>($"users/{i}");
-                    Assert.NotNull(doc);
-                }
-            }
-            using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
-            {
-                for (int i = 0; i < 10; i++)
-                {
-                    var doc = await session.LoadAsync<Order>($"orders/{i}");
-                    Assert.NotNull(doc);
-                }
-            }
-            using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
-            {
-                for (int i = 0; i < 10; i++)
-                {
-                    var doc = await session.LoadAsync<Employee>($"employees/{i}");
-                    Assert.NotNull(doc);
+                    var employee = await session.LoadAsync<Employee>($"employees/{i}");
+                    Assert.NotNull(employee);
                 }
             }
 
-            var bucketStats = new Dictionary<int, List<BucketStats>>();
-            await foreach (var db in Sharding.GetShardsDocumentDatabaseInstancesFor(store))
+            // assert valid bucket stats
+            await foreach (var db in Sharding.GetShardsDocumentDatabaseInstancesFor(restoredDatabaseName))
             {
                 using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
                 using (ctx.OpenReadTransaction())
                 {
                     var stats = ShardedDocumentsStorage.GetBucketStatistics(ctx, 0, int.MaxValue).ToList();
-                    Assert.Equal(10, stats.Count);
-                    bucketStats[db.ShardNumber] = stats;
-                }
-            }
+                    var originalStats = bucketStats[db.ShardNumber];
 
-            var waitHandles = await Sharding.Backup.WaitForBackupToComplete(store);
-            var backupPath = NewDataPath(suffix: "BackupFolder");
-            var config = Backup.CreateBackupConfiguration(backupPath);
-
-            await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store, config);
-            Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
-
-            var dirs = Directory.GetDirectories(backupPath);
-            Assert.Equal(3, dirs.Length);
-
-            sharding = await Sharding.GetShardingConfigurationAsync(store);
-            var settings = Sharding.Backup.GenerateShardRestoreSettings(dirs, sharding);
-
-            // restore the database with a different name
-            var restoredDatabaseName = $"restored_database-{Guid.NewGuid()}";
-            using (Sharding.Backup.ReadOnly(backupPath))
-            using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
-            {
-                DatabaseName = restoredDatabaseName,
-                ShardRestoreSettings = settings
-
-            }, timeout: TimeSpan.FromSeconds(60)))
-            {
-                var newDatabaseRecord = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(restoredDatabaseName));
-                Assert.Equal(3, newDatabaseRecord.Sharding.Shards.Count);
-                Assert.Equal(3, newDatabaseRecord.Sharding.Prefixed.Count);
-
-                var usersPrefixSetting = newDatabaseRecord.Sharding.Prefixed[0];
-                Assert.Equal("users/", usersPrefixSetting.Prefix);
-                Assert.Equal(1, usersPrefixSetting.Shards.Count);
-                Assert.Equal(0, usersPrefixSetting.Shards[0]);
-                Assert.Equal(ShardHelper.NumberOfBuckets, usersPrefixSetting.BucketRangeStart);
-
-                var ordersPrefixSetting = newDatabaseRecord.Sharding.Prefixed[1];
-                Assert.Equal("orders/", ordersPrefixSetting.Prefix);
-                Assert.Equal(1, ordersPrefixSetting.Shards.Count);
-                Assert.Equal(1, ordersPrefixSetting.Shards[0]);
-                Assert.Equal(ShardHelper.NumberOfBuckets * 2, ordersPrefixSetting.BucketRangeStart);
-
-                var employeesPrefixSetting = newDatabaseRecord.Sharding.Prefixed[2];
-                Assert.Equal("employees/", employeesPrefixSetting.Prefix);
-                Assert.Equal(1, employeesPrefixSetting.Shards.Count);
-                Assert.Equal(2, employeesPrefixSetting.Shards[0]);
-                Assert.Equal(ShardHelper.NumberOfBuckets * 3, employeesPrefixSetting.BucketRangeStart);
-
-                Assert.Equal(6, sharding.BucketRanges.Count);
-                Assert.Equal(ShardHelper.NumberOfBuckets, sharding.BucketRanges[3].BucketRangeStart);
-                Assert.Equal(ShardHelper.NumberOfBuckets * 2, sharding.BucketRanges[4].BucketRangeStart);
-                Assert.Equal(ShardHelper.NumberOfBuckets * 3, sharding.BucketRanges[5].BucketRangeStart);
-
-                using (var session = store.OpenAsyncSession(database: restoredDatabaseName))
-                {
-                    for (int i = 0; i < 10; i++)
+                    Assert.Equal(originalStats.Count, stats.Count);
+                    for (int i = 0; i < stats.Count; i++)
                     {
-                        var user = await session.LoadAsync<User>($"users/{i}");
-                        Assert.NotNull(user);
-
-                        var order = await session.LoadAsync<Order>($"orders/{i}");
-                        Assert.NotNull(order);
-
-                        var employee = await session.LoadAsync<Employee>($"employees/{i}");
-                        Assert.NotNull(employee);
+                        Assert.Equal(originalStats[i].Bucket, stats[i].Bucket);
+                        Assert.Equal(originalStats[i].NumberOfDocuments, stats[i].NumberOfDocuments);
                     }
                 }
-
-                // assert valid bucket stats
-                await foreach (var db in Sharding.GetShardsDocumentDatabaseInstancesFor(restoredDatabaseName))
-                {
-                    using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
-                    using (ctx.OpenReadTransaction())
-                    {
-                        var stats = ShardedDocumentsStorage.GetBucketStatistics(ctx, 0, int.MaxValue).ToList();
-                        var originalStats = bucketStats[db.ShardNumber];
-
-                        Assert.Equal(originalStats.Count, stats.Count);
-                        for (int i = 0; i < stats.Count; i++)
-                        {
-                            Assert.Equal(originalStats[i].Bucket, stats[i].Bucket);
-                            Assert.Equal(originalStats[i].NumberOfDocuments, stats[i].NumberOfDocuments);
-                        }
-                    }
-                }
-
-                using (var session = store.OpenAsyncSession(database: restoredDatabaseName))
-                {
-                    await session.StoreAsync(new User(), "users/11");
-                    await session.StoreAsync(new Order(), "orders/11");
-                    await session.StoreAsync(new Employee(), "employees/11");
-
-                    await session.SaveChangesAsync();
-                }
-
-                using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(restoredDatabaseName, 0)))
-                {
-                    var user = await session.LoadAsync<User>("users/11");
-                    Assert.NotNull(user);
-                }
-
-                using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(restoredDatabaseName, 1)))
-                {
-                    var order = await session.LoadAsync<Order>("orders/11");
-                    Assert.NotNull(order);
-                }
-
-                using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(restoredDatabaseName, 2)))
-                {
-                    var employee = await session.LoadAsync<Employee>("employees/11");
-                    Assert.NotNull(employee);
-                }
             }
-        }
-    }
 
-    [RavenFact(RavenTestCategory.Sharding)]
-    public async Task CanMoveOneBucketFromPrefixedRange()
-    {
-        using var store = Sharding.GetDocumentStore(new Options
-        {
-            ModifyDatabaseRecord = record =>
+            using (var session = store.OpenAsyncSession(database: restoredDatabaseName))
             {
-                record.Sharding ??= new ShardingConfiguration();
-                record.Sharding.Prefixed = new List<PrefixedShardingSetting>
-                    {
-                        new PrefixedShardingSetting
-                        {
-                            // bucket range for 'users/' is : 
-                            // shard 0 : [1M, 1.5M]
-                            // shard 1 : [1.5M, 2M]
-                            Prefix = "users/",
-                            Shards = new List<int> { 0, 1 }
-                        }
-                    };
+                await session.StoreAsync(new User(), "users/11");
+                await session.StoreAsync(new Order(), "orders/11");
+                await session.StoreAsync(new Employee(), "employees/11");
+
+                await session.SaveChangesAsync();
             }
-        });
 
-        const string id = "users/1";
-        using (var session = store.OpenAsyncSession())
-        {
-            var user = new User
+            using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(restoredDatabaseName, 0)))
             {
-                Name = "Original shard"
-            };
-            await session.StoreAsync(user, id);
-            await session.SaveChangesAsync();
-        }
+                var user = await session.LoadAsync<User>("users/11");
+                Assert.NotNull(user);
+            }
 
-        var shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+            using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(restoredDatabaseName, 1)))
+            {
+                var order = await session.LoadAsync<Order>("orders/11");
+                Assert.NotNull(order);
+            }
 
-        Assert.Equal(5, shardingConfiguration.BucketRanges.Count);
-        Assert.Equal(ShardHelper.NumberOfBuckets, shardingConfiguration.Prefixed[0].BucketRangeStart);
-
-        var bucket = await Sharding.GetBucketAsync(store, id);
-
-        var originalLocation = ShardHelper.GetShardNumberFor(shardingConfiguration, bucket);
-        Assert.Contains(originalLocation, shardingConfiguration.Prefixed[0].Shards);
-        var newLocation = shardingConfiguration.Prefixed[0].Shards.Single(s => s != originalLocation);
-
-        await Sharding.Resharding.MoveShardForId(store, id);
-
-        shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
-        Assert.Equal(7, shardingConfiguration.BucketRanges.Count);
-
-        Assert.Equal(bucket, shardingConfiguration.BucketRanges[^2].BucketRangeStart);
-        Assert.Equal(newLocation, shardingConfiguration.BucketRanges[^2].ShardNumber);
-
-        Assert.Equal(bucket + 1, shardingConfiguration.BucketRanges[^1].BucketRangeStart);
-        Assert.Equal(originalLocation, shardingConfiguration.BucketRanges[^1].ShardNumber);
-
-        using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, originalLocation)))
-        {
-            var user = await session.LoadAsync<User>(id);
-            Assert.Null(user);
-        }
-        using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, newLocation)))
-        {
-            var user = await session.LoadAsync<User>(id);
-            Assert.Equal("Original shard", user.Name);
-        }
-
-        // the document will be written to the new location
-        using (var session = store.OpenAsyncSession())
-        {
-            var user = await session.LoadAsync<User>(id);
-            user.Name = "New shard";
-            await session.SaveChangesAsync();
-        }
-
-        using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, originalLocation)))
-        {
-            var user = await session.LoadAsync<User>(id);
-            Assert.Null(user);
-        }
-
-        using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, newLocation)))
-        {
-            var user = await session.LoadAsync<User>(id);
-            Assert.Equal("New shard", user.Name);
+            using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(restoredDatabaseName, 2)))
+            {
+                var employee = await session.LoadAsync<Employee>("employees/11");
+                Assert.NotNull(employee);
+            }
         }
     }
 
@@ -712,19 +658,19 @@ public class PrefixedSharding : RavenTestBase
             ModifyDatabaseRecord = record =>
             {
                 record.Sharding ??= new ShardingConfiguration();
-                record.Sharding.Prefixed = new List<PrefixedShardingSetting>
-                   {
-                       new PrefixedShardingSetting()
-                       {
-                           Prefix = "Users/",
-                           Shards = new List<int> { 0 }
-                       },
-                       new PrefixedShardingSetting()
-                       {
-                           Prefix = "Orders/",
-                           Shards = new List<int> { 1 }
-                       }
-                   };
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "Users/", 
+                        Shards = [0]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "Orders/", 
+                        Shards = [1]
+                    }
+                ];
             }
         }))
         {
@@ -798,24 +744,25 @@ public class PrefixedSharding : RavenTestBase
             ModifyDatabaseRecord = record =>
             {
                 record.Sharding ??= new ShardingConfiguration();
-                record.Sharding.Prefixed = new List<PrefixedShardingSetting>
-                {
+                record.Sharding.Prefixed =
+                [
                     new PrefixedShardingSetting
                     {
                         // range for 'eu/' is : 
                         // shard 0 : [1M, 2M]
-                        Prefix = "eu/",
-                        Shards = new List<int> { 0 }
+                        Prefix = "eu/", 
+                        Shards = [0]
                     },
+
                     new PrefixedShardingSetting
                     {
                         // range for 'asia/' is :
                         // shard 1 : [2M, 2.5M]
                         // shard 2 : [2.5M, 3M]
-                        Prefix = "asia/",
-                        Shards = new List<int> { 1, 2 }
+                        Prefix = "asia/", 
+                        Shards = [1, 2]
                     }
-                };
+                ];
             }
         });
 
@@ -838,6 +785,1918 @@ public class PrefixedSharding : RavenTestBase
             Assert.Equal(2, asiaSetting.Shards.Count);
             Assert.Equal(1, asiaSetting.Shards[0]);
             Assert.Equal(2, asiaSetting.Shards[1]);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task CanUpdatePrefixSetting()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "eu/", 
+                        Shards = [0, 1]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "us/", 
+                        Shards = [1, 2]
+                    }
+                ];
+            }
+        });
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                string id = "eu/users/" + i;
+                await session.StoreAsync(new Item(), id);
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        var shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+        var bucketRanges = shardingConfiguration.BucketRanges;
+        Assert.Equal(7, bucketRanges.Count);
+        
+        Assert.Equal(ShardHelper.NumberOfBuckets, shardingConfiguration.BucketRanges[3].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 1.5, shardingConfiguration.BucketRanges[4].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 2, shardingConfiguration.BucketRanges[5].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 2.5, shardingConfiguration.BucketRanges[6].BucketRangeStart);
+
+        // update 'eu/' prefix setting : add shard #2
+
+        await store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "eu/",
+            Shards = new List<int> { 0, 1, 2 }
+        }));
+
+        shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(2, shardingConfiguration.Prefixed.Count);
+        Assert.Equal("eu/", shardingConfiguration.Prefixed[1].Prefix);
+        Assert.Equal(3, shardingConfiguration.Prefixed[1].Shards.Count);
+
+        // shard #2 should get no bucket ranges for the 'eu/' prefix
+        Assert.Equal(bucketRanges.Count, shardingConfiguration.BucketRanges.Count);
+        for (int index = 0; index < bucketRanges.Count; index++)
+        {
+            ShardBucketRange oldRange = bucketRanges[index];
+            var newRange = shardingConfiguration.BucketRanges[index];
+
+            Assert.Equal(oldRange.BucketRangeStart, newRange.BucketRangeStart);
+            Assert.Equal(oldRange.ShardNumber, newRange.ShardNumber);
+        }
+
+        // attempt to remove shard #1 from 'us/' setting should throw
+        // we cannot remove shard #1 because there are bucket ranges mapped to shard #1 for this prefix
+
+        await Assert.ThrowsAsync<RavenException>(async () => 
+            await store.Maintenance.SendAsync(
+            new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+            {
+                Prefix = "us/", Shards = [2]
+            })));
+
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task CanHandlePrefixOfPrefix()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/", 
+                        Shards = [0]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/us/utah/", 
+                        Shards = [1]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/us/", 
+                        Shards = [2]
+                    }
+                ];
+            }
+        });
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                string id = "users/us/california/" + i;
+                await session.StoreAsync(new Item(), id);
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/")).ToList();
+            Assert.Equal(0, docs.Count);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/")).ToList();
+            Assert.Equal(0, docs.Count);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/")).ToList();
+            Assert.Equal(10, docs.Count);
+        }
+
+        var shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(3, shardingConfiguration.Prefixed.Count);
+
+        // should be sorted by descending 
+        Assert.Equal("users/us/utah/", shardingConfiguration.Prefixed[0].Prefix);
+        Assert.Equal("users/us/", shardingConfiguration.Prefixed[1].Prefix);
+        Assert.Equal("users/", shardingConfiguration.Prefixed[2].Prefix);
+
+        var bucketRanges = shardingConfiguration.BucketRanges;
+        Assert.Equal(6, bucketRanges.Count);
+        Assert.Equal(ShardHelper.NumberOfBuckets, bucketRanges[3].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 2, bucketRanges[4].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 3, bucketRanges[5].BucketRangeStart);
+
+        Assert.Equal(ShardHelper.NumberOfBuckets, shardingConfiguration.Prefixed[0].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 2, shardingConfiguration.Prefixed[1].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 3, shardingConfiguration.Prefixed[2].BucketRangeStart);
+
+        // add 'users/us/arizona/' prefix setting
+        await store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/us/arizona/",
+            Shards = [1]
+        }));
+
+        shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(4, shardingConfiguration.Prefixed.Count);
+
+        // should still be sorted
+        Assert.Equal("users/us/utah/", shardingConfiguration.Prefixed[0].Prefix);
+        Assert.Equal("users/us/arizona/", shardingConfiguration.Prefixed[1].Prefix);
+        Assert.Equal("users/us/", shardingConfiguration.Prefixed[2].Prefix);
+        Assert.Equal("users/", shardingConfiguration.Prefixed[3].Prefix);
+
+        Assert.Equal(ShardHelper.NumberOfBuckets, shardingConfiguration.Prefixed[0].BucketRangeStart);
+        
+        // new prefix should be added at the end of BucketRanges
+        Assert.Equal(ShardHelper.NumberOfBuckets * 4, shardingConfiguration.Prefixed[1].BucketRangeStart);
+
+        Assert.Equal(ShardHelper.NumberOfBuckets * 2, shardingConfiguration.Prefixed[2].BucketRangeStart);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 3, shardingConfiguration.Prefixed[3].BucketRangeStart);
+
+        // check bucket ranges
+
+        var newBucketRanges = shardingConfiguration.BucketRanges;
+        Assert.Equal(7, newBucketRanges.Count);
+
+        for (int i = 0; i < bucketRanges.Count; i++)
+        {
+            var oldRange = bucketRanges[i];
+            var newRange = newBucketRanges[i];
+
+            Assert.Equal(oldRange.BucketRangeStart, newRange.BucketRangeStart);
+            Assert.Equal(oldRange.ShardNumber, newRange.ShardNumber);
+        }
+
+        Assert.Equal(ShardHelper.NumberOfBuckets * 4, newBucketRanges[6].BucketRangeStart);
+        Assert.Equal(1, newBucketRanges[6].ShardNumber);
+
+        // should all go to shard #1
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                string id = "users/us/arizona/" + i;
+                await session.StoreAsync(new Item(), id);
+            }
+
+            await session.SaveChangesAsync();
+
+            WaitForUserToContinueTheTest(store);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/arizona/")).ToList();
+            Assert.Equal(0, docs.Count);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/arizona/")).ToList();
+            Assert.Equal(10, docs.Count);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/arizona/")).ToList();
+            Assert.Equal(0, docs.Count);
+        }
+
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task AfterAddingNewPrefixMatchingDocsShouldNotGoToWrongShard()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/", 
+                        Shards = [0]
+                    },
+
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/eu/", 
+                        Shards = [0]
+                    },
+
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/asia/", 
+                        Shards = [2]
+                    },
+
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/africa/", 
+                        Shards = [2]
+                    }
+                ];
+            }
+        });
+
+        await foreach (var shard in Sharding.GetShardsDocumentDatabaseInstancesFor(store))
+        {
+            shard.ForTestingPurposes ??= new DocumentDatabase.TestingStuff
+            {
+                EnableWritesToTheWrongShard = true
+            };
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                string id = "users/eu/" + i;
+                await session.StoreAsync(new Item(), id);
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        // add 'users/us/' prefix setting
+        await store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/us/",
+            Shards = [1]
+        }));
+
+        // should all go to shard #1
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                string id = "users/us/" + i;
+                await session.StoreAsync(new Item(), id);
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/")).ToList();
+            Assert.Equal(0, docs.Count);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/")).ToList();
+            Assert.Equal(10, docs.Count);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/")).ToList();
+            Assert.Equal(0, docs.Count);
+        }
+
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task PrefixesOperationsShouldBeCaseInsensitive()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "Users/", 
+                        Shards = [0, 1]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "Companies/", 
+                        Shards = [0, 1, 2]
+                    }
+                ];
+            }
+        });
+
+
+        await store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/",
+            Shards = [0, 1, 2]
+        }));
+
+        var shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+
+        Assert.Equal(2, shardingConfiguration.Prefixed.Count);
+        Assert.Equal("Users/", shardingConfiguration.Prefixed[0].Prefix);
+        Assert.Equal(new[] { 0, 1, 2 }, shardingConfiguration.Prefixed[0].Shards);
+
+        await store.Maintenance.SendAsync(new DeletePrefixedShardingSettingOperation("COMPANIES/"));
+
+        shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+
+        Assert.Equal(1, shardingConfiguration.Prefixed.Count);
+
+        await store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "products/",
+            Shards = new List<int> { 2 }
+        }));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var id = $"Products/{i}";
+                await session.StoreAsync(new Item(), id);
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("PRODUCTS/")).ToList();
+            Assert.Equal(0, docs.Count);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("PRODUCTS/")).ToList();
+            Assert.Equal(0, docs.Count);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("PRODUCTS/")).ToList();
+            Assert.Equal(10, docs.Count);
+        }
+
+        var task = store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting()
+        {
+            Prefix = "Products/", 
+            Shards = new List<int>() { 1 }
+        }));
+        await Assert.ThrowsAsync<RavenException>(async () => await task);
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task UpdatePrefixesInCluster()
+    {
+        var cluster = await CreateRaftCluster(3, watcherCluster: true);
+        var options = Sharding.GetOptionsForCluster(cluster.Leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 3);
+        options.ModifyDatabaseRecord += record =>
+        {
+            record.Sharding ??= new ShardingConfiguration();
+            record.Sharding.Prefixed =
+            [
+                new PrefixedShardingSetting
+                {
+                    Prefix = "users/", 
+                    Shards = [0]
+                },
+                new PrefixedShardingSetting
+                {
+                    Prefix = "users/us/utah/", 
+                    Shards = [1]
+                },
+                new PrefixedShardingSetting
+                {
+                    Prefix = "users/us/", 
+                    Shards = [2]
+                }
+            ];
+        };
+        using var store = GetDocumentStore(options);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await session.StoreAsync(new Item(), "users/eu/sweden/" + i);
+                await session.StoreAsync(new Item(), "users/us/utah/" + i);
+                await session.StoreAsync(new Item(), "users/us/california/" + i);
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        //var stores = Cluster.GetDocumentStores()
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/")).ToList();
+            Assert.Equal(10, docs.Count);
+
+            foreach (var doc in docs)
+            {
+                Assert.StartsWith("users/eu/sweden/", doc.Id);
+            }
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/")).ToList();
+            Assert.Equal(10, docs.Count);
+
+            foreach (var doc in docs)
+            {
+                Assert.StartsWith("users/us/utah/", doc.Id);
+            }
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/")).ToList();
+            Assert.Equal(10, docs.Count);
+
+            foreach (var doc in docs)
+            {
+                Assert.StartsWith("users/us/california/", doc.Id);
+            }
+        }
+
+        // add 'users/us/arizona/' prefix setting
+        await store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/us/arizona/",
+            Shards = new List<int> { 1 }
+        }));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                string id = "users/us/arizona/" + i;
+                await session.StoreAsync(new Item(), id);
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        var stores = GetDocumentStores(cluster.Nodes, store.Database, disableTopologyUpdates: true);
+        foreach (var s in stores)
+        {
+            using (var session = s.OpenAsyncSession())
+            {
+                var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/arizona/")).ToList();
+                Assert.Equal(10, docs.Count);
+            }
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/arizona/")).ToList();
+            Assert.Equal(0, docs.Count);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/arizona/")).ToList();
+            Assert.Equal(10, docs.Count);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            var docs = (await session.Advanced.LoadStartingWithAsync<User>("users/us/arizona/")).ToList();
+            Assert.Equal(0, docs.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task CanMoveOneBucketFromPrefixedRange()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        // bucket range for 'users/' is : 
+                        // shard 0 : [1M, 1.5M]
+                        // shard 1 : [1.5M, 2M]
+                        Prefix = "users/", 
+                        Shards = [0, 1]
+                    }
+                ];
+            }
+        });
+
+        const string id = "users/1";
+        using (var session = store.OpenAsyncSession())
+        {
+            var user = new User
+            {
+                Name = "Original shard"
+            };
+            await session.StoreAsync(user, id);
+            await session.SaveChangesAsync();
+        }
+
+        var shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+
+        Assert.Equal(5, shardingConfiguration.BucketRanges.Count);
+        Assert.Equal(ShardHelper.NumberOfBuckets, shardingConfiguration.Prefixed[0].BucketRangeStart);
+
+        var bucket = await Sharding.GetBucketAsync(store, id);
+
+        var originalLocation = ShardHelper.GetShardNumberFor(shardingConfiguration, bucket);
+        Assert.Contains(originalLocation, shardingConfiguration.Prefixed[0].Shards);
+        var newLocation = shardingConfiguration.Prefixed[0].Shards.Single(s => s != originalLocation);
+
+        await Sharding.Resharding.MoveShardForId(store, id);
+
+        shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(7, shardingConfiguration.BucketRanges.Count);
+
+        Assert.Equal(bucket, shardingConfiguration.BucketRanges[^2].BucketRangeStart);
+        Assert.Equal(newLocation, shardingConfiguration.BucketRanges[^2].ShardNumber);
+
+        Assert.Equal(bucket + 1, shardingConfiguration.BucketRanges[^1].BucketRangeStart);
+        Assert.Equal(originalLocation, shardingConfiguration.BucketRanges[^1].ShardNumber);
+
+        using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, originalLocation)))
+        {
+            var user = await session.LoadAsync<User>(id);
+            Assert.Null(user);
+        }
+        using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, newLocation)))
+        {
+            var user = await session.LoadAsync<User>(id);
+            Assert.Equal("Original shard", user.Name);
+        }
+
+        // the document will be written to the new location
+        using (var session = store.OpenAsyncSession())
+        {
+            var user = await session.LoadAsync<User>(id);
+            user.Name = "New shard";
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, originalLocation)))
+        {
+            var user = await session.LoadAsync<User>(id);
+            Assert.Null(user);
+        }
+
+        using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, newLocation)))
+        {
+            var user = await session.LoadAsync<User>(id);
+            Assert.Equal("New shard", user.Name);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task CanMoveOneBucketFromPrefixedRangeToNewShard()
+    {
+        var (_, leader) = await CreateRaftCluster(3, watcherCluster: true);
+        var options = Sharding.GetOptionsForCluster(leader, shards: 2, shardReplicationFactor: 2, orchestratorReplicationFactor: 2);
+        options.ModifyDatabaseRecord += record =>
+        {
+            record.Sharding.Prefixed =
+            [
+                new PrefixedShardingSetting
+                {
+                    Prefix = "foo/", 
+                    Shards = [0]
+                }
+            ];
+
+        };
+
+        using (var store = GetDocumentStore(options))
+        {
+            var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+            var shardTopology = record.Sharding.Shards[0];
+            Assert.Equal(2, shardTopology.Members.Count);
+            Assert.Equal(0, shardTopology.Promotables.Count);
+            Assert.Equal(2, shardTopology.ReplicationFactor);
+
+            //create new shard
+            var res = store.Maintenance.Server.Send(new AddDatabaseShardOperation(store.Database));
+            var newShardNumber = res.ShardNumber;
+            Assert.Equal(2, newShardNumber);
+            Assert.Equal(2, res.ShardTopology.ReplicationFactor);
+            Assert.Equal(2, res.ShardTopology.AllNodes.Count());
+            await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(res.RaftCommandIndex);
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                return record.Sharding.Shards.Count;
+            }, 3);
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                record.Sharding.Shards.TryGetValue(newShardNumber, out shardTopology);
+                return shardTopology?.Members?.Count;
+            }, 2);
+
+            var nodesContainingNewShard = shardTopology.Members;
+
+            foreach (var node in nodesContainingNewShard)
+            {
+                var serverWithNewShard = Servers.Single(x => x.ServerStore.NodeTag == node);
+                Assert.True(serverWithNewShard.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(ShardHelper.ToShardName(store.Database, newShardNumber), out _));
+            }
+
+            var id = "foo/bar";
+            var bucket = await Sharding.GetBucketAsync(store, id);
+            var originalDocShard = await Sharding.GetShardNumberForAsync(store, id);
+            Assert.Equal(0, originalDocShard);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1);
+
+                var user = new User
+                {
+                    Name = "Original shard"
+                };
+                await session.StoreAsync(user, id);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, originalDocShard)))
+            {
+                var user = await session.LoadAsync<User>(id);
+                Assert.NotNull(user);
+            }
+
+            // first we need to add the new shard to the prefix setting
+            await store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+            {
+                Prefix = "foo/", 
+                Shards = [0, newShardNumber]
+            }));
+
+            // move bucket
+            await Sharding.Resharding.MoveShardForId(store, id, newShardNumber);
+
+            var exists = WaitForDocument<User>(store, id, predicate: null, database: ShardHelper.ToShardName(store.Database, newShardNumber));
+            Assert.True(exists);
+
+            using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, newShardNumber)))
+            {
+                var user = await session.LoadAsync<User>(id);
+                Assert.NotNull(user);
+            }
+
+            // check bucket ranges
+            var sharding = await Sharding.GetShardingConfigurationAsync(store);
+            Assert.Equal(5, sharding.BucketRanges.Count);
+            Assert.Equal(ShardHelper.NumberOfBuckets ,sharding.BucketRanges[2].BucketRangeStart);
+            Assert.Equal(bucket, sharding.BucketRanges[3].BucketRangeStart);
+            Assert.Equal(bucket + 1, sharding.BucketRanges[4].BucketRangeStart);
+
+            // the document will be written to the new location
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>(id);
+                user.Name = "New shard";
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, originalDocShard)))
+            {
+                var user = await session.LoadAsync<User>(id);
+                Assert.Null(user);
+            }
+            using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, newShardNumber)))
+            {
+                var user = await session.LoadAsync<User>(id);
+                Assert.Equal("New shard", user.Name);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task ShouldThrowOnAttemptToMovePrefixedBucketToShardNotInPrefixSetting()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/", 
+                        Shards = [0, 1]
+                    }
+                ];
+            }
+        });
+
+        var shardingConfig = await Sharding.GetShardingConfigurationAsync(store);
+        var bucket =  Sharding.GetBucket(shardingConfig, "users/1");
+
+        // shard #2 is not a part of Prefixed['users/'].Shards 
+        await Assert.ThrowsAsync<RachisApplyException>(async ()=> 
+            await Server.ServerStore.Sharding.StartBucketMigration(store.Database, bucket, toShard : 2, prefix: "users/", RaftIdGenerator.NewId()));
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task ShardByDocumentsPrefixWithManyDocs_CanMoveBigBucketToNewShard()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/",
+                        Shards = [0 , 1]
+                    }
+                ];
+            }
+        });
+
+        const string bigBucketId = "users/123";
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < 100_000; i++)
+            {
+                var id = $"users/{i}";
+                bulk.Store(new User(), id);
+                bulk.Store(new User(), $"{id}${bigBucketId}");
+            }
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            var numberOfDocs = (await session.Advanced.LoadStartingWithAsync<User>("users/", pageSize: int.MaxValue)).Count();
+            Assert.Equal(149724, numberOfDocs);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            var numberOfDocs = (await session.Advanced.LoadStartingWithAsync<User>("users/", pageSize: int.MaxValue)).Count();
+            Assert.Equal(50276, numberOfDocs);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            var numberOfDocs = (await session.Advanced.LoadStartingWithAsync<User>("users/", pageSize: int.MaxValue)).Count();
+            Assert.Equal(0, numberOfDocs);
+        }
+
+        int bucket, shardNumber;
+        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+        using (var allocator = new ByteStringContext(SharedMultipleUseFlag.None))
+            (shardNumber, bucket) =  ShardHelper.GetShardNumberAndBucketFor(record.Sharding, allocator, bigBucketId);
+
+        var shard = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, shardNumber));
+
+        using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+        using (ctx.OpenReadTransaction())
+        {
+            var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
+            Assert.Equal(30303958, stats.Size);
+            Assert.Equal(100_001, stats.NumberOfDocuments);
+        }
+
+        // add shard #2 to prefix setting
+        await store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/", 
+            Shards = [0, 1, 2]
+        }));
+
+        // move big bucket to the newly added shard
+        await Sharding.Resharding.MoveShardForId(store, $"users/0${bigBucketId}", toShard: 2);
+
+        // assert stats 
+        using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+        using (ctx.OpenReadTransaction())
+        {
+            var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
+            Assert.Equal(0, stats.NumberOfDocuments);
+            Assert.Equal(9988978, stats.Size);
+
+            var tombsCount = shard.DocumentsStorage.GetNumberOfTombstones(ctx);
+            Assert.Equal(100_001, tombsCount);
+
+            await shard.TombstoneCleaner.ExecuteCleanup();
+        }
+
+        using (shard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+        using (ctx.OpenReadTransaction())
+        {
+            var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
+            Assert.Null(stats);
+
+            var tombsCount = shard.DocumentsStorage.GetNumberOfTombstones(ctx);
+            Assert.Equal(0, tombsCount);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            var numberOfDocs = (await session.Advanced.LoadStartingWithAsync<User>("users/", pageSize: int.MaxValue)).Count();
+            Assert.Equal(49723, numberOfDocs);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            var numberOfDocs = (await session.Advanced.LoadStartingWithAsync<User>("users/", pageSize: int.MaxValue)).Count();
+            Assert.Equal(50276, numberOfDocs);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            var numberOfDocs = (await session.Advanced.LoadStartingWithAsync<User>("users/", pageSize: int.MaxValue)).Count();
+            Assert.Equal(100_001, numberOfDocs);
+        }
+
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task CanMoveBucketFromPrefixedRangeWhileWriting()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/",
+                        Shards = [0, 1]
+                    }
+                ];
+            }
+        });
+
+        using (var bulk = store.BulkInsert())
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                var id = $"users/{i}";
+                bulk.Store(new User(), id);
+            }
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(538, numberOfDocs);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(462, numberOfDocs);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(0, numberOfDocs);
+        }
+
+        // add shard #2 to prefix setting
+        await store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/",
+            Shards = [0, 1, 2]
+        }));
+
+        // move bucket to the newly added shard while writing
+        var docId = "users/1";
+        var bucket = await Sharding.GetBucketAsync(store, docId);
+        var originalShardNumber = await Sharding.GetShardNumberForAsync(store, docId);
+
+        var writes = Task.Run(async () =>
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 1000; i < 2000; i++)
+                {
+                    var id = $"users/{i}${docId}";
+                    await session.StoreAsync(new User(), id);
+                }
+
+                await session.SaveChangesAsync();
+            }
+        });
+        var bucketMigration = Sharding.Resharding.MoveShardForId(store, docId, toShard: 2);
+
+        await Task.WhenAll(bucketMigration, writes);
+
+        // assert bucket ranges
+        var shardingConfig = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(7, shardingConfig.BucketRanges.Count);
+
+        Assert.Equal(ShardHelper.NumberOfBuckets, shardingConfig.BucketRanges[3].BucketRangeStart);
+        Assert.Equal(0, shardingConfig.BucketRanges[3].ShardNumber);
+
+        Assert.Equal(ShardHelper.NumberOfBuckets * 1.5, shardingConfig.BucketRanges[4].BucketRangeStart);
+        Assert.Equal(1, shardingConfig.BucketRanges[4].ShardNumber);
+
+        Assert.Equal(bucket, shardingConfig.BucketRanges[5].BucketRangeStart);
+        Assert.Equal(2, shardingConfig.BucketRanges[5].ShardNumber);
+
+        Assert.Equal(bucket + 1, shardingConfig.BucketRanges[6].BucketRangeStart);
+        Assert.Equal(1, shardingConfig.BucketRanges[6].ShardNumber);
+
+        // assert stats 
+        var originalShard = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, originalShardNumber));
+        using (originalShard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+        using (ctx.OpenReadTransaction())
+        {
+            var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
+            Assert.Equal(0, stats.NumberOfDocuments);
+        }
+
+        var newShard = await GetDocumentDatabaseInstanceFor(store, ShardHelper.ToShardName(store.Database, shard: 2));
+        using (newShard.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+        using (ctx.OpenReadTransaction())
+        {
+            var stats = ShardedDocumentsStorage.GetBucketStatisticsFor(ctx, bucket);
+            Assert.Equal(1001, stats.NumberOfDocuments);
+        }
+
+        // assert docs
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 0)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(538, numberOfDocs);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 1)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(461, numberOfDocs);
+        }
+
+        using (var session = store.OpenAsyncSession(database: ShardHelper.ToShardName(store.Database, 2)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(1001, numberOfDocs);
+        }
+
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task ShouldNotAllowToRemoveShardFromDbIfItHasPrefixesSettings()
+    {
+        var cluster = await CreateRaftCluster(numberOfNodes: 3, watcherCluster: true);
+        var options = Sharding.GetOptionsForCluster(cluster.Leader, shards: 2, shardReplicationFactor: 1, orchestratorReplicationFactor: 3);
+        options.ModifyDatabaseRecord += record =>
+        {
+            record.Sharding ??= new ShardingConfiguration();
+            record.Sharding.Prefixed =
+            [
+                new PrefixedShardingSetting
+                {
+                    Prefix = "users/", 
+                    Shards = [0, 1]
+                }
+            ];
+        };
+
+        using var store = Sharding.GetDocumentStore(options);
+
+        using var session = store.OpenAsyncSession();
+        for (int i = 0; i < 1000; i++)
+        {
+            var id = $"users/{i}";
+            await session.StoreAsync(new User(), id);
+        }
+        await session.SaveChangesAsync();
+
+        // add shard #2 to database
+        var sharding = await Sharding.GetShardingConfigurationAsync(store);
+        var shardNodes = sharding.Shards.Select(kvp => kvp.Value.Members[0]);
+        var nodeNotInDbGroup = cluster.Nodes.SingleOrDefault(n => shardNodes.Contains(n.ServerStore.NodeTag) == false)?.ServerStore.NodeTag;
+        Assert.NotNull(nodeNotInDbGroup);
+
+        var addShardRes = store.Maintenance.Server.Send(new AddDatabaseShardOperation(store.Database, [nodeNotInDbGroup]));
+        Assert.Equal(2, addShardRes.ShardNumber);
+        await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(addShardRes.RaftCommandIndex);
+
+        await AssertWaitForValueAsync(async () =>
+        {
+            sharding = await Sharding.GetShardingConfigurationAsync(store);
+            sharding.Shards.TryGetValue(2, out var topology);
+            return topology?.Members.Count;
+        }, expectedVal: 1);
+
+
+        // add shard #2 to 'users/' prefix setting
+        await store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/", 
+            Shards = [0, 1, 2]
+        }));
+
+        // should not allow to delete shard #2 because it's part of 'users/' prefix setting
+        var deleteShardTask = store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, shardNumber: 2, hardDelete: true, fromNode: nodeNotInDbGroup));
+        await Assert.ThrowsAsync<RavenException>(async () => await deleteShardTask);
+
+        // remove shard #2 from 'users/' prefix setting
+        // can be removed because shard #2 has no bucket ranges for this prefix
+        await store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/",
+            Shards = [0, 1]
+        }));
+
+        // now we should be able to delete shard #2 from database
+        var res = await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, shardNumber: 2, hardDelete: true, fromNode: nodeNotInDbGroup));
+        await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(res.RaftCommandIndex);
+
+        await AssertWaitForValueAsync(async () =>
+        {
+            sharding = await Sharding.GetShardingConfigurationAsync(store);
+            return sharding.Shards.TryGetValue(2, out _);
+        }, expectedVal: false);
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task WhenAddingNewPrefixShouldFillBucketRangeGaps()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/a/",
+                        Shards = [0]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/b/",
+                        Shards = [1]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/c/",
+                        Shards = [0, 1]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/d/",
+                        Shards = [0, 1, 2]
+                    },
+                ];
+            }
+        });
+
+        var sharding = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(4, sharding.Prefixed.Count);
+        Assert.Equal("users/d/", sharding.Prefixed[0].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets, sharding.Prefixed[0].BucketRangeStart);
+
+        Assert.Equal("users/c/", sharding.Prefixed[1].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 2, sharding.Prefixed[1].BucketRangeStart);
+
+        Assert.Equal("users/b/", sharding.Prefixed[2].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 3, sharding.Prefixed[2].BucketRangeStart);
+
+        Assert.Equal("users/a/", sharding.Prefixed[3].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 4, sharding.Prefixed[3].BucketRangeStart);
+
+        // deleting 'users/c/' will create a gap in prefixes bucket range start (range 1M - 2M range is missing)
+        await store.Maintenance.SendAsync(new DeletePrefixedShardingSettingOperation("users/c/"));
+        sharding = await Sharding.GetShardingConfigurationAsync(store);
+
+        Assert.Equal(3, sharding.Prefixed.Count);
+        Assert.Equal("users/d/", sharding.Prefixed[0].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets, sharding.Prefixed[0].BucketRangeStart);
+
+        Assert.Equal("users/b/", sharding.Prefixed[1].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 3, sharding.Prefixed[1].BucketRangeStart);
+
+        Assert.Equal("users/a/", sharding.Prefixed[2].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 4, sharding.Prefixed[2].BucketRangeStart);
+
+        // add a new prefix, 1M - 2M range should be assigned to it
+        await store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/z/",
+            Shards = [1, 2]
+        }));
+
+        sharding = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(4, sharding.Prefixed.Count);
+        Assert.Equal("users/z/", sharding.Prefixed[0].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 2, sharding.Prefixed[0].BucketRangeStart);
+
+        Assert.Equal("users/d/", sharding.Prefixed[1].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets, sharding.Prefixed[1].BucketRangeStart);
+
+        Assert.Equal("users/b/", sharding.Prefixed[2].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 3, sharding.Prefixed[2].BucketRangeStart);
+
+        Assert.Equal("users/a/", sharding.Prefixed[3].Prefix);
+        Assert.Equal(ShardHelper.NumberOfBuckets * 4, sharding.Prefixed[3].BucketRangeStart);
+
+    }
+
+    [RavenTheory(RavenTestCategory.Sharding | RavenTestCategory.Etl)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task ReshardingWithEtl_PrefixedSource(Options options)
+    {
+        using var srcStore = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/",
+                        Shards = [0, 1]
+                    }
+                ];
+            }
+        });
+
+        using var dstStore = GetDocumentStore(options);
+        Etl.AddEtl(srcStore, dstStore, "users", script: null);
+
+        using (var bulk = srcStore.BulkInsert())
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                var id = $"users/{i}";
+                bulk.Store(new User(), id);
+            }
+        }
+
+        await AssertWaitForValueAsync(async () =>
+        {
+            using var session = dstStore.OpenAsyncSession();
+            return await session.Query<User>().CountAsync();
+        }, expectedVal: 1000);
+
+
+        // add shard #2 to prefix setting
+        await srcStore.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/",
+            Shards = [0, 1, 2]
+        }));
+
+        var docId = "users/1";
+        var writes = Task.Run(async () =>
+        {
+            using (var session = srcStore.OpenAsyncSession())
+            {
+                for (int i = 1000; i < 2000; i++)
+                {
+                    var id = $"users/{i}${docId}";
+                    await session.StoreAsync(new User(), id);
+                }
+
+                await session.SaveChangesAsync();
+            }
+        });
+
+        await Sharding.Resharding.MoveShardForId(srcStore, docId, toShard: 2);
+        await writes;
+
+        // assert docs
+        using (var session = srcStore.OpenAsyncSession(database: ShardHelper.ToShardName(srcStore.Database, 0)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(538, numberOfDocs);
+        }
+
+        using (var session = srcStore.OpenAsyncSession(database: ShardHelper.ToShardName(srcStore.Database, 1)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(461, numberOfDocs);
+        }
+
+        using (var session = srcStore.OpenAsyncSession(database: ShardHelper.ToShardName(srcStore.Database, 2)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(1001, numberOfDocs);
+        }
+
+        await AssertWaitForValueAsync(async () =>
+        {
+            using var session = dstStore.OpenAsyncSession();
+            return await session.Query<User>().CountAsync();
+        }, expectedVal: 2000);
+    }
+
+    [RavenTheory(RavenTestCategory.Sharding | RavenTestCategory.Etl)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task ReshardingWithEtl_PrefixedDestination(Options options)
+    {
+        using var srcStore = GetDocumentStore(options);
+        using var dstStore = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/",
+                        Shards = [0, 1]
+                    }
+                ];
+            }
+        });
+
+        Etl.AddEtl(srcStore, dstStore, "users", script: null);
+
+        using (var bulk = srcStore.BulkInsert())
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                var id = $"users/{i}";
+                bulk.Store(new User(), id);
+            }
+        }
+
+        await AssertWaitForValueAsync(async () =>
+        {
+            using var session = dstStore.OpenAsyncSession();
+            return await session.Query<User>().CountAsync();
+        }, expectedVal: 1000);
+
+
+        // add shard #2 to prefix setting
+        await dstStore.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/",
+            Shards = [0, 1, 2]
+        }));
+
+        var docId = "users/1";
+        var writes = Task.Run(() =>
+        {
+            using (var bulk = srcStore.BulkInsert())
+            {
+                for (int i = 1000; i < 2000; i++)
+                {
+                    var id = $"users/{i}${docId}";
+                    bulk.Store(new User(), id);
+                }
+            }
+        });
+
+        await Sharding.Resharding.MoveShardForId(dstStore, docId, toShard: 2);
+        await writes;
+
+        await AssertWaitForValueAsync(async () =>
+        {
+            using var session = dstStore.OpenAsyncSession();
+            return await session.Query<User>().CountAsync();
+        }, expectedVal: 2000);
+
+        // assert docs
+        using (var session = dstStore.OpenAsyncSession(database: ShardHelper.ToShardName(dstStore.Database, 0)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(538, numberOfDocs);
+        }
+
+        using (var session = dstStore.OpenAsyncSession(database: ShardHelper.ToShardName(dstStore.Database, 1)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(461, numberOfDocs);
+        }
+
+        using (var session = dstStore.OpenAsyncSession(database: ShardHelper.ToShardName(dstStore.Database, 2)))
+        {
+            var numberOfDocs = await session.Query<User>().CountAsync();
+            Assert.Equal(1001, numberOfDocs);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding)]
+    public async Task CanImportIncrementalIntoPrefixedShardedDatabase()
+    {
+        var backupPath = NewDataPath(suffix: "_BackupFolder");
+
+        using (var store1 = Sharding.GetDocumentStore(new Options() 
+        {
+           ModifyDatabaseRecord = record =>
+           {
+               record.Sharding ??= new();
+               record.Sharding.Prefixed = [new PrefixedShardingSetting
+               {
+                   Prefix = "Users/", 
+                   Shards = [0, 1]
+               }];
+
+           }
+        }))
+        using (var store2 = Sharding.GetDocumentStore(new Options()
+        {
+           ModifyDatabaseRecord = record =>
+           {
+               record.Sharding ??= new();
+               record.Sharding.Prefixed = [new PrefixedShardingSetting
+               {
+                   Prefix = "Users/",
+                   Shards = [1 , 2]
+               }];
+           }
+        }))
+        {
+            var shardNumToDocIds = new Dictionary<int, List<string>>();
+            var dbRecord = await store1.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store1.Database));
+            var shardedCtx = new ShardedDatabaseContext(Server.ServerStore, dbRecord);
+
+            // generate data on store1, keep track of doc-ids per shard
+            using (var session = store1.OpenAsyncSession())
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                for (int i = 0; i < 100; i++)
+                {
+                    var user = new User { Name = i.ToString() };
+                    var id = $"users/{i}";
+
+                    var shardNumber = shardedCtx.GetShardNumberFor(context, id);
+                    if (shardNumToDocIds.TryGetValue(shardNumber, out var ids) == false)
+                    {
+                        shardNumToDocIds[shardNumber] = ids = new List<string>();
+                    }
+                    ids.Add(id);
+
+                    await session.StoreAsync(user, id);
+                }
+
+                Assert.Equal(2, shardNumToDocIds.Count);
+                Assert.False(shardNumToDocIds.ContainsKey(2));
+
+                await session.SaveChangesAsync();
+            }
+
+            var waitHandles = await Sharding.Backup.WaitForBackupToComplete(store1);
+
+            var config = Backup.CreateBackupConfiguration(backupPath, incrementalBackupFrequency: "* * * * *");
+            await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store1, config);
+
+            Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+
+            // import
+            var dirs = Directory.GetDirectories(backupPath);
+            Assert.Equal(3, dirs.Length);
+
+            foreach (var dir in dirs)
+            {
+                await store2.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), dir);
+            }
+
+            using (var session = store2.OpenAsyncSession(ShardHelper.ToShardName(store2.Database, 0)))
+            {
+                var docs = await session.Query<User>().ToListAsync();
+                Assert.Equal(0, docs.Count);
+            }
+            using (var session = store2.OpenAsyncSession(ShardHelper.ToShardName(store2.Database, 1)))
+            {
+                var docs = await session.Query<User>().ToListAsync();
+                Assert.Equal(shardNumToDocIds[0].Count, docs.Count);
+
+                foreach (var doc in docs)
+                {
+                    var id = doc.Id;
+                    Assert.True(shardNumToDocIds[0].Contains(id));
+                }
+            }
+            using (var session = store2.OpenAsyncSession(ShardHelper.ToShardName(store2.Database, 2)))
+            {
+                var docs = await session.Query<User>().ToListAsync();
+                Assert.Equal(shardNumToDocIds[1].Count, docs.Count);
+
+                foreach (var doc in docs)
+                {
+                    var id = doc.Id;
+                    Assert.True(shardNumToDocIds[1].Contains(id));
+                }
+            }
+
+            // add more data to store1
+            using (var session = store1.OpenAsyncSession())
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                for (int i = 100; i < 200; i++)
+                {
+                    var user = new User { Name = i.ToString() };
+                    var id = $"users/{i}";
+
+                    var shardNumber = shardedCtx.GetShardNumberFor(context, id);
+                    shardNumToDocIds[shardNumber].Add(id);
+
+                    await session.StoreAsync(user, id);
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            waitHandles = await Sharding.Backup.WaitForBackupToComplete(store1);
+
+            await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(Server, store1, config);
+
+            Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+
+            // import
+            var newDirs = Directory.GetDirectories(backupPath).Except(dirs).ToList();
+            Assert.Equal(3, newDirs.Count);
+
+            foreach (var dir in newDirs)
+            {
+                await store2.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), dir);
+            }
+
+            // assert
+            using (var session = store2.OpenAsyncSession(ShardHelper.ToShardName(store2.Database, 0)))
+            {
+                var docs = await session.Query<User>().ToListAsync();
+                Assert.Equal(0, docs.Count);
+            }
+            using (var session = store2.OpenAsyncSession(ShardHelper.ToShardName(store2.Database, 1)))
+            {
+                var docs = await session.Query<User>().ToListAsync();
+                Assert.Equal(shardNumToDocIds[0].Count, docs.Count);
+
+                foreach (var doc in docs)
+                {
+                    var id = doc.Id;
+                    Assert.True(shardNumToDocIds[0].Contains(id));
+                }
+            }
+            using (var session = store2.OpenAsyncSession(ShardHelper.ToShardName(store2.Database, 2)))
+            {
+                var docs = await session.Query<User>().ToListAsync();
+                Assert.Equal(shardNumToDocIds[1].Count, docs.Count);
+
+                foreach (var doc in docs)
+                {
+                    var id = doc.Id;
+                    Assert.True(shardNumToDocIds[1].Contains(id));
+                }
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding)]
+    public async Task CanBackupAndRestorePrefixedShardedDatabase_FromIncrementalBackup()
+    {
+        var backupPath = NewDataPath(suffix: "BackupFolder");
+        var cluster = await CreateRaftCluster(3, watcherCluster: true);
+
+        var options = Sharding.GetOptionsForCluster(cluster.Leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 3);
+        options.ModifyDatabaseRecord += record =>
+        {
+            record.Sharding.Prefixed = [new PrefixedShardingSetting
+            {
+                Prefix = "users/", 
+                Shards = [0, 1]
+            }];
+        };
+
+        using (var store = Sharding.GetDocumentStore(options))
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    await session.StoreAsync(new User(), $"users/{i}");
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            var waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
+
+            var config = Backup.CreateBackupConfiguration(backupPath);
+            var backupTaskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(cluster.Nodes, store, config, isFullBackup: false);
+
+            Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+
+            // add more data
+            waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 10; i < 20; i++)
+                {
+                    await session.StoreAsync(new User(), $"users/{i}");
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            // add shard #2 to prefix setting and move one bucket to the new shard
+            await store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+            {
+                Prefix = "users/", 
+                Shards = [0, 1, 2]
+            }));
+
+            await Sharding.Resharding.MoveShardForId(store, "users/11", toShard: 2);
+
+            using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, 0)))
+            {
+                var count = await session.Query<User>().CountAsync();
+                Assert.Equal(9, count);
+            }
+
+            using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, 1)))
+            {
+                var count = await session.Query<User>().CountAsync();
+                Assert.Equal(10, count);
+            }
+
+            using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, 2)))
+            {
+                var count = await session.Query<User>().CountAsync();
+                Assert.Equal(1, count);
+            }
+
+            await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+            Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
+
+            var dirs = Directory.GetDirectories(backupPath);
+            Assert.Equal(cluster.Nodes.Count, dirs.Length);
+
+            foreach (var dir in dirs)
+            {
+                var files = Directory.GetFiles(dir);
+                Assert.Equal(2, files.Length);
+            }
+
+            var sharding = await Sharding.GetShardingConfigurationAsync(store);
+            var settings = Sharding.Backup.GenerateShardRestoreSettings(dirs, sharding);
+
+            // restore the database with a different name
+            var restoredDatabaseName = $"restored_database-{Guid.NewGuid()}";
+            using (Sharding.Backup.ReadOnly(backupPath))
+            using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+            {
+                DatabaseName = restoredDatabaseName,
+                ShardRestoreSettings = settings
+            }, timeout: TimeSpan.FromSeconds(60)))
+            { 
+                var dbRec = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(restoredDatabaseName));
+                Assert.Equal(3, dbRec.Sharding.Shards.Count);
+
+                var shardNodes = new HashSet<string>();
+                foreach (var shardToTopology in dbRec.Sharding.Shards)
+                {
+                    var shardTopology = shardToTopology.Value;
+                    Assert.Equal(1, shardTopology.Members.Count);
+                    Assert.Equal(sharding.Shards[shardToTopology.Key].Members[0], shardTopology.Members[0]);
+                    Assert.True(shardNodes.Add(shardTopology.Members[0]));
+                }
+
+                using (var session = store.OpenSession(restoredDatabaseName))
+                {
+                    for (int i = 0; i < 20; i++)
+                    {
+                        var doc = session.Load<User>($"users/{i}");
+                        Assert.NotNull(doc);
+                    }
+                }
+
+                sharding = await Sharding.GetShardingConfigurationAsync(store, restoredDatabaseName);
+
+                Assert.Equal(1, sharding.Prefixed.Count);
+                Assert.Equal("users/", sharding.Prefixed[0].Prefix);
+                Assert.Equal(ShardHelper.NumberOfBuckets, sharding.Prefixed[0].BucketRangeStart);
+                Assert.Equal(3, sharding.Prefixed[0].Shards.Count);
+
+                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(restoredDatabaseName, 0)))
+                {
+                    var count = await session.Query<User>().CountAsync();
+                    Assert.Equal(9, count);
+                }
+
+                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(restoredDatabaseName, 1)))
+                {
+                    var count = await session.Query<User>().CountAsync();
+                    Assert.Equal(10, count);
+                }
+
+                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(restoredDatabaseName, 2)))
+                {
+                    var count = await session.Query<User>().CountAsync();
+                    Assert.Equal(1, count);
+                }
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task DeletingPrefixAfterShardsDistributionHasBeenUpdated()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/",
+                        Shards = [0]
+                    }
+                ];
+            }
+        });
+
+        var shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(4, shardingConfiguration.BucketRanges.Count);
+
+        await store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
+        {
+            Prefix = "users/",
+            Shards = [0, 1, 2]
+        }));
+
+        shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(4, shardingConfiguration.BucketRanges.Count);
+
+        await store.Maintenance.SendAsync(new DeletePrefixedShardingSettingOperation("users/"));
+
+        shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+
+        Assert.Equal(3, shardingConfiguration.BucketRanges.Count);
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task DeletingPrefixAfterBucketMigration()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/",
+                        Shards = [0, 1, 2]
+                    }
+                ];
+            }
+        });
+
+        var shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(6, shardingConfiguration.BucketRanges.Count);
+
+        var id = "users/2";
+        var originalShardForId = await Sharding.GetShardNumberForAsync(store, id);
+
+        Assert.Equal(0, originalShardForId);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new User(), id);
+            await session.SaveChangesAsync();
+        }
+
+        await Sharding.Resharding.MoveShardForId(store, id, toShard: 2);
+
+        shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(8, shardingConfiguration.BucketRanges.Count);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            session.Delete(id);
+            await session.SaveChangesAsync();
+        }
+
+        // this should delete all 5 bucket ranges assigned for this prefix
+        await store.Maintenance.SendAsync(new DeletePrefixedShardingSettingOperation("users/"));
+
+        shardingConfiguration = await Sharding.GetShardingConfigurationAsync(store);
+        Assert.Equal(3, shardingConfiguration.BucketRanges.Count);
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public void PrefixedSharding_CanQueryWithSpecifiedShardContext()
+    {
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/us/",
+                        Shards = [0]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/eu/",
+                        Shards = [1]
+                    },
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "users/asia/",
+                        Shards = [2]
+                    }
+                ];
+            }
+        });
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User(), "users/us/1");
+                session.Store(new User(), "users/us/2");
+                session.Store(new User(), "users/us/3");
+
+                session.Store(new User(), "users/eu/1");
+                session.Store(new User(), "users/eu/2");
+
+                session.Store(new User(), "users/asia/1");
+
+
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var results = session.Query<User>()
+                    .Customize(x => x.ShardContext(s => s.ByDocumentId("users/us/1")))
+                    .ToList();
+
+                Assert.Equal(3, results.Count);
+
+                var results2 = session.Query<User>()
+                    .Customize(x => x.ShardContext(s => s.ByDocumentIds(new[] { "users/us/1", "users/eu/1" })))
+                    .Select(x => x.Id)
+                    .ToList();
+
+                Assert.Equal(5, results2.Count);
+                Assert.Contains("users/us/1", results2);
+                Assert.Contains("users/us/2", results2);
+                Assert.Contains("users/us/3", results2);
+                Assert.Contains("users/eu/1", results2);
+                Assert.Contains("users/eu/2", results2);
+
+                var results3 = session.Query<User>()
+                    .Customize(x => x.ShardContext(s => s.ByDocumentId("users/asia/")))
+                    .ToList();
+
+                Assert.Equal(1, results3.Count);
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var results = session.Advanced.DocumentQuery<User>()
+                    .ShardContext(s => s.ByDocumentId("users/us/1"))
+                    .ToList();
+
+                Assert.Equal(3, results.Count);
+
+                var results2 = session.Advanced.DocumentQuery<User>()
+                    .ShardContext(s => s.ByDocumentIds(new[] { "users/us/1", "users/eu/2" }))
+                    .ToList();
+
+                Assert.Equal(5, results2.Count);
+                var results3 = session.Advanced.DocumentQuery<User>()
+                    .ShardContext(s => s.ByDocumentId("users/asia/1"))
+                    .ToList();
+
+                Assert.Equal(1, results3.Count);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Sharding)]
+    public async Task PrefixesShouldGetPrecedenceOverAnchoring()
+    {
+        const string companyId = "companies/1";
+        const string relatedDocId = $"products/1${companyId}";
+        const int productsShard = 0;
+
+        using var store = Sharding.GetDocumentStore(new Options
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Sharding ??= new ShardingConfiguration();
+                record.Sharding.Prefixed =
+                [
+                    new PrefixedShardingSetting
+                    {
+                        Prefix = "products/",
+                        Shards = [productsShard]
+                    }
+                ];
+            }
+        });
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Company(), companyId);
+                session.SaveChanges();
+            }
+
+            var companyShardNumber = await Sharding.GetShardNumberForAsync(store, companyId);
+            Assert.Equal(1, companyShardNumber);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Product(), relatedDocId);
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession(ShardHelper.ToShardName(store.Database, companyShardNumber)))
+            {
+                var product = session.Query<Product>()
+                    .FirstOrDefault();
+
+                Assert.Null(product);
+            }
+
+            using (var session = store.OpenSession(ShardHelper.ToShardName(store.Database, productsShard)))
+            {
+                var product = session.Query<Product>()
+                    .FirstOrDefault();
+
+                Assert.NotNull(product);
+            }
         }
     }
 

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionSlowTests.cs
@@ -821,9 +821,7 @@ namespace SlowTests.Sharding.Subscriptions
         [InlineData(false)]
         public async Task CanUseSubscriptionWithDocumentIncludes(bool diff)
         {
-            DoNotReuseServer();
-            Server.ServerStore.Sharding.BlockPrefixedSharding = false;
-
+            
             var ops = diff
                 ? new Options
                 {
@@ -1141,9 +1139,6 @@ namespace SlowTests.Sharding.Subscriptions
         [InlineData(false)]
         public void SubscriptionWithIncludeAllCountersOfDocumentAndOfRelatedDocument(bool diff)
         {
-            DoNotReuseServer();
-            Server.ServerStore.Sharding.BlockPrefixedSharding = false;
-
             var ops = diff
                 ? new Options
                 {

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -111,15 +111,12 @@ public partial class RavenTestBase
             return options;
         }
 
-        public static int GetNextSortedShardNumber(PrefixedShardingSetting prefixedShardingSetting, int shardNumber)
-        {
-            var shardsSorted = prefixedShardingSetting.Shards.OrderBy(x => x).ToArray();
-            return GetNextSortedShardNumber(shardNumber, shardsSorted);
-        }
+        public static int GetNextSortedShardNumber(Dictionary<int, DatabaseTopology> shards, int shardNumber) =>
+            GetNextSortedShardNumber(shards.Keys, shardNumber);
 
-        public static int GetNextSortedShardNumber(Dictionary<int, DatabaseTopology> shards, int shardNumber)
+        public static int GetNextSortedShardNumber(ICollection<int> shards, int shardNumber)
         {
-            var shardsSorted = shards.Keys.OrderBy(x => x).ToArray();
+            var shardsSorted = shards.OrderBy(x => x).ToArray();
             return GetNextSortedShardNumber(shardNumber, shardsSorted);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17793/Shard-by-prefix

### Additional description

- Completed the work started here https://github.com/ravendb/ravendb/pull/15051
- Prefixed sharding gives you the option to control documents distribution between shards based on the document-id prefix
- Users can configure PrefixedSharding settings in database creation (via db-record), or at a later stage by using
dedicated operations (Add, Delete, Update). 
You cannot modify PrefixedSharding settings via db-record after database creation

```
// configure prefixed sharding settings during database creation
await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(new DatabaseRecord
{
    DatabaseName = "nw",
    Sharding = new ShardingConfiguration
    {
        Shards = new Dictionary<int, DatabaseTopology>
        {
            [0] = new DatabaseTopology(), 
            [1] = new DatabaseTopology(), 
            [2] = new DatabaseTopology()
        },
        Prefixed =
        [
            new PrefixedShardingSetting
            {
                Prefix = "eu/", 
                Shards = [0, 1]
            },
            new PrefixedShardingSetting
            {
                Prefix = "usa/", 
                Shards = [1, 2]
            }
        ]
    }
}));

// add prefixed setting
await store.Maintenance.SendAsync(new AddPrefixedShardingSettingOperation(new PrefixedShardingSetting
{
    Prefix = "asia/",
    Shards = [1, 2]
}));

// delete prefixed setting
await store.Maintenance.SendAsync(new DeletePrefixedShardingSettingOperation("eu/"));

// update shards distribution for a specific prefixed setting
await store.Maintenance.SendAsync(new UpdatePrefixedShardingSettingOperation(new PrefixedShardingSetting
{
    Prefix = "usa/",
    Shards = [0, 2]
}));


```


- Prefixes are sorted in a descending order - so that we can easily support having a prefix of prefix (e.g. `users/` and `users/usa/`)
- Can have up to 4K prefixes
- Each prefix setting gets a range of 1M buckets. buckets 0 - 1M are used for "regular" (non-prefixed) items.
e.g. :

```
// docs starting with 'eu/' will reside on shard #0
// docs starting with 'asia/' will reside on shard #1
// docs starting with 'us/' will reside on shard #0 or shard #2

DbRecord.Sharding.Prefixed = 
{ 
	'eu/' 	: [shard 0], 
	'asia/' : [shard 1], 
	'us/' 	: [shard 0, shard 2] 	
} 

DbRecord.Sharding.BucketRanges = 

// default bucket ranges
shard 0 : [0, 333K] 
shard 1 : [333K, 666K]
shard 2 : [666K, 1M] 

// prefixed ranges
shard 0 : [1M, 2M] // 'eu/' range
shard 1 : [2M, 3M]  // 'asia/' range
shard 0 : [3M, 3.5M]  // 'us/' range
shard 2 : [3.5M, 4M]  // 'us/' range

```

Some restrictions : 
- When adding or deleting a prefixed sharding setting, you cannot have any documents in the database the start with this prefix.
we validate that on the server side, but in a race condition some docs can slip between the time of validation and command execution - which can lead to mapping problem (ids mapped to *wrong* buckets). It is therefore the user's responsibly to make sure no matching docs exist when adding/deleting a prefix.
- Update - cannot remove shards from prefixed sharding setting if they still have buckets assigned to them (for this prefix).
in order to do that, first you'll need to move all the shard's buckets to a different shard
- Adding a shard to an existing prefix setting distribution will not assign any buckets for the new shard. Users need to manually 
move buckets to the new shard.
- Cannot remove the last copy of a shard from the database if this shard is still a part of any PrefixedSharding settings
- Prefixes get precedence over anchoring when choosing shard number for an id, e.g. :
```
* dbRecord.Sharding.Prefixed = { "products/" : [shard #2] }
* id = "companies/1" => bucket = 12345 => belongs to shard #0 
* id = "products/1$companies/1" => bucket is 12345 + 1_000_000 (RangeStart of `products/` prefix) =>
 belongs to shard #2
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [X] New feature

### How risky is the change?

- [ ] Low 
- [X] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [X] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [X] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
