### PR TITLE
RavenDB-16208 wrap JavascriptCompilationOptions in lazy

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -97,7 +97,7 @@ namespace Raven.Client.Documents.Session
 
         private Dictionary<string, object> _externalState;
 
-        public IDictionary<string, object> ExternalState => _externalState ?? (_externalState = new Dictionary<string, object>());
+        public IDictionary<string, object> ExternalState => _externalState ??= new Dictionary<string, object>();
 
         public async Task<ServerNode> GetCurrentSessionNode()
         {
@@ -139,12 +139,12 @@ namespace Raven.Client.Documents.Session
         /// hold the data required to manage Counters tracking for RavenDB's Unit of Work
         /// </summary>
         protected internal Dictionary<string, (bool GotAll, Dictionary<string, long?> Values)> CountersByDocId =>
-            _countersByDocId ?? (_countersByDocId = new Dictionary<string, (bool GotAll, Dictionary<string, long?> Values)>(StringComparer.OrdinalIgnoreCase));
+            _countersByDocId ??= new Dictionary<string, (bool GotAll, Dictionary<string, long?> Values)>(StringComparer.OrdinalIgnoreCase);
 
         private Dictionary<string, (bool GotAll, Dictionary<string, long?> Values)> _countersByDocId;
 
         protected internal Dictionary<string, Dictionary<string, List<TimeSeriesRangeResult>>> TimeSeriesByDocId =>
-            _timeSeriesByDocId ?? (_timeSeriesByDocId = new Dictionary<string, Dictionary<string, List<TimeSeriesRangeResult>>>(StringComparer.OrdinalIgnoreCase));
+            _timeSeriesByDocId ??= new Dictionary<string, Dictionary<string, List<TimeSeriesRangeResult>>>(StringComparer.OrdinalIgnoreCase);
 
         private Dictionary<string, Dictionary<string, List<TimeSeriesRangeResult>>> _timeSeriesByDocId;
 
@@ -222,7 +222,7 @@ namespace Raven.Client.Documents.Session
         public GenerateEntityIdOnTheClient GenerateEntityIdOnTheClient { get; }
         public ISessionBlittableJsonConverter JsonConverter { get; }
 
-        protected internal IJsonSerializer JsonSerializer => _jsonSerializer ?? (_jsonSerializer = RequestExecutor.Conventions.Serialization.CreateSerializer());
+        protected internal IJsonSerializer JsonSerializer => _jsonSerializer ??= RequestExecutor.Conventions.Serialization.CreateSerializer();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InMemoryDocumentSessionOperations"/> class.
@@ -254,16 +254,16 @@ namespace Raven.Client.Documents.Session
             if (shardedBatchOptions != null)
                 _saveChangesOptions = new BatchOptions { ShardedOptions = shardedBatchOptions };
 
-            _javascriptCompilationOptions = new JavascriptCompilationOptions(
+            _javascriptCompilationOptions = new Lazy<JavascriptCompilationOptions>(() => new JavascriptCompilationOptions(
                 flags: JsCompilationFlags.BodyOnly | JsCompilationFlags.ScopeParameter,
-                extensions: new JavascriptConversionExtension[]
-                {
+                extensions:
+                [
                     JavascriptConversionExtensions.LinqMethodsSupport.Instance,
                     JavascriptConversionExtensions.NullableSupport.Instance
-                })
+                ])
             {
                 CustomMetadataProvider = new PropertyNameConventionJSMetadataProvider(RequestExecutor.Conventions)
-            };
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16208

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
