### PR TITLE
RavenDB-22116 add debug method to delete document by etag

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.Debug.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.Debug.cs
@@ -1,0 +1,37 @@
+﻿using Raven.Server.ServerWide.Context;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents
+{
+    public partial class DocumentsStorage
+    {
+        public Debugging ForDebug => new Debugging(this);
+
+        public class Debugging
+        {
+            private readonly DocumentsStorage _storage;
+
+            public Debugging(DocumentsStorage storage)
+            {
+                _storage = storage;
+            }
+            // Used to delete corrupted document from the JS admin console
+            public void DeleteDocumentByEtag(long etag)
+            {
+                using (_storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+                    var index = DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice];
+
+                    if (table.FindByIndex(index, etag, out var reader))
+                    {
+                        var doc = _storage.TableValueToDocument(context, ref reader, DocumentFields.Id);
+                        _storage.Delete(context, doc.Id, DocumentFlags.None);
+                        tx.Commit();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -36,7 +36,7 @@ using Voron.Impl;
 
 namespace Raven.Server.Documents
 {
-    public unsafe class DocumentsStorage : IDisposable
+    public unsafe partial class DocumentsStorage : IDisposable
     {
         private static readonly Slice DocsSlice;
         public static readonly Slice CollectionEtagsSlice;

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1830,7 +1830,6 @@ namespace Voron.Data.Tables
 
         public bool FindByIndex(TableSchema.FixedSizeSchemaIndexDef index, long value, out TableValueReader reader)
         {
-            AssertWritableTable();
             reader = default;
             var fst = GetFixedSizeTree(index);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22116

### Additional description

add debug method to delete document by etag

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
