### PR TITLE
RavenDB-21998 Skip sorting for fields with no terms used in order by clause

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -107,7 +107,7 @@ public static class CoraxQueryBuilder
                     break;
             }
             
-            if (orderMetadata is null
+            if (orderMetadata is null or {Length: 0}
                 || hasSpecialSorter
                 || searcher.HasMultipleTermsInField(orderMetadata[0].Field) 
                 || hasBoosting)
@@ -1305,12 +1305,16 @@ public static class CoraxQueryBuilder
 
                 continue;
             }
-
+            
+            var fieldMetadata = QueryBuilderHelper.GetFieldIdForOrderBy(allocator, field.Name, index, builderParameters.HasDynamics,
+                builderParameters.DynamicFields, indexMapping, queryMapping, false);
+            
+            if (builderParameters.IndexSearcher.GetTermAmountInField(fieldMetadata) == 0)
+                continue;
+            
             if (field.OrderingType == OrderByFieldType.Distance)
             {
                 var spatialField = getSpatialField(field.Name);
-                var fieldMetadata = QueryBuilderHelper.GetFieldIdForOrderBy(allocator, field.Name, index, builderParameters.HasDynamics,
-                    builderParameters.DynamicFields, indexMapping, queryMapping, false);
 
                 int lastArgument;
                 IPoint point;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1360,7 +1360,7 @@ public static class CoraxQueryBuilder
             }
 
             var orderingType = field.OrderingType;
-            if (index.Configuration.OrderByTicksAutomaticallyWhenDatesAreInvolved && index.IndexFieldsPersistence.HasTimeValues(field.Name.Value))
+            if (orderingType is OrderByFieldType.Implicit && index.Configuration.OrderByTicksAutomaticallyWhenDatesAreInvolved && index.IndexFieldsPersistence.HasTimeValues(field.Name.Value))
                 orderingType = OrderByFieldType.Long;
 
             var metadataField = QueryBuilderHelper.GetFieldIdForOrderBy(allocator, field.Name.Value, index, builderParameters.HasDynamics,

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
@@ -75,7 +75,7 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
             if (orderByFieldMetadata.Ascending != orderByField.Ascending)
                 continue;
 
-            if (CompareCoraxAndQueryOrderFieldType(orderByFieldMetadata.FieldType, orderByField.OrderingType) == false)
+            if (IsSameOrderType(orderByFieldMetadata.FieldType, orderByField.OrderingType) == false)
                 continue;
 
             currentCoraxOrderIndex++;
@@ -146,9 +146,9 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
         return result;
     }
 
-    private static bool CompareCoraxAndQueryOrderFieldType(MatchCompareFieldType corax, OrderByFieldType query)
+    private static bool IsSameOrderType(MatchCompareFieldType coraxOrderField, OrderByFieldType queryOrderField)
     {
-        bool result = (corax, query) switch
+        bool result = (coraxOrderField, queryOrderField) switch
         {
             (MatchCompareFieldType.Random, OrderByFieldType.Random) => true,
             (MatchCompareFieldType.Alphanumeric, OrderByFieldType.AlphaNumeric) => true,
@@ -156,7 +156,10 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
             (MatchCompareFieldType.Integer, OrderByFieldType.Long) => true,
             (MatchCompareFieldType.Floating, OrderByFieldType.Double) => true,
             (MatchCompareFieldType.Spatial, OrderByFieldType.Distance) => true,
-            (_, _) => false
+            (MatchCompareFieldType.Sequence, OrderByFieldType.String) => true,
+            (MatchCompareFieldType.Sequence, OrderByFieldType.Implicit) => true,
+            (MatchCompareFieldType.Integer, OrderByFieldType.Implicit) => true,
+            _ => false
         };
 
         return result;

--- a/test/FastTests/Corax/StreamingOptimization_QueryBuilder.cs
+++ b/test/FastTests/Corax/StreamingOptimization_QueryBuilder.cs
@@ -564,9 +564,16 @@ public class StreamingOptimization_QueryBuilder : RavenTestBase
                     {
                         foreach (var field in mapping)
                         {
-                            builder.Write(field.FieldId, Encoding.UTF8.GetBytes(someValue), 3, 3.14D);
                             if (hasMultipleValues)
+                                builder.IncrementList();
+
+                            builder.Write(field.FieldId, Encoding.UTF8.GetBytes(someValue), 3, 3.14D);
+                            
+                            if (hasMultipleValues)
+                            {
                                 builder.Write(field.FieldId, Encoding.UTF8.GetBytes(someValue), 3, 3.14D);
+                                builder.DecrementList();
+                            }
                         }
                     }
                     indexWriter.Commit();

--- a/test/SlowTests/Issues/RavenDB-14806.cs
+++ b/test/SlowTests/Issues/RavenDB-14806.cs
@@ -41,7 +41,7 @@ public class RavenDB_14806 : RavenTestBase
                     SortOrder = c.SortOrder,
                     Description = c.Description
                 });
-WaitForUserToContinueTheTest(store);
+            
             var result = await query.ToListAsync();
             Assert.Equal(1, result.Count);
         }

--- a/test/SlowTests/Issues/RavenDB-21998.cs
+++ b/test/SlowTests/Issues/RavenDB-21998.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries.Timings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21998 : RavenTestBase
+{
+    public RavenDB_21998(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void AssertNoSortingWhenThereAreNoTermsInOrderByField()
+    {
+        const int numberOfDocsToPut = 5000;
+
+        using (var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax)))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Question()
+                {
+                    Community = "SomeCommunity"
+                });
+                
+                session.SaveChanges();
+                
+                session.Advanced.DocumentStore.Operations.ForDatabase(session.Advanced.DocumentStore.Database).Send(new PatchByQueryOperation(
+                    """
+                    from Questions
+                    update
+                    {
+                        delete this.CreatedAt;
+                        for (var i = 0; i < 4999; ++i) {
+                            put(id(this)+i, this);
+                        }
+                    }
+                    """)).WaitForCompletion(TimeSpan.FromSeconds(30));
+                
+                var index = new DummyIndex();
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+
+                QueryTimings timings = null;
+                
+                var result = session.Query<Question, DummyIndex>().Customize(x => x.Timings(out timings)).Where(x => x.Community == "SomeCommunity").OrderByDescending(x => x.CreatedAt).ToList();
+                
+                Assert.IsType<QueryInspectionNode>(timings.QueryPlan);
+                
+                Assert.DoesNotContain("sorting", ((QueryInspectionNode)timings.QueryPlan).Operation, StringComparison.InvariantCultureIgnoreCase);
+                Assert.Equal(numberOfDocsToPut, result.Count);
+            }
+        }
+    }
+    
+    private class Question
+    {
+        public string Id { get; set; }
+        public string Community { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Question>
+    {
+        public DummyIndex()
+        {
+            Map = questions => from question in questions
+                select new
+                {
+                    question.Community,
+                    question.CreatedAt
+                };
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-21998.cs
+++ b/test/SlowTests/Issues/RavenDB-21998.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Linq;
+using Corax.Querying.Matches.SortingMatches;
 using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Queries.Timings;
@@ -12,44 +15,21 @@ namespace SlowTests.Issues;
 
 public class RavenDB_21998 : RavenTestBase
 {
+    private const int NumberOfDocsToPut = 5000;
     public RavenDB_21998(ITestOutputHelper output) : base(output)
     {
     }
 
-    [RavenFact(RavenTestCategory.Querying)]
-    public void AssertNoSortingWhenThereAreNoTermsInOrderByField()
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void AssertNoSortingWhenThereAreNoTermsInOrderByField(Options options)
     {
-        const int numberOfDocsToPut = 5000;
-
-        using (var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax)))
+        using (var store = GetDocumentStore(options))
         {
+            PrepareData(store, NumberOfDocsToPut);
+            
             using (var session = store.OpenSession())
             {
-                session.Store(new Question()
-                {
-                    Community = "SomeCommunity"
-                });
-                
-                session.SaveChanges();
-                
-                session.Advanced.DocumentStore.Operations.ForDatabase(session.Advanced.DocumentStore.Database).Send(new PatchByQueryOperation(
-                    """
-                    from Questions
-                    update
-                    {
-                        delete this.CreatedAt;
-                        for (var i = 0; i < 4999; ++i) {
-                            put(id(this)+i, this);
-                        }
-                    }
-                    """)).WaitForCompletion(TimeSpan.FromSeconds(30));
-                
-                var index = new DummyIndex();
-                
-                index.Execute(store);
-                
-                Indexes.WaitForIndexing(store);
-
                 QueryTimings timings = null;
                 
                 var result = session.Query<Question, DummyIndex>().Customize(x => x.Timings(out timings)).Where(x => x.Community == "SomeCommunity").OrderByDescending(x => x.CreatedAt).ToList();
@@ -57,8 +37,92 @@ public class RavenDB_21998 : RavenTestBase
                 Assert.IsType<QueryInspectionNode>(timings.QueryPlan);
                 
                 Assert.DoesNotContain("sorting", ((QueryInspectionNode)timings.QueryPlan).Operation, StringComparison.InvariantCultureIgnoreCase);
-                Assert.Equal(numberOfDocsToPut, result.Count);
+                Assert.Equal(NumberOfDocsToPut, result.Count);
             }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void AssertOnlyFieldsWithNoTermsAreSkipped(Options options)
+    {
+        const int numberOfDocsToPut = 5000;
+        
+        using (var store = GetDocumentStore(options))
+        {
+            PrepareData(store, numberOfDocsToPut);
+
+            using (var session = store.OpenSession())
+            {
+                QueryTimings timings = null;
+                
+                var result = session.Query<Question, DummyIndex>().Customize(x => x.Timings(out timings)).Where(x => x.Community == "SomeCommunity").OrderBy(x => x.SomeValue).ThenBy(x => x.CreatedAt).ToList();
+                
+                Assert.IsType<QueryInspectionNode>(timings.QueryPlan);
+                
+                Assert.DoesNotContain(nameof(SortingMultiMatch), ((QueryInspectionNode)timings.QueryPlan).Operation, StringComparison.InvariantCultureIgnoreCase);
+                Assert.Contains(nameof(SortingMatch), ((QueryInspectionNode)timings.QueryPlan).Operation, StringComparison.InvariantCultureIgnoreCase);
+                
+                Assert.Equal(NumberOfDocsToPut, result.Count);
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void AssertOnlyFieldsWithNoTermsAreSkippedInSharding(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            PrepareData(store, NumberOfDocsToPut);
+            
+            using (var session = store.OpenSession())
+            {
+                var result = session.Query<Question, DummyIndex>().Where(x => x.Community == "SomeCommunity").OrderByDescending(x => x.CreatedAt).ThenByDescending(x => x.SomeValue).ToList();
+                
+                Assert.Equal(Enumerable.Range(1, 5000).Reverse(), result.Select(x => x.SomeValue));
+                Assert.Equal(NumberOfDocsToPut, result.Count);
+            }
+        }
+    }
+
+    private void PrepareData(IDocumentStore store, int numberOfDocumentsToInsert)
+    {
+        using (var session = store.OpenSession())
+        {
+            var q1 = new Question() { Community = "SomeCommunity", SomeValue = 1 };
+            
+            session.Store(q1);
+            
+            using (BulkInsertOperation bulkInsert = store.BulkInsert())
+            {
+                for (int i = 2; i < numberOfDocumentsToInsert + 1; i++)
+                {
+                    bulkInsert.Store(new Question()
+                    {
+                        Id = $"questions/{i}${q1.Id}",
+                        Community = "SomeCommunity",
+                        SomeValue = i
+                    });
+                }
+            }
+            
+            session.SaveChanges();
+            
+            session.Advanced.DocumentStore.Operations.ForDatabase(session.Advanced.DocumentStore.Database).Send(new PatchByQueryOperation(
+                """
+                from Questions
+                update
+                {
+                    delete this.CreatedAt;
+                }
+                """)).WaitForCompletion(TimeSpan.FromSeconds(30));
+
+            var index = new DummyIndex();
+
+            index.Execute(store);
+
+            Indexes.WaitForIndexing(store);
         }
     }
     
@@ -67,6 +131,7 @@ public class RavenDB_21998 : RavenTestBase
         public string Id { get; set; }
         public string Community { get; set; }
         public DateTime CreatedAt { get; set; }
+        public int SomeValue { get; set; }
     }
 
     private class DummyIndex : AbstractIndexCreationTask<Question>
@@ -77,7 +142,8 @@ public class RavenDB_21998 : RavenTestBase
                 select new
                 {
                     question.Community,
-                    question.CreatedAt
+                    question.CreatedAt,
+                    question.SomeValue
                 };
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21998/NullReferenceException-in-Corax-query

### Additional description

Currently attempt to order index query results by field that doesn't have any terms throws NRE (happens in a code path with  more than 4096 results, we don't create tree for such field). We should catch this case, and skip ordering by this field.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
