### PR TITLE
RavenDB-22041 Fix usage of AndNot in CoraxQueryBuilder

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -354,7 +354,7 @@ public static class CoraxQueryBuilder
                                 right = ToCoraxQuery(builderParameters, ne1.Expression, ref builderParameters.StreamingDisabled, exact);
                                 TryMergeTwoNodesForAnd(indexSearcher, builderParameters, ref left, ref right, out merged,
                                     ref builderParameters.StreamingDisabled,  requiredMaterialization: true);
-                                return indexSearcher.AndNot(right, left, token: builderParameters.Token);
+                                return indexSearcher.AndNot(left, right, token: builderParameters.Token);
                             }
 
                             if (@where.Right is TrueExpression)

--- a/test/SlowTests/Issues/RavenDB-22041.cs
+++ b/test/SlowTests/Issues/RavenDB-22041.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22041 : RavenTestBase
+{
+    public RavenDB_22041(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public async Task ShouldWork(Options options)
+    {
+        using IDocumentStore store = GetDocumentStore(options);
+
+        await store.ExecuteIndexAsync(new Index());
+        await AddTestDataAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
+        await CountResultsAsync(store);
+    }
+
+    private static async Task CountResultsAsync(IDocumentStore store)
+    {
+        using IAsyncDocumentSession session = store.OpenAsyncSession();
+
+        IAsyncDocumentQuery<Index.Result> query = session
+            .Advanced
+            .AsyncDocumentQuery<Index.Result, Index>()
+            .OpenSubclause()
+            .Not.WhereIn(t => t.NumberA, [-1])
+            .AndAlso()
+            .WhereEquals(t => t.DeletedAt, (DateTime?)null)
+            .AndAlso()
+            .WhereEquals(t => t.IsClosed, false)
+            .AndAlso()
+            .WhereNotEquals(t => t.NumberB, (int?)null)
+            .CloseSubclause();
+        int count = await query.CountAsync();
+        Assert.Equal(1, count);
+    }
+
+    private static async Task AddTestDataAsync(IDocumentStore store)
+    {
+        using IAsyncDocumentSession session = store.OpenAsyncSession();
+
+        foreach (Dto dto in TestData())
+        {
+            await session.StoreAsync(dto);
+        }
+
+        await session.SaveChangesAsync();
+    }
+
+    private static IEnumerable<Dto> TestData()
+    {
+        yield return new Dto { NumberA = null, NumberB = null, DeletedAt = null, IsClosed = true };
+
+        yield return new Dto { NumberA = 1, NumberB = 2, DeletedAt = null, IsClosed = false };
+
+        yield return new Dto { NumberA = 2, NumberB = 3, DeletedAt = DateTime.UtcNow, IsClosed = true };
+    }
+
+    private class Dto
+    {
+        public int? NumberA { get; set; }
+
+        public int? NumberB { get; set; }
+
+        public DateTime? DeletedAt { get; set; }
+
+        public bool IsClosed { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<Dto, Index.Result>
+    {
+        public Index()
+        {
+            Map = dtos =>
+                from dto in dtos
+                select new Result { NumberA = dto.NumberA, NumberB = dto.NumberB, DeletedAt = dto.DeletedAt, IsClosed = dto.IsClosed };
+        }
+
+
+        public class Result
+        {
+            public int? NumberA { get; set; }
+
+            public int? NumberB { get; set; }
+
+            public DateTime? DeletedAt { get; set; }
+
+            public bool IsClosed { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22041/Corax-BooleanQuery-returns-different-number-of-elements.

### Additional description

When using `AndNot`, second parameter is the set we get excluded documents from. In this codepath it's stored in `right` variable.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
