### PR TITLE
RavenDB-22067 - make sure not task delay a negative timespan

### DIFF
--- a/test/StressTests/Issues/RavenDB_14292.cs
+++ b/test/StressTests/Issues/RavenDB_14292.cs
@@ -114,7 +114,11 @@ namespace StressTests.Issues
                     lastBackup = status.LastFullBackup.Value;
                 }
                 var nextBackup = backupParser.GetNextOccurrence(lastBackup);
-                await Task.Delay(nextBackup - DateTime.UtcNow);
+                var timeToWait = nextBackup - DateTime.UtcNow;
+                if (timeToWait > TimeSpan.Zero)
+                {
+                    await Task.Delay(timeToWait);
+                }
 
                 status = await AssertWaitForNextBackup(store.Database, status);
                 controlGroupStatus = await AssertWaitForNextBackup(controlgroupDbName, controlGroupStatus);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22067/


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
