### PR TITLE
RavenDB-22096 Extract exception also when no sync context fo v5.4

### DIFF
--- a/src/Raven.Client/Util/AsyncHelpers.cs
+++ b/src/Raven.Client/Util/AsyncHelpers.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,6 +33,7 @@ namespace Raven.Client.Util
         public static void RunSync(Func<Task> task)
         {
             var oldContext = SynchronizationContext.Current;
+            var sw = Stopwatch.StartNew();
 
             // Do we have an active synchronization context?
             if (UseTaskAwaiterWhenNoSynchronizationContextIsAvailable && oldContext == null)
@@ -43,13 +45,11 @@ namespace Raven.Client.Util
                 }
                 catch (AggregateException ex)
                 {
-                    var exception = ex.ExtractSingleInnerException();
-                    ExceptionDispatchInfo.Capture(exception).Throw();
+                    HandleException(ex, sw);
                 }
                 return;
             }
 
-            var sw = Stopwatch.StartNew();
             var synch = _pool.Allocate();
 
             SynchronizationContext.SetSynchronizationContext(synch);
@@ -75,10 +75,7 @@ namespace Raven.Client.Util
             }
             catch (AggregateException ex)
             {
-                var exception = ex.ExtractSingleInnerException();
-                if (exception is OperationCanceledException)
-                    throw new TimeoutException("Operation timed out after: " + sw.Elapsed, ex);
-                ExceptionDispatchInfo.Capture(exception).Throw();
+                HandleException(ex, sw);
             }
             finally
             {
@@ -91,17 +88,23 @@ namespace Raven.Client.Util
         public static T RunSync<T>(Func<Task<T>> task)
         {
             var oldContext = SynchronizationContext.Current;
+            var sw = Stopwatch.StartNew();
 
             // Do we have an active synchronization context?
             if (UseTaskAwaiterWhenNoSynchronizationContextIsAvailable && oldContext == null)
             {
                 // We can run synchronously without any issue.
-                return task().GetAwaiter().GetResult();
+                try
+                {
+                    return task().GetAwaiter().GetResult();
+                }
+                catch (AggregateException ex)
+                {
+                    HandleException(ex, sw);
+                }
             }
 
             var result = default(T);
-
-            var sw = Stopwatch.StartNew();
             var synch = _pool.Allocate();
 
             SynchronizationContext.SetSynchronizationContext(synch);
@@ -128,10 +131,7 @@ namespace Raven.Client.Util
             }
             catch (AggregateException ex)
             {
-                var exception = ex.ExtractSingleInnerException();
-                if (exception is OperationCanceledException)
-                    throw new TimeoutException("Operation timed out after: " + sw.Elapsed, ex);
-                ExceptionDispatchInfo.Capture(exception).Throw();
+                HandleException(ex, sw);
             }
             finally
             {
@@ -146,6 +146,7 @@ namespace Raven.Client.Util
         internal static T RunSync<T>(Func<ValueTask<T>> taskFactory)
         {
             var oldContext = SynchronizationContext.Current;
+            var sw = Stopwatch.StartNew();
 
             var task = taskFactory();
 
@@ -153,12 +154,17 @@ namespace Raven.Client.Util
             if (UseTaskAwaiterWhenNoSynchronizationContextIsAvailable && oldContext == null && task.IsCompleted)
             {
                 // We can run synchronously without any issue.
-                return task.GetAwaiter().GetResult();
+                try
+                {
+                    return task.GetAwaiter().GetResult();
+                }
+                catch (AggregateException ex)
+                {
+                    HandleException(ex, sw);
+                }
             }
 
             var result = default(T);
-
-            var sw = Stopwatch.StartNew();
             var synch = _pool.Allocate();
 
             SynchronizationContext.SetSynchronizationContext(synch);
@@ -185,10 +191,7 @@ namespace Raven.Client.Util
             }
             catch (AggregateException ex)
             {
-                var exception = ex.ExtractSingleInnerException();
-                if (exception is OperationCanceledException)
-                    throw new TimeoutException("Operation timed out after: " + sw.Elapsed, ex);
-                ExceptionDispatchInfo.Capture(exception).Throw();
+                HandleException(ex, sw);
             }
             finally
             {
@@ -198,6 +201,18 @@ namespace Raven.Client.Util
             _pool.Free(synch);
 
             return result;
+        }
+
+#if !NETSTANDARD2_0
+        [DoesNotReturn]
+#endif
+        private static void HandleException(AggregateException ex, Stopwatch sw)
+        {
+            var exception = ex.ExtractSingleInnerException();
+            if (exception is OperationCanceledException)
+                throw new TimeoutException("Operation timed out after: " + sw.Elapsed, ex);
+
+            ExceptionDispatchInfo.Capture(exception).Throw();
         }
 
         private sealed class ExclusiveSynchronizationContext : SynchronizationContext

--- a/src/Raven.Client/Util/AsyncHelpers.cs
+++ b/src/Raven.Client/Util/AsyncHelpers.cs
@@ -37,7 +37,15 @@ namespace Raven.Client.Util
             if (UseTaskAwaiterWhenNoSynchronizationContextIsAvailable && oldContext == null)
             {
                 // We can run synchronously without any issue.
-                task().GetAwaiter().GetResult();
+                try
+                {
+                    task().GetAwaiter().GetResult();
+                }
+                catch (AggregateException ex)
+                {
+                    var exception = ex.ExtractSingleInnerException();
+                    ExceptionDispatchInfo.Capture(exception).Throw();
+                }
                 return;
             }
 

--- a/test/FastTests/Client/AsyncHelperTest.cs
+++ b/test/FastTests/Client/AsyncHelperTest.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Raven.Client.Util;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Client;
+
+public class AsyncHelperTest : RavenTestBase
+{
+    public AsyncHelperTest(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public void RunSync_WhenThrow_ShouldThrowSameExceptionWithAndWithoutAsyncContest()
+    {
+        var oldContext = SynchronizationContext.Current;
+        TestException testException = new TestException();
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext(null);
+            var withoutContext = Assert.ThrowsAny<Exception>(() => AsyncHelpers.RunSync(() => throw testException));
+
+            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+            var withContext = Assert.ThrowsAny<Exception>(() => AsyncHelpers.RunSync(() => throw testException));
+                
+            Assert.Equal(withoutContext.GetType(), withContext.GetType());
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(oldContext);
+        }
+    }
+        
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public void RunSync_WhenThrowAggregateException_ShouldThrowSameExceptionWithAndWithoutAsyncContest()
+    {
+        var oldContext = SynchronizationContext.Current;
+
+        var aggregateException = new AggregateException(new List<Exception>{new TestException()});
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext(null);
+            var withoutContext = Assert.ThrowsAny<Exception>(() => AsyncHelpers.RunSync(() => throw aggregateException));
+
+            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+            var withContext = Assert.ThrowsAny<Exception>(() => AsyncHelpers.RunSync(() => throw aggregateException));
+        
+            Assert.Equal(withoutContext.GetType(), withContext.GetType());
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(oldContext);
+        }
+    }
+        
+    private class TestException : Exception
+    {
+            
+    }
+        
+    private class SimpleSynchronizationContext : SynchronizationContext
+    {
+        public override void Post(SendOrPostCallback d, object state) => d(state);
+    }
+}

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -1049,7 +1049,7 @@ namespace RachisTests.DatabaseCluster
                 try
                 {
                     var db = await srcLeader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(srcDB);
-                    var ex = await Assert.ThrowsAsync<AggregateException>(async () =>
+                    var ex = await Assert.ThrowsAsync<TimeoutException>(async () =>
                     {
                         var wait = Task.Delay(TimeSpan.FromSeconds(30));
                         var exec = Task.Run(() =>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22096

### Additional description
I have some doubts here
We can make sure the behavior is the same for running `AsyncHelpers.RunSync` with and without sync context.
I think extracting the exception from the `AggregateException` is the right way to go
but it is a public client API and a very basic one so maybe better to leave it (and just adjust the test to handle that)

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
