### PR TITLE
RavenDB-21947 - RachisTests.DatabaseCluster.ClusterDatabaseMaintenance.ClientShouldFailoverWhenTalkingToLoneDisconnectedNode

### DIFF
--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -1171,6 +1171,12 @@ namespace RachisTests.DatabaseCluster
 
                 await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
 
+                var res = await WaitForValueAsync(() =>
+                {
+                    return re?._nodeSelector?.Topology != null;
+                }, true);
+                Assert.True(res);
+
                 var selectorNodes = re._nodeSelector.Topology.Nodes;
                 Assert.Equal(3, selectorNodes.Count);
                 Assert.True(selectorNodes.All(x => x.ServerRole == ServerNode.Role.Member));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21947

### Additional description

Wait for topology population in test

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
