### PR TITLE
RavenDB-21985 Make show staleness reason button better visible

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
@@ -86,10 +86,21 @@ export function IndexProgressTooltip(props: IndexProgressTooltipProps) {
                     </LocationSpecificDetailsItem>
                     {nodeInfo.details.stale ? (
                         <LocationSpecificDetailsItem className="status updating">
-                            <Icon icon="waiting" margin="me-xl-1" />{" "}
-                            <a href="#" onClick={withPreventDefault(() => showStaleReason(nodeInfo.location))}>
-                                {formatTimeLeftToProcess(nodeInfo.progress?.global, nodeInfo.details)}
-                            </a>
+                            <div>
+                                <div>
+                                    <Icon icon="waiting" margin="me-xl-1" />{" "}
+                                    {formatTimeLeftToProcess(nodeInfo.progress?.global, nodeInfo.details)}
+                                </div>
+                                <div className="mt-2">
+                                    <a
+                                        href="#"
+                                        className="mt-2"
+                                        onClick={withPreventDefault(() => showStaleReason(nodeInfo.location))}
+                                    >
+                                        show staleness reason
+                                    </a>
+                                </div>
+                            </div>
                         </LocationSpecificDetailsItem>
                     ) : (
                         <LocationSpecificDetailsItem className="status">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21985 

### Additional description

Make show staleness reason button better visible

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
