### PR TITLE
RavenDB-22121 Ingoring expected exceptions in a test when waiting for index replacement operation

### DIFF
--- a/test/SlowTests/Issues/RavenDB_11255.cs
+++ b/test/SlowTests/Issues/RavenDB_11255.cs
@@ -49,10 +49,21 @@ namespace SlowTests.Issues
 
                     for (int i = 0; i < 10; i++)
                     {
-                        persistedDef = MapIndexDefinition.Load(index._indexStorage.Environment(), out var version);
+                        try
+                        {
+                            persistedDef = MapIndexDefinition.Load(index._indexStorage.Environment(), out var version);
 
-                        if (persistedDef.Priority == IndexPriority.High)
-                            break;
+                            if (persistedDef.Priority == IndexPriority.High)
+                                break;
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // index is being replaced, storage environment is being disposed
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // index is being replaced, storage environment is being disposed
+                        }
 
                         Thread.Sleep(1000);
                     }


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22121

### Additional description

We're using low level methods to access the storage environment so it might happen that it's being disposed.

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
