### PR TITLE
RavenDB-21860 apply changes of #18133 to v6.0

### DIFF
--- a/src/Raven.Client/Extensions/TaskExtensions.cs
+++ b/src/Raven.Client/Extensions/TaskExtensions.cs
@@ -38,7 +38,7 @@ namespace Raven.Client.Extensions
 
         public static async Task<bool> WaitWithTimeout(this Task task, TimeSpan? timeout)
         {
-            if (timeout == null)
+            if (timeout == null || timeout == Timeout.InfiniteTimeSpan)
             {
                 await task.ConfigureAwait(false);
                 return true;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -797,9 +797,9 @@ namespace Raven.Server.Documents
             catch (Exception e)
             {
                 // nothing we can do
-                if (_logger.IsInfoEnabled)
+                if (_logger.IsOperationsEnabled)
                 {
-                    _logger.Info($"Failed to notify about transaction completion for database '{Name}'.", e);
+                    _logger.Operations($"Failed to notify about transaction completion for database '{Name}'.", e);
                 }
             }
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2061,7 +2061,7 @@ namespace Raven.Server.Documents
                     {
                         if (flags.Contain(DocumentFlags.FromClusterTransaction) == false)
                         {
-                            Debug.Assert(false, $"flags must set FromClusterTransaction for the change vector: {changeVector}");
+                            Debug.Assert(false, $"flags: '{flags}' must set FromClusterTransaction for the change vector: {changeVector}");
                         }
                     }
                     break;

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
@@ -73,7 +73,7 @@ public abstract class AbstractClusterTransactionRequestProcessor<TRequestHandler
         using (RequestHandler.ServerStore.Cluster.ClusterTransactionWaiter.CreateTask(id: options.TaskId, out var tcs))
         await using (token.Register(() => tcs.TrySetCanceled()))
         {
-            (index, object result) = await RequestHandler.ServerStore.SendToLeaderAsync(clusterTransactionCommand);
+            (index, object result) = await RequestHandler.ServerStore.SendToLeaderAsync(clusterTransactionCommand, token);
             array = await GetClusterTransactionDatabaseCommandsResults(result, clusterTransactionCommand.DatabaseCommandsCount, index, options, onDatabaseCompletionTask: tcs.Task, token);
         }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
@@ -65,6 +65,8 @@ public abstract class AbstractClusterTransactionRequestProcessor<TRequestHandler
             };
 
         ClusterTransactionCommand clusterTransactionCommand = CreateClusterTransactionCommand(parsedCommands, options, raftRequestId);
+        clusterTransactionCommand.Timeout = Timeout.InfiniteTimeSpan; // we rely on the http token to cancel the command
+
         DynamicJsonArray array;
         long index;
 
@@ -108,7 +110,7 @@ public abstract class AbstractClusterTransactionRequestProcessor<TRequestHandler
 
         // leader isn't updated (thats why the result is empty),
         // so we'll try to take the result from the local history log.
-        await RequestHandler.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index, token);
+        await RequestHandler.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index, Timeout.InfiniteTimeSpan, token);
         using (RequestHandler.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
         using (ctx.OpenReadTransaction())
         {

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -169,7 +169,7 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
         foreach (var command in readCommands)
         {
             batchCollector.MaxIndex = command.Index;
-            batchCollector.MaxCommandCount = command.PreviousCount + command.Commands.Length;
+            batchCollector.MaxCommandCount = command.PreviousCount + command.Commands.Count;
             if (command.ShardNumber == ShardNumber)
                 batchCollector.Add(command);
         }

--- a/src/Raven.Server/Rachis/Commands/Leader.RachisMergedCommand.cs
+++ b/src/Raven.Server/Rachis/Commands/Leader.RachisMergedCommand.cs
@@ -174,6 +174,8 @@ namespace Raven.Server.Rachis
 
             public void Dispose()
             {
+                Command.Raw?.Dispose();
+                Command.Raw = null;
                 BlittableResultWriter?.Dispose();
                 _ctxReturn?.Dispose();
             }

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -665,27 +665,13 @@ namespace Raven.Server.Rachis
 
         public async Task<(long Index, object Result)> PutAsync(CommandBase command, TimeSpan timeout)
         {
-            using var blittableResultWriter = command is IBlittableResultCommand crCommand ? new BlittableResultWriter(crCommand.WriteResult) : null;
-            using var _ = _engine.ContextPool.AllocateOperationContext(out JsonOperationContext context);
-            var djv = command.ToJson(context);
-
-            var rachisMergedCommand = new RachisMergedCommand(leader: this, engine: _engine)
-            {
-                Command = command,
-                CommandAsJson = context.ReadObject(djv, "raft/command"),
-                BlittableResultWriter = blittableResultWriter
-            };
+            using var rachisMergedCommand = new RachisMergedCommand(leader: this, command, timeout);
+            
+            rachisMergedCommand.Initialize();
 
             await _engine.TxMerger.Enqueue(rachisMergedCommand);
 
-            var t = rachisMergedCommand.TaskResult;
-            if (await t.WaitWithTimeout(timeout) == false)
-            {
-                throw new TimeoutException($"Waited for {timeout} but the command {command.RaftCommandIndex} was not applied in this time.");
-            }
-
-            var result = await t;
-            return blittableResultWriter == null ? result : (result.Index, blittableResultWriter.Result);
+            return await rachisMergedCommand.Result();
         }
 
         public ConcurrentQueue<(string node, AlertRaised error)> ErrorsList = new ConcurrentQueue<(string, AlertRaised)>();

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -317,7 +317,7 @@ namespace Raven.Server.Rachis
 
         public Action<ClusterOperationContext> SwitchToSingleLeaderAction;
 
-        public Action<ClusterOperationContext, CommandBase> BeforeAppendToRaftLog;
+        public Action<ClusterOperationContext, Leader.RachisMergedCommand> BeforeAppendToRaftLog;
 
         private string _tag;
         private string _clusterId;
@@ -2256,7 +2256,7 @@ namespace Raven.Server.Rachis
         internal readonly AsyncManualResetEvent _leadershipTimeChanged = new AsyncManualResetEvent();
         private int _heartbeatWaitersCounter;
 
-        public void InvokeBeforeAppendToRaftLog(ClusterOperationContext context, CommandBase cmd)
+        public void InvokeBeforeAppendToRaftLog(ClusterOperationContext context, Leader.RachisMergedCommand cmd)
         {
             BeforeAppendToRaftLog?.Invoke(context, cmd);
         }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1835,9 +1835,9 @@ namespace Raven.Server.Rachis
             context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += _ => TaskExecutor.CompleteAndReplace(ref _commitIndexChanged);
         }
 
-        public async Task WaitForCommitIndexChange(CommitIndexModification modification, long value, CancellationToken token = default)
+        public async Task WaitForCommitIndexChange(CommitIndexModification modification, long value, TimeSpan? timeout = null, CancellationToken token = default)
         {
-            var timeoutTask = TimeoutManager.WaitFor(OperationTimeout, token);
+            var timeoutTask = TimeoutManager.WaitFor(timeout ?? OperationTimeout, token);
             while (timeoutTask.IsCompleted == false)
             {
                 token.ThrowIfCancellationRequested();

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2177,7 +2177,7 @@ namespace Raven.Server.ServerWide
             DeleteValueCommand delCmd = null;
             try
             {
-                delCmd = (DeleteValueCommand)CommandBase.CreateFrom(cmd);
+                delCmd = (DeleteValueCommand)JsonDeserializationCluster.Commands[type](cmd);
                 if (delCmd.Name.StartsWith("db/"))
                     throw new RachisApplyException("Cannot delete " + delCmd.Name + " using DeleteValueCommand, only via dedicated database calls");
 
@@ -2201,7 +2201,7 @@ namespace Raven.Server.ServerWide
         {
             try
             {
-                var command = (DeleteCertificateFromClusterCommand)CommandBase.CreateFrom(cmd);
+                var command = (DeleteCertificateFromClusterCommand)JsonDeserializationCluster.Commands[type](cmd);
 
                 DeleteCertificate(context, command.Name);
             }
@@ -2215,7 +2215,7 @@ namespace Raven.Server.ServerWide
         {
             try
             {
-                var command = (DeleteCertificateCollectionFromClusterCommand)CommandBase.CreateFrom(cmd);
+                var command = (DeleteCertificateCollectionFromClusterCommand)JsonDeserializationCluster.Commands[type](cmd);
 
                 foreach (var thumbprint in command.Names)
                 {
@@ -2326,7 +2326,7 @@ namespace Raven.Server.ServerWide
             try
             {
                 var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
-                command = (UpdateValueCommand<T>)CommandBase.CreateFrom(cmd);
+                command = (UpdateValueCommand<T>)JsonDeserializationCluster.Commands[type](cmd);
                 if (command.Name.StartsWith(Constants.Documents.Prefix))
                     throw new RachisApplyException("Cannot set " + command.Name + " using PutValueCommand, only via dedicated database calls");
 
@@ -2411,7 +2411,7 @@ namespace Raven.Server.ServerWide
             try
             {
                 var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
-                command = (PutValueCommand<T>)CommandBase.CreateFrom(cmd);
+                command = (PutValueCommand<T>)JsonDeserializationCluster.Commands[type](cmd);
                 if (command.Name.StartsWith(Constants.Documents.Prefix))
                     throw new RachisApplyException("Cannot set " + command.Name + " using PutValueCommand, only via dedicated database calls");
 
@@ -2452,7 +2452,7 @@ namespace Raven.Server.ServerWide
             try
             {
                 var certs = context.Transaction.InnerTransaction.OpenTable(CertificatesSchema, CertificatesSlice);
-                var command = (PutCertificateCommand)CommandBase.CreateFrom(cmd);
+                var command = (PutCertificateCommand)JsonDeserializationCluster.Commands[type](cmd);
 
                 using (Slice.From(context.Allocator, command.PublicKeyPinningHash, out var hashSlice))
                 using (Slice.From(context.Allocator, command.Name.ToLowerInvariant(), out var thumbprintSlice))
@@ -2474,7 +2474,7 @@ namespace Raven.Server.ServerWide
 
         private void BulkPutReplicationCertificate(ClusterOperationContext context, string type, BlittableJsonReaderObject cmd, long index, ServerStore serverStore)
         {
-            var command = (BulkRegisterReplicationHubAccessCommand)CommandBase.CreateFrom(cmd);
+            var command = (BulkRegisterReplicationHubAccessCommand)JsonDeserializationCluster.Commands[type](cmd);
             try
             {
                 var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
@@ -2492,7 +2492,7 @@ namespace Raven.Server.ServerWide
 
         private void PutReplicationCertificate(ClusterOperationContext context, string type, BlittableJsonReaderObject cmd, long index, ServerStore serverStore)
         {
-            var command = (RegisterReplicationHubAccessCommand)CommandBase.CreateFrom(cmd);
+            var command = (RegisterReplicationHubAccessCommand)JsonDeserializationCluster.Commands[type](cmd);
             try
             {
                 var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
@@ -2555,7 +2555,7 @@ namespace Raven.Server.ServerWide
 
         private void RemoveReplicationCertificate(ClusterOperationContext context, string type, BlittableJsonReaderObject cmd, long index, ServerStore serverStore)
         {
-            var command = (UnregisterReplicationHubAccessCommand)CommandBase.CreateFrom(cmd);
+            var command = (UnregisterReplicationHubAccessCommand)JsonDeserializationCluster.Commands[type](cmd);
             try
             {
                 var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -811,7 +811,7 @@ namespace Raven.Server.ServerWide.Commands
         public sealed class SingleClusterDatabaseCommand : IDynamicJson
         {
             public ClusterTransactionOptions Options;
-            public BlittableJsonReaderArray Commands;
+            public List<ClusterTransactionDataCommand> Commands;
             public long Index;
             public long PreviousCount;
             public string Database;
@@ -891,7 +891,7 @@ namespace Raven.Server.ServerWide.Commands
             if (ptr == null)
                 return null;
 
-            var blittable = new BlittableJsonReaderObject(ptr, size, context);
+            using var blittable = new BlittableJsonReaderObject(ptr, size, context);
             blittable.TryGet(nameof(DatabaseCommands), out BlittableJsonReaderArray array);
 
             ClusterTransactionOptions options = null;
@@ -904,12 +904,20 @@ namespace Raven.Server.ServerWide.Commands
             var keyPtr = reader.Read((int)TransactionCommandsColumn.Key, out size);
             var database = Encoding.UTF8.GetString(keyPtr, size - sizeof(long) - 1);
 
+            var databaseCommands = new List<ClusterTransactionDataCommand>();
+            foreach (BlittableJsonReaderObject blittableCommand in array)
+            {
+                var cmd = JsonDeserializationServer.ClusterTransactionDataCommand(blittableCommand);
+                cmd.Document = cmd.Document?.CloneOnTheSameContext(); // we need to get it out of the array
+                databaseCommands.Add(cmd);
+            }
+
             blittable.TryGet(nameof(SingleClusterDatabaseCommand.ShardNumber), out int? shardNumber);
 
             return new SingleClusterDatabaseCommand
             {
                 Options = options,
-                Commands = array,
+                Commands = databaseCommands,
                 Index = index,
                 PreviousCount = Bits.SwapBytes(*(long*)(keyPtr + size - sizeof(long))),
                 Database = database,

--- a/src/Raven.Server/ServerWide/Commands/CommandBase.cs
+++ b/src/Raven.Server/ServerWide/Commands/CommandBase.cs
@@ -32,6 +32,8 @@ namespace Raven.Server.ServerWide.Commands
         // if (null) value is passed, it will be treated as a bug. (will throw an exception only in Debug builds to support old clients)
         public string UniqueRequestId;
 
+        public BlittableJsonReaderObject Raw;
+
         protected CommandBase() { }
 
         protected CommandBase(string uniqueRequestId)
@@ -46,10 +48,25 @@ namespace Raven.Server.ServerWide.Commands
                 throw new RachisApplyException("Command must contain 'Type' field.");
             }
 
+            if (type == nameof(ClusterTransactionCommand))
+            {
+                // we optimize here the case of cluster wide tx
+                // since we do not use anything other from the inner properties of the command in this code path
+                
+                var command = new ClusterTransactionCommand { Raw = json };
+                
+                json.TryGet(nameof(UniqueRequestId), out command.UniqueRequestId);
+                json.TryGet(nameof(Timeout), out command.Timeout);
+
+                return command;
+            }
+
             if (JsonDeserializationCluster.Commands.TryGetValue(type, out Func<BlittableJsonReaderObject, CommandBase> deserializer) == false)
                 throw new InvalidOperationException($"There is not deserializer for '{type}' command.");
 
-            return deserializer(json);
+            var r = deserializer(json);
+            r.Raw = json;
+            return r;
         }
 
         public virtual void VerifyCanExecuteCommand(ServerStore store, TransactionOperationContext context, bool isClusterAdmin)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3261,7 +3261,7 @@ namespace Raven.Server.ServerWide
             Exception requestException = null;
             while (true)
             {
-                ServerShutdown.ThrowIfCancellationRequested();
+                _shutdownNotification.Token.ThrowIfCancellationRequested();
 
                 if (_engine.CurrentState == RachisState.Leader && _engine.CurrentLeader?.Running == true)
                 {
@@ -3289,7 +3289,7 @@ namespace Raven.Server.ServerWide
                     if (cachedLeaderTag == null)
                     {
                         await Task.WhenAny(logChange, timeoutTask);
-                        if (logChange.IsCompleted == false)
+                        if (timeoutTask.IsCompleted)
                             ThrowTimeoutException(cmd, requestException);
 
                         continue;
@@ -3310,7 +3310,9 @@ namespace Raven.Server.ServerWide
                 }
 
                 await Task.WhenAny(logChange, timeoutTask);
-                if (logChange.IsCompleted == false)
+                _shutdownNotification.Token.ThrowIfCancellationRequested();
+
+                if (timeoutTask.IsCompleted)
                 {
                     ThrowTimeoutException(cmd, requestException);
                 }
@@ -3570,9 +3572,14 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public async Task WaitForCommitIndexChange(RachisConsensus.CommitIndexModification modification, long value, CancellationToken token = default)
+        public Task WaitForCommitIndexChange(RachisConsensus.CommitIndexModification modification, long value, TimeSpan timeout, CancellationToken token = default)
         {
-            await _engine.WaitForCommitIndexChange(modification, value, token);
+            return _engine.WaitForCommitIndexChange(modification, value, timeout, token);
+        }
+
+        public Task WaitForCommitIndexChange(RachisConsensus.CommitIndexModification modification, long value, CancellationToken token = default)
+        {
+            return _engine.WaitForCommitIndexChange(modification, value, timeout: null, token);
         }
 
         public string LastStateChangeReason()

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3199,8 +3199,17 @@ namespace Raven.Server.ServerWide
 
         public async Task<(long Index, object Result)> SendToLeaderAsync(CommandBase cmd, CancellationToken? token = null)
         {
-            using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                return await SendToLeaderAsyncInternal(context, cmd, token ?? _shutdownNotification.Token);
+            token ??= CancellationToken.None;
+            using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token.Value, _shutdownNotification.Token))
+            {
+                if (cmd.Timeout != null)
+                {
+                    cts.CancelAfter(cmd.Timeout.Value);
+                } 
+
+                using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    return await SendToLeaderAsyncInternal(context, cmd, cts.Token);
+            }
         }
 
         private async Task<(long Index, object Result)> SendToLeaderAsyncInternal(TransactionOperationContext context, CommandBase cmd, CancellationToken token)

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -212,8 +212,12 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        public async Task UpdatePrefixedShardingIfNeeded(ClusterOperationContext context, DatabaseRecord databaseRecord, ClusterTopology clusterTopology)
+        public async Task UpdatePrefixedShardingIfNeeded(ClusterOperationContext context, DatabaseRecord databaseRecord)
         {
+            if (_serverStore.Cluster.DatabaseExists(context, databaseRecord.DatabaseName) == false)
+                return;
+
+            var clusterTopology = _serverStore.GetClusterTopology(context);
             var existingConfiguration = _serverStore.Cluster.ReadShardingConfiguration(context, databaseRecord.DatabaseName);
             if (databaseRecord.Sharding.Prefixed.SequenceEqual(existingConfiguration.Prefixed))
                 return;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -408,17 +408,16 @@ namespace Raven.Server.Web.System
             ValidateClusterMembers(clusterTopology, databaseRecord);
             UpdateDatabaseTopology(databaseRecord, clusterTopology, replicationFactor);
 
-            if (dbRecordExist && databaseRecord.IsSharded)
+            if (databaseRecord.IsSharded)
             {
-                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal,
-                    "remove this and introduce a dedicated command for updating Sharding.Prefixed");
-                await ServerStore.Sharding.UpdatePrefixedShardingIfNeeded(context, databaseRecord, clusterTopology);
-
+                if (dbRecordExist)
+                {
+                    DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal,
+                        "remove this and introduce a dedicated command for updating Sharding.Prefixed");
+                    await ServerStore.Sharding.UpdatePrefixedShardingIfNeeded(context, databaseRecord, clusterTopology);
+                }
+                
                 Server.ServerStore.Sharding.FillShardingConfiguration(databaseRecord, clusterTopology, index);
-                Server.ServerStore.AssignNodesToDatabase(clusterTopology,
-                    databaseRecord.DatabaseName,
-                    databaseRecord.Encrypted,
-                    databaseRecord.Sharding.Orchestrator.Topology);
             }
             else
             {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -386,51 +386,7 @@ namespace Raven.Server.Web.System
 
         private async Task<(long Index, DatabaseTopology Topology, List<string> Urls)> CreateDatabase(string name, DatabaseRecord databaseRecord, ClusterOperationContext context, int replicationFactor, long? index, string raftRequestId)
         {
-            var dbRecordExist = ServerStore.Cluster.DatabaseExists(context, name);
-            if (index.HasValue && dbRecordExist == false)
-                throw new BadRequestException($"Attempted to modify non-existing database: '{name}'");
-
-            if (dbRecordExist && index.HasValue == false)
-                throw new ConcurrencyException($"Database '{name}' already exists!");
-
-            if (replicationFactor <= 0)
-                throw new ArgumentException("Replication factor must be greater than 0.");
-
-            try
-            {
-                DatabaseHelper.Validate(name, databaseRecord, Server.Configuration);
-            }
-            catch (Exception e)
-            {
-                throw new BadRequestException("Database document validation failed.", e);
-            }
-            var clusterTopology = ServerStore.GetClusterTopology(context);
-            ValidateClusterMembers(clusterTopology, databaseRecord);
-            UpdateDatabaseTopology(databaseRecord, clusterTopology, replicationFactor);
-
-            if (databaseRecord.IsSharded)
-            {
-                if (dbRecordExist)
-                {
-                    DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal,
-                        "remove this and introduce a dedicated command for updating Sharding.Prefixed");
-                    await ServerStore.Sharding.UpdatePrefixedShardingIfNeeded(context, databaseRecord, clusterTopology);
-                }
-                
-                Server.ServerStore.Sharding.FillShardingConfiguration(databaseRecord, clusterTopology, index);
-            }
-            else
-            {
-                databaseRecord.Topology ??= new DatabaseTopology();
-                databaseRecord.Topology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
-
-                Server.ServerStore.AssignNodesToDatabase(clusterTopology,
-                    databaseRecord.DatabaseName,
-                    databaseRecord.Encrypted,
-                    databaseRecord.Topology);
-            }
-
-            var (newIndex, result) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index, raftRequestId);
+            var (newIndex, result) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index, raftRequestId, replicationFactor: replicationFactor);
             await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, newIndex);
 
             var members = (List<string>)result;
@@ -444,6 +400,7 @@ namespace Raven.Server.Web.System
                     $"The database '{name}' was created but is not accessible, because one or more of the nodes on which this database was supposed to reside on, threw an exception.", e);
             }
 
+            var clusterTopology = ServerStore.GetClusterTopology(context);
             var nodeUrlsAddedTo = new List<string>();
             foreach (var member in members)
             {
@@ -468,52 +425,6 @@ namespace Raven.Server.Web.System
                 return (newIndex, topology, nodeUrlsAddedTo);
             }
         }
-
-        private static void UpdateDatabaseTopology(DatabaseRecord databaseRecord, ClusterTopology clusterTopology, int replicationFactor)
-        {
-            var clusterTransactionId = Guid.NewGuid().ToBase64Unpadded();
-
-            if (databaseRecord.IsSharded)
-            {
-                databaseRecord.Sharding.Orchestrator ??= new OrchestratorConfiguration();
-                databaseRecord.Sharding.Orchestrator.Topology ??= new OrchestratorTopology();
-                UpdateDatabaseTopology(databaseRecord.Sharding.Orchestrator.Topology, clusterTopology, replicationFactor, clusterTransactionId);
-
-                foreach (var (shardNumber, databaseTopology) in databaseRecord.Sharding.Shards)
-                    UpdateDatabaseTopology(databaseTopology, clusterTopology, replicationFactor, clusterTransactionId);
-            }
-            else
-            {
-                databaseRecord.Topology ??= new DatabaseTopology();
-                UpdateDatabaseTopology(databaseRecord.Topology, clusterTopology, replicationFactor, clusterTransactionId);
-            }
-        }
-
-        private static void SetReplicationFactor(DatabaseTopology databaseTopology, ClusterTopology clusterTopology, int replicationFactor)
-        {
-            databaseTopology.ReplicationFactor = Math.Max(databaseTopology.ReplicationFactor, replicationFactor);
-            databaseTopology.ReplicationFactor = Math.Min(databaseTopology.ReplicationFactor, clusterTopology.AllNodes.Count);
-        }
-
-        private static void UpdateDatabaseTopology(DatabaseTopology databaseTopology, ClusterTopology clusterTopology, int replicationFactor, string clusterTransactionId)
-        {
-            if (databaseTopology.Members?.Count > 0)
-            {
-                foreach (var member in databaseTopology.Members)
-                {
-                    if (clusterTopology.Contains(member) == false)
-                        throw new ArgumentException($"Failed to add node {member}, because we don't have it in the cluster.");
-                }
-
-                replicationFactor = databaseTopology.Count;
-            }
-
-            SetReplicationFactor(databaseTopology, clusterTopology, replicationFactor);
-
-            databaseTopology.ClusterTransactionIdBase64 ??= clusterTransactionId;
-            databaseTopology.DatabaseTopologyIdBase64 ??= Guid.NewGuid().ToBase64Unpadded();
-        }
-
 
         [RavenAction("/admin/databases/reorder", "POST", AuthorizationStatus.Operator)]
         public async Task Reorder()
@@ -549,31 +460,6 @@ namespace Raven.Server.Web.System
                 await ServerStore.Cluster.WaitForIndexNotification(res.Index);
 
                 NoContentStatus();
-            }
-        }
-
-        private void ValidateClusterMembers(ClusterTopology clusterTopology, DatabaseRecord databaseRecord)
-        {
-            var topology = databaseRecord.Topology;
-
-            if (topology == null)
-                return;
-
-            if (topology.Members?.Count == 1 && topology.Members[0] == "?")
-            {
-                // this is a special case where we pass '?' as member.
-                topology.Members.Clear();
-            }
-
-            var unique = new HashSet<string>();
-            foreach (var node in topology.AllNodes)
-            {
-                if (unique.Add(node) == false)
-                    throw new InvalidOperationException($"node '{node}' already exists. This is not allowed. Database Topology : {topology}");
-
-                var url = clusterTopology.GetUrlFromTag(node);
-                if (databaseRecord.Encrypted && NotUsingHttps(url) && Server.AllowEncryptedDatabasesOverHttp == false)
-                    throw new InvalidOperationException($"{databaseRecord.DatabaseName} is encrypted but node {node} with url {url} doesn't use HTTPS. This is not allowed.");
             }
         }
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -413,6 +413,22 @@ namespace Raven.Server.Web.System
                 DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal,
                     "remove this and introduce a dedicated command for updating Sharding.Prefixed");
                 await ServerStore.Sharding.UpdatePrefixedShardingIfNeeded(context, databaseRecord, clusterTopology);
+
+                Server.ServerStore.Sharding.FillShardingConfiguration(databaseRecord, clusterTopology, index);
+                Server.ServerStore.AssignNodesToDatabase(clusterTopology,
+                    databaseRecord.DatabaseName,
+                    databaseRecord.Encrypted,
+                    databaseRecord.Sharding.Orchestrator.Topology);
+            }
+            else
+            {
+                databaseRecord.Topology ??= new DatabaseTopology();
+                databaseRecord.Topology.ReplicationFactor = Math.Min(replicationFactor, clusterTopology.AllNodes.Count);
+
+                Server.ServerStore.AssignNodesToDatabase(clusterTopology,
+                    databaseRecord.DatabaseName,
+                    databaseRecord.Encrypted,
+                    databaseRecord.Topology);
             }
 
             var (newIndex, result) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index, raftRequestId);

--- a/src/Sparrow.Server/AsyncManualResetEvent.cs
+++ b/src/Sparrow.Server/AsyncManualResetEvent.cs
@@ -101,7 +101,7 @@ namespace Sparrow.Server
                 if (_parent._token.IsCancellationRequested)
                     return false;
 
-                var result = await Task.WhenAny(waitAsync, TimeoutManager.WaitFor(timeout, _parent._token)).ConfigureAwait(false);
+                var result = await waitAsync.WaitFor(timeout, _parent._token).ConfigureAwait(false);
 
                 if (result.IsFaulted)
                     throw result.Exception;

--- a/src/Sparrow/Utils/TimeoutManager.cs
+++ b/src/Sparrow/Utils/TimeoutManager.cs
@@ -111,6 +111,35 @@ namespace Sparrow.Utils
             return value;
         }
 
+        public static async Task<Task> WaitFor(this Task outer, TimeSpan duration, CancellationToken token = default)
+        {
+            if (duration == TimeSpan.Zero)
+                return Task.CompletedTask;
+
+            if (token.IsCancellationRequested)
+            {
+                return Task.CompletedTask;
+            }
+
+            Task task;
+            // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
+            if (duration != Timeout.InfiniteTimeSpan)
+                task = WaitForInternal(duration, token);
+            else
+                task = InfiniteTask;
+            
+            if (token == CancellationToken.None || token.CanBeCanceled == false)
+            {
+                return await Task.WhenAny(outer, task).ConfigureAwait(false);
+            }
+            
+            var onCancel = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (token.Register(tcs => onCancel.TrySetCanceled(), onCancel))
+            {
+                return await Task.WhenAny(outer, task, onCancel.Task).ConfigureAwait(false);
+            }
+        }
+
         public static async Task WaitFor(TimeSpan duration, CancellationToken token = default)
         {
             if (duration == TimeSpan.Zero)
@@ -135,6 +164,12 @@ namespace Sparrow.Utils
             }
 
             var onCancel = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (task == InfiniteTask)
+            {
+                await onCancel.Task.ConfigureAwait(false);
+                return;
+            }
+
             using (token.Register(tcs => onCancel.TrySetCanceled(), onCancel))
             {
                 await Task.WhenAny(task, onCancel.Task).ConfigureAwait(false);

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -1482,11 +1482,11 @@ namespace FastTests.Server.Documents.Indexing.Auto
             {
                 context.OpenReadTransaction();
 
-                var databaseRecord = Server.ServerStore.Cluster.ReadDatabase(context, databaseName);
+                var databaseRecord = Server.ServerStore.Cluster.ReadDatabase(context, databaseName, out var dbEtag);
 
                 modifySettings(databaseRecord);
 
-                var (etag, _) = await Server.ServerStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, null, Guid.NewGuid().ToString());
+                var (etag, _) = await Server.ServerStore.WriteDatabaseRecordAsync(databaseName, databaseRecord, dbEtag, Guid.NewGuid().ToString());
                 await Server.ServerStore.Cluster.WaitForIndexNotification(etag);
             }
         }

--- a/test/SlowTests/Issues/RavenDB_16966.cs
+++ b/test/SlowTests/Issues/RavenDB_16966.cs
@@ -42,17 +42,13 @@ namespace SlowTests.Issues
                 try
                 {
                     await tasks[i];
+                    var res = await AssertWaitForNotNullAsync(() => store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>("test/" + i)));
+                    Assert.Equal("Karmel/" + i, res.Value);
                 }
-                catch (RavenException e) when (e.InnerException is TimeoutException)
+                catch (RavenException e) when (e.InnerException is OperationCanceledException)
                 {
 
                 }
-            }
-
-            for (int i = 0; i < size; i++)
-            {
-                var res = await AssertWaitForNotNullAsync(() => store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>("test/" + i)));
-                Assert.Equal("Karmel/" + i, res.Value);
             }
         }
     }

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -866,7 +866,7 @@ namespace Tests.Infrastructure
                     }
 
                     leader.ServerStore.Engine.GetLastCommitIndex(out var index, out _);
-                    await follower.ServerStore.Engine.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index, cts.Token);
+                    await follower.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index, cts.Token);
                 }
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21860 

### Additional description

Apply the changes that were done here https://github.com/ravendb/ravendb/pull/18133 (improve cluster-wide tx performance)

v6.0 seems to have a completely different hot paths, since applying those changes didn't resulted in performance increase.



### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
