### PR TITLE
RavenDB-22105 Prevent from unloading an idle database it if has an active Queue Sink task so it will be able to consume incoming messages

### DIFF
--- a/src/Raven.Client/Documents/Operations/QueueSink/QueueSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/QueueSink/QueueSinkConfiguration.cs
@@ -87,6 +87,7 @@ public class QueueSinkConfiguration : IDynamicJsonValueConvertible, IDatabaseTas
         {
             [nameof(Name)] = Name,
             [nameof(TaskId)] = TaskId,
+            [nameof(Disabled)] = Disabled,
             [nameof(ConnectionStringName)] = ConnectionStringName,
             [nameof(MentorNode)] = MentorNode,
             [nameof(PinToMentorNode)] = PinToMentorNode,

--- a/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
+++ b/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
@@ -155,6 +155,7 @@ public abstract class QueueSinkProcess : IDisposable, ILowMemoryHandler
     {
         while (true)
         {
+            using var _ = Database.PreventFromUnloadingByIdleOperations();
             try
             {
                 if (CancellationToken.IsCancellationRequested)

--- a/test/SlowTests/Server/Documents/QueueSink/Issues/RavenDB_22105.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/Issues/RavenDB_22105.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Server.Documents.QueueSink.Issues;
 
-public class RavenDB_22105 : QueueSinkTestBase
+public class RavenDB_22105 : RabbitMqQueueSinkTestBase
 {
     public RavenDB_22105(ITestOutputHelper output) : base(output)
     {
@@ -33,9 +33,7 @@ public class RavenDB_22105 : QueueSinkTestBase
 
         byte[] userBytes1 = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(user1));
 
-        var producer = CreateRabbitMqProducer();
-
-        producer.QueueDeclare(queue: UsersQueueName, exclusive: false);
+        var producer = CreateRabbitMqProducer(UsersQueueName);
 
         producer.BasicPublish(exchange: "", routingKey: UsersQueueName, basicProperties: null,
             body: new ReadOnlyMemory<byte>(userBytes1));

--- a/test/SlowTests/Server/Documents/QueueSink/Issues/RavenDB_22105.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/Issues/RavenDB_22105.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using RabbitMQ.Client;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.QueueSink.Issues;
+
+public class RavenDB_22105 : QueueSinkTestBase
+{
+    public RavenDB_22105(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RequiresRabbitMqRetryFact]
+    public async Task Queue_sink_process_will_prevent_from_unloading_idle_database()
+    {
+        DoNotReuseServer();
+
+        var landlord = Server.ServerStore.DatabasesLandlord;
+
+        using var store = GetDocumentStore(new Options
+        {
+            RunInMemory = false // in memory databases aren't unloaded
+        });
+
+        var user1 = new User { Id = "users/1", FirstName = "John", LastName = "Doe" };
+
+        byte[] userBytes1 = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(user1));
+
+        var producer = CreateRabbitMqProducer();
+
+        producer.QueueDeclare(queue: UsersQueueName, exclusive: false);
+
+        producer.BasicPublish(exchange: "", routingKey: UsersQueueName, basicProperties: null,
+            body: new ReadOnlyMemory<byte>(userBytes1));
+
+        var config = SetupRabbitMqQueueSink(store, "this['@metadata']['@collection'] = 'Users'; put(this.Id, this)",
+            new List<string>() { UsersQueueName });
+
+        var etlDone = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= 1);
+        AssertQueueSinkDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+
+        using (var session = store.OpenSession())
+        {
+            var users = session.Query<User>().ToList();
+            Assert.Equal(1, users.Count);
+
+            var fetchedUser1 = session.Load<User>("users/1");
+            Assert.NotNull(fetchedUser1);
+            Assert.Equal("users/1", fetchedUser1.Id);
+            Assert.Equal("John", fetchedUser1.FirstName);
+            Assert.Equal("Doe", fetchedUser1.LastName);
+        }
+
+        // Try to idle a database
+
+        landlord.SkipShouldContinueDisposeCheck = true;
+
+        var database = await GetDatabase(store.Database);
+        database.ResetIdleTime();
+
+        landlord.LastRecentlyUsed.AddOrUpdate(database.Name, DateTime.MinValue, (_, time) => DateTime.MinValue);
+
+        foreach (var env in database.GetAllStoragesEnvironment())
+            env.Environment.ResetLastWorkTime();
+
+        database.LastAccessTime = DateTime.MinValue;
+
+        Server.ServerStore.IdleOperations(null);
+
+        Assert.Equal(0, Server.ServerStore.IdleDatabases.Count); // active queue sink process must prevent from unloading a database
+        
+        Assert.False(producer.IsClosed);
+
+        var user2 = new User { Id = "users/2", FirstName = "Jane", LastName = "Smith" };
+        byte[] userBytes2 = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(user2));
+        producer.BasicPublish(exchange: "", routingKey: UsersQueueName, basicProperties: null,
+            body: new ReadOnlyMemory<byte>(userBytes2));
+
+        var etlDone2 = WaitForQueueSinkBatch(store, (n, statistics) => statistics.ConsumeSuccesses >= 1);
+
+        AssertQueueSinkDone(etlDone2, TimeSpan.FromMinutes(1), store.Database, config);
+
+        using (var session = store.OpenSession())
+        {
+            Assert.Equal(2, session.Query<User>().ToList().Count);
+
+            var fetchedUser2 = session.Load<User>("users/2");
+            Assert.NotNull(fetchedUser2);
+            Assert.Equal("users/2", fetchedUser2.Id);
+            Assert.Equal("Jane", fetchedUser2.FirstName);
+            Assert.Equal("Smith", fetchedUser2.LastName);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
@@ -13,7 +13,6 @@ using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Json;
-using Tests.Infrastructure.ConnectionString;
 using Xunit;
 using Xunit.Abstractions;
 using QueueSinkConfiguration = Raven.Client.Documents.Operations.QueueSink.QueueSinkConfiguration;
@@ -127,39 +126,6 @@ namespace SlowTests.Server.Documents.QueueSink
             public string LastName { get; set; }
 
             public string FullName { get; set; }
-        }
-
-        protected QueueSinkConfiguration SetupRabbitMqQueueSink(DocumentStore store, string script, List<string> queues,
-            string configurationName = null, string transformationName = null)
-        {
-            var connectionStringName = $"RabbitMQ to {store.Database}";
-
-            QueueSinkScript queueSinkScript = new QueueSinkScript
-            {
-                Name = transformationName ?? $"Queue Sink : {connectionStringName}",
-                Queues = new List<string>(queues),
-                Script = script,
-            };
-            var config = new QueueSinkConfiguration
-            {
-                Name = configurationName ?? connectionStringName,
-                ConnectionStringName = connectionStringName,
-                Scripts = { queueSinkScript },
-                BrokerType = QueueBrokerType.RabbitMq
-            };
-
-            AddQueueSink(store, config,
-                new QueueConnectionString
-                {
-                    Name = connectionStringName,
-                    BrokerType = QueueBrokerType.RabbitMq,
-                    RabbitMqConnectionSettings = new RabbitMqConnectionSettings
-                    {
-                        ConnectionString = RabbitMqConnectionString.Instance.VerifiedConnectionString.Value
-                    }
-                });
-
-            return config;
         }
     }
 }

--- a/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
@@ -4,10 +4,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
+using RabbitMQ.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Client.Documents.Operations.QueueSink;
+using Raven.Server;
 using Raven.Server.Documents.QueueSink;
 using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
@@ -160,6 +162,14 @@ namespace SlowTests.Server.Documents.QueueSink
                 });
 
             return config;
+        }
+
+        protected IModel CreateRabbitMqProducer()
+        {
+            var connectionFactory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString.Instance.VerifiedConnectionString.Value) };
+            var connection = connectionFactory.CreateConnection();
+            var producer = connection.CreateModel();
+            return producer;
         }
     }
 }

--- a/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/QueueSinkTestBase.cs
@@ -4,12 +4,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
-using RabbitMQ.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Client.Documents.Operations.QueueSink;
-using Raven.Server;
 using Raven.Server.Documents.QueueSink;
 using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
@@ -162,14 +160,6 @@ namespace SlowTests.Server.Documents.QueueSink
                 });
 
             return config;
-        }
-
-        protected IModel CreateRabbitMqProducer()
-        {
-            var connectionFactory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString.Instance.VerifiedConnectionString.Value) };
-            var connection = connectionFactory.CreateConnection();
-            var producer = connection.CreateModel();
-            return producer;
         }
     }
 }

--- a/test/SlowTests/Server/Documents/QueueSink/RabbitMqQueueSinkTestBase.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/RabbitMqQueueSinkTestBase.cs
@@ -6,6 +6,9 @@ using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using System.Collections.Generic;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ETL.Queue;
+using Raven.Client.Documents.Operations.QueueSink;
 
 namespace SlowTests.Server.Documents.QueueSink;
 
@@ -16,6 +19,40 @@ public abstract class RabbitMqQueueSinkTestBase : QueueSinkTestBase
 
     protected RabbitMqQueueSinkTestBase(ITestOutputHelper output) : base(output)
     {
+    }
+
+    protected QueueSinkConfiguration SetupRabbitMqQueueSink(DocumentStore store, string script, List<string> queues,
+        string configurationName = null, string transformationName = null, bool disabled = false)
+    {
+        var connectionStringName = $"RabbitMQ to {store.Database}";
+
+        QueueSinkScript queueSinkScript = new QueueSinkScript
+        {
+            Name = transformationName ?? $"Queue Sink : {connectionStringName}",
+            Queues = new List<string>(queues),
+            Script = script,
+        };
+        var config = new QueueSinkConfiguration
+        {
+            Name = configurationName ?? connectionStringName,
+            ConnectionStringName = connectionStringName,
+            Scripts = { queueSinkScript },
+            BrokerType = QueueBrokerType.RabbitMq,
+            Disabled = disabled
+        };
+
+        AddQueueSink(store, config,
+            new QueueConnectionString
+            {
+                Name = connectionStringName,
+                BrokerType = QueueBrokerType.RabbitMq,
+                RabbitMqConnectionSettings = new RabbitMqConnectionSettings
+                {
+                    ConnectionString = RabbitMqConnectionString.Instance.VerifiedConnectionString.Value
+                }
+            });
+
+        return config;
     }
 
     protected IModel CreateRabbitMqProducer(params string[] queuesToDeclare)

--- a/test/SlowTests/Server/Documents/QueueSink/RabbitMqQueueSinkTestBase.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/RabbitMqQueueSinkTestBase.cs
@@ -1,0 +1,55 @@
+﻿using RabbitMQ.Client.Events;
+using RabbitMQ.Client;
+using System;
+using Tests.Infrastructure.ConnectionString;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using System.Collections.Generic;
+
+namespace SlowTests.Server.Documents.QueueSink;
+
+[Trait("Category", "QueueSink")]
+public abstract class RabbitMqQueueSinkTestBase : QueueSinkTestBase
+{
+    private readonly HashSet<string> _definedQueues = new();
+
+    protected RabbitMqQueueSinkTestBase(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected IModel CreateRabbitMqProducer(params string[] queuesToDeclare)
+    {
+        var connectionFactory = new ConnectionFactory() { Uri = new Uri(RabbitMqConnectionString.Instance.VerifiedConnectionString.Value) };
+        var connection = connectionFactory.CreateConnection();
+        var producer = connection.CreateModel();
+
+        foreach (string queue in queuesToDeclare)
+        {
+            producer.QueueDeclare(queue, exclusive: false);
+            _definedQueues.Add(queue);
+        }
+
+        return producer;
+    }
+
+    private void CleanupQueues()
+    {
+        if (_definedQueues.Count == 0 || RequiresRabbitMqRetryFactAttribute.CanConnect == false)
+            return;
+
+        using var channel = CreateRabbitMqProducer();
+        var consumer = new EventingBasicConsumer(channel);
+
+        foreach (string definedExchangeAndQueue in _definedQueues)
+        {
+            consumer.Model.QueueDelete(definedExchangeAndQueue);
+        }
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        CleanupQueues();
+    }
+}

--- a/test/SlowTests/Server/Documents/QueueSink/RabbitMqSinkTests.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/RabbitMqSinkTests.cs
@@ -240,12 +240,4 @@ public class RabbitMqSinkTests : QueueSinkTestBase
 
         Assert.Equal("Script 'test' must not be empty", errors[0]);
     }
-
-    private IModel CreateRabbitMqProducer()
-    {
-        var connectionFactory = new ConnectionFactory { Uri = new Uri(RabbitMqConnectionString.Instance.VerifiedConnectionString.Value) };
-        var connection = connectionFactory.CreateConnection();
-        var producer = connection.CreateModel();
-        return producer;
-    }
 }

--- a/test/SlowTests/Server/Documents/QueueSink/RabbitMqSinkTests.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/RabbitMqSinkTests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Server.Documents.QueueSink;
 
-public class RabbitMqSinkTests : QueueSinkTestBase
+public class RabbitMqSinkTests : RabbitMqQueueSinkTestBase
 {
     public RabbitMqSinkTests(ITestOutputHelper output) : base(output)
     {
@@ -28,9 +28,7 @@ public class RabbitMqSinkTests : QueueSinkTestBase
         byte[] userBytes1 = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(user1));
         byte[] userBytes2 = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(user2));
 
-        var producer = CreateRabbitMqProducer();
-
-        producer.QueueDeclare(queue: UsersQueueName, exclusive: false);
+        var producer = CreateRabbitMqProducer(UsersQueueName);
 
         producer.BasicPublish(exchange: "", routingKey: UsersQueueName, basicProperties: null,
             body: new ReadOnlyMemory<byte>(userBytes1));
@@ -75,11 +73,9 @@ public class RabbitMqSinkTests : QueueSinkTestBase
         byte[] userBytes3 = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(user3));
         byte[] userBytes4 = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(user4));
 
-        var producer = CreateRabbitMqProducer();
-
-        producer.QueueDeclare(queue: UsersQueueName, exclusive: false);
         string developersQueueName = $"developers{QueueSuffix}";
-        producer.QueueDeclare(queue: developersQueueName, exclusive: false);
+
+        var producer = CreateRabbitMqProducer(UsersQueueName, developersQueueName);
 
         producer.BasicPublish(exchange: "", routingKey: UsersQueueName, basicProperties: null,
             body: new ReadOnlyMemory<byte>(userBytes1));
@@ -141,9 +137,7 @@ public class RabbitMqSinkTests : QueueSinkTestBase
         byte[] userBytes1 = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(user1));
         byte[] userBytes2 = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(user2));
 
-        var producer = CreateRabbitMqProducer();
-
-        producer.QueueDeclare(queue: UsersQueueName, exclusive: false);
+        var producer = CreateRabbitMqProducer(UsersQueueName);
 
         producer.BasicPublish(exchange: "", routingKey: UsersQueueName, basicProperties: null,
             body: new ReadOnlyMemory<byte>(userBytes1));
@@ -178,9 +172,7 @@ public class RabbitMqSinkTests : QueueSinkTestBase
     {
         var numberOfUsers = 10;
 
-        var producer = CreateRabbitMqProducer();
-
-        producer.QueueDeclare(queue: UsersQueueName, exclusive: false);
+        var producer = CreateRabbitMqProducer(UsersQueueName);
 
         for (int i = 0; i < numberOfUsers; i++)
         {

--- a/test/Tests.Infrastructure/ConnectionString/RabbitMqConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/RabbitMqConnectionString.cs
@@ -59,7 +59,7 @@ public class RabbitMqConnectionString
         if (TryConnect(ConnectionString.Value, out var ex))
             return ConnectionString.Value;
 
-        throw new InvalidOperationException($"Can't access Kafka instance. Provided url: {ConnectionString.Value}", ex);
+        throw new InvalidOperationException($"Can't access RabbitMQ instance. Provided url: {ConnectionString.Value}", ex);
 
 
         bool TryConnect(string connectionString, out Exception exception)


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22105/QueueSink-with-idle-database-will-stop-consuming
https://issues.hibernatingrhinos.com/issue/RavenDB-22075

### Additional description

We must not idle a database running Queue Sink task because we won't consume incoming messages then

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
