### PR TITLE
RavenDB-22033 Filter out expired certificates by default

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/certificates.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/certificates.ts
@@ -94,7 +94,7 @@ class certificates extends viewModelBase {
     showUserCertificates = ko.observable<boolean>(true);
 
     showValidCertificates = ko.observable<boolean>(true);
-    showExpiredCertificates = ko.observable<boolean>(true);
+    showExpiredCertificates = ko.observable<boolean>(false);
     showAboutToExpireCertificates = ko.observable<boolean>(true);
     
     databases = databasesManager.default.databases;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22033 

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
