### PR TITLE
RavenDB-21979: Avoid allocations at the RecentlyFoundTreePages level.

### DIFF
--- a/src/Voron/Data/BTrees/RecentlyFoundTreePages.cs
+++ b/src/Voron/Data/BTrees/RecentlyFoundTreePages.cs
@@ -1,149 +1,252 @@
-// -----------------------------------------------------------------------
-//  <copyright file="BinaryTree.cs" company="Hibernating Rhinos LTD">
-//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
-//  </copyright>
-// -----------------------------------------------------------------------
-
 using System;
-using Sparrow.Server;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using Sparrow;
 
 namespace Voron.Data.BTrees
 {
-    public sealed class RecentlyFoundTreePages
+    [SkipLocalsInit]
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct FoundTreePageDescriptor
     {
-        public sealed class FoundTreePage : IDisposable
+        public const int MaxCursorPath = 8;
+        public const int MaxKeyStorage = 256;
+
+        public TreePage Page;
+        public long Number;
+
+        // We are setting ourselves to not allow pages whose path sequences are longer than MaxCursorPath, this makes sense
+        // because if we are in such a long sequence, it is highly unlikely this cache would be useful anyway. 
+        public fixed long PathSequence[MaxCursorPath];
+
+        public fixed byte KeyStorage[MaxKeyStorage];
+
+        public SliceOptions FirstKeyOptions;
+        public SliceOptions LastKeyOptions;
+
+        public int PathLength;
+        public int FirstKeyLength;
+        public int LastKeyLength;
+
+        public Span<byte> FirstKey => MemoryMarshal.CreateSpan(ref KeyStorage[0], FirstKeyLength);
+        public Span<byte> LastKey => MemoryMarshal.CreateSpan(ref KeyStorage[FirstKeyLength], LastKeyLength);
+
+        public ReadOnlySpan<long> Cursor => MemoryMarshal.CreateReadOnlySpan(ref PathSequence[0], PathLength);
+    }
+
+    [SkipLocalsInit]
+    public unsafe class RecentlyFoundTreePages()
+    {
+        // PERF: We are using a cache size that we can access directly from a 512 bits instruction when supported
+        // or two 256 instructions.
+        public const int CacheSize = 8;
+
+        private Vector512<long> _pageNumberCache = Vector512<long>.AllBitsSet;
+        private Vector256<uint> _pageGenerationCache = Vector256<uint>.Zero;
+
+        private uint _current;
+        private uint _currentGeneration = 1;
+
+        private readonly FoundTreePageDescriptor[] _pageDescriptors = new FoundTreePageDescriptor[CacheSize];
+
+        private int Compare(ReadOnlySpan<byte> x1, ReadOnlySpan<byte> y1)
         {
-            public readonly long Number;
-            public readonly Slice FirstKey;
-            public readonly Slice LastKey;
-            public readonly long[] CursorPath;
-            private ByteStringContext.Scope _firstScope;
-            private ByteStringContext.Scope _lastScope;
+            int x1Length = x1.Length;
+            int y1Length = y1.Length;
+            var keyDiff = x1Length - y1Length;
 
-            public TreePage Page;
-
-            public FoundTreePage(long number, TreePage page, Slice firstKey, Slice lastKey, long[] cursorPath, ByteStringContext.Scope firstScope, ByteStringContext.Scope lastScope)
-            {
-                Number = number;
-                Page = page;
-                FirstKey = firstKey;
-                LastKey = lastKey;
-                CursorPath = cursorPath;
-                _firstScope = firstScope;
-                _lastScope = lastScope;
-            }
-
-            public void Dispose()
-            {
-                _firstScope.Dispose();
-               _lastScope.Dispose();
-            }
+            var r = Memory.CompareInline(x1, y1, Math.Min(x1Length, y1Length));
+            return r != 0 ? r : keyDiff;
         }
 
-        private readonly FoundTreePage[] _cache;
-
-        private readonly int _cacheSize;
-
-        private int _current = 0;
-
-        public RecentlyFoundTreePages(int cacheSize)
+        public bool TryFind(Slice key, out FoundTreePageDescriptor foundPage)
         {
-            _cache = new FoundTreePage[cacheSize];
-            _cacheSize = cacheSize;
+            return TryFind(key.Options, key.AsReadOnlySpan(), out foundPage);
         }
 
-        public void Add(FoundTreePage page)
+        public bool TryFind(SliceOptions keyOption, ReadOnlySpan<byte> key, out FoundTreePageDescriptor foundPage)
         {
-            int itemsLeft = _cacheSize;
-            int position = _current + _cacheSize;
-            while (itemsLeft > 0)
+            Debug.Assert(_currentGeneration > 0);
+            Debug.Assert(_pageDescriptors.Length == CacheSize);
+
+            var descriptors = _pageDescriptors;
+
+            uint location = FindMatchingByGeneration(_currentGeneration);
+
+            int i = -1;
+            while (location != 0)
             {
-                var itemIndex = position % _cacheSize;
-                var item = _cache[itemIndex];
-                if (item == null || item.Number == page.Number)
-                {
-                    item?.Dispose();
-                    _cache[itemIndex] = page;
-                    return;
-                }
+                // We will find the next matching item in the cache and advance the pointer to its rightful place.
+                int advance = BitOperations.TrailingZeroCount(location) + 1;
+                i += advance;
 
-                itemsLeft--;
-                position--;
-            }
+                // We will advance the bitmask to the location. If there are no more, it will be zero and fail
+                // the re-entry check on the while loop. 
+                location >>= advance;
 
-            _current = (++_current) % _cacheSize;
-            _cache[_current]?.Dispose();
-            _cache[_current] = page;
-        }
+                ref var current = ref descriptors[i];
 
-        public FoundTreePage Find(Slice key)
-        {
-            int position = _current;
-
-            int itemsLeft = _cacheSize;
-            while ( itemsLeft > 0 )
-            {
-                var page = _cache[position % _cacheSize];
-                if (page == null)
-                {
-                    itemsLeft--;
-                    position++;
-
-                    continue;
-                }
-
-                var first = page.FirstKey;
-                var last = page.LastKey;
-
-                switch (key.Options)
+                switch (keyOption)
                 {
                     case SliceOptions.Key:
-                        if ((first.Options != SliceOptions.BeforeAllKeys && SliceComparer.Compare(key, first) < 0))
+                        if ((current.FirstKeyOptions != SliceOptions.BeforeAllKeys && Compare(key, current.FirstKey) < 0))
                             break;
-                        if (last.Options != SliceOptions.AfterAllKeys && SliceComparer.Compare(key, last) > 0)
+                        if (current.LastKeyOptions != SliceOptions.AfterAllKeys && Compare(key, current.LastKey) > 0)
                             break;
-                        return page;
+
+                        foundPage = current;
+                        return true;
                     case SliceOptions.BeforeAllKeys:
-                        if (first.Options == SliceOptions.BeforeAllKeys)
-                            return page;
+                        if (current.FirstKeyOptions == SliceOptions.BeforeAllKeys)
+                        {
+                            foundPage = current;
+                            return true;
+                        }
                         break;
                     case SliceOptions.AfterAllKeys:
-                        if (last.Options == SliceOptions.AfterAllKeys)
-                            return page;
+                        if (current.LastKeyOptions == SliceOptions.AfterAllKeys)
+                        {
+                            foundPage = current;
+                            return true;
+                        }
+
                         break;
                     default:
-                        throw new ArgumentException(key.Options.ToString());
+                        throw new ArgumentException(keyOption.ToString());
                 }
-
-                itemsLeft--;
-                position++;
             }
 
-            return null;
+            Unsafe.SkipInit(out foundPage);
+            return false;
         }
 
-        public void Clear()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private uint FindMatchingByGeneration(uint generation)
         {
-            for (var i = 0; i < _cacheSize; i++)
-            {
-                var page = _cache[i];
-                page?.Dispose();
-            }
-            
-            Array.Clear(_cache, 0, _cacheSize);
+            // PERF: We will check the entire small cache for current generation matches all at the same time
+            // by comparing element-wise each item against a constant. Then since we will extract the most 
+            // significant bit which will be set by the result of the .Equals() instruction and with that
+            // we create a bitmask we will use during the search procedure.
+            return Vector256.Equals(
+                _pageGenerationCache,
+                Vector256.Create(generation)
+            ).ExtractMostSignificantBits();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private uint FindMatchingByPageNumber(long pageNumber)
+        {
+            // PERF: We will check the entire small cache for current page number matches all at the same time
+            // by comparing element-wise each item against a constant. Then since we will extract the most 
+            // significant bit which will be set by the result of the .Equals() instruction and with that
+            // we create a bitmask we will use during the search procedure. In this case we can actually coerce
+            // to uint because we know there are no more than 8 elements in the cache.
+
+            return (uint)Vector512.Equals(
+                        _pageNumberCache,
+                        Vector512.Create(pageNumber)
+                    ).ExtractMostSignificantBits();
         }
 
         public void Reset(long num)
         {
-            for (int i = 0; i < _cache.Length; i++)
+            Debug.Assert(_currentGeneration > 0);
+            Debug.Assert(_pageDescriptors.Length == CacheSize);
+
+            var matchesByGeneration = FindMatchingByGeneration(_currentGeneration);
+            var matchesByPageNumber = FindMatchingByPageNumber(num);
+
+            var matches = matchesByPageNumber & matchesByGeneration;
+
+            int i = -1;
+            while (matches != 0)
             {
-                var page = _cache[i];
-                if (page != null && page.Number == num)
-                {
-                    page.Page = null;
-                    return;
-                }
+                // We will find the next matching item in the cache and advance the pointer to its rightful place.
+                int advance = BitOperations.TrailingZeroCount(matches) + 1;
+                i += advance;
+
+                Debug.Assert(_pageNumberCache[i] == num);
+
+                // We will advance the bitmask to the location. If there are no more, it will be zero and fail
+                // the re-entry check on the while loop. 
+                matches >>= advance;
+
+                // This just reset the cached page instance. 
+                _pageGenerationCache = _pageGenerationCache.WithElement(i, (uint)0);
+                _pageNumberCache = _pageNumberCache.WithElement(i, -1L);
             }
+
+            Debug.Assert((FindMatchingByPageNumber(num) & FindMatchingByGeneration(_currentGeneration)) == 0);
+        }
+
+        public void Clear()
+        {
+            _pageNumberCache = Vector512<long>.AllBitsSet;
+            _pageGenerationCache = Vector256<uint>.Zero;
+
+            _currentGeneration++;
+            if (_currentGeneration == int.MaxValue)
+                _currentGeneration = 1;
+
+            Debug.Assert(FindMatchingByGeneration(_currentGeneration) == 0);
+        }
+
+        public void Add(TreePage page, SliceOptions firstKeyOption, ReadOnlySpan<byte> firstKey, SliceOptions lastKeyOption, ReadOnlySpan<byte> lastKey, ReadOnlySpan<long> cursorPath)
+        {
+            // PERF: The idea behind this check is that IF the page has a bigger cursor path than what we support
+            // on the struct, and this been a performance improvement we are going to reject it outright. We will
+            // not try to accomodate variability in this regard in order to avoid allocations.
+            if (cursorPath.Length > FoundTreePageDescriptor.MaxCursorPath ||
+                firstKey.Length + lastKey.Length > FoundTreePageDescriptor.MaxKeyStorage)
+                return;
+
+            Debug.Assert(_currentGeneration > 0);
+            Debug.Assert(_pageDescriptors.Length == CacheSize);
+
+            var currentPage = page.PageNumber;
+
+            // If we already have the page in the cache (regardless of generation), we will overwrite it.
+            // This would also ensure that every page whenever it was added to this cache, will have its
+            // bucket assigned until it is removed completely.
+            var match = FindMatchingByPageNumber(currentPage);
+
+            // We will find the next matching item in the cache or get a new location.
+            var position = match == 0 ? _current % CacheSize : (uint)BitOperations.TrailingZeroCount(match);
+
+            ref var current = ref _pageDescriptors[(int)position];
+            current.Page = page;
+            current.Number = page.PageNumber;
+            current.PathLength = cursorPath.Length;
+            if (cursorPath.Length > 0)
+                cursorPath.CopyTo(MemoryMarshal.CreateSpan(ref current.PathSequence[0], cursorPath.Length));
+
+            // We update the information regarding the keys to ensure we can get the Span<byte> representing it.
+            current.FirstKeyLength = firstKey.Length;
+            current.FirstKeyOptions = firstKeyOption;
+            current.LastKeyLength = lastKey.Length;
+            current.LastKeyOptions = lastKeyOption;
+
+            if (firstKey.Length > 0)
+            {
+                Debug.Assert(current.FirstKey.Length == firstKey.Length);
+                firstKey.CopyTo(current.FirstKey);
+            }
+
+            if (lastKey.Length > 0)
+            {
+                Debug.Assert(current.LastKey.Length == lastKey.Length);
+                lastKey.CopyTo(current.LastKey);
+            }
+
+            _pageGenerationCache = _pageGenerationCache.WithElement((int)position, _currentGeneration);
+            _pageNumberCache = _pageNumberCache.WithElement((int)position, page.PageNumber);
+
+            _current++;
+
+            Debug.Assert(FindMatchingByPageNumber(currentPage) != 0);
         }
     }
 }

--- a/src/Voron/Data/BTrees/TreePage.cs
+++ b/src/Voron/Data/BTrees/TreePage.cs
@@ -614,7 +614,15 @@ namespace Voron.Data.BTrees
                 return TreeNodeHeader.ToSlice(tx.Allocator, node, type, out result);
             }
             return TreeNodeHeader.ToSlicePtr(tx.Allocator, node, type, out result);
-        }  
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void GetNodeKey(int nodeNumber, out ReadOnlySpan<byte> result)
+        {
+            var node = GetNode(nodeNumber);
+            byte* ptr = TreeNodeHeader.GetKeyPtr(node, out int size);
+            result = new ReadOnlySpan<byte>(ptr, size);
+        }
 
         public string DebugView(LowLevelTransaction tx)
         {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21979

### Additional description

The original version of RecentlyFoundTreePages requires us to perform allocations for each access to a tree. We want to avoid those allocations as much as we can. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
