### PR TITLE
RavenDB-21992 Changed test to run only on x64

### DIFF
--- a/test/SlowTests/SlowTests/Indexes/MapReduceIndexOnLargeDataSet.cs
+++ b/test/SlowTests/SlowTests/Indexes/MapReduceIndexOnLargeDataSet.cs
@@ -16,11 +16,12 @@ namespace SlowTests.SlowTests.Indexes
         {
         }
 
-        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
-        public void WillNotProduceAnyErrors(Options options)
+        [MultiplatformTheory(RavenArchitecture.X64)]
+        [InlineData(RavenSearchEngineMode.Corax)]
+        [InlineData(RavenSearchEngineMode.Lucene)]
+        public void WillNotProduceAnyErrors(RavenSearchEngineMode mode)
         {
-            using (var store = GetDocumentStore(options))
+            using (var store = GetDocumentStore(Options.ForSearchEngine(mode)))
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[] { new IndexDefinition
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21992/SlowTests.SlowTests.Indexes.MapReduceIndexOnLargeDataSet.WillNotProduceAnyErrorsoptions-DatabaseMode-Single-SearchEngineMode

### Additional description

We should run this test only on x64 architectures

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
