### PR TITLE
RavenDB-21945 Wait limited time for get disk stats

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2811,6 +2811,7 @@ namespace Raven.Server
                 if (SkipCertificateDispose == false)
                     ea.Execute(() => Certificate?.Dispose());
 
+                ea.Execute(() => DiskStatsGetter?.Dispose());
                 // this should be last
                 ea.Execute(() => AfterDisposal?.Invoke());
 

--- a/src/Sparrow.Server/Utils/DiskStatsGetter/IDiskStatsGetter.cs
+++ b/src/Sparrow.Server/Utils/DiskStatsGetter/IDiskStatsGetter.cs
@@ -1,8 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Sparrow.Server.Utils.DiskStatsGetter;
 
-public interface IDiskStatsGetter
+public interface IDiskStatsGetter : IDisposable
 {
     DiskStatsResult Get(string drive);
     Task<DiskStatsResult> GetAsync(string drive);

--- a/src/Sparrow.Server/Utils/DiskStatsGetter/NotImplementedDiskStatsGetter.cs
+++ b/src/Sparrow.Server/Utils/DiskStatsGetter/NotImplementedDiskStatsGetter.cs
@@ -6,4 +6,5 @@ internal class NotImplementedDiskStatsGetter : IDiskStatsGetter
 {
     public DiskStatsResult Get(string drive) => null;
     public Task<DiskStatsResult> GetAsync(string drive) => null;
+    public void Dispose() { }
 }

--- a/src/Sparrow.Server/Utils/DiskUtils.cs
+++ b/src/Sparrow.Server/Utils/DiskUtils.cs
@@ -250,7 +250,9 @@ namespace Sparrow.Server.Utils
 #pragma warning disable CA1416
             return PlatformDetails.RunningOnLinux
                 ? new LinuxDiskStatsGetter(minInterval)
-                : new NotImplementedDiskStatsGetter();
+                : PlatformDetails.RunningOnWindows
+                    ? new WindowsDiskStatsGetter(minInterval)
+                    : new NotImplementedDiskStatsGetter();
 #pragma warning restore CA1416
         }
 

--- a/test/Tests.Infrastructure/RavenTestCategory.cs
+++ b/test/Tests.Infrastructure/RavenTestCategory.cs
@@ -56,4 +56,5 @@ public enum RavenTestCategory : long
     Smuggler = 1L << 41,
     Lucene = 1L << 42,
     Security = 1L << 43,
+    Monitoring = 1L << 44,
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21945

### Additional description
In Windows, the disk counters functionality can take time depending on the disk.
In our test, the specific method was hung a little bit (20-30 minutes, enough for the test to fail) is 
`PerformanceCounterCategory.GetInstanceNames`.
This function is called once per disk (but in the test, it was called at the disposing of the server).

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [x] Yes. Windows (but the fix is for a potential issue also in Linux)
- [ ] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
