### PR TITLE
RavenDB-19533 Fix TotalResults number in query statistics for collection query with load or include

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19533.cs
+++ b/test/SlowTests/Issues/RavenDB-19533.cs
@@ -1,0 +1,74 @@
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19533 : RavenTestBase
+{
+    public RavenDB_19533(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Querying)]
+    public void CanGetStreamStatsCorrectlyWithRelatedDocsProjection()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                for (int i = 0; i < 200; i++)
+                {
+                    var address = new Address { City = "London", Country = "UK", Street = "xxx" };
+                    var user = new User();
+                    
+                    session.Store(address);
+                    user.AddressId = address.Id;
+                    
+                    session.Store(user);
+                }
+
+                session.SaveChanges();
+            }
+            
+            using (var session = store.OpenSession())
+            {
+                var queryDefinition = @"from Users as u 
+                           load u.AddressId as a
+                           select {
+                               User: u,
+                               Address: a
+                           }";
+
+                var query = session.Advanced.RawQuery<ProjectedClass>(queryDefinition);
+
+                var reader = session.Advanced.Stream(query, out var stats);
+                
+                Assert.Equal(200, stats.TotalResults);
+            }
+        }
+    }
+    
+    private class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string LastName { get; set; }
+        public string AddressId { get; set; } 
+    }
+
+    private class Address
+    {
+        public string Id { get; set; }
+        public string Country { get; set; }
+        public string City { get; set; }
+        public string Street { get; set; }
+    }
+
+    private class ProjectedClass
+    {
+        public User User { get; set; }
+        public Address Address { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19533/Incorrect-totalResults-number-when-streaming-a-query-with-a-related-documents-projection

### Additional description

For collection query with load or include we want to have `TotalResults` equal to the number of documents in this collection

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
