### PR TITLE
RavenDB-22050 NRE in bulk insert heartbeat

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -218,6 +218,14 @@ namespace Raven.Client.Documents.BulkInsert
                             finally
                             {
                                 _streamLock.Release();
+                                try
+                                {
+                                    _timer?.Dispose();
+                                }
+                                catch
+                                {
+                                    // ignored
+                                }
                             }
                         }
                         catch (Exception e)
@@ -251,14 +259,6 @@ namespace Raven.Client.Documents.BulkInsert
                 {
                     _streamExposerContent?.Dispose();
                     _resetContext.Dispose();
-                    try
-                    {
-                        _timer?.Dispose();
-                    }
-                    catch
-                    {
-                        // ignored
-                    }
                 }
             });
             CompressionLevel = options?.CompressionLevel ?? CompressionLevel.NoCompression;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22050

### Additional description

The bulk insert Heartbeat continued to run after we started to dispose bulk insert and was done with client-side writing.
Now we dispose the timer after we write the end object and flush it all to the stream.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
