### PR TITLE
RavenDB-21860 do not use CommandBase.CreateFrom inside the cluster state machine

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1921,7 +1921,7 @@ namespace Raven.Server.ServerWide
             DeleteValueCommand delCmd = null;
             try
             {
-                delCmd = (DeleteValueCommand)CommandBase.CreateFrom(cmd);
+                delCmd = (DeleteValueCommand)JsonDeserializationCluster.Commands[type](cmd);
                 if (delCmd.Name.StartsWith("db/"))
                     throw new RachisApplyException("Cannot delete " + delCmd.Name + " using DeleteValueCommand, only via dedicated database calls");
 
@@ -1945,7 +1945,7 @@ namespace Raven.Server.ServerWide
         {
             try
             {
-                var command = (DeleteCertificateFromClusterCommand)CommandBase.CreateFrom(cmd);
+                var command = (DeleteCertificateFromClusterCommand)JsonDeserializationCluster.Commands[type](cmd);
 
                 DeleteCertificate(context, command.Name);
             }
@@ -1959,7 +1959,7 @@ namespace Raven.Server.ServerWide
         {
             try
             {
-                var command = (DeleteCertificateCollectionFromClusterCommand)CommandBase.CreateFrom(cmd);
+                var command = (DeleteCertificateCollectionFromClusterCommand)JsonDeserializationCluster.Commands[type](cmd);
 
                 foreach (var thumbprint in command.Names)
                 {
@@ -2066,7 +2066,7 @@ namespace Raven.Server.ServerWide
             try
             {
                 var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
-                command = (UpdateValueCommand<T>)CommandBase.CreateFrom(cmd);
+                command = (UpdateValueCommand<T>)JsonDeserializationCluster.Commands[type](cmd);
                 if (command.Name.StartsWith(Constants.Documents.Prefix))
                     throw new RachisApplyException("Cannot set " + command.Name + " using PutValueCommand, only via dedicated database calls");
 
@@ -2151,7 +2151,7 @@ namespace Raven.Server.ServerWide
             try
             {
                 var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
-                command = (PutValueCommand<T>)CommandBase.CreateFrom(cmd);
+                command = (PutValueCommand<T>)JsonDeserializationCluster.Commands[type](cmd);
                 if (command.Name.StartsWith(Constants.Documents.Prefix))
                     throw new RachisApplyException("Cannot set " + command.Name + " using PutValueCommand, only via dedicated database calls");
 
@@ -2192,7 +2192,7 @@ namespace Raven.Server.ServerWide
             try
             {
                 var certs = context.Transaction.InnerTransaction.OpenTable(CertificatesSchema, CertificatesSlice);
-                var command = (PutCertificateCommand)CommandBase.CreateFrom(cmd);
+                var command = (PutCertificateCommand)JsonDeserializationCluster.Commands[type](cmd);
 
                 using (Slice.From(context.Allocator, command.PublicKeyPinningHash, out var hashSlice))
                 using (Slice.From(context.Allocator, command.Name.ToLowerInvariant(), out var thumbprintSlice))
@@ -2214,7 +2214,7 @@ namespace Raven.Server.ServerWide
 
         private void BulkPutReplicationCertificate(ClusterOperationContext context, string type, BlittableJsonReaderObject cmd, long index, ServerStore serverStore)
         {
-            var command = (BulkRegisterReplicationHubAccessCommand)CommandBase.CreateFrom(cmd);
+            var command = (BulkRegisterReplicationHubAccessCommand)JsonDeserializationCluster.Commands[type](cmd);
             try
             {
                 var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
@@ -2232,7 +2232,7 @@ namespace Raven.Server.ServerWide
 
         private void PutReplicationCertificate(ClusterOperationContext context, string type, BlittableJsonReaderObject cmd, long index, ServerStore serverStore)
         {
-            var command = (RegisterReplicationHubAccessCommand)CommandBase.CreateFrom(cmd);
+            var command = (RegisterReplicationHubAccessCommand)JsonDeserializationCluster.Commands[type](cmd);
             try
             {
                 var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);
@@ -2295,7 +2295,7 @@ namespace Raven.Server.ServerWide
 
         private void RemoveReplicationCertificate(ClusterOperationContext context, string type, BlittableJsonReaderObject cmd, long index, ServerStore serverStore)
         {
-            var command = (UnregisterReplicationHubAccessCommand)CommandBase.CreateFrom(cmd);
+            var command = (UnregisterReplicationHubAccessCommand)JsonDeserializationCluster.Commands[type](cmd);
             try
             {
                 var certs = context.Transaction.InnerTransaction.OpenTable(ReplicationCertificatesSchema, ReplicationCertificatesSlice);

--- a/test/SlowTests/Issues/RavenDB_16966.cs
+++ b/test/SlowTests/Issues/RavenDB_16966.cs
@@ -42,17 +42,13 @@ namespace SlowTests.Issues
                 try
                 {
                     await tasks[i];
+                    var res = await AssertWaitForNotNullAsync(() => store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>("test/" + i)));
+                    Assert.Equal("Karmel/" + i, res.Value);
                 }
-                catch (RavenException e) when (e.InnerException is TimeoutException)
+                catch (RavenException e) when (e.InnerException is OperationCanceledException)
                 {
 
                 }
-            }
-
-            for (int i = 0; i < size; i++)
-            {
-                var res = await AssertWaitForNotNullAsync(() => store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>("test/" + i)));
-                Assert.Equal("Karmel/" + i, res.Value);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21860

### Additional description

Debug assert was failing because `CommandBase.CreateFrom` would populate the `Raw` field of the command.
Inside the cluster state machine we should use the `JsonDeserializationCluster.Commands` for deserializing the raft commands

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
