### PR TITLE
RavenDB-22131 - use cluster nodes in test instead of all Servers list

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19922.cs
+++ b/test/SlowTests/Issues/RavenDB-19922.cs
@@ -52,7 +52,7 @@ namespace SlowTests.Issues
                 Database = databaseName
             })
             {
-                var mentorNode = Servers.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
+                var mentorNode = nodes.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: mentorNode.ServerStore.NodeTag, name:"backup");
 
                 long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
@@ -62,7 +62,7 @@ namespace SlowTests.Issues
 
                 CheckDecisionLog(leaderServer, new MentorNode(tag1, config.Name).ReasonForDecisionLog);
                 
-                var disposedServer = Servers.First(s => s.ServerStore.NodeTag == tag1);
+                var disposedServer = nodes.First(s => s.ServerStore.NodeTag == tag1);
 
                 await DisposeServerAndWaitForFinishOfDisposalAsync(disposedServer);
 
@@ -108,7 +108,7 @@ namespace SlowTests.Issues
                 Database = databaseName
             })
             {
-                var mentorNode = Servers.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
+                var mentorNode = nodes.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: mentorNode.ServerStore.NodeTag, name: "backup");
                 long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
                 
@@ -117,7 +117,7 @@ namespace SlowTests.Issues
 
                 CheckDecisionLog(leaderServer, new MentorNode(tag1, config.Name).ReasonForDecisionLog);
 
-                var disposedServer = Servers.First(s => s.ServerStore.NodeTag == tag1);
+                var disposedServer = nodes.First(s => s.ServerStore.NodeTag == tag1);
                 var result = await DisposeServerAndWaitForFinishOfDisposalAsync(disposedServer);
                 nodes.Remove(disposedServer);
                 Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId);
@@ -135,13 +135,11 @@ namespace SlowTests.Issues
                 CheckDecisionLog(leaderServer, new CurrentResponsibleNodeNotResponding(tag2, config.Name, tag1,TimeSpan.FromMinutes(0)).ReasonForDecisionLog);
 
                 settings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url;
-                nodes.Add(GetNewServer(new ServerCreationOptions
+                using var server = GetNewServer(new ServerCreationOptions
                 {
-                    DeletePrevious = false,
-                    RunInMemory = false,
-                    DataDirectory = result.DataDirectory,
-                    CustomSettings = settings
-                }));
+                    DeletePrevious = false, RunInMemory = false, DataDirectory = result.DataDirectory, CustomSettings = settings
+                });
+                nodes.Add(server);
                 var val = await WaitForValueAsync(async () => await GetMembersCount(store), clusterSize);
                 Assert.Equal(clusterSize, val);
 
@@ -186,7 +184,7 @@ namespace SlowTests.Issues
                 Database = databaseName
             })
             {
-                var mentorNode = Servers.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
+                var mentorNode = nodes.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: mentorNode.ServerStore.NodeTag, name: "backup", pinToMentorNode:true);
                 long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
 
@@ -195,7 +193,7 @@ namespace SlowTests.Issues
 
                 CheckDecisionLog(leaderServer, new PinnedMentorNode(tag1, config.Name).ReasonForDecisionLog);
 
-                var disposedServer = Servers.First(s => s.ServerStore.NodeTag == tag1);
+                var disposedServer = nodes.First(s => s.ServerStore.NodeTag == tag1);
                 nodes.Remove(disposedServer);
                 var result = await DisposeServerAndWaitForFinishOfDisposalAsync(disposedServer);
 
@@ -211,13 +209,11 @@ namespace SlowTests.Issues
                 Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId);
 
                 settings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = result.Url;
-                nodes.Add(GetNewServer(new ServerCreationOptions
+                using var server = GetNewServer(new ServerCreationOptions
                 {
-                    DeletePrevious = false,
-                    RunInMemory = false,
-                    DataDirectory = result.DataDirectory,
-                    CustomSettings = settings
-                }));
+                    DeletePrevious = false, RunInMemory = false, DataDirectory = result.DataDirectory, CustomSettings = settings
+                });
+                nodes.Add(server);
                 var val = await WaitForValueAsync(async () => await GetMembersCount(store), clusterSize);
                 Assert.Equal(clusterSize, val);
 
@@ -261,7 +257,7 @@ namespace SlowTests.Issues
                 Database = databaseName
             })
             {
-                var mentorNode = Servers.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
+                var mentorNode = nodes.First(s => s.ServerStore.NodeTag != leaderServer.ServerStore.NodeTag);
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: mentorNode.ServerStore.NodeTag, name: "backup");
                 long taskId = await InitializeBackup(store, clusterSize, leaderServer, nodes, config);
 
@@ -269,7 +265,7 @@ namespace SlowTests.Issues
                 var tag1 = database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
                 CheckDecisionLog(leaderServer, new MentorNode(tag1, config.Name).ReasonForDecisionLog);
 
-                var removedNode = Servers.First(s => s.ServerStore.NodeTag == tag1);
+                var removedNode = nodes.First(s => s.ServerStore.NodeTag == tag1);
 
                 await ActionWithLeader(l => l.ServerStore.RemoveFromClusterAsync(removedNode.ServerStore.NodeTag));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22131

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
