### PR TITLE
RavenDB-22090: Disallow multiple calls to Dispose and usage of disposed trees.

### DIFF
--- a/src/Corax/Querying/SpatialReader.cs
+++ b/src/Corax/Querying/SpatialReader.cs
@@ -8,7 +8,7 @@ using Voron.Impl;
 
 namespace Corax.Querying;
 
-public struct SpatialReader : IDisposable
+public readonly struct SpatialReader
 {
     private readonly FixedSizeTree _fst;
 
@@ -32,10 +32,5 @@ public struct SpatialReader : IDisposable
         coords = (Unsafe.ReadUnaligned<double>(coordPtr.Content.Ptr),
             Unsafe.ReadUnaligned<double>(coordPtr.Content.Ptr + sizeof(double)));
         return true;
-    }
-
-    public void Dispose()
-    {
-        _fst.Dispose();
     }
 }

--- a/src/Corax/Utils/TimeFields.cs
+++ b/src/Corax/Utils/TimeFields.cs
@@ -38,7 +38,7 @@ public static class TimeFields
         if (fieldsNames == null || fieldsNames.Count == 0)
             return;
 
-        using var indexTimeFieldsTree = tx.CreateTree(Constants.IndexTimeFieldsSlice);
+        var indexTimeFieldsTree = tx.CreateTree(Constants.IndexTimeFieldsSlice);
         foreach (var field in fieldsNames)
             indexTimeFieldsTree.MultiAdd(Constants.IndexTimeFieldsSlice, field);
     }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -68,18 +68,11 @@ namespace Raven.Server.Documents
 
         public static long ReadLastEtag(Transaction tx)
         {
-            var tableTree = tx.ReadTree(Attachments.AttachmentsMetadataSlice, RootObjectType.Table);
+            var tableTree = tx.ReadTree(AttachmentsMetadataSlice, RootObjectType.Table);
+            var fst = tableTree.FixedTreeFor(AttachmentsEtagSlice, valSize: sizeof(long));
 
-            using (var fst = tableTree.FixedTreeFor(Attachments.AttachmentsEtagSlice, valSize: sizeof(long)))
-            {
-                using (var it = fst.Iterate())
-                {
-                    if (it.SeekToLast())
-                        return it.CurrentKey;
-                }
-            }
-
-            return 0;
+            using var it = fst.Iterate();
+            return it.SeekToLast() ? it.CurrentKey : 0;
         }
 
         public IEnumerable<ReplicationBatchItem> GetAttachmentsFrom(DocumentsOperationContext context, long etag)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -570,19 +570,11 @@ namespace Raven.Server.Documents
 
         private static long ReadLastEtagFrom(Transaction tx, Slice name)
         {
-            using (var fst = new FixedSizeTree(tx.LowLevelTransaction,
-                tx.LowLevelTransaction.RootObjects,
-                name, sizeof(long),
-                clone: false))
-            {
-                using (var it = fst.Iterate())
-                {
-                    if (it.SeekToLast())
-                        return it.CurrentKey;
-                }
-            }
+            var fst = new FixedSizeTree(tx.LowLevelTransaction, tx.LowLevelTransaction.RootObjects, 
+                                        name, sizeof(long), clone: false);
 
-            return 0;
+            using var it = fst.Iterate();
+            return it.SeekToLast() ? it.CurrentKey : 0;
         }
 
         public long ReadLastEtag(Transaction tx)

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -179,14 +179,11 @@ namespace Raven.Server.Documents.Indexes.Debugging
                 var mapEntries = new List<FixedSizeTree>(docIds.Length);
                 foreach (var docId in docIds)
                 {
-                    FixedSizeTree mapEntriesTree;
-                    scope.EnsureDispose(mapEntriesTree = mapPhaseTree.FixedTreeFor(docId.ToLower(), sizeof(long)));
+                    FixedSizeTree mapEntriesTree = mapPhaseTree.FixedTreeFor(docId.ToLower(), sizeof(long));
                     mapEntries.Add(mapEntriesTree);
                 }
 
-                FixedSizeTree typePerHash;
-                scope.EnsureDispose(typePerHash = reducePhaseTree.FixedTreeFor(MapReduceIndexBase<MapReduceIndexDefinition, IndexField>.ResultsStoreTypesTreeName, sizeof(byte)));
-
+                FixedSizeTree typePerHash = reducePhaseTree.FixedTreeFor(MapReduceIndexBase<MapReduceIndexDefinition, IndexField>.ResultsStoreTypesTreeName, sizeof(byte));
                 trees = IterateTrees(self, mapEntries, reducePhaseTree, typePerHash, indexContext, scope);
 
                 return scope.Delay();

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -15,6 +15,7 @@ using Sparrow.Binary;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
+using Sparrow.Server.Utils;
 using Voron;
 using Voron.Data;
 using Voron.Data.BTrees;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -38,7 +38,6 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
         public void Dispose()
         {
-            DocumentMapEntries?.Dispose();
             DocumentMapEntries = null;
             MapPhaseTree = null;
             ReducePhaseTree = null;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
@@ -202,7 +202,6 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         public void Dispose()
         {
             _nestedValueKeyScope.Dispose();
-            Tree?.Dispose();
         }
     }
 }

--- a/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
@@ -12,6 +12,7 @@ using Sparrow;
 using Sparrow.Binary;
 using Sparrow.Json;
 using Sparrow.Logging;
+using Sparrow.Server.Utils;
 using Voron;
 using Voron.Data.Tables;
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1656,7 +1656,7 @@ namespace Raven.Server.ServerWide
 
         private static void CleanupDatabaseReplicationCertificate(ClusterOperationContext context, string databaseName)
         {
-            using var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
+            var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
 
             string prefixString = (databaseName + "/").ToLowerInvariant();
             using var _ = Slice.From(context.Allocator, prefixString, out var prefix);
@@ -4777,7 +4777,7 @@ namespace Raven.Server.ServerWide
 
         public IEnumerable<BlittableJsonReaderObject> GetReplicationHubCertificateByHub(ClusterOperationContext context, string database, string hub, string filter, int start, int pageSize)
         {
-            using var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
+            var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
 
             string prefixString = (database + "/" + hub + "/").ToLowerInvariant();
             using var _ = Slice.From(context.Allocator, prefixString, out var prefix);
@@ -4816,7 +4816,7 @@ namespace Raven.Server.ServerWide
 
         public IEnumerable<(string Hub, ReplicationHubAccess Access)> GetReplicationHubCertificateForDatabase(ClusterOperationContext context, string database)
         {
-            using var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
+            var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
 
             string prefixString = (database + "/").ToLowerInvariant();
             using var _ = Slice.From(context.Allocator, prefixString, out var prefix);
@@ -4854,7 +4854,7 @@ namespace Raven.Server.ServerWide
 
         public bool IsReplicationCertificate(ClusterOperationContext context, string database, string hub, X509Certificate2 userCert, out DetailedReplicationHubAccess access)
         {
-            using var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
+            var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
 
             using var __ = Slice.From(context.Allocator, (database + "/" + hub + "/" + userCert.Thumbprint).ToLowerInvariant(), out var key);
 
@@ -4872,7 +4872,7 @@ namespace Raven.Server.ServerWide
 
         public unsafe bool IsReplicationCertificateByPublicKeyPinningHash(ClusterOperationContext context, string database, string hub, X509Certificate2 userCert, SecurityConfiguration securityConfiguration, out DetailedReplicationHubAccess access)
         {
-            using var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
+            var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
             // maybe we need to check by public key hash?
             string publicKeyPinningHash = userCert.GetPublicKeyPinningHash();
 

--- a/src/Raven.Server/Storage/Schema/SchemaUpgradeExtensions.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgradeExtensions.cs
@@ -12,9 +12,9 @@ namespace Raven.Server.Storage.Schema
         {
             var dbs = new List<string>();
 
-            using (var items = step.ReadTx.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items))
             using (Slice.From(step.ReadTx.Allocator, DbKey, out var loweredPrefix))
             {
+                var items = step.ReadTx.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items);
                 foreach (var result in items.SeekByPrimaryKeyPrefix(loweredPrefix, Slices.Empty, 0))
                 {
                     dbs.Add(ClusterStateMachine.GetCurrentItemKey(result.Value).Substring(DbKey.Length));

--- a/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/40011/From40010.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/40011/From40010.cs
@@ -1,4 +1,4 @@
-﻿using Voron;
+using Voron;
 using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.Tables;
@@ -62,15 +62,12 @@ namespace Raven.Server.Storage.Schema.Updates.LuceneIndex
             newTableSchema.Create(step.WriteTx, "Errors", 16);
             
             var newErrorsTable = step.WriteTx.OpenTable(newTableSchema, "Errors");
-
+            var indexTree = Tree.Create(step.WriteTx.LowLevelTransaction, step.WriteTx, indexDef.Name, isIndexTree: true);
+            
             var newErrorsTableTableTree = step.WriteTx.ReadTree("Errors", RootObjectType.Table);
-
-            using (var indexTree = Tree.Create(step.WriteTx.LowLevelTransaction, step.WriteTx, indexDef.Name, isIndexTree:true))
+            using (newErrorsTableTableTree.DirectAdd(indexDef.Name, sizeof(TreeRootHeader), out byte* ptr))
             {
-                using (newErrorsTableTableTree.DirectAdd(indexDef.Name, sizeof(TreeRootHeader),out byte* ptr))
-                {
-                    indexTree.State.CopyTo((TreeRootHeader*)ptr);
-                }
+                indexTree.State.CopyTo((TreeRootHeader*)ptr);
             }
 
             var newErrorTimestampsIndexTree = newErrorsTable.GetTree(newTableSchema.Indexes[errorTimestampsSlice]);

--- a/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/40011/From40010.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/40011/From40010.cs
@@ -65,10 +65,9 @@ namespace Raven.Server.Storage.Schema.Updates.LuceneIndex
 
             var newErrorsTableTableTree = step.WriteTx.ReadTree("Errors", RootObjectType.Table);
 
-            byte* ptr;
             using (var indexTree = Tree.Create(step.WriteTx.LowLevelTransaction, step.WriteTx, indexDef.Name, isIndexTree:true))
             {
-                using (newErrorsTableTableTree.DirectAdd(indexDef.Name, sizeof(TreeRootHeader),out ptr))
+                using (newErrorsTableTableTree.DirectAdd(indexDef.Name, sizeof(TreeRootHeader),out byte* ptr))
                 {
                     indexTree.State.CopyTo((TreeRootHeader*)ptr);
                 }

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42013/From42012.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42013/From42012.cs
@@ -27,9 +27,9 @@ namespace Raven.Server.Storage.Schema.Updates.Server
             var identities = step.ReadTx.ReadTree(ClusterStateMachine.Identities);
             step.WriteTx.DeleteTree(ClusterStateMachine.Identities);
 
-            using (var items = step.ReadTx.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items))
             using (Slice.From(step.ReadTx.Allocator, dbKey, out Slice loweredPrefix))
             {
+                var items = step.ReadTx.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items);
                 foreach (var result in items.SeekByPrimaryKeyPrefix(loweredPrefix, Slices.Empty, 0))
                 {
                     dbs.Add(ClusterStateMachine.GetCurrentItemKey(result.Value).Substring(dbKey.Length));
@@ -86,7 +86,8 @@ namespace Raven.Server.Storage.Schema.Updates.Server
 
                 // update db backup status
                 var dbLower = db.ToLowerInvariant();
-                using (var items = step.WriteTx.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items))
+                var items = step.WriteTx.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items);
+
                 using (Slice.From(step.ReadTx.Allocator, $"{dbKey}{dbLower}", out Slice lowerKey))
                 using (var ctx = JsonOperationContext.ShortTermSingleUse())
                 {

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42014/From42013.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42014/From42013.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
                     Name = ClusterStateMachine.IdentitiesIndex
                 });
 
-            using (var items = step.ReadTx.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items))
+            var items = step.ReadTx.OpenTable(ClusterStateMachine.ItemsSchema, ClusterStateMachine.Items);
             using (Slice.From(step.ReadTx.Allocator, dbKey, out Slice loweredPrefix))
             {
                 foreach (var result in items.SeekByPrimaryKeyPrefix(loweredPrefix, Slices.Empty, 0))

--- a/src/Sparrow.Server/Utils/DisposableScope.cs
+++ b/src/Sparrow.Server/Utils/DisposableScope.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Raven.Server.Utils
+namespace Sparrow.Server.Utils
 {
     public sealed class DisposableScope : IDisposable
     {
-        private readonly LinkedList<IDisposable> _disposables = new LinkedList<IDisposable>();
+        private readonly LinkedList<IDisposable> _disposables = new();
         private int _delayedDispose;
 
         public void EnsureDispose(IDisposable toDispose)
@@ -19,7 +19,6 @@ namespace Raven.Server.Utils
                 return;
 
             List<Exception> errors = null; 
-
             foreach (var disposable in _disposables)
             {
                 try
@@ -28,9 +27,7 @@ namespace Raven.Server.Utils
                 }
                 catch (Exception e)
                 {
-                    if (errors == null)
-                        errors = new List<Exception>();
-                    
+                    errors ??= new List<Exception>();
                     errors.Add(e);
                 }
             }

--- a/src/Sparrow.Server/Utils/UnguardedDisposableScope.cs
+++ b/src/Sparrow.Server/Utils/UnguardedDisposableScope.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Sparrow.Server.Utils;
+
+public sealed class UnguardedDisposableScope : IDisposable
+{
+    private readonly LinkedList<IDisposable> _disposables = new();
+    private int _delayedDispose;
+
+    public void EnsureDispose(IDisposable toDispose)
+    {
+        _disposables.AddFirst(toDispose);
+    }
+
+    public void Dispose()
+    {
+        if (_delayedDispose-- > 0)
+            return;
+
+        foreach (var disposable in _disposables)
+            disposable.Dispose();
+    }
+
+    public IDisposable Delay()
+    {
+        _delayedDispose++;
+
+        return this;
+    }
+}

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -1347,22 +1347,6 @@ namespace Voron.Data.BTrees
             // https://issues.hibernatingrhinos.com/issue/RavenDB-22090
             _isDisposed = true;
             
-            if (_fixedSizeTrees != null)
-            {
-                foreach (var tree in _fixedSizeTrees)
-                {
-                    tree.Value.Dispose();
-                }
-            }
-            
-            if (_fixedSizeTreesForDouble != null)
-            {
-                foreach (var tree in _fixedSizeTreesForDouble)
-                {
-                    tree.Value.Dispose();
-                }
-            }
-
             DecompressionsCache?.Dispose();
             _prepareLocator?.Dispose();
 

--- a/src/Voron/Data/Compression/DecompressedLeafPage.cs
+++ b/src/Voron/Data/Compression/DecompressedLeafPage.cs
@@ -31,10 +31,11 @@ namespace Voron.Data.Compression
 
         public void Dispose()
         {
-            if (Cached)
+            // RavenDB-22090: We must not dispose leaf pages more than once.
+            if (_disposed)
                 return;
 
-            if (_disposed)
+            if (Cached)
                 return;
 
             _disposable.Dispose();

--- a/src/Voron/Data/Compression/DecompressedPagesCache.cs
+++ b/src/Voron/Data/Compression/DecompressedPagesCache.cs
@@ -150,11 +150,8 @@ namespace Voron.Data.Compression
                     continue;
                 }
 
-                Slice first;
-                Slice last;
-
-                using (page.GetNodeKey(tx, 0, out first))
-                using (page.GetNodeKey(tx, page.NumberOfEntries - 1, out last))
+                using (page.GetNodeKey(tx, 0, out Slice first))
+                using (page.GetNodeKey(tx, page.NumberOfEntries - 1, out Slice last))
                 {
                     if (SliceComparer.Compare(key, first) >= 0 && SliceComparer.Compare(key, last) <= 0)
                     {

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -22,14 +22,14 @@ using Constants = Voron.Global.Constants;
 
 namespace Voron.Data.Fixed
 {
-    public sealed class FixedSizeTree : FixedSizeTree<long>
-    {
-        public FixedSizeTree(LowLevelTransaction tx, Tree parent, Slice treeName, ushort valSize, bool clone = true, bool isIndexTree = false, NewPageAllocator newPageAllocator = null) : base(tx, parent, treeName, valSize, clone, isIndexTree, newPageAllocator)
-        {
-        }
-    } 
+    public sealed class FixedSizeTree(
+            LowLevelTransaction tx,
+            Tree parent, Slice treeName,
+            ushort valSize, bool clone = true, bool isIndexTree = false,
+            NewPageAllocator newPageAllocator = null)
+        : FixedSizeTree<long>(tx, parent, treeName, valSize, clone, isIndexTree, newPageAllocator); 
     
-    public unsafe partial class FixedSizeTree<TVal> : IDisposable
+    public unsafe partial class FixedSizeTree<TVal> 
         where TVal: unmanaged, IBinaryNumber<TVal>, IMinMaxValue<TVal>
     {
 #if VALIDATE_DIRECT_ADD_STACKTRACE
@@ -83,7 +83,7 @@ namespace Voron.Data.Fixed
             return header->ValueSize;
         }
 
-        public struct DirectAddScope : IDisposable
+        public readonly struct DirectAddScope : IDisposable
         {
             private readonly FixedSizeTree<TVal> _parent;
 
@@ -1659,10 +1659,6 @@ namespace Voron.Data.Fixed
         public void DebugRenderAndShow()
         {
             DebugStuff.RenderAndShow_FixedSizeTree(_tx, this);
-        }
-
-        public void Dispose()
-        {
         }
 
         private Tree.DirectAddScope ModifyLargeHeader(out FixedSizeTreeHeader.Large* largeHeader)

--- a/src/Voron/Data/PostingLists/PostingList.cs
+++ b/src/Voron/Data/PostingLists/PostingList.cs
@@ -123,7 +123,8 @@ namespace Voron.Data.PostingLists
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void ResizeCursorState()
         {
-            _llt.Allocator.Allocate(_stk.Length * 2 * sizeof(PostingListCursorState), out ByteString buffer);
+            _scope.Dispose();
+            _scope = _llt.Allocator.Allocate(_stk.Length * 2 * sizeof(PostingListCursorState), out ByteString buffer);
             var newStk = new UnmanagedSpan<PostingListCursorState>(buffer.Ptr, buffer.Size);
             _stk.ToReadOnlySpan().CopyTo(newStk.ToSpan());
             _stk = newStk;

--- a/src/Voron/Data/RawData/RawDataSection.cs
+++ b/src/Voron/Data/RawData/RawDataSection.cs
@@ -11,7 +11,7 @@ using Voron.Impl;
 
 namespace Voron.Data.RawData
 {
-    public unsafe class RawDataSection : IDisposable
+    public unsafe class RawDataSection
     {
         protected const ushort ReservedHeaderSpace = 96;
 
@@ -359,9 +359,6 @@ namespace Voron.Data.RawData
                    $"Density: {Density:P}";
         }
 
-        public void Dispose()
-        {
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void EnsureHeaderModified()

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -2400,20 +2400,8 @@ namespace Voron.Data.Tables
                     item.Value.Dispose();
             }
 
-            if (_fixedSizeTreeCache != null)
-            {
-                foreach (var item in _fixedSizeTreeCache)
-                {
-                    foreach (var item2 in item.Value)
-                    {
-                        item2.Value.Dispose();
-                    }
-                }
-            }
-
-            _activeCandidateSection?.Dispose();
             _activeDataSmallSection?.Dispose();
-            _inactiveSections?.Dispose();
+
             _tableTree?.Dispose();
         }
 

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -2400,8 +2400,6 @@ namespace Voron.Data.Tables
                     item.Value.Dispose();
             }
 
-            _activeDataSmallSection?.Dispose();
-
             _tableTree?.Dispose();
         }
 

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1207,7 +1207,6 @@ namespace Voron.Data.Tables
                 throw new VoronErrorException($"Cannot find tree {name} in table {Name}");
 
             tree = Tree.Open(_tx.LowLevelTransaction, _tx, name, (TreeRootHeader*)treeHeader, isIndexTree: isIndexTree, newPageAllocator: TablePageAllocator);
-            _tx.LowLevelTransaction.RegisterDisposable(tree);
             
             _treesBySliceCache ??= new Dictionary<Slice, Tree>(SliceStructComparer.Instance);
             _treesBySliceCache[name] = tree;

--- a/src/Voron/Data/Tables/TableSchema.cs
+++ b/src/Voron/Data/Tables/TableSchema.cs
@@ -197,7 +197,7 @@ namespace Voron.Data.Tables
             {
                 if (_primaryKey.IsGlobal == false)
                 {
-                    using (var indexTree = Tree.Create(tx.LowLevelTransaction, tx, _primaryKey.Name, isIndexTree: true, newPageAllocator: tablePageAllocator))
+                    var indexTree = Tree.Create(tx.LowLevelTransaction, tx, _primaryKey.Name, isIndexTree: true, newPageAllocator: tablePageAllocator);
                     using (tableTree.DirectAdd(_primaryKey.Name, sizeof(TreeRootHeader), out var ptr))
                     {
                         indexTree.State.CopyTo((TreeRootHeader*)ptr);
@@ -213,7 +213,7 @@ namespace Voron.Data.Tables
             {
                 if (indexDef.IsGlobal == false)
                 {
-                    using (var indexTree = Tree.Create(tx.LowLevelTransaction, tx, indexDef.Name, isIndexTree: true, newPageAllocator: tablePageAllocator))
+                    var indexTree = Tree.Create(tx.LowLevelTransaction, tx, indexDef.Name, isIndexTree: true, newPageAllocator: tablePageAllocator);
                     using (tableTree.DirectAdd(indexDef.Name, sizeof(TreeRootHeader), out var ptr))
                     {
                         indexTree.State.CopyTo((TreeRootHeader*)ptr);
@@ -229,7 +229,7 @@ namespace Voron.Data.Tables
             {
                 if (dynamicKeyIndexDef.IsGlobal == false)
                 {
-                    using (var indexTree = Tree.Create(tx.LowLevelTransaction, tx, dynamicKeyIndexDef.Name, isIndexTree: true, newPageAllocator: tablePageAllocator))
+                    var indexTree = Tree.Create(tx.LowLevelTransaction, tx, dynamicKeyIndexDef.Name, isIndexTree: true, newPageAllocator: tablePageAllocator);
                     using (tableTree.DirectAdd(dynamicKeyIndexDef.Name, sizeof(TreeRootHeader), out var ptr))
                     {
                         indexTree.State.CopyTo((TreeRootHeader*)ptr);

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -972,7 +972,6 @@ namespace Voron.Impl
                 }
 
                 _disposableScope.Dispose();
-                _root?.Dispose();
 
                 _allocator.AllocationFailed -= MarkTransactionAsFailed;
               

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -958,6 +958,8 @@ namespace Voron.Impl
                 // transaction. First the pagers and internal resources, then registered ones by external parties.
                 _env.TransactionCompleted(this);
 
+                _disposableScope.Dispose();
+
                 foreach (var pagerState in _pagerStates)
                 {
                     pagerState.Release();
@@ -970,8 +972,6 @@ namespace Voron.Impl
                         journalFile.Release();
                     }
                 }
-
-                _disposableScope.Dispose();
 
                 _allocator.AllocationFailed -= MarkTransactionAsFailed;
               

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -25,6 +25,7 @@ using Constants = Voron.Global.Constants;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using Sparrow.Server.Utils;
 
 namespace Voron.Impl
 {

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -440,9 +440,6 @@ namespace Voron.Impl
 
             if (isInRoot)
                 _lowLevelTransaction.RootObjects.Delete(tree.Name);
-
-            // Since we are deleting a tree we need to register the tree for disposal. 
-            _lowLevelTransaction.RegisterDisposable(tree);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -514,25 +511,7 @@ namespace Voron.Impl
         
         public void Dispose()
         {
-            if (_trees != null)
-            {
-                foreach (var tree in _trees)
-                {
-                    tree.Value?.Dispose();
-                }
-            }
-
-            if (_multiValueTrees != null)
-            {
-                foreach (var item in _multiValueTrees)
-                {
-                    item.Value?.Dispose();
-                    item.Key.Item1?.Dispose();
-                }
-            }
-
             _lowLevelTransaction?.Dispose();
-
             _lowLevelTransaction = null;
         }
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -541,14 +541,6 @@ namespace Voron.Impl
                 }
             }
 
-            if (_globalFixedSizeTree != null)
-            {
-                foreach (var tree in _globalFixedSizeTree)
-                {
-                    tree.Value?.Dispose();
-                }
-            }
-
             _lowLevelTransaction?.Dispose();
 
             _lowLevelTransaction = null;

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -314,9 +314,9 @@ namespace Voron
             Interlocked.Exchange(ref _transactionsCounter, header->TransactionId == 0 ? entry.TransactionId : header->TransactionId);
             var transactionPersistentContext = new TransactionPersistentContext(true);
             using (var tx = NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite))
-            using (var root = Tree.Open(tx, null, Constants.RootTreeNameSlice, header->TransactionId == 0 ? &entry.Root : &header->Root))
             using (var writeTx = new Transaction(tx))
             {
+                var root = Tree.Open(tx, null, Constants.RootTreeNameSlice, header->TransactionId == 0 ? &entry.Root : &header->Root);
                 tx.UpdateRootsIfNeeded(root);
 
                 var metadataTree = writeTx.ReadTree(Constants.MetadataTreeNameSlice);

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -456,15 +456,14 @@ namespace Voron
 
             var transactionPersistentContext = new TransactionPersistentContext();
             using (var tx = NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite))
-            using (var root = Tree.Create(tx, null, Constants.RootTreeNameSlice))
             {
-
+                var root = Tree.Create(tx, null, Constants.RootTreeNameSlice);
+                
                 // important to first create the root trees, then set them on the env
                 tx.UpdateRootsIfNeeded(root);
 
                 using (var treesTx = new Transaction(tx))
                 {
-
                     FillBase64Id(Guid.NewGuid());
 
                     var metadataTree = treesTx.CreateTree(Constants.MetadataTreeNameSlice);
@@ -476,7 +475,6 @@ namespace Voron
                     tx.Commit();
                 }
             }
-
         }
 
         public IFreeSpaceHandling FreeSpaceHandling => _freeSpaceHandling;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22090

### Additional description

We have discovered that under very specific conditions we were using disposed tree instances. This is particularly dangerous, so we moving the disposing to it's rightful owners and remove any disposable interface from Voron data structures when they are not needed.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
