### PR TITLE
RavenDB-21951 Handle fieldnames of boosted index entry definition in JavaScriptMapOperation

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
@@ -160,20 +160,14 @@ namespace Raven.Server.Documents.Indexes.Static
                     case CallExpression ce:
 
                         if (IsBoostExpression(ce))
-                            HasBoostedFields = true;
-                        else if (IsArrowFunctionExpressionWithObjectExpressionBody(ce, out var oea))
                         {
-                            foreach (var prop in oea.Properties)
-                            {
-                                if (prop is Property property)
-                                {
-                                    var fieldName = property.GetKey(engine);
-                                    var fieldNameAsString = fieldName.AsString();
+                            HasBoostedFields = true;
 
-                                    Fields.Add(fieldNameAsString);
-                                }
-                            }
+                            if (ce.Arguments[0] is ObjectExpression oe)
+                                AddObjectFieldsToIndexFields(oe);
                         }
+                        else if (IsArrowFunctionExpressionWithObjectExpressionBody(ce, out var oea))
+                            AddObjectFieldsToIndexFields(oea);
                         else
                             HasDynamicReturns = true;
                         break;
@@ -196,6 +190,20 @@ namespace Raven.Server.Documents.Indexes.Static
                     oea = _oea;
                 
                 return oea != null;
+            }
+
+            void AddObjectFieldsToIndexFields(ObjectExpression oe)
+            {
+                foreach (var prop in oe.Properties)
+                {
+                    if (prop is Property property)
+                    {
+                        var fieldName = property.GetKey(engine);
+                        var fieldNameAsString = fieldName.AsString();
+
+                        Fields.Add(fieldNameAsString);
+                    }
+                }
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-21951.cs
+++ b/test/SlowTests/Issues/RavenDB-21951.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FastTests;
+using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Tests.Infrastructure;
@@ -15,35 +16,45 @@ public class RavenDB_21951 : RavenTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.JavaScript)]
-    public void JavaScriptIndexWithBoostOnIndexEntryShouldWork()
+    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.JavaScript)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void JavaScriptIndexWithBoostOnIndexEntryShouldWork(Options options)
     {
-        using (var store = GetDocumentStore())
+        using (var store = GetDocumentStore(options))
         {
             using (var session = store.OpenSession())
             {
                 var o1 = new Order() { Name = "CoolName", Freight = 21.37 };
                 var o2 = new Order() { Name = "SomeOtherName", Freight = 1 };
                 var o3 = new Order() { Name = "CoolName", Freight = 10 };
-                
+
                 session.Store(o1);
                 session.Store(o2);
                 session.Store(o3);
-                
-                session.SaveChanges();
-                
-                var index = new DummyIndex();
-                
-                index.Execute(store);
-                
-                Indexes.WaitForIndexing(store);
 
+                session.SaveChanges();
+
+                var index = new DummyIndex();
+
+                index.Execute(store);
+
+                Indexes.WaitForIndexing(store);
+            }
+
+            using (var session = store.OpenSession())
+            {
                 var result = session.Query<Order, DummyIndex>().Where(x => x.Name == "CoolName").OrderByScore().ToList();
-                
+
                 Assert.Equal(2, result.Count);
-                
-                Assert.Equal(21.37, result[0].Freight);
-                Assert.Equal(10, result[1].Freight);
+
+                var metadata1 = session.Advanced.GetMetadataFor(result[0]);
+                var metadata2 = session.Advanced.GetMetadataFor(result[1]);
+
+                var score1 = metadata1[Constants.Documents.Metadata.IndexScore];
+                var score2 = metadata2[Constants.Documents.Metadata.IndexScore];
+
+                Assert.Equal(20, (long)score1);
+                Assert.Equal(10, (long)score2);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-21951.cs
+++ b/test/SlowTests/Issues/RavenDB-21951.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21951 : RavenTestBase
+{
+    public RavenDB_21951(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.JavaScript)]
+    public void JavaScriptIndexWithBoostOnIndexEntryShouldWork()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var o1 = new Order() { Name = "CoolName", Freight = 21.37 };
+                var o2 = new Order() { Name = "SomeOtherName", Freight = 1 };
+                var o3 = new Order() { Name = "CoolName", Freight = 10 };
+                
+                session.Store(o1);
+                session.Store(o2);
+                session.Store(o3);
+                
+                session.SaveChanges();
+                
+                var index = new DummyIndex();
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+
+                var result = session.Query<Order, DummyIndex>().Where(x => x.Name == "CoolName").OrderByScore().ToList();
+                
+                Assert.Equal(2, result.Count);
+                
+                Assert.Equal(21.37, result[0].Freight);
+                Assert.Equal(10, result[1].Freight);
+            }
+        }
+    }
+
+    private class DummyIndex : AbstractJavaScriptIndexCreationTask
+    {
+        public DummyIndex()
+        {
+            Maps = new HashSet<string>()
+            {
+               @"map('orders', function(order) {
+                    return boost({
+                        Name: order.Name
+                    }, order.Freight)
+                })"
+            };
+        }
+    }
+
+    private class Order
+    {
+        public string Name { get; set; }
+        public double Freight { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21951/Cannot-query-a-JavaScript-index-that-has-a-Boost-value-applied-to-the-index-entry

### Additional description

When analyzing JS index definition that returns boosted index entry, we want to add its fields to output fields.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
