### PR TITLE
RavenDB-22120 Wait more than 1s for cleanup in flaky tests.

### DIFF
--- a/test/SlowTests/Server/Documents/Indexing/ExactSearchOnAutoIndex_RavenDB_8006.cs
+++ b/test/SlowTests/Server/Documents/Indexing/ExactSearchOnAutoIndex_RavenDB_8006.cs
@@ -83,9 +83,11 @@ namespace SlowTests.Server.Documents.Indexing
 
                 IndexInformation[] indexes = null;
 
-                Assert.True(SpinWait.SpinUntil(() => (indexes = store.Maintenance.Send(new GetStatisticsOperation()).Indexes).Length == 1, 1000));
-
-                Assert.Equal(1, indexes.Length);
+                WaitForValue(() =>
+                {
+                    indexes = store.Maintenance.Send(new GetStatisticsOperation()).Indexes;
+                    return indexes.Length;
+                }, 1);
                 Assert.Equal("Auto/Users/ByExact(Name)AndSearch(LastName)", indexes[0].Name);
             }
         }
@@ -207,9 +209,11 @@ namespace SlowTests.Server.Documents.Indexing
 
                 IndexInformation[] indexes = null;
 
-                Assert.True(SpinWait.SpinUntil(() => (indexes = store.Maintenance.Send(new GetStatisticsOperation()).Indexes).Length == 1, 1000));
-
-                Assert.Equal(1, indexes.Length);
+                WaitForValue(() =>
+                {
+                    indexes = store.Maintenance.Send(new GetStatisticsOperation()).Indexes;
+                    return indexes.Length;
+                }, 1);
                 Assert.Equal("Auto/Users/BySearch(Name)AndExact(Name)", indexes[0].Name);
             }
         }
@@ -289,8 +293,11 @@ namespace SlowTests.Server.Documents.Indexing
                 }
 
                 IndexInformation[] indexes = null;
-
-                Assert.True(SpinWait.SpinUntil(() => (indexes = store.Maintenance.Send(new GetStatisticsOperation()).Indexes).Length == 1, 1000));
+                WaitForValue(() =>
+                {
+                    indexes = store.Maintenance.Send(new GetStatisticsOperation()).Indexes;
+                    return indexes.Length;
+                }, 1);
 
                 Assert.Equal(1, indexes.Length);
                 Assert.Equal("Auto/Users/ByCountReducedByExact(Name)AndSearch(LastName)", indexes[0].Name);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22120

### Additional description

Map-reduce cleanup tests started to fail. After investigation, it seems that 1s in debug mode may not be enough to clean up.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
