### PR TITLE
RavenDB-22040 Send a notification when adding a tombstone without an existing document to force indexes to run indexing batches and update etags.

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1883,6 +1883,15 @@ namespace Raven.Server.Documents
                     documentFlags,
                     nonPersistentFlags).Etag;
 
+                // We've to add notification since we're updating last tombstone etag, and we can end up in situation when our indexes will be stale due unprocessed tombstones after replication.
+                context.Transaction.AddAfterCommitNotification(new DocumentChange
+                {
+                    Type = DocumentChangeTypes.Delete,
+                    Id = id,
+                    ChangeVector = changeVector,
+                    CollectionName = collectionName.Name,
+                });
+
                 return new DeleteOperationResult
                 {
                     Collection = collectionName,

--- a/test/SlowTests/Issues/RavenDB-22040.cs
+++ b/test/SlowTests/Issues/RavenDB-22040.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Indexes;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22040 : ReplicationTestBase
+{
+    public RavenDB_22040(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Indexes)]
+    public async Task ReplicatedTombstonesWillSendNotificationToIndexes()
+    {
+        var order1 = new Order() { Company = "Company1" };
+        var order2 = new Order() { Company = "Company2" };
+        var defaultTimeout = TimeSpan.FromSeconds(15);
+
+        var cluster = await CreateRaftCluster(2);
+
+        var store = GetDocumentStore(new Options { ReplicationFactor = 2, Server = cluster.Leader, });
+
+        var database = store.Database;
+
+        var node1 = await cluster.Nodes[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+        var node2 = await cluster.Nodes[1].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+
+        var t1 = await BreakReplication(cluster.Nodes[0].ServerStore, database);
+        var t2 = await BreakReplication(cluster.Nodes[1].ServerStore, database);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(order1);
+            await session.SaveChangesAsync();
+            await new Index().ExecuteAsync(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        t1.Mend();
+        t2.Mend();
+
+        await WaitForDocumentInClusterAsync<Order>(cluster.Nodes, database, order1.Id, predicate: null, defaultTimeout);
+
+        t1 = await BreakReplication(cluster.Nodes[0].ServerStore, database);
+        t2 = await BreakReplication(cluster.Nodes[1].ServerStore, database);
+        var markerDocument = new Employee() { FirstName = "MARKER" };
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(order2);
+            await session.SaveChangesAsync();
+            Indexes.WaitForIndexing(store);
+
+            session.Delete(order2.Id);
+            await session.SaveChangesAsync();
+
+            await session.StoreAsync(markerDocument);
+            await session.SaveChangesAsync();
+        }
+
+        t1.Mend();
+        t2.Mend();
+
+        await WaitForDocumentInClusterAsync<Employee>(cluster.Nodes, database, markerDocument.Id, null, defaultTimeout);
+        Indexes.WaitForIndexing(store, database, timeout: defaultTimeout, nodeTag: "A");
+        Indexes.WaitForIndexing(store, database, timeout: defaultTimeout, nodeTag: "B");
+    }
+
+    private class Index : AbstractIndexCreationTask<Order>
+    {
+        public Index()
+        {
+            Map = orders => orders.Select(x => new { x.Company });
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22040
### Additional description

When we replicate tombstones we've to force indexing threads to run indexing batch to process new tombstones (even it's noop) since we've to update last etags in indexes. If not this leads to situation when indexes will be stale due unprocessed tombstones.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
