### PR TITLE
RavenDB-22086 Fix order by score descending in CoraxQueryBuilder

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1299,9 +1299,9 @@ public static class CoraxQueryBuilder
             if (field.OrderingType == OrderByFieldType.Score)
             {
                 if (field.Ascending)
-                    sortArray[sortIndex++] = new OrderMetadata(true, MatchCompareFieldType.Score, true);
-                else
                     sortArray[sortIndex++] = new OrderMetadata(true, MatchCompareFieldType.Score);
+                else
+                    sortArray[sortIndex++] = new OrderMetadata(true, MatchCompareFieldType.Score, ascending: false);
 
                 continue;
             }

--- a/test/SlowTests/Issues/RavenDB-22086.cs
+++ b/test/SlowTests/Issues/RavenDB-22086.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22086 : RavenTestBase
+{
+    public RavenDB_22086(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void Test(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var d1 = new Dto() { Name = "CoolName", SomeValue = 21 };
+                var d2 = new Dto() { Name = "CoolerName", SomeValue = 37 };
+                
+                session.Store(d1);
+                session.Store(d2);
+                
+                session.SaveChanges();
+
+                var resultsByScoreAscending = session.Query<Dto>().Where(x => x.Name == "CoolName" || x.SomeValue > 20).OrderByScore().ToList();
+                
+                Assert.Equal(2, resultsByScoreAscending.Count);
+                
+                Assert.Equal("CoolName", resultsByScoreAscending[0].Name);
+                Assert.Equal("CoolerName", resultsByScoreAscending[1].Name);
+
+                var resultsByScoreDescending = session.Query<Dto>().Where(x => x.Name == "CoolName" || x.SomeValue > 20).OrderByScoreDescending().ToList();
+                
+                Assert.Equal(2, resultsByScoreDescending.Count);
+                
+                Assert.Equal("CoolerName", resultsByScoreDescending[0].Name);
+                Assert.Equal("CoolName", resultsByScoreDescending[1].Name);
+            }
+        }
+    }
+    
+    private class DummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public DummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new {  };
+        }
+    }
+    
+    private class Dto
+    {
+        public string Name { get; set; }
+        public int SomeValue { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22086/Ordering-by-score-in-Corax-ignores-desc-keyword

### Additional description

When creating `OrderMetadata` in `CoraxQueryBuilder` for ordering by score, `ascending: true` is the default value, so in case of descending order we should set it to false.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
