### PR TITLE
RavenDB-21990: Fix for `PeriodicBackupTestsSlow.ShouldProperlyPlaceOriginalBackupTimePropertyWithDelay`

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2974,6 +2974,16 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.NotNull(database);
                 database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
+                WaitForValue(() =>
+                    {
+                        var now = DateTime.Now;
+                        return now.Minute % 2 == 0 && now.Second <= 10;
+                    },
+                    expectedVal: true,
+                    timeout: (int)TimeSpan.FromMinutes(2).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds
+                );
+
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: fullBackupFrequency);
                 var taskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21990

### Additional description

The test failed under specific conditions when the backup start occurred just before the beginning of the scheduled backup time. Because of this, inside the `GetNextBackupDetails()` method, we entered the code path for an expired backup. In the case of an expired backup, the value of `NextBackup.DateTime` would be set to `DateTime.Now`, called within this method, since this is the first backup within this configuration:
https://github.com/ravendb/ravendb/blob/9f604582ce6b55b94647627152ae2a17a7558474/src/Raven.Server/Utils/BackupUtils.cs#L260-L282

**Scenario in which the `OriginalBackupTime` value would receive an unexpected value**:
1. The user must create a new backup task.
2. Wait and just before the start of the next scheduled backup, manually trigger a one-time backup.
3. Immediately apply a `Delay` to it.

**Impact**:
The `OriginalBackupTime` will differ from the expected by several milliseconds.

Additionally, the test itself contained a flaw and did not always check what it was intended to check:
The test was designed for a configuration with backups scheduled every two minutes. 
However, we wanted to check the value of `OriginalBackupTime` in two scenarios: when the time until which we apply a `Delay` is less than the time of the next scheduled backup and when it is greater. The start time of the test was not controlled.

Correcting this error also resolves the test failure caused by initiating the test just before the scheduled backup start time.

### Type of change

- [x] Increasing test stability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [X] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
