### PR TITLE
RavenDB-22008 - Use a separate semaphore for database record changes and value changes

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -91,6 +91,8 @@ namespace Raven.Server.Documents.Indexes
 
         public int HandleDatabaseRecordChange(DatabaseRecord record, long raftIndex, bool startIndexes = true)
         {
+            ForTestingPurposes?.BeforeHandleDatabaseRecordChange?.Invoke();
+
             try
             {
                 if (record == null)
@@ -2559,6 +2561,8 @@ namespace Raven.Server.Documents.Indexes
 
             internal Action<Index> BeforeIndexThreadExit;
             internal Action<Index> BeforeIndexStart;
+
+            public Action BeforeHandleDatabaseRecordChange;
 
             public TestingStuff(IndexStore parent)
             {

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -2562,7 +2562,7 @@ namespace Raven.Server.Documents.Indexes
             internal Action<Index> BeforeIndexThreadExit;
             internal Action<Index> BeforeIndexStart;
 
-            public Action BeforeHandleDatabaseRecordChange;
+            internal Action BeforeHandleDatabaseRecordChange;
 
             public TestingStuff(IndexStore parent)
             {

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1024,6 +1024,14 @@ namespace Raven.Server.ServerWide
                     var database = await completedTask;
                     await database.RefreshFeaturesAsync();
                 }
+                catch (OperationCanceledException)
+                {
+                    // database shutdown
+                }
+                catch (ObjectDisposedException)
+                {
+                    // database shutdown
+                }
                 catch (Exception e)
                 {
                     if (Logger.IsInfoEnabled)

--- a/test/SlowTests/Issues/RavenDB-22008.cs
+++ b/test/SlowTests/Issues/RavenDB-22008.cs
@@ -19,7 +19,7 @@ namespace SlowTests.Issues
         {
         }
 
-        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Subscriptions)]
         public async Task Index_Update_With_Subscription_Update()
         {
             using (var store = GetDocumentStore())
@@ -41,14 +41,11 @@ namespace SlowTests.Issues
                 var indexDisposeMre = new AsyncManualResetEvent(false);
                 var mreBeforeSendingCommand = new AsyncManualResetEvent(false);
 
-                var mreWasSet = false;
-
                 using (var cts = new CancellationTokenSource(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan * 2))
                 using (index.ForTestingPurposesOnly().CallDuringFinallyOfExecuteIndexing(() =>
                 {
                     // simulating a long indexing batch completion
                     indexDisposeMre.Wait(cts.Token);
-                    mreWasSet = indexDisposeMre.IsSet;
                 }))
                 {
                     database.IndexStore.ForTestingPurposesOnly().BeforeHandleDatabaseRecordChange = () =>
@@ -78,8 +75,6 @@ namespace SlowTests.Issues
 
                     indexDisposeMre.Set();
                     await deleteIndexTask;
-
-                    Assert.True(mreWasSet);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-22008.cs
+++ b/test/SlowTests/Issues/RavenDB-22008.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Util;
+using Raven.Server.ServerWide.Commands.Subscriptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22008 : RavenTestBase
+    {
+        public RavenDB_22008(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        public async Task Index_Update_With_Subscription_Update()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var indexDefinition = new Index();
+                await indexDefinition.ExecuteAsync(store);
+
+                var database = await GetDatabase(store.Database);
+                var index = database.IndexStore.GetIndex(indexDefinition.IndexName);
+
+                var subscriptionCreationParams = new SubscriptionCreationOptions
+                {
+                    Query = "from People"
+                };
+
+                var subName = await store.Subscriptions.CreateAsync(subscriptionCreationParams);
+                var subscriptionState = await store.Subscriptions.GetSubscriptionStateAsync(subName);
+
+                var indexDisposeMre = new ManualResetEventSlim(false);
+                var mreBeforeSendingCommand = new ManualResetEventSlim(false);
+
+                var mreWasSet = false;
+
+                using (index.ForTestingPurposesOnly().CallDuringFinallyOfExecuteIndexing(() =>
+                {
+                    // simulating a long indexing batch completion
+                    mreWasSet = indexDisposeMre.Wait(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
+                }))
+                {
+                    var deleteIndexTask = store.Maintenance.SendAsync(new DeleteIndexOperation(indexDefinition.IndexName));
+
+                    database.IndexStore.ForTestingPurposesOnly().BeforeHandleDatabaseRecordChange = () =>
+                    {
+                        mreBeforeSendingCommand.Set();
+                    };
+
+                    mreBeforeSendingCommand.Wait(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
+
+                    var command = new AcknowledgeSubscriptionBatchCommand(store.Database, RaftIdGenerator.NewId())
+                    {
+                        ChangeVector = "A:1",
+                        NodeTag = Server.ServerStore.NodeTag,
+                        HasHighlyAvailableTasks = true,
+                        SubscriptionId = subscriptionState.SubscriptionId,
+                        SubscriptionName = subscriptionState.SubscriptionName,
+                        LastTimeServerMadeProgressWithDocuments = DateTime.UtcNow,
+                        LastKnownSubscriptionChangeVector = null,
+                        DatabaseName = database.Name,
+                    };
+
+                    var (etag, _) = await Server.ServerStore.SendToLeaderAsync(command);
+                    await database.RachisLogIndexNotifications.WaitForIndexNotification(etag, Server.ServerStore.Engine.OperationTimeout);
+
+                    indexDisposeMre.Set();
+                    await deleteIndexTask;
+
+                    Assert.True(mreWasSet);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-22008.cs
+++ b/test/SlowTests/Issues/RavenDB-22008.cs
@@ -45,17 +45,17 @@ namespace SlowTests.Issues
                 using (index.ForTestingPurposesOnly().CallDuringFinallyOfExecuteIndexing(() =>
                 {
                     // simulating a long indexing batch completion
-                    mreWasSet = indexDisposeMre.Wait(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
+                    mreWasSet = indexDisposeMre.Wait(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan * 2);
                 }))
                 {
-                    var deleteIndexTask = store.Maintenance.SendAsync(new DeleteIndexOperation(indexDefinition.IndexName));
-
                     database.IndexStore.ForTestingPurposesOnly().BeforeHandleDatabaseRecordChange = () =>
                     {
                         mreBeforeSendingCommand.Set();
                     };
 
-                    mreBeforeSendingCommand.Wait(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
+                    var deleteIndexTask = store.Maintenance.SendAsync(new DeleteIndexOperation(indexDefinition.IndexName));
+
+                    mreBeforeSendingCommand.Wait(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan * 2);
 
                     var command = new AcknowledgeSubscriptionBatchCommand(store.Database, RaftIdGenerator.NewId())
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22008/Large-amount-of-threads-are-waiting-on-NotifyFeaturesAboutValueChange

### Additional description

- Use a separate semaphore for database record changes and value changes to improve the performance of updating database values.
Index updates that require to deletion of the previous index might take some time. In the current implementation, updating the subscription value will be delayed until the index operation is completed.
(To delete an index, for example, we need to wait until the currently running batch is done - we cannot cancel if we are in the middle of a Voron commit, and delete the index folder, which might take a while).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
