### PR TITLE
RavenDB-22079: Apply .ConfigureAwait(false) to hot methods.

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
@@ -49,16 +49,18 @@ public static class SettingsZipFileHelper
                     {
                         var export = parameters.CompleteClusterConfigurationResult.ClientCert.Export(X509ContentType.Pfx);
                         if (parameters.Token != CancellationToken.None)
-                            await entryStream.WriteAsync(export, parameters.Token);
+                            await entryStream.WriteAsync(export, parameters.Token)
+                                             .ConfigureAwait(false);
                         else
-                            await entryStream.WriteAsync(export, CancellationToken.None);
+                            await entryStream.WriteAsync(export, CancellationToken.None)
+                                             .ConfigureAwait(false);
                     }
                     
                     await LetsEncryptCertificateUtil.WriteCertificateAsPemToZipArchiveAsync(
                         $"admin.client.certificate.{parameters.CompleteClusterConfigurationResult.Domain}",
                         parameters.CompleteClusterConfigurationResult.CertBytes,
-                        null,
-                        archive);
+                        null, archive)
+                        .ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -71,7 +73,8 @@ public static class SettingsZipFileHelper
                     string settingsPath = parameters.OnSettingsPath.Invoke();
                     await using (var fs = SafeFileStream.Create(settingsPath, FileMode.Open, FileAccess.Read))
                     {
-                        settingsJson = await context.ReadForMemoryAsync(fs, "settings-json");
+                        settingsJson = await context.ReadForMemoryAsync(fs, "settings-json")
+                                                    .ConfigureAwait(false);
                     }
                 }
                 else
@@ -81,7 +84,8 @@ public static class SettingsZipFileHelper
                         ms2.WriteByte((byte)'{');
                         ms2.WriteByte((byte)'}');
                         ms2.Position = 0;
-                        settingsJson = await context.ReadForMemoryAsync(ms2, "settings-json");
+                        settingsJson = await context.ReadForMemoryAsync(ms2, "settings-json")
+                                                    .ConfigureAwait(false);
                     }
                 }
 
@@ -101,7 +105,8 @@ public static class SettingsZipFileHelper
                         await using (var entryStream = entry.Open())
                         await using (var writer = new StreamWriter(entryStream))
                         {
-                            await writer.WriteAsync(licenseString);
+                            await writer.WriteAsync(licenseString)
+                                        .ConfigureAwait(false);
                         }
                     }
                     catch (Exception e)
@@ -120,7 +125,8 @@ public static class SettingsZipFileHelper
                 if (parameters.SetupInfo.Environment != StudioConfiguration.StudioEnvironment.None)
                 {
                     if (parameters.OnPutServerWideStudioConfigurationValues != null && parameters.ZipOnly == false)
-                        await parameters.OnPutServerWideStudioConfigurationValues(parameters.SetupInfo.Environment);
+                        await parameters.OnPutServerWideStudioConfigurationValues(parameters.SetupInfo.Environment)
+                                        .ConfigureAwait(false);
                 }
 
                 var certificateFileName = $"cluster.server.certificate.{parameters.CompleteClusterConfigurationResult.Domain}.pfx";
@@ -131,7 +137,8 @@ public static class SettingsZipFileHelper
                 {
                     await using (var certFile = SafeFileStream.Create(certPath, FileMode.Create))
                     {
-                        await certFile.WriteAsync(parameters.CompleteClusterConfigurationResult.ServerCertBytes, parameters.Token);
+                        await certFile.WriteAsync(parameters.CompleteClusterConfigurationResult.ServerCertBytes, parameters.Token)
+                                      .ConfigureAwait(false);
                     } // we'll be flushing the directory when we'll write the settings.json
                 }
 

--- a/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
+++ b/src/Raven.Server/Documents/CatastrophicFailureHandler.cs
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents
 
                 // let it propagate the exception to the client first and do
                 // the internal failure handling e.g. Index.HandleIndexCorruption
-                await Task.Delay(TimeToWaitBeforeUnloadingDatabase); 
+                await Task.Delay(TimeToWaitBeforeUnloadingDatabase).ConfigureAwait(false);
 
                 stats.NumberOfUnloads++;
                 stats.LastUnloadTime = DateTime.UtcNow;

--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -141,7 +141,7 @@ namespace Raven.Server.Documents
                             maxTransactionSize: 16 * Voron.Global.Constants.Size.Megabyte,
                             batchSize: OperationBatchSize);
 
-                        await Database.TxMerger.Enqueue(command);
+                        await Database.TxMerger.Enqueue(command).ConfigureAwait(false);
 
                         progress.Processed += command.Processed;
 

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -128,12 +128,12 @@ namespace Raven.Server.Documents.Handlers.Batches
         public async Task<bool> IsClusterTransaction(Stream stream, UnmanagedJsonParser parser, JsonOperationContext.MemoryBuffer buffer, JsonParserState state)
         {
             while (parser.Read() == false)
-                await RefillParserBuffer(stream, buffer, parser);
+                await RefillParserBuffer(stream, buffer, parser).ConfigureAwait(false);
 
             if (ReadClusterTransactionProperty(state))
             {
                 while (parser.Read() == false)
-                    await RefillParserBuffer(stream, buffer, parser);
+                    await RefillParserBuffer(stream, buffer, parser).ConfigureAwait(false);
 
                 return GetStringPropertyValue(state) == nameof(TransactionMode.ClusterWide);
             }
@@ -167,7 +167,7 @@ namespace Raven.Server.Documents.Handlers.Batches
             while (true)
             {
                 while (parser.Read() == false)
-                    await RefillParserBuffer(stream, buffer, parser, token);
+                    await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
 
                 if (state.CurrentTokenType == JsonParserToken.EndObject)
                 {
@@ -183,7 +183,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                 {
                     case CommandPropertyName.Type:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         if (state.CurrentTokenType != JsonParserToken.String)
                         {
                             ThrowUnexpectedToken(JsonParserToken.String, state);
@@ -193,7 +193,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.Id:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
 
                         switch (state.CurrentTokenType)
                         {
@@ -219,14 +219,14 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                         CommandParsingObserver?.OnIdsStart(parser);
 
-                        commandData.Ids = await ReadJsonArray(ctx, stream, parser, state, buffer, token);
+                        commandData.Ids = await ReadJsonArray(ctx, stream, parser, state, buffer, token).ConfigureAwait(false);
 
                         CommandParsingObserver?.OnIdsEnd(parser);
                         break;
 
                     case CommandPropertyName.Name:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -245,7 +245,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.DestinationId:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -263,7 +263,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                         break;
                     case CommandPropertyName.From:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -279,7 +279,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                         break;
                     case CommandPropertyName.To:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -295,7 +295,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                         break;
                     case CommandPropertyName.DestinationName:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -314,7 +314,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.ContentType:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         switch (state.CurrentTokenType)
                         {
                             case JsonParserToken.Null:
@@ -333,8 +333,8 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.Document:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
-                        commandData.Document = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                        commandData.Document = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
                         commandData.SeenAttachments = modifier.SeenAttachments;
                         commandData.SeenCounters = modifier.SeenCounters;
                         commandData.SeenTimeSeries = modifier.SeenTimeSeries;
@@ -343,23 +343,23 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.Patch:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
-                        var patch = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                        var patch = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
                         commandData.Patch = PatchRequest.Parse(patch, out commandData.PatchArgs);
                         break;
 
                     case CommandPropertyName.JsonPatch:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
-                        var jsonPatch = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                        var jsonPatch = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
                         commandData.JsonPatchCommands = JsonPatchCommand.Parse(jsonPatch);
                         break;
 
                     case CommandPropertyName.TimeSeries:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
 
-                        using (var timeSeriesOperations = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token))
+                        using (var timeSeriesOperations = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false))
                         {
                             commandData.TimeSeries = commandData.Type == CommandType.TimeSeriesBulkInsert ?
                                 TimeSeriesOperation.ParseForBulkInsert(timeSeriesOperations) :
@@ -370,20 +370,20 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.CreateIfMissing:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
-                        var createIfMissing = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                        var createIfMissing = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
                         commandData.CreateIfMissing = createIfMissing;
                         break;
                     case CommandPropertyName.PatchIfMissing:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
-                        var patchIfMissing = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+                        var patchIfMissing = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
                         commandData.PatchIfMissing = PatchRequest.Parse(patchIfMissing, out commandData.PatchIfMissingArgs);
                         break;
 
                     case CommandPropertyName.ChangeVector:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         if (state.CurrentTokenType == JsonParserToken.Null)
                         {
                             commandData.ChangeVector = null;
@@ -402,7 +402,7 @@ namespace Raven.Server.Documents.Handlers.Batches
                         break;
                     case CommandPropertyName.OriginalChangeVector:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         if (state.CurrentTokenType == JsonParserToken.Null)
                         {
                             commandData.OriginalChangeVector = null;
@@ -421,7 +421,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.Index:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         if (state.CurrentTokenType != JsonParserToken.Integer)
                         {
                             ThrowUnexpectedToken(JsonParserToken.Integer, state);
@@ -432,7 +432,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.IdPrefixed:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
 
                         if (state.CurrentTokenType != JsonParserToken.True && state.CurrentTokenType != JsonParserToken.False)
                         {
@@ -444,7 +444,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.ReturnDocument:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
 
                         if (state.CurrentTokenType != JsonParserToken.True && state.CurrentTokenType != JsonParserToken.False)
                         {
@@ -456,15 +456,15 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.Counters:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
 
-                        var counterOps = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
+                        var counterOps = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
                         commandData.Counters = DocumentCountersOperation.Parse(counterOps);
                         break;
 
                     case CommandPropertyName.FromEtl:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
 
                         if (state.CurrentTokenType != JsonParserToken.True && state.CurrentTokenType != JsonParserToken.False)
                         {
@@ -476,7 +476,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.AttachmentType:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         if (state.CurrentTokenType == JsonParserToken.Null)
                         {
                             commandData.AttachmentType = AttachmentType.Document;
@@ -494,7 +494,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
                     case CommandPropertyName.ContentLength:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         if (state.CurrentTokenType != JsonParserToken.Integer)
                         {
                             ThrowUnexpectedToken(JsonParserToken.Integer, state);
@@ -505,17 +505,17 @@ namespace Raven.Server.Documents.Handlers.Batches
                     case CommandPropertyName.NoSuchProperty:
                         // unknown command - ignore it
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         if (state.CurrentTokenType == JsonParserToken.StartObject ||
                             state.CurrentTokenType == JsonParserToken.StartArray)
                         {
-                            await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
+                            await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token).ConfigureAwait(false);
                         }
                         break;
 
                     case CommandPropertyName.ForceRevisionCreationStrategy:
                         while (parser.Read() == false)
-                            await RefillParserBuffer(stream, buffer, parser, token);
+                            await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                         if (state.CurrentTokenType != JsonParserToken.String)
                         {
                             ThrowUnexpectedToken(JsonParserToken.String, state);
@@ -627,7 +627,8 @@ namespace Raven.Server.Documents.Handlers.Batches
                 {
                     if (builder.Read())
                         break;
-                    await RefillParserBuffer(stream, buffer, parser, token);
+
+                    await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                 }
 
                 builder.FinalizeDocument();
@@ -654,7 +655,8 @@ namespace Raven.Server.Documents.Handlers.Batches
                 {
                     if (builder.Read())
                         break;
-                    await RefillParserBuffer(stream, buffer, parser, token);
+
+                    await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
                 }
                 builder.FinalizeDocument();
                 reader = builder.CreateReader();
@@ -1020,7 +1022,7 @@ namespace Raven.Server.Documents.Handlers.Batches
 
             // Although we using here WithCancellation and passing the token,
             // the stream will stay open even after the cancellation until the entire server will be disposed.
-            var read = await stream.ReadAsync(buffer.Memory.Memory, token);
+            var read = await stream.ReadAsync(buffer.Memory.Memory, token).ConfigureAwait(false);
             if (read == 0)
                 ThrowUnexpectedEndOfStream();
             parser.SetBuffer(buffer, 0, read);

--- a/src/Raven.Server/Documents/Handlers/Batches/DatabaseBatchCommandsReader.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/DatabaseBatchCommandsReader.cs
@@ -33,13 +33,13 @@ public sealed class DatabaseBatchCommandsReader : AbstractBatchCommandsReader<Me
             Stream = AttachmentStreamsTempFile.StartNewStream()
         };
         attachmentStream.Hash = await AttachmentsStorageHelper.CopyStreamToFileAndCalculateHash(context, input, attachmentStream.Stream, token);
-        await attachmentStream.Stream.FlushAsync(token);
+        await attachmentStream.Stream.FlushAsync(token).ConfigureAwait(false);
         AttachmentStreams.Add(attachmentStream);
     }
 
     public override async ValueTask<MergedBatchCommand> GetCommandAsync(DocumentsOperationContext context)
     {
-        await ExecuteGetIdentitiesAsync();
+        await ExecuteGetIdentitiesAsync().ConfigureAwait(false);
 
         return new MergedBatchCommand(_database)
         {

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForHead(this))
             {
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
             }
         }
 
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForGetDocSize(this))
             {
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
             }
         }
 
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForGet(HttpMethod.Get, this))
             {
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
             }
         }
 
@@ -53,7 +53,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForGet(HttpMethod.Post, this))
             {
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
             }
         }
 
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForDelete(this))
             {
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
             }
         }
 
@@ -71,7 +71,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForPut(this))
             {
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
             }
         }
 
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForPatch(this))
             {
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
             }
         }
 
@@ -89,7 +89,7 @@ namespace Raven.Server.Documents.Handlers
         {
             using (var processor = new DocumentHandlerProcessorForGenerateClassFromDocument(this))
             {
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Documents/DocumentHandlerProcessorForGet.cs
@@ -48,7 +48,7 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
 
         if (counters.Count > 0)
         {
-            if (counters.Count == 1 && counters[0] == Constants.Counters.All)
+            if (counters is [Constants.Counters.All])
                 counters = Array.Empty<string>();
 
             includeCounters = new IncludeCountersCommand(RequestHandler.Database, context, counters);
@@ -103,8 +103,7 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
                         Debug.Assert(includeCompareExchangeValues != null, nameof(includeCompareExchangeValues) + " != null");
                         if (includeCompareExchangeValues.TryGetAtomicGuard(ClusterTransactionCommand.GetAtomicGuardKey(id), lastModifiedIndex, out var index, out _))
                         {
-                            var (isValid, cv) = ChangeVectorUtils.TryUpdateChangeVector(ChangeVectorParser.TrxnTag, RequestHandler.Database.ClusterTransactionId,
-                                index, changeVector);
+                            var (isValid, cv) = ChangeVectorUtils.TryUpdateChangeVector(ChangeVectorParser.TrxnTag, RequestHandler.Database.ClusterTransactionId, index, changeVector);
                             Debug.Assert(isValid, "ChangeVector didn't have ClusterTransactionId tag but now does?!");
                             document.ChangeVector = cv;
                         }
@@ -153,20 +152,20 @@ internal sealed class DocumentHandlerProcessorForGet : AbstractDocumentHandlerPr
     protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
         DocumentsOperationContext context, IEnumerable<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
     {
-        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
+        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token).ConfigureAwait(false);
     }
 
     protected override async ValueTask<(long NumberOfResults, long TotalDocumentsSizeInBytes)> WriteDocumentsAsync(AsyncBlittableJsonTextWriter writer,
         DocumentsOperationContext context, IAsyncEnumerable<Document> documentsToWrite, bool metadataOnly, CancellationToken token)
     {
-        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token);
+        return await writer.WriteDocumentsAsync(context, documentsToWrite, metadataOnly, token).ConfigureAwait(false);
     }
 
     protected override async ValueTask WriteIncludesAsync(AsyncBlittableJsonTextWriter writer, DocumentsOperationContext context, string propertyName, List<Document> includes, CancellationToken token)
     {
         writer.WritePropertyName(propertyName);
 
-        await writer.WriteIncludesAsync(context, includes, token);
+        await writer.WriteIncludesAsync(context, includes, token).ConfigureAwait(false);
     }
 
     protected override ValueTask<DocumentsResult> GetDocumentsImplAsync(DocumentsOperationContext context, long? etag, StartsWithParams startsWith, string changeVector)

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetDocs.cs
@@ -23,7 +23,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
             {
                 await GetDocumentsAndWriteAsync(context, RequestHandler.GetStart(), RequestHandler.GetPageSize(), RequestHandler.GetStringQueryString("startsWith", required: false),
                     RequestHandler.GetStringQueryString("excludes", required: false), RequestHandler.GetStringQueryString("matches", required: false),
-                    RequestHandler.GetStringQueryString("startAfter", required: false), RequestHandler.GetStringQueryString("format", required: false), token);
+                    RequestHandler.GetStringQueryString("startAfter", required: false), RequestHandler.GetStringQueryString("format", required: false), token)
+                    .ConfigureAwait(false);
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/AbstractStreamingHandlerProcessorForGetStreamQuery.cs
@@ -69,7 +69,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                     var fromDocument = RequestHandler.GetStringQueryString("fromDocument", false);
                     if (string.IsNullOrEmpty(fromDocument) == false)
                     {
-                        var docData = await GetDocumentDataAsync(context, fromDocument);
+                        var docData = await GetDocumentDataAsync(context, fromDocument).ConfigureAwait(false);
                         if (docData == null)
                         {
                             throw new DocumentDoesNotExistException($"Was request to stream a query taken from {fromDocument} document, but it does not exist.");
@@ -81,13 +81,15 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                                 $"Expected {fromDocument} to have a property named 'Query' of type 'String' but couldn't locate such property.");
                         }
                     }
-                    query = await IndexQueryServerSide.CreateAsync(HttpContext, start, pageSize, context, tracker, overrideQuery: overrideQuery);
+                    query = await IndexQueryServerSide.CreateAsync(HttpContext, start, pageSize, context, tracker, overrideQuery: overrideQuery)
+                                                      .ConfigureAwait(false);
                     query.IsStream = true;
                 }
                 else
                 {
                     await using var stream = RequestHandler.TryGetRequestFromStream("ExportOptions") ?? RequestHandler.RequestBodyStream();
-                    var queryJson = await context.ReadForMemoryAsync(stream, "index/query");
+                    var queryJson = await context.ReadForMemoryAsync(stream, "index/query")
+                                                 .ConfigureAwait(false);
                     query = IndexQueryServerSide.Create(HttpContext, queryJson, GetQueryMetadataCache(), tracker);
                     query.IsStream = true;
                 }
@@ -109,7 +111,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                 {
                     if (string.Equals(debug, "entries", StringComparison.OrdinalIgnoreCase))
                     {
-                        await ExecuteAndWriteIndexQueryStreamEntriesAsync(context, query, format, debug, propertiesArray, fileNamePrefix, ignoreLimit, fromSharded, token);
+                        await ExecuteAndWriteIndexQueryStreamEntriesAsync(context, query, format, debug, propertiesArray, fileNamePrefix, ignoreLimit, fromSharded, token)
+                                    .ConfigureAwait(false);
                     }
                     else
                     {
@@ -118,7 +121,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                 }
                 else
                 {
-                    await ExecuteAndWriteQueryStreamAsync(context, query, format, propertiesArray, fileNamePrefix, ignoreLimit, fromSharded, token);
+                    await ExecuteAndWriteQueryStreamAsync(context, query, format, propertiesArray, fileNamePrefix, ignoreLimit, fromSharded, token)
+                                .ConfigureAwait(false);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -11,35 +11,35 @@ namespace Raven.Server.Documents.Handlers
         public async Task Post()
         {
             using (var processor = new DatabaseQueriesHandlerProcessorForGet(this, HttpMethod.Post))
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
         }
 
         [RavenAction("/databases/*/queries", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, DisableOnCpuCreditsExhaustion = true)]
         public async Task Get()
         {
             using (var processor = new DatabaseQueriesHandlerProcessorForGet(this, HttpMethod.Get))
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
         }
 
         [RavenAction("/databases/*/queries", "PATCH", AuthorizationStatus.ValidUser, EndpointType.Write, DisableOnCpuCreditsExhaustion = true)]
         public async Task Patch()
         {
             using (var processor = new DatabaseQueriesHandlerProcessorForPatch(this)) 
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
         }
 
         [RavenAction("/databases/*/queries/test", "PATCH", AuthorizationStatus.ValidUser, EndpointType.Write, DisableOnCpuCreditsExhaustion = true)]
         public async Task PatchTest()
         {
             using (var processor = new DatabaseQueriesHandlerProcessorForPatchTest(this))
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
         }
 
         [RavenAction("/databases/*/queries", "DELETE", AuthorizationStatus.ValidUser, EndpointType.Write)]
         public async Task Delete()
         {
             using (var processor = new DatabaseQueriesHandlerProcessorForDelete(this))
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/StreamCsvBlittableQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvBlittableQueryResultWriter.cs
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Handlers
                 GetCsvWriter().WriteField(o?.ToString());
             }
 
-            await GetCsvWriter().NextRecordAsync();
+            await GetCsvWriter().NextRecordAsync().ConfigureAwait(false);
         }
 
         public StreamCsvBlittableQueryResultWriter(HttpResponse response, Stream stream, string[] properties = null,

--- a/src/Raven.Server/Documents/Handlers/StreamCsvDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvDocumentQueryResultWriter.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents.Handlers
                 }
             }
 
-            await GetCsvWriter().NextRecordAsync();
+            await GetCsvWriter().NextRecordAsync().ConfigureAwait(false);
         }
 
         public StreamCsvDocumentQueryResultWriter(HttpResponse response, Stream stream, string[] properties = null,

--- a/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
@@ -82,10 +82,10 @@ namespace Raven.Server.Documents.Handlers
         public async ValueTask DisposeAsync()
         {
             if (_csvWriter != null)
-                await _csvWriter.DisposeAsync();
+                await _csvWriter.DisposeAsync().ConfigureAwait(false);
 
             if (_writer != null)
-                await _writer.DisposeAsync();
+                await _writer.DisposeAsync().ConfigureAwait(false);
         }
 
         public void StartResponse()
@@ -151,12 +151,12 @@ namespace Raven.Server.Documents.Handlers
 
         public async ValueTask WriteErrorAsync(Exception e)
         {
-            await _writer.WriteLineAsync(e.ToString());
+            await _writer.WriteLineAsync(e.ToString()).ConfigureAwait(false);
         }
 
         public async ValueTask WriteErrorAsync(string error)
         {
-            await _writer.WriteLineAsync(error);
+            await _writer.WriteLineAsync(error).ConfigureAwait(false);
         }
 
         public void WriteQueryStatistics(long resultEtag, bool isStale, string indexName, long totalResults, DateTime timestamp)

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
         public async Task StreamDocsGet()
         {
             using (var processor = new StreamingHandlerProcessorForGetDocs(this))
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
         }
 
         [RavenAction("/databases/*/streams/timeseries", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
         {
             using (var processor = new StreamingHandlerProcessorForGetTimeSeries(this))
             {
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
             }
         }
 
@@ -33,14 +33,14 @@ namespace Raven.Server.Documents.Handlers.Streaming
         public async Task StreamQueryGet()
         {
             using (var processor = new StreamingHandlerProcessorForGetStreamQuery(this, HttpMethod.Get))
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
         }
 
         [RavenAction("/databases/*/streams/queries", "POST", AuthorizationStatus.ValidUser, EndpointType.Read, DisableOnCpuCreditsExhaustion = true)]
         public async Task StreamQueryPost()
         {
             using (var processor = new StreamingHandlerProcessorForGetStreamQuery(this, HttpMethod.Post))
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/AbstractDatabaseQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractDatabaseQueryRunner.cs
@@ -95,7 +95,7 @@ public abstract class AbstractDatabaseQueryRunner : AbstractQueryRunner
                 return SuggestionQueryResult.NotModifiedResult;
         }
 
-        return await index.SuggestionQuery(query, queryContext, token);
+        return await index.SuggestionQuery(query, queryContext, token).ConfigureAwait(false);
     }
 
     protected Task<IOperationResult> ExecuteDelete(IndexQueryServerSide query, Index index, QueryOperationOptions options, QueryOperationContext queryContext, Action<DeterminateProgress> onProgress, OperationCancelToken token)
@@ -203,7 +203,7 @@ public abstract class AbstractDatabaseQueryRunner : AbstractQueryRunner
                     maxTransactionSize: 16 * Constants.Size.Megabyte,
                     batchSize: batchSize);
 
-                await Database.TxMerger.Enqueue(command);
+                await Database.TxMerger.Enqueue(command).ConfigureAwait(false);
 
                 progress.Processed += command.Processed;
 

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -65,7 +65,8 @@ namespace Raven.Server.Documents.Queries
                         if (scope == null)
                             sw = Stopwatch.StartNew();
 
-                        result = await GetRunner(query).ExecuteQuery(query, queryContext, existingResultEtag, token);
+                        result = await GetRunner(query).ExecuteQuery(query, queryContext, existingResultEtag, token)
+                                                       .ConfigureAwait(false);
                     }
 
                     result.DurationInMs = sw != null ? (long)sw.Elapsed.TotalMilliseconds : (long)scope.Duration.TotalMilliseconds;
@@ -79,7 +80,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
                 catch (OperationCanceledException e)
                 {
@@ -91,7 +92,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
             }
 
@@ -105,7 +106,8 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
-                    await GetRunner(query).ExecuteStreamQuery(query, queryContext, response, writer, token);
+                    await GetRunner(query).ExecuteStreamQuery(query, queryContext, response, writer, token)
+                                          .ConfigureAwait(false);
                     return;
                 }
                 catch (ObjectDisposedException e)
@@ -115,7 +117,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
                 catch (OperationCanceledException e)
                 {
@@ -127,7 +129,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
             }
 
@@ -143,7 +145,8 @@ namespace Raven.Server.Documents.Queries
                 try
                 {
                     queryContext.CloseTransaction();
-                    await GetRunner(query).ExecuteStreamIndexEntriesQuery(query, queryContext, response, writer, ignoreLimit, token);
+                    await GetRunner(query).ExecuteStreamIndexEntriesQuery(query, queryContext, response, writer, ignoreLimit, token)
+                                          .ConfigureAwait(false);
                     return;
                 }
                 catch (ObjectDisposedException e)
@@ -153,7 +156,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
                 catch (OperationCanceledException e)
                 {
@@ -165,7 +168,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
             }
 
@@ -192,7 +195,7 @@ namespace Raven.Server.Documents.Queries
                         if (scope == null)
                             sw = Stopwatch.StartNew();
 
-                        result = await _static.ExecuteFacetedQuery(query, existingResultEtag, queryContext, token);
+                        result = await _static.ExecuteFacetedQuery(query, existingResultEtag, queryContext, token).ConfigureAwait(false);
                     }
 
                     result.DurationInMs = sw != null ? (long)sw.Elapsed.TotalMilliseconds : (long)scope.Duration.TotalMilliseconds;
@@ -206,7 +209,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
                 catch (OperationCanceledException e)
                 {
@@ -218,7 +221,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
             }
 
@@ -283,7 +286,8 @@ namespace Raven.Server.Documents.Queries
                         if (scope == null)
                             sw = Stopwatch.StartNew();
 
-                        result = await GetRunner(query).ExecuteSuggestionQuery(query, queryContext, existingResultEtag, token);
+                        result = await GetRunner(query).ExecuteSuggestionQuery(query, queryContext, existingResultEtag, token)
+                                                       .ConfigureAwait(false);
                     }
 
                     result.DurationInMs = sw != null ? (long)sw.Elapsed.TotalMilliseconds : (long)scope.Duration.TotalMilliseconds;
@@ -297,7 +301,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
                 catch (OperationCanceledException e)
                 {
@@ -309,7 +313,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
             }
 
@@ -323,7 +327,8 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
-                    return await GetRunner(query).ExecuteIndexEntriesQuery(query, queryContext, ignoreLimit, existingResultEtag, token);
+                    return await GetRunner(query).ExecuteIndexEntriesQuery(query, queryContext, ignoreLimit, existingResultEtag, token)
+                                                 .ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException e)
                 {
@@ -332,7 +337,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
                 catch (OperationCanceledException e)
                 {
@@ -344,7 +349,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
             }
 
@@ -358,7 +363,8 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
-                    return await GetRunner(query).ExecuteDeleteQuery(query, options, queryContext, onProgress, token);
+                    return await GetRunner(query).ExecuteDeleteQuery(query, options, queryContext, onProgress, token)
+                                                 .ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException e)
                 {
@@ -367,7 +373,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
                 catch (OperationCanceledException e)
                 {
@@ -379,7 +385,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
             }
 
@@ -393,7 +399,8 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
-                    return await GetRunner(query).ExecutePatchQuery(query, options, patch, patchArgs, queryContext, onProgress, token);
+                    return await GetRunner(query).ExecutePatchQuery(query, options, patch, patchArgs, queryContext, onProgress, token)
+                                                 .ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException e)
                 {
@@ -402,7 +409,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
                 catch (OperationCanceledException e)
                 {
@@ -414,7 +421,7 @@ namespace Raven.Server.Documents.Queries
 
                     lastException = e;
 
-                    await WaitForIndexBeingLikelyReplacedDuringQuery();
+                    await WaitForIndexBeingLikelyReplacedDuringQuery().ConfigureAwait(false);
                 }
             }
 

--- a/src/Raven.Server/Documents/Queries/StreamBlittableDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Queries/StreamBlittableDocumentQueryResultWriter.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents.Queries
             }
 
             Writer.WriteObject(res);
-            await Writer.MaybeFlushAsync(token);
+            await Writer.MaybeFlushAsync(token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/StreamJsonDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Queries/StreamJsonDocumentQueryResultWriter.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Documents.Queries
             }
             
             Writer.WriteDocument(Context, res, metadataOnly: false);
-            await Writer.MaybeFlushAsync(token);
+            await Writer.MaybeFlushAsync(token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Raven.Server/Documents/Queries/StreamJsonlDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Queries/StreamJsonlDocumentQueryResultWriter.cs
@@ -45,7 +45,7 @@ namespace Raven.Server.Documents.Queries
             _writer.WriteEndObject();
 
             _writer.WriteNewLine();
-            await _writer.MaybeFlushAsync(token);
+            await _writer.MaybeFlushAsync(token).ConfigureAwait(false);
         }
 
         public void EndResponse()
@@ -61,7 +61,7 @@ namespace Raven.Server.Documents.Queries
 
             _writer.WriteNewLine();
 
-            await _writer.FlushAsync();
+            await _writer.FlushAsync().ConfigureAwait(false);
         }
 
         public async ValueTask WriteErrorAsync(string error)
@@ -73,7 +73,7 @@ namespace Raven.Server.Documents.Queries
 
             _writer.WriteNewLine();
 
-            await _writer.FlushAsync();
+            await _writer.FlushAsync().ConfigureAwait(false);
         }
 
         public void WriteQueryStatistics(long resultEtag, bool isStale, string indexName, long totalResults, DateTime timestamp)

--- a/src/Raven.Server/Documents/Queries/StreamQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/StreamQueryResult.cs
@@ -103,7 +103,7 @@ namespace Raven.Server.Documents.Queries
             _anyExceptions = true;
 
             _writer.EndResults();
-            await _writer.WriteErrorAsync(e);
+            await _writer.WriteErrorAsync(e).ConfigureAwait(false);
 
             throw e;
         }

--- a/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs
@@ -121,7 +121,7 @@ namespace Raven.Server.Documents.TransactionMerger
 
             try
             {
-                await cmd.TaskCompletionSource.Task;
+                await cmd.TaskCompletionSource.Task.ConfigureAwait(false);
             }
             finally
             {

--- a/src/Raven.Server/Https/HttpsConnectionMiddleware.cs
+++ b/src/Raven.Server/Https/HttpsConnectionMiddleware.cs
@@ -80,12 +80,12 @@ namespace Raven.Server.Https
         public async Task OnConnectionAsync(ConnectionContext context, Func<Task> next)
         {
             if (_server.ServerStore.Initialized == false)
-                await _server.ServerStore.InitializationCompleted.WaitAsync();
+                await _server.ServerStore.InitializationCompleted.WaitAsync().ConfigureAwait(false);
 
             var tlsConnectionFeature = context.Features.Get<ITlsConnectionFeature>();
             X509Certificate2 certificate = null;
             if (tlsConnectionFeature != null)
-                certificate = await tlsConnectionFeature.GetClientCertificateAsync(context.ConnectionClosed);
+                certificate = await tlsConnectionFeature.GetClientCertificateAsync(context.ConnectionClosed).ConfigureAwait(false);
 
             var httpConnectionFeature = context.Features.Get<IHttpConnectionFeature>();
             var authenticationStatus = _server.AuthenticateConnectionCertificate(certificate, httpConnectionFeature);
@@ -93,7 +93,7 @@ namespace Raven.Server.Https
             // build the token
             context.Features.Set<IHttpAuthenticationFeature>(authenticationStatus);
 
-            await next();
+            await next().ConfigureAwait(false);
         }
 
         internal static X509Certificate2 ConvertToX509Certificate2(X509Certificate certificate)

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -317,7 +317,8 @@ namespace Raven.Server.Json
                 writer.WriteComma();
             }
 
-            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token)
+                                                                                  .ConfigureAwait(false);
 
             writer.WriteEndObject();
 
@@ -343,7 +344,8 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
-            var (numberOfResults, _) = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            var (numberOfResults, _) = await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token)
+                                                        .ConfigureAwait(false);
 
             writer.WriteEndObject();
 
@@ -599,7 +601,8 @@ namespace Raven.Server.Json
             writer.WriteInteger(result.DurationInMs);
             writer.WriteComma();
 
-            await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token);
+            await writer.WriteQueryResultAsync(context, result, metadataOnly: false, partial: true, token)
+                        .ConfigureAwait(false);
 
             writer.WriteEndObject();
         }
@@ -637,7 +640,8 @@ namespace Raven.Server.Json
             writer.WriteArray(nameof(result.IncludedPaths), result.IncludedPaths);
             writer.WriteComma();
 
-            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly, partial: true, token);
+            var numberOfResults = await writer.WriteQueryResultAsync(context, result, metadataOnly, partial: true, token)
+                                                                                  .ConfigureAwait(false);
 
             if (result.Highlightings != null)
             {
@@ -695,7 +699,8 @@ namespace Raven.Server.Json
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.RevisionIncludes));
                 writer.WriteStartArray();
-                await revisionIncludes.WriteIncludesAsync(writer, context, token);
+                await revisionIncludes.WriteIncludesAsync(writer, context, token)
+                                      .ConfigureAwait(false);
                 writer.WriteEndArray();
             }
 
@@ -704,7 +709,8 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.CounterIncludes));
-                await counters.WriteIncludesAsync(writer, context, token);
+                await counters.WriteIncludesAsync(writer, context, token)
+                              .ConfigureAwait(false);
 
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.IncludedCounterNames));
@@ -716,7 +722,8 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.TimeSeriesIncludes));
-                await timeSeries.WriteIncludesAsync(writer, context, token);
+                await timeSeries.WriteIncludesAsync(writer, context, token)
+                                .ConfigureAwait(false);
             }
 
             if (result.TimeSeriesFields != null)
@@ -730,7 +737,8 @@ namespace Raven.Server.Json
             {
                 writer.WriteComma();
                 writer.WritePropertyName(nameof(result.CompareExchangeValueIncludes));
-                await writer.WriteCompareExchangeValuesAsync(compareExchangeValues, token);
+                await writer.WriteCompareExchangeValuesAsync(compareExchangeValues, token)
+                            .ConfigureAwait(false);
             }
 
             var spatialProperties = result.SpatialProperties;
@@ -821,13 +829,15 @@ namespace Raven.Server.Json
             if (results is List<Document> documents)
             {
                 writer.WritePropertyName(nameof(result.Results));
-                (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteDocumentsAsync(context, documents, metadataOnly, token);
+                (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteDocumentsAsync(context, documents, metadataOnly, token)
+                                                                           .ConfigureAwait(false);
                 writer.WriteComma();
             }
             else if (results is List<BlittableJsonReaderObject> objects)
             {
                 writer.WritePropertyName(nameof(result.Results));
-                (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteObjectsAsync(context, objects, token);
+                (numberOfResults, totalDocumentsSizeInBytes) = await writer.WriteObjectsAsync(context, objects, token)
+                                                                           .ConfigureAwait(false);
                 writer.WriteComma();
             }
             else if (results is List<FacetResult> facets)
@@ -835,14 +845,16 @@ namespace Raven.Server.Json
                 numberOfResults = facets.Count;
                 writer.WriteArray(context, nameof(result.Results), facets, (w, c, facet) => w.WriteFacetResult(c, facet));
                 writer.WriteComma();
-                await writer.MaybeFlushAsync(token);
+                await writer.MaybeFlushAsync(token)
+                            .ConfigureAwait(false);
             }
             else if (results is List<SuggestionResult> suggestions)
             {
                 numberOfResults = suggestions.Count;
                 writer.WriteArray(context, nameof(result.Results), suggestions, (w, c, suggestion) => w.WriteSuggestionResult(c, suggestion));
                 writer.WriteComma();
-                await writer.MaybeFlushAsync(token);
+                await writer.MaybeFlushAsync(token)
+                            .ConfigureAwait(false);
             }
             else
                 throw new NotSupportedException($"Cannot write query result of '{typeof(TResult)}' type in '{result.GetType()}'.");
@@ -851,13 +863,15 @@ namespace Raven.Server.Json
             if (includes is List<Document> includeDocuments)
             {
                 writer.WritePropertyName(nameof(result.Includes));
-                await writer.WriteIncludesAsync(context, includeDocuments, token);
+                await writer.WriteIncludesAsync(context, includeDocuments, token)
+                            .ConfigureAwait(false);
                 writer.WriteComma();
             }
             else if (includes is List<BlittableJsonReaderObject> includeObjects)
             {
                 writer.WritePropertyName(nameof(result.Includes));
-                await writer.WriteIncludesAsync(includeObjects, token);
+                await writer.WriteIncludesAsync(includeObjects, token)
+                            .ConfigureAwait(false);
                 writer.WriteComma();
             }
             else
@@ -1759,7 +1773,8 @@ namespace Raven.Server.Json
                 first = false;
 
                 WriteDocument(writer, context, documents.Current, metadataOnly);
-                await writer.MaybeFlushAsync(token);
+                await writer.MaybeFlushAsync(token)
+                            .ConfigureAwait(false);
             }
 
             writer.WriteEndArray();
@@ -1792,7 +1807,8 @@ namespace Raven.Server.Json
                 first = false;
 
                 WriteDocument(writer, context, document, metadataOnly);
-                await writer.FlushAsync(token); // we must flush here because we dispose the document
+                await writer.FlushAsync(token)
+                            .ConfigureAwait(false); // we must flush here because we dispose the document
             }
 
             writer.WriteEndArray();
@@ -1851,13 +1867,15 @@ namespace Raven.Server.Json
                 {
                     writer.WritePropertyName(conflict.Id);
                     WriteConflict(writer, conflict);
-                    await writer.MaybeFlushAsync(token);
+                    await writer.MaybeFlushAsync(token)
+                                .ConfigureAwait(false);
                     continue;
                 }
 
                 writer.WritePropertyName(document.Id);
                 WriteDocument(writer, context, metadataOnly: false, document: document);
-                await writer.MaybeFlushAsync(token);
+                await writer.MaybeFlushAsync(token)
+                            .ConfigureAwait(false);
             }
 
             writer.WriteEndObject();
@@ -1884,7 +1902,8 @@ namespace Raven.Server.Json
                 writer.WritePropertyName(includeDoc.GetMetadata().GetId());
                 writer.WriteObject(includeDoc);
 
-                await writer.MaybeOuterFlushAsync();
+                await writer.MaybeOuterFlushAsync()
+                            .ConfigureAwait(false);
             }
 
             writer.WriteEndObject();
@@ -1941,7 +1960,7 @@ namespace Raven.Server.Json
                 {
                     writer.WriteObject(o);
 
-                    var writtenBytes = await writer.MaybeFlushAsync(token);
+                    var writtenBytes = await writer.MaybeFlushAsync(token).ConfigureAwait(false);
 
                     if (o.HasParent)
                     {
@@ -1984,7 +2003,7 @@ namespace Raven.Server.Json
                 {
                     writer.WriteObject(o);
 
-                    var writtenBytes = await writer.MaybeFlushAsync(token);
+                    var writtenBytes = await writer.MaybeFlushAsync(token).ConfigureAwait(false);
 
                     if (o.HasParent)
                     {
@@ -2071,7 +2090,7 @@ namespace Raven.Server.Json
                 if (counter == null)
                 {
                     writer.WriteNull();
-                    await writer.MaybeFlushAsync(token);
+                    await writer.MaybeFlushAsync(token).ConfigureAwait(false);
                     continue;
                 }
 
@@ -2090,7 +2109,7 @@ namespace Raven.Server.Json
 
                 writer.WriteEndObject();
 
-                await writer.MaybeFlushAsync(token);
+                await writer.MaybeFlushAsync(token).ConfigureAwait(false);
             }
 
             writer.WriteEndArray();
@@ -2132,7 +2151,7 @@ namespace Raven.Server.Json
 
                 writer.WriteEndObject();
 
-                await writer.MaybeFlushAsync(token);
+                await writer.MaybeFlushAsync(token).ConfigureAwait(false);
             }
 
             writer.WriteEndObject();

--- a/src/Raven.Server/Platform/Posix/LimitsReader.cs
+++ b/src/Raven.Server/Platform/Posix/LimitsReader.cs
@@ -28,12 +28,12 @@ namespace Raven.Server.Platform.Posix
             if (PlatformDetails.RunningOnPosix == false)
                 throw new InvalidOperationException("Cannot read Current Limits because it requires POSIX");
 
-            if (await _lock.WaitAsync(0) == false)
+            if (await _lock.WaitAsync(0).ConfigureAwait(false) == false)
                 return LimitsInfo.Current;
 
             try
             {
-                LimitsInfo.Current.MapCountCurrent = await GetCurrentMapCountAsync();
+                LimitsInfo.Current.MapCountCurrent = await GetCurrentMapCountAsync().ConfigureAwait(false);
                 LimitsInfo.Current.ThreadsCurrent = GetCurrentThreadsCount();
                 LimitsInfo.Current.SetValues();
             }
@@ -107,7 +107,8 @@ namespace Raven.Server.Platform.Posix
             long currentMapCount;
             await using (FileStream stream = File.OpenRead(CurrentMapCountFilePath))
             {
-                currentMapCount = await GetEolCountAsync(stream);
+                currentMapCount = await GetEolCountAsync(stream).ConfigureAwait(false);
+                ;
             }
 
             return currentMapCount;
@@ -119,7 +120,8 @@ namespace Raven.Server.Platform.Posix
             long eolCount = 0L;
             while (true)
             {
-                var result = await reader.ReadAsync();
+                var result = await reader.ReadAsync().ConfigureAwait(false);
+                ;
                 var buffer = result.Buffer;
 
                 while (TryReadLine(ref buffer))

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -383,8 +383,10 @@ namespace Raven.Server
         {
             try
             {
-                var response = await LicenseManager.GetUpdatedLicenseResponseMessage(license, contextPool);
-                var leasedLicense = await LicenseManager.ConvertResponseToLeasedLicense(response);
+                var response = await LicenseManager.GetUpdatedLicenseResponseMessage(license, contextPool)
+                                                   .ConfigureAwait(false);
+                var leasedLicense = await LicenseManager.ConvertResponseToLeasedLicense(response)
+                                                        .ConfigureAwait(false);
                 return leasedLicense.License;
             }
             catch

--- a/src/Raven.Server/Routing/RouteInformation.cs
+++ b/src/Raven.Server/Routing/RouteInformation.cs
@@ -206,18 +206,18 @@ namespace Raven.Server.Routing
             DatabasesLandlord databasesLandlord, StringSegment databaseName)
         {
             var time = databasesLandlord.DatabaseLoadTimeout;
-            if (await database.DatabaseShutdownCompleted.WaitAsync(time) == false)
+            if (await database.DatabaseShutdownCompleted.WaitAsync(time).ConfigureAwait(false) == false)
             {
                 ThrowDatabaseUnloadTimeout(databaseName, databasesLandlord.DatabaseLoadTimeout);
             }
-            await CreateDatabase(context);
+            await CreateDatabase(context).ConfigureAwait(false);
         }
 
         private async Task UnlikelyWaitForDatabaseToLoad(RequestHandlerContext context, Task<DocumentDatabase> database,
             DatabasesLandlord databasesLandlord, StringSegment databaseName)
         {
             var time = databasesLandlord.DatabaseLoadTimeout;
-            await Task.WhenAny(database, Task.Delay(time));
+            await Task.WhenAny(database, Task.Delay(time)).ConfigureAwait(false);
             if (database.IsCompleted == false)
             {
                 if (databasesLandlord.InitLog.TryGetValue(databaseName.Value, out var initLogQueue))
@@ -230,7 +230,7 @@ namespace Raven.Server.Routing
                 }
                 ThrowDatabaseLoadTimeout(databaseName, databasesLandlord.DatabaseLoadTimeout);
             }
-            context.Database = await database;
+            context.Database = await database.ConfigureAwait(false);
             if (context.Database == null)
                 DatabaseDoesNotExistException.Throw(databaseName.Value);
         }
@@ -280,7 +280,7 @@ namespace Raven.Server.Routing
 
         private async Task<HandleRequest> WaitForDb(Task databaseLoading)
         {
-            await databaseLoading;
+            await databaseLoading.ConfigureAwait(false);
 
             return _request;
         }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1120,13 +1120,13 @@ namespace Raven.Server.ServerWide
             }
             while (tasks.Count != 0)
             {
-                var completedTask = await Task.WhenAny(tasks.Values);
+                var completedTask = await Task.WhenAny(tasks.Values).ConfigureAwait(false);
                 var name = tasks.Single(t => t.Value == completedTask).Key;
                 tasks.Remove(name);
                 try
                 {
-                    var database = await completedTask;
-                    await database.RefreshFeaturesAsync();
+                    var database = await completedTask.ConfigureAwait(false);
+                    await database.RefreshFeaturesAsync().ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Web.System
         public async Task Databases()
         {
             using (var processor = new DatabasesHandlerProcessorForGet(this))
-                await processor.ExecuteAsync();
+                await processor.ExecuteAsync().ConfigureAwait(false);
         }
 
         [RavenAction("/admin/databases/topology/modify", "POST", AuthorizationStatus.Operator)]

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
@@ -38,7 +38,8 @@ namespace Raven.Server.Web.System
             var databaseGroupId = GetStringQueryString("groupId");
             var remoteTask = GetStringQueryString("remote-task");
 
-            if (await AuthenticateAsync(HttpContext, ServerStore, database, remoteTask) == false)
+            var authResult = await AuthenticateAsync(HttpContext, ServerStore, database, remoteTask).ConfigureAwait(false);
+            if (authResult == false)
                 return;
 
             List<string> nodes;
@@ -97,7 +98,8 @@ namespace Raven.Server.Web.System
                 }
             }
 
-            if (await AuthenticateAsync(HttpContext, ServerStore, database, remoteTask) == false)
+            var authResult = await AuthenticateAsync(HttpContext, ServerStore, database, remoteTask).ConfigureAwait(false);
+            if (authResult == false)
                 return;
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -127,11 +129,13 @@ namespace Raven.Server.Web.System
                     if (feature.CanAccess(database, requireAdmin: false, requireWrite: false))
                         return true;
 
-                    await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess);
+                    await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess)
+                                       .ConfigureAwait(false);
                     return false;
 
                 case RavenServer.AuthenticationStatus.UnfamiliarIssuer:
-                    await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess);
+                    await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess)
+                                       .ConfigureAwait(false);
                     return false;
 
                 case RavenServer.AuthenticationStatus.UnfamiliarCertificate:
@@ -149,7 +153,8 @@ namespace Raven.Server.Web.System
                                 return true;
                         }
 
-                        await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess);
+                        await RequestRouter.UnlikelyFailAuthorizationAsync(httpContext, database, feature, AuthorizationStatus.RestrictedAccess)
+                                           .ConfigureAwait(false);
                         return false;
                     }
 

--- a/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AsyncBlittableJsonTextWriter.cs
@@ -17,6 +17,13 @@ namespace Sparrow.Json
             _cancellationToken = cancellationToken;
         }
 
+
+        public static ConfiguredAsyncDisposable Create(JsonOperationContext context, Stream stream, out AsyncBlittableJsonTextWriter writer, CancellationToken cancellationToken = default)
+        {
+            writer = new AsyncBlittableJsonTextWriter(context, stream, cancellationToken);
+            return writer.ConfigureAwait(false);
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ValueTask<int> MaybeOuterFlushAsync()
         {

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -971,7 +971,7 @@ namespace Sparrow.Json
         public async ValueTask WriteAsync(Stream stream, BlittableJsonReaderObject json, CancellationToken token = default)
         {
             EnsureNotDisposed();
-            await using (var writer = new AsyncBlittableJsonTextWriter(this, stream))
+            await using (AsyncBlittableJsonTextWriter.Create(this, stream, out var writer))
             {
                 writer.WriteObject(json);
                 await writer.FlushAsync(token).ConfigureAwait(false);

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -208,7 +208,8 @@ namespace Voron
                 // the reference to storage environment won't be copied to the state-machine produced by await TimeoutManager.WaitFor() call
                 // otherwise the reference is hold and that prevents from running the finalizer of the environment
 
-                var result = await IdleFlushTimerInternal(weakRef);
+                var result = await IdleFlushTimerInternal(weakRef)
+                                            .ConfigureAwait(false);
                 switch (result)
                 {
                     case true:
@@ -216,7 +217,8 @@ namespace Voron
                     case false:
                         return;
                     case null:
-                        await TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(1000), token);
+                        await TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(1000), token)
+                                            .ConfigureAwait(false);
                         break;
                 }
             }
@@ -232,7 +234,9 @@ namespace Voron
 
                 try
                 {
-                    if (await env._writeTransactionRunning.WaitAsync(TimeSpan.FromMilliseconds(env.Options.IdleFlushTimeout)) == false)
+                    var result = await env._writeTransactionRunning.WaitAsync(TimeSpan.FromMilliseconds(env.Options.IdleFlushTimeout))
+                                                                       .ConfigureAwait(false);     
+                    if (result == false)
                     {
                         if (env.Journal.Applicator.ShouldFlush)
                             GlobalFlushingBehavior.GlobalFlusher.Value.MaybeFlushEnvironment(env);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22079

### Additional description
When overloaded forcing the tasks to capture the context is not only a unwanted burden but also a problem because we have no guarantee when that thread is going to be available again. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
