### PR TITLE
RavenDB-22109: Ensure `VerifyLicense` is invoked in all `RavenServer` instantiations

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Buffers;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -28,11 +27,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Exceptions.Commercial;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Security;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
+using Raven.Client.Properties;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
@@ -152,6 +153,9 @@ namespace Raven.Server
             _tcpLogger = LoggingSource.Instance.GetLogger<RavenServer>("Server/TCP");
             _externalCertificateValidator = new ExternalCertificateValidator(this, Logger);
             _tcpContextPool = new JsonContextPool(Configuration.Memory.MaxContextSizeToKeep);
+
+            // doing this before the schema upgrade to allow to downgrade in case we cannot start the server
+            BeforeSchemaUpgrade = x => VerifyLicense(x, ServerStore);
         }
 
         public TcpListenerStatus GetTcpServerStatus()
@@ -3018,5 +3022,149 @@ namespace Raven.Server
             ArrayPool<byte>.Shared.Return(buffer);
         }
 
+        private static void VerifyLicense(StorageEnvironment environment, ServerStore serverStore)
+        {
+            using (var contextPool = new TransactionContextPool(environment, serverStore.Configuration.Memory.MaxContextSizeToKeep))
+            {
+                var license = serverStore.LoadLicense(contextPool);
+                if (license == null)
+                    return;
+
+                var licenseStatus = LicenseManager.GetLicenseStatus(license);
+
+                VerifyLicenseVersion(licenseStatus, license, serverStore, contextPool);
+                VerifyLicenseExpiration(licenseStatus, serverStore, environment, license, contextPool);
+            }
+        }
+
+        private static void VerifyLicenseVersion(LicenseStatus licenseStatus, License license, ServerStore serverStore, TransactionContextPool contextPool)
+        {
+            if (licenseStatus.Version.Major >= 6 || licenseStatus.IsCloud)
+                return;
+
+            var licenseFromApi = GetLicenseFromApi(license, contextPool).GetAwaiter().GetResult();
+            if (licenseFromApi != null)
+            {
+                licenseStatus = LicenseManager.GetLicenseStatus(licenseFromApi);
+                if (licenseStatus.Version.Major >= 6)
+                {
+                    serverStore.LicenseManager.OnBeforeInitialize += () =>
+                        serverStore.LicenseManager.ActivateAsync(licenseFromApi, RaftIdGenerator.NewId())
+                            .Wait(serverStore.ServerShutdown);
+                    return;
+                }
+            }
+
+            var licenseJson = GetLicenseJson(serverStore, out _);
+            if (string.IsNullOrEmpty(licenseJson) == false &&
+                LicenseHelper.TryDeserializeLicense(licenseJson, out License localLicense))
+            {
+                licenseStatus = LicenseManager.GetLicenseStatus(localLicense);
+                if (licenseStatus.Version.Major >= 6)
+                {
+                    serverStore.LicenseManager.OnBeforeInitialize += () =>
+                        serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure)
+                            .Wait(serverStore.ServerShutdown);
+                    return;
+                }
+            }
+
+            throw new LicenseLimitException($"Your license ('{licenseStatus.Id}') version '{licenseStatus.Version}' doesn't allow you to upgrade to server version '{RavenVersionAttribute.Instance.FullVersion}'. " +
+                                            $"Please proceed to the https://ravendb.net/l/8O2YU1 website to perform the license upgrade first. " +
+                                            $"After the upgrade, if your server has access to {ApiHttpClient.ApiRavenDbNet}, your license will be automatically updated. " +
+                                            $"In case of connectivity issues with {ApiHttpClient.ApiRavenDbNet} please either update the license via one of the configuration options '{RavenConfiguration.GetKey(x => x.Licensing.LicensePath)}', '{RavenConfiguration.GetKey(x => x.Licensing.License)}', " +
+                                            $"or downgrade to the previous version of RavenDB, apply the new license and continue the update procedure.");
+        }
+
+        private static async Task<License> GetLicenseFromApi(License license, TransactionContextPool contextPool)
+        {
+            try
+            {
+                var response = await LicenseManager.GetUpdatedLicenseResponseMessage(license, contextPool)
+                    .ConfigureAwait(false);
+                var leasedLicense = await LicenseManager.ConvertResponseToLeasedLicense(response)
+                    .ConfigureAwait(false);
+                return leasedLicense.License;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static void VerifyLicenseExpiration(LicenseStatus licenseStatus, ServerStore serverStore, StorageEnvironment environment, License license, TransactionContextPool contextPool)
+        {
+            if (licenseStatus.Expiration >= RavenVersionAttribute.Instance.ReleaseDate)
+                return;
+
+            var licenseJson = GetLicenseJson(serverStore, out bool fromPath);
+
+            var errorMessage = $"Cannot start the RavenDB server because the expiration date of current license ({FormattedDateTime(licenseStatus.Expiration ?? DateTime.MinValue)}) " +
+                               $"is before the release date of this version ({FormattedDateTime(RavenVersionAttribute.Instance.ReleaseDate)})";
+
+            string expiredLicenseMessage = "";
+            if (string.IsNullOrEmpty(licenseJson) == false)
+            {
+                if (LicenseHelper.TryDeserializeLicense(licenseJson, out License localLicense))
+                {
+                    var localLicenseStatus = LicenseManager.GetLicenseStatus(localLicense);
+                    if (localLicenseStatus.Expiration >= RavenVersionAttribute.Instance.ReleaseDate)
+                    {
+                        serverStore.LicenseManager.OnBeforeInitialize += () => serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).Wait(serverStore.ServerShutdown);
+                        return;
+                    }
+
+                    var configurationKey =
+                        fromPath ? RavenConfiguration.GetKey(x => x.Licensing.LicensePath) : RavenConfiguration.GetKey(x => x.Licensing.License);
+                    expiredLicenseMessage = localLicense.Id == license.Id
+                        ? ". You can update current license using the setting.json file"
+                        : $". The license '{localLicense.Id}' obtained from '{configurationKey}' with expiration date of '{FormattedDateTime(localLicenseStatus.Expiration ?? DateTime.MinValue)}' is also expired.";
+                }
+                else
+                {
+                    errorMessage += ". Could not parse the license from setting.json file.";
+                    throw new LicenseExpiredException(errorMessage);
+                }
+            }
+
+            var licenseStorage = new LicenseStorage();
+            licenseStorage.Initialize(environment, contextPool);
+
+            var buildInfo = licenseStorage.GetBuildInfo();
+            if (buildInfo != null)
+                errorMessage += $" You can downgrade to the latest build that was working ({buildInfo.FullVersion})";
+            if (string.IsNullOrEmpty(expiredLicenseMessage) == false)
+                errorMessage += expiredLicenseMessage;
+            throw new LicenseExpiredException(errorMessage);
+
+            static string FormattedDateTime(DateTime dateTime)
+            {
+                return dateTime.ToString("dd MMMM yyyy");
+            }
+        }
+
+        private static string GetLicenseJson(ServerStore serverStore, out bool fromPath)
+        {
+            string licenseJson = null;
+            fromPath = false;
+            if (string.IsNullOrEmpty(serverStore.Configuration.Licensing.License) == false)
+            {
+                licenseJson = serverStore.Configuration.Licensing.License;
+            }
+            else if (File.Exists(serverStore.Configuration.Licensing.LicensePath.FullPath))
+            {
+                try
+                {
+                    licenseJson = File.ReadAllText(serverStore.Configuration.Licensing.LicensePath.FullPath);
+                    fromPath = true;
+                }
+                catch
+                {
+                    // expected
+                }
+            }
+
+            return licenseJson;
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22109/

### Additional description

I discovered an inconsistency in how our `RavenServer` was handling license verification. 
Specifically, we were setting a delegate to perform license verification with this line of code:

```csharp
BeforeSchemaUpgrade = x => VerifyLicense(x, ServerStore);
```

This delegate was intended to ensure that the license is verified before any schema upgrade actions are taken. 
However, this setup was only being applied when `RavenServer` was started as a regular application and was inadvertently missed when starting `RavenServer` as a Windows Service.

To address this oversight and ensure uniform behavior across different startup scenarios, I've moved the delegate assignment into the `RavenServer` constructor. This change guarantees that every `RavenServer` instance, no matter how it's started, will have this license verification step firmly in place before proceeding with schema upgrades.

**Benefits**:
- **Uniform License Verification**: Now, every `RavenServer` startup scenario includes a license verification step, ensuring consistent security checks.
- **Increased Reliability**: By automatically including this verification step, we reduce the risk of running without proper license checks, which enhances the system's overall reliability.
- **Improved Code Clarity**: Centralizing this delegate assignment simplifies understanding and maintenance of our codebase, as it clearly associates license verification with server instantiation.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes: Windows only
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed