### PR TITLE
RavenDB-22074 - Add an option to specify max items to process in sing…

### DIFF
--- a/src/Raven.Client/Documents/Operations/Expiration/ExpirationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Expiration/ExpirationConfiguration.cs
@@ -8,11 +8,16 @@ namespace Raven.Client.Documents.Operations.Expiration
 
         public long? DeleteFrequencyInSec { get; set; }
 
+        public long? ExpirationMaxItemsToProcess { get; set; }
+
         public override int GetHashCode()
         {
             unchecked
             {
-                return (Disabled.GetHashCode() * 397) ^ DeleteFrequencyInSec.GetHashCode();
+                int hashCode = Disabled.GetHashCode();
+                hashCode = (hashCode * 397) ^ (DeleteFrequencyInSec?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (ExpirationMaxItemsToProcess?.GetHashCode() ?? 0);
+                return hashCode;
             }
         }
 
@@ -26,7 +31,7 @@ namespace Raven.Client.Documents.Operations.Expiration
 
         protected bool Equals(ExpirationConfiguration other)
         {
-            return Disabled == other.Disabled && DeleteFrequencyInSec == other.DeleteFrequencyInSec;
+            return Disabled == other.Disabled && DeleteFrequencyInSec == other.DeleteFrequencyInSec && ExpirationMaxItemsToProcess == other.ExpirationMaxItemsToProcess;
         }
 
         public DynamicJsonValue ToJson()
@@ -34,7 +39,8 @@ namespace Raven.Client.Documents.Operations.Expiration
             return new DynamicJsonValue
             {
                 [nameof(Disabled)] = Disabled,
-                [nameof(DeleteFrequencyInSec)] = DeleteFrequencyInSec
+                [nameof(DeleteFrequencyInSec)] = DeleteFrequencyInSec,
+                [nameof(ExpirationMaxItemsToProcess)] = ExpirationMaxItemsToProcess
             };
         }
     }

--- a/src/Raven.Client/Documents/Operations/Expiration/ExpirationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Expiration/ExpirationConfiguration.cs
@@ -8,7 +8,7 @@ namespace Raven.Client.Documents.Operations.Expiration
 
         public long? DeleteFrequencyInSec { get; set; }
 
-        public long? ExpirationMaxItemsToProcess { get; set; }
+        public long? MaxItemsToProcess { get; set; }
 
         public override int GetHashCode()
         {
@@ -16,7 +16,7 @@ namespace Raven.Client.Documents.Operations.Expiration
             {
                 int hashCode = Disabled.GetHashCode();
                 hashCode = (hashCode * 397) ^ (DeleteFrequencyInSec?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (ExpirationMaxItemsToProcess?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (MaxItemsToProcess?.GetHashCode() ?? 0);
                 return hashCode;
             }
         }
@@ -31,7 +31,7 @@ namespace Raven.Client.Documents.Operations.Expiration
 
         protected bool Equals(ExpirationConfiguration other)
         {
-            return Disabled == other.Disabled && DeleteFrequencyInSec == other.DeleteFrequencyInSec && ExpirationMaxItemsToProcess == other.ExpirationMaxItemsToProcess;
+            return Disabled == other.Disabled && DeleteFrequencyInSec == other.DeleteFrequencyInSec && MaxItemsToProcess == other.MaxItemsToProcess;
         }
 
         public DynamicJsonValue ToJson()
@@ -40,7 +40,7 @@ namespace Raven.Client.Documents.Operations.Expiration
             {
                 [nameof(Disabled)] = Disabled,
                 [nameof(DeleteFrequencyInSec)] = DeleteFrequencyInSec,
-                [nameof(ExpirationMaxItemsToProcess)] = ExpirationMaxItemsToProcess
+                [nameof(MaxItemsToProcess)] = MaxItemsToProcess
             };
         }
     }

--- a/src/Raven.Client/Documents/Operations/Refresh/RefreshConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/RefreshConfiguration.cs
@@ -8,11 +8,11 @@ namespace Raven.Client.Documents.Operations.Refresh
 
         public long? RefreshFrequencyInSec { get; set; }
 
-        public long? RefreshMaxItemsToProcess { get; set; }
+        public long? MaxItemsToProcess { get; set; }
 
         protected bool Equals(RefreshConfiguration other)
         {
-            return Disabled == other.Disabled && RefreshFrequencyInSec == other.RefreshFrequencyInSec && RefreshMaxItemsToProcess == other.RefreshMaxItemsToProcess;
+            return Disabled == other.Disabled && RefreshFrequencyInSec == other.RefreshFrequencyInSec && MaxItemsToProcess == other.MaxItemsToProcess;
         }
 
         public override bool Equals(object obj)
@@ -32,7 +32,7 @@ namespace Raven.Client.Documents.Operations.Refresh
             {
                 int hashCode = Disabled.GetHashCode();
                 hashCode = (hashCode * 397) ^ (RefreshFrequencyInSec?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (RefreshMaxItemsToProcess?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (MaxItemsToProcess?.GetHashCode() ?? 0);
                 return hashCode;
             }
         }
@@ -43,7 +43,7 @@ namespace Raven.Client.Documents.Operations.Refresh
             {
                 [nameof(Disabled)] = Disabled,
                 [nameof(RefreshFrequencyInSec)] = RefreshFrequencyInSec,
-                [nameof(RefreshMaxItemsToProcess)] = RefreshMaxItemsToProcess
+                [nameof(MaxItemsToProcess)] = MaxItemsToProcess
             };
         }
     }

--- a/src/Raven.Client/Documents/Operations/Refresh/RefreshConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/RefreshConfiguration.cs
@@ -8,10 +8,11 @@ namespace Raven.Client.Documents.Operations.Refresh
 
         public long? RefreshFrequencyInSec { get; set; }
 
+        public long? RefreshMaxItemsToProcess { get; set; }
 
         protected bool Equals(RefreshConfiguration other)
         {
-            return Disabled == other.Disabled && RefreshFrequencyInSec == other.RefreshFrequencyInSec;
+            return Disabled == other.Disabled && RefreshFrequencyInSec == other.RefreshFrequencyInSec && RefreshMaxItemsToProcess == other.RefreshMaxItemsToProcess;
         }
 
         public override bool Equals(object obj)
@@ -29,12 +30,12 @@ namespace Raven.Client.Documents.Operations.Refresh
         {
             unchecked
             {
-                var hashCode = Disabled.GetHashCode();
-                hashCode = (hashCode * 397) ^ RefreshFrequencyInSec.GetHashCode();
+                int hashCode = Disabled.GetHashCode();
+                hashCode = (hashCode * 397) ^ (RefreshFrequencyInSec?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (RefreshMaxItemsToProcess?.GetHashCode() ?? 0);
                 return hashCode;
             }
         }
-
 
         public DynamicJsonValue ToJson()
         {
@@ -42,6 +43,7 @@ namespace Raven.Client.Documents.Operations.Refresh
             {
                 [nameof(Disabled)] = Disabled,
                 [nameof(RefreshFrequencyInSec)] = RefreshFrequencyInSec,
+                [nameof(RefreshMaxItemsToProcess)] = RefreshMaxItemsToProcess
             };
         }
     }

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -176,6 +176,7 @@ namespace Raven.Server.Documents.Expiration
                                     if (allExpired)
                                     {
                                         expiredDocs.Add((clonedId, id));
+                                        totalCount++;
                                     }
                                 }
                             } while (multiIt.MoveNext() 

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -14,7 +14,6 @@ using Raven.Client.ServerWide;
 using Raven.Server.Background;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
-using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Platform;
 using Voron;
@@ -27,9 +26,7 @@ namespace Raven.Server.Documents.Expiration
             ? 4096
             : 1024;
 
-        internal static int MaxItemsToProcess = PlatformDetails.Is32Bits == false
-            ? int.MaxValue
-            : BatchSize * 16;
+        internal static int DefaultMaxItemsToProcessInSingleRun = int.MaxValue;
 
         private readonly DocumentDatabase _database;
         private readonly TimeSpan _refreshPeriod;
@@ -123,12 +120,12 @@ namespace Raven.Server.Documents.Expiration
 
         internal Task CleanupExpiredDocs(int? batchSize = null)
         {
-            return CleanupDocs(batchSize ?? BatchSize, ExpirationConfiguration.MaxItemsToProcess ?? MaxItemsToProcess, forExpiration: true);
+            return CleanupDocs(batchSize ?? BatchSize, ExpirationConfiguration.MaxItemsToProcess ?? DefaultMaxItemsToProcessInSingleRun, forExpiration: true);
         }
 
         internal Task RefreshDocs(int? batchSize = null)
         {
-            return CleanupDocs(batchSize ?? BatchSize, RefreshConfiguration.MaxItemsToProcess ?? MaxItemsToProcess, forExpiration: false);
+            return CleanupDocs(batchSize ?? BatchSize, RefreshConfiguration.MaxItemsToProcess ?? DefaultMaxItemsToProcessInSingleRun, forExpiration: false);
         }
         
         private async Task CleanupDocs(int batchSize, long maxItemsToProcess, bool forExpiration)

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -123,12 +123,12 @@ namespace Raven.Server.Documents.Expiration
 
         internal Task CleanupExpiredDocs(int? batchSize = null)
         {
-            return CleanupDocs(batchSize ?? BatchSize, ExpirationConfiguration.ExpirationMaxItemsToProcess ?? MaxItemsToProcess, forExpiration: true);
+            return CleanupDocs(batchSize ?? BatchSize, ExpirationConfiguration.MaxItemsToProcess ?? MaxItemsToProcess, forExpiration: true);
         }
 
         internal Task RefreshDocs(int? batchSize = null)
         {
-            return CleanupDocs(batchSize ?? BatchSize, RefreshConfiguration.RefreshMaxItemsToProcess ?? MaxItemsToProcess, forExpiration: false);
+            return CleanupDocs(batchSize ?? BatchSize, RefreshConfiguration.MaxItemsToProcess ?? MaxItemsToProcess, forExpiration: false);
         }
         
         private async Task CleanupDocs(int batchSize, long maxItemsToProcess, bool forExpiration)

--- a/test/SlowTests/Issues/RDBS-68.cs
+++ b/test/SlowTests/Issues/RDBS-68.cs
@@ -98,7 +98,7 @@ namespace SlowTests.Issues
                     using (context.OpenReadTransaction())
                     {
                         var currentTime = database.Time.GetUtcNow();
-                        var options = new ExpirationStorage.ExpiredDocumentsOptions(context, currentTime, false, batchSize, 1024);
+                        var options = new ExpirationStorage.ExpiredDocumentsOptions(context, currentTime, false, batchSize, maxItemsToProcess: 1024);
 
                         var totalCount = 0;
                         var expired = database.DocumentsStorage.ExpirationStorage.GetExpiredDocuments(options, ref totalCount, out _, CancellationToken.None);

--- a/test/SlowTests/Issues/RDBS-68.cs
+++ b/test/SlowTests/Issues/RDBS-68.cs
@@ -99,16 +99,12 @@ namespace SlowTests.Issues
                     {
                         var currentTime = database.Time.GetUtcNow();
                         var options = new ExpirationStorage.ExpiredDocumentsOptions(context, currentTime, false, batchSize, 1024);
-                        
-                        var expired = database.DocumentsStorage.ExpirationStorage.GetExpiredDocuments(options, out _, out var totalCount, CancellationToken.None);
+
+                        var totalCount = 0;
+                        var expired = database.DocumentsStorage.ExpirationStorage.GetExpiredDocuments(options, ref totalCount, out _, CancellationToken.None);
                         Assert.Equal(expected, totalCount);
                     }
-
-
-                    
                 }
-
-                
             }
         }
 

--- a/test/SlowTests/Issues/RDBS-68.cs
+++ b/test/SlowTests/Issues/RDBS-68.cs
@@ -98,18 +98,9 @@ namespace SlowTests.Issues
                     using (context.OpenReadTransaction())
                     {
                         var currentTime = database.Time.GetUtcNow();
-                        var options = new ExpirationStorage.ExpiredDocumentsOptions(context, currentTime, false, batchSize);
+                        var options = new ExpirationStorage.ExpiredDocumentsOptions(context, currentTime, false, batchSize, 1024);
                         
-                        var expired = database.DocumentsStorage.ExpirationStorage.GetExpiredDocuments(options, out _, CancellationToken.None);
-                        var totalCount = 0;
-                        if (expired != null)
-                        {
-                            foreach (var singleExpired in expired)
-                            {
-                                totalCount += singleExpired.Value.Count;
-                            }
-                        }
-
+                        var expired = database.DocumentsStorage.ExpirationStorage.GetExpiredDocuments(options, out _, out var totalCount, CancellationToken.None);
                         Assert.Equal(expected, totalCount);
                     }
 

--- a/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
+++ b/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
@@ -309,8 +309,8 @@ namespace SlowTests.Server.Documents.Expiration
                 var config = new ExpirationConfiguration
                 {
                     Disabled = false,
-                    DeleteFrequencyInSec = TimeSpan.FromMinutes(10).Ticks,
-                    ExpirationMaxItemsToProcess = 9
+                    DeleteFrequencyInSec = (long)TimeSpan.FromMinutes(10).TotalSeconds,
+                    MaxItemsToProcess = 9
                 };
 
                 await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
@@ -357,8 +357,8 @@ namespace SlowTests.Server.Documents.Expiration
                 var config = new RefreshConfiguration()
                 {
                     Disabled = false,
-                    RefreshFrequencyInSec = TimeSpan.FromMinutes(10).Ticks,
-                    RefreshMaxItemsToProcess = 9
+                    RefreshFrequencyInSec = (long)TimeSpan.FromMinutes(10).TotalSeconds,
+                    MaxItemsToProcess = 9
                 };
 
                 await RefreshHelper.SetupExpiration(store, Server.ServerStore, config);

--- a/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
+++ b/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
@@ -15,6 +15,7 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Operations.Refresh;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Client.Util;
@@ -22,6 +23,7 @@ using Raven.Server.Documents.Expiration;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -206,12 +208,12 @@ namespace SlowTests.Server.Documents.Expiration
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var options = new ExpirationStorage.ExpiredDocumentsOptions(context, SystemTime.UtcNow.AddMinutes(10), true, 10);
+                    var options = new ExpirationStorage.ExpiredDocumentsOptions(context, SystemTime.UtcNow.AddMinutes(10), true, 10, 10);
                     
-                    var expired = database.DocumentsStorage.ExpirationStorage.GetExpiredDocuments(options, out _, CancellationToken.None);
+                    var expired = database.DocumentsStorage.ExpirationStorage.GetExpiredDocuments(options, out _, out _, CancellationToken.None);
                     Assert.Equal(1, expired.Count);
 
-                    var toRefresh = database.DocumentsStorage.ExpirationStorage.GetDocumentsToRefresh(options, out _, CancellationToken.None);
+                    var toRefresh = database.DocumentsStorage.ExpirationStorage.GetDocumentsToRefresh(options, out _, out _, CancellationToken.None);
                     Assert.Equal(1, toRefresh.Count);
                 }
             }
@@ -237,13 +239,12 @@ namespace SlowTests.Server.Documents.Expiration
                     await session.SaveChangesAsync();
                 }
 
-
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenWriteTransaction())
                 {
                     DateTime time = SystemTime.UtcNow.AddMinutes(10);
-                    var options = new ExpirationStorage.ExpiredDocumentsOptions(context, time, true, 10);
-                    var toRefresh = database.DocumentsStorage.ExpirationStorage.GetDocumentsToRefresh(options, out _, CancellationToken.None);
+                    var options = new ExpirationStorage.ExpiredDocumentsOptions(context, time, true, 10, 10);
+                    var toRefresh = database.DocumentsStorage.ExpirationStorage.GetDocumentsToRefresh(options, out _, out _, CancellationToken.None);
                     database.DocumentsStorage.ExpirationStorage.RefreshDocuments(context, toRefresh, time);
                 }
             }
@@ -278,6 +279,108 @@ namespace SlowTests.Server.Documents.Expiration
 
                     var error = await Assert.ThrowsAsync<RavenException>(async () => await session.SaveChangesAsync());
                     Assert.Contains($"The expiration date format for document '{company.Id.ToLowerInvariant()}' is not valid", error.Message);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ExpirationRefresh)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ExpirationWithMaxItemsToProcessConfiguredShouldWork(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                // Insert documents with expiration before activating the expiration
+                var expires = SystemTime.UtcNow.AddMinutes(5);
+                for (int i = 0; i < 10; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var company = new Company { Name = "Company Name", Id = $"companies/{i}" };
+                        await session.StoreAsync(company);
+                        var metadata = session.Advanced.GetMetadataFor(company);
+                        metadata[Constants.Documents.Metadata.Expires] = expires.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                var config = new ExpirationConfiguration
+                {
+                    Disabled = false,
+                    DeleteFrequencyInSec = TimeSpan.FromMinutes(10).Ticks,
+                    ExpirationMaxItemsToProcess = 9
+                };
+
+                await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
+
+                var database = await GetDatabase(store.Database);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                var expiredDocumentsCleaner = database.ExpiredDocumentsCleaner;
+                await expiredDocumentsCleaner.CleanupExpiredDocs();
+
+                var count = 0;
+                for (int i = 0; i < 10; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var company = await session.LoadAsync<Company>($"companies/{i}");
+                        if (company != null)
+                            count++;
+                    }
+                }
+                Assert.Equal(1, count);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ExpirationRefresh)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task RefreshWithMaxItemsToProcessConfiguredShouldWork(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                // Insert documents with refresh before activating the refresh
+                var refresh = SystemTime.UtcNow.AddMinutes(5);
+                for (int i = 0; i < 10; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var company = new Company { Name = "Company Name", Id = $"companies/{i}" };
+                        await session.StoreAsync(company);
+                        var metadata = session.Advanced.GetMetadataFor(company);
+                        metadata[Constants.Documents.Metadata.Refresh] = refresh.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                var config = new RefreshConfiguration()
+                {
+                    Disabled = false,
+                    RefreshFrequencyInSec = TimeSpan.FromMinutes(10).Ticks,
+                    RefreshMaxItemsToProcess = 9
+                };
+
+                await RefreshHelper.SetupExpiration(store, Server.ServerStore, config);
+
+                var database = await GetDatabase(store.Database);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+
+                DateTime time = SystemTime.UtcNow.AddMinutes(10);
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenWriteTransaction())
+                {
+                    var refreshOptions = new ExpirationStorage.ExpiredDocumentsOptions(context, time, true, 10, 10);
+                    var toRefresh = database.DocumentsStorage.ExpirationStorage.GetDocumentsToRefresh(refreshOptions, out _, out var totalCount, CancellationToken.None);
+                    Assert.Equal(10, totalCount);
+                }
+
+                var expiredDocumentsCleaner = database.ExpiredDocumentsCleaner;
+                await expiredDocumentsCleaner.RefreshDocs();
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenWriteTransaction())
+                {
+                    var refreshOptions = new ExpirationStorage.ExpiredDocumentsOptions(context, time, true, 10, 10);
+                    var toRefresh = database.DocumentsStorage.ExpirationStorage.GetDocumentsToRefresh(refreshOptions, out _, out var totalCount, CancellationToken.None);
+                    Assert.Equal(1, totalCount);
                 }
             }
         }


### PR DESCRIPTION
…le expiration and refresh run

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22074/Add-an-option-to-specify-max-items-to-process-in-single-expiration-and-refresh-run

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
