### PR TITLE
RavenDB-21233 Add ignore MaxStepsForScript limit button in studio

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/patch/patchCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/patch/patchCommand.ts
@@ -9,6 +9,7 @@ interface patchCommandOptions {
     staleTimeout?: string;
     maxOpsPerSecond?: number;
     disableAutoIndexCreation?: boolean;
+    ignoreMaxStepsForScript?: boolean;
 }
 
 class patchCommand extends commandBase {
@@ -31,7 +32,8 @@ class patchCommand extends commandBase {
             staleTimeout: this.options.staleTimeout,
             maxOpsPerSec: this.options.maxOpsPerSecond,
             id: this.options.test ? this.options.documentId : undefined,
-            disableAutoIndexCreation: this.options.disableAutoIndexCreation
+            disableAutoIndexCreation: this.options.disableAutoIndexCreation,
+            ignoreMaxStepsForScript: this.options.ignoreMaxStepsForScript ? true : undefined
         };
 
         const payload = {

--- a/src/Raven.Studio/typescript/viewmodels/database/patch/patch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/patch/patch.ts
@@ -131,6 +131,7 @@ class patch extends viewModelBase {
     defineMaxOperationsPerSecond = ko.observable<boolean>(false);
     
     disableAutoIndexCreation = ko.observable<boolean>(false);
+    ignoreMaxStepsForScript = ko.observable<boolean>(false);
     
     static readonly recentKeyword = 'Recent Patch';
 
@@ -441,7 +442,8 @@ class patch extends viewModelBase {
                         allowStale: this.staleIndexBehavior() === "patchStale",
                         staleTimeout: this.staleIndexBehavior() === "timeoutDefined" ? generalUtils.formatAsTimeSpan(this.staleTimeout() * 1000) : undefined,
                         maxOpsPerSecond: this.maxOperationsPerSecond(),
-                        disableAutoIndexCreation: this.disableAutoIndexCreation()
+                        disableAutoIndexCreation: this.disableAutoIndexCreation(),
+                        ignoreMaxStepsForScript: this.ignoreMaxStepsForScript(),
                     })
                         .execute()
                         .done((operation: operationIdDto) => {

--- a/src/Raven.Studio/wwwroot/App/views/database/patch/patch.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/patch/patch.html
@@ -416,6 +416,10 @@
                 <label for="disableAutoIndex">Don't create a new Auto-Index</label>
             </div>
             <div class="toggle">
+                <input id="ignoreMaxStepsForScript" type="checkbox" data-bind="checked: ignoreMaxStepsForScript">
+                <label for="ignoreMaxStepsForScript">Ignore maximum number of steps for script</label>
+            </div>
+            <div class="toggle">
                 <input id="maxOperations" class="styled" type="checkbox" data-bind="checked: defineMaxOperationsPerSecond">
                 <label for="maxOperations">Limit number of operations</label>
             </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21233 

### Additional description

Allow to ignore max script steps during patching

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
