### PR TITLE
RavenDB-22132 - Fix ClusterTransactionTests.ClusterTransactionConflict test for sharding

### DIFF
--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -1281,6 +1281,15 @@ namespace SlowTests.Cluster
                     await session.SaveChangesAsync();
                 }
 
+                await WaitAndAssertForValueAsync(async () =>
+                {
+                    using (var session = store1.OpenAsyncSession())
+                    {
+                        var u = await session.LoadAsync<User>("users/1");
+                        return u.Name;
+                    }
+                }, "Karmel");
+
                 using (var session = store2.OpenAsyncSession(new SessionOptions
                 {
                     TransactionMode = TransactionMode.ClusterWide
@@ -1292,6 +1301,15 @@ namespace SlowTests.Cluster
                     }, "users/1");
                     await session.SaveChangesAsync();
                 }
+
+                await WaitAndAssertForValueAsync(async () =>
+                {
+                    using (var session = store2.OpenAsyncSession())
+                    {
+                        var u = await session.LoadAsync<User>("users/1");
+                        return u.Name;
+                    }
+                }, "Grisha");
 
                 await Task.WhenAll(SetupReplicationAsync(store1, store2), SetupReplicationAsync(store2, store1));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22132/SlowTests.Cluster.ClusterTransactionTests.ClusterTransactionConflictoptions-DatabaseMode-Sharded-SearchEngineMode-Lucene

### Additional description

The test was failing because we don't wait for the doc that will be really stored after SaveChanges when we store a doc in cluster transaction on shared db.
So there is a chance that "Karmel" will be saved after "Grisha".

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
