### PR TITLE
RavenDB-22124 Add info in Queue sink Info Hub - that database will not become idle

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditKafkaSinkTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditKafkaSinkTaskInfoHub.tsx
@@ -30,7 +30,7 @@ export function EditKafkaSinkTaskInfoHub() {
                     Define a <strong>Kafka Sink</strong> ongoing-task in order to consume and process incoming messages from Kafka topics.
                 </p>
                 <p>
-                    Add one or more <strong>scripts</strong> that Load, Put, or Delete documents in RavenDB based on the incoming messages.
+                    Add one or more <strong>scripts</strong> that Load, Put, or Delete documents in RavenDB based on the incoming messages:
                 </p>
                 <ul>
                     <li className="margin-top-sm">
@@ -46,6 +46,10 @@ export function EditKafkaSinkTaskInfoHub() {
                         Incoming messages are expected only as JSON.
                     </li>
                 </ul>
+                <p>
+                    A database with a defined Kafka Sink task will Not become idle,<br />
+                    ensuring continuous processing of incoming messages.
+                </p>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper
                 isUnlimited={hasQueueSink}

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRabbitMqSinkTaskInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditRabbitMqSinkTaskInfoHub.tsx
@@ -32,7 +32,7 @@ export function EditRabbitMqSinkTaskInfoHub() {
                 </p>
                 <p>
                     Add one or more <strong>scripts</strong> that Load, Put, or Delete documents in RavenDB based on the
-                    incoming messages.
+                    incoming messages:
                 </p>
                 <ul>
                     <li className="margin-top-sm">
@@ -49,6 +49,10 @@ export function EditRabbitMqSinkTaskInfoHub() {
                     </li>
                     <li className="margin-top-xxs">Incoming messages are expected only as JSON.</li>
                 </ul>
+                <p>
+                    A database with a defined RabbitMQ Sink task will Not become idle,<br />
+                    ensuring continuous processing of incoming messages.
+                </p>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper
                 isUnlimited={hasQueueSink}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22124

### Additional description

Added text in info hub (Kafak Sink & RabbitMQ Sink)
that a database with a defined Sink task will Not become idle

### Type of change
- [x] Cosmetics
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing (only tested the info Hub UI)

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
