### PR TITLE
RavenDB-21799 Updated SlowTests.Issues.RavenDB_21668.Can_Query_Map_Reduce_Index

### DIFF
--- a/test/SlowTests/Issues/RavenDB-21668.cs
+++ b/test/SlowTests/Issues/RavenDB-21668.cs
@@ -84,18 +84,10 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     var rql = "from 'Messages' " +
-                              "group by Name, Tries[].ResultMessage " +
-                              "select Name, Tries[].ResultMessage as ResultMessage, sum(Data.Items[].TotalPrice) as Total";
-
-                    var results = HandleQuery<ResultDifferentPath>(store, session, rql);
-                    
-                    Assert.Equal(0, results.Count); // expected - wrong rql will produce 0 results
-
-                    rql = "from 'Messages' " +
                           "group by Name, Tries[].ResultMessage " +
                           "select Name, Tries[].ResultMessage as ResultMessage, sum(Data[].Items[].TotalPrice) as Total";
 
-                    results = HandleQuery<ResultDifferentPath>(store, session, rql);
+                    var results = HandleQuery<ResultDifferentPath>(store, session, rql);
                     
                     Assert.Equal(1, results.Count);
                     Assert.Equal("Initial", results[0].Name);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21799/SlowTests.Issues.RavenDB21668.CanQueryMapReduceIndex

### Additional description

Using wrong RQL doesn't test anything here. It's an auto index on small number of documents, so indexing errors are usually added after the query execution. If they're added before it, we get an exception and test fails.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
