### PR TITLE
RavenDB-22138 When receiving 503 Studio says the document was not found

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1120,20 +1120,26 @@ class editDocument extends shardViewModelBase {
             })
             .fail((xhr: JQueryXHR) => {
                 // if revisions is enabled try to load revisions bin entry
-                if (xhr.status === 404 && db.hasRevisionsConfiguration()) {
-                    this.loadRevisionsBinEntry(id)
-                        .done(doc => {
-                            if (doc) {
-                                loadTask.resolve(doc);
-                            } else {
-                                messagePublisher.reportWarning("Could not find document: " + id);
-                                loadTask.reject();
-                            }
-                        })
-                        .fail(() => loadTask.reject());
+                if (xhr.status === 404) {
+                    if (db.hasRevisionsConfiguration()) {
+                        this.loadRevisionsBinEntry(id)
+                            .done(doc => {
+                                if (doc) {
+                                    loadTask.resolve(doc);
+                                } else {
+                                    messagePublisher.reportWarning("Could not find document: " + id);
+                                    loadTask.reject();
+                                }
+                            })
+                            .fail(() => loadTask.reject());
+                    } else {
+                        this.dirtyFlag().reset();
+                        messagePublisher.reportWarning("Could not find document: " + id);
+                        loadTask.reject();
+                    }
                 } else {
                     this.dirtyFlag().reset();
-                    messagePublisher.reportWarning("Could not find document: " + id);
+                    messagePublisher.reportError("Could not load document: " + id);
                     loadTask.reject();
                 }
             })

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1139,7 +1139,7 @@ class editDocument extends shardViewModelBase {
                     }
                 } else {
                     this.dirtyFlag().reset();
-                    messagePublisher.reportError("Could not load document: " + id);
+                    messagePublisher.reportError("Could not load document: " + id, xhr.responseText, xhr.statusText);  
                     loadTask.reject();
                 }
             })


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22138 

### Additional description

Fixed handling 404 for load document

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
