### PR TITLE
RavenDB-21846 Tombstones view: show what's blocking tombstones

### DIFF
--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -1993,6 +1993,27 @@ namespace Raven.Server.Documents
             }
         }
 
+        public IEnumerable<CounterTombstoneDetailWithCollection> GetCounterWithCollectionTombstonesFrom(DocumentsOperationContext context, string collectionName, long etag)
+        {
+            var table = new Table(CounterTombstonesSchema, context.Transaction.InnerTransaction);
+
+            foreach (var result in table.SeekForwardFrom(CounterTombstonesSchema.FixedSizeIndexes[AllCounterTombstonesEtagSlice], etag, 0))
+            {
+                var tombstoneDetail = TableValueToCounterTombstoneDetail(context, ref result.Reader);
+                var documentOrTombstone = _documentsStorage.GetDocumentOrTombstone(context, tombstoneDetail.DocumentId);
+
+                if (documentOrTombstone.Missing)
+                    continue;
+
+                string collection = documentOrTombstone.Document != null ?
+                    _documentDatabase.DocumentsStorage.ExtractCollectionName(context, documentOrTombstone.Document.Data).Name :
+                    documentOrTombstone.Tombstone.Collection;
+
+                if (collection.Equals(collectionName))
+                    yield return new CounterTombstoneDetailWithCollection(tombstoneDetail, collection);
+            }
+        }
+
         public long PurgeCountersAndCounterTombstones(DocumentsOperationContext context, string collection, long upto, long numberOfEntriesToDelete)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
@@ -2825,11 +2846,25 @@ namespace Raven.Server.Documents
         public LazyStringValue Name { get; set; }
         public long Etag { get; set; }
 
+        public CounterTombstoneDetail() { }
+
+        public CounterTombstoneDetail(LazyStringValue documentId, LazyStringValue changeVector, LazyStringValue name, long etag)
+        {
+            DocumentId = documentId;
+            ChangeVector = changeVector;
+            Name = name;
+            Etag = etag;
+        }
         public void Dispose()
         {
             DocumentId?.Dispose();
             ChangeVector?.Dispose();
             Name?.Dispose();
         }
+    }
+    public class CounterTombstoneDetailWithCollection(CounterTombstoneDetail counterTombstoneDetail, string collection)
+        : CounterTombstoneDetail(counterTombstoneDetail.DocumentId, counterTombstoneDetail.ChangeVector, counterTombstoneDetail.Name, counterTombstoneDetail.Etag)
+    {
+        public string Collection { get; private set; } = collection ?? throw new ArgumentNullException(nameof(collection));
     }
 }

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -1026,7 +1026,6 @@ namespace Raven.Server.Documents.ETL
             else if (value < old.Etag)
             {
                 old.Etag = value;
-                dic[key] = old;
             }
         }
     }

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -875,7 +875,7 @@ namespace Raven.Server.Documents.ETL
 
         public string TombstoneCleanerIdentifier => $"ETL loader for {_database.Name}";
 
-        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             var lastProcessedTombstones = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
 
@@ -883,12 +883,12 @@ namespace Raven.Server.Documents.ETL
             if (tombstoneType == ITombstoneAware.TombstoneType.TimeSeries)
             {
                 foreach (var config in ravenEtls)
-                    MarkTimeSeriesTombstonesForDeletion(config, lastProcessedTombstones);
+                    MarkTimeSeriesTombstonesForDeletion(config, lastProcessedTombstones, lastProcessedTombstonesInfo, ITombstoneAware.TombstoneDeletionBlockerType.RavenEtl);
             }
             else if (tombstoneType == ITombstoneAware.TombstoneType.Counters)
             {
                 foreach (var config in ravenEtls)
-                    MarkCounterTombstonesForDeletion(config, lastProcessedTombstones);
+                    MarkCounterTombstonesForDeletion(config, lastProcessedTombstones, lastProcessedTombstonesInfo, ITombstoneAware.TombstoneDeletionBlockerType.RavenEtl);
             }
             else
             {
@@ -896,13 +896,13 @@ namespace Raven.Server.Documents.ETL
                 var elasticSearchEtls = _databaseRecord.ElasticSearchEtls;
 
                 foreach (var config in ravenEtls)
-                    MarkDocumentTombstonesForDeletion(config, lastProcessedTombstones);
+                    MarkDocumentTombstonesForDeletion(config, lastProcessedTombstones, lastProcessedTombstonesInfo, ITombstoneAware.TombstoneDeletionBlockerType.RavenEtl);
 
                 foreach (var config in sqlEtls)
-                    MarkDocumentTombstonesForDeletion(config, lastProcessedTombstones);
+                    MarkDocumentTombstonesForDeletion(config, lastProcessedTombstones, lastProcessedTombstonesInfo, ITombstoneAware.TombstoneDeletionBlockerType.SqlEtl);
 
                 foreach (var config in elasticSearchEtls)
-                    MarkDocumentTombstonesForDeletion(config, lastProcessedTombstones);
+                    MarkDocumentTombstonesForDeletion(config, lastProcessedTombstones, lastProcessedTombstonesInfo, ITombstoneAware.TombstoneDeletionBlockerType.ElasticSearchEtl);
             }
             return lastProcessedTombstones;
         }
@@ -944,7 +944,8 @@ namespace Raven.Server.Documents.ETL
             return dict;
         }
 
-        private void MarkDocumentTombstonesForDeletion<T>(EtlConfiguration<T> config, Dictionary<string, long> lastProcessedTombstones) where T : ConnectionString
+        private void MarkDocumentTombstonesForDeletion<T>(EtlConfiguration<T> config, Dictionary<string, long> lastProcessedTombstones,
+            Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo, ITombstoneAware.TombstoneDeletionBlockerType type) where T : ConnectionString
         {
             foreach (var transform in config.Transforms)
             {
@@ -955,21 +956,29 @@ namespace Raven.Server.Documents.ETL
                 if (transform.ApplyToAllDocuments)
                 {
                     AddOrUpdate(lastProcessedTombstones, Constants.Documents.Collections.AllDocumentsCollection, etag);
+                    AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, Constants.Documents.Collections.AllDocumentsCollection, etag, type);
                     continue;
                 }
 
                 foreach (var collection in transform.Collections)
+                {
                     AddOrUpdate(lastProcessedTombstones, collection, etag);
+                    AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, collection, etag, type);
+                }
 
                 if (typeof(T) == typeof(RavenConnectionString))
                 {
                     if (RavenEtl.ShouldTrackAttachmentTombstones(transform))
+                    {
                         AddOrUpdate(lastProcessedTombstones, AttachmentsStorage.AttachmentsTombstones, etag);
+                        AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, AttachmentsStorage.AttachmentsTombstones, etag, type);
+                    }
                 }
             }
         }
 
-        private void MarkTimeSeriesTombstonesForDeletion<T>(EtlConfiguration<T> config, Dictionary<string, long> lastProcessedTombstones) where T : ConnectionString
+        private void MarkTimeSeriesTombstonesForDeletion<T>(EtlConfiguration<T> config, Dictionary<string, long> lastProcessedTombstones,
+            Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo, ITombstoneAware.TombstoneDeletionBlockerType type) where T : ConnectionString
         {
             foreach (var transform in config.Transforms)
             {
@@ -977,10 +986,12 @@ namespace Raven.Server.Documents.ETL
                 var etag = ChangeVectorUtils.GetEtagById(state.ChangeVector, _database.DbBase64Id);
 
                 AddOrUpdate(lastProcessedTombstones, Constants.TimeSeries.All, etag);
+                AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, Constants.TimeSeries.All, etag, type);
             }
         }
 
-        private void MarkCounterTombstonesForDeletion<T>(EtlConfiguration<T> config, Dictionary<string, long> lastProcessedTombstones) where T : ConnectionString
+        private void MarkCounterTombstonesForDeletion<T>(EtlConfiguration<T> config, Dictionary<string, long> lastProcessedTombstones,
+            Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo, ITombstoneAware.TombstoneDeletionBlockerType type) where T : ConnectionString
         {
             foreach (var transform in config.Transforms)
             {
@@ -988,6 +999,7 @@ namespace Raven.Server.Documents.ETL
                 var etag = ChangeVectorUtils.GetEtagById(state.ChangeVector, _database.DbBase64Id);
 
                 AddOrUpdate(lastProcessedTombstones, Constants.Counters.All, etag);
+                AddOrUpdateInfo(lastProcessedTombstonesInfo, config.Name, Constants.Counters.All, etag, type);
             }
         }
 
@@ -1001,6 +1013,21 @@ namespace Raven.Server.Documents.ETL
 
             var min = Math.Min(value, old);
             dic[key] = min;
+        }
+        private void AddOrUpdateInfo(Dictionary<string, LastTombstoneInfo> dic, string name, string collection, long value, ITombstoneAware.TombstoneDeletionBlockerType type)
+        {
+            if (dic == null)
+                return;
+            var key = $"{name}/{collection}";
+            if (dic.TryGetValue(key, out var old) == false)
+            {
+                dic[key] = new LastTombstoneInfo(name, collection, value, type);
+            }
+            else if (value < old.Etag)
+            {
+                old.Etag = value;
+                dic[key] = old;
+            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
@@ -93,7 +93,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                     writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.PerSubscriptionInfo));
                     writer.WriteStartArray();
-                    if (state.PerSubscriptionInfo != null)
+                    if (state.PerSubscriptionInfoExtended != null)
                     {
                         var first = true;
 
@@ -117,6 +117,51 @@ namespace Raven.Server.Documents.Handlers.Admin
                             writer.WriteComma();
                             writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfo.Etag));
                             writer.WriteInteger(info.Etag);
+
+                            writer.WriteEndObject();
+                        }
+                    }
+                    writer.WriteEndArray();
+                    writer.WriteComma();
+
+                    writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.PerSubscriptionInfoExtended));
+                    writer.WriteStartArray();
+                    if (state.PerSubscriptionInfoExtended != null)
+                    {
+                        var first = true;
+
+                        foreach (var info in state.PerSubscriptionInfoExtended)
+                        {
+                            if (first == false)
+                                writer.WriteComma();
+
+                            first = false;
+
+                            writer.WriteStartObject();
+
+                            writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfo.Identifier));
+                            writer.WriteString(info.Value.Identifier);
+                            writer.WriteComma();
+                            writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfo.Type));
+                            writer.WriteString(info.Value.Type.ToString());
+                            writer.WriteComma();
+                            writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfo.Collection));
+                            writer.WriteString(info.Value.Collection);
+                            writer.WriteComma();
+                            writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfo.Etag));
+                            writer.WriteInteger(info.Value.Etag);
+                            writer.WriteComma();
+                            writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfoExtended.NumberOfTombstoneLeft));
+                            writer.WriteInteger(info.Value.NumberOfTombstoneLeft);
+                            writer.WriteComma();
+                            writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfoExtended.Types));
+                            context.Write(writer, info.Value.Types?.ToJson());
+                            writer.WriteComma();
+                            writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfoExtended.CleanupStatus));
+                            writer.WriteString(info.Value.CleanupStatus.ToString());
+                            writer.WriteComma();
+                            writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfoExtended.Process));
+                            writer.WriteString(info.Value.Process.ToString());
 
                             writer.WriteEndObject();
                         }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
@@ -157,8 +157,8 @@ namespace Raven.Server.Documents.Handlers.Admin
                             writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfoExtended.Types));
                             context.Write(writer, info.Value.Types?.ToJson());
                             writer.WriteComma();
-                            writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfoExtended.CleanupStatus));
-                            writer.WriteString(info.Value.CleanupStatus.ToString());
+                            writer.WritePropertyName("CleanupStatus");
+                            writer.WriteString(info.Value.NumberOfTombstoneLeft > 0 ? "Blocking" : "Not Blocking");
                             writer.WriteComma();
                             writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfoExtended.Process));
                             writer.WriteString(info.Value.Process.ToString());

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
@@ -93,7 +93,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                     writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.PerSubscriptionInfo));
                     writer.WriteStartArray();
-                    if (state.PerSubscriptionInfoExtended != null)
+                    if (state.PerSubscriptionInfo != null)
                     {
                         var first = true;
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4164,7 +4164,7 @@ namespace Raven.Server.Documents.Indexes
 
         public string BlockingSourceName => TombstoneCleanerIdentifier;
 
-        public virtual Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public virtual Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             if (tombstoneType != ITombstoneAware.TombstoneType.Documents)
                 return null;
@@ -4175,7 +4175,7 @@ namespace Raven.Server.Documents.Indexes
                 {
                     using (var tx = context.OpenReadTransaction())
                     {
-                        return GetLastProcessedDocumentTombstonesPerCollection(tx);
+                        return GetLastProcessedDocumentTombstonesPerCollection(tx, lastProcessedTombstonesInfo);
                     }
                 }
             }
@@ -4194,12 +4194,14 @@ namespace Raven.Server.Documents.Indexes
             return dict;
         }
 
-        internal Dictionary<string, long> GetLastProcessedDocumentTombstonesPerCollection(RavenTransaction tx)
+        internal Dictionary<string, long> GetLastProcessedDocumentTombstonesPerCollection(RavenTransaction tx, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             var etags = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
             foreach (var collection in Collections)
             {
-                etags[collection] = _indexStorage.ReadLastProcessedTombstoneEtag(tx, collection);
+                var lastEtag = _indexStorage.ReadLastProcessedTombstoneEtag(tx, collection);
+                etags[collection] = lastEtag;
+                lastProcessedTombstonesInfo?.Add($"{Name}/{collection}", new LastTombstoneInfo(Name, collection, lastEtag, ITombstoneAware.TombstoneDeletionBlockerType.Index));
             }
 
             return etags;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -377,7 +377,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             return new StaticIndexItemEnumerator<DynamicBlittableJson>(items, filter: null, _compiled.Maps[collection], collection, stats, type);
         }
 
-        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             if (tombstoneType != ITombstoneAware.TombstoneType.Documents)
                 return null;
@@ -385,7 +385,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             using (CurrentlyInUse())
             {
                 return StaticIndexHelper.GetLastProcessedDocumentTombstonesPerCollection(
-                    this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage);
+                    this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage, lastProcessedTombstonesInfo);
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
@@ -260,14 +260,14 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             progressStats.TotalNumberOfItems += totalNumberOfItems;
         }
 
-        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             if (tombstoneType == ITombstoneAware.TombstoneType.Documents)
             {
                 using (CurrentlyInUse())
                 {
                     return StaticIndexHelper.GetLastProcessedDocumentTombstonesPerCollection(
-                        this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage);
+                        this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage, lastProcessedTombstonesInfo);
                 }
             }
 
@@ -275,7 +275,7 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             {
                 using (CurrentlyInUse())
                 {
-                    return StaticIndexHelper.GetLastProcessedEtagsPerCollection(this, Collections, _indexStorage);
+                    return StaticIndexHelper.GetLastProcessedEtagsPerCollection(this, Collections, _indexStorage, lastProcessedTombstonesInfo);
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
@@ -140,14 +140,14 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             progressStats.TotalNumberOfItems += totalCount;
         }
 
-        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             if (tombstoneType == ITombstoneAware.TombstoneType.Documents)
             {
                 using (CurrentlyInUse())
                 {
                     return StaticIndexHelper.GetLastProcessedDocumentTombstonesPerCollection(
-                        this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage);
+                        this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage, lastProcessedTombstonesInfo);
                 }
             }
 
@@ -155,7 +155,7 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             {
                 using (CurrentlyInUse())
                 {
-                    return StaticIndexHelper.GetLastProcessedEtagsPerCollection(this, Collections, _indexStorage);
+                    return StaticIndexHelper.GetLastProcessedEtagsPerCollection(this, Collections, _indexStorage, lastProcessedTombstonesInfo);
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -180,7 +180,7 @@ namespace Raven.Server.Documents.Indexes.Static
             return new StaticIndexItemEnumerator<DynamicBlittableJson>(items, filter: null, _compiled.Maps[collection], collection, stats, type);
         }
 
-        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             if (tombstoneType != ITombstoneAware.TombstoneType.Documents)
                 return null;
@@ -188,7 +188,7 @@ namespace Raven.Server.Documents.Indexes.Static
             using (CurrentlyInUse())
             {
                 return StaticIndexHelper.GetLastProcessedDocumentTombstonesPerCollection(
-                    this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage);
+                    this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage, lastProcessedTombstonesInfo);
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
@@ -67,14 +67,14 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             return new StaticIndexItemEnumerator<DynamicTimeSeriesSegment>(items, filter: null, _compiled.Maps[collection], collection, stats, type);
         }
 
-        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             if (tombstoneType == ITombstoneAware.TombstoneType.Documents)
             {
                 using (CurrentlyInUse())
                 {
                     return StaticIndexHelper.GetLastProcessedDocumentTombstonesPerCollection(
-                        this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage);
+                        this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage, lastProcessedTombstonesInfo);
                 }
             }
 
@@ -82,7 +82,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             {
                 using (CurrentlyInUse())
                 {
-                    return StaticIndexHelper.GetLastProcessedEtagsPerCollection(this, Collections, _indexStorage);
+                    return StaticIndexHelper.GetLastProcessedEtagsPerCollection(this, Collections, _indexStorage, lastProcessedTombstonesInfo);
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
@@ -226,14 +226,14 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             return new TimeSeriesDeletedRangeIndexItem(tombstone.Key, tombstone.DocId, tombstone.Etag, tombstone.Name, sizeof(long) * 2, tombstone);
         }
 
-        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             if (tombstoneType == ITombstoneAware.TombstoneType.Documents)
             {
                 using (CurrentlyInUse())
                 {
                     return StaticIndexHelper.GetLastProcessedDocumentTombstonesPerCollection(
-                        this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage);
+                        this, _referencedCollections, Collections, _compiled.ReferencedCollections, _indexStorage, lastProcessedTombstonesInfo);
                 }
             }
 
@@ -241,7 +241,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             {
                 using (CurrentlyInUse())
                 {
-                    return StaticIndexHelper.GetLastProcessedEtagsPerCollection(this, Collections, _indexStorage);
+                    return StaticIndexHelper.GetLastProcessedEtagsPerCollection(this, Collections, _indexStorage, lastProcessedTombstonesInfo);
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
+++ b/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Raven.Client;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.Persistence;
-using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Indexes.Static.Counters;
 using Raven.Server.Documents.Indexes.Static.TimeSeries;
@@ -262,12 +260,12 @@ namespace Raven.Server.Documents.Indexes
         public static Dictionary<string, long> GetLastProcessedDocumentTombstonesPerCollection(
             Index index, HashSet<string> referencedCollections, IEnumerable<string> collections,
             Dictionary<string, HashSet<CollectionName>> compiledReferencedCollections,
-            IndexStorage indexStorage)
+            IndexStorage indexStorage, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             using (index._contextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = context.OpenReadTransaction())
             {
-                var etags = index.GetLastProcessedDocumentTombstonesPerCollection(tx);
+                var etags = index.GetLastProcessedDocumentTombstonesPerCollection(tx, lastProcessedTombstonesInfo);
 
                 if (referencedCollections.Count <= 0)
                     return etags;
@@ -281,13 +279,21 @@ namespace Raven.Server.Documents.Indexes
                     {
                         var etag = indexStorage.ReferencesForDocuments.ReadLastProcessedReferenceTombstoneEtag(tx.InnerTransaction, collection, collectionName);
                         if (etags.TryGetValue(collectionName.Name, out long currentEtag) == false || etag < currentEtag)
+                        {
                             etags[collectionName.Name] = etag;
+                            if (lastProcessedTombstonesInfo != null)
+                            {
+                                lastProcessedTombstonesInfo[$"{index.Name}/{collection}"] =
+                                    new LastTombstoneInfo(index.Name, collection, etag, ITombstoneAware.TombstoneDeletionBlockerType.Index);
+                            }
+                        }
                     }
                 }
 
                 return etags;
             }
         }
+
 
         public static (long? LastProcessedCompareExchangeReferenceEtag, long? LastProcessedCompareExchangeReferenceTombstoneEtag) GetLastProcessedCompareExchangeReferenceEtags(Index index, AbstractStaticIndexBase compiled, TransactionOperationContext indexContext)
         {
@@ -309,7 +315,7 @@ namespace Raven.Server.Documents.Indexes
             return (lastProcessedCompareExchangeReferenceEtag, lastProcessedCompareExchangeReferenceTombstoneEtag);
         }
 
-        internal static Dictionary<string, long> GetLastProcessedEtagsPerCollection(Index index, HashSet<string> collections, IndexStorage indexStorage)
+        internal static Dictionary<string, long> GetLastProcessedEtagsPerCollection(Index index, HashSet<string> collections, IndexStorage indexStorage, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             using (index._contextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (var tx = context.OpenReadTransaction())
@@ -317,7 +323,9 @@ namespace Raven.Server.Documents.Indexes
                 var etags = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
                 foreach (var collection in collections)
                 {
-                    etags[collection] = indexStorage.ReadLastIndexedEtag(tx, collection);
+                    var lastEtag = indexStorage.ReadLastIndexedEtag(tx, collection);
+                    etags[collection] = lastEtag;
+                    lastProcessedTombstonesInfo?.Add($"{index.Name}/{collection}", new LastTombstoneInfo(index.Name, collection, lastEtag, ITombstoneAware.TombstoneDeletionBlockerType.Index));
                 }
 
                 return etags;

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -621,7 +621,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
         }
 
-        private long GetMinLastEtag()
+        private long GetMinLastEtag(Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null, string collection = null)
         {
             var min = long.MaxValue;
 
@@ -641,9 +641,11 @@ namespace Raven.Server.Documents.PeriodicBackup
                     if (status == null)
                     {
                         // if there is no status for this, we don't need to take into account tombstones
+                        lastProcessedTombstonesInfo?.Add($"{config.Name}/{collection}", new LastTombstoneInfo(config.Name, collection, 0, ITombstoneAware.TombstoneDeletionBlockerType.Backup));
                         return 0; // cannot delete the tombstones until we've done a full backup
                     }
                     var etag = ChangeVectorUtils.GetEtagById(status.LastDatabaseChangeVector, _database.DbBase64Id);
+                    lastProcessedTombstonesInfo?.Add($"{config.Name}/{collection}", new LastTombstoneInfo(config.Name, collection, etag, ITombstoneAware.TombstoneDeletionBlockerType.Backup));
                     min = Math.Min(etag, min);
                 }
 
@@ -999,28 +1001,22 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         public string TombstoneCleanerIdentifier => "Periodic Backup";
 
-        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
-            var minLastEtag = GetMinLastEtag();
+            string collection = tombstoneType switch
+            {
+                ITombstoneAware.TombstoneType.Documents => Constants.Documents.Collections.AllDocumentsCollection,
+                ITombstoneAware.TombstoneType.TimeSeries => Constants.TimeSeries.All,
+                ITombstoneAware.TombstoneType.Counters => Constants.Counters.All,
+                _ => throw new NotSupportedException($"Tombstone type '{tombstoneType}' is not supported.")
+            };
+
+            var minLastEtag = GetMinLastEtag(lastProcessedTombstonesInfo, collection);
 
             if (minLastEtag == long.MaxValue)
                 return null;
 
-            var result = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
-            switch (tombstoneType)
-            {
-                case ITombstoneAware.TombstoneType.Documents:
-                    result.Add(Constants.Documents.Collections.AllDocumentsCollection, minLastEtag);
-                    break;
-                case ITombstoneAware.TombstoneType.TimeSeries:
-                    result.Add(Constants.TimeSeries.All, minLastEtag);
-                    break;
-                case ITombstoneAware.TombstoneType.Counters:
-                    result.Add(Constants.Counters.All, minLastEtag);
-                    break;
-                default:
-                    throw new NotSupportedException($"Tombstone type '{tombstoneType}' is not supported.");
-            }
+            var result = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase) { { collection, minLastEtag } };
 
             return result;
         }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -127,7 +127,7 @@ namespace Raven.Server.Documents.Replication
                         var state = GetExternalReplicationState(_server, Database.Name, external.TaskId, ctx);
                         var myEtag = ChangeVectorUtils.GetEtagById(state.DestinationChangeVector, Database.DbBase64Id);
                         minEtag = Math.Min(myEtag, minEtag);
-                        lastProcessedTombstonesInfo?.Add(external.Name, new LastTombstoneInfo(external.Name, collection, myEtag, ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication));
+                        AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, external.Name, myEtag, ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication);
                     }
                 }
             }
@@ -150,7 +150,21 @@ namespace Raven.Server.Documents.Replication
             {
                 replicationNodes.Remove(lastEtagPerDestination.Key);
                 minEtag = Math.Min(lastEtagPerDestination.Value.LastEtag, minEtag);
-                lastProcessedTombstonesInfo?.Add(lastEtagPerDestination.Key.Url, new LastTombstoneInfo(lastEtagPerDestination.Key.Url, collection, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.InternalReplication));
+                switch (lastEtagPerDestination.Key)
+                {
+                    case PullReplicationAsHub pullReplicationAsHub:
+                        AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, pullReplicationAsHub.Name, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsHub);
+                        break;
+                    case PullReplicationAsSink pullReplicationAsSink:
+                        AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, pullReplicationAsSink.Name, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsSink);
+                        break;
+                    case ExternalReplication externalReplication:
+                        AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, externalReplication.Name, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication);
+                        break;
+                    case InternalReplication internalReplication:
+                        AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, internalReplication.NodeTag, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.InternalReplication);
+                        break;
+                }
             }
 
             if (replicationNodes.Count > 0)
@@ -163,13 +177,26 @@ namespace Raven.Server.Documents.Replication
 
                 foreach (var node in replicationNodes)
                 {
-                    lastProcessedTombstonesInfo.Add(node.Url, new LastTombstoneInfo(node.Url, collection, 0, ITombstoneAware.TombstoneDeletionBlockerType.InternalReplication));
+                    AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, ((InternalReplication)node).NodeTag, 0, ITombstoneAware.TombstoneDeletionBlockerType.InternalReplication);
                 }
 
                 return 0;
             }
 
             return minEtag;
+        }
+
+        private static void AddOrUpdateLastEtag(Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo, string collection, string name, long etag, ITombstoneAware.TombstoneDeletionBlockerType type)
+        {
+            if (lastProcessedTombstonesInfo?.TryGetValue(name, out LastTombstoneInfo info) == true)
+            {
+                info.Etag = Math.Min(etag, info.Etag);
+                lastProcessedTombstonesInfo[name] = info;
+            }
+            else
+            {
+                lastProcessedTombstonesInfo?.Add(name, new LastTombstoneInfo(name, collection, etag, type));
+            }
         }
 
         public long GetMinimalEtagForTombstoneCleanupWithHubReplication(Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null, string collection = null)

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -150,20 +150,20 @@ namespace Raven.Server.Documents.Replication
             {
                 replicationNodes.Remove(lastEtagPerDestination.Key);
                 minEtag = Math.Min(lastEtagPerDestination.Value.LastEtag, minEtag);
-                switch (lastEtagPerDestination.Key)
+                if (lastProcessedTombstonesInfo != null)
                 {
-                    case PullReplicationAsHub pullReplicationAsHub:
-                        AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, pullReplicationAsHub.Name, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsHub);
-                        break;
-                    case PullReplicationAsSink pullReplicationAsSink:
-                        AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, pullReplicationAsSink.Name, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsSink);
-                        break;
-                    case ExternalReplication externalReplication:
-                        AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, externalReplication.Name, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication);
-                        break;
-                    case InternalReplication internalReplication:
-                        AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, internalReplication.NodeTag, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.InternalReplication);
-                        break;
+                    switch (lastEtagPerDestination.Key)
+                    {
+                        case PullReplicationAsSink pullReplicationAsSink:
+                            AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, pullReplicationAsSink.Name, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsSink);
+                            break;
+                        case ExternalReplication externalReplication and not PullReplicationAsHub:
+                            AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, externalReplication.Name, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication);
+                            break;
+                        case InternalReplication internalReplication:
+                            AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, internalReplication.NodeTag, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.InternalReplication);
+                            break;
+                    }
                 }
             }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -109,7 +109,7 @@ namespace Raven.Server.Documents.Replication
         private readonly ConcurrentDictionary<ReplicationNode, LastEtagPerDestination> _lastSendEtagPerDestination =
             new ConcurrentDictionary<ReplicationNode, LastEtagPerDestination>();
 
-        public long GetMinimalEtagForReplication()
+        public long GetMinimalEtagForReplication(Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null, string collection = null)
         {
             DatabaseTopology topology;
             long minEtag = long.MaxValue;
@@ -127,6 +127,7 @@ namespace Raven.Server.Documents.Replication
                         var state = GetExternalReplicationState(_server, Database.Name, external.TaskId, ctx);
                         var myEtag = ChangeVectorUtils.GetEtagById(state.DestinationChangeVector, Database.DbBase64Id);
                         minEtag = Math.Min(myEtag, minEtag);
+                        lastProcessedTombstonesInfo?.Add(external.Name, new LastTombstoneInfo(external.Name, collection, myEtag, ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication));
                     }
                 }
             }
@@ -149,6 +150,7 @@ namespace Raven.Server.Documents.Replication
             {
                 replicationNodes.Remove(lastEtagPerDestination.Key);
                 minEtag = Math.Min(lastEtagPerDestination.Value.LastEtag, minEtag);
+                lastProcessedTombstonesInfo?.Add(lastEtagPerDestination.Key.Url, new LastTombstoneInfo(lastEtagPerDestination.Key.Url, collection, lastEtagPerDestination.Value.LastEtag, ITombstoneAware.TombstoneDeletionBlockerType.InternalReplication));
             }
 
             if (replicationNodes.Count > 0)
@@ -156,14 +158,23 @@ namespace Raven.Server.Documents.Replication
                 // if we don't have information from all our destinations, we don't know what tombstones
                 // we can remove. Note that this explicitly _includes_ disabled destinations, which prevents
                 // us from doing any tombstone cleanup.
+                if (lastProcessedTombstonesInfo == null)
+                    return 0;
+
+                foreach (var node in replicationNodes)
+                {
+                    lastProcessedTombstonesInfo.Add(node.Url, new LastTombstoneInfo(node.Url, collection, 0, ITombstoneAware.TombstoneDeletionBlockerType.InternalReplication));
+                }
+
                 return 0;
             }
 
             return minEtag;
         }
 
-        public long GetMinimalEtagForTombstoneCleanupWithHubReplication()
+        public long GetMinimalEtagForTombstoneCleanupWithHubReplication(Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null, string collection = null)
         {
+            const string hubReplicationKey = "Hub Replication";
             long minEtag = long.MaxValue;
 
             using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
@@ -176,7 +187,10 @@ namespace Raven.Server.Documents.Replication
                 var lastCleanUp = _hubInfoForCleaner?.LastCleanup ?? DateTime.MinValue;
                 if (lastCleanUp.AddMinutes(time) > Database.Time.GetUtcNow())
                 {
-                    return _hubInfoForCleaner?.LastEtag ?? minEtag;
+                    var etag = _hubInfoForCleaner?.LastEtag ?? minEtag;
+                    lastProcessedTombstonesInfo?.Add(hubReplicationKey, new LastTombstoneInfo(hubReplicationKey, collection, etag, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsHub));
+
+                    return etag;
                 }
             }
 
@@ -197,6 +211,7 @@ namespace Raven.Server.Documents.Replication
                 {
                     //All tombstones can be deleted
                     Interlocked.Exchange(ref _hubInfoForCleaner, new HubInfoForCleaner { LastCleanup = Database.Time.GetUtcNow(), LastEtag = max });
+                    lastProcessedTombstonesInfo?.Add(hubReplicationKey, new LastTombstoneInfo(hubReplicationKey, collection, max, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsHub));
                     return max;
                 }
 
@@ -207,6 +222,7 @@ namespace Raven.Server.Documents.Replication
                 {
                     // Can't delete tombstones yet
                     Interlocked.Exchange(ref _hubInfoForCleaner, new HubInfoForCleaner { LastCleanup = Database.Time.GetUtcNow(), LastEtag = minTombstone.Etag - 1 });
+                    lastProcessedTombstonesInfo?.Add(hubReplicationKey, new LastTombstoneInfo(hubReplicationKey, collection, minTombstone.Etag - 1, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsHub));
                     return minTombstone.Etag - 1;
                 }
                 var oldEtag = -1L;
@@ -217,6 +233,7 @@ namespace Raven.Server.Documents.Replication
                     if (newEtag == oldEtag)
                     {
                         Interlocked.Exchange(ref _hubInfoForCleaner, new HubInfoForCleaner { LastCleanup = Database.Time.GetUtcNow(), LastEtag = min });
+                        lastProcessedTombstonesInfo?.Add(hubReplicationKey, new LastTombstoneInfo(hubReplicationKey, collection, min, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsHub));
                         return min;
                     }
 
@@ -230,6 +247,7 @@ namespace Raven.Server.Documents.Replication
                         if (newTombstone.Etag == min)
                         {
                             Interlocked.Exchange(ref _hubInfoForCleaner, new HubInfoForCleaner { LastCleanup = Database.Time.GetUtcNow(), LastEtag = min });
+                            lastProcessedTombstonesInfo?.Add(hubReplicationKey, new LastTombstoneInfo(hubReplicationKey, collection, min, ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsHub));
                             return min;
                         }
                     }
@@ -1875,27 +1893,24 @@ namespace Raven.Server.Documents.Replication
 
         public event Action<ReplicationNode, IncomingReplicationFailureToConnectReporter> IncomingReplicationConnectionErrored;
 
-        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
-            var minEtag = Math.Min(GetMinimalEtagForTombstoneCleanupWithHubReplication(), GetMinimalEtagForReplication());
+            string collection = tombstoneType switch
+            {
+                ITombstoneAware.TombstoneType.Documents => Constants.Documents.Collections.AllDocumentsCollection,
+                ITombstoneAware.TombstoneType.TimeSeries => Constants.TimeSeries.All,
+                ITombstoneAware.TombstoneType.Counters => Constants.Counters.All,
+                _ => throw new NotSupportedException($"Tombstone type '{tombstoneType}' is not supported.")
+            };
+
+            var minEtag = Math.Min(GetMinimalEtagForTombstoneCleanupWithHubReplication(lastProcessedTombstonesInfo, collection), GetMinimalEtagForReplication(lastProcessedTombstonesInfo, collection));
             if (minEtag == long.MaxValue)
                 return null;
 
             var result = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
-            switch (tombstoneType)
-            {
-                case ITombstoneAware.TombstoneType.Documents:
-                    result.Add(Constants.Documents.Collections.AllDocumentsCollection, minEtag);
-                    break;
-                case ITombstoneAware.TombstoneType.TimeSeries:
-                    result.Add(Constants.TimeSeries.All, minEtag);
-                    break;
-                case ITombstoneAware.TombstoneType.Counters:
-                    result.Add(Constants.Counters.All, minEtag);
-                    break;
-                default:
-                    throw new NotSupportedException($"Tombstone type '{tombstoneType}' is not supported.");
-            }
+
+            result.Add(collection, minEtag);
+
 
             if (Destinations == null)
                 return result;

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -391,7 +391,7 @@ namespace Raven.Server.Documents
                     }
                     else
                     {
-                        var newSubscriptionInfo = CreateSubscriptionInfo(subscription, type, tombstoneInfo.Value, collection, numberOfTombstonesLeft);
+                        var newSubscriptionInfo = CreateSubscriptionInfo(type, tombstoneInfo.Value, collection, numberOfTombstonesLeft);
                         PerSubscriptionInfoExtended[key] = newSubscriptionInfo;
                     }
                 }
@@ -400,6 +400,9 @@ namespace Raven.Server.Documents
             private long CalculateRemainingTombstones(LastTombstoneInfo tombstoneInfo, ITombstoneAware.TombstoneType type, DocumentDatabase documentDatabase,
                 string collection)
             {
+                if (tombstoneInfo.Type == ITombstoneAware.TombstoneDeletionBlockerType.Index && type != ITombstoneAware.TombstoneType.Documents)
+                    return 0;
+
                 using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
@@ -425,10 +428,6 @@ namespace Raven.Server.Documents
             {
                 SetTombstoneTypes(type, subscriptionInfo, remainingTombstones);
                 subscriptionInfo.NumberOfTombstoneLeft += remainingTombstones;
-                if (subscriptionInfo.CleanupStatus == CleanupStatus.NotBlocking)
-                {
-                    subscriptionInfo.CleanupStatus = subscriptionInfo.NumberOfTombstoneLeft > 0 ? CleanupStatus.Blocking : CleanupStatus.NotBlocking;
-                }
             }
 
             private void SetTombstoneTypes(ITombstoneAware.TombstoneType type, SubscriptionInfoExtended subscriptionInfo, long numberOfTombstoneLeft)
@@ -468,8 +467,6 @@ namespace Raven.Server.Documents
 
                 public long NumberOfTombstoneLeft { get; set; }
 
-                public CleanupStatus CleanupStatus { get; set; }
-
                 public TombstoneTypes Types { get; set; }
             }
 
@@ -487,7 +484,7 @@ namespace Raven.Server.Documents
                 }
             }
 
-            private SubscriptionInfoExtended CreateSubscriptionInfo(ITombstoneAware subscription, ITombstoneAware.TombstoneType type, LastTombstoneInfo tombstoneInfo, string collection,
+            private SubscriptionInfoExtended CreateSubscriptionInfo(ITombstoneAware.TombstoneType type, LastTombstoneInfo tombstoneInfo, string collection,
                 long remainingTombstones)
             {
                 var newSubscriptionInfo = new SubscriptionInfoExtended
@@ -497,7 +494,6 @@ namespace Raven.Server.Documents
                     Collection = collection,
                     Etag = tombstoneInfo.Etag,
                     NumberOfTombstoneLeft = remainingTombstones,
-                    CleanupStatus = remainingTombstones > 0 ? CleanupStatus.Blocking : CleanupStatus.NotBlocking,
                     Types = new TombstoneTypes()
                 };
                 SetTombstoneTypes(type, newSubscriptionInfo, remainingTombstones);

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -4,13 +4,14 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
 using Raven.Client;
-using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Raven.Client.Util;
 using Raven.Server.Background;
 using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 
 namespace Raven.Server.Documents
@@ -218,7 +219,11 @@ namespace Raven.Server.Documents
                 {
                     foreach (var tombstoneType in _tombstoneTypes)
                     {
-                        var subscriptionTombstones = subscription.GetLastProcessedTombstonesPerCollection(tombstoneType);
+                        Dictionary<string, LastTombstoneInfo> lastTombstoneInfo = null;
+                        if (addInfoForDebug)
+                            lastTombstoneInfo = new Dictionary<string, LastTombstoneInfo>();
+
+                        var subscriptionTombstones = subscription.GetLastProcessedTombstonesPerCollection(tombstoneType, lastTombstoneInfo);
                         if (subscriptionTombstones == null)
                             continue;
 
@@ -254,6 +259,9 @@ namespace Raven.Server.Documents
                                 state.Etag = tombstone.Value;
                             }
                         }
+
+                        if (addInfoForDebug)
+                            result.AddPerSubscriptionInfoExtended(subscription, lastTombstoneInfo, tombstoneType, _documentDatabase);
                     }
                 }
 
@@ -350,16 +358,97 @@ namespace Raven.Server.Documents
 
             public List<SubscriptionInfo> PerSubscriptionInfo;
 
+            public readonly Dictionary<string, SubscriptionInfoExtended> PerSubscriptionInfoExtended = new(StringComparer.OrdinalIgnoreCase);
+
             public void AddPerSubscriptionInfo(string identifier, ITombstoneAware.TombstoneType type, string collection, long etag)
             {
                 PerSubscriptionInfo ??= new List<SubscriptionInfo>();
-                PerSubscriptionInfo.Add(new SubscriptionInfo
+                PerSubscriptionInfo.Add(new SubscriptionInfo { Identifier = identifier, Type = type, Collection = collection, Etag = etag });
+
+            }
+
+            internal void AddPerSubscriptionInfoExtended(ITombstoneAware subscription, Dictionary<string, LastTombstoneInfo> lastTombstoneInfo, ITombstoneAware.TombstoneType type,
+                DocumentDatabase documentDatabase)
+            {
+                foreach (var tombstoneInfo in lastTombstoneInfo)
                 {
-                    Identifier = identifier,
-                    Type = type,
-                    Collection = collection,
-                    Etag = etag
-                });
+                    var collection = tombstoneInfo.Value.Collection;
+
+                    if (tombstoneInfo.Value.Collection == Constants.TimeSeries.All ||
+                        tombstoneInfo.Value.Collection == Constants.Documents.Collections.AllDocumentsCollection ||
+                        tombstoneInfo.Value.Collection == Constants.Counters.All)
+                    {
+                        collection = string.Empty;
+                    }
+
+                    long numberOfTombstonesLeft = CalculateRemainingTombstones(tombstoneInfo.Value, type, documentDatabase, collection);
+
+                    var key = $"{subscription.TombstoneCleanerIdentifier}/{tombstoneInfo.Value.Name}/{collection}";
+
+                    if (PerSubscriptionInfoExtended.TryGetValue(key, out SubscriptionInfoExtended existingSubscriptionInfo))
+                    {
+                        UpdateSubscriptionInfo(existingSubscriptionInfo, type, numberOfTombstonesLeft);
+                    }
+                    else
+                    {
+                        var newSubscriptionInfo = CreateSubscriptionInfo(subscription, type, tombstoneInfo.Value, collection, numberOfTombstonesLeft);
+                        PerSubscriptionInfoExtended[key] = newSubscriptionInfo;
+                    }
+                }
+            }
+
+            private long CalculateRemainingTombstones(LastTombstoneInfo tombstoneInfo, ITombstoneAware.TombstoneType type, DocumentDatabase documentDatabase,
+                string collection)
+            {
+                using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    return type switch
+                    {
+                        ITombstoneAware.TombstoneType.Documents => collection.IsNullOrEmpty()
+                            ? documentDatabase.DocumentsStorage.GetTombstonesFrom(context, tombstoneInfo.Etag + 1, 0, long.MaxValue).Count()
+                            : documentDatabase.DocumentsStorage.GetTombstonesFrom(context, collection, tombstoneInfo.Etag + 1, 0, long.MaxValue).Count(),
+                        ITombstoneAware.TombstoneType.Counters => collection.IsNullOrEmpty()
+                            ? documentDatabase.DocumentsStorage.CountersStorage.GetCounterTombstonesFrom(context, tombstoneInfo.Etag + 1).Count()
+                            : documentDatabase.DocumentsStorage.CountersStorage.GetCounterWithCollectionTombstonesFrom(context, collection, tombstoneInfo.Etag + 1)
+                                .Count(),
+                        ITombstoneAware.TombstoneType.TimeSeries => collection.IsNullOrEmpty()
+                            ? documentDatabase.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(context, tombstoneInfo.Etag + 1).Count()
+                            : documentDatabase.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(context, collection, tombstoneInfo.Etag + 1).Count(), 
+                        _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unsupported tombstone type: {type}"),
+                    };
+                }
+
+            }
+
+            private void UpdateSubscriptionInfo(SubscriptionInfoExtended subscriptionInfo, ITombstoneAware.TombstoneType type, long remainingTombstones)
+            {
+                SetTombstoneTypes(type, subscriptionInfo, remainingTombstones);
+                subscriptionInfo.NumberOfTombstoneLeft += remainingTombstones;
+                if (subscriptionInfo.CleanupStatus == CleanupStatus.NotBlocking)
+                {
+                    subscriptionInfo.CleanupStatus = subscriptionInfo.NumberOfTombstoneLeft > 0 ? CleanupStatus.Blocking : CleanupStatus.NotBlocking;
+                }
+            }
+
+            private void SetTombstoneTypes(ITombstoneAware.TombstoneType type, SubscriptionInfoExtended subscriptionInfo, long numberOfTombstoneLeft)
+            {
+                subscriptionInfo.Types ??= new TombstoneTypes();
+
+                switch (type)
+                {
+                    case ITombstoneAware.TombstoneType.Documents:
+                        subscriptionInfo.Types.Documents = numberOfTombstoneLeft;
+                        break;
+                    case ITombstoneAware.TombstoneType.TimeSeries:
+                        subscriptionInfo.Types.TimeSeries = numberOfTombstoneLeft;
+                        break;
+                    case ITombstoneAware.TombstoneType.Counters:
+                        subscriptionInfo.Types.Counters = numberOfTombstoneLeft;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(type), $"Unsupported tombstone type: {type}");
+                }
             }
 
             public class SubscriptionInfo
@@ -371,6 +460,54 @@ namespace Raven.Server.Documents
                 public string Collection { get; set; }
 
                 public long Etag { get; set; }
+            }
+
+            public class SubscriptionInfoExtended : SubscriptionInfo
+            {
+                public ITombstoneAware.TombstoneDeletionBlockerType Process { get; set; }
+
+                public long NumberOfTombstoneLeft { get; set; }
+
+                public CleanupStatus CleanupStatus { get; set; }
+
+                public TombstoneTypes Types { get; set; }
+            }
+
+            public class TombstoneTypes : IDynamicJson
+            {
+                public long Documents;
+
+                public long TimeSeries;
+
+                public long Counters;
+
+                public DynamicJsonValue ToJson()
+                {
+                    return new DynamicJsonValue { [nameof(Documents)] = Documents, [nameof(TimeSeries)] = TimeSeries, [nameof(Counters)] = Counters };
+                }
+            }
+
+            private SubscriptionInfoExtended CreateSubscriptionInfo(ITombstoneAware subscription, ITombstoneAware.TombstoneType type, LastTombstoneInfo tombstoneInfo, string collection,
+                long remainingTombstones)
+            {
+                var newSubscriptionInfo = new SubscriptionInfoExtended
+                {
+                    Process = tombstoneInfo.Type,
+                    Identifier = tombstoneInfo.Name,
+                    Collection = collection,
+                    Etag = tombstoneInfo.Etag,
+                    NumberOfTombstoneLeft = remainingTombstones,
+                    CleanupStatus = remainingTombstones > 0 ? CleanupStatus.Blocking : CleanupStatus.NotBlocking,
+                    Types = new TombstoneTypes()
+                };
+                SetTombstoneTypes(type, newSubscriptionInfo, remainingTombstones);
+                return newSubscriptionInfo;
+            }
+
+            internal enum CleanupStatus
+            {
+                Blocking,
+                NotBlocking
             }
         }
 
@@ -512,7 +649,7 @@ namespace Raven.Server.Documents
     {
         string TombstoneCleanerIdentifier { get; }
 
-        Dictionary<string, long> GetLastProcessedTombstonesPerCollection(TombstoneType type);
+        Dictionary<string, long> GetLastProcessedTombstonesPerCollection(TombstoneType type, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null);
 
         Dictionary<TombstoneDeletionBlockageSource, HashSet<string>> GetDisabledSubscribersCollections(HashSet<string> tombstoneCollections);
 
@@ -537,5 +674,13 @@ namespace Raven.Server.Documents
             PullReplicationAsSink,
             Index
         }
+    }
+
+    public class LastTombstoneInfo(string name, string collection, long etag, ITombstoneAware.TombstoneDeletionBlockerType type)
+    {
+        public string Name { get; set; } = name;
+        public string Collection { get; set; } = collection;
+        public long Etag { get; set; } = etag;
+        public ITombstoneAware.TombstoneDeletionBlockerType Type { get; set; } = type;
     }
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/advanced/tombstonesState.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/advanced/tombstonesState.ts
@@ -4,7 +4,8 @@ import appUrl = require("common/appUrl");
 import getTombstonesStateCommand = require("commands/database/debug/getTombstonesStateCommand");
 import virtualGridController = require("widgets/virtualGrid/virtualGridController");
 import textColumn = require("widgets/virtualGrid/columns/textColumn");
-import SubscriptionInfo = Raven.Server.Documents.TombstoneCleaner.TombstonesState.SubscriptionInfo;
+import subscriptionInfoExtended = Raven.Server.Documents.TombstoneCleaner.TombstonesState.SubscriptionInfoExtended;
+import tombstoneTypes = Raven.Server.Documents.TombstoneCleaner.TombstonesState.TombstoneTypes;
 import forceTombstonesCleanup = require("commands/database/debug/forceTombstonesCleanupCommand");
 
 class tombstonesState extends viewModelBase {
@@ -12,7 +13,7 @@ class tombstonesState extends viewModelBase {
     view = require("views/database/advanced/tombstonesState.html");
 
     private collectionsStateController = ko.observable<virtualGridController<TombstoneItem>>();
-    private subscriptionsStateController = ko.observable<virtualGridController<SubscriptionInfo>>();
+    private subscriptionsStateController = ko.observable<virtualGridController<subscriptionInfoExtended>>();
     
     isForbidden = ko.observable<boolean>(false);
     
@@ -84,19 +85,28 @@ class tombstonesState extends viewModelBase {
 
         subscriptionsGrid.init(() => this.subscriptionsFetcher(), () => {
             return [
-                new textColumn<SubscriptionInfo>(subscriptionsGrid, x => x.Identifier, "Process", "30%", {
+                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => x.Process, "Process", "15%", {
                     sortable: "string"
                 }),
-                new textColumn<SubscriptionInfo>(subscriptionsGrid, x => x.Type, "Type", "20%", {
+                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => x.Identifier, "Name", "15%", {
                     sortable: "string"
                 }),
-                new textColumn<SubscriptionInfo>(subscriptionsGrid, x => x.Collection, "Collection", "25%", {
+                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => x.NumberOfTombstoneLeft, "Number of tombstones left", "10%", {
+                    sortable: "number"
+                }),
+                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => this.formatTombstoneTypes(x.Types), "Tombstone Types", "25%", {
                     sortable: "string"
                 }),
-                new textColumn<SubscriptionInfo>(subscriptionsGrid, x => this.formatEtag(x.Etag), "Etag", "25%", {
-                    sortable: "string", title: (x) => this.getEtagTitle(x.Etag)
+                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => x.Collection, "Collection", "10%", {
+                    sortable: "string"
                 }),
-            ]
+                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => this.formatEtag(x.Etag), "Etag", "10%", {
+                    sortable: "number", title: (x) => this.getEtagTitle(x.Etag)
+                }),
+                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => x.CleanupStatus, "CleanupStatus", "15%", {
+                    sortable: "string"
+                }),
+            ];
         });
     }
 
@@ -109,8 +119,8 @@ class tombstonesState extends viewModelBase {
             });
     }
 
-    private subscriptionsFetcher(): JQueryPromise<pagedResult<SubscriptionInfo>> {
-        const info = this.state().PerSubscriptionInfo;
+    private subscriptionsFetcher(): JQueryPromise<pagedResult<subscriptionInfoExtended>> {
+        const info = this.state().PerSubscriptionInfoExtended;
         return $.Deferred<pagedResult<any>>()
             .resolve({
                 items: info,
@@ -182,6 +192,14 @@ class tombstonesState extends viewModelBase {
         }
         
         return "Can remove any tombstone";
+    }
+
+    private formatTombstoneTypes(types: tombstoneTypes) {
+        if (!types) {
+            return '';
+        }
+
+        return `Documents: ${types.Documents}, TimeSeries: ${types.TimeSeries}, Counters: ${types.Counters}`;
     }
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/advanced/tombstonesState.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/advanced/tombstonesState.ts
@@ -4,8 +4,8 @@ import appUrl = require("common/appUrl");
 import getTombstonesStateCommand = require("commands/database/debug/getTombstonesStateCommand");
 import virtualGridController = require("widgets/virtualGrid/virtualGridController");
 import textColumn = require("widgets/virtualGrid/columns/textColumn");
-import subscriptionInfoExtended = Raven.Server.Documents.TombstoneCleaner.TombstonesState.SubscriptionInfoExtended;
-import tombstoneTypes = Raven.Server.Documents.TombstoneCleaner.TombstonesState.TombstoneTypes;
+import SubscriptionInfoExtended = Raven.Server.Documents.TombstoneCleaner.TombstonesState.SubscriptionInfoExtended;
+import TombstoneTypes = Raven.Server.Documents.TombstoneCleaner.TombstonesState.TombstoneTypes;
 import forceTombstonesCleanup = require("commands/database/debug/forceTombstonesCleanupCommand");
 
 class tombstonesState extends viewModelBase {
@@ -13,7 +13,7 @@ class tombstonesState extends viewModelBase {
     view = require("views/database/advanced/tombstonesState.html");
 
     private collectionsStateController = ko.observable<virtualGridController<TombstoneItem>>();
-    private subscriptionsStateController = ko.observable<virtualGridController<subscriptionInfoExtended>>();
+    private subscriptionsStateController = ko.observable<virtualGridController<SubscriptionInfoExtended>>();
     
     isForbidden = ko.observable<boolean>(false);
     
@@ -85,25 +85,25 @@ class tombstonesState extends viewModelBase {
 
         subscriptionsGrid.init(() => this.subscriptionsFetcher(), () => {
             return [
-                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => x.Process, "Process", "15%", {
+                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => x.Process, "Process", "15%", {
                     sortable: "string"
                 }),
-                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => x.Identifier, "Name", "15%", {
+                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => x.Identifier, "Name", "15%", {
                     sortable: "string"
                 }),
-                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => x.NumberOfTombstoneLeft, "Number of tombstones left", "10%", {
+                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => x.NumberOfTombstoneLeft, "Number of tombstones left", "10%", {
                     sortable: "number"
                 }),
-                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => this.formatTombstoneTypes(x.Types), "Tombstone Types", "25%", {
+                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => this.formatTombstoneTypes(x.Types), "Tombstone Types", "25%", {
                     sortable: "string"
                 }),
-                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => x.Collection, "Collection", "10%", {
+                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => x.Collection, "Collection", "10%", {
                     sortable: "string"
                 }),
-                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => this.formatEtag(x.Etag), "Etag", "10%", {
+                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => this.formatEtag(x.Etag), "Etag", "10%", {
                     sortable: "number", title: (x) => this.getEtagTitle(x.Etag)
                 }),
-                new textColumn<subscriptionInfoExtended>(subscriptionsGrid, x => x.CleanupStatus, "CleanupStatus", "15%", {
+                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => x.CleanupStatus, "CleanupStatus", "15%", {
                     sortable: "string"
                 }),
             ];
@@ -119,7 +119,7 @@ class tombstonesState extends viewModelBase {
             });
     }
 
-    private subscriptionsFetcher(): JQueryPromise<pagedResult<subscriptionInfoExtended>> {
+    private subscriptionsFetcher(): JQueryPromise<pagedResult<SubscriptionInfoExtended>> {
         const info = this.state().PerSubscriptionInfoExtended;
         return $.Deferred<pagedResult<any>>()
             .resolve({
@@ -194,7 +194,7 @@ class tombstonesState extends viewModelBase {
         return "Can remove any tombstone";
     }
 
-    private formatTombstoneTypes(types: tombstoneTypes) {
+    private formatTombstoneTypes(types: TombstoneTypes) {
         if (!types) {
             return '';
         }

--- a/src/Raven.Studio/typescript/viewmodels/database/advanced/tombstonesState.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/advanced/tombstonesState.ts
@@ -94,7 +94,7 @@ class tombstonesState extends viewModelBase {
                 new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => x.NumberOfTombstoneLeft, "Number of tombstones left", "10%", {
                     sortable: "number"
                 }),
-                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => this.formatTombstoneTypes(x.Types), "Tombstone Types", "25%", {
+                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => this.formatTombstoneTypes(x.Types, x.Process), "Tombstone Types", "25%", {
                     sortable: "string"
                 }),
                 new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => x.Collection, "Collection", "10%", {
@@ -103,7 +103,8 @@ class tombstonesState extends viewModelBase {
                 new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => this.formatEtag(x.Etag), "Etag", "10%", {
                     sortable: "number", title: (x) => this.getEtagTitle(x.Etag)
                 }),
-                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => x.CleanupStatus, "CleanupStatus", "15%", {
+                new textColumn<SubscriptionInfoExtended>(subscriptionsGrid, x => x.NumberOfTombstoneLeft > 0 ? "Blocking" : "Not Blocking"
+                    , "CleanupStatus", "15%", {
                     sortable: "string"
                 }),
             ];
@@ -194,9 +195,13 @@ class tombstonesState extends viewModelBase {
         return "Can remove any tombstone";
     }
 
-    private formatTombstoneTypes(types: TombstoneTypes) {
+    private formatTombstoneTypes(types: TombstoneTypes, process: Raven.Server.Documents.ITombstoneAware.TombstoneDeletionBlockerType) {
         if (!types) {
             return '';
+        }
+
+        if (process === 'Index') {
+            return `Documents: ${types.Documents}`;
         }
 
         return `Documents: ${types.Documents}, TimeSeries: ${types.TimeSeries}, Counters: ${types.Counters}`;

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -970,4 +970,7 @@ interface taskInfo {
 }
 
 type TombstoneItem = Raven.Server.Documents.TombstoneCleaner.StateHolder & { Collection: string };
-type TombstonesStateOnWire = Omit<Raven.Server.Documents.TombstoneCleaner.TombstonesState, "Tombstones"> & { Results: TombstoneItem[]; PerSubscriptionInfoExtended: subscriptionInfoExtended[] };
+type TombstonesStateOnWire = Omit<Raven.Server.Documents.TombstoneCleaner.TombstonesState,"Tombstones" | "PerSubscriptionInfoExtended"> & {
+    Results: TombstoneItem[];
+    PerSubscriptionInfoExtended: Raven.Server.Documents.TombstoneCleaner.TombstonesState.SubscriptionInfoExtended[];
+};

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -970,4 +970,4 @@ interface taskInfo {
 }
 
 type TombstoneItem = Raven.Server.Documents.TombstoneCleaner.StateHolder & { Collection: string };
-type TombstonesStateOnWire = Omit<Raven.Server.Documents.TombstoneCleaner.TombstonesState, "Tombstones"> & { Results: TombstoneItem[] };
+type TombstonesStateOnWire = Omit<Raven.Server.Documents.TombstoneCleaner.TombstonesState, "Tombstones"> & { Results: TombstoneItem[]; PerSubscriptionInfoExtended: subscriptionInfoExtended[] };

--- a/test/SlowTests/Issues/RavenDB_10656.cs
+++ b/test/SlowTests/Issues/RavenDB_10656.cs
@@ -136,7 +136,7 @@ namespace SlowTests.Issues
 
         public string TombstoneCleanerIdentifier => nameof(RavenDB_10656);
 
-        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             return new Dictionary<string, long>
             {

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionReplicationTests.cs
@@ -93,7 +93,7 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
 
         public string TombstoneCleanerIdentifier => nameof(OutputReduceToCollectionReplicationTests);
 
-        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             return new Dictionary<string, long>
             {

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -987,7 +987,7 @@ namespace SlowTests.Server.Documents.Revisions
 
         public string TombstoneCleanerIdentifier => nameof(RevisionsReplication);
 
-        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
+        public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)
         {
             return new Dictionary<string, long>
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21846

### Additional description

Add more information to the tombstone view.
   * Added number  of tombstones left
   * Split info for process by task
   * combine the info for Tombstone type
   * added info if blocking or not

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
