### PR TITLE
RavenDB-21860 improve cluster-wide tx performance

### DIFF
--- a/src/Raven.Client/Extensions/TaskExtensions.cs
+++ b/src/Raven.Client/Extensions/TaskExtensions.cs
@@ -38,7 +38,7 @@ namespace Raven.Client.Extensions
 
         public static async Task<bool> WaitWithTimeout(this Task task, TimeSpan? timeout)
         {
-            if (timeout == null)
+            if (timeout == null || timeout == Timeout.InfiniteTimeSpan)
             {
                 await task.ConfigureAwait(false);
                 return true;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -672,9 +672,9 @@ namespace Raven.Server.Documents
             catch (Exception e)
             {
                 // nothing we can do
-                if (_logger.IsInfoEnabled)
+                if (_logger.IsOperationsEnabled)
                 {
-                    _logger.Info($"Failed to notify about transaction completion for database '{Name}'.", e);
+                    _logger.Operations($"Failed to notify about transaction completion for database '{Name}'.", e);
                 }
             }
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2136,7 +2136,7 @@ namespace Raven.Server.Documents
                     {
                         if (flags.Contain(DocumentFlags.FromClusterTransaction) == false)
                         {
-                            Debug.Assert(false, $"flags must set FromClusterTransaction for the change vector: {changeVector}");
+                            Debug.Assert(false, $"flags: '{flags}' must set FromClusterTransaction for the change vector: {changeVector}");
                         }
                     }
                     break;

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -262,7 +262,7 @@ namespace Raven.Server.Documents.Handlers
             using (Database.ClusterTransactionWaiter.CreateTask(id: options.TaskId, out var tcs))
             await using (token.Register(() => tcs.TrySetCanceled()))
             {
-                (index, object result) = await ServerStore.SendToLeaderAsync(clusterTransactionCommand);
+                (index, object result) = await ServerStore.SendToLeaderAsync(clusterTransactionCommand, token);
                 array = await GetClusterTransactionDatabaseCommandsResults(result, clusterTransactionCommand.DatabaseCommandsCount, index, options, onDatabaseCompletionTask: tcs.Task, token);
             }
 

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -692,11 +692,10 @@ namespace Raven.Server.Documents.Handlers
 
                     if (commands != null)
                     {
-                        foreach (BlittableJsonReaderObject blittableCommand in commands)
+                        foreach (var cmd in commands)
                         {
                             count++;
                             var changeVector = ChangeVectorUtils.GetClusterWideChangeVector(Database.DatabaseGroupId, count, options.DisableAtomicDocumentWrites == false, command.Index, Database.ClusterTransactionId);
-                            var cmd = JsonDeserializationServer.ClusterTransactionDataCommand(blittableCommand);
 
                             switch (cmd.Type)
                             {
@@ -715,10 +714,10 @@ namespace Raven.Server.Documents.Handlers
                                             }
                                         }
 
-                                        var document = cmd.Document.Clone(context);
-                                        var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, document, changeVector: changeVector,
+                                        //var document = cmd.Document.Clone(context);
+                                        var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, cmd.Document, changeVector: changeVector,
                                             flags: DocumentFlags.FromClusterTransaction);
-                                        context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, document.Size);
+                                        context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, cmd.Document.Size);
                                         AddPutResult(putResult);
                                     }
                                     else

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -250,7 +250,12 @@ namespace Raven.Server.Documents.Handlers
                 };
 
 
-            var clusterTransactionCommand = new ClusterTransactionCommand(Database.Name, Database.IdentityPartsSeparator, topology, command.ParsedCommands, options, raftRequestId);
+            var clusterTransactionCommand =
+                new ClusterTransactionCommand(Database.Name, Database.IdentityPartsSeparator, topology, command.ParsedCommands, options, raftRequestId)
+                {
+                    Timeout = Timeout.InfiniteTimeSpan // we rely on the http token to cancel the command
+                };
+
             DynamicJsonArray array;
             long index;
 
@@ -300,7 +305,7 @@ namespace Raven.Server.Documents.Handlers
 
             // leader isn't updated (thats why the result is empty),
             // so we'll try to take the result from the local history log.
-            await ServerStore.Engine.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index, token);
+            await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index, Timeout.InfiniteTimeSpan, token);
             using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {

--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -714,7 +714,6 @@ namespace Raven.Server.Documents.Handlers
                                             }
                                         }
 
-                                        //var document = cmd.Document.Clone(context);
                                         var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, cmd.Document, changeVector: changeVector,
                                             flags: DocumentFlags.FromClusterTransaction);
                                         context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, cmd.Document.Size);

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -832,7 +832,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     if (executed.Count == 0)
                         break;
 
-                    totalExecutedCommands += executed.Sum(x => x.Commands.Length);
+                    totalExecutedCommands += executed.Sum(x => x.Commands.Count);
                     result.AddInfo($"Executed {totalExecutedCommands:#,#;;0} cluster transaction commands.");
                     onProgress.Invoke(result.Progress);
                 }

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -713,6 +713,8 @@ namespace Raven.Server.Rachis
 
             public void Dispose()
             {
+                Command.Raw?.Dispose();
+                Command.Raw = null;
                 BlittableResultWriter?.Dispose();
                 _ctxReturn?.Dispose();
             }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -313,7 +313,7 @@ namespace Raven.Server.Rachis
 
         public Action<ClusterOperationContext> SwitchToSingleLeaderAction;
 
-        public Action<ClusterOperationContext, CommandBase> BeforeAppendToRaftLog;
+        public Action<ClusterOperationContext, Leader.RachisMergedCommand> BeforeAppendToRaftLog;
 
         private string _tag;
         private string _clusterId;
@@ -2313,7 +2313,7 @@ namespace Raven.Server.Rachis
         private readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();
         private int _heartbeatWaitersCounter;
 
-        public void InvokeBeforeAppendToRaftLog(ClusterOperationContext context, CommandBase cmd)
+        public void InvokeBeforeAppendToRaftLog(ClusterOperationContext context, Leader.RachisMergedCommand cmd)
         {
             BeforeAppendToRaftLog?.Invoke(context, cmd);
         }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1844,9 +1844,9 @@ namespace Raven.Server.Rachis
             context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += _ => TaskExecutor.CompleteAndReplace(ref _commitIndexChanged);
         }
 
-        public async Task WaitForCommitIndexChange(CommitIndexModification modification, long value, CancellationToken token = default)
+        public async Task WaitForCommitIndexChange(CommitIndexModification modification, long value, TimeSpan? timeout = null, CancellationToken token = default)
         {
-            var timeoutTask = TimeoutManager.WaitFor(OperationTimeout, token);
+            var timeoutTask = TimeoutManager.WaitFor(timeout ?? OperationTimeout, token);
             while (timeoutTask.IsCompleted == false)
             {
                 token.ThrowIfCancellationRequested();

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -686,7 +686,7 @@ namespace Raven.Server.ServerWide.Commands
             foreach (BlittableJsonReaderObject blittableCommand in array)
             {
                 var cmd = JsonDeserializationServer.ClusterTransactionDataCommand(blittableCommand);
-                cmd.Document = cmd.Document.CloneOnTheSameContext(); // we need to get it out of the array
+                cmd.Document = cmd.Document?.CloneOnTheSameContext(); // we need to get it out of the array
                 databaseCommands.Add(cmd);
             }
 

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -591,7 +591,7 @@ namespace Raven.Server.ServerWide.Commands
         public class SingleClusterDatabaseCommand : IDynamicJson
         {
             public ClusterTransactionOptions Options;
-            public BlittableJsonReaderArray Commands;
+            public List<ClusterTransactionDataCommand> Commands;
             public long Index;
             public long PreviousCount;
             public string Database;
@@ -669,7 +669,7 @@ namespace Raven.Server.ServerWide.Commands
             if (ptr == null)
                 return null;
 
-            var blittable = new BlittableJsonReaderObject(ptr, size, context);
+            using var blittable = new BlittableJsonReaderObject(ptr, size, context);
             blittable.TryGet(nameof(DatabaseCommands), out BlittableJsonReaderArray array);
 
             ClusterTransactionOptions options = null;
@@ -682,10 +682,18 @@ namespace Raven.Server.ServerWide.Commands
             var keyPtr = reader.Read((int)TransactionCommandsColumn.Key, out size);
             var database = Encoding.UTF8.GetString(keyPtr, size - sizeof(long) - 1);
 
+            var databaseCommands = new List<ClusterTransactionDataCommand>();
+            foreach (BlittableJsonReaderObject blittableCommand in array)
+            {
+                var cmd = JsonDeserializationServer.ClusterTransactionDataCommand(blittableCommand);
+                cmd.Document = cmd.Document.CloneOnTheSameContext(); // we need to get it out of the array
+                databaseCommands.Add(cmd);
+            }
+
             return new SingleClusterDatabaseCommand
             {
                 Options = options,
-                Commands = array,
+                Commands = databaseCommands,
                 Index = index,
                 PreviousCount = Bits.SwapBytes(*(long*)(keyPtr + size - sizeof(long))),
                 Database = database

--- a/src/Raven.Server/ServerWide/Commands/CommandBase.cs
+++ b/src/Raven.Server/ServerWide/Commands/CommandBase.cs
@@ -32,6 +32,8 @@ namespace Raven.Server.ServerWide.Commands
         // if (null) value is passed, it will be treated as a bug. (will throw an exception only in Debug builds to support old clients)
         public string UniqueRequestId;
 
+        public BlittableJsonReaderObject Raw;
+
         protected CommandBase() { }
 
         protected CommandBase(string uniqueRequestId)
@@ -46,10 +48,25 @@ namespace Raven.Server.ServerWide.Commands
                 throw new RachisApplyException("Command must contain 'Type' field.");
             }
 
+            if (type == nameof(ClusterTransactionCommand))
+            {
+                // we optimize here the case of cluster wide tx
+                // since we do not use anything other from the inner properties of the command in this code path
+                
+                var command = new ClusterTransactionCommand { Raw = json };
+                
+                json.TryGet(nameof(UniqueRequestId), out command.UniqueRequestId);
+                json.TryGet(nameof(Timeout), out command.Timeout);
+
+                return command;
+            }
+
             if (JsonDeserializationCluster.Commands.TryGetValue(type, out Func<BlittableJsonReaderObject, CommandBase> deserializer) == false)
                 throw new InvalidOperationException($"There is not deserializer for '{type}' command.");
 
-            return deserializer(json);
+            var r = deserializer(json);
+            r.Raw = json;
+            return r;
         }
 
         public virtual void VerifyCanExecuteCommand(ServerStore store, TransactionOperationContext context, bool isClusterAdmin)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3048,7 +3048,7 @@ namespace Raven.Server.ServerWide
             Exception requestException = null;
             while (true)
             {
-                ServerShutdown.ThrowIfCancellationRequested();
+                _shutdownNotification.Token.ThrowIfCancellationRequested();
 
                 if (_engine.CurrentState == RachisState.Leader && _engine.CurrentLeader?.Running == true)
                 {
@@ -3076,7 +3076,7 @@ namespace Raven.Server.ServerWide
                     if (cachedLeaderTag == null)
                     {
                         await Task.WhenAny(logChange, timeoutTask);
-                        if (logChange.IsCompleted == false)
+                        if (timeoutTask.IsCompleted)
                             ThrowTimeoutException(cmd, requestException);
 
                         continue;
@@ -3097,7 +3097,9 @@ namespace Raven.Server.ServerWide
                 }
 
                 await Task.WhenAny(logChange, timeoutTask);
-                if (logChange.IsCompleted == false)
+                _shutdownNotification.Token.ThrowIfCancellationRequested();
+
+                if (timeoutTask.IsCompleted)
                 {
                     ThrowTimeoutException(cmd, requestException);
                 }
@@ -3352,9 +3354,14 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public async Task WaitForCommitIndexChange(RachisConsensus.CommitIndexModification modification, long value, CancellationToken token = default)
+        public Task WaitForCommitIndexChange(RachisConsensus.CommitIndexModification modification, long value, TimeSpan timeout, CancellationToken token = default)
         {
-            await _engine.WaitForCommitIndexChange(modification, value, token);
+            return _engine.WaitForCommitIndexChange(modification, value, timeout, token);
+        }
+
+        public Task WaitForCommitIndexChange(RachisConsensus.CommitIndexModification modification, long value, CancellationToken token = default)
+        {
+            return _engine.WaitForCommitIndexChange(modification, value, timeout: null, token);
         }
 
         public string LastStateChangeReason()

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -885,14 +885,15 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        private void BeforeAppendToRaftLog(ClusterOperationContext ctx, CommandBase cmd)
+        private void BeforeAppendToRaftLog(ClusterOperationContext ctx, Leader.RachisMergedCommand rachisMergedCommand)
         {
-            switch (cmd)
+            switch (rachisMergedCommand.Command)
             {
                 case AddDatabaseCommand addDatabase:
                     if (addDatabase.Record.Topology.Count == 0)
                     {
                         AssignNodesToDatabase(GetClusterTopology(ctx), addDatabase.Record);
+                        rachisMergedCommand.CommandAsJson = ctx.ReadObject(rachisMergedCommand.Command.ToJson(ctx), "topology-modified");
                     }
                     Debug.Assert(addDatabase.Record.Topology.Count != 0, "Empty topology after AssignNodesToDatabase");
                     break;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -828,7 +828,6 @@ namespace Raven.Server.ServerWide
             CheckSwapOrPageFileAndRaiseNotification();
 
             _engine = new RachisConsensus<ClusterStateMachine>(this);
-            _engine.BeforeAppendToRaftLog = BeforeAppendToRaftLog;
 
             var myUrl = GetNodeHttpServerUrl();
             _engine.Initialize(_env, Configuration, clusterChanges, myUrl, out _lastClusterTopologyIndex);
@@ -882,21 +881,6 @@ namespace Raven.Server.ServerWide
                         "Your system has no PageFile. It is recommended to have a PageFile in order for Server to work properly",
                         AlertType.LowSwapSize,
                         NotificationSeverity.Warning));
-            }
-        }
-
-        private void BeforeAppendToRaftLog(ClusterOperationContext ctx, Leader.RachisMergedCommand rachisMergedCommand)
-        {
-            switch (rachisMergedCommand.Command)
-            {
-                case AddDatabaseCommand addDatabase:
-                    if (addDatabase.Record.Topology.Count == 0)
-                    {
-                        AssignNodesToDatabase(GetClusterTopology(ctx), addDatabase.Record);
-                        rachisMergedCommand.CommandAsJson = ctx.ReadObject(rachisMergedCommand.Command.ToJson(ctx), "topology-modified");
-                    }
-                    Debug.Assert(addDatabase.Record.Topology.Count != 0, "Empty topology after AssignNodesToDatabase");
-                    break;
             }
         }
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -408,8 +408,9 @@ namespace Raven.Server.Web.System
             else
             {
                 databaseRecord.Topology ??= new DatabaseTopology();
-
                 databaseRecord.Topology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
+
+                Server.ServerStore.AssignNodesToDatabase(clusterTopology, databaseRecord);
             }
 
             databaseRecord.Topology.ClusterTransactionIdBase64 ??= Guid.NewGuid().ToBase64Unpadded();

--- a/src/Sparrow.Server/AsyncManualResetEvent.cs
+++ b/src/Sparrow.Server/AsyncManualResetEvent.cs
@@ -101,7 +101,7 @@ namespace Sparrow.Server
                 if (_parent._token.IsCancellationRequested)
                     return false;
 
-                var result = await Task.WhenAny(waitAsync, TimeoutManager.WaitFor(timeout, _parent._token)).ConfigureAwait(false);
+                var result = await waitAsync.WaitFor(timeout, _parent._token).ConfigureAwait(false);
 
                 if (result.IsFaulted)
                     throw result.Exception;

--- a/src/Sparrow/Utils/TimeoutManager.cs
+++ b/src/Sparrow/Utils/TimeoutManager.cs
@@ -112,6 +112,35 @@ namespace Sparrow.Utils
             return value;
         }
 
+        public static async Task<Task> WaitFor(this Task outer, TimeSpan duration, CancellationToken token = default)
+        {
+            if (duration == TimeSpan.Zero)
+                return Task.CompletedTask;
+
+            if (token.IsCancellationRequested)
+            {
+                return Task.CompletedTask;
+            }
+
+            Task task;
+            // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
+            if (duration != Timeout.InfiniteTimeSpan)
+                task = WaitForInternal(duration, token);
+            else
+                task = InfiniteTask;
+            
+            if (token == CancellationToken.None || token.CanBeCanceled == false)
+            {
+                return await Task.WhenAny(outer, task).ConfigureAwait(false);
+            }
+            
+            var onCancel = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (token.Register(tcs => onCancel.TrySetCanceled(), onCancel))
+            {
+                return await Task.WhenAny(outer, task, onCancel.Task).ConfigureAwait(false);
+            }
+        }
+
         public static async Task WaitFor(TimeSpan duration, CancellationToken token = default)
         {
             if (duration == TimeSpan.Zero)
@@ -136,6 +165,12 @@ namespace Sparrow.Utils
             }
 
             var onCancel = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (task == InfiniteTask)
+            {
+                await onCancel.Task.ConfigureAwait(false);
+                return;
+            }
+
             using (token.Register(tcs => onCancel.TrySetCanceled(), onCancel))
             {
                 await Task.WhenAny(task, onCancel.Task).ConfigureAwait(false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21860
https://issues.hibernatingrhinos.com/issue/RavenDB-21615
### Additional description

- use Http token instead of the operational 15s timeout, this would cause to spam even more requests when the timeout was reached.
- Clone the document outside of the write-tx, since it can be very costly to clone a large document especially if it contain an array with many elements.
- Avoid this cloning when the database execute the transaction
- Avoid this cloning when the leader is getting the command from a follower.
- Avoid leaking token registration callback when we wait for an infinite task.

Tested on our cloud with P10 cluster (sample size is 30)
<img width="433" alt="image" src="https://github.com/ravendb/ravendb/assets/6377808/a5df53c8-1558-4e98-8e7e-9ca0ee189835">

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. 
The format over the wire as well as the persistent format were not changed.
- [x] Breaking change - minor? 
Cluster tx with not throw on timeout after 15s (operational timeout), but instead are linked with the Http request token. Same as the normal tx.
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
