### PR TITLE
RavenDB-22141 EntryReader must use more accurate comparison than lowest bit set for storing numeric values.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -1487,8 +1487,9 @@ namespace Corax.Indexing
                         recordedTermContainerId |= 1; // marker!
                         recordedTerm.Long = entries.Long.Value;
 
-                        // only if the double value can not be computed by casting from long, we store it 
-                        if (entries.Double != null && entries.Double.Value.AlmostEquals(recordedTerm.Long) == false)
+                        // only if the double value can not be computed by casting from long, we store it
+                        // Since we store double values internally as longs, converted via BitConverter, it is good to check whether equal elements have exactly the same value in this form.
+                        if (entries.Double != null && BitConverter.DoubleToInt64Bits(entries.Double.Value) != BitConverter.DoubleToInt64Bits(recordedTerm.Long))
                         {
                             recordedTermContainerId |= 2; // marker!
                             recordedTerm.Double = entries.Double.Value;

--- a/src/Voron/Data/Lookups/DoubleLookupKey.cs
+++ b/src/Voron/Data/Lookups/DoubleLookupKey.cs
@@ -67,6 +67,13 @@ public struct DoubleLookupKey : ILookupKey
         }
 
         var o = (DoubleLookupKey)(object)k;
+
+        if (Value is 0 && o.Value is 0)
+        {
+            // It's possible that we have a negative zero, in which case BitConverter will return completely different numbers for 0 and -0. In such case we use standard double comparer.
+            return true;
+        }
+        
         return BitConverter.DoubleToInt64Bits(Value) == BitConverter.DoubleToInt64Bits(o.Value);
     }
 

--- a/src/Voron/Data/Lookups/DoubleLookupKey.cs
+++ b/src/Voron/Data/Lookups/DoubleLookupKey.cs
@@ -67,7 +67,7 @@ public struct DoubleLookupKey : ILookupKey
         }
 
         var o = (DoubleLookupKey)(object)k;
-        return Value.AlmostEquals(o.Value);
+        return BitConverter.DoubleToInt64Bits(Value) == BitConverter.DoubleToInt64Bits(o.Value);
     }
 
     public void OnNewKeyAddition<T>(Lookup<T> parent) where T : struct, ILookupKey


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22141

### Additional description

This modified changes made in https://github.com/ravendb/ravendb/pull/18079

`IndexWriter`:
- In case the user stores integer value, we don't store double value in the index entry (since it's only cast). To see if we can reconstruct the double value from the long value, let's compare the values returned by `BitConventer`, since we use this method to prepare terms to insert into Lookup.
 
### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
