### PR TITLE
RavenDB-22054 After creating an incremental backup, `Last full backup…

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
@@ -76,8 +76,8 @@ function Details(props: PeriodicBackupPanelProps) {
         ? data.shared.backupDestinations.join(", ")
         : "No destinations defined";
 
-    const lastFullBackupHumanized = data.shared.lastIncrementalBackup
-        ? genUtils.formatDurationByDate(moment.utc(data.shared.lastIncrementalBackup), true)
+    const lastFullBackupHumanized = data.shared.lastFullBackup
+        ? genUtils.formatDurationByDate(moment.utc(data.shared.lastFullBackup), true)
         : neverBackedUpText;
 
     const lastIncrementalBackupHumanized = data.shared.lastIncrementalBackup


### PR DESCRIPTION
…` info is also changed

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22054 

### Additional description

Fixed typo in code

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
