### PR TITLE
RavenDB-21812 - Cluster_identity_for_single_document_in_parallel_on_different_nodes_should_work fails

### DIFF
--- a/test/SlowTests/Issues/RavenDB-6886.cs
+++ b/test/SlowTests/Issues/RavenDB-6886.cs
@@ -293,7 +293,7 @@ namespace SlowTests.Issues
             //LoggingSource.Instance.SetupLogMode(LogMode.Information, "D:\\raven-test-log");
             const int clusterSize = 3;
             const string databaseName = "Cluster_identity_for_multiple_documents_on_different_nodes_should_work";
-            var (_, leaderServer) = await CreateRaftCluster(clusterSize, leaderIndex: 2);
+            var (_, leaderServer) = await CreateRaftCluster(clusterSize, watcherCluster: true);
             var followers = Servers.Where(s => s != leaderServer).ToList();
             using (var leaderStore = GetDocumentStore(new Options
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20273/SlowTests.Cluster.ClusterTransactionTests.ClusterTransactionRequestWithRevisions

### Additional description

Test fails because it passes 'leaderIndex' to the 'CreateRaftCluster'.
In CreateRaftClusterInternal, when we pass leaderIndex (actualLeaderIndex isn't null), if the leader is changing, it throws, and it can happen if the cluster isn't a watcher cluster and that's what happens.
In case it isn't watcher cluster it will return the current new leader instead of throwing.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
  , because unit test will require adding testing stuff field and check\invoke it inside the `Leader.Run` method.

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
