### PR TITLE
RavenDB-19481 - Cluster transactions are reapplied after restore (v6.0)

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -635,7 +635,7 @@ namespace Raven.Server.Documents
         protected virtual ClusterTransactionBatchCollector CollectCommandsBatch(ClusterOperationContext context, long lastCompletedClusterTransactionIndex, int take)
         {
             var batchCollector = new ClusterTransactionBatchCollector(take);
-            var readCommands = ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, take, lastCompletedClusterTransactionIndex);
+            var readCommands = ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, lastCompletedClusterTransactionIndex, take);
             batchCollector.Add(readCommands);
             return batchCollector;
         }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -635,7 +635,7 @@ namespace Raven.Server.Documents
         protected virtual ClusterTransactionBatchCollector CollectCommandsBatch(ClusterOperationContext context, long lastCompletedClusterTransactionIndex, int take)
         {
             var batchCollector = new ClusterTransactionBatchCollector(take);
-            var readCommands = ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, take);
+            var readCommands = ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, take, lastCompletedClusterTransactionIndex);
             batchCollector.Add(readCommands);
             return batchCollector;
         }

--- a/src/Raven.Server/Documents/Handlers/Debugging/Processors/AbstractTransactionDebugHandlerProcessorForGetClusterInfo.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/Processors/AbstractTransactionDebugHandlerProcessorForGetClusterInfo.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Handlers.Debugging.Processors
             {
                 context.Write(writer, new DynamicJsonValue
                 {
-                    ["Results"] = new DynamicJsonArray(ClusterTransactionCommand.ReadCommandsBatch(context, RequestHandler.DatabaseName, from, take))
+                    ["Results"] = new DynamicJsonArray(ClusterTransactionCommand.ReadCommandsBatch(context, RequestHandler.DatabaseName, fromCount: from, take: take))
                 });
             }
         }

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -164,12 +164,10 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
     protected override ClusterTransactionBatchCollector CollectCommandsBatch(ClusterOperationContext context, long lastCompletedClusterTransactionIndex, int take)
     {
         var batchCollector = new ShardedClusterTransactionBatchCollector(this, take);
-        var readCommands = ClusterTransactionCommand.ReadCommandsBatch(context, ShardedDatabaseName, fromCount: _nextClusterCommand, take: take);
+        var readCommands = ClusterTransactionCommand.ReadCommandsBatch(context, ShardedDatabaseName, fromCount: _nextClusterCommand, take: take, lastCompletedClusterTransactionIndex);
 
         foreach (var command in readCommands)
         {
-            if (command.Index <= lastCompletedClusterTransactionIndex)
-                continue;
             batchCollector.MaxIndex = command.Index;
             batchCollector.MaxCommandCount = command.PreviousCount + command.Commands.Count;
             if (command.ShardNumber == ShardNumber)

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -161,13 +161,15 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
         }
     }
     
-    protected override ClusterTransactionBatchCollector CollectCommandsBatch(ClusterOperationContext context, int take)
+    protected override ClusterTransactionBatchCollector CollectCommandsBatch(ClusterOperationContext context, long lastCompletedClusterTransactionIndex, int take)
     {
         var batchCollector = new ShardedClusterTransactionBatchCollector(this, take);
         var readCommands = ClusterTransactionCommand.ReadCommandsBatch(context, ShardedDatabaseName, fromCount: _nextClusterCommand, take: take);
 
         foreach (var command in readCommands)
         {
+            if (command.Index <= lastCompletedClusterTransactionIndex)
+                continue;
             batchCollector.MaxIndex = command.Index;
             batchCollector.MaxCommandCount = command.PreviousCount + command.Commands.Count;
             if (command.ShardNumber == ShardNumber)

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -164,7 +164,7 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
     protected override ClusterTransactionBatchCollector CollectCommandsBatch(ClusterOperationContext context, long lastCompletedClusterTransactionIndex, int take)
     {
         var batchCollector = new ShardedClusterTransactionBatchCollector(this, take);
-        var readCommands = ClusterTransactionCommand.ReadCommandsBatch(context, ShardedDatabaseName, fromCount: _nextClusterCommand, take: take, lastCompletedClusterTransactionIndex);
+        var readCommands = ClusterTransactionCommand.ReadCommandsBatch(context, ShardedDatabaseName, fromCount: _nextClusterCommand, lastCompletedClusterTransactionIndex, take);
 
         foreach (var command in readCommands)
         {

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -858,7 +858,7 @@ namespace Raven.Server.ServerWide.Commands
         }
 
 
-        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long? lastCompletedClusterTransactionIndex = null, long take = 128)
+        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long take = 128, long? lastCompletedClusterTransactionIndex = null)
             where TTransaction : RavenTransaction
         {
             var lowerDb = database.ToLowerInvariant();

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -858,7 +858,7 @@ namespace Raven.Server.ServerWide.Commands
         }
 
 
-        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long take = 128)
+        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long? lastCompletedClusterTransactionIndex = null, long take = 128)
             where TTransaction : RavenTransaction
         {
             var lowerDb = database.ToLowerInvariant();
@@ -875,6 +875,8 @@ namespace Raven.Server.ServerWide.Commands
                     if (result.Database != lowerDb) // beware of reading commands of other databases.
                         continue;
                     if (result.PreviousCount < fromCount)
+                        continue;
+                    if (lastCompletedClusterTransactionIndex.HasValue && result.Index <= lastCompletedClusterTransactionIndex)
                         continue;
                     if (take <= 0)
                         yield break;

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -858,7 +858,7 @@ namespace Raven.Server.ServerWide.Commands
         }
 
 
-        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long take = 128, long? lastCompletedClusterTransactionIndex = null)
+        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long? lastCompletedClusterTransactionIndex = null, long take = 128)
             where TTransaction : RavenTransaction
         {
             var lowerDb = database.ToLowerInvariant();

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3842,6 +3842,7 @@ namespace Raven.Server.ServerWide
             internal Action<CompareExchangeCommandBase> ModifyCompareExchangeTimeout;
             internal Action RestoreDatabaseAfterSavingDatabaseRecord;
             internal Action AfterCommitInClusterTransaction;
+            internal Action<string, List<ClusterTransactionCommand.SingleClusterDatabaseCommand>> BeforeExecuteClusterTransactionBatch;
         }
 
         public readonly MemoryCache QueryClauseCache;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -16,6 +16,7 @@ using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
@@ -654,7 +655,8 @@ namespace Raven.Server.Smuggler.Documents
                         if ((document.NonPersistentFlags.Contain(NonPersistentDocumentFlags.FromSmuggler)) &&
                             (_missingDocumentsForRevisions != null))
                         {
-                            if (_database.DocumentsStorage.Get(context, document.Id) == null)
+                            if (_database.DocumentsStorage.Get(context, document.Id) == null &&
+                                document.ChangeVector.Contains(ChangeVectorParser.TrxnTag) == false)
                             {
                                 var collection = _database.DocumentsStorage.ExtractCollectionName(context, document.Data);
                                 _missingDocumentsForRevisions.TryAdd(document.Id.ToString(), collection);

--- a/test/SlowTests/Issues/RavenDB-19481.cs
+++ b/test/SlowTests/Issues/RavenDB-19481.cs
@@ -97,7 +97,7 @@ namespace SlowTests.Issues
                 var clusterTransactions = new Dictionary<string, long>();
                 Server.ServerStore.ForTestingPurposesOnly().BeforeExecuteClusterTransactionBatch = (dbName, batch) =>
                 {
-                    if (dbName == restoredDatabaseName)
+                    if (dbName.StartsWith(restoredDatabaseName))
                     {
                         foreach (var clusterTx in batch)
                         {
@@ -117,7 +117,7 @@ namespace SlowTests.Issues
                 foreach (var kvp in clusterTransactions)
                 {
                     var timesWasApplied = kvp.Value;
-                    Assert.True(timesWasApplied <= 1, $"cluster transaction \"{kvp.Key}\" was reapplied more then once ({timesWasApplied} times)");
+                    Assert.True(timesWasApplied == 1, $"cluster transaction \"{kvp.Key}\" was reapplied more then once ({timesWasApplied} times)");
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-19481.cs
+++ b/test/SlowTests/Issues/RavenDB-19481.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Session;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using static Raven.Server.Smuggler.Documents.CounterItem;
+using Assert = Xunit.Assert;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19481 : RavenTestBase
+    {
+        public RavenDB_19481(ITestOutputHelper output) : base(output)
+        {
+        }
+
+
+        [RavenTheory(RavenTestCategory.Smuggler)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ShouldntReapplyClusterTransactionTwiceInRestore(Options options)
+        {
+            DoNotReuseServer();
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var store = GetDocumentStore(options))
+            {
+                const string id = "users/1";
+
+                await RevisionsHelper.SetupRevisionsAsync(Server.ServerStore, store.Database);
+
+                using (var session = store.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                }))
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "Grisha"
+                    }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+                Assert.Equal(1, stats.CountOfRevisionDocuments);
+
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.RunBackupAndReturnStatusAsync(Server, backupTaskId, store, isFullBackup: false, expectedEtag: 4);
+
+                var databaseName = $"restored_database-{Guid.NewGuid()}";
+
+                var clusterTransactions = new Dictionary<string, long>();
+                Server.ServerStore.ForTestingPurposesOnly().BeforeExecuteClusterTransactionBatch = (dbName, batch) =>
+                {
+                    if (dbName == databaseName)
+                    {
+                        foreach (var clusterTx in batch)
+                        {
+                            var raftRequestId = clusterTx.Options.TaskId;
+                            if (clusterTransactions.ContainsKey(clusterTx.Options.TaskId) == false)
+                                clusterTransactions.Add(raftRequestId, 1);
+                            else
+                                clusterTransactions[raftRequestId]++;
+                        }
+                    }
+                };
+
+                using (Backup.RestoreDatabase(store,
+                           new RestoreBackupConfiguration
+                           {
+                               BackupLocation = Directory.GetDirectories(backupPath).First(),
+                               DatabaseName = databaseName
+                           }))
+                {
+                }
+
+                foreach (var kvp in clusterTransactions)
+                {
+                    var timesWasApplied = kvp.Value;
+                    Assert.True(timesWasApplied <= 1, $"cluster transaction \"{kvp.Key}\" was reapplied more then once ({timesWasApplied} times)");
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Smuggler)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task RestoredDocThatCreatedByClusterWideTransactionShouldntHaveDeleteRevision(Options options)
+        {
+            DoNotReuseServer();
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using var store = GetDocumentStore(options);
+
+            const string id = "users/1";
+
+            await RevisionsHelper.SetupRevisionsAsync(Server.ServerStore, store.Database);
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new Company { Name = "Grisha" }, id);
+                await session.SaveChangesAsync();
+            }
+
+            var stats = await store.Maintenance.SendAsync(new GetStatisticsOperation());
+            Assert.Equal(1, stats.CountOfRevisionDocuments);
+
+            var config = Backup.CreateBackupConfiguration(backupPath);
+            var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+            await Backup.RunBackupAndReturnStatusAsync(Server, backupTaskId, store, isFullBackup: false, expectedEtag: 2);
+
+            var databaseName = $"restored_database-{Guid.NewGuid()}";
+
+            using (Backup.RestoreDatabase(store,
+                       new RestoreBackupConfiguration { BackupLocation = Directory.GetDirectories(backupPath).First(), DatabaseName = databaseName }))
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions()
+                {
+                    Database = databaseName
+                }))
+                {
+                    var user = await session.LoadAsync<Company>(id);
+                    Assert.NotNull(user);
+
+                    var revisionsMetadata = await session.Advanced.Revisions.GetMetadataForAsync(id);
+                    foreach (var metadata in revisionsMetadata)
+                    {
+                        Assert.False(metadata.GetString(Constants.Documents.Metadata.Flags).Contains(DocumentFlags.DeleteRevision.ToString()),
+                            $"Restored document \"{id}\" has \'DeleteRevision\'");
+                    }
+                }
+            }
+
+        }
+
+        private class Company
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
@@ -159,7 +159,7 @@ namespace SlowTests.Sharding.Backup
                     Assert.Equal(1, databaseRecord.PeriodicBackups.Count);
                     Assert.NotNull(databaseRecord.Revisions);
 
-                    await Sharding.Backup.CheckData(store2, RavenDatabaseMode.Sharded, expectedRevisionsCount: 18, database: databaseName);
+                    await Sharding.Backup.CheckData(store2, RavenDatabaseMode.Sharded, expectedRevisionsCount: 16, database: databaseName);
                 }
             }
         }
@@ -263,7 +263,7 @@ namespace SlowTests.Sharding.Backup
                             Assert.True(shardNodes.Add(shardTopology.Members[0]));
                         }
 
-                        await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 18, database: databaseName);
+                        await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 16, database: databaseName);
                     }
                 }
             }
@@ -327,7 +327,7 @@ namespace SlowTests.Sharding.Backup
                             Assert.True(shardNodes.Add(shardTopology.Members[0]));
                         }
 
-                        await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 18, database: databaseName);
+                        await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 16, database: databaseName);
                     }
                 }
             }
@@ -390,7 +390,7 @@ namespace SlowTests.Sharding.Backup
                             Assert.True(shardNodes.Add(shardTopology.Members[0]));
                         }
 
-                        await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 18, database: databaseName);
+                        await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 16, database: databaseName);
                     }
                 }
             }
@@ -549,7 +549,7 @@ namespace SlowTests.Sharding.Backup
                         Assert.True(shardNodes.Add(shardTopology.Members[0]));
                     }
 
-                    await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 18, database: databaseName);
+                    await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 16, database: databaseName);
                 }
             }
         }
@@ -748,7 +748,7 @@ namespace SlowTests.Sharding.Backup
                             Assert.True(shardNodes.Add(shardTopology.Members[0]));
                         }
 
-                        await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 18, newDbName);
+                        await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 16, newDbName);
                     }
                 }
             }
@@ -836,7 +836,7 @@ namespace SlowTests.Sharding.Backup
                         Assert.Equal(i, shardBucketRange.ShardNumber);
                     }
 
-                    await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 18, database: databaseName);
+                    await Sharding.Backup.CheckData(store, RavenDatabaseMode.Sharded, expectedRevisionsCount: 16, database: databaseName);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19481/Cluster-transactions-are-reapplied-after-restore

### Additional description

After restoring the cluster transactions and starting the database again, we reapply the cluster transactions again (since we process the commands that exist in the ClusterStateMachine).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
