### PR TITLE
RavenDB-22069 - Fix ShouldNotBlockClusterTransactionOnDatabaseStartup stuck on SaveChanges

### DIFF
--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -5,13 +5,11 @@ using Raven.Client;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Exceptions;
-using Raven.Client.Exceptions.Database;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Json;
-using Raven.Server.Monitoring.Snmp.Objects.Database;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -125,16 +123,6 @@ namespace Raven.Server.Documents
             {
                 await ServerStore.Cluster.WaitForIndexNotification(index);
             }
-        }
-
-        public bool IsShutdownRequested() =>  ServerStore.ServerShutdown.IsCancellationRequested || Database.DatabaseShutdown.IsCancellationRequested;
-
-        public void ThrowShutdownException(Exception inner = null) => throw new DatabaseDisabledException("The database " + Database.Name + " is shutting down", inner);
-
-        public void ThrowShutdownExceptionIfNeeded()
-        {
-            if (IsShutdownRequested())
-                ThrowShutdownException();
         }
 
         protected OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationToken()

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -5,11 +5,13 @@ using Raven.Client;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Database;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Json;
+using Raven.Server.Monitoring.Snmp.Objects.Database;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -123,6 +125,16 @@ namespace Raven.Server.Documents
             {
                 await ServerStore.Cluster.WaitForIndexNotification(index);
             }
+        }
+
+        public bool IsShutdownRequested() =>  ServerStore.ServerShutdown.IsCancellationRequested || Database.DatabaseShutdown.IsCancellationRequested;
+
+        public void ThrowShutdownException(Exception inner = null) => throw new DatabaseDisabledException("The database " + Database.Name + " is shutting down", inner);
+
+        public void ThrowShutdownExceptionIfNeeded()
+        {
+            if (IsShutdownRequested())
+                ThrowShutdownException();
         }
 
         protected OperationCancelToken CreateHttpRequestBoundTimeLimitedOperationToken()

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -57,95 +57,88 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/bulk_docs", "POST", AuthorizationStatus.ValidUser, EndpointType.Write, DisableOnCpuCreditsExhaustion = true)]
         public async Task BulkDocs()
         {
-            try
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (var token = CreateHttpRequestBoundOperationToken())
+            using (var command = new MergedBatchCommand(Database))
             {
-                using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                using (var token = CreateHttpRequestBoundOperationToken())
-                using (var command = new MergedBatchCommand(Database))
+                var contentType = HttpContext.Request.ContentType;
+                try
                 {
-                    var contentType = HttpContext.Request.ContentType;
-                    try
+                    if (contentType == null ||
+                        contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (contentType == null ||
-                            contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
-                        {
-                            await BatchRequestParser.BuildCommandsAsync(context, command, RequestBodyStream(), Database, ServerStore, token.Token);
-                        }
-                        else if (contentType.StartsWith("multipart/mixed", StringComparison.OrdinalIgnoreCase) ||
-                                 contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
-                        {
-                            await ParseMultipart(context, command, token.Token);
-                        }
-                        else
-                            ThrowNotSupportedType(contentType);
+                        await BatchRequestParser.BuildCommandsAsync(context, command, RequestBodyStream(), Database, ServerStore, token.Token);
                     }
-                    finally
+                    else if (contentType.StartsWith("multipart/mixed", StringComparison.OrdinalIgnoreCase) ||
+                             contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (TrafficWatchManager.HasRegisteredClients)
-                        {
-                            BatchTrafficWatch(command.ParsedCommands);
-                        }
+                        await ParseMultipart(context, command, token.Token);
                     }
-
-                    var disableAtomicDocumentWrites = GetBoolValueQueryString("disableAtomicDocumentWrites", required: false) ??
-                                                      Database.Configuration.Cluster.DisableAtomicDocumentWrites;
-
-                    CheckBackwardCompatibility(ref disableAtomicDocumentWrites);
-
-                    var waitForIndexesTimeout = GetTimeSpanQueryString("waitForIndexesTimeout", required: false);
-                    var waitForIndexThrow = GetBoolValueQueryString("waitForIndexThrow", required: false) ?? true;
-                    var specifiedIndexesQueryString = HttpContext.Request.Query["waitForSpecificIndex"];
-
-                    if (command.IsClusterTransaction)
+                    else
+                        ThrowNotSupportedType(contentType);
+                }
+                finally
+                {
+                    if (TrafficWatchManager.HasRegisteredClients)
                     {
-                        await HandleClusterTransaction(context, command, disableAtomicDocumentWrites, specifiedIndexesQueryString, waitForIndexesTimeout,
-                            waitForIndexThrow,
-                            token.Token);
-
-                        return;
-                    }
-
-                    if (waitForIndexesTimeout != null)
-                        command.ModifiedCollections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-                    try
-                    {
-                        await Database.TxMerger.Enqueue(command);
-                    }
-                    catch (ConcurrencyException)
-                    {
-                        HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;
-                        throw;
-                    }
-
-                    var waitForReplicasTimeout = GetTimeSpanQueryString("waitForReplicasTimeout", required: false);
-                    if (waitForReplicasTimeout != null)
-                    {
-                        var numberOfReplicasStr = GetStringQueryString("numberOfReplicasToWaitFor", required: false) ?? "1";
-                        var throwOnTimeoutInWaitForReplicas = GetBoolValueQueryString("throwOnTimeoutInWaitForReplicas", required: false) ?? true;
-
-                        await WaitForReplicationAsync(Database, waitForReplicasTimeout.Value, numberOfReplicasStr, throwOnTimeoutInWaitForReplicas,
-                            command.LastChangeVector);
-                    }
-
-                    if (waitForIndexesTimeout != null)
-                    {
-                        long lastEtag = ChangeVectorUtils.GetEtagById(command.LastChangeVector, Database.DbBase64Id);
-                        await WaitForIndexesAsync(Database, waitForIndexesTimeout.Value, specifiedIndexesQueryString.ToList(), waitForIndexThrow,
-                            lastEtag, command.LastTombstoneEtag, command.ModifiedCollections);
-                    }
-
-                    HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
-                    await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
-                    {
-                        context.Write(writer, new DynamicJsonValue { [nameof(BatchCommandResult.Results)] = command.Reply });
+                        BatchTrafficWatch(command.ParsedCommands);
                     }
                 }
-            }
-            catch (OperationCanceledException)
-            {
-                ThrowShutdownExceptionIfNeeded();
-                throw;
+
+                var disableAtomicDocumentWrites = GetBoolValueQueryString("disableAtomicDocumentWrites", required: false) ??
+                                                  Database.Configuration.Cluster.DisableAtomicDocumentWrites;
+
+                CheckBackwardCompatibility(ref disableAtomicDocumentWrites);
+
+                var waitForIndexesTimeout = GetTimeSpanQueryString("waitForIndexesTimeout", required: false);
+                var waitForIndexThrow = GetBoolValueQueryString("waitForIndexThrow", required: false) ?? true;
+                var specifiedIndexesQueryString = HttpContext.Request.Query["waitForSpecificIndex"];
+
+                if (command.IsClusterTransaction)
+                {
+                    await HandleClusterTransaction(context, command, disableAtomicDocumentWrites, specifiedIndexesQueryString, waitForIndexesTimeout, waitForIndexThrow,
+                        token.Token);
+
+                    return;
+                }
+
+                if (waitForIndexesTimeout != null)
+                    command.ModifiedCollections = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                try
+                {
+                    await Database.TxMerger.Enqueue(command);
+                }
+                catch (ConcurrencyException)
+                {
+                    HttpContext.Response.StatusCode = (int)HttpStatusCode.Conflict;
+                    throw;
+                }
+
+                var waitForReplicasTimeout = GetTimeSpanQueryString("waitForReplicasTimeout", required: false);
+                if (waitForReplicasTimeout != null)
+                {
+                    var numberOfReplicasStr = GetStringQueryString("numberOfReplicasToWaitFor", required: false) ?? "1";
+                    var throwOnTimeoutInWaitForReplicas = GetBoolValueQueryString("throwOnTimeoutInWaitForReplicas", required: false) ?? true;
+
+                    await WaitForReplicationAsync(Database, waitForReplicasTimeout.Value, numberOfReplicasStr, throwOnTimeoutInWaitForReplicas, command.LastChangeVector);
+                }
+
+                if (waitForIndexesTimeout != null)
+                {
+                    long lastEtag = ChangeVectorUtils.GetEtagById(command.LastChangeVector, Database.DbBase64Id);
+                    await WaitForIndexesAsync(Database, waitForIndexesTimeout.Value, specifiedIndexesQueryString.ToList(), waitForIndexThrow,
+                        lastEtag, command.LastTombstoneEtag, command.ModifiedCollections);
+                }
+
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                {
+                    context.Write(writer, new DynamicJsonValue
+                    {
+                        [nameof(BatchCommandResult.Results)] = command.Reply
+                    });
+                }
             }
         }
 

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -262,10 +262,10 @@ namespace Raven.Server
             }
         }
 
-        private static void CheckDatabaseShutdownAndThrowIfNeeded(DocumentDatabase database, ref Exception e)
+        private static void CheckDatabaseShutdownAndThrowIfNeeded(DocumentDatabase database, ref Exception e) 
         {
-            if(database != null && database.DatabaseShutdown.IsCancellationRequested && e is TaskCanceledException)
-                e = new DatabaseDisabledException("The database " + database.Name + " is shutting down");
+            if(e is OperationCanceledException && database != null && database.DatabaseShutdown.IsCancellationRequested)
+                e = new DatabaseDisabledException("The database " + database.Name + " is shutting down", e);
         }
 
         private static void CheckVersionAndWrapException(HttpContext context, ref Exception e)

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -26,6 +26,7 @@ using Raven.Client.Exceptions.Security;
 using Raven.Client.Properties;
 using Raven.Client.Util;
 using Raven.Server.Config;
+using Raven.Server.Documents;
 using Raven.Server.Exceptions;
 using Raven.Server.Rachis;
 using Raven.Server.Routing;
@@ -40,6 +41,7 @@ using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Server.Exceptions;
 using Voron.Exceptions;
+using static Raven.Server.Utils.MetricCacher.Keys;
 
 namespace Raven.Server
 {
@@ -189,6 +191,8 @@ namespace Raven.Server
                     sp?.Stop();
                     exception = e;
 
+                    CheckDatabaseShutdownAndThrowIfNeeded(requestHandlerContext.Database, ref e);
+
                     CheckVersionAndWrapException(context, ref e);
 
                     MaybeSetExceptionStatusCode(context, _server.ServerStore, e);
@@ -256,6 +260,12 @@ namespace Raven.Server
                     _logger.Info($"{context.Request.Method} {context.Request.Path.Value}{context.Request.QueryString.Value} - {context.Response.StatusCode} - {(sp?.ElapsedMilliseconds ?? 0):#,#;;0} ms", exception);
                 }
             }
+        }
+
+        private static void CheckDatabaseShutdownAndThrowIfNeeded(DocumentDatabase database, ref Exception e)
+        {
+            if(database != null && database.DatabaseShutdown.IsCancellationRequested && e is TaskCanceledException)
+                e = new DatabaseDisabledException("The database " + database.Name + " is shutting down");
         }
 
         private static void CheckVersionAndWrapException(HttpContext context, ref Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22069/SlowTests.Issues.RavenDB20708.ShouldNotBlockClusterTransactionOnDatabaseStartup

### Additional description
The database is shutting down, not the server, so you stuck on waiting for the cluster transaction task (which come from the cluster transaction waiter) forever because it isn't being set (the waiting inside the BulkDocs EP).
I tried to link the token (in the BulkDocs endpoint) to the Database.ShudDown token, but that will cause the RequestHandler to throw RavenException (which wrap TaskCancelledException) instead of DatabaseDisabledExcetion, and the client won't perform failover as it should.
So only in the BulkDocs EP, I catch the TaskCancelledException and throw DatabaseDisabledException in case the database was shut down.
I do it in the BulkDocs EP and not in the request handler because I don't want to change the behavior of the other EP's in case of throwing TaskCancelledException and maybe fail other tests.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
