### PR TITLE
RavenDB-21926: Preparation to the removal of mutable state

### DIFF
--- a/src/Voron/Data/BTrees/TreeMutableState.cs
+++ b/src/Voron/Data/BTrees/TreeMutableState.cs
@@ -58,6 +58,19 @@ namespace Voron.Data.BTrees
             header->RootPageNumber = RootPageNumber;
         }
 
+        public void CopyTo(ref TreeRootHeader header)
+        {
+            header.RootObjectType = RootObjectType;
+            header.Flags = Flags;
+            header.BranchPages = BranchPages;
+            header.Depth = Depth;
+            header.LeafPages = LeafPages;
+            header.OverflowPages = OverflowPages;
+            header.PageCount = PageCount;
+            header.NumberOfEntries = NumberOfEntries;
+            header.RootPageNumber = RootPageNumber;
+        }
+
         public TreeMutableState Clone()
         {
             return new TreeMutableState(_tx)

--- a/src/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/src/Voron/Impl/Backup/IncrementalBackup.cs
@@ -419,8 +419,7 @@ namespace Voron.Impl.Backup
                 var root = Tree.Open(txw, null, Constants.RootTreeNameSlice, &lastTxHeader->Root);
 
                 txw.UpdateRootsIfNeeded(root);
-
-                txw.State.NextPageNumber = lastTxHeader->LastPageNumber + 1;
+                txw.State.UpdateNextPage(lastTxHeader->LastPageNumber + 1);
 
                 txw.Commit();
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1,15 +1,19 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
+using System.Linq; // Needed in DEBUG
+using System.Text; // Needed in DEBUG
 using Sparrow;
 using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Threading;
 using Sparrow.Utils;
+using Sparrow.Server.Utils;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
 using Voron.Data.Fixed;
@@ -22,10 +26,7 @@ using Voron.Impl.Scratch;
 using Voron.Debugging;
 using Voron.Util;
 using Constants = Voron.Global.Constants;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using Sparrow.Server.Utils;
+
 
 namespace Voron.Impl
 {
@@ -168,7 +169,7 @@ namespace Voron.Impl
             // the new transaction will create its own mapping, using the existing page translation
             // table and install itself as the same transaction id as the current one. 
 
-            Debug.Assert(previous.Flags == TransactionFlags.Read);
+            Debug.Assert(previous.Flags is TransactionFlags.Read);
 
             IsCloned = true;
 
@@ -197,6 +198,8 @@ namespace Voron.Impl
 
                 _scratchPagerStates = previous._scratchPagerStates;
 
+                // RavenDB-21926: We can just use the previous one without cloning because the transaction when constructed here
+                // is guaranteed to be ReadOnly.
                 _state = previous._state;
 
                 InitializeRoots();
@@ -223,7 +226,7 @@ namespace Voron.Impl
             // so it makes a lot of assumptions about the usage scenario
             // and what it can do
 
-            Debug.Assert(previous.Flags == TransactionFlags.ReadWrite);
+            Debug.Assert(previous.Flags is TransactionFlags.ReadWrite);
 
             var env = previous._env;
             env.Options.AssertNoCatastrophicFailure();
@@ -336,19 +339,19 @@ namespace Voron.Impl
                 env.Options.AssertNoCatastrophicFailure();
 
             DataPager = env.Options.DataPager;
+            PersistentContext = transactionPersistentContext;
+            Flags = flags;
+
             _env = env;
             _journal = env.Journal;
             _id = id;
             _freeSpaceHandling = freeSpaceHandling;
+
             _allocator = context ?? new ByteStringContext(SharedMultipleUseFlag.None);
-
             _allocator.AllocationFailed += MarkTransactionAsFailed;
-
             _disposeAllocator = context == null;
-            _pagerStates = new HashSet<PagerState>(ReferenceEqualityComparer<PagerState>.Default);
 
-            PersistentContext = transactionPersistentContext;
-            Flags = flags;
+            _pagerStates = new HashSet<PagerState>(ReferenceEqualityComparer<PagerState>.Default);
 
             var scratchPagerStates = env.ScratchBufferPool.GetPagerStatesOfAllScratches();
 
@@ -363,41 +366,44 @@ namespace Voron.Impl
 
                 _pageLocator = transactionPersistentContext.AllocatePageLocator(this);
 
-                if (flags != TransactionFlags.ReadWrite)
+                switch (flags)
                 {
-                    // for read transactions, we need to keep the pager state frozen
-                    // for write transactions, we can use the current one (which == null)
-                    _scratchPagerStates = scratchPagerStates;
+                    case TransactionFlags.Read:
+                        // for read transactions, we need to keep the pager state frozen
+                        _scratchPagerStates = scratchPagerStates;
+                        _state = env.State;
 
-                    _state = env.State;
+                        JournalSnapshots = _journal.GetSnapshots();
 
-                    InitializeRoots();
+                        break;
+                    case TransactionFlags.ReadWrite:
+                        // for write transactions, we can use the current one (which == null)
+                        EnsureNoDuplicateTransactionId(id);
+                        _state = env.State.Clone();
 
-                    JournalSnapshots = _journal.GetSnapshots();
+                        // we keep this copy to make sure that if we use async commit, we have a stable copy of the journals
+                        // as they were at the time we started the original transaction, this is required because async commit
+                        // may modify the list of files we have available
+                        JournalFiles = _journal.Files;
+                        foreach (var journalFile in JournalFiles)
+                        {
+                            journalFile.AddRef();
+                        }
 
-                    return;
+                        _env.WriteTransactionPool.Reset();
+
+                        _scratchPagesTable = _env.WriteTransactionPool.ScratchPagesInUse;
+                        _dirtyPages = _env.WriteTransactionPool.DirtyPagesPool;
+                        _freedPages = new HashSet<long>();
+                        _unusedScratchPages = new List<PageFromScratchBuffer>();
+                        _transactionPages = new HashSet<PageFromScratchBuffer>(PageFromScratchBufferEqualityComparer.Instance);
+                        _pagesToFreeOnCommit = new Stack<long>();
+
+                        InitTransactionHeader();
+                        break;
                 }
 
-                EnsureNoDuplicateTransactionId(id);
-                // we keep this copy to make sure that if we use async commit, we have a stable copy of the jounrals
-                // as they were at the time we started the original transaction, this is required because async commit
-                // may modify the list of files we have available
-                JournalFiles = _journal.Files;
-                foreach (var journalFile in JournalFiles)
-                {
-                    journalFile.AddRef();
-                }
-                _env.WriteTransactionPool.Reset();
-                _scratchPagesTable = _env.WriteTransactionPool.ScratchPagesInUse;
-                _dirtyPages = _env.WriteTransactionPool.DirtyPagesPool;
-                _freedPages = new HashSet<long>();
-                _unusedScratchPages = new List<PageFromScratchBuffer>();
-                _transactionPages = new HashSet<PageFromScratchBuffer>(PageFromScratchBufferEqualityComparer.Instance);
-                _pagesToFreeOnCommit = new Stack<long>();
-
-                _state = env.State.Clone();
                 InitializeRoots();
-                InitTransactionHeader();
             }
             catch
             {
@@ -1430,6 +1436,7 @@ namespace Voron.Impl
         }
 
 #if DEBUG
+
         //overflowPageId, Parent
         private readonly Dictionary<long, long> _overflowPagesToBeRemoved = new();
         [Conditional("DEBUG")]

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -128,7 +128,9 @@ namespace Voron.Impl
         private readonly IFreeSpaceHandling _freeSpaceHandling;
         internal FixedSizeTree _freeSpaceTree;
 
-        private TransactionHeader* _txHeader;
+        private TransactionHeader _txHeader;
+
+        internal ref TransactionHeader TransactionHeader => ref _txHeader;
 
         private readonly HashSet<PageFromScratchBuffer> _transactionPages;
         private readonly HashSet<long> _freedPages;
@@ -155,7 +157,7 @@ namespace Voron.Impl
 
         public ByteStringContext Allocator => _allocator;
 
-        public ulong Hash => _txHeader->Hash;
+        public ulong Hash => _txHeader.Hash;
 
         public LowLevelTransaction(LowLevelTransaction previous, TransactionPersistentContext transactionPersistentContext, ByteStringContext allocator = null)
         {
@@ -174,6 +176,7 @@ namespace Voron.Impl
 
             TxStartTime = previous.TxStartTime;
             DataPager = previous.DataPager;
+            _txHeader = TxHeaderInitializerTemplate;
             _env = previous._env;
             _journal = previous._journal;
             _id = previous._id;
@@ -234,11 +237,12 @@ namespace Voron.Impl
             CurrentTransactionHolder = previous.CurrentTransactionHolder;
             TxStartTime = DateTime.UtcNow;
             DataPager = env.Options.DataPager;
+            _txHeader = TxHeaderInitializerTemplate;
             _env = env;
             _journal = env.Journal;
             _id = txId;
             _freeSpaceHandling = previous._freeSpaceHandling;
-            Debug.Assert(persistentContext != null, "persistentContext != null");
+            Debug.Assert(persistentContext != null, $"{nameof(persistentContext)} != null");
             PersistentContext = persistentContext;
 
             _allocator = new ByteStringContext(SharedMultipleUseFlag.None);
@@ -456,26 +460,27 @@ namespace Voron.Impl
             }
         }
 
+        private static readonly TransactionHeader TxHeaderInitializerTemplate = new()
+        {
+            HeaderMarker = Constants.TransactionHeaderMarker,
+            LastPageNumber = -1,
+            PageCount = -1,
+            TxMarker = TransactionMarker.None,
+            CompressedSize = 0,
+            UncompressedSize = 0
+        };
+
+
         private void InitTransactionHeader()
         {
-            Allocator.Allocate(sizeof(TransactionHeader), out _txHeaderMemory);
-            Memory.Set(_txHeaderMemory.Ptr, 0, sizeof(TransactionHeader));
-
-            _txHeader = (TransactionHeader*)_txHeaderMemory.Ptr;
-            _txHeader->HeaderMarker = Constants.TransactionHeaderMarker;
-
             if (_id > 1 && _state.NextPageNumber <= 1)
                 ThrowNextPageNumberCannotBeSmallerOrEqualThanOne();
 
-            _txHeader->TransactionId = _id;
-            _txHeader->NextPageNumber = _state.NextPageNumber;
-            _txHeader->LastPageNumber = -1;
-            _txHeader->PageCount = -1;
-            _txHeader->Hash = 0;
-            _txHeader->TimeStampTicksUtc = DateTime.UtcNow.Ticks;
-            _txHeader->TxMarker = TransactionMarker.None;
-            _txHeader->CompressedSize = 0;
-            _txHeader->UncompressedSize = 0;
+            _txHeader.HeaderMarker = Constants.TransactionHeaderMarker;
+
+            _txHeader.TransactionId = _id;
+            _txHeader.NextPageNumber = _state.NextPageNumber;
+            _txHeader.TimeStampTicksUtc = DateTime.UtcNow.Ticks;
         }
 
         internal HashSet<PageFromScratchBuffer> GetTransactionPages()
@@ -598,8 +603,7 @@ namespace Voron.Impl
         {
             // Check if we can hit the lowest level locality cache.
             Page p;
-            PageFromScratchBuffer value;
-            if (_scratchPagesTable != null && _scratchPagesTable.TryGetValue(pageNumber, out value)) // Scratch Pages Table will be null in read transactions
+            if (_scratchPagesTable != null && _scratchPagesTable.TryGetValue(pageNumber, out PageFromScratchBuffer value)) // Scratch Pages Table will be null in read transactions
             {
                 Debug.Assert(value != null);
                 PagerState state = null;
@@ -618,7 +622,7 @@ namespace Voron.Impl
                 }
 
                 p = _env.ScratchBufferPool.ReadPage(this, value.ScratchFileNumber, value.PositionInScratchBuffer, state);
-                Debug.Assert(p.PageNumber == pageNumber, string.Format("Requested ReadOnly page #{0}. Got #{1} from scratch", pageNumber, p.PageNumber));
+                Debug.Assert(p.PageNumber == pageNumber, $"Requested ReadOnly page #{pageNumber}. Got #{p.PageNumber} from scratch");
             }
             else
             {
@@ -626,13 +630,13 @@ namespace Voron.Impl
                 if (pageFromJournal != null)
                 {
                     p = pageFromJournal.Value;
-                    Debug.Assert(p.PageNumber == pageNumber, string.Format("Requested ReadOnly page #{0}. Got #{1} from journal", pageNumber, p.PageNumber));
+                    Debug.Assert(p.PageNumber == pageNumber, $"Requested ReadOnly page #{pageNumber}. Got #{p.PageNumber} from journal");
                 }
                 else
                 {
                     p = new Page(DataPager.AcquirePagePointerWithOverflowHandling(this, pageNumber));
 
-                    Debug.Assert(p.PageNumber == pageNumber, string.Format("Requested ReadOnly page #{0}. Got #{1} from data file", pageNumber, p.PageNumber));
+                    Debug.Assert(p.PageNumber == pageNumber, $"Requested ReadOnly page #{pageNumber}. Got #{p.PageNumber} from data file");
 
                     // When encryption is off, we do validation by checksum
                     if (_env.Options.Encryption.IsEnabled == false)
@@ -654,8 +658,7 @@ namespace Voron.Impl
                 return *(T*)page.Pointer;
 
             T result;
-            PageFromScratchBuffer value;
-            if (_scratchPagesTable != null && _scratchPagesTable.TryGetValue(pageNumber, out value)) // Scratch Pages Table will be null in read transactions
+            if (_scratchPagesTable != null && _scratchPagesTable.TryGetValue(pageNumber, out PageFromScratchBuffer value)) // Scratch Pages Table will be null in read transactions
             {
                 Debug.Assert(value != null);
                 PagerState state = null;
@@ -833,11 +836,9 @@ namespace Voron.Impl
         private void ThrowQuotaExceededException(long pageNumber, long? maxAvailablePageNumber)
         {
             throw new QuotaException(
-                string.Format(
-                    "The maximum storage size quota ({0} bytes) has been reached. " +
-                    "Currently configured storage quota is allowing to allocate the following maximum page number {1}, while the requested page number is {2}. " +
-                    "To increase the quota, use the MaxStorageSize property on the storage environment options.",
-                    _env.Options.MaxStorageSize, maxAvailablePageNumber, pageNumber));
+                $"The maximum storage size quota ({_env.Options.MaxStorageSize} bytes) has been reached. " +
+                $"Currently configured storage quota is allowing to allocate the following maximum page number {maxAvailablePageNumber}, while the requested page number is {pageNumber}. " +
+                "To increase the quota, use the MaxStorageSize property on the storage environment options.");
         }
 
         internal void BreakLargeAllocationToSeparatePages(long pageNumber)
@@ -845,8 +846,7 @@ namespace Voron.Impl
             if (_txState != TxState.None)
                 ThrowObjectDisposed();
 
-            PageFromScratchBuffer value;
-            if (_scratchPagesTable.TryGetValue(pageNumber, out value) == false)
+            if (_scratchPagesTable.TryGetValue(pageNumber, out PageFromScratchBuffer value) == false)
                 throw new InvalidOperationException("The page " + pageNumber + " was not previous allocated in this transaction");
 
             if (value.NumberOfPages == 1)
@@ -874,14 +874,12 @@ namespace Voron.Impl
             if (_txState != TxState.None)
                 ThrowObjectDisposed();
 
-            PageFromScratchBuffer value;
-            if (_scratchPagesTable.TryGetValue(pageNumber, out value) == false)
-                throw new InvalidOperationException("The page " + pageNumber + " was not previous allocated in this transaction");
+            if (_scratchPagesTable.TryGetValue(pageNumber, out PageFromScratchBuffer value) == false)
+                throw new InvalidOperationException($"The page {pageNumber} was not previous allocated in this transaction");
 
             var page = _env.ScratchBufferPool.ReadPage(this, value.ScratchFileNumber, value.PositionInScratchBuffer);
             if (page.IsOverflow == false || page.OverflowSize < newSize)
-                throw new InvalidOperationException("The page " + pageNumber +
-                                                    " was is not an overflow page greater than " + newSize);
+                throw new InvalidOperationException($"The page {pageNumber} was is not an overflow page greater than {newSize}");
 
             var prevNumberOfPages = VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(page.OverflowSize);
             page.OverflowSize = newSize;
@@ -914,10 +912,9 @@ namespace Voron.Impl
             var pageNums = new HashSet<long>();
             foreach (var txPage in _transactionPages)
             {
-                var scratchPage = Environment.ScratchBufferPool.ReadPage(this, txPage.ScratchFileNumber,
-                    txPage.PositionInScratchBuffer);
+                var scratchPage = Environment.ScratchBufferPool.ReadPage(this, txPage.ScratchFileNumber, txPage.PositionInScratchBuffer);
                 if (pageNums.Add(scratchPage.PageNumber) == false)
-                    throw new InvalidDataException("Duplicate page in transaction: " + scratchPage.PageNumber);
+                    throw new InvalidDataException($"Duplicate page in transaction: {scratchPage.PageNumber}");
             }
         }
 
@@ -1279,10 +1276,11 @@ namespace Voron.Impl
             if (_state.NextPageNumber <= 1)
                 ThrowNextPageNumberCannotBeSmallerOrEqualThanOne();
 
-            _txHeader->LastPageNumber = _state.NextPageNumber - 1;
-            _state.Root.CopyTo(&_txHeader->Root);
+            _txHeader.LastPageNumber = _state.NextPageNumber - 1;
+            ref var rootHeader = ref _txHeader.Root;
+            _state.Root.CopyTo(ref rootHeader);
 
-            _txHeader->TxMarker |= TransactionMarker.Commit;
+            _txHeader.TxMarker |= TransactionMarker.Commit;
 
             LastChanceToReadFromWriteTransactionBeforeCommit?.Invoke(this);
         }
@@ -1301,8 +1299,6 @@ namespace Voron.Impl
             try
             {
                 ValidateAllPages();
-
-                Allocator.Release(ref _txHeaderMemory);
 
                 Committed = true;
 
@@ -1369,9 +1365,6 @@ namespace Voron.Impl
                 _env.ScratchBufferPool.Free(this, pageFromScratch.ScratchFileNumber, pageFromScratch.PositionInScratchBuffer, null);
             }
 
-            // release scratch file page allocated for the transaction header
-            Allocator.Release(ref _txHeaderMemory);
-
             using (_env.PreventNewTransactions())
             {
                 _env.ScratchBufferPool.UpdateCacheForPagerStatesOfAllScratches();
@@ -1394,7 +1387,7 @@ namespace Voron.Impl
         private PagerState _lastState;
 
         internal bool FlushInProgressLockTaken;
-        private ByteString _txHeaderMemory;
+
         internal ImmutableAppendOnlyList<JournalFile> JournalFiles;
         internal bool AlreadyAllowedDisposeWithLazyTransactionRunning;
         public DateTime TxStartTime;
@@ -1605,11 +1598,6 @@ namespace Voron.Impl
         [Conditional("VALIDATE_PAGES")]
         private void UntrackDirtyPage(long page) { }
 #endif
-
-        internal TransactionHeader* GetTransactionHeader()
-        {
-            return _txHeader;
-        }
 
         internal TestingStuff ForTestingPurposesOnly()
         {

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -197,7 +197,7 @@ namespace Voron.Impl
 
                 _scratchPagerStates = previous._scratchPagerStates;
 
-                _state = previous._state.Clone();
+                _state = previous._state;
 
                 InitializeRoots();
 
@@ -369,7 +369,7 @@ namespace Voron.Impl
                     // for write transactions, we can use the current one (which == null)
                     _scratchPagerStates = scratchPagerStates;
 
-                    _state = env.State.Clone();
+                    _state = env.State;
 
                     InitializeRoots();
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -447,7 +447,7 @@ namespace Voron.Impl
             if (State.Root != null)
                 return;
 
-            State.Root = root.State;
+            State.Initialize(root.State);
 
             _root = root;
         }
@@ -732,7 +732,7 @@ namespace Voron.Impl
                 if (pageNumber == null) // allocate from end of file
                 {
                     pageNumber = State.NextPageNumber;
-                    State.NextPageNumber += numberOfPages;
+                    State.UpdateNextPage(State.NextPageNumber + numberOfPages);
                 }
             }
             return AllocatePage(numberOfPages, pageNumber.Value, previousPage, zeroPage);

--- a/src/Voron/Impl/StorageEnvironmentState.cs
+++ b/src/Voron/Impl/StorageEnvironmentState.cs
@@ -1,4 +1,6 @@
-﻿using Voron.Data.BTrees;
+﻿using System.Diagnostics;
+using Voron.Data.BTrees;
+using Voron.Global;
 
 namespace Voron.Impl
 {
@@ -19,9 +21,9 @@ namespace Voron.Impl
             NextPageNumber = nextPage;
         }
 
-        public void Initialize(TreeMutableState state)
+        public void Initialize(TreeMutableState rootObjectsState)
         {
-            Root = state;
+            Root = rootObjectsState;
         }
 
         public void UpdateNextPage(long nextPage)

--- a/src/Voron/Impl/StorageEnvironmentState.cs
+++ b/src/Voron/Impl/StorageEnvironmentState.cs
@@ -4,28 +4,34 @@ namespace Voron.Impl
 {
     public sealed class StorageEnvironmentState
     {
-        public TreeMutableState Root { get; set; }
-        public StorageEnvironmentOptions Options { get; set; }
+        public TreeMutableState Root { get; private set; }
 
-        public long NextPageNumber;
+        public long NextPageNumber { get; private set; }
 
-        public StorageEnvironmentState() { }
-
-        public StorageEnvironmentState(Tree root, long nextPageNumber)
+        private StorageEnvironmentState(TreeMutableState root, long nextPageNumber)
         {
-            if (root != null)
-                Root = root.State;
+            Root = root;
             NextPageNumber = nextPageNumber;
+        }
+
+        public StorageEnvironmentState(long nextPage)
+        {
+            NextPageNumber = nextPage;
+        }
+
+        public void Initialize(TreeMutableState state)
+        {
+            Root = state;
+        }
+
+        public void UpdateNextPage(long nextPage)
+        {
+            NextPageNumber = nextPage;
         }
 
         public StorageEnvironmentState Clone()
         {
-            return new StorageEnvironmentState
-                {
-                    Root = Root?.Clone(),
-                    NextPageNumber = NextPageNumber,
-                    Options = Options
-                };
+            return new StorageEnvironmentState(Root?.Clone(), NextPageNumber);
         }
     }
 }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -305,11 +305,7 @@ namespace Voron
 
             var entry = _headerAccessor.CopyHeader();
             var nextPageNumber = (header->TransactionId == 0 ? entry.LastPageNumber : header->LastPageNumber) + 1;
-            State = new StorageEnvironmentState(null, nextPageNumber)
-            {
-                NextPageNumber = nextPageNumber,
-                Options = Options
-            };
+            State = new StorageEnvironmentState(nextPageNumber);
 
             Interlocked.Exchange(ref _transactionsCounter, header->TransactionId == 0 ? entry.TransactionId : header->TransactionId);
             var transactionPersistentContext = new TransactionPersistentContext(true);
@@ -446,10 +442,7 @@ namespace Voron
         private void CreateNewDatabase()
         {
             const int initialNextPageNumber = 0;
-            State = new StorageEnvironmentState(null, initialNextPageNumber)
-            {
-                Options = Options
-            };
+            State = new StorageEnvironmentState(initialNextPageNumber);
 
             if (Options.SimulateFailureOnDbCreation)
                 ThrowSimulateFailureOnDbCreation();

--- a/test/FastTests/Voron/Trees/FreeSpaceTest.cs
+++ b/test/FastTests/Voron/Trees/FreeSpaceTest.cs
@@ -90,7 +90,7 @@ namespace FastTests.Voron.Trees
 
             using (var tx = Env.WriteTransaction())
             {
-                tx.LowLevelTransaction.State.NextPageNumber = maxPageNumber + 1;
+                tx.LowLevelTransaction.State.UpdateNextPage(maxPageNumber + 1);
 
                 tx.Commit();
             }
@@ -146,7 +146,7 @@ namespace FastTests.Voron.Trees
 
             using (var tx = Env.WriteTransaction())
             {
-                tx.LowLevelTransaction.State.NextPageNumber = maxPageNumber + 1;
+                tx.LowLevelTransaction.State.UpdateNextPage(maxPageNumber + 1);
 
                 tx.Commit();
             }

--- a/test/SlowTests/Voron/Issues/RavenDB_10813.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_10813.cs
@@ -29,7 +29,7 @@ namespace SlowTests.Voron.Issues
 
             using (var tx = Env.WriteTransaction())
             {
-                tx.LowLevelTransaction.State.NextPageNumber = 10;
+                tx.LowLevelTransaction.State.UpdateNextPage(10);
 
                 tx.LowLevelTransaction.AllocatePage(1, 3);
                 tx.LowLevelTransaction.AllocatePage(1, 4);

--- a/test/SlowTests/Voron/Issues/RavenDB_10825.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_10825.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Voron.Issues
         {
             using (var tx = Env.WriteTransaction())
             {
-                tx.LowLevelTransaction.State.NextPageNumber = 10;
+                tx.LowLevelTransaction.State.UpdateNextPage(10);
                 
                 var page = tx.LowLevelTransaction.AllocatePage(1, 4);
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21926

### Additional description

During the removal of the mutable state it was found that there is a lot of complexity around the concept of storage state. Since doing all the changes at the same time is too risky this is an intermediate simplification of some of the required work. This allow to diminish the risk and test independently the important moving parts.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
