### PR TITLE
RavenDB-22111 Fix ShouldNotBlockClusterTransactionOnDatabaseStartup test

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -261,6 +261,8 @@ namespace Raven.Server.Documents.Handlers
                 array = await GetClusterTransactionDatabaseCommandsResults(result, clusterTransactionCommand.DatabaseCommandsCount, index, options, onDatabaseCompletionTask: tcs.Task, token);
             }
 
+            token.ThrowIfCancellationRequested();
+
             foreach (var clusterCommands in clusterTransactionCommand.ClusterCommands)
             {
                 array.Add(new DynamicJsonValue

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -262,9 +262,9 @@ namespace Raven.Server
             }
         }
 
-        private static void CheckDatabaseShutdownAndThrowIfNeeded(DocumentDatabase database, ref Exception e) 
+        private static void CheckDatabaseShutdownAndThrowIfNeeded(DocumentDatabase database, ref Exception e)
         {
-            if(e is OperationCanceledException && database != null && database.DatabaseShutdown.IsCancellationRequested)
+            if (e is OperationCanceledException && database != null && (database.DatabaseShutdownCompleted.IsSet || database.DatabaseShutdown.IsCancellationRequested))
                 e = new DatabaseDisabledException("The database " + database.Name + " is shutting down", e);
         }
 

--- a/test/SlowTests/Issues/RavenDB_20708.cs
+++ b/test/SlowTests/Issues/RavenDB_20708.cs
@@ -48,14 +48,9 @@ namespace SlowTests.Issues
                     var key = AlertRaised.GetKey(AlertType.ClusterTransactionFailure, $"{database.Name}/ClusterTransaction");
                     Assert.False(database.NotificationCenter.Exists(key));
                 }
-                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
-                {
-                    var user = await session.LoadAsync<User>("users/1", cts.Token);
-                    Assert.Equal(user1.Name, user.Name);
 
-                    user = await session.LoadAsync<User>("users/2", cts.Token);
-                    Assert.Equal(user2.Name, user.Name);
-                }
+                WaitForDocument<User>(store, "users/1", u => u.Name == user1.Name, timeout: 5_000);
+                WaitForDocument<User>(store, "users/2", u => u.Name == user2.Name, timeout: 5_000);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22111

### Additional description

- Avoid race between executing cluster tx at initial start and shutting down the database
- Fix `CheckDatabaseShutdownAndThrowIfNeeded`, since the token might be already disposed

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
