### PR TITLE
RavenDB-22047 - few fixes for backup

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1140,12 +1140,13 @@ namespace Raven.Server.Documents
                                 if (ex is DatabaseConcurrentLoadTimeoutException e)
                                 {
                                     // database failed to load, retry after 1 min
-                                    ForTestingPurposes?.RescheduleDatabaseWakeupMre?.Set();
 
                                     if (_logger.IsInfoEnabled)
                                         _logger.Info($"Failed to start database '{databaseName}' on timer, will retry the wakeup in '{_dueTimeOnRetry}' ms", e);
 
                                     nextIdleDatabaseActivity.DateTime = DateTime.UtcNow.AddMilliseconds(_dueTimeOnRetry);
+                                    ForTestingPurposes?.RescheduleDatabaseWakeupMre?.Set();
+
                                     RescheduleNextIdleDatabaseActivity(databaseName, nextIdleDatabaseActivity);
                                 }
                             }, TaskContinuationOptions.OnlyOnFaulted);

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1039,19 +1039,17 @@ namespace Raven.Server.Documents
                 UnloadDatabaseInternal(databaseName.Value, caller);
                 LastRecentlyUsed.TryRemove(databaseName, out _);
 
-                if (idleDatabaseActivity?.DueTime > 0)
+                if (idleDatabaseActivity != null)
                     _wakeupTimers.TryAdd(databaseName.Value, new Timer(
                         callback: _ => NextScheduledActivityCallback(databaseName.Value, idleDatabaseActivity),
                         state: null,
-                        dueTime: idleDatabaseActivity.DueTime,
+                        // in case the DueTime is negative or zero, the callback will be called immediately and database will be loaded.
+                        dueTime: idleDatabaseActivity.DueTime > 0 ? idleDatabaseActivity.DueTime : 0,
                         period: Timeout.Infinite));
 
                 if (_logger.IsOperationsEnabled)
                 {
-                    var msg = idleDatabaseActivity?.DueTime > 0
-                        ? $"wakeup timer set to: {idleDatabaseActivity.DateTime.Value}, which will happen in {idleDatabaseActivity.DueTime} ms."
-                        : "without setting a wakeup timer.";
-
+                    var msg = idleDatabaseActivity == null ? "without setting a wakeup timer." : $"wakeup timer set to: '{idleDatabaseActivity.DateTime.GetValueOrDefault()}', which will happen in '{idleDatabaseActivity.DueTime}' ms.";
                     _logger.Operations($"Unloading directly database '{databaseName}', {msg}");
                 }
 

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -398,10 +398,11 @@ namespace Raven.Server.Web.System
             var nodeTag = Database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
             if (nodeTag == null)
             {
-                // this can happen for a new task that was just created
-                // we'll wait for the cluster observer to determine the responsible node for the backup
+                // this can happen if the database was just created or if a new task that was just created
+                // we'll wait for the cluster observer to give more time for the database stats to become stable,
+                // and then we'll wait for the cluster observer to determine the responsible node for the backup
 
-                var task = Task.Delay(Database.Configuration.Cluster.StabilizationTime.AsTimeSpan);
+                var task = Task.Delay(Database.Configuration.Cluster.StabilizationTime.AsTimeSpan + Database.Configuration.Cluster.StabilizationTime.AsTimeSpan);
                 
                 while (true)
                 {

--- a/test/SlowTests/Issues/RavenDB-18442.cs
+++ b/test/SlowTests/Issues/RavenDB-18442.cs
@@ -51,11 +51,7 @@ namespace SlowTests.Issues
             Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, result.TaskId);
 
             // Turn Database offline in second server.
-            Assert.Equal(1, WaitForValue(() => secondServer.ServerStore.IdleDatabases.Count, 1, timeout: 60000, interval: 1000)); //wait for db to be idle
-            var online = secondServer.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(store.Database, out Task<DocumentDatabase> dbTask) &&
-                         dbTask != null &&
-                         dbTask.IsCompleted;
-            Assert.False(online);
+            secondServer.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
 
             // Backup run in first server
             await Backup.RunBackupAsync(firstServer, result.TaskId, store);

--- a/test/StressTests/Issues/RavenDB_18420.cs
+++ b/test/StressTests/Issues/RavenDB_18420.cs
@@ -60,7 +60,11 @@ public class RavenDB_18420 : RavenTestBase
 
                 var mre = server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().RescheduleDatabaseWakeupMre = new ManualResetEventSlim();
 
-                // enable backup
+                // we wait here for UpdateResponsibleNodeForTasksCommand, it won't wake up the database since the db task is faulted with DatabaseConcurrentLoadTimeoutException
+                Backup.WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, putConfiguration.TaskId);
+                Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
+
+                // enable backup and this will set wakeup timer
                 await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
 
                 Assert.True(mre.Wait(TimeSpan.FromSeconds(65)));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22047

### Additional description

1. In case we have negative `dueTime` after unloading (disposing) the `DocumentDatabase` we have to load it immediately
2. after adding new database to server with server wide backup, and immediately starting backup of the new database, we have to wait for cluster observer make database stats to become stable (takes `Database.Configuration.Cluster.StabilizationTime`) and then wait for cluster observer to set responsible node for this backup (so I wait `2xDatabase.Configuration.Cluster.StabilizationTime`)
3. fix failing tests,
4. make sure `IdleDatabaseActivity.DateTime` set to `null` only in tests

### Type of change

- [x] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
