### PR TITLE
RavenDB-21012 Fixing occasionally failing test related to a tombstone blockage notification

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19967.cs
+++ b/test/SlowTests/Issues/RavenDB-19967.cs
@@ -325,7 +325,7 @@ namespace SlowTests.Issues
                 switch (etlType)
                 {
                     case EtlType.Raven:
-                        var ravenConnectionString = new RavenConnectionString { Name = store.Identifier, Database = store.Database, TopologyDiscoveryUrls = store.Urls };
+                        var ravenConnectionString = new RavenConnectionString { Name = store.Identifier, Database = store.Database + "-non-existing", TopologyDiscoveryUrls = store.Urls };
                         var ravenConfiguration = new RavenEtlConfiguration { Name = _customTaskName, ConnectionStringName = ravenConnectionString.Name, Transforms = { transforms } };
                         taskId = await AddEtlAndDisableIt(store, ravenConnectionString, ravenConfiguration, OngoingTaskType.RavenEtl);
                         blockerType = ITombstoneAware.TombstoneDeletionBlockerType.RavenEtl;


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21012

### Additional description

The fix is to avoid doing ETL to the same database as it's used by the test.

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
