### PR TITLE
RavenDB-21922 - Replication - Usability & Self-Service

### DIFF
--- a/src/Raven.Client/Documents/Replication/IncomingReplicationPerformanceStats.cs
+++ b/src/Raven.Client/Documents/Replication/IncomingReplicationPerformanceStats.cs
@@ -17,16 +17,20 @@ namespace Raven.Client.Documents.Replication
         public long ReceivedLastEtag { get; set; }
 
         public NetworkStats Network { get; set; }
-        
+
         public sealed class NetworkStats
         {
             public int InputCount { get; set; }
 
             public int DocumentReadCount { get; set; }
             public int DocumentTombstoneReadCount { get; set; }
-            public int AttachmentTombstoneReadCount { get; set; }
+            public int RevisionReadCount { get; set; }
+            public int RevisionTombstoneReadCount { get; set; }
             public int AttachmentReadCount { get; set; }
+            public int AttachmentTombstoneReadCount { get; set; }
             public int CounterReadCount { get; set; }
+            public int TimeSeriesReadCount { get; set; }
+            public int TimeSeriesDeletedRangeReadCount { get; set; }
         }
     }
 }

--- a/src/Raven.Client/Documents/Replication/IncomingReplicationPerformanceStats.cs
+++ b/src/Raven.Client/Documents/Replication/IncomingReplicationPerformanceStats.cs
@@ -15,6 +15,7 @@ namespace Raven.Client.Documents.Replication
         }
 
         public long ReceivedLastEtag { get; set; }
+        public string DatabaseChangeVector { get; set; }
 
         public NetworkStats Network { get; set; }
 
@@ -23,14 +24,34 @@ namespace Raven.Client.Documents.Replication
             public int InputCount { get; set; }
 
             public int DocumentReadCount { get; set; }
+            public long DocumentReadSizeInBytes { get; set; }
+
             public int DocumentTombstoneReadCount { get; set; }
+            public long DocumentTombstoneReadSizeInBytes { get; set; }
+
             public int RevisionReadCount { get; set; }
+            public long RevisionReadSizeInBytes { get; set; }
+
             public int RevisionTombstoneReadCount { get; set; }
+            public long RevisionTombstoneReadSizeInBytes { get; set; }
+
             public int AttachmentReadCount { get; set; }
+            public long AttachmentReadSizeInBytes { get; set; }
+
+            public int AttachmentStreamReadCount { get; set; }
+            public long AttachmentStreamReadSizeInBytes { get; set; }
+
             public int AttachmentTombstoneReadCount { get; set; }
+            public long AttachmentTombstoneReadSizeInBytes { get; set; }
+
             public int CounterReadCount { get; set; }
+            public long CounterReadSizeInBytes { get; set; }
+
             public int TimeSeriesReadCount { get; set; }
+            public long TimeSeriesReadSizeInBytes { get; set; }
+
             public int TimeSeriesDeletedRangeReadCount { get; set; }
+            public long TimeSeriesDeletedRangeReadSizeInBytes { get; set; }
         }
     }
 }

--- a/src/Raven.Client/Documents/Replication/OutgoingReplicationPerformanceStats.cs
+++ b/src/Raven.Client/Documents/Replication/OutgoingReplicationPerformanceStats.cs
@@ -35,11 +35,16 @@ namespace Raven.Client.Documents.Replication
             public int DocumentOutputCount { get; set; }
             public long DocumentOutputSizeInBytes { get; set; }
 
+            public int RevisionOutputCount { get; set; }
+            public long RevisionOutputSizeInBytes { get; set; }
+
             public int CounterOutputCount { get; set; }
             public long CounterOutputSizeInBytes { get; set; }
 
             public int TimeSeriesSegmentsOutputCount { get; set; }
             public long TimeSeriesSegmentsSizeInBytes { get; set; }
+
+            public int TimeSeriesDeletedRangeOutputCount { get; set; }
         }
 
         public sealed class StorageStats

--- a/src/Raven.Client/Documents/Replication/OutgoingReplicationPerformanceStats.cs
+++ b/src/Raven.Client/Documents/Replication/OutgoingReplicationPerformanceStats.cs
@@ -42,6 +42,9 @@ namespace Raven.Client.Documents.Replication
             public int RevisionOutputCount { get; set; }
             public long RevisionOutputSizeInBytes { get; set; }
 
+            public int RevisionTombstoneOutputCount { get; set; }
+            public long RevisionTombstoneOutputSizeInBytes { get; set; }
+
             public int CounterOutputCount { get; set; }
             public long CounterOutputSizeInBytes { get; set; }
 

--- a/src/Raven.Client/Documents/Replication/OutgoingReplicationPerformanceStats.cs
+++ b/src/Raven.Client/Documents/Replication/OutgoingReplicationPerformanceStats.cs
@@ -10,21 +10,25 @@ namespace Raven.Client.Documents.Replication
             // for deserialization
         }
 
-        public OutgoingReplicationPerformanceStats(TimeSpan duration) 
+        public OutgoingReplicationPerformanceStats(TimeSpan duration)
             : base(duration)
         {
         }
 
         public long SendLastEtag { get; set; }
+        public string LastAcceptedChangeVector { get; set; }
 
         public StorageStats Storage { get; set; }
 
         public NetworkStats Network { get; set; }
-        
+
         public sealed class NetworkStats
         {
             public int AttachmentOutputCount { get; set; }
             public long AttachmentOutputSizeInBytes { get; set; }
+
+            public int AttachmentStreamOutputCount { get; set; }
+            public long AttachmentStreamOutputSizeInBytes { get; set; }
 
             public int AttachmentTombstoneOutputCount { get; set; }
             public long AttachmentTombstoneOutputSizeInBytes { get; set; }
@@ -45,12 +49,12 @@ namespace Raven.Client.Documents.Replication
             public long TimeSeriesSegmentsSizeInBytes { get; set; }
 
             public int TimeSeriesDeletedRangeOutputCount { get; set; }
+            public long TimeSeriesDeletedRangeOutputSizeInBytes { get; set; }
         }
 
         public sealed class StorageStats
         {
             public int InputCount { get; set; }
-
             public int ArtificialDocumentSkipCount { get; set; }
             public int SystemDocumentSkipCount { get; set; }
             public int ChangeVectorSkipCount { get; set; }
@@ -76,6 +80,8 @@ namespace Raven.Client.Documents.Replication
         public double DurationInMs { get; set; }
 
         public DateTime? Completed { get; set; }
+
+        public long? BatchSizeInBytes { get; set; }
 
         public ReplicationPerformanceOperation Details { get; set; }
 

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -355,10 +355,6 @@ namespace Raven.Server.Documents.Replication.Incoming
             }
         }
 
-        protected virtual void RecordDatabaseChangeVector(TOperationContext context, IncomingReplicationStatsScope stats)
-        {
-        }
-
         protected void AddReplicationPerformance(IncomingReplicationStatsAggregator stats)
         {
             _lastReplicationStats.Enqueue(stats);
@@ -463,7 +459,6 @@ namespace Raven.Server.Documents.Replication.Incoming
                 {
                     using (var networkStats = stats.For(ReplicationOperation.Incoming.Network))
                     {
-                        RecordDatabaseChangeVector(context, networkStats);
                         // this will read the documents to memory from the network
                         // without holding the write tx open
                         var reader = new Reader(_stream, _copiedBuffer, incomingReplicationAllocator);

--- a/src/Raven.Server/Documents/Replication/Incoming/IAbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IAbstractIncomingReplicationHandler.cs
@@ -11,6 +11,7 @@ namespace Raven.Server.Documents.Replication.Incoming
         public string SourceFormatted { get; }
         public long LastDocumentEtag { get; }
         public IncomingReplicationPerformanceStats[] GetReplicationPerformance();
+        public IncomingReplicationStatsAggregator GetLatestReplicationPerformance();
         public LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType();
     }
 }

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -243,6 +243,14 @@ namespace Raven.Server.Documents.Replication.Incoming
                 : LiveReplicationPerformanceCollector.ReplicationPerformanceType.IncomingExternal;
         }
 
+        protected override void RecordDatabaseChangeVector(DocumentsOperationContext context, IncomingReplicationStatsScope stats)
+        {
+            using (context.OpenReadTransaction())
+            {
+                stats.RecordDatabaseChangeVector(DocumentsStorage.GetDatabaseChangeVector(context)?.AsString());
+            }
+        }
+
         protected override Task HandleBatchAsync(DocumentsOperationContext context, DataForReplicationCommand batch, long lastEtag)
         {
             var replicationCommand = GetMergeDocumentsCommand(context, batch, lastEtag);

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -247,9 +247,8 @@ namespace Raven.Server.Documents.Replication.Outgoing
                             }
                             catch (Exception e)
                             {
-                                AddReplicationPulse(ReplicationPulseDirection.OutgoingError, e.Message);
-
                                 scope.AddError(e);
+                                AddReplicationPulse(ReplicationPulseDirection.OutgoingError, e.Message);
                                 throw;
                             }
                         }

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -130,8 +130,10 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                         tempBufferPos += sizeToCopy;
                         docReadPos += sizeToCopy;
                     }
-
-                    stats.RecordDocumentOutput(Data.Size);
+                    if (Flags.Contain(DocumentFlags.Revision))
+                        stats.RecordRevisionOutput(Data.Size);
+                    else
+                        stats.RecordDocumentOutput(Data.Size);
                 }
                 else
                 {

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/DocumentReplicationItem.cs
@@ -167,7 +167,6 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             if (Type == ReplicationItemType.Document)
             {
                 scope = stats.For(ReplicationOperation.Incoming.DocumentRead, start: false);
-                stats.RecordDocumentRead();
             }
             else
             {
@@ -186,6 +185,11 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 var documentSize = *(int*)Reader.ReadExactly(sizeof(int));
                 if (documentSize != -1) //if -1, then this is a tombstone
                 {
+                    if (Flags.Contain(DocumentFlags.Revision))
+                        stats.RecordRevisionRead();
+                    else
+                        stats.RecordDocumentRead();
+
                     var mem = Reader.AllocateMemory(documentSize);
                     Reader.ReadExactly(mem, documentSize);
 

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
@@ -6,7 +6,6 @@ using System.Text;
 using Raven.Server.Documents.Replication.Incoming;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide;
-using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -38,9 +37,12 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             return $"{Type} {ChangeVector}";
         }
 
-        public abstract long AssertChangeVectorSize();
+        public virtual long Size => sizeof(byte) + // type
+                                    sizeof(int) + //  size of change vector
+                                    Encodings.Utf8.GetByteCount(ChangeVector) +
+                                    sizeof(short); // transaction marker
 
-        public abstract long Size { get; }
+        public abstract long AssertChangeVectorSize();
 
         public abstract void Write(Slice changeVector, Stream stream, byte[] tempBuffer, OutgoingReplicationStatsScope stats);
 

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
@@ -79,16 +79,20 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
 
         public override unsafe void Read(JsonOperationContext context, ByteStringContext allocator, IncomingReplicationStatsScope stats)
         {
+            using (stats.For(ReplicationOperation.Incoming.TimeSeriesDeletedRangeRead))
+            {
+                stats.RecordTimeSeriesDeletedRangeRead();
 
-            var keySize = *(int*)Reader.ReadExactly(sizeof(int));
-            var key = Reader.ReadExactly(keySize);
-            ToDispose(Slice.From(allocator, key, keySize, ByteStringType.Immutable, out Key));
+                var keySize = *(int*)Reader.ReadExactly(sizeof(int));
+                var key = Reader.ReadExactly(keySize);
+                ToDispose(Slice.From(allocator, key, keySize, ByteStringType.Immutable, out Key));
 
-            From = new DateTime(*(long*)Reader.ReadExactly(sizeof(long)));
-            To = new DateTime(*(long*)Reader.ReadExactly(sizeof(long)));
+                From = new DateTime(*(long*)Reader.ReadExactly(sizeof(long)));
+                To = new DateTime(*(long*)Reader.ReadExactly(sizeof(long)));
 
-            SetLazyStringValueFromString(context, out Collection);
-            Debug.Assert(Collection != null);
+                SetLazyStringValueFromString(context, out Collection);
+                Debug.Assert(Collection != null);
+            }
         }
 
         protected override ReplicationBatchItem CloneInternal(JsonOperationContext context, ByteStringContext allocator)
@@ -184,21 +188,25 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
 
         public override unsafe void Read(JsonOperationContext context, ByteStringContext allocator, IncomingReplicationStatsScope stats)
         {
-            // TODO: add stats
-            var keySize = *(int*)Reader.ReadExactly(sizeof(int));
-            var key = Reader.ReadExactly(keySize);
-            ToDispose(Slice.From(allocator, key, keySize, ByteStringType.Immutable, out Key));
+            using (stats.For(ReplicationOperation.Incoming.TimeSeriesRead))
+            {
+                stats.RecordTimeSeriesRead();
 
-            var segmentSize = *(int*)Reader.ReadExactly(sizeof(int));
-            var mem = Reader.AllocateMemory(segmentSize);
-            Memory.Copy(mem, Reader.ReadExactly(segmentSize), segmentSize);
-            Segment = new TimeSeriesValuesSegment(mem, segmentSize);
+                var keySize = *(int*)Reader.ReadExactly(sizeof(int));
+                var key = Reader.ReadExactly(keySize);
+                ToDispose(Slice.From(allocator, key, keySize, ByteStringType.Immutable, out Key));
 
-            SetLazyStringValueFromString(context, out Collection);
-            Debug.Assert(Collection != null);
+                var segmentSize = *(int*)Reader.ReadExactly(sizeof(int));
+                var mem = Reader.AllocateMemory(segmentSize);
+                Memory.Copy(mem, Reader.ReadExactly(segmentSize), segmentSize);
+                Segment = new TimeSeriesValuesSegment(mem, segmentSize);
 
-            SetLazyStringValueFromString(context, out Name);
-            Debug.Assert(Name != null);
+                SetLazyStringValueFromString(context, out Collection);
+                Debug.Assert(Collection != null);
+
+                SetLazyStringValueFromString(context, out Name);
+                Debug.Assert(Name != null);
+            }
         }
 
 

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
@@ -74,6 +74,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 tempBufferPos += Collection.Size;
 
                 stream.Write(tempBuffer, 0, tempBufferPos);
+                stats.RecordTimeSeriesDeletedRangeOutput();
             }
         }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationOperation.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationOperation.cs
@@ -15,6 +15,8 @@
             public const string Network = "Network/Read";
             public const string DocumentRead = "Network/DocumentRead";
             public const string AttachmentRead = "Network/AttachmentRead";
+            public const string TimeSeriesRead = "Network/TimeSeriesRead";
+            public const string TimeSeriesDeletedRangeRead = "Network/TimeSeriesDeletedRangeRead";
             public const string TombstoneRead = "Network/TombstoneRead";
 
             public const string Storage = "Storage/Write";

--- a/src/Raven.Server/Documents/Replication/ReplicationOperation.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationOperation.cs
@@ -14,6 +14,7 @@
 
             public const string Network = "Network/Read";
             public const string DocumentRead = "Network/DocumentRead";
+            public const string CounterRead = "Network/CounterRead";
             public const string AttachmentRead = "Network/AttachmentRead";
             public const string TimeSeriesRead = "Network/TimeSeriesRead";
             public const string TimeSeriesDeletedRangeRead = "Network/TimeSeriesDeletedRangeRead";

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -617,7 +617,7 @@ namespace Raven.Server.Documents.Replication.Senders
             };
 
             stats.RecordLastEtag(_lastEtag);
-
+            stats.RecordLastAcceptedChangeVector(_parent.LastAcceptedChangeVector);
             _parent.WriteToServer(headerJson);
 
             foreach (var item in _orderedReplicaItems)
@@ -633,9 +633,8 @@ namespace Raven.Server.Documents.Replication.Senders
             {
                 using (item.Value)
                 {
-                item.Value.WriteStream(_stream, _tempBuffer);
-                stats.RecordAttachmentOutput(item.Value.Stream.Length);
-            }
+                    item.Value.WriteStream(_stream, _tempBuffer, stats);
+                }
             }
 
             // close the transaction as early as possible, and before we wait for reply

--- a/src/Raven.Server/Documents/Replication/Stats/IncomingReplicationStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/IncomingReplicationStatsAggregator.cs
@@ -64,9 +64,13 @@ namespace Raven.Server.Documents.Replication.Stats
                     InputCount = Stats.InputCount,
                     AttachmentReadCount = Stats.AttachmentReadCount,
                     DocumentReadCount = Stats.DocumentReadCount,
+                    RevisionReadCount = Stats.RevisionReadCount,
                     DocumentTombstoneReadCount = Stats.DocumentTombstoneReadCount,
                     AttachmentTombstoneReadCount = Stats.AttachmentTombstoneReadCount,
-                    CounterReadCount = Stats.CounterReadCount
+                    CounterReadCount = Stats.CounterReadCount,
+                    RevisionTombstoneReadCount = Stats.RevisionTombstoneReadCount,
+                    TimeSeriesDeletedRangeReadCount = Stats.TimeSeriesDeletedRangeReadCount,
+                    TimeSeriesReadCount = Stats.TimeSeriesReadCount
                 },
                 Errors = Stats.Errors
             };
@@ -125,14 +129,29 @@ namespace Raven.Server.Documents.Replication.Stats
             _stats.RevisionTombstoneReadCount++;
         }
 
+        public void RecordRevisionRead()
+        {
+            _stats.RevisionReadCount++;
+        }
+
         public void RecordAttachmentRead()
         {
             _stats.AttachmentReadCount++;
         }
-        
+
         public void RecordCountersRead(int numberOfCounters)
         {
             _stats.CounterReadCount += numberOfCounters;
+        }
+
+        public void RecordTimeSeriesRead()
+        {
+            _stats.TimeSeriesReadCount++;
+        }
+
+        public void RecordTimeSeriesDeletedRangeRead()
+        {
+            _stats.TimeSeriesDeletedRangeReadCount++;
         }
 
         public void RecordInputAttempt()
@@ -162,6 +181,9 @@ namespace Raven.Server.Documents.Replication.Stats
         public int AttachmentTombstoneReadCount;
         public int AttachmentReadCount;
         public int RevisionTombstoneReadCount;
+        public int RevisionReadCount;
         public int CounterReadCount;
+        public int TimeSeriesReadCount;
+        public int TimeSeriesDeletedRangeReadCount;
     }
 }

--- a/src/Raven.Server/Documents/Replication/Stats/OutgoingReplicationStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/OutgoingReplicationStatsAggregator.cs
@@ -79,6 +79,8 @@ namespace Raven.Server.Documents.Replication.Stats
                     AttachmentStreamOutputSizeInBytes = Stats.AttachmentStreamOutputSize.GetValue(SizeUnit.Bytes),
                     RevisionOutputCount = Stats.RevisionOutputCount,
                     RevisionOutputSizeInBytes = Stats.RevisionOutputSize.GetValue(SizeUnit.Bytes),
+                    RevisionTombstoneOutputCount = Stats.RevisionTombstoneOutputCount,
+                    RevisionTombstoneOutputSizeInBytes = Stats.RevisionTombstoneOutputSize.GetValue(SizeUnit.Bytes),
                     AttachmentTombstoneOutputCount = Stats.AttachmentTombstoneOutputCount,
                     AttachmentTombstoneOutputSizeInBytes = Stats.AttachmentTombstoneOutputSize.GetValue(SizeUnit.Bytes),
                     DocumentTombstoneOutputCount = Stats.DocumentTombstoneOutputCount,

--- a/src/Raven.Server/Documents/Replication/Stats/OutgoingReplicationStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/OutgoingReplicationStatsAggregator.cs
@@ -73,12 +73,15 @@ namespace Raven.Server.Documents.Replication.Stats
                     AttachmentOutputSizeInBytes = Stats.AttachmentOutputSize.GetValue(SizeUnit.Bytes),
                     DocumentOutputCount = Stats.DocumentOutputCount,
                     DocumentOutputSizeInBytes = Stats.DocumentOutputSize.GetValue(SizeUnit.Bytes),
+                    RevisionOutputCount = Stats.RevisionOutputCount,
+                    RevisionOutputSizeInBytes = Stats.RevisionOutputSize.GetValue(SizeUnit.Bytes),
                     AttachmentTombstoneOutputCount = Stats.AttachmentTombstoneOutputCount,
                     DocumentTombstoneOutputCount = Stats.DocumentTombstoneOutputCount,
                     CounterOutputCount = Stats.CounterOutputCount,
                     CounterOutputSizeInBytes = Stats.CounterOutputSize.GetValue(SizeUnit.Bytes),
                     TimeSeriesSegmentsOutputCount = Stats.TimeSeriesOutputCount,
-                    TimeSeriesSegmentsSizeInBytes =  Stats.TimeSeriesOutputSize.GetValue(SizeUnit.Bytes)
+                    TimeSeriesSegmentsSizeInBytes =  Stats.TimeSeriesOutputSize.GetValue(SizeUnit.Bytes),
+                    TimeSeriesDeletedRangeOutputCount = Stats.TimeSeriesDeletedRangeOutputCount
                 },
                 Errors = Stats.Errors
             };
@@ -142,6 +145,12 @@ namespace Raven.Server.Documents.Replication.Stats
             _stats.DocumentTombstoneOutputCount++;
         }
 
+        public void RecordRevisionOutput(long sizeInBytes)
+        {
+            _stats.RevisionOutputCount++;
+            _stats.RevisionOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+        }
+
         public void RecordTimeSeriesOutput(long sizeInBytes)
         {
             _stats.TimeSeriesOutputCount++;
@@ -151,6 +160,11 @@ namespace Raven.Server.Documents.Replication.Stats
         public void RecordCountersOutput(int numberOfCounters)
         {
             _stats.CounterOutputCount += numberOfCounters;
+        }
+
+        public void RecordTimeSeriesDeletedRangeOutput()
+        {
+            _stats.TimeSeriesDeletedRangeOutputCount++;
         }
 
         public void RecordLastEtag(long etag)
@@ -200,10 +214,13 @@ namespace Raven.Server.Documents.Replication.Stats
         public int AttachmentTombstoneOutputCount;
         public int RevisionTombstoneOutputCount;
         public int DocumentTombstoneOutputCount;
-        public int CounterTombstoneOutputCount;
+        public int TimeSeriesDeletedRangeOutputCount;
 
         public int DocumentOutputCount;
         public Size DocumentOutputSize;
+
+        public int RevisionOutputCount;
+        public Size RevisionOutputSize;
 
         public int TimeSeriesOutputCount;
         public Size TimeSeriesOutputSize;

--- a/src/Raven.Server/Documents/Replication/Stats/OutgoingReplicationStatsAggregator.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/OutgoingReplicationStatsAggregator.cs
@@ -60,6 +60,8 @@ namespace Raven.Server.Documents.Replication.Stats
                 Completed = completed ? StartTime.Add(Scope.Duration) : (DateTime?)null,
                 Details = Scope.ToReplicationPerformanceOperation("Replication"),
                 SendLastEtag = Stats.LastEtag,
+                LastAcceptedChangeVector = Stats.LastAcceptedChangeVector,
+                BatchSizeInBytes = completed ? Stats.LastBatchSize.GetValue(SizeUnit.Bytes) : null,
                 Storage = new OutgoingReplicationPerformanceStats.StorageStats
                 {
                     InputCount = Stats.InputCount,
@@ -69,19 +71,24 @@ namespace Raven.Server.Documents.Replication.Stats
                 },
                 Network = new OutgoingReplicationPerformanceStats.NetworkStats
                 {
-                    AttachmentOutputCount = Stats.AttachmentOutputCount,
-                    AttachmentOutputSizeInBytes = Stats.AttachmentOutputSize.GetValue(SizeUnit.Bytes),
                     DocumentOutputCount = Stats.DocumentOutputCount,
                     DocumentOutputSizeInBytes = Stats.DocumentOutputSize.GetValue(SizeUnit.Bytes),
+                    AttachmentOutputCount = Stats.AttachmentOutputCount,
+                    AttachmentOutputSizeInBytes = Stats.AttachmentOutputSize.GetValue(SizeUnit.Bytes),
+                    AttachmentStreamOutputCount = Stats.AttachmentStreamOutputCount,
+                    AttachmentStreamOutputSizeInBytes = Stats.AttachmentStreamOutputSize.GetValue(SizeUnit.Bytes),
                     RevisionOutputCount = Stats.RevisionOutputCount,
                     RevisionOutputSizeInBytes = Stats.RevisionOutputSize.GetValue(SizeUnit.Bytes),
                     AttachmentTombstoneOutputCount = Stats.AttachmentTombstoneOutputCount,
+                    AttachmentTombstoneOutputSizeInBytes = Stats.AttachmentTombstoneOutputSize.GetValue(SizeUnit.Bytes),
                     DocumentTombstoneOutputCount = Stats.DocumentTombstoneOutputCount,
+                    DocumentTombstoneOutputSizeInBytes = Stats.DocumentTombstoneOutputSize.GetValue(SizeUnit.Bytes),
                     CounterOutputCount = Stats.CounterOutputCount,
                     CounterOutputSizeInBytes = Stats.CounterOutputSize.GetValue(SizeUnit.Bytes),
                     TimeSeriesSegmentsOutputCount = Stats.TimeSeriesOutputCount,
                     TimeSeriesSegmentsSizeInBytes =  Stats.TimeSeriesOutputSize.GetValue(SizeUnit.Bytes),
-                    TimeSeriesDeletedRangeOutputCount = Stats.TimeSeriesDeletedRangeOutputCount
+                    TimeSeriesDeletedRangeOutputCount = Stats.TimeSeriesDeletedRangeOutputCount,
+                    TimeSeriesDeletedRangeOutputSizeInBytes = Stats.TimeSeriesDeletedRangeOutputSize.GetValue(SizeUnit.Bytes)
                 },
                 Errors = Stats.Errors
             };
@@ -122,54 +129,80 @@ namespace Raven.Server.Documents.Replication.Stats
         {
             _stats.AttachmentOutputCount++;
             _stats.AttachmentOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+            _stats.LastBatchSize.Add(sizeInBytes, SizeUnit.Bytes);
         }
 
-        public void RecordAttachmentTombstoneOutput()
+        public void RecordAttachmentStreamOutput(long sizeInBytes)
+        {
+            _stats.AttachmentStreamOutputCount++;
+            _stats.AttachmentStreamOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+            _stats.LastBatchSize.Add(sizeInBytes, SizeUnit.Bytes);
+        }
+
+        public void RecordAttachmentTombstoneOutput(long sizeInBytes)
         {
             _stats.AttachmentTombstoneOutputCount++;
+            _stats.AttachmentTombstoneOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+            _stats.LastBatchSize.Add(sizeInBytes, SizeUnit.Bytes);
         }
 
-        public void RecordRevisionTombstoneOutput()
+        public void RecordRevisionTombstoneOutput(long sizeInBytes)
         {
             _stats.RevisionTombstoneOutputCount++;
+            _stats.RevisionTombstoneOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+            _stats.LastBatchSize.Add(sizeInBytes, SizeUnit.Bytes);
         }
 
         public void RecordDocumentOutput(long sizeInBytes)
         {
             _stats.DocumentOutputCount++;
             _stats.DocumentOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+            _stats.LastBatchSize.Add(sizeInBytes, SizeUnit.Bytes);
         }
 
-        public void RecordDocumentTombstoneOutput()
+        public void RecordDocumentTombstoneOutput(long sizeInBytes)
         {
             _stats.DocumentTombstoneOutputCount++;
+            _stats.DocumentTombstoneOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+            _stats.LastBatchSize.Add(sizeInBytes, SizeUnit.Bytes);
         }
 
         public void RecordRevisionOutput(long sizeInBytes)
         {
             _stats.RevisionOutputCount++;
             _stats.RevisionOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+            _stats.LastBatchSize.Add(sizeInBytes, SizeUnit.Bytes);
         }
 
         public void RecordTimeSeriesOutput(long sizeInBytes)
         {
             _stats.TimeSeriesOutputCount++;
             _stats.TimeSeriesOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+            _stats.LastBatchSize.Add(sizeInBytes, SizeUnit.Bytes);
         }
 
-        public void RecordCountersOutput(int numberOfCounters)
+        public void RecordCountersOutput(int numberOfCounters, long sizeInBytes)
         {
             _stats.CounterOutputCount += numberOfCounters;
+            _stats.CounterOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+            _stats.LastBatchSize.Add(sizeInBytes, SizeUnit.Bytes);
         }
 
-        public void RecordTimeSeriesDeletedRangeOutput()
+        public void RecordTimeSeriesDeletedRangeOutput(long sizeInBytes)
         {
             _stats.TimeSeriesDeletedRangeOutputCount++;
+            _stats.TimeSeriesDeletedRangeOutputSize.Add(sizeInBytes, SizeUnit.Bytes);
+            _stats.LastBatchSize.Add(sizeInBytes, SizeUnit.Bytes);
         }
 
         public void RecordLastEtag(long etag)
         {
             _stats.LastEtag = etag;
+        }
+
+        public void RecordLastAcceptedChangeVector(string changeVector)
+        {
+            _stats.LastAcceptedChangeVector = changeVector;
         }
 
         public ReplicationPerformanceOperation ToReplicationPerformanceOperation(string name)
@@ -198,23 +231,14 @@ namespace Raven.Server.Documents.Replication.Stats
     public sealed class OutgoingReplicationRunStats : ReplicationRunStatsBase
     {
         public long LastEtag;
+        public Size LastBatchSize;
+        public string LastAcceptedChangeVector;
 
         public int InputCount;
 
         public int ArtificialDocumentSkipCount;
         public int SystemDocumentSkipCount;
         public int ChangeVectorSkipCount;
-
-        public int AttachmentOutputCount;
-        public Size AttachmentOutputSize;
-
-        public int CounterOutputCount;
-        public Size CounterOutputSize;
-
-        public int AttachmentTombstoneOutputCount;
-        public int RevisionTombstoneOutputCount;
-        public int DocumentTombstoneOutputCount;
-        public int TimeSeriesDeletedRangeOutputCount;
 
         public int DocumentOutputCount;
         public Size DocumentOutputSize;
@@ -224,5 +248,26 @@ namespace Raven.Server.Documents.Replication.Stats
 
         public int TimeSeriesOutputCount;
         public Size TimeSeriesOutputSize;
+
+        public int AttachmentOutputCount;
+        public Size AttachmentOutputSize;
+
+        public int AttachmentStreamOutputCount;
+        public Size AttachmentStreamOutputSize;
+
+        public int CounterOutputCount;
+        public Size CounterOutputSize;
+
+        public int DocumentTombstoneOutputCount;
+        public Size DocumentTombstoneOutputSize;
+
+        public int AttachmentTombstoneOutputCount;
+        public Size AttachmentTombstoneOutputSize;
+
+        public int RevisionTombstoneOutputCount;
+        public Size RevisionTombstoneOutputSize;
+
+        public int TimeSeriesDeletedRangeOutputCount;
+        public Size TimeSeriesDeletedRangeOutputSize;
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -107,6 +107,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             WriteToServer(headerJson);
 
             stats.RecordLastEtag(_lastEtag);
+            stats.RecordLastAcceptedChangeVector(LastAcceptedChangeVector);
 
             foreach (var item in batch.Items)
             {
@@ -127,8 +128,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                         var attachment = kvp.Value;
                         try
                         {
-                            attachment.WriteStream(_stream, _tempBuffer);
-                            stats.RecordAttachmentOutput(attachment.Stream.Length);
+                            attachment.WriteStream(_stream, _tempBuffer, stats);
                         }
                         catch
                         {

--- a/src/Raven.Studio/typescript/common/liveReplicationStatsWebSocketClient.ts
+++ b/src/Raven.Studio/typescript/common/liveReplicationStatsWebSocketClient.ts
@@ -98,7 +98,7 @@ class liveReplicationStatsWebSocketClient extends abstractWebSocketClient<result
             replicationStatsFromEndpoint.Performance.forEach(perf => {  // each obj in Performance can be either outgoing or incoming..
                 liveReplicationStatsWebSocketClient.fillCache(perf, replicationStatsFromEndpoint.Type, replicationStatsFromEndpoint.Description);
                 
-                if (this.dateCutOff && this.dateCutOff.getTime() >= (perf as ReplicationPerformanceBaseWithCache).StartedAsDate.getTime()) {
+                if (this.dateCutOff && this.dateCutOff.getTime() >= (perf as ReplicationPerformanceWithCache).StartedAsDate.getTime()) {
                     return;
                 }
                 
@@ -122,7 +122,7 @@ class liveReplicationStatsWebSocketClient extends abstractWebSocketClient<result
                      type: Raven.Server.Documents.Replication.Stats.LiveReplicationPerformanceCollector.ReplicationPerformanceType,
                      description: string) {
 
-        const withCache = perf as ReplicationPerformanceBaseWithCache;
+        const withCache = perf as ReplicationPerformanceWithCache;
         withCache.CompletedAsDate = perf.Completed ? liveReplicationStatsWebSocketClient.isoParser.parse(perf.Completed) : undefined;
         withCache.StartedAsDate = liveReplicationStatsWebSocketClient.isoParser.parse(perf.Started);
         withCache.Type = type;

--- a/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/ongoingTasksStats.ts
@@ -2211,6 +2211,7 @@ class ongoingTasksStats extends shardViewModelBase {
                             appendCounts("Time Series Segments output", elementWithData.Network.TimeSeriesSegmentsOutputCount, elementWithData.Network.TimeSeriesSegmentsSizeInBytes);
                             appendCounts("Time Series Deleted Ranges output", elementWithData.Network.TimeSeriesDeletedRangeOutputCount, elementWithData.Network.TimeSeriesDeletedRangeOutputSizeInBytes);
                             appendCounts("Revisions output", elementWithData.Network.RevisionOutputCount, elementWithData.Network.RevisionOutputSizeInBytes);
+                            appendCounts("Revisions Tombstone output", elementWithData.Network.RevisionTombstoneOutputCount, elementWithData.Network.RevisionTombstoneOutputSizeInBytes);
                             
                             break;
                         }

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -384,13 +384,17 @@ type subscriptionType =  "SubscriptionConnection" | "SubscriptionBatch" | "Aggre
 
 type ongoingTaskStatType = Raven.Server.Documents.Replication.LiveReplicationPerformanceCollector.ReplicationPerformanceType | StudioEtlType | subscriptionType | StudioQueueSinkType;
 
-interface ReplicationPerformanceBaseWithCache extends Raven.Client.Documents.Replication.ReplicationPerformanceBase {
+interface ReplicationPerformanceBaseCache {
     StartedAsDate: Date;
     CompletedAsDate: Date;
     Type: Raven.Server.Documents.Replication.LiveReplicationPerformanceCollector.ReplicationPerformanceType;
     Description: string;
     HasErrors: boolean;
 }
+
+type OutgoingReplicationPerformanceWithCache = Raven.Client.Documents.Replication.OutgoingReplicationPerformanceStats & ReplicationPerformanceBaseCache;
+type IncomingReplicationPerformanceWithCache = Raven.Client.Documents.Replication.IncomingReplicationPerformanceStats & ReplicationPerformanceBaseCache;
+type ReplicationPerformanceWithCache = OutgoingReplicationPerformanceWithCache | IncomingReplicationPerformanceWithCache;
 
 interface EtlPerformanceBaseWithCache extends Raven.Server.Documents.ETL.Stats.EtlPerformanceStats {
     StartedAsDate: Date;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21922/Replication-Usability-Self-Service

### Additional description

This PR includes the following changes for the `/databases/*/replication/performance/live` view (ws):
* Fix `ReplicationBatchItems` size (compute the entire item size).
* Add `Network/CounterRead` ([RavenDB-13470](https://issues.hibernatingrhinos.com/issue/RavenDB-13470/Replication-stats-graph-missing-information-about-number-of-replicated-counters)).
* Record and expose all `ReplicationBatchItems` with sizes for outgoing and incoming connections.
* Add `BatchSize`.
* Add `DatabaseChangeVector`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
