### PR TITLE
RavenDB-19481 - Cluster transactions are reapplied after restore

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -525,7 +525,10 @@ namespace Raven.Server.Documents
         public List<ClusterTransactionCommand.SingleClusterDatabaseCommand> ExecuteClusterTransaction(TransactionOperationContext context, int batchSize)
         {
             var batch = new List<ClusterTransactionCommand.SingleClusterDatabaseCommand>(
-                ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, take: batchSize));
+                ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, 
+                    lastCompletedClusterTransactionIndex: LastCompletedClusterTransactionIndex, take: batchSize));
+            
+            ServerStore.ForTestingPurposes?.BeforeExecuteClusterTransactionBatch?.Invoke(Name, batch);
 
             Stopwatch stopwatch = null;
             if (_logger.IsInfoEnabled)

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -636,7 +636,7 @@ namespace Raven.Server.ServerWide.Commands
         }
 
 
-        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long take = 128)
+        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long? lastCompletedClusterTransactionIndex = null, long take = 128)
             where TTransaction : RavenTransaction
         {
             var lowerDb = database.ToLowerInvariant();
@@ -653,6 +653,8 @@ namespace Raven.Server.ServerWide.Commands
                     if (result.Database != lowerDb) // beware of reading commands of other databases.
                         continue;
                     if (result.PreviousCount < fromCount)
+                        continue;
+                    if (lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
                         continue;
                     if (take <= 0)
                         yield break;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3645,6 +3645,7 @@ namespace Raven.Server.ServerWide
             internal Action<CompareExchangeCommandBase> ModifyCompareExchangeTimeout;
             internal Action RestoreDatabaseAfterSavingDatabaseRecord;
             internal Action AfterCommitInClusterTransaction;
+            internal Action<string, List<ClusterTransactionCommand.SingleClusterDatabaseCommand>> BeforeExecuteClusterTransactionBatch;
         }
         
         public readonly MemoryCache QueryClauseCache;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1566,7 +1566,7 @@ namespace Raven.Server.Smuggler.Documents
                             (_missingDocumentsForRevisions != null))
                         {
                             if (_database.DocumentsStorage.Get(context, document.Id) == null && 
-                                document.ChangeVector.Contains(ChangeVectorParser.RaftTag) == false)
+                                document.ChangeVector.Contains(ChangeVectorParser.TrxnTag) == false)
                             {
                                 var collection = _database.DocumentsStorage.ExtractCollectionName(context, document.Data);
                                 _missingDocumentsForRevisions.TryAdd(document.Id.ToString(), collection);

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -26,6 +26,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.TransactionCommands;
 using Raven.Server.Exceptions;
 using Raven.Server.Integrations.PostgreSQL.Commands;
@@ -1564,7 +1565,8 @@ namespace Raven.Server.Smuggler.Documents
                         if ((document.NonPersistentFlags.Contain(NonPersistentDocumentFlags.FromSmuggler)) &&
                             (_missingDocumentsForRevisions != null))
                         {
-                            if (_database.DocumentsStorage.Get(context, document.Id) == null)
+                            if (_database.DocumentsStorage.Get(context, document.Id) == null && 
+                                document.ChangeVector.Contains(ChangeVectorParser.RaftTag) == false)
                             {
                                 var collection = _database.DocumentsStorage.ExtractCollectionName(context, document.Data);
                                 _missingDocumentsForRevisions.TryAdd(document.Id.ToString(), collection);

--- a/test/SlowTests/Issues/RavenDB-19481.cs
+++ b/test/SlowTests/Issues/RavenDB-19481.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Graph;
+using FastTests.Utils;
+using Nest;
+using NetTopologySuite.Utilities;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Session;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using static Raven.Server.Smuggler.Documents.CounterItem;
+using Assert = Xunit.Assert;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19481 : RavenTestBase
+    {
+        public RavenDB_19481(ITestOutputHelper output) : base(output)
+        {
+        }
+
+
+        [RavenFact(RavenTestCategory.Smuggler)]
+        public async Task ShouldntReapplyClusterTransactionTwiceInRestore()
+        {
+            DoNotReuseServer();
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var store = GetDocumentStore())
+            {
+                const string id = "users/1";
+
+                await RevisionsHelper.SetupRevisions(Server.ServerStore, store.Database);
+
+                using (var session = store.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Grisha"
+                    }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+                Assert.Equal(1, stats.CountOfRevisionDocuments);
+
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.RunBackupAndReturnStatusAsync(Server, backupTaskId, store, isFullBackup: false, expectedEtag: 4);
+
+                var databaseName = $"restored_database-{Guid.NewGuid()}";
+
+                var clusterTransactions = new Dictionary<string, long>();
+                Server.ServerStore.ForTestingPurposesOnly().BeforeExecuteClusterTransactionBatch = (dbName, batch) =>
+                {
+                    if (dbName == databaseName)
+                    {
+                        lock (clusterTransactions) 
+                        {
+                            foreach (var clusterTx in batch)
+                            {
+                                var raftRequestId = clusterTx.Options.TaskId;
+
+                                if (clusterTransactions.ContainsKey(clusterTx.Options.TaskId) == false)
+                                    clusterTransactions.Add(raftRequestId, 1);
+                                else
+                                    clusterTransactions[raftRequestId]++;
+                            }
+                        }
+                    }
+                };
+
+                using (Backup.RestoreDatabase(store,
+                           new RestoreBackupConfiguration
+                           {
+                               BackupLocation = Directory.GetDirectories(backupPath).First(),
+                               DatabaseName = databaseName
+                           }))
+                {
+                }
+
+                foreach (var kvp in clusterTransactions)
+                {
+                    var timesWasApplied = kvp.Value;
+                    Assert.True(timesWasApplied <=1 , $"cluster transaction \"{kvp.Key}\" was reapplied more then once ({timesWasApplied} times)");
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19481/Cluster-transactions-are-reapplied-after-restore

### Additional description

After restoring the cluster transactions and starting the database again, we reapply the cluster transactions again (since we process the commands that exist in the ClusterStateMachine).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
