### PR TITLE
RavenDB-20714 Removed the reproduced error cause 

### DIFF
--- a/test/SlowTests/Issues/RavenDB-20136.cs
+++ b/test/SlowTests/Issues/RavenDB-20136.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using FastTests.Utils;
 using Raven.Client.Documents.Operations.ETL;
 using SlowTests.Core.Utils.Entities;
@@ -16,7 +17,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async void DeletingDocumentWithRevisionsDoesntCorruptEtlProcess()
+        public async Task DeletingDocumentWithRevisionsDoesntCorruptEtlProcess()
         {
             using (var src = GetDocumentStore())
             using (var dst = GetDocumentStore())
@@ -29,13 +30,28 @@ namespace SlowTests.Issues
 
                 AddEtl(src, configuration, new RavenConnectionString {Name = "test", TopologyDiscoveryUrls = dst.Urls, Database = dst.Database,});
 
-                var loadDone = WaitForEtl(src, (_, statistics) => statistics.LoadSuccesses == 2);
+                var loadDone1 = WaitForEtl(src, (_, statistics) => statistics.LoadSuccesses == 1);
+                var loadDone2 = WaitForEtl(src, (_, statistics) => statistics.LoadSuccesses == 2);
                 var deleteDone = WaitForEtl(src, (_, statistics) => statistics.LoadSuccesses == 3);
 
                 using (var session = src.OpenSession())
                 {
-                    session.Store(new User(), "users/1");
+                    session.Store(new User{Name="Bob"}, "users/1");
                     session.SaveChanges();
+                }
+                
+                if (loadDone1.Wait(TimeSpan.FromSeconds(30)) == false)
+                {
+                    TryGetLoadError(src.Database, configuration, out var loadError);
+                    TryGetTransformationError(src.Database, configuration, out var transformationError);
+
+                    Assert.True(false, $"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
+                }
+
+                using (var session = dst.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.Equal("Bob", user.Name);
                 }
                 
                 using (var session = src.OpenSession())
@@ -45,7 +61,7 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
                 
-                if (loadDone.Wait(TimeSpan.FromSeconds(30)) == false)
+                if (loadDone2.Wait(TimeSpan.FromSeconds(30)) == false)
                 {
                     TryGetLoadError(src.Database, configuration, out var loadError);
                     TryGetTransformationError(src.Database, configuration, out var transformationError);
@@ -57,6 +73,7 @@ namespace SlowTests.Issues
                 {
                     var user = session.Load<User>("users/1");
                     Assert.NotNull(user);
+                    Assert.Equal("Gracjan", user.Name);
                 }
                 
                 using (var session = src.OpenSession())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20714/SlowTests.Server.Documents.ETL.RavenDB20136.DeletingDocumentWithRevisionsDoesntCorruptETLProcess

### Additional description

I've reproduced the error by building and running with `-c Debug -r  win-x86` args, it was being thrown every circa 3000 test runs. Added an extra wait after storing the document. After that sole extra wait, the error didn't reproduce for more than 30_000 test runs. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
