### PR TITLE
RavenDB-21636 SlowTests.Issues.RavenDB_20084.ShouldUpdateBackupInfoIf…

### DIFF
--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -231,7 +231,8 @@ internal static class BackupUtils
 
     public static NextBackup GetNextBackupDetails(NextBackupDetailsParameters parameters)
     {
-        var nowUtc = SystemTime.UtcNow;
+        var nowUtc = DateTime.UtcNow;
+
         var lastFullBackupUtc = parameters.BackupStatus.LastFullBackupInternal ?? parameters.DatabaseWakeUpTimeUtc ?? parameters.Configuration.CreatedAt ?? nowUtc;
         var lastIncrementalBackupUtc = parameters.BackupStatus.LastIncrementalBackupInternal ?? parameters.BackupStatus.LastFullBackupInternal ?? parameters.DatabaseWakeUpTimeUtc ?? nowUtc;
         var nextFullBackup = GetNextBackupOccurrence(new NextBackupOccurrenceParameters
@@ -258,10 +259,9 @@ internal static class BackupUtils
         Debug.Assert(parameters.Configuration.TaskId != 0);
 
         var isFullBackup = IsFullBackup(parameters.BackupStatus, parameters.Configuration, nextFullBackup, nextIncrementalBackup, parameters.ResponsibleNodeTag);
-        var nextBackupTimeLocal = GetNextBackupDateTime(nextFullBackup, nextIncrementalBackup, parameters.BackupStatus.DelayUntil);
+        var nextBackupTimeUtc = GetNextBackupDateTime(nextFullBackup, nextIncrementalBackup, parameters.BackupStatus.DelayUntil);
 
-        var nowLocalTime = SystemTime.UtcNow.ToLocalTime();
-        var timeSpan = nextBackupTimeLocal - nowLocalTime;
+        var timeSpan = nextBackupTimeUtc - nowUtc;
 
         TimeSpan nextBackupTimeSpan;
         if (timeSpan.Ticks <= 0)
@@ -271,13 +271,13 @@ internal static class BackupUtils
             {
                 // the backup will run now
                 nextBackupTimeSpan = TimeSpan.Zero;
-                nextBackupTimeLocal = nowLocalTime;
+                nextBackupTimeUtc = nowUtc;
             }
             else
             {
                 // overdue backup from other node
                 nextBackupTimeSpan = TimeSpan.FromMinutes(1);
-                nextBackupTimeLocal = nowLocalTime + nextBackupTimeSpan;
+                nextBackupTimeUtc = nowUtc + nextBackupTimeSpan;
             }
         }
         else
@@ -285,10 +285,11 @@ internal static class BackupUtils
             nextBackupTimeSpan = timeSpan;
         }
 
+        nextBackupTimeUtc = DateTime.SpecifyKind(nextBackupTimeUtc, DateTimeKind.Utc);
         return new NextBackup
         {
             TimeSpan = nextBackupTimeSpan,
-            DateTime = nextBackupTimeLocal.ToUniversalTime(),
+            DateTime = nextBackupTimeUtc,
             OriginalBackupTime = parameters.BackupStatus.OriginalBackupTime,
             IsFull = isFullBackup,
             TaskId = parameters.Configuration.TaskId
@@ -303,7 +304,7 @@ internal static class BackupUtils
         try
         {
             var backupParser = CrontabSchedule.Parse(parameters.BackupFrequency);
-            return backupParser.GetNextOccurrence(parameters.LastBackupUtc.ToLocalTime());
+            return backupParser.GetNextOccurrence(parameters.LastBackupUtc);
         }
         catch (Exception e)
         {
@@ -330,9 +331,8 @@ internal static class BackupUtils
         else
             nextBackup = nextFullBackup <= nextIncrementalBackup ? nextFullBackup.Value : nextIncrementalBackup.Value;
 
-        return delayUntil.HasValue && delayUntil.Value.ToLocalTime() > nextBackup.Value
-            ? delayUntil.Value.ToLocalTime()
-            : nextBackup.Value;
+        return delayUntil.HasValue && delayUntil.Value > nextBackup.Value
+            ? delayUntil.Value : nextBackup.Value;
     }
 
     private static bool IsFullBackup(PeriodicBackupStatus backupStatus,
@@ -473,7 +473,7 @@ internal static class BackupUtils
             return null;
         }
 
-        var nowUtc = SystemTime.UtcNow;
+        var nowUtc = DateTime.UtcNow;
         if (nextBackup.DateTime < nowUtc)
         {
             // this backup is delayed

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2974,9 +2974,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.NotNull(taskBackupInfo.OnGoingBackup);
                     Assert.NotNull(taskBackupInfo.OnGoingBackup.StartTime);
 
-                    var delayDuration = TimeSpan.FromMinutes(delayDurationInMinutes);
-                    var delayUntil = DateTime.Now + delayDuration;
-                    await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
+                var delayDuration = TimeSpan.FromMinutes(delayDurationInMinutes);
+                var delayUntil = DateTime.UtcNow + delayDuration;
+                await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
 
                     // There should be no OnGoingBackup operation in the OngoingTaskBackup
                     await WaitForValueAsync(async () =>
@@ -3001,7 +3001,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(backupStatus.OriginalBackupTime,
                         delayUntil < nextFullBackup
                             ? taskBackupInfo.OnGoingBackup.StartTime    // until the next scheduled backup time.
-                            : nextFullBackup.Value.ToUniversalTime());  // after the next scheduled backup.
+                            : nextFullBackup.Value);  // after the next scheduled backup.
                 }, tcs: new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
             }
         }
@@ -3091,7 +3091,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.NotNull(taskBackupInfo);
                     Assert.NotNull(taskBackupInfo.OnGoingBackup);
 
-                    var expectedNextBackupDateTime = new DateTime(DateTime.Now.Year + 1, 1, 1, 0, 0, 0, DateTimeKind.Local).ToUniversalTime();
+                    var expectedNextBackupDateTime = new DateTime(DateTime.UtcNow.Year + 1, 1, 1, 0, 0, 0, DateTimeKind.Utc);
                     Assert.Equal(expectedNextBackupDateTime, taskBackupInfo.NextBackup.DateTime);
 
                     // Let's delay the backup task to next occurence + 1 hour


### PR DESCRIPTION
…DatabaseUnloaded

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21636

### Additional description

The issue arises from our reliance on local time for calculating the next backup time, during the transition to winter time in Israel.

On October 29, 2023, the period from 1 AM to 2 AM occurs twice due to the time change, resulting in two possible times: one before and one after the transition. When we converted 22:17:30 to local time, it became 1:17:30. consequently, we calculated the next backup time as 1:18:00 (the correct answer). However, upon reverting to UTC, the time became 23:18:00 instead.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
