### PR TITLE
RavenDB-21980 - documentation for DocumentSession stream

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Stream.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Stream.cs
@@ -95,46 +95,48 @@ namespace Raven.Client.Documents.Session
             }
         }
 
+        
+        /// <inheritdoc/>
         public Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncRawDocumentQuery<T> query, CancellationToken token = default)
         {
             return StreamAsync((IAsyncDocumentQuery<T>)query, token);
         }
-
+        /// <inheritdoc/>
         public Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncRawDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats, CancellationToken token = default)
         {
             return StreamAsync((IAsyncDocumentQuery<T>)query, out streamQueryStats, token);
         }
-
+        /// <inheritdoc/>
         public Task StreamIntoAsync<T>(IAsyncRawDocumentQuery<T> query, Stream output, CancellationToken token = default)
         {
             return StreamIntoAsync((IAsyncDocumentQuery<T>)query, output, token);
         }
-
+        /// <inheritdoc/>
         public Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncDocumentQuery<T> query, CancellationToken token = default)
         {
             return PerformQueryStreamOperation(query, null, token);
         }
-
+        /// <inheritdoc/>
         public Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats, CancellationToken token = default)
         {
             streamQueryStats = new StreamQueryStatistics();
             return PerformQueryStreamOperation(query, streamQueryStats, token);
         }
-
+        /// <inheritdoc/>
         public Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IQueryable<T> query, CancellationToken token = default)
         {
             var queryInspector = (IRavenQueryProvider)query.Provider;
             var indexQuery = queryInspector.ToAsyncDocumentQuery<T>(query.Expression);
             return StreamAsync(indexQuery, token);
         }
-
+        /// <inheritdoc/>
         public Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IQueryable<T> query, out StreamQueryStatistics streamQueryStats, CancellationToken token = default)
         {
             var queryInspector = (IRavenQueryProvider)query.Provider;
             var indexQuery = queryInspector.ToAsyncDocumentQuery<T>(query.Expression);
             return StreamAsync(indexQuery, out streamQueryStats, token);
         }
-
+        /// <inheritdoc/>
         public async Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(string startsWith, string matches = null, int start = 0,
                                    int pageSize = int.MaxValue, string startAfter = null, CancellationToken token = default)
         {
@@ -147,7 +149,7 @@ namespace Raven.Client.Documents.Session
                 return new YieldStream<T>(this, result, null, null, token);
             }
         }
-
+        /// <inheritdoc/>
         public async Task StreamIntoAsync<T>(IAsyncDocumentQuery<T> query, Stream output, CancellationToken token = default)
         {
             using (AsyncTaskHolder())

--- a/src/Raven.Client/Documents/Session/DocumentSession.Stream.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.Stream.cs
@@ -10,6 +10,7 @@ namespace Raven.Client.Documents.Session
 {
     public partial class DocumentSession
     {
+        /// <inheritdoc/>
         public IEnumerator<StreamResult<T>> Stream<T>(IQueryable<T> query)
         {
             var queryProvider = (IRavenQueryProvider)query.Provider;
@@ -17,6 +18,7 @@ namespace Raven.Client.Documents.Session
             return Stream(docQuery);
         }
 
+        /// <inheritdoc/>
         public IEnumerator<StreamResult<T>> Stream<T>(IQueryable<T> query, out StreamQueryStatistics streamQueryStats)
         {
             var queryProvider = (IRavenQueryProvider)query.Provider;
@@ -24,6 +26,7 @@ namespace Raven.Client.Documents.Session
             return Stream(docQuery, out streamQueryStats);
         }
 
+        /// <inheritdoc/>
         public IEnumerator<StreamResult<T>> Stream<T>(IDocumentQuery<T> query)
         {
             var streamOperation = new StreamOperation(this);
@@ -37,16 +40,19 @@ namespace Raven.Client.Documents.Session
             return YieldResults(query, result);
         }
 
+        /// <inheritdoc/>
         public IEnumerator<StreamResult<T>> Stream<T>(IRawDocumentQuery<T> query)
         {
             return Stream((IDocumentQuery<T>)query);
         }
 
+        /// <inheritdoc/>
         public IEnumerator<StreamResult<T>> Stream<T>(IRawDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats)
         {
             return Stream((IDocumentQuery<T>)query, out streamQueryStats);
         }
 
+        /// <inheritdoc/>
         public IEnumerator<StreamResult<T>> Stream<T>(IDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats)
         {
             var stats = new StreamQueryStatistics();
@@ -82,11 +88,13 @@ namespace Raven.Client.Documents.Session
             }
         }
 
+        /// <inheritdoc/>
         public void StreamInto<T>(IRawDocumentQuery<T> query, Stream output)
         {
             StreamInto((IDocumentQuery<T>)query, output);
         }
 
+        /// <inheritdoc/>
         public void StreamInto<T>(IDocumentQuery<T> query, Stream output)
         {
             var streamOperation = new StreamOperation(this);
@@ -102,6 +110,7 @@ namespace Raven.Client.Documents.Session
             }
         }
 
+        /// <inheritdoc/>
         public IEnumerator<StreamResult<T>> Stream<T>(string startsWith, string matches = null, int start = 0, int pageSize = int.MaxValue,
              string startAfter = null)
         {

--- a/src/Raven.Client/Documents/Session/IAdvancedSessionOperations.Stream.cs
+++ b/src/Raven.Client/Documents/Session/IAdvancedSessionOperations.Stream.cs
@@ -28,83 +28,77 @@ namespace Raven.Client.Documents.Session
     public interface IDocumentsSessionOperations
     {
         /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
+        ///     Creates a stream to fetch documents that satisfy criteria <paramref name="query"/>.
+        /// <para>
+        ///     Documents are converted to CLR type <typeparamref name="T"/> along the way and wrapped in <see cref="StreamResult{T}"/> containing document metadata.
+        /// </para>
         /// </summary>
-        /// <param name="query">Query to stream results for</param>
+        /// <remarks>
+        ///     Does NOT track the entities in the session and will not include its changes when <see cref="IDocumentSession.SaveChanges"/> is called.
+        /// </remarks>
+        /// <param name="query">The criteria by which to fetch documents from the database</param>
+        /// <returns>An enumerator used to iterate over the collection of documents received via the stream</returns>
         IEnumerator<StreamResult<T>> Stream<T>(IQueryable<T> query);
 
         /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
+        ///     Creates a stream to fetch documents that satisfy criteria <paramref name="query"/>.
+        /// <para>
+        ///     Documents are converted to CLR type <typeparamref name="T"/> along the way and wrapped in <see cref="StreamResult{T}"/> containing document metadata.
+        /// </para>
         /// </summary>
-        /// <param name="query">Query to stream results for</param>
-        /// <param name="streamQueryStats">Information about the performed query</param>
+        /// <remarks>
+        ///     Does NOT track the entities in the session and will not include its changes when <see cref="IDocumentSession.SaveChanges"/> is called.
+        /// </remarks>
+        /// <param name="query">The criteria by which to fetch documents from the database</param>
+        /// <param name="streamQueryStats">Information and statistics about the performed query</param>
+        /// <returns>An enumerator used to iterate over the collection of documents received via the stream</returns>
         IEnumerator<StreamResult<T>> Stream<T>(IQueryable<T> query, out StreamQueryStatistics streamQueryStats);
 
-        /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="query">Query to stream results for</param>
+        /// <inheritdoc cref="Stream{T}(IQueryable{T}) "/>
         IEnumerator<StreamResult<T>> Stream<T>(IDocumentQuery<T> query);
 
-        /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="query">Query to stream results for</param>
+        /// <inheritdoc cref="Stream{T}(IQueryable{T}) "/>
         IEnumerator<StreamResult<T>> Stream<T>(IRawDocumentQuery<T> query);
 
-        
-        /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="query">Query to stream results for</param>
-        /// <param name="streamQueryStats">Information about the performed query</param>
+        /// <inheritdoc cref="Stream{T}(IQueryable{T}, out StreamQueryStatistics) "/>
         IEnumerator<StreamResult<T>> Stream<T>(IRawDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats);
 
-        /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="query">Query to stream results for</param>
-        /// <param name="streamQueryStats">Information about the performed query</param>
+        /// <inheritdoc cref="Stream{T}(IQueryable{T}, out StreamQueryStatistics) "/>
         IEnumerator<StreamResult<T>> Stream<T>(IDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats);
 
         /// <summary>
-        ///     Stream the results of documents search to the client, converting them to CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
+        ///     Creates a stream to fetch documents whose IDs match the given parameters.
+        /// <para>
+        ///     Documents are converted to CLR type <typeparamref name="T"/> along the way and wrapped in <see cref="StreamResult{T}"/> containing document metadata.
+        /// </para>
         /// </summary>
-        /// <param name="startsWith">prefix for which documents should be returned e.g. "products/"</param>
+        /// <remarks>
+        ///     Does NOT track the entities in the session and will not include its changes when <see cref="IDocumentSession.SaveChanges"/> is called.
+        /// </remarks>
+        /// <example></example>
+        /// <param name="startsWith">ID prefix for which documents should be returned. e.g. "products/"</param>
         /// <param name="matches">
-        ///     pipe ('|') separated values for which document ID (after 'idPrefix') should be matched ('?'
-        ///     any single character, '*' any characters)
+        ///     pipe ('|') separated values by which to match the part following <paramref name="startsWith"/>. <br/>
+        ///     '?' - any single character <br/>
+        ///     '*' - any characters
         /// </param>
-        /// <param name="start">number of documents that should be skipped</param>
-        /// <param name="pageSize">maximum number of documents that will be retrieved</param>
-        /// <param name="startAfter">
-        ///     skip document fetching until given ID is found and return documents after that ID (default:
-        ///     null)
-        /// </param>
+        /// <param name="start">The number of documents that should be skipped</param>
+        /// <param name="pageSize">The maximum number of documents that will be retrieved</param>
+        /// <param name="startAfter">Skip document fetching until given ID is found and only return documents after that ID.</param>
+        /// <returns>An enumerator used to iterate over the collection of documents received via the stream</returns>
         IEnumerator<StreamResult<T>> Stream<T>(string startsWith, string matches = null, int start = 0, int pageSize = int.MaxValue, string startAfter = null);
 
         /// <summary>
-        ///     Returns the results of a query directly into stream 
+        ///     Feeds the query results into given stream <paramref name="output"/>.
         /// </summary>
+        /// <remarks>
+        ///     Does NOT track the entities in the session and will not include its changes when <see cref="IDocumentSession.SaveChanges"/> is called.
+        /// </remarks>
+        /// <param name="query">The criteria by which to fetch documents from the database</param>
+        /// <param name="output">The stream to feed the results into</param>
         void StreamInto<T>(IDocumentQuery<T> query, Stream output);
 
-
-        /// <summary>
-        ///     Returns the results of a query directly into stream 
-        /// </summary>
+        /// <inheritdoc cref="StreamInto{T}(IDocumentQuery{T}, Stream) "/>
         void StreamInto<T>(IRawDocumentQuery<T> query, Stream output);
     }
 

--- a/src/Raven.Client/Documents/Session/IAsyncAdvancedSessionOperations.Stream.cs
+++ b/src/Raven.Client/Documents/Session/IAsyncAdvancedSessionOperations.Stream.cs
@@ -75,89 +75,33 @@ namespace Raven.Client.Documents.Session
 
     public interface IAsyncAdvancedDocumentsSessionOperations
     {
-        /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="query">Query to stream results for</param>
-        /// <param name="token">The cancellation token.</param>
+        /// <inheritdoc cref="IDocumentsSessionOperations.Stream{T}(IDocumentQuery{T}) "/>
         Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncDocumentQuery<T> query, CancellationToken token = default);
 
-        /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="query">Query to stream results for</param>
-        /// <param name="streamQueryStats">Information about the performed query</param>
-        /// <param name="token">The cancellation token.</param>
+        /// <inheritdoc cref="IDocumentsSessionOperations.Stream{T}(IDocumentQuery{T}, out StreamQueryStatistics) "/>
         Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats, CancellationToken token = default);
 
-        /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="query">Query to stream results for</param>
-        /// <param name="token">The cancellation token.</param>
+        /// <inheritdoc cref="IDocumentsSessionOperations.Stream{T}(IRawDocumentQuery{T}) "/>
         Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncRawDocumentQuery<T> query, CancellationToken token = default);
 
-        /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="query">Query to stream results for</param>
-        /// <param name="streamQueryStats">Information about the performed query</param>
-        /// <param name="token">The cancellation token.</param>
+        /// <inheritdoc cref="IDocumentsSessionOperations.Stream{T}(IRawDocumentQuery{T}, out StreamQueryStatistics) "/>
         Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IAsyncRawDocumentQuery<T> query, out StreamQueryStatistics streamQueryStats, CancellationToken token = default);
 
-        /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="query">Query to stream results for</param>
-        /// <param name="token">The cancellation token.</param>
+        /// <inheritdoc cref="IDocumentsSessionOperations.Stream{T}(IQueryable{T}) "/>
         Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IQueryable<T> query, CancellationToken token = default);
 
-        /// <summary>
-        ///     Stream the results on the query to the client, converting them to
-        ///     CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="query">Query to stream results for</param>
-        /// <param name="streamQueryStats">Information about the performed query</param>
-        /// <param name="token">The cancellation token.</param>
+        /// <inheritdoc cref="IDocumentsSessionOperations.Stream{T}(IQueryable{T}, out StreamQueryStatistics) "/>
         Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(IQueryable<T> query, out StreamQueryStatistics streamQueryStats, CancellationToken token = default);
 
-        /// <summary>
-        ///     Stream the results of documents search to the client, converting them to CLR types along the way.
-        ///     <para>Does NOT track the entities in the session, and will not includes changes there when SaveChanges() is called</para>
-        /// </summary>
-        /// <param name="startsWith">prefix for which documents should be returned e.g. "products/"</param>
-        /// <param name="matches">
-        ///     pipe ('|') separated values for which document IDs (after 'idPrefix') should be matched ('?'
-        ///     any single character, '*' any characters)
-        /// </param>
-        /// <param name="start">number of documents that should be skipped</param>
-        /// <param name="pageSize">maximum number of documents that will be retrieved</param>
-        /// <param name="startAfter">
-        ///     skip document fetching until given ID is found and return documents after that ID (default:
-        ///     null)
-        /// </param>
-        /// <param name="token">The cancellation token.</param>
+        /// <inheritdoc cref="IDocumentsSessionOperations.Stream{T}(string, string, int, int, string) "/>
         Task<IAsyncEnumerator<StreamResult<T>>> StreamAsync<T>(string startsWith, string matches = null, int start = 0, int pageSize = int.MaxValue, string startAfter = null, CancellationToken token = default);
 
-        /// <summary>
-        ///     Returns the results of a query directly into stream
-        /// </summary>
+        /// <inheritdoc cref="IDocumentsSessionOperations.StreamInto{T}(IDocumentQuery{T}, Stream) "/>
+        /// <returns>A task responsible for feeding the results into the given stream</returns>
         Task StreamIntoAsync<T>(IAsyncDocumentQuery<T> query, Stream output, CancellationToken token = default);
 
-        /// <summary>
-        ///     Returns the results of a query directly into stream
-        /// </summary>
+        /// <inheritdoc cref="IDocumentsSessionOperations.StreamInto{T}(IRawDocumentQuery{T}, Stream) "/>
+        /// <returns>A task responsible for feeding the results into the given stream</returns>
         Task StreamIntoAsync<T>(IAsyncRawDocumentQuery<T> query, Stream output, CancellationToken token = default);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21980

### Additional description

Documentation for DocumentSession's streaming functions

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
