### PR TITLE
RavenDB-22097 - fix test 'RavenDB_20628_backward_compatibility.UpgradeFollowerToLatest' (v6.0)

### DIFF
--- a/test/InterversionTests/RavenDB-20628-backward-compatibility.cs
+++ b/test/InterversionTests/RavenDB-20628-backward-compatibility.cs
@@ -113,8 +113,7 @@ namespace InterversionTests
                        }))
                 {
                     await session.StoreAsync(user1);
-                    var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await session.SaveChangesAsync());
-                    Assert.True(e.InnerException is InvalidOperationException);
+                    await session.SaveChangesAsync();
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22097/InterversionTests.RavenDB20628backwardcompatibility.UpgradeFollowerToLatestlatest-5.4.107

### Additional description

Updated follower shouldn't throw anymore when the leader is outdated in cluster transaction,
because this PR:
https://issues.hibernatingrhinos.com/issue/RavenDB-22072/UpgradeDirectlyFrom52X-fails

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
