### PR TITLE
RavenDB-21965 Avoid adding to `Reply` if shouldn't

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
@@ -132,18 +132,16 @@ public sealed class MergedBatchCommand : TransactionMergedCommand
                 case CommandType.BatchPATCH:
                     cmd.PatchCommand.ExecuteDirectly(context);
 
-                    var lastChangeVector = cmd.PatchCommand.HandleReply(Reply, ModifiedCollections);
-
+                    var lastChangeVector = cmd.PatchCommand.HandleReply(IncludeReply ? Reply : null, ModifiedCollections);
                     if (lastChangeVector != null)
                         LastChangeVector = lastChangeVector;
 
                     break;
 
                 case CommandType.JsonPatch:
-
                     cmd.JsonPatchCommand.ExecuteDirectly(context);
 
-                    var lastChangeVectorJsonPatch = cmd.JsonPatchCommand.HandleReply(Reply, ModifiedCollections, Database);
+                    var lastChangeVectorJsonPatch = cmd.JsonPatchCommand.HandleReply(IncludeReply ? Reply : null, ModifiedCollections, Database);
                     if (lastChangeVectorJsonPatch != null)
                         LastChangeVector = lastChangeVectorJsonPatch;
 
@@ -500,10 +498,11 @@ public sealed class MergedBatchCommand : TransactionMergedCommand
 
     public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
     {
-        return new MergedBatchCommandDto(includeReply: true)
+        return new MergedBatchCommandDto
         {
             ParsedCommands = ParsedCommands.ToArray(),
-            AttachmentStreams = AttachmentStreams
+            AttachmentStreams = AttachmentStreams,
+            IncludeReply = IncludeReply
         };
     }
 

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommandDto.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommandDto.cs
@@ -8,14 +8,9 @@ namespace Raven.Server.Documents.Handlers.Batches.Commands;
 
 public sealed class MergedBatchCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedBatchCommand>
 {
-    public BatchRequestParser.CommandData[] ParsedCommands { get; set; }
-    public List<MergedBatchCommand.AttachmentStream> AttachmentStreams;
-    private readonly bool _includeReply;
-
-    public MergedBatchCommandDto(bool includeReply)
-    {
-        _includeReply = includeReply;
-    }
+    public BatchRequestParser.CommandData[] ParsedCommands { get; init; }
+    public List<MergedBatchCommand.AttachmentStream> AttachmentStreams { get; init; }
+    public bool IncludeReply { get; init; }
 
     public MergedBatchCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
     {
@@ -42,7 +37,7 @@ public sealed class MergedBatchCommandDto : IReplayableCommandDto<DocumentsOpera
 
         var newCmd = new MergedBatchCommand(database)
         {
-            IncludeReply = _includeReply,
+            IncludeReply = IncludeReply,
             ParsedCommands = ParsedCommands,
             AttachmentStreams = AttachmentStreams
         };

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -346,7 +346,7 @@ namespace Raven.Server.Documents.Patch
                 patchReply[nameof(PatchResult.ModifiedDocument)] = patchResult.ModifiedDocument;
             }
 
-            reply.Add(patchReply);
+            reply?.Add(patchReply);
 
             return patchResult.ChangeVector;
         }

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/JsonPatchCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/JsonPatchCommand.cs
@@ -132,7 +132,7 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
             if (_returnDocument)
                 patchReply[nameof(PatchResult.ModifiedDocument)] = _patchResult.ModifiedDocument;
 
-            reply.Add(patchReply);
+            reply?.Add(patchReply);
 
             return _patchResult.ChangeVector;
         }

--- a/test/FastTests/Client/BatchCommandWithNoReplyFlagTest.cs
+++ b/test/FastTests/Client/BatchCommandWithNoReplyFlagTest.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.JsonPatch;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Http;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using PatchRequest = Raven.Client.Documents.Operations.PatchRequest;
+
+namespace FastTests.Client;
+
+public class BatchCommandWithNoReplyFlagTest : RavenTestBase
+{
+    public BatchCommandWithNoReplyFlagTest(ITestOutputHelper output) : base(output)
+    {
+    }
+        
+    [RavenFact(RavenTestCategory.Patching)]
+    public async Task BatchWithNoReply_WhenPatch_ShouldNotFail()
+    {
+        const string user1Id = "users/1";
+        const string user1Value = "SomeValue";
+        
+        var store = GetDocumentStore();
+        var requestExecutor = store.GetRequestExecutor();
+        
+        using (var session = store.OpenSession())
+        using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+        {
+            session.Store(new TestObj(), user1Id);
+            session.SaveChanges();
+                
+            var result = new InMemoryDocumentSessionOperations.SaveChangesData((InMemoryDocumentSessionOperations)session);
+            var patchRequest = new PatchRequest{Script = "this.Name = args.val_0;", Values = new Dictionary<string, object>{{"val_0", user1Value}}};
+            result.SessionCommands.Add(new PatchCommandData(user1Id, null, patchRequest));
+            
+            var sbc = new TestSingleNodeBatchCommand(DocumentConventions.Default, context, result.SessionCommands, result.Options);
+            
+            await requestExecutor.ExecuteAsync(sbc, context);
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var user = session.Load<TestObj>(user1Id);
+            Assert.Equal(user1Value, user.Name);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Patching)]
+    public async Task BatchWithNoReply_WhenJsonPatch_ShouldNotFail()
+    {
+        const string user2Id = "users/1";
+        const string user2Value = "SomeValue";
+        
+        var store = GetDocumentStore();
+        var requestExecutor = store.GetRequestExecutor();
+        
+        using (var session = store.OpenSession())
+        using (requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+        {
+            session.Store(new TestObj(), user2Id);
+            session.SaveChanges();
+                
+            var result = new InMemoryDocumentSessionOperations.SaveChangesData((InMemoryDocumentSessionOperations)session);
+            var jpd = new JsonPatchDocument();
+            jpd.Add("/Name", user2Value);
+            result.SessionCommands.Add(new JsonPatchCommandData(user2Id, jpd));
+            var sbc = new TestSingleNodeBatchCommand(DocumentConventions.Default, context, result.SessionCommands, result.Options);
+            
+            await requestExecutor.ExecuteAsync(sbc, context);
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var user = session.Load<TestObj>(user2Id);
+            Assert.Equal(user2Value, user.Name);
+        }
+    }
+    
+    private class TestObj
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+    
+    private class TestSingleNodeBatchCommand : SingleNodeBatchCommand
+    {
+        public TestSingleNodeBatchCommand(DocumentConventions conventions, JsonOperationContext context, IList<ICommandData> commands, BatchOptions options = null, TransactionMode mode = TransactionMode.SingleNode) : base(conventions, context, commands, options, mode)
+        {
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            var httpRequestMessage = base.CreateRequest(ctx, node, out url);
+            url += "noreply=true";
+            return httpRequestMessage;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21965

### Additional description
There are two issues:
1. The `IncludeReply` is not serialized/deserialized since the field is private and has no explicit attribute.
2. Because of the first issue the reply transactions in the test run with `IncludeReply` set to `false`. That revealed another issue in patch cases the patch replays are added even if the `IncludeReply` is `false`.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
