### PR TITLE
RavenDB-21273 Import should check for license restrictions

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -1288,7 +1288,7 @@ namespace Raven.Server.Commercial
             return configuration.Collections.Any(x => x.Value != null && x.Value.Disabled == false);
         }
 
-        private static bool HasAdditionalAssembliesFromNuGet(Dictionary<string, IndexDefinition> indexes)
+        internal static bool HasAdditionalAssembliesFromNuGet(Dictionary<string, IndexDefinition> indexes)
         {
             if (indexes == null || indexes.Count == 0)
                 return false;
@@ -1322,7 +1322,7 @@ namespace Raven.Server.Commercial
             return false;
         }
 
-        private static (bool HasSnapshotBackup, bool HasCloudBackup, bool HasEncryptedBackup) GetBackupTypes(
+        internal static (bool HasSnapshotBackup, bool HasCloudBackup, bool HasEncryptedBackup) GetBackupTypes(
             IEnumerable<PeriodicBackupConfiguration> periodicBackups)
         {
             var hasSnapshotBackup = false;

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -30,8 +30,8 @@ namespace Raven.Server.ServerWide;
 public sealed partial class ClusterStateMachine
 {
     private const int MinBuildVersion60000 = 60_000;
-    private const int MinBuildVersion60102 = 60_102;
-    private const int MinBuildVersion60105 = 60_105;
+    private const int MinBuildVersion60102 = 60_026;
+    private const int MinBuildVersion60105 = 60_039;
 
     private static readonly List<string> _licenseLimitsCommandsForCreateDatabase = new()
     {

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Exceptions.Commercial;
 using Raven.Client.ServerWide;
@@ -11,6 +12,7 @@ using Raven.Server.Json;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Commands.Analyzers;
+using Raven.Server.ServerWide.Commands.ETL;
 using Raven.Server.ServerWide.Commands.Indexes;
 using Raven.Server.ServerWide.Commands.PeriodicBackup;
 using Raven.Server.ServerWide.Commands.QueueSink;
@@ -29,24 +31,33 @@ public sealed partial class ClusterStateMachine
 {
     private const int MinBuildVersion60000 = 60_000;
     private const int MinBuildVersion60102 = 60_102;
+    private const int MinBuildVersion60105 = 60_105;
 
     private static readonly List<string> _licenseLimitsCommandsForCreateDatabase = new()
     {
         nameof(PutIndexesCommand),
         nameof(PutAutoIndexCommand),
         nameof(PutSortersCommand),
-        nameof(PutSortersCommand),
         nameof(PutAnalyzersCommand),
         nameof(PutIndexCommand),
-        nameof(PutAutoIndexCommand),
         nameof(EditRevisionsConfigurationCommand),
         nameof(EditExpirationCommand),
         nameof(EditRefreshCommand),
-        nameof(PutSortersCommand),
-        nameof(PutAnalyzersCommand),
         nameof(PutDatabaseClientConfigurationCommand),
         nameof(EditDatabaseClientConfigurationCommand),
         nameof(PutDatabaseStudioConfigurationCommand),
+        nameof(UpdatePeriodicBackupCommand),
+        nameof(UpdatePullReplicationAsSinkCommand),
+        nameof(UpdatePullReplicationAsHubCommand),
+        nameof(UpdateExternalReplicationCommand),
+        nameof(AddRavenEtlCommand),
+        nameof(AddSqlEtlCommand),
+        nameof(AddOlapEtlCommand),
+        nameof(AddQueueEtlCommand),
+        nameof(EditTimeSeriesConfigurationCommand),
+        nameof(EditDocumentsCompressionCommand),
+        nameof(AddElasticSearchEtlCommand),
+        nameof(PutServerWideExternalReplicationCommand),
     };
 
     private void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context)
@@ -58,6 +69,7 @@ public sealed partial class ClusterStateMachine
                 AssertMultiNodeSharding(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(PutIndexCommand):
+                AssertAdditionalAssembliesFromNuGetLicenseLimits(serverStore, databaseRecord, context);
                 AssertStaticIndexesCount(databaseRecord, serverStore.LicenseManager.LicenseStatus, context, items, type);
                 break;
 
@@ -66,6 +78,7 @@ public sealed partial class ClusterStateMachine
                 break;
 
             case nameof(PutIndexesCommand):
+                AssertAdditionalAssembliesFromNuGetLicenseLimits(serverStore, databaseRecord, context);
                 AssertStaticIndexesCount(databaseRecord, serverStore.LicenseManager.LicenseStatus, context, items, type);
                 AssertAutoIndexesCount(databaseRecord, serverStore.LicenseManager.LicenseStatus, context, items, type);
                 break;
@@ -91,6 +104,7 @@ public sealed partial class ClusterStateMachine
                 break;
 
             case nameof(UpdatePeriodicBackupCommand):
+                AssertPeriodicBackupLicenseLimits(serverStore, databaseRecord, context);
                 if (AssertPeriodicBackup(serverStore.LicenseManager.LicenseStatus, context) == false)
                     throw new LicenseLimitException(LimitType.PeriodicBackup, "Your license doesn't support adding periodic backups.");
                 break;
@@ -123,6 +137,40 @@ public sealed partial class ClusterStateMachine
             case nameof(EditDataArchivalCommand):
                 if (AssertDataArchival(serverStore.LicenseManager.LicenseStatus, context) == false )
                     throw new LicenseLimitException(LimitType.DataArchival, "Your license doesn't support using the data archival feature.");
+                break;
+
+            case nameof(UpdatePullReplicationAsSinkCommand):
+                AssertPullReplicationAsSinkLicenseLimits(serverStore, databaseRecord, context);
+                break;
+            case nameof(UpdatePullReplicationAsHubCommand):
+                AssertPullReplicationAsHubLicenseLimits(serverStore, databaseRecord, context);
+                break;
+            case nameof(UpdateExternalReplicationCommand):
+                AssertExternalReplicationLicenseLimits(serverStore, databaseRecord, context);
+                break;
+            case nameof(AddRavenEtlCommand):
+                AssertRavenEtlLicenseLimits(serverStore, databaseRecord, context);
+                break;
+            case nameof(AddSqlEtlCommand):
+                AssertSqlEtlLicenseLimits(serverStore, databaseRecord, context);
+                break;
+            case nameof(AddOlapEtlCommand):
+                AssertOlapEtlLicenseLimits(serverStore, databaseRecord, context);
+                break;
+            case nameof(AddQueueEtlCommand):
+                AssertQueueEtlLicenseLimits(serverStore, databaseRecord, context);
+                break;
+            case nameof(AddElasticSearchEtlCommand):
+                AssertElasticSearchEtlLicenseLimits(serverStore, databaseRecord, context);
+                break;
+            case nameof(EditTimeSeriesConfigurationCommand):
+                AssertTimeSeriesConfigurationLicenseLimits(serverStore, databaseRecord, context);
+                break;
+            case nameof(EditDocumentsCompressionCommand):
+                AssertDocumentsCompressionLicenseLimits(serverStore, databaseRecord, context);
+                break;
+            case nameof(PutServerWideExternalReplicationCommand):
+                AssertServerWideExternalReplicationLicenseLimits(serverStore, context);
                 break;
         }
     }
@@ -709,6 +757,213 @@ public sealed partial class ClusterStateMachine
 
                 break;
         }
+    }
+    private void AssertPeriodicBackupLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        foreach (var configuration in databaseRecord.PeriodicBackups)
+        {
+            if (configuration != null)
+            {
+                if (configuration.BackupType == BackupType.Backup &&
+                    configuration.HasCloudBackup() == false &&
+                    configuration.BackupEncryptionSettings?.Key == null)
+                    return;
+            }
+        }
+
+        var backupTypes = LicenseManager.GetBackupTypes(databaseRecord.PeriodicBackups);
+
+        if (backupTypes.HasSnapshotBackup)
+            if (serverStore.LicenseManager.LicenseStatus.HasSnapshotBackups == false)
+                throw new LicenseLimitException(LimitType.SnapshotBackup, "Your license doesn't support adding Snapshot backups feature.");
+
+        if (backupTypes.HasCloudBackup)
+            if (serverStore.LicenseManager.LicenseStatus.HasCloudBackups == false)
+                throw new LicenseLimitException(LimitType.CloudBackup, "Your license doesn't support adding Cloud backups feature.");
+
+        if (backupTypes.HasEncryptedBackup)
+            if (serverStore.LicenseManager.LicenseStatus.HasEncryptedBackups == false)
+                throw new LicenseLimitException(LimitType.EncryptedBackup, "Your license doesn't support adding Encrypted backups feature.");
+    }
+
+    private void AssertPullReplicationAsSinkLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasPullReplicationAsSink)
+            return;
+
+        if (databaseRecord.SinkPullReplications.Count == 0)
+            return;
+
+        throw new LicenseLimitException(LimitType.PullReplicationAsSink, "Your license doesn't support adding Sink Replication feature.");
+    }
+
+    private void AssertPullReplicationAsHubLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasPullReplicationAsHub)
+            return;
+
+        if (databaseRecord.HubPullReplications.Count == 0)
+            return;
+
+        throw new LicenseLimitException(LimitType.PullReplicationAsHub, "Your license doesn't support adding Hub Replication feature.");
+    }
+
+    private void AssertExternalReplicationLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasDelayedExternalReplication)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasExternalReplication == false && databaseRecord.ExternalReplications.Count > 0)
+            throw new LicenseLimitException(LimitType.ExternalReplication, "Your license doesn't support adding External Replication.");
+
+        if (databaseRecord.ExternalReplications.All(exRep => exRep.DelayReplicationFor == TimeSpan.Zero))
+            return;
+
+        throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding Delayed External Replication.");
+    }
+
+    private void AssertRavenEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasRavenEtl)
+            return;
+
+        if (databaseRecord.RavenEtls.Count == 0)
+            return;
+
+        throw new LicenseLimitException(LimitType.RavenEtl, "Your license doesn't support adding Raven ETL feature.");
+    }
+
+    private void AssertSqlEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasSqlEtl)
+            return;
+
+        if (databaseRecord.SqlEtls.Count == 0)
+            return;
+
+        throw new LicenseLimitException(LimitType.SqlEtl, "Your license doesn't support adding SQL ETL feature.");
+    }
+
+    private void AssertOlapEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasOlapEtl)
+            return;
+
+        if (databaseRecord.OlapEtls.Count == 0)
+            return;
+
+        throw new LicenseLimitException(LimitType.OlapEtl, "Your license doesn't support adding Olap ETL feature.");
+    }
+
+    private void AssertQueueEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasQueueEtl)
+            return;
+
+        if (databaseRecord.QueueEtls.Count == 0)
+            return;
+
+        throw new LicenseLimitException(LimitType.QueueEtl, "Your license doesn't support adding Queue ETL feature.");
+    }
+
+    private void AssertElasticSearchEtlLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasElasticSearchEtl)
+            return;
+
+        if (databaseRecord.ElasticSearchEtls.Count == 0)
+            return;
+
+        throw new LicenseLimitException(LimitType.QueueEtl, "Your license doesn't support adding Elastic Search ETL feature.");
+    }
+
+    private void AssertTimeSeriesConfigurationLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasTimeSeriesRollupsAndRetention)
+            return;
+
+        if (databaseRecord.TimeSeries == null)
+            return;
+
+        if (databaseRecord.TimeSeries.Collections.Count > 0 && databaseRecord.TimeSeries.Collections.All(x => x.Value.Disabled))
+            return;
+
+        throw new LicenseLimitException(LimitType.TimeSeriesRollupsAndRetention, "Your license doesn't support adding Time Series Rollups And Retention feature.");
+    }
+
+    private void AssertDocumentsCompressionLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasDocumentsCompression)
+            return;
+
+        if (databaseRecord.DocumentsCompression == null)
+            return;
+
+        if (databaseRecord.DocumentsCompression.CompressAllCollections == false && databaseRecord.DocumentsCompression.CompressRevisions == false)
+            return;
+
+        throw new LicenseLimitException(LimitType.DocumentsCompression, "Your license doesn't support adding Documents Compression feature.");
+    }
+
+    private void AssertAdditionalAssembliesFromNuGetLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasAdditionalAssembliesFromNuGet)
+            return;
+
+        if (LicenseManager.HasAdditionalAssembliesFromNuGet(databaseRecord.Indexes) == false)
+            return;
+
+        throw new LicenseLimitException(LimitType.AdditionalAssembliesFromNuGet, "Your license doesn't support Additional Assemblies From NuGet feature.");
+    }
+
+    private void AssertServerWideExternalReplicationLicenseLimits(ServerStore serverStore, ClusterOperationContext context)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasDelayedExternalReplication)
+            return;
+
+        if (serverStore.LicenseManager.LicenseStatus.HasExternalReplication == false)
+            throw new LicenseLimitException(LimitType.ExternalReplication, "Your license doesn't support adding server wide External Replication.");
+
+        throw new LicenseLimitException(LimitType.DelayedExternalReplication, "Your license doesn't support adding server wide Delayed External Replication.");
     }
 
     private enum DatabaseRecordElementType

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions.Commercial;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
@@ -1020,6 +1021,10 @@ namespace Raven.Server.Smuggler.Documents
                 try
                 {
                     await actions.WriteDatabaseRecordAsync(databaseRecord, result, _options.AuthorizationStatus, _options.OperateOnDatabaseRecordTypes);
+                }
+                catch (LicenseLimitException)
+                {
+                    throw;
                 }
                 catch (Exception e)
                 {

--- a/test/SlowTests/Issues/RavenDB-21273.cs
+++ b/test/SlowTests/Issues/RavenDB-21273.cs
@@ -1,0 +1,546 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Operations.TimeSeries;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions.Commercial;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
+using Raven.Server;
+using Raven.Server.Commercial;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21273 : RavenTestBase
+    {
+        private const string RL_COMM = "RAVEN_LICENSE_COMMUNITY";
+        private const string RL_PRO = "RAVEN_LICENSE_PROFESSIONAL";
+
+        public RavenDB_21273(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingAdditionalAssembliesWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    var dbrecord = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+                    dbrecord.DocumentsCompression.CompressRevisions = false;
+                    store.Maintenance.Server.Send(new UpdateDatabaseOperation(dbrecord, dbrecord.Etag));
+
+
+                    store.Maintenance.Send(new PutIndexesOperation(new[]
+                    {
+                        new IndexDefinition
+                        {
+                            Maps = { "from doc in docs.Images select new { doc.Tags }" },
+                            Name = "test",
+                            AdditionalAssemblies = { AdditionalAssembly.FromNuGet("System.Drawing.Common", "4.7.0") }
+                        }
+                    }));
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_COMM);
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                    var index = store.Maintenance.Send(new GetIndexOperation("test"));
+                    Assert.Null(index);
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingSnapshotWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Snapshot);
+                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_COMM);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding Snapshot backups feature"));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+
+
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingSnapshotWithProLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Snapshot);
+                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_PRO);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding Snapshot backups feature"));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+
+
+        }
+
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingExternalReplicationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+
+            var file = GetTempFileName();
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    var connectionString = new RavenConnectionString
+                    {
+                        Name = csName,
+                        Database = dbName,
+                        TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
+                    };
+
+                    var result = await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                    Assert.NotNull(result.RaftCommandIndex);
+
+                    var watcher = new ExternalReplication(dbName, csName);
+                    await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_COMM);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding External Replication."));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingDelayedExternalReplicationWithProLicense()
+        {
+            DoNotReuseServer();
+
+            var file = GetTempFileName();
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    var connectionString = new RavenConnectionString
+                    {
+                        Name = csName,
+                        Database = dbName,
+                        TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
+                    };
+
+                    var result = await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                    Assert.NotNull(result.RaftCommandIndex);
+
+                    var watcher = new ExternalReplication(dbName, csName);
+                    await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_COMM);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding External Replication."));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingTsRollupAndRetentionWithCommunityLicense()
+        {
+            DoNotReuseServer();
+
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    var salesTsConfig = new TimeSeriesCollectionConfiguration
+                    {
+                        Policies = new List<TimeSeriesPolicy>
+                        {
+                            new("DailyRollupForOneYear",
+                                TimeValue.FromDays(1),
+                                TimeValue.FromYears(1))
+                },
+                        RawPolicy = new RawTimeSeriesPolicy(TimeValue.FromDays(7))
+                    };
+                    var databaseTsConfig = new TimeSeriesConfiguration();
+                    databaseTsConfig.Collections["Sales"] = salesTsConfig;
+                    store.Maintenance.Send(new ConfigureTimeSeriesOperation(databaseTsConfig));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_COMM);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding Time Series Rollups And Retention feature."));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingCompressionWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    var dbrecord = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+                    dbrecord.DocumentsCompression.CompressAllCollections = true;
+                    store.Maintenance.Server.Send(new UpdateDatabaseOperation(dbrecord, dbrecord.Etag));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_COMM);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding Documents Compression feature."));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingCompressionWithProLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    var dbrecord = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+                    dbrecord.DocumentsCompression.CompressAllCollections = true;
+                    store.Maintenance.Server.Send(new UpdateDatabaseOperation(dbrecord, dbrecord.Etag));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_PRO);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding Documents Compression feature."));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingPullReplicationAsSinkWithCommunityLicense()
+        {
+            DoNotReuseServer();
+
+            var file = GetTempFileName();
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    var pullAsSink = new PullReplicationAsSink(dbName, csName, "hub");
+                    var result = await store.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(pullAsSink));
+                    Assert.NotNull(result.RaftCommandIndex);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_COMM);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding Sink Replication feature."));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingPullReplicationAsHubWithCommunityLicense()
+        {
+            DoNotReuseServer();
+
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    store.Maintenance.Send(new PutPullReplicationAsHubOperation("sink"));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_COMM);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding Hub Replication feature."));
+                    WaitForUserToContinueTheTest(store);
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingPullReplicationAsHubWithProLicense()
+        {
+            DoNotReuseServer();
+
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    store.Maintenance.Send(new PutPullReplicationAsHubOperation("sink"));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_PRO);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding Hub Replication feature."));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [MultiLicenseRequiredFact]
+        public async Task ExceptionWhenImportingRavenEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    var etlConfiguration = new RavenEtlConfiguration
+                    {
+                        Name = csName,
+                        ConnectionStringName = csName,
+                        Transforms = { new Transformation { Name = $"ETL : {csName}", ApplyToAllDocuments = true } },
+                        MentorNode = "A",
+                    };
+                    var connectionString = new RavenConnectionString
+                    {
+                        Name = csName,
+                        Database = dbName,
+                        TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" },
+                    };
+
+                    Assert.NotNull(store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString)));
+                    store.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(etlConfiguration));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await ChangeLicense(Server, RL_COMM);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                    Assert.Equal(LimitType.InvalidLicense, exception.Type);
+                    Assert.True(exception.Message.Contains("Your license doesn't support adding Raven ETL feature."));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+
+        private static async Task ChangeLicense(RavenServer server, string licenseType)
+        {
+            var license = Environment.GetEnvironmentVariable(licenseType);
+            LicenseHelper.TryDeserializeLicense(license, out License li);
+
+            await server.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21273

### Additional description

check for license restrictions when import a database
v5.4 pr - https://github.com/ravendb/ravendb/pull/17346

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
