### PR TITLE
RavenDB-21521: Fix for memory corruption at CompactKey

### DIFF
--- a/src/Sparrow/Json/PerCoreStatic.cs
+++ b/src/Sparrow/Json/PerCoreStatic.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Sparrow.Utils;
+
+namespace Sparrow.Json
+{
+    public sealed class PerCoreStatic<T> where T : class
+    {
+        private readonly T[] _perCoreArrays;
+
+        public PerCoreStatic(Func<T> creationFunc)
+        {
+            _perCoreArrays = new T[Environment.ProcessorCount];
+            for (int i = 0; i < _perCoreArrays.Length; i++)
+                _perCoreArrays[i] = creationFunc();
+        }
+
+        public T Get()
+        {
+            return _perCoreArrays[CurrentProcessorIdHelper.GetCurrentProcessorId() % _perCoreArrays.Length];
+        }
+    }
+}

--- a/src/Voron/Data/CompactTrees/CompactKey.cs
+++ b/src/Voron/Data/CompactTrees/CompactKey.cs
@@ -20,20 +20,30 @@ namespace Voron.Data.CompactTrees;
 public sealed unsafe class CompactKey : IDisposable
 {
     public static readonly CompactKey NullInstance = new();
-    
-    private static readonly ArrayPool<byte> StoragePool = ArrayPool<byte>.Shared;
-    private static readonly ArrayPool<long> KeyMappingPool = ArrayPool<long>.Shared;
+
+    [ThreadStatic]
+    private static ArrayPool<byte> StoragePool;
 
     private LowLevelTransaction _owner;
 
     private const int MappingTableSize = 64;
     private const int MappingTableMask = MappingTableSize - 1;
 
-    private long[] _keyMappingCache;
-    private ref long KeyMappingCache(int i) => ref _keyMappingCache[i];
-    private ref long KeyMappingCacheIndex(int i) => ref _keyMappingCache[MappingTableSize + i];
+    private struct KeyMappingCache
+    {
+        private fixed long _keyMappingCache[MappingTableSize * 2];
 
+        public long GetMap(int i) => _keyMappingCache[i];
+        public long GetIndex(int i) => _keyMappingCache[MappingTableSize + i];
 
+        public void Set(int i, long map, long index)
+        {
+            _keyMappingCache[i] = map;
+            _keyMappingCache[MappingTableSize + i] = index;
+        }
+    }
+
+    private KeyMappingCache _keyMappingCache;
     private byte[] _storage;
 
     // The storage data will be used in an arena fashion. If there is no enough, we just create a bigger one and
@@ -66,22 +76,20 @@ public sealed unsafe class CompactKey : IDisposable
         _currentIdx = 0;
         MaxLength = 0;
 
+        StoragePool ??= ArrayPool<byte>.Create();
+
         _storage = StoragePool.Rent(2 * Constants.CompactTree.MaximumKeySize);
-        _keyMappingCache = KeyMappingPool.Rent(2 * MappingTableMask);
     }
 
     public void Reset()
     {
-        if (_storage is null || _keyMappingCache is null)
+        if (_storage is null)
             throw new InvalidOperationException("The key has not been initialized before calling reset.");
 
         _owner = null;
 
         StoragePool.Return(_storage);
         _storage = null;
-
-        KeyMappingPool.Return(_keyMappingCache);
-        _keyMappingCache = null;
     }
 
     public bool IsValid => Dictionary > 0;
@@ -109,8 +117,7 @@ public sealed unsafe class CompactKey : IDisposable
 
             // We look for an appropriate place to put this key
             int buckedIdx = SelectBucketForWrite();
-            KeyMappingCache(buckedIdx) = dictionaryId;
-            KeyMappingCacheIndex(buckedIdx) = _currentIdx;
+            _keyMappingCache.Set(buckedIdx, dictionaryId, _currentIdx);
 
             var dictionary = _owner.GetEncodingDictionary(dictionaryId);
             int maxSize = dictionary.GetMaxEncodingBytes(decodedKey.Length) + 4;
@@ -147,12 +154,12 @@ public sealed unsafe class CompactKey : IDisposable
             }
             else
             {
-                startIdx = (int)KeyMappingCacheIndex(bucketIdx);
+                startIdx = (int)_keyMappingCache.GetIndex(bucketIdx);
             }
 
             // Because we are decoding for the current dictionary, we will update the lazy index to avoid searching again next time. 
             if (Dictionary == dictionaryId)
-                _currentKeyIdx = (int)KeyMappingCacheIndex(bucketIdx);
+                _currentKeyIdx = (int)_keyMappingCache.GetIndex(bucketIdx);
         }
 
 
@@ -167,11 +174,11 @@ public sealed unsafe class CompactKey : IDisposable
 
         long currentDictionary = Dictionary;
         int currentKeyIdx = _currentKeyIdx;
-        if (currentKeyIdx == Invalid && KeyMappingCache(0) != 0)
+        if (currentKeyIdx == Invalid && _keyMappingCache.GetMap(0) != 0)
         {
             // We don't have any decoded version, so we pick the first one and do it. 
-            currentDictionary = KeyMappingCache(0);
-            currentKeyIdx = (int)KeyMappingCacheIndex(0);
+            currentDictionary = _keyMappingCache.GetMap(0);
+            currentKeyIdx = (int)_keyMappingCache.GetIndex(0);
         }
 
         Debug.Assert(currentKeyIdx != Invalid);
@@ -273,8 +280,7 @@ public sealed unsafe class CompactKey : IDisposable
         Dictionary = dictionaryId;
 
         int bucketIdx = SelectBucketForWrite();
-        KeyMappingCache(bucketIdx) = dictionaryId;
-        KeyMappingCacheIndex(bucketIdx) = _currentKeyIdx;
+        _keyMappingCache.Set(bucketIdx, dictionaryId, _currentKeyIdx);
 
         // We write the size and the key. 
         Unsafe.WriteUnaligned(ref _storage[0], keyLengthInBits);
@@ -295,7 +301,7 @@ public sealed unsafe class CompactKey : IDisposable
         int elementIdx = Math.Min(_lastKeyMappingItem, MappingTableSize - 1);
         while (elementIdx >= 0)
         {
-            long currentDictionary = _keyMappingCache[elementIdx];
+            long currentDictionary = _keyMappingCache.GetMap(elementIdx);
             if (currentDictionary == dictionaryId)
                 return elementIdx;
 

--- a/test/FastTests/Voron/CompactTrees/RavenDB-21521.cs
+++ b/test/FastTests/Voron/CompactTrees/RavenDB-21521.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Voron.FixedSize;
+using Raven.Server.Documents.Indexes.Static;
+using Sparrow;
+using Tests.Infrastructure;
+using Voron.Data.CompactTrees;
+using Voron.Global;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron.CompactTrees
+{
+    public class RavenDB_21521 : StorageTest
+    {
+        public RavenDB_21521(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public class RandomTrainIterator : IReadOnlySpanEnumerator
+        {
+            private ReadOnlySpan<byte> Chars => "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"u8;
+            private Random _generator;
+            private int _currentIdx;
+            private int _maxSize;
+
+
+            public RandomTrainIterator(int count, int maxSize, int seed)
+            {
+                _generator = new Random(seed);
+
+                _currentIdx = 0;
+                _maxSize = maxSize;
+
+                Count = count;
+            }
+
+            public int Count { get; }
+
+            public void Reset()
+            {
+                _currentIdx = 0;
+            }
+
+            public bool MoveNext(out ReadOnlySpan<byte> result)
+            {
+                if (_currentIdx > Count)
+                {
+                    result = ReadOnlySpan<byte>.Empty;
+                    return false;
+                }
+
+                var output = new byte[_generator.Next(_maxSize)];
+
+                for (int i = 0; i < output.Length; i++)
+                    output[i] = Chars[_generator.Next(Chars.Length)];
+
+                _currentIdx++;
+
+                result = output.AsSpan();
+                return true;
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed]
+        public void CompactKeyFuzzy(int seed)
+        {
+            using var wtx = Env.WriteTransaction();
+
+            var dict1 = PersistentDictionary.CreateDefault(wtx.LowLevelTransaction);
+            Assert.True(PersistentDictionary.TryCreate(wtx.LowLevelTransaction, new RandomTrainIterator(1024, 30, seed), out var dict2));
+            Assert.True(PersistentDictionary.TryCreate(wtx.LowLevelTransaction, new RandomTrainIterator(1024, 30, seed), out var dict3));
+            Assert.True(PersistentDictionary.TryCreate(wtx.LowLevelTransaction, new RandomTrainIterator(1024, 30, seed), out var dict4));
+            Assert.True(PersistentDictionary.TryCreate(wtx.LowLevelTransaction, new RandomTrainIterator(1024, 30, seed), out var dict5));
+
+            var key = new CompactKey();
+            key.Initialize(wtx.LowLevelTransaction);
+            
+            var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"u8;
+            var random = new Random(seed);
+
+            var stringChars = new byte[2 * Constants.CompactTree.MaximumKeySize];
+            for (int i = 0; i < stringChars.Length; i++)
+                stringChars[i] = chars[random.Next(chars.Length)];
+
+            int j = 1;
+            while (j < stringChars.Length)
+            {
+                key.Set(stringChars[..j]);
+                key.ChangeDictionary(dict1);
+
+                Assert.Equal(stringChars[..j], key.Decoded());
+
+                var dict1EncodedKey = key.EncodedWith(dict1, out var dict1LengthInBits);
+                var dict2EncodedKey = key.EncodedWith(dict2.DictionaryId, out var dict2LengthInBits);
+                var dict3EncodedKey = key.EncodedWith(dict3.DictionaryId, out var dict3LengthInBits);
+                var dict4EncodedKey = key.EncodedWith(dict4.DictionaryId, out var dict4LengthInBits);
+                var dict5EncodedKey = key.EncodedWith(dict5.DictionaryId, out var dict5LengthInBits);
+
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict1EncodedKey), dict1LengthInBits, dict1));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict2EncodedKey), dict2LengthInBits, dict2.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict3EncodedKey), dict3LengthInBits, dict3.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict4EncodedKey), dict4LengthInBits, dict4.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict5EncodedKey), dict5LengthInBits, dict5.DictionaryId));
+
+                key.ChangeDictionary(dict2.DictionaryId);
+
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict1EncodedKey), dict1LengthInBits, dict1));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict2EncodedKey), dict2LengthInBits, dict2.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict3EncodedKey), dict3LengthInBits, dict3.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict4EncodedKey), dict4LengthInBits, dict4.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict5EncodedKey), dict5LengthInBits, dict5.DictionaryId));
+
+                Assert.Equal(stringChars[..j], key.Decoded());
+
+                key.ChangeDictionary(dict3.DictionaryId);
+
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict1EncodedKey), dict1LengthInBits, dict1));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict2EncodedKey), dict2LengthInBits, dict2.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict3EncodedKey), dict3LengthInBits, dict3.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict4EncodedKey), dict4LengthInBits, dict4.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict5EncodedKey), dict5LengthInBits, dict5.DictionaryId));
+
+                Assert.Equal(stringChars[..j], key.Decoded());
+
+                key.ChangeDictionary(dict4.DictionaryId);
+
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict1EncodedKey), dict1LengthInBits, dict1));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict2EncodedKey), dict2LengthInBits, dict2.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict3EncodedKey), dict3LengthInBits, dict3.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict4EncodedKey), dict4LengthInBits, dict4.DictionaryId));
+                Assert.Equal(0, key.CompareEncodedWith(ref MemoryMarshal.GetReference(dict5EncodedKey), dict5LengthInBits, dict5.DictionaryId));
+
+                Assert.Equal(stringChars[..j], key.Decoded());
+
+                using var key1 = new CompactKey();
+                key1.Initialize(wtx.LowLevelTransaction);
+                key1.Set(dict1LengthInBits, dict1EncodedKey, dict1);
+
+                using var key2 = new CompactKey();
+                key2.Initialize(wtx.LowLevelTransaction);
+                key2.Set(dict2LengthInBits, dict2EncodedKey, dict2.DictionaryId);
+
+                using var key3 = new CompactKey();
+                key3.Initialize(wtx.LowLevelTransaction);
+                key3.Set(dict3LengthInBits, dict3EncodedKey, dict3.DictionaryId);
+
+                using var key4 = new CompactKey();
+                key4.Initialize(wtx.LowLevelTransaction);
+                key4.Set(dict4LengthInBits, dict4EncodedKey, dict4.DictionaryId);
+
+                Assert.Equal(0, key.Compare(key1));
+                Assert.Equal(0, key.Compare(key2));
+                Assert.Equal(0, key.Compare(key3));
+                Assert.Equal(0, key.Compare(key4));
+
+                j++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21521

### Additional description
The suspicion that the corruption is caused by compact key memory handling lead us to disable the original mechanism that introduce it which was optimizing access to the compact keys during lock convoy critical code path. This PR implements the fix for the memory condition. It is important to note that the error was already present, it was just harder for it to trigger with a single `ArrayPool` because of the sharing dynamics. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
