### PR TITLE
RavenDB-22108: fix hanged test

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -108,9 +108,9 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (_forTestingPurposes != null && _forTestingPurposes.SimulateFailedBackup)
                     throw new Exception(nameof(_forTestingPurposes.SimulateFailedBackup));
                 if (_forTestingPurposes != null && _forTestingPurposes.OnBackupTaskRunHoldBackupExecution != null)
-                    _forTestingPurposes.OnBackupTaskRunHoldBackupExecution.Task.Wait();
+                    _forTestingPurposes.OnBackupTaskRunHoldBackupExecution?.Task.Wait();
                 if (Database.ForTestingPurposes != null && Database.ForTestingPurposes.ActionToCallOnGetTempPath != null)
-                    Database.ForTestingPurposes.ActionToCallOnGetTempPath.Invoke(_tempBackupPath);
+                    Database.ForTestingPurposes.ActionToCallOnGetTempPath?.Invoke(_tempBackupPath);
 
                 if (runningBackupStatus.LocalBackup == null)
                     runningBackupStatus.LocalBackup = new LocalBackup();

--- a/test/RachisTests/BasicTests.cs
+++ b/test/RachisTests/BasicTests.cs
@@ -61,7 +61,7 @@ namespace RachisTests
         {
             var leader = await CreateNetworkAndGetLeader(1);
             var mre = new ManualResetEvent(false);
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             leader.Timeout.Start(() =>
             {
@@ -73,11 +73,11 @@ namespace RachisTests
                     {
 
                     }
-                    tcs.SetResult(null);
+                    tcs.TrySetResult(null);
                 }
                 catch (Exception e)
                 {
-                    tcs.SetException(e);
+                    tcs.TrySetException(e);
                 }
             });
 

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -170,46 +170,49 @@ namespace SlowTests.Client.Subscriptions
                     var con1Docs = new List<string>();
                     var con2Docs = new List<string>();
 
-                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    var mre = new ManualResetEvent(false);
-
-                    var _ = Subscription2.Run(x =>
+                    var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    await Backup.HoldBackupExecutionIfNeededAndInvoke(ts: null, async () =>
                     {
-                        foreach (var item in x.Items)
+                        var mre = new ManualResetEvent(false);
+
+                        var _ = Subscription2.Run(async x =>
                         {
-                            con2Docs.Add(item.Id);
-                        }
-
-                        mre.Set();
-                        tcs.Task.Wait();
-                    });
-
-                    mre.WaitOne();
-
-                    var exception = string.Empty;
-                    var t = subscription.Run(x =>
-                    {
-                        foreach (var item in x.Items)
-                        {
-                            if (string.IsNullOrEmpty(exception) && string.IsNullOrEmpty(item.ExceptionMessage) == false)
+                            foreach (var item in x.Items)
                             {
-                                exception = item.ExceptionMessage;
+                                con2Docs.Add(item.Id);
                             }
 
-                            con1Docs.Add(item.Id);
-                        }
-                    });
+                            mre.Set();
+                            await tcs.Task;
+                        });
 
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(con2Docs.Count == 2), true, 6000, 100), $"connection 2 has {con2Docs.Count} docs");
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(con1Docs.Count == 4), true, 6000, 100), $"connection 1 has {con1Docs.Count} docs");
+                        mre.WaitOne();
 
-                    tcs.SetException(new InvalidOperationException());
-                    await Subscription2.DisposeAsync(waitForSubscriptionTask: true);
+                        var exception = string.Empty;
+                        var t = subscription.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                if (string.IsNullOrEmpty(exception) && string.IsNullOrEmpty(item.ExceptionMessage) == false)
+                                {
+                                    exception = item.ExceptionMessage;
+                                }
 
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(con1Docs.Count == 6), true, 6000, 100), $"connection 1 has {con1Docs.Count} docs");
-                    Assert.True(string.IsNullOrEmpty(exception), $"string.IsNullOrEmpty(exception): " + exception);
+                                con1Docs.Add(item.Id);
+                            }
+                        });
 
-                    await AssertNoLeftovers(store, id);
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(con2Docs.Count == 2), true, 6000, 100), $"connection 2 has {con2Docs.Count} docs");
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(con1Docs.Count == 4), true, 6000, 100), $"connection 1 has {con1Docs.Count} docs");
+
+                        tcs.SetException(new InvalidOperationException());
+                        await Subscription2.DisposeAsync(waitForSubscriptionTask: true);
+
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(con1Docs.Count == 6), true, 6000, 100), $"connection 1 has {con1Docs.Count} docs");
+                        Assert.True(string.IsNullOrEmpty(exception), $"string.IsNullOrEmpty(exception): " + exception);
+
+                        await AssertNoLeftovers(store, id);
+                    }, tcs);
                 }
             }
         }
@@ -339,44 +342,47 @@ namespace SlowTests.Client.Subscriptions
                     var con1Docs = new List<string>();
                     var con2Docs = new List<string>();
 
-                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    var mre = new ManualResetEvent(false);
-
-                    var _ = subscription2.Run(x =>
+                    var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    await Backup.HoldBackupExecutionIfNeededAndInvoke(ts: null, async () =>
                     {
-                        foreach (var item in x.Items)
+                        var mre = new ManualResetEvent(false);
+
+                        var _ = subscription2.Run(async x =>
                         {
-                            con2Docs.Add(item.Id);
+                            foreach (var item in x.Items)
+                            {
+                                con2Docs.Add(item.Id);
+                            }
+
+                            mre.Set();
+                            await tcs.Task;
+                        });
+
+                        mre.WaitOne();
+
+                        using (var session = store.OpenAsyncSession())
+                        {
+                            session.Delete("users/1");
+                            await session.StoreAsync(new User(), "users/7");
+                            await session.SaveChangesAsync();
                         }
 
-                        mre.Set();
-                        tcs.Task.Wait();
-                    });
-
-                    mre.WaitOne();
-
-                    using (var session = store.OpenAsyncSession())
-                    {
-                        session.Delete("users/1");
-                        await session.StoreAsync(new User(), "users/7");
-                        await session.SaveChangesAsync();
-                    }
-
-                    var t = subscription.Run(x =>
-                    {
-                        foreach (var item in x.Items)
+                        var t = subscription.Run(x =>
                         {
-                            con1Docs.Add(item.Id);
-                        }
-                    });
+                            foreach (var item in x.Items)
+                            {
+                                con1Docs.Add(item.Id);
+                            }
+                        });
 
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(con2Docs.Count == 2), true, 6000, 100), $"connection 2 has {con2Docs.Count} docs");
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(con1Docs.Count == 5), true, 6000, 100), $"connection 1 has {con1Docs.Count} docs");
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(con2Docs.Count == 2), true, 6000, 100), $"connection 2 has {con2Docs.Count} docs");
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(con1Docs.Count == 5), true, 6000, 100), $"connection 1 has {con1Docs.Count} docs");
 
-                    Assert.Contains("users/7", con1Docs);
-                    tcs.SetException(new InvalidOperationException());
+                        Assert.Contains("users/7", con1Docs);
+                        tcs.SetException(new InvalidOperationException());
 
-                    await WaitForNoExceptionAsync(() => AssertNoLeftovers(store, id));
+                        await WaitForNoExceptionAsync(() => AssertNoLeftovers(store, id));
+                    }, tcs);
                 }
             }
         }
@@ -435,51 +441,54 @@ namespace SlowTests.Client.Subscriptions
                     var con1Docs = new List<string>();
                     var con2Docs = new List<string>();
 
-                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    var mre = new ManualResetEvent(false);
-
-                    var _ = Subscription2.Run(x =>
+                    var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    await Backup.HoldBackupExecutionIfNeededAndInvoke(ts: null, async () =>
                     {
-                        foreach (var item in x.Items)
+                        var mre = new ManualResetEvent(false);
+
+                        var _ = Subscription2.Run(async x =>
                         {
-                            con2Docs.Add(item.Id);
-                        }
-
-                        mre.Set();
-                        tcs.Task.Wait();
-                    });
-
-                    mre.WaitOne();
-
-                    using (var session = store.OpenAsyncSession())
-                    {
-                        await session.StoreAsync(new User { Name = "Changed" }, "users/1");
-                        await session.StoreAsync(new User(), "users/7");
-                        await session.SaveChangesAsync();
-                    }
-
-                    var gotIt = false;
-                    var t = subscription.Run(x =>
-                    {
-                        foreach (var item in x.Items)
-                        {
-                            con1Docs.Add(item.Id);
-                            if (item.Result.Name == "Changed")
+                            foreach (var item in x.Items)
                             {
-                                gotIt = true;
+                                con2Docs.Add(item.Id);
                             }
+
+                            mre.Set();
+                            await tcs.Task;
+                        });
+
+                        mre.WaitOne();
+
+                        using (var session = store.OpenAsyncSession())
+                        {
+                            await session.StoreAsync(new User { Name = "Changed" }, "users/1");
+                            await session.StoreAsync(new User(), "users/7");
+                            await session.SaveChangesAsync();
                         }
-                    });
 
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(con2Docs.Count == 2), true, 6000, 100), $"connection 2 has {con2Docs.Count} docs");
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(con1Docs.Count == 5), true, 6000, 100), $"connection 1 has {con1Docs.Count} docs");
+                        var gotIt = false;
+                        var t = subscription.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                con1Docs.Add(item.Id);
+                                if (item.Result.Name == "Changed")
+                                {
+                                    gotIt = true;
+                                }
+                            }
+                        });
 
-                    Assert.Contains("users/7", con1Docs);
-                    tcs.SetException(new InvalidOperationException());
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(con2Docs.Count == 2), true, 6000, 100), $"connection 2 has {con2Docs.Count} docs");
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(con1Docs.Count == 5), true, 6000, 100), $"connection 1 has {con1Docs.Count} docs");
 
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(gotIt), true), $"updated document didn't arrived");
+                        Assert.Contains("users/7", con1Docs);
+                        tcs.SetException(new InvalidOperationException());
 
-                    await AssertNoLeftovers(store, id);
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(gotIt), true), $"updated document didn't arrived");
+
+                        await AssertNoLeftovers(store, id);
+                    }, tcs);
                 }
             }
         }
@@ -531,51 +540,54 @@ namespace SlowTests.Client.Subscriptions
                     var con1Docs = new List<string>();
                     var con2Docs = new List<string>();
 
-                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                    var mre = new ManualResetEvent(false);
-
-                    var _ = Subscription2.Run(x =>
+                    var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    await Backup.HoldBackupExecutionIfNeededAndInvoke(ts: null, async () =>
                     {
-                        foreach (var item in x.Items)
+                        var mre = new ManualResetEvent(false);
+
+                        var _ = Subscription2.Run(async x =>
                         {
-                            con2Docs.Add(item.Id);
-                        }
-
-                        mre.Set();
-                        tcs.Task.Wait();
-                    });
-
-                    mre.WaitOne();
-
-                    using (var session = store.OpenAsyncSession())
-                    {
-                        await session.StoreAsync(new User { Name = "Changed" }, "users/1");
-                        await session.StoreAsync(new User { Name = "Changed" }, "users/2");
-                        await session.StoreAsync(new User(), "users/7");
-                        await session.SaveChangesAsync();
-                    }
-
-                    var gotIt = false;
-                    var t = subscription.Run(x =>
-                    {
-                        foreach (var item in x.Items)
-                        {
-                            con1Docs.Add(item.Id);
-                            if (item.Result.Name == "Changed")
+                            foreach (var item in x.Items)
                             {
-                                gotIt = true;
+                                con2Docs.Add(item.Id);
                             }
+
+                            mre.Set();
+                            await tcs.Task;
+                        });
+
+                        mre.WaitOne();
+
+                        using (var session = store.OpenAsyncSession())
+                        {
+                            await session.StoreAsync(new User { Name = "Changed" }, "users/1");
+                            await session.StoreAsync(new User { Name = "Changed" }, "users/2");
+                            await session.StoreAsync(new User(), "users/7");
+                            await session.SaveChangesAsync();
                         }
-                    });
 
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(con2Docs.Count == 2), true, 6000, 100), $"connection 2 has {con2Docs.Count} docs");
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(con1Docs.Count == 5), true, 6000, 100), $"connection 1 has {con1Docs.Count} docs");
+                        var gotIt = false;
+                        var t = subscription.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                con1Docs.Add(item.Id);
+                                if (item.Result.Name == "Changed")
+                                {
+                                    gotIt = true;
+                                }
+                            }
+                        });
 
-                    Assert.Contains("users/7", con1Docs);
-                    tcs.SetException(new InvalidOperationException());
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(con2Docs.Count == 2), true, 6000, 100), $"connection 2 has {con2Docs.Count} docs");
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(con1Docs.Count == 5), true, 6000, 100), $"connection 1 has {con1Docs.Count} docs");
 
-                    Assert.True(await WaitForValueAsync(() => Task.FromResult(gotIt), true), $"updated document didn't arrived");
-                    await AssertNoLeftovers(store, id);
+                        Assert.Contains("users/7", con1Docs);
+                        tcs.SetException(new InvalidOperationException());
+
+                        Assert.True(await WaitForValueAsync(() => Task.FromResult(gotIt), true), $"updated document didn't arrived");
+                        await AssertNoLeftovers(store, id);
+                    }, tcs);
                 }
             }
         }
@@ -968,54 +980,58 @@ namespace SlowTests.Client.Subscriptions
             const int expectedNumberOfDocsToResend = 7;
 
             string databaseName = GetDatabaseName();
-            using (var store = GetDocumentStore(new Options { ModifyDatabaseName = _ => databaseName }))
+
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            await Backup.HoldBackupExecutionIfNeededAndInvoke(ts: null, async () =>
             {
-                var subscriptionId = await store.Subscriptions.CreateAsync<User>();
-                await using var subscriptionWorker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(subscriptionId)
+                using (var store = GetDocumentStore(new Options { ModifyDatabaseName = _ => databaseName }))
                 {
-                    Strategy = SubscriptionOpeningStrategy.Concurrent,
-                    TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(2),
-                    MaxDocsPerBatch = expectedNumberOfDocsToResend
-                });
+                    var subscriptionId = await store.Subscriptions.CreateAsync<User>();
+                    await using var subscriptionWorker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(subscriptionId)
+                    {
+                        Strategy = SubscriptionOpeningStrategy.Concurrent,
+                        TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(2),
+                        MaxDocsPerBatch = expectedNumberOfDocsToResend
+                    });
 
-                using (var session = store.OpenSession())
-                {
-                    for (int i = 0; i < 10; i++)
-                        session.Store(new User { Name = $"UserNo{i}" });
+                    using (var session = store.OpenSession())
+                    {
+                        for (int i = 0; i < 10; i++)
+                            session.Store(new User { Name = $"UserNo{i}" });
 
-                    session.SaveChanges();
+                        session.SaveChanges();
+                    }
+
+                    _ = subscriptionWorker.Run(async x =>
+                    {
+                        await tcs.Task;
+                    });
+
+                    await AssertWaitForValueAsync(() =>
+                    {
+                        List<SubscriptionStorage.ResendItem> items;
+
+                        using (Server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+                        using (context.OpenReadTransaction())
+                            items = SubscriptionStorage.GetResendItemsForDatabase(context, store.Database).ToList();
+
+                        return Task.FromResult(items.Count);
+                    }, expectedNumberOfDocsToResend);
                 }
 
-                _ = subscriptionWorker.Run(x =>
-                {
-                    var tcs = new TaskCompletionSource<bool>();
-                    tcs.Task.Wait();
-                });
-
-                await AssertWaitForValueAsync(() =>
+                // Upon disposing of the store, the database gets deleted.
+                // Then we recreate the database to ensure no leftover subscription data from the previous instance.
+                using (var _ = GetDocumentStore(new Options { ModifyDatabaseName = _ => databaseName }))
                 {
                     List<SubscriptionStorage.ResendItem> items;
 
                     using (Server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                     using (context.OpenReadTransaction())
-                        items = SubscriptionStorage.GetResendItemsForDatabase(context, store.Database).ToList();
+                        items = SubscriptionStorage.GetResendItemsForDatabase(context, databaseName).ToList();
 
-                    return Task.FromResult(items.Count);
-                }, expectedNumberOfDocsToResend);
-            }
-
-            // Upon disposing of the store, the database gets deleted.
-            // Then we recreate the database to ensure no leftover subscription data from the previous instance.
-            using (var _ = GetDocumentStore(new Options { ModifyDatabaseName = _ => databaseName }))
-            {
-                List<SubscriptionStorage.ResendItem> items;
-
-                using (Server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-                using (context.OpenReadTransaction())
-                    items = SubscriptionStorage.GetResendItemsForDatabase(context, databaseName).ToList();
-
-                Assert.Equal(0, items.Count);
-            }
+                    Assert.Equal(0, items.Count);
+                }
+            }, tcs);
         }
 
         [RavenTheory(RavenTestCategory.Subscriptions)]

--- a/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
@@ -46,7 +46,7 @@ namespace SlowTests.Client.Subscriptions
                 {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromMilliseconds(100)
                 });
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 var signalWhenForcefullyUpdatedCV = new AsyncManualResetEvent();
                 var signalWhenStartedProcessingDoc = new AsyncManualResetEvent();
 

--- a/test/SlowTests/Cluster/ClusterObserverTests.cs
+++ b/test/SlowTests/Cluster/ClusterObserverTests.cs
@@ -48,7 +48,7 @@ namespace SlowTests.Cluster
                 }
             }))
             {
-                var tcs = new TaskCompletionSource<DocumentDatabase>();
+                var tcs = new TaskCompletionSource<DocumentDatabase>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 var databaseName = store.Database;
                 using (var session = store.OpenSession())
@@ -66,7 +66,7 @@ namespace SlowTests.Cluster
                 using (new DisposableAction(() =>
                 {
                     if (preferred.ServerStore.DatabasesLandlord.DatabasesCache.TryRemove(databaseName, tcs.Task))
-                        tcs.SetCanceled();
+                        tcs.TrySetCanceled();
                 }))
                 {
                     var t = preferred.ServerStore.DatabasesLandlord.DatabasesCache.ForTestingPurposesOnly().Replace(databaseName, tcs.Task);

--- a/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
+++ b/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
@@ -416,12 +416,12 @@ exit 0";
                 throw new CryptographicException($"Failed to load the test certificate from {certificates}.", e);
             }
 
-            var ts = new TaskCompletionSource();
+            var ts = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             Server.ServerStore.Engine.StateMachine.Changes.ValueChanged += (index, type) =>
             {
                 if (type == nameof(InstallUpdatedServerCertificateCommand))
                 {
-                    ts.SetResult();
+                    ts.TrySetResult();
                 }
 
                 return Task.CompletedTask;

--- a/test/SlowTests/Issues/RavenDB-15754.cs
+++ b/test/SlowTests/Issues/RavenDB-15754.cs
@@ -201,7 +201,7 @@ namespace SlowTests.Issues
                 await AssertCount(store, _companyName1, _employeesCount);
 
                 var batchCount = 0;
-                var tcs = new TaskCompletionSource<object>();
+                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
                 store.Changes().ForIndex(index.IndexName).Subscribe(x =>
                 {
                     if (x.Type == IndexChangeTypes.BatchCompleted)

--- a/test/SlowTests/Server/Documents/ETL/EtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlTestBase.cs
@@ -143,7 +143,7 @@ namespace SlowTests.Server.Documents.ETL
         {
             var database = GetDatabase(store.Database).Result;
 
-            var taskCompletionSource = new TaskCompletionSource<(string, string, EtlProcessStatistics)>();
+            var taskCompletionSource = new TaskCompletionSource<(string, string, EtlProcessStatistics)>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             void EtlLoaderOnBatchCompleted((string ConfigurationName, string TransformationName, EtlProcessStatistics Statistics) x)
             {
@@ -151,11 +151,11 @@ namespace SlowTests.Server.Documents.ETL
                 {
                     if (predicate($"{x.ConfigurationName}/{x.TransformationName}", x.Statistics) == false)
                         return;
-                    taskCompletionSource.SetResult(x);
+                    taskCompletionSource.TrySetResult(x);
                 }
                 catch (Exception e)
                 {
-                    taskCompletionSource.SetException(e);
+                    taskCompletionSource.TrySetException(e);
                 }
             }
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2103,13 +2103,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 };
 
                 var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
-                try
-                {
-                    database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
+                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(database.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
+                {
                     var operationId = store.Maintenance.SendAsync(new BackupOperation(config)).Result.Id;
                     await store.Commands().ExecuteAsync(new KillOperationCommand(operationId));
-                    database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution.SetResult(null);
+                    tcs.TrySetResult(null);
 
                     WaitForValue(() => database.Operations.HasActive, false);
                     Assert.False(database.Operations.HasActive);
@@ -2120,11 +2120,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.True(operation.State.Status is OperationStatus.Canceled);
                     Assert.Null(operation.State.Progress);
                     Assert.Null(operation.State.Result);
-                }
-                finally
-                {
-                    database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = null;
-                }
+                }, tcs);
             }
         }
 
@@ -2838,9 +2834,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                 Assert.NotNull(documentDatabase);
-                var tcs = new TaskCompletionSource<object>();
-                documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = tcs;
-                try
+
+                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
                     var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
                     var record1 = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
@@ -2855,7 +2851,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = true;
                     responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
-                    tcs.SetResult(null);
+                    tcs.TrySetResult(null);
 
                     responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
                     var getPeriodicBackupStatus = new GetPeriodicBackupStatusOperation(taskId);
@@ -2868,20 +2864,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.NotNull(status);
                     Assert.Null(status.Error);
                     Assert.True(val, "Failed to complete the backup in time");
-                }
-                finally
-                {
-                    try
-                    {
-                        tcs.TrySetResult(null);
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
-
-                    documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = null;
-                }
+                }, tcs);
             }
         }
 
@@ -2906,9 +2889,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                 Assert.NotNull(documentDatabase);
-                var tcs = new TaskCompletionSource<object>();
-                documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = tcs;
-                try
+                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
                     var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
                     var record1 = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
@@ -2923,7 +2905,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateDisableNodeStatus_UpdateConfigurations = true;
                     responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
-                    tcs.SetResult(null);
+                    tcs.TrySetResult(null);
 
                     responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
                     var val = WaitForValue(() =>
@@ -2939,19 +2921,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         return ongoingTaskBackup.OnGoingBackup == null;
                     }, true, timeout: 66666, interval: 444);
                     Assert.True(val, "Failed to complete the backup in time");
-                }
-                finally
-                {
-                    try
-                    {
-                        tcs.TrySetResult(null);
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
-                    documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = null;
-                }
+                }, tcs);
             }
         }
 
@@ -2972,55 +2942,56 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                 Assert.NotNull(database);
-                database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
-
-                WaitForValue(() =>
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(database.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
+                {
+                    WaitForValue(() =>
                     {
                         var now = DateTime.Now;
                         return now.Minute % 2 == 0 && now.Second <= 10;
                     },
-                    expectedVal: true,
-                    timeout: (int)TimeSpan.FromMinutes(2).TotalMilliseconds,
-                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds
-                );
+                       expectedVal: true,
+                       timeout: (int)TimeSpan.FromMinutes(2).TotalMilliseconds,
+                       interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds
+                   );
 
-                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: fullBackupFrequency);
-                var taskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
+                    var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: fullBackupFrequency);
+                    var taskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
 
-                // Let's delay the backup task
-                var taskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                Assert.NotNull(taskBackupInfo);
-                Assert.NotNull(taskBackupInfo.OnGoingBackup);
-                Assert.NotNull(taskBackupInfo.OnGoingBackup.StartTime);
+                    // Let's delay the backup task
+                    var taskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                    Assert.NotNull(taskBackupInfo);
+                    Assert.NotNull(taskBackupInfo.OnGoingBackup);
+                    Assert.NotNull(taskBackupInfo.OnGoingBackup.StartTime);
 
-                var delayDuration = TimeSpan.FromMinutes(delayDurationInMinutes);
-                var delayUntil = DateTime.Now + delayDuration;
-                await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
+                    var delayDuration = TimeSpan.FromMinutes(delayDurationInMinutes);
+                    var delayUntil = DateTime.Now + delayDuration;
+                    await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
 
-                // There should be no OnGoingBackup operation in the OngoingTaskBackup
-                await WaitForValueAsync(async () =>
-                {
-                    var afterDelayTaskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                    return afterDelayTaskBackupInfo is { OnGoingBackup: null };
-                }, true);
+                    // There should be no OnGoingBackup operation in the OngoingTaskBackup
+                    await WaitForValueAsync(async () =>
+                    {
+                        var afterDelayTaskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                        return afterDelayTaskBackupInfo is { OnGoingBackup: null };
+                    }, true);
 
-                var backupStatus = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
-                Assert.NotNull(backupStatus);
-                Assert.NotNull(backupStatus.DelayUntil);
-                Assert.NotNull(backupStatus.OriginalBackupTime);
+                    var backupStatus = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    Assert.NotNull(backupStatus);
+                    Assert.NotNull(backupStatus.DelayUntil);
+                    Assert.NotNull(backupStatus.OriginalBackupTime);
 
-                var nextFullBackup = GetNextBackupOccurrence(new NextBackupOccurrenceParameters
-                {
-                    BackupFrequency = fullBackupFrequency,
-                    Configuration = config,
-                    LastBackupUtc = taskBackupInfo.OnGoingBackup.StartTime.Value
-                });
-                Assert.NotNull(nextFullBackup);
+                    var nextFullBackup = GetNextBackupOccurrence(new NextBackupOccurrenceParameters
+                    {
+                        BackupFrequency = fullBackupFrequency,
+                        Configuration = config,
+                        LastBackupUtc = taskBackupInfo.OnGoingBackup.StartTime.Value
+                    });
+                    Assert.NotNull(nextFullBackup);
 
-                Assert.Equal(backupStatus.OriginalBackupTime,
-                    delayUntil < nextFullBackup
-                        ? taskBackupInfo.OnGoingBackup.StartTime    // until the next scheduled backup time.
-                        : nextFullBackup.Value.ToUniversalTime());  // after the next scheduled backup.
+                    Assert.Equal(backupStatus.OriginalBackupTime,
+                        delayUntil < nextFullBackup
+                            ? taskBackupInfo.OnGoingBackup.StartTime    // until the next scheduled backup time.
+                            : nextFullBackup.Value.ToUniversalTime());  // after the next scheduled backup.
+                }, tcs: new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
             }
         }
 
@@ -3037,47 +3008,50 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                 Assert.NotNull(database);
-                database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
-                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *");
-                var taskId = store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config)).Result.TaskId;
-
-                OngoingTaskBackup taskBackupInfo = null;
-                using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(server.WebUrl, null, DocumentConventions.DefaultForServer))
-                using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
+                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(database.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
+                    var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *");
+                    var taskId = store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config)).Result.TaskId;
+
+                    OngoingTaskBackup taskBackupInfo = null;
+                    using (var requestExecutor = ClusterRequestExecutor.CreateForSingleNode(server.WebUrl, null, DocumentConventions.DefaultForServer))
+                    using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
+                    {
+                        await WaitForValueAsync(async () =>
+                        {
+                            taskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                            return taskBackupInfo?.OnGoingBackup != null;
+                        },
+                            expectedVal: true,
+                            timeout: (int)TimeSpan.FromMinutes(2).TotalMilliseconds,
+                            interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+
+                        Assert.NotNull(taskBackupInfo);
+                        Assert.Null(taskBackupInfo.LastFullBackup);
+                        Assert.NotNull(taskBackupInfo.OnGoingBackup);
+
+                        await store.GetRequestExecutor(store.Database)
+                            .ExecuteAsync(new KillOperationCommand(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, server.ServerStore.NodeTag), ctx);
+
+                        tcs.TrySetResult(null);
+                    }
+
+                    PeriodicBackupStatus backupStatus = null;
                     await WaitForValueAsync(async () =>
                     {
-                        taskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                        return taskBackupInfo?.OnGoingBackup != null;
-                    },
-                        expectedVal: true,
-                        timeout: (int)TimeSpan.FromMinutes(2).TotalMilliseconds,
-                        interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+                        backupStatus = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                        return backupStatus != null;
+                    }, true);
 
-                    Assert.NotNull(taskBackupInfo);
-                    Assert.Null(taskBackupInfo.LastFullBackup);
-                    Assert.NotNull(taskBackupInfo.OnGoingBackup);
-
-                    await store.GetRequestExecutor(store.Database)
-                        .ExecuteAsync(new KillOperationCommand(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, server.ServerStore.NodeTag), ctx);
-
-                    database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution?.SetResult(null);
-                }
-
-                PeriodicBackupStatus backupStatus = null;
-                await WaitForValueAsync(async () =>
-                {
-                    backupStatus = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
-                    return backupStatus != null;
-                }, true);
-
-                Assert.True(backupStatus != null,
-                    $"The cluster did not display data about the successful completion of at least one backup at the designated time. The {nameof(backupStatus)} is null.");
-                Assert.True(backupStatus.LastOperationId > taskBackupInfo.OnGoingBackup.RunningBackupTaskId,
-                    "The first backup operation unexpectedly completed successfully. " +
-                    "We were testing failover behavior and expected the first operation to be cancelled, followed by successful completion of the second operation. " +
-                    "This scenario should never occur.");
+                    Assert.True(backupStatus != null,
+                        $"The cluster did not display data about the successful completion of at least one backup at the designated time. The {nameof(backupStatus)} is null.");
+                    Assert.True(backupStatus.LastOperationId > taskBackupInfo.OnGoingBackup.RunningBackupTaskId,
+                        "The first backup operation unexpectedly completed successfully. " +
+                        "We were testing failover behavior and expected the first operation to be cancelled, followed by successful completion of the second operation. " +
+                        "This scenario should never occur.");
+                }, tcs);
             }
         }
 
@@ -3085,7 +3059,6 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task CanDelayBackupTask()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
             using (var server = GetNewServer())
             using (var store = GetDocumentStore(new Options { Server = server }))
             {
@@ -3094,46 +3067,55 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                 Assert.NotNull(database);
-                database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
-                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *");
-                var taskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
-
-                // The backup task is running, and the next backup should be scheduled for the next minute (based on the backup configuration)
-                var taskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup), cts.Token) as OngoingTaskBackup;
-                Assert.NotNull(taskBackupInfo);
-                Assert.NotNull(taskBackupInfo.OnGoingBackup);
-                var expectedNextBackupDateTime = DateTime.UtcNow.Date
-                    .AddHours(DateTime.UtcNow.Hour)
-                    .AddMinutes(DateTime.UtcNow.Minute + 1);
-                Assert.Equal(expectedNextBackupDateTime, taskBackupInfo.NextBackup.DateTime);
-
-                // Let's delay the backup task to 1 hour
-                var delayDuration = TimeSpan.FromHours(1);
-                var sw = Stopwatch.StartNew();
-                await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration), cts.Token);
-
-                // There should be no OnGoingBackup operation in the OngoingTaskBackup
-                // The next backup should be scheduled in almost 1 hour
-                OngoingTaskBackup afterDelayTaskBackupInfo = null;
-                Assert.True(await WaitForValueAsync(async () =>
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(database.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
-                    afterDelayTaskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup), cts.Token) as OngoingTaskBackup;
-                    return afterDelayTaskBackupInfo is { OnGoingBackup: null };
-                }, true));
+                    var config = Backup.CreateBackupConfiguration(backupPath);
+                    var taskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
 
-                cts.Token.ThrowIfCancellationRequested();
-                Assert.Null(afterDelayTaskBackupInfo.LastFullBackup);
-                Assert.True(afterDelayTaskBackupInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
-                            afterDelayTaskBackupInfo.NextBackup.TimeSpan <= delayDuration,
-                    $"NextBackup in: `{afterDelayTaskBackupInfo.NextBackup.TimeSpan}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
-                    $"delayDuration: `{delayDuration}`");
+                    // The backup task is running, and the next backup should be scheduled for the 1 January next year (local time)
+                    var taskBackupInfo =
+                        await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
 
-                // DelayUntil value in backup status and the time of scheduled next backup should be equal
-                var backupStatus = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId), cts.Token)).Status;
-                Assert.NotNull(backupStatus);
-                Assert.NotNull(backupStatus.DelayUntil);
-                Assert.Equal(backupStatus.DelayUntil, afterDelayTaskBackupInfo.NextBackup.DateTime);
+                    Assert.NotNull(taskBackupInfo);
+                    Assert.NotNull(taskBackupInfo.OnGoingBackup);
+
+                    var expectedNextBackupDateTime = new DateTime(DateTime.Now.Year + 1, 1, 1, 0, 0, 0, DateTimeKind.Local).ToUniversalTime();
+                    Assert.Equal(expectedNextBackupDateTime, taskBackupInfo.NextBackup.DateTime);
+
+                    // Let's delay the backup task to next occurence + 1 hour
+                    var delayDuration = expectedNextBackupDateTime - DateTime.UtcNow + TimeSpan.FromHours(1);
+                    var sw = Stopwatch.StartNew();
+                    await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
+
+                    // There should be no OnGoingBackup operation in the OngoingTaskBackup
+                    // The next backup should be scheduled in delayDuration
+                    OngoingTaskBackup afterDelayTaskBackupInfo = null;
+                    var expectedAfterDelay = expectedNextBackupDateTime.AddHours(1);
+
+                    Assert.True(await WaitForValueAsync(async () =>
+                    {
+                        afterDelayTaskBackupInfo =
+                            await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+
+                        return afterDelayTaskBackupInfo != null && afterDelayTaskBackupInfo.OnGoingBackup == null
+                                                                && afterDelayTaskBackupInfo.NextBackup.DateTime.Year == expectedAfterDelay.Year
+                                                                && afterDelayTaskBackupInfo.NextBackup.DateTime.Month == expectedAfterDelay.Month
+                                                                && afterDelayTaskBackupInfo.NextBackup.DateTime.Hour == expectedAfterDelay.Hour
+                                                                && afterDelayTaskBackupInfo.NextBackup.DateTime.Minute == expectedAfterDelay.Minute
+                                                                && afterDelayTaskBackupInfo.NextBackup.DateTime.Second == expectedAfterDelay.Second;
+                    }, true), $"NextBackup in: `{afterDelayTaskBackupInfo.NextBackup.TimeSpan}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
+                              $"delayDuration: `{delayDuration}`");
+
+
+                    Assert.Null(afterDelayTaskBackupInfo.LastFullBackup);
+
+                    // DelayUntil value in backup status and the time of scheduled next backup should be equal
+                    var backupStatus = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    Assert.NotNull(backupStatus);
+                    Assert.NotNull(backupStatus.DelayUntil);
+                    Assert.Equal(backupStatus.DelayUntil, afterDelayTaskBackupInfo.NextBackup.DateTime);
+                }, tcs: new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
             }
         }
 
@@ -3163,87 +3145,89 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var responsibleDatabase = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(leaderStore.Database).ConfigureAwait(false);
                 Assert.NotNull(responsibleDatabase);
-                responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
-                var now = DateTime.UtcNow;
-                var expectedNextBackupDateTime = now.Date
-                    .AddHours(now.Hour)
-                    .AddMinutes(now.Minute + 1);
-
-                await Backup.RunBackupInClusterAsync(leaderStore, taskId, opStatus: OperationStatus.InProgress);
-
-                // Just to be sure, the DelayUntil value was not set before the task delaying
-                var backupStatus = (await leaderStore.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
-                Assert.NotNull(backupStatus);
-                Assert.Null(backupStatus.DelayUntil);
-
-                // The backup task is running on the mentor node, and the next backup should be scheduled for the next minute (based on the backup configuration) without any errors
-                OngoingTaskBackup onGoingTaskInfo = null;
-                await WaitForValueAsync(async () =>
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
-                    onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                    var now = DateTime.UtcNow;
+                    var expectedNextBackupDateTime = now.Date
+                        .AddHours(now.Hour)
+                        .AddMinutes(now.Minute + 1);
 
-                    return onGoingTaskInfo != null &&
-                           leaderServer.ServerStore.NodeTag == onGoingTaskInfo.MentorNode &&
-                           onGoingTaskInfo.Error == null &&
-                           expectedNextBackupDateTime == onGoingTaskInfo.NextBackup.DateTime &&
-                           onGoingTaskInfo.OnGoingBackup != null &&
-                           onGoingTaskInfo.TaskConnectionStatus == OngoingTaskConnectionStatus.Active;
-                }, expectedVal: true,
-                    timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
-                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+                    await Backup.RunBackupInClusterAsync(leaderStore, taskId, opStatus: OperationStatus.InProgress);
 
-                Assert.NotNull(onGoingTaskInfo);
-                Assert.True(leaderServer.ServerStore.NodeTag == onGoingTaskInfo.MentorNode, userMessage: $"The value of 'leaderServer.ServerStore.NodeTag': {leaderServer.ServerStore.NodeTag} is not equal to 'onGoingTaskInfo.MentorNode': {onGoingTaskInfo.MentorNode}.");
-                Assert.True(onGoingTaskInfo.Error == null, userMessage: $"The onGoingTaskInfo.Error is not null: {onGoingTaskInfo.Error}.");
-                Assert.True(expectedNextBackupDateTime == onGoingTaskInfo.NextBackup.DateTime, userMessage: $"The 'expectedNextBackupDateTime': {expectedNextBackupDateTime} is not equal to 'onGoingTaskInfo.NextBackup.DateTime': {onGoingTaskInfo.NextBackup.DateTime}.");
-                Assert.NotNull(onGoingTaskInfo.OnGoingBackup);
-                Assert.True(onGoingTaskInfo.TaskConnectionStatus == OngoingTaskConnectionStatus.Active, userMessage: $"The onGoingTaskInfo.TaskConnectionStatus is {onGoingTaskInfo.TaskConnectionStatus}, which is not {nameof(OngoingTaskConnectionStatus.Active)} as expected.");
+                    // Just to be sure, the DelayUntil value was not set before the task delaying
+                    var backupStatus = (await leaderStore.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    Assert.NotNull(backupStatus);
+                    Assert.Null(backupStatus.DelayUntil);
 
-                // Let's delay the backup task to 1 hour
-                var delayDuration = TimeSpan.FromHours(1);
-                var sw = Stopwatch.StartNew();
-                var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
-                await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
+                    // The backup task is running on the mentor node, and the next backup should be scheduled for the next minute (based on the backup configuration) without any errors
+                    OngoingTaskBackup onGoingTaskInfo = null;
+                    await WaitForValueAsync(async () =>
+                    {
+                        onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
 
-                // The next backup should be scheduled in almost 1 hour on the current periodic backup task
-                Raven.Server.Documents.PeriodicBackup.PeriodicBackup periodicBackup = null;
-                TimeSpan nextBackup = default;
-                WaitForValue(() =>
-                {
-                    periodicBackup = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.Single(x => x.BackupStatus.TaskId == taskId);
-                    nextBackup = periodicBackup.GetNextBackup().TimeSpan;
+                        return onGoingTaskInfo != null &&
+                               leaderServer.ServerStore.NodeTag == onGoingTaskInfo.MentorNode &&
+                               onGoingTaskInfo.Error == null &&
+                               expectedNextBackupDateTime == onGoingTaskInfo.NextBackup.DateTime &&
+                               onGoingTaskInfo.OnGoingBackup != null &&
+                               onGoingTaskInfo.TaskConnectionStatus == OngoingTaskConnectionStatus.Active;
+                    }, expectedVal: true,
+                        timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
+                        interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
 
-                    return periodicBackup is { RunningTask: null, RunningBackupStatus: null } &&
-                           nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration;
-                }, expectedVal: true,
-                    timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
-                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+                    Assert.NotNull(onGoingTaskInfo);
+                    Assert.True(leaderServer.ServerStore.NodeTag == onGoingTaskInfo.MentorNode, userMessage: $"The value of 'leaderServer.ServerStore.NodeTag': {leaderServer.ServerStore.NodeTag} is not equal to 'onGoingTaskInfo.MentorNode': {onGoingTaskInfo.MentorNode}.");
+                    Assert.True(onGoingTaskInfo.Error == null, userMessage: $"The onGoingTaskInfo.Error is not null: {onGoingTaskInfo.Error}.");
+                    Assert.True(expectedNextBackupDateTime == onGoingTaskInfo.NextBackup.DateTime, userMessage: $"The 'expectedNextBackupDateTime': {expectedNextBackupDateTime} is not equal to 'onGoingTaskInfo.NextBackup.DateTime': {onGoingTaskInfo.NextBackup.DateTime}.");
+                    Assert.NotNull(onGoingTaskInfo.OnGoingBackup);
+                    Assert.True(onGoingTaskInfo.TaskConnectionStatus == OngoingTaskConnectionStatus.Active, userMessage: $"The onGoingTaskInfo.TaskConnectionStatus is {onGoingTaskInfo.TaskConnectionStatus}, which is not {nameof(OngoingTaskConnectionStatus.Active)} as expected.");
 
-                Assert.NotNull(periodicBackup);
-                Assert.Null(periodicBackup.RunningTask);
-                Assert.Null(periodicBackup.RunningBackupStatus);
-                Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration,
-                    $"The NextBackup is set for: {nextBackup}, the delay duration with tolerance is: {delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}, and the actual delay duration is: {delayDuration}.");
+                    // Let's delay the backup task to 1 hour
+                    var delayDuration = TimeSpan.FromHours(1);
+                    var sw = Stopwatch.StartNew();
+                    var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
+                    await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
 
-                await WaitForValueAsync(async () =>
-                {
-                    onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                    // The next backup should be scheduled in almost 1 hour on the current periodic backup task
+                    Raven.Server.Documents.PeriodicBackup.PeriodicBackup periodicBackup = null;
+                    TimeSpan nextBackup = default;
+                    WaitForValue(() =>
+                    {
+                        periodicBackup = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.Single(x => x.BackupStatus.TaskId == taskId);
+                        nextBackup = periodicBackup.GetNextBackup().TimeSpan;
 
-                    return onGoingTaskInfo != null &&
-                           onGoingTaskInfo.ResponsibleNode.NodeTag == leaderServer.ServerStore.NodeTag;
-                }, expectedVal: true,
-                    timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
-                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+                        return periodicBackup is { RunningTask: null, RunningBackupStatus: null } &&
+                               nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration;
+                    }, expectedVal: true,
+                         timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
+                         interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
 
-                Assert.NotNull(onGoingTaskInfo);
-                Assert.Equal(onGoingTaskInfo.ResponsibleNode.NodeTag, leaderServer.ServerStore.NodeTag);
+                    Assert.NotNull(periodicBackup);
+                    Assert.Null(periodicBackup.RunningTask);
+                    Assert.Null(periodicBackup.RunningBackupStatus);
+                    Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration,
+                        $"The NextBackup is set for: {nextBackup}, the delay duration with tolerance is: {delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}, and the actual delay duration is: {delayDuration}.");
 
-                // We'll check another (not leader) nodes in cluster
-                foreach (var server in nodes.Where(node => node != leaderServer))
-                {
-                    await AssertNextBackupSchedule(server, delayDuration, databaseName, taskId, sw);
-                }
+                    await WaitForValueAsync(async () =>
+                    {
+                        onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+
+                        return onGoingTaskInfo != null &&
+                               onGoingTaskInfo.ResponsibleNode.NodeTag == leaderServer.ServerStore.NodeTag;
+                    }, expectedVal: true,
+                        timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
+                        interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+
+                    Assert.NotNull(onGoingTaskInfo);
+                    Assert.Equal(onGoingTaskInfo.ResponsibleNode.NodeTag, leaderServer.ServerStore.NodeTag);
+
+                    // We'll check another (not leader) nodes in cluster
+                    foreach (var server in nodes.Where(node => node != leaderServer))
+                    {
+                        await AssertNextBackupSchedule(server, delayDuration, databaseName, taskId, sw);
+                    }
+                }, tcs: new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
             }
         }
 
@@ -3274,29 +3258,31 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var database = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(leaderStore.Database).ConfigureAwait(false);
                 Assert.NotNull(database);
-                database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
-                await Backup.RunBackupAsync(leaderServer, taskId, leaderStore, opStatus: OperationStatus.InProgress);
-
-                // Let's delay the backup task to 1 hour
-                var delayDuration = TimeSpan.FromHours(1);
-                var sw = Stopwatch.StartNew();
-                var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                Assert.NotNull(onGoingTaskInfo);
-                var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
-                await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
-
-                var disposingResult = await DisposeServerAndWaitForFinishOfDisposalAsync(notLeaderServer);
-                using var newServer = GetNewServer(new ServerCreationOptions
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(database.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
-                    DeletePrevious = false,
-                    RunInMemory = false,
-                    DataDirectory = disposingResult.DataDirectory,
-                    CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = disposingResult.Url }
-                });
-                Assert.NotNull(newServer);
+                    await Backup.RunBackupAsync(leaderServer, taskId, leaderStore, opStatus: OperationStatus.InProgress);
 
-                await AssertNextBackupSchedule(serverToObserve: newServer, delayDuration, databaseName, taskId, sw);
+                    // Let's delay the backup task to 1 hour
+                    var delayDuration = TimeSpan.FromHours(1);
+                    var sw = Stopwatch.StartNew();
+                    var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                    Assert.NotNull(onGoingTaskInfo);
+                    var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
+                    await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
+
+                    var disposingResult = await DisposeServerAndWaitForFinishOfDisposalAsync(notLeaderServer);
+                    using var newServer = GetNewServer(new ServerCreationOptions
+                    {
+                        DeletePrevious = false,
+                        RunInMemory = false,
+                        DataDirectory = disposingResult.DataDirectory,
+                        CustomSettings = new Dictionary<string, string> { [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = disposingResult.Url }
+                    });
+                    Assert.NotNull(newServer);
+
+                    await AssertNextBackupSchedule(serverToObserve: newServer, delayDuration, databaseName, taskId, sw);
+                }, tcs: new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
             }
         }
 
@@ -3371,47 +3357,49 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var responsibleDatabase = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(leaderStore.Database).ConfigureAwait(false);
                 Assert.NotNull(responsibleDatabase);
-                responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
-                await Backup.RunBackupInClusterAsync(leaderStore, taskId, opStatus: OperationStatus.InProgress);
-
-                // Let's delay the backup task to 1 hour
-                var delayDuration = TimeSpan.FromHours(1);
-                var sw = Stopwatch.StartNew();
-                var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                Assert.NotNull(onGoingTaskInfo);
-                var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
-                await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
-
-                // We'll check another (not leader) nodes in cluster
-                foreach (var server in nodes.Where(node => node != leaderServer))
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
-                    using (var store = new DocumentStore
-                    {
-                        Urls = new[] { server.WebUrl },
-                        Conventions = new DocumentConventions { DisableTopologyUpdates = true },
-                        Database = databaseName
-                    })
-                    {
-                        store.Initialize();
+                    await Backup.RunBackupInClusterAsync(leaderStore, taskId, opStatus: OperationStatus.InProgress);
 
-                        var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
-                        documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().BackupStatusFromMemoryOnly = true;
+                    // Let's delay the backup task to 1 hour
+                    var delayDuration = TimeSpan.FromHours(1);
+                    var sw = Stopwatch.StartNew();
+                    var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                    Assert.NotNull(onGoingTaskInfo);
+                    var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
+                    await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
 
-                        PeriodicBackupStatus inMemoryStatus = null;
-                        WaitForValue(() =>
+                    // We'll check another (not leader) nodes in cluster
+                    foreach (var server in nodes.Where(node => node != leaderServer))
+                    {
+                        using (var store = new DocumentStore
                         {
-                            inMemoryStatus = documentDatabase.PeriodicBackupRunner.GetBackupStatus(taskId);
-                            return inMemoryStatus != null;
-                        }, true);
+                            Urls = new[] { server.WebUrl },
+                            Conventions = new DocumentConventions { DisableTopologyUpdates = true },
+                            Database = databaseName
+                        })
+                        {
+                            store.Initialize();
 
-                        var nextBackupTimeSpan = inMemoryStatus.DelayUntil - DateTime.UtcNow;
-                        Assert.True(nextBackupTimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
-                                    nextBackupTimeSpan <= delayDuration,
-                            $"NextBackup in: `{nextBackupTimeSpan}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
-                            $"delayDuration: `{delayDuration}`");
+                            var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                            documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().BackupStatusFromMemoryOnly = true;
+
+                            PeriodicBackupStatus inMemoryStatus = null;
+                            WaitForValue(() =>
+                            {
+                                inMemoryStatus = documentDatabase.PeriodicBackupRunner.GetBackupStatus(taskId);
+                                return inMemoryStatus != null;
+                            }, true);
+
+                            var nextBackupTimeSpan = inMemoryStatus.DelayUntil - DateTime.UtcNow;
+                            Assert.True(nextBackupTimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
+                                        nextBackupTimeSpan <= delayDuration,
+                                $"NextBackup in: `{nextBackupTimeSpan}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
+                                $"delayDuration: `{delayDuration}`");
+                        }
                     }
-                }
+                }, tcs: new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
             }
         }
 
@@ -3438,37 +3426,39 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var responsibleDatabase = await leaderServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(leaderStore.Database).ConfigureAwait(false);
                 Assert.NotNull(responsibleDatabase);
-                responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
-                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: leaderServer.ServerStore.NodeTag);
-                var taskId = await Backup.UpdateConfigAndRunBackupAsync(leaderServer, config, leaderStore, opStatus: OperationStatus.InProgress);
-
-                // Simulate Cluster Down state
-                foreach (var node in nodes.Where(x => x != leaderServer))
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
-                    await DisposeAndRemoveServer(node);
-                }
+                    var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: leaderServer.ServerStore.NodeTag);
+                    var taskId = await Backup.UpdateConfigAndRunBackupAsync(leaderServer, config, leaderStore, opStatus: OperationStatus.InProgress);
 
-                // Let's delay the backup task to 1 hour
-                var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                Assert.NotNull(onGoingTaskInfo);
-                var delayDuration = TimeSpan.FromHours(1);
-                var sw = Stopwatch.StartNew();
-                var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
-                await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
+                    // Simulate Cluster Down state
+                    foreach (var node in nodes.Where(x => x != leaderServer))
+                    {
+                        await DisposeAndRemoveServer(node);
+                    }
 
-                // Check that there is no ongoing backup and new task scheduled properly
-                onGoingTaskInfo = null;
-                await WaitForValueAsync(async () =>
-                {
-                    onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                    return onGoingTaskInfo is { OnGoingBackup: null };
-                }, true);
-                Assert.Null(onGoingTaskInfo.LastFullBackup);
-                Assert.True(onGoingTaskInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
-                            onGoingTaskInfo.NextBackup.TimeSpan <= delayDuration,
-                    $"NextBackup in: `{onGoingTaskInfo.NextBackup.TimeSpan}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
-                    $"delayDuration: `{delayDuration}`");
+                    // Let's delay the backup task to 1 hour
+                    var onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                    Assert.NotNull(onGoingTaskInfo);
+                    var delayDuration = TimeSpan.FromHours(1);
+                    var sw = Stopwatch.StartNew();
+                    var runningBackupTaskId = onGoingTaskInfo.OnGoingBackup.RunningBackupTaskId;
+                    await leaderStore.Maintenance.SendAsync(new DelayBackupOperation(runningBackupTaskId, delayDuration));
+
+                    // Check that there is no ongoing backup and new task scheduled properly
+                    onGoingTaskInfo = null;
+                    await WaitForValueAsync(async () =>
+                    {
+                        onGoingTaskInfo = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                        return onGoingTaskInfo is { OnGoingBackup: null };
+                    }, true);
+                    Assert.Null(onGoingTaskInfo.LastFullBackup);
+                    Assert.True(onGoingTaskInfo.NextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) &&
+                                onGoingTaskInfo.NextBackup.TimeSpan <= delayDuration,
+                        $"NextBackup in: `{onGoingTaskInfo.NextBackup.TimeSpan}`, delayDuration with tolerance: `{delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}`, " +
+                        $"delayDuration: `{delayDuration}`");
+                }, tcs: new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
             }
         }
 
@@ -3484,37 +3474,39 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var database = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                 Assert.NotNull(database);
-                database.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = new TaskCompletionSource<object>();
 
-                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *");
-                var taskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store, opStatus: OperationStatus.InProgress);
-
-                // The backup task is running, and the next backup should be scheduled for the next minute (based on the backup configuration)
-                var taskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
-                Assert.NotNull(taskBackupInfo);
-                Assert.NotNull(taskBackupInfo.OnGoingBackup);
-
-                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (context.OpenReadTransaction())
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(database.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
-                    AssertNumberOfConcurrentBackups(expectedNumber: 1);
+                    var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *");
+                    var taskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store, opStatus: OperationStatus.InProgress);
 
-                    // Let's delay the backup task to 1 hour
-                    var delayDuration = TimeSpan.FromHours(1);
-                    await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
+                    // The backup task is running, and the next backup should be scheduled for the next minute (based on the backup configuration)
+                    var taskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+                    Assert.NotNull(taskBackupInfo);
+                    Assert.NotNull(taskBackupInfo.OnGoingBackup);
 
-                    AssertNumberOfConcurrentBackups(expectedNumber: 0);
-
-                    void AssertNumberOfConcurrentBackups(int expectedNumber)
+                    using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    using (context.OpenReadTransaction())
                     {
-                        int concurrentBackups = WaitForValue(() => Server.ServerStore.ConcurrentBackupsCounter.CurrentNumberOfRunningBackups,
-                            expectedVal: expectedNumber,
-                            timeout: Convert.ToInt32(TimeSpan.FromMinutes(1).TotalMilliseconds),
-                            interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
+                        AssertNumberOfConcurrentBackups(expectedNumber: 1);
 
-                        Assert.Equal(expectedNumber, concurrentBackups);
+                        // Let's delay the backup task to 1 hour
+                        var delayDuration = TimeSpan.FromHours(1);
+                        await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
+
+                        AssertNumberOfConcurrentBackups(expectedNumber: 0);
+
+                        void AssertNumberOfConcurrentBackups(int expectedNumber)
+                        {
+                            int concurrentBackups = WaitForValue(() => Server.ServerStore.ConcurrentBackupsCounter.CurrentNumberOfRunningBackups,
+                                expectedVal: expectedNumber,
+                                timeout: Convert.ToInt32(TimeSpan.FromMinutes(1).TotalMilliseconds),
+                                interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
+
+                            Assert.Equal(expectedNumber, concurrentBackups);
+                        }
                     }
-                }
+                }, tcs: new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
             }
         }
 
@@ -3539,9 +3531,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                 Assert.NotNull(documentDatabase);
-                var tcs = new TaskCompletionSource<object>();
-                documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = tcs;
-                try
+
+                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                await Backup.HoldBackupExecutionIfNeededAndInvoke(documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly(), async () =>
                 {
                     var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
                     var record1 = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
@@ -3559,7 +3551,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByOtherNodeStatus_UpdateConfigurations = false;
                     responsibleDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().SimulateActiveByCurrentNode_UpdateConfigurations = true;
                     responsibleDatabase.PeriodicBackupRunner.UpdateConfigurations(record1.PeriodicBackups);
-                    tcs.SetResult(null);
+                    tcs.TrySetResult(null);
 
                     responsibleDatabase.PeriodicBackupRunner._forTestingPurposes = null;
                     var getPeriodicBackupStatus = new GetPeriodicBackupStatusOperation(taskId);
@@ -3576,20 +3568,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     var pb2 = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.FirstOrDefault();
                     Assert.NotNull(pb2);
                     Assert.True(pb2.HasScheduledBackup(), "Completed backup didn't schedule next one.");
-                }
-                finally
-                {
-                    try
-                    {
-                        tcs.TrySetResult(null);
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
-
-                    documentDatabase.PeriodicBackupRunner.ForTestingPurposesOnly().OnBackupTaskRunHoldBackupExecution = null;
-                }
+                }, tcs);
             }
         }
 

--- a/test/SlowTests/SparrowTests/MicrosoftLogTests.cs
+++ b/test/SlowTests/SparrowTests/MicrosoftLogTests.cs
@@ -295,8 +295,8 @@ public class MicrosoftLogTests : RavenTestBase
     private class MyDummyWebSocket : WebSocket
     {
         private readonly Predicate<string> _assert;
-        private readonly TaskCompletionSource<WebSocketReceiveResult> _tcs = new TaskCompletionSource<WebSocketReceiveResult>();
-        private readonly TaskCompletionSource _checkTcs = new TaskCompletionSource();
+        private readonly TaskCompletionSource<WebSocketReceiveResult> _tcs = new TaskCompletionSource<WebSocketReceiveResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _checkTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public Task Task => _checkTcs.Task;
         
@@ -311,7 +311,7 @@ public class MicrosoftLogTests : RavenTestBase
         }
         
         public string LogsReceived { get; private set; } = "";
-        public void Close() => _tcs.SetCanceled();
+        public void Close() => _tcs.TrySetCanceled();
         public override void Abort() { }
         public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
             => Task.CompletedTask;
@@ -332,7 +332,7 @@ public class MicrosoftLogTests : RavenTestBase
             }
             catch (Exception e)
             {
-                _checkTcs.SetException(e);
+                _checkTcs.TrySetException(e);
             }
         }
         public override WebSocketCloseStatus? CloseStatus => default;

--- a/test/StressTests/Rachis/DatabaseCluster/ClusterDatabaseMaintenanceStress.cs
+++ b/test/StressTests/Rachis/DatabaseCluster/ClusterDatabaseMaintenanceStress.cs
@@ -45,7 +45,7 @@ namespace StressTests.Rachis.DatabaseCluster
                 ReplicationFactor = clusterSize
             }))
             {
-                var tcs = new TaskCompletionSource<DocumentDatabase>();
+                var tcs = new TaskCompletionSource<DocumentDatabase>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 var databaseName = store.Database;
                 using (var session = store.OpenSession())
@@ -63,7 +63,7 @@ namespace StressTests.Rachis.DatabaseCluster
                 using (new DisposableAction(() =>
                 {
                     if (preferred.ServerStore.DatabasesLandlord.DatabasesCache.TryRemove(databaseName, tcs.Task))
-                        tcs.SetCanceled();
+                        tcs.TrySetCanceled();
                 }))
                 {
                     var t = preferred.ServerStore.DatabasesLandlord.DatabasesCache.ForTestingPurposesOnly().Replace(databaseName, tcs.Task);
@@ -108,7 +108,7 @@ namespace StressTests.Rachis.DatabaseCluster
                 ReplicationFactor = clusterSize
             }))
             {
-                var tcs = new TaskCompletionSource<DocumentDatabase>();
+                var tcs = new TaskCompletionSource<DocumentDatabase>(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 var databaseName = store.Database;
                 using (var session = store.OpenSession())
@@ -129,7 +129,7 @@ namespace StressTests.Rachis.DatabaseCluster
                 using (new DisposableAction(() =>
                 {
                     if (preferred.ServerStore.DatabasesLandlord.DatabasesCache.TryRemove(databaseName, tcs.Task))
-                        tcs.SetCanceled();
+                        tcs.TrySetCanceled();
                 }))
                 {
                     var t = preferred.ServerStore.DatabasesLandlord.DatabasesCache.ForTestingPurposesOnly().Replace(databaseName, tcs.Task);

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -574,6 +574,22 @@ namespace FastTests
                     await FillDatabaseWithRandomDataAsync(databaseSizeInMb, session, (int?)timeoutTimeSpan.TotalMilliseconds);
                 }   
             }
+
+            internal async Task HoldBackupExecutionIfNeededAndInvoke(PeriodicBackupRunner.TestingStuff ts, Func<Task> func, TaskCompletionSource<object> tcs)
+            {
+                // hold backup execution 
+                try
+                {
+                    if (ts != null)
+                        ts.OnBackupTaskRunHoldBackupExecution = tcs;
+
+                    await func.Invoke();
+                }
+                finally
+                {
+                    tcs.TrySetResult(null);
+                }
+            }
         }
     }
 }

--- a/test/Tests.Infrastructure/Utils/DummyWebSocket.cs
+++ b/test/Tests.Infrastructure/Utils/DummyWebSocket.cs
@@ -45,7 +45,7 @@ namespace Tests.Infrastructure.Utils
         private void Close()
         {
             if (Interlocked.CompareExchange(ref _isClosed, 1, 0) == 0)
-                _completionSource.SetResult(Result);
+                _completionSource.TrySetResult(Result);
         }
 
         public override void Abort() { }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22108
### Additional description

* CanDelayBackupTask - in case test would start on certain time it would break the test, and we would hang forever on document database dispose.
* ShouldClearSubscriptionInfoFromStorageAfterDatabaseDeletion - subscription worker task was alive forever until the process finishes

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
