### PR TITLE
RavenDB-21911 Fix significance level calculation

### DIFF
--- a/test/SlowTests/Monitoring/DiskStatsGetterTest.cs
+++ b/test/SlowTests/Monitoring/DiskStatsGetterTest.cs
@@ -19,21 +19,21 @@ namespace SlowTests.Monitoring
         }
 
         [NightlyBuildMultiplatformFact(RavenPlatform.Linux)]
-        public async Task LinuxDiskStats_WhenGet_ShouldBeLessThenTwoSimpleGet()
+        public async Task LinuxDiskStats_WhenGetInParallel_ShouldTakeTheSameAsSequential()
         {
 #pragma warning disable CA1416
             var diskStatsGetter = new LinuxDiskStatsGetter(TimeSpan.FromMilliseconds(100));
 #pragma warning restore CA1416
-            await DiskStats_WhenGet_ShouldBeLessThenTwoSimpleGet(diskStatsGetter);
+            await DiskStats_WhenGetInParallel_ShouldTakeTheSameAsSequential(diskStatsGetter);
         }
 
         [NightlyBuildMultiplatformFact(RavenPlatform.Windows)]
-        public async Task WindowsDiskStats_WhenGet_ShouldBeLessThenTwoSimpleGet()
+        public async Task WindowsDiskStats_WhenGetInParallel_ShouldTakeTheSameAsSequential()
         {
 #pragma warning disable CA1416
             var diskStatsGetter = new WindowsDiskStatsGetter(TimeSpan.FromMilliseconds(100));
 #pragma warning restore CA1416
-            await DiskStats_WhenGet_ShouldBeLessThenTwoSimpleGet(diskStatsGetter);
+            await DiskStats_WhenGetInParallel_ShouldTakeTheSameAsSequential(diskStatsGetter);
         }
 
         [RavenFact(RavenTestCategory.Monitoring)]
@@ -106,7 +106,7 @@ namespace SlowTests.Monitoring
             public int Value { get; init; }
         }
 
-        private static async Task DiskStats_WhenGet_ShouldBeLessThenTwoSimpleGet(IDiskStatsGetter diskStatsGetter)
+        private static async Task DiskStats_WhenGetInParallel_ShouldTakeTheSameAsSequential(IDiskStatsGetter diskStatsGetter)
         {
             var currentDirectory = Directory.GetCurrentDirectory();
 
@@ -142,7 +142,7 @@ namespace SlowTests.Monitoring
                 })).ToArray();
 
             await Task.WhenAll(tasks);
-            var α = (double)errorCount / taskCount * iterationsCount;
+            var α = (double)errorCount / (taskCount * iterationsCount);
             Assert.True(α < 0.01, $"baseTime:{baseTime} errorCount:{errorCount} total:{taskCount * iterationsCount} α:{α}");
         }
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21911

### Additional description
Brackets were missing in significance level calculation in the test

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] The test was fixed

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
