### PR TITLE
RavenDB-22065 Removing wrong assertion for PhraseQuery.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -1317,7 +1317,6 @@ namespace Corax.Indexing
                 //Update mapping virtual<=> storage location location. Final writing will be done after inserting ALL terms for specific field.
                 if (_writer.FieldSupportsPhraseQuery(_indexedField))
                 {
-                    Debug.Assert(_virtualTermIdToTermContainerId.Count == _indexedField.Textual.Count(), "virtualMapping.Count == _indexedField.Textual.Count()");
                     Debug.Assert(_virtualTermIdToTermContainerId[storageLocation] == Constants.IndexedField.Invalid, "virtualMapping[entries.StorageLocation] == Constants.IndexedField.Invalid, Term was already set! Persisted: {_virtualTermIdToTermContainerId[storageLocation]}, new: {termContainerId}");
                     _virtualTermIdToTermContainerId[storageLocation] = termContainerId;
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22065 
### Additional description

Since our terms are lazily initialized during Phrase Query indexing, we have to build a mapping based on virtual IDs. Since all terms (and their posting lists) are stored in the Storage array, I made it virtual based on that. However, there is a case where you've mixed values under a field, so some of the storage values will be related to longs/doubles posting lists, causing an assertion to fail.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
