### PR TITLE
RavenDB-22134 MaybeBreakTies has to use non-negative number for comparison. IndirectComparer has to apply negative scalar to the result after comparison.

### DIFF
--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -717,7 +717,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
 
              Debug.Assert(yIdx < SortingMatch.SortBatchSize && xIdx < SortingMatch.SortBatchSize);
 
-             var cmp = 0;
+            var cmp = 0;
             for (int comparerId = 0; cmp == 0 && comparerId < _maxDegreeOfInnerComparer; ++comparerId)
             {
                 cmp = comparerId switch
@@ -729,7 +729,9 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
                 };
             }
             
-            return cmp;
+            return _descending 
+                ? -cmp
+                : cmp;
         }
 
 

--- a/test/SlowTests/Corax/CoraxOrderBy.cs
+++ b/test/SlowTests/Corax/CoraxOrderBy.cs
@@ -14,6 +14,54 @@ public class CoraxOrderBy : RavenTestBase
     public CoraxOrderBy(ITestOutputHelper output) : base(output)
     {
     }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void MaybeBreakTiesCompensiveTests(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        Output.WriteLine(DateTime.Now.ToString("f"));
+        session.Store(new SortingStruct("C", "2024"));
+        session.Store(new SortingStruct("C", "2023"));
+        session.Store(new SortingStruct("C", "2022"));
+        session.SaveChanges();
+
+        var query = session.Query<SortingStruct>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .Where(x => x.Name == "C" && x.Year != null)
+            .OrderByDescending(x => x.Year);
+            
+        var results = query.ToList();
+        Assert.Equal(3, results.Count);
+        Assert.Equal("2024", results[0].Year);
+        Assert.Equal("2023", results[1].Year);
+        Assert.Equal("2022", results[2].Year);
+
+        results = session.Query<SortingStruct>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .Where(x => x.Name == "C" && x.Year != null)
+            .OrderBy(x => x.Name)
+            .ThenByDescending(x => x.Year)
+            .ToList();
+        Assert.Equal(3, results.Count);
+        Assert.Equal("2024", results[0].Year);
+        Assert.Equal("2023", results[1].Year);
+        Assert.Equal("2022", results[2].Year);
+        
+        results = session.Query<SortingStruct>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .Where(x => x.Name == "C" && x.Year != null)
+            .OrderByDescending(x => x.Year)
+            .ThenByDescending(x => x.Name)
+            .ToList();
+        Assert.Equal(3, results.Count);
+        Assert.Equal("2024", results[0].Year);
+        Assert.Equal("2023", results[1].Year);
+        Assert.Equal("2022", results[2].Year);
+    }
+    
+    private record SortingStruct(string Name, string Year, string Id = null);
 
     [RavenTheory(RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22134

### Additional description

In the case of descending, we'll set the sign bit to the value from the dictionary. In case of `BreakTie`s, when we have negative numbers, shifting has a different behavior and our conditions don't work as same for natural numbers.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
