### PR TITLE
RavenDB-22107 - ReplicationActiveConnectionsPreview deserialization i…

### DIFF
--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplication.cs
@@ -8,8 +8,6 @@ namespace Raven.Client.Documents.Operations.Replication
     {
         public TimeSpan DelayReplicationFor { get; set; }
 
-        public ReplicationType Type = ReplicationType.External;
-
         public ExternalReplication()
         {
         }
@@ -18,11 +16,12 @@ namespace Raven.Client.Documents.Operations.Replication
         {
         }
 
+        public override ReplicationType GetReplicationType() => ReplicationType.External;
+
         public override DynamicJsonValue ToJson()
         {
             var json = base.ToJson();
             json[nameof(DelayReplicationFor)] = DelayReplicationFor;
-            json[nameof(Type)] = Type;
             return json;
         }
 
@@ -30,6 +29,7 @@ namespace Raven.Client.Documents.Operations.Replication
         {
             return ToJson();
         }
+
         public override bool IsEqualTo(ReplicationNode other)
         {
             if (other is ExternalReplication externalReplication)

--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplication.cs
@@ -6,6 +6,10 @@ namespace Raven.Client.Documents.Operations.Replication
 {
     public class ExternalReplication : ExternalReplicationBase, IExternalReplication
     {
+        public TimeSpan DelayReplicationFor { get; set; }
+
+        public ReplicationType Type = ReplicationType.External;
+
         public ExternalReplication()
         {
         }
@@ -14,12 +18,11 @@ namespace Raven.Client.Documents.Operations.Replication
         {
         }
 
-        public TimeSpan DelayReplicationFor { get; set; }
-
         public override DynamicJsonValue ToJson()
         {
             var json = base.ToJson();
             json[nameof(DelayReplicationFor)] = DelayReplicationFor;
+            json[nameof(Type)] = Type;
             return json;
         }
 

--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
@@ -84,11 +84,6 @@ namespace Raven.Client.Documents.Operations.Replication
             return ToJson();
         }
 
-        public override string FromString()
-        {
-            return $"[{Database} @ {Url}]";
-        }
-
         public virtual ulong GetTaskKey()
         {
             var hashCode = CalculateStringHash(Database);

--- a/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
@@ -19,7 +19,7 @@ namespace Raven.Client.Documents.Operations.Replication
             }
         }
 
-        public ReplicationType Type = ReplicationType.Internal;
+        public override ReplicationType GetReplicationType() => ReplicationType.Internal;
 
         public override string FromString()
         {
@@ -50,7 +50,6 @@ namespace Raven.Client.Documents.Operations.Replication
         {
             var json = base.ToJson();
             json[nameof(NodeTag)] = NodeTag;
-            json[nameof(Type)] = Type;
             return json;
         }
     }

--- a/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/InternalReplication.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Raven.Client.Documents.Replication;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
@@ -17,6 +18,9 @@ namespace Raven.Client.Documents.Operations.Replication
                 _nodeTag = value;
             }
         }
+
+        public ReplicationType Type = ReplicationType.Internal;
+
         public override string FromString()
         {
             return $"[{NodeTag}/{Url}]";
@@ -31,7 +35,7 @@ namespace Raven.Client.Documents.Operations.Replication
             }
             return false;
         }
-        
+
         public override int GetHashCode()
         {
             unchecked
@@ -40,6 +44,14 @@ namespace Raven.Client.Documents.Operations.Replication
                 HashCodeSealed = true;
                 return hashCode;
             }
+        }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+            json[nameof(NodeTag)] = NodeTag;
+            json[nameof(Type)] = Type;
+            return json;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -18,8 +18,6 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public string HubName;
 
-        public ReplicationType Type = ReplicationType.PullAsSink;
-
         public PullReplicationAsSink()
         {
         }
@@ -28,6 +26,8 @@ namespace Raven.Client.Documents.Operations.Replication
         {
             HubName = hubName;
         }
+
+        public override ReplicationType GetReplicationType() => ReplicationType.PullAsSink;
 
         public override bool IsEqualTo(ReplicationNode other)
         {
@@ -66,8 +66,6 @@ namespace Raven.Client.Documents.Operations.Replication
             djv[nameof(AllowedHubToSinkPaths)] = AllowedHubToSinkPaths;
             djv[nameof(AllowedSinkToHubPaths)] = AllowedSinkToHubPaths;
             djv[nameof(AccessName)] = AccessName;
-            djv[nameof(Type)] = Type;
-
             return djv;
         }
 
@@ -80,8 +78,6 @@ namespace Raven.Client.Documents.Operations.Replication
             djv[nameof(AllowedHubToSinkPaths)] = AllowedHubToSinkPaths;
             djv[nameof(AllowedSinkToHubPaths)] = AllowedSinkToHubPaths;
             djv[nameof(AccessName)] = AccessName;
-            djv[nameof(Type)] = Type;
-
             return djv;
         }
 

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -18,6 +18,8 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public string HubName;
 
+        public ReplicationType Type = ReplicationType.PullAsSink;
+
         public PullReplicationAsSink()
         {
         }
@@ -64,6 +66,7 @@ namespace Raven.Client.Documents.Operations.Replication
             djv[nameof(AllowedHubToSinkPaths)] = AllowedHubToSinkPaths;
             djv[nameof(AllowedSinkToHubPaths)] = AllowedSinkToHubPaths;
             djv[nameof(AccessName)] = AccessName;
+            djv[nameof(Type)] = Type;
 
             return djv;
         }
@@ -77,6 +80,7 @@ namespace Raven.Client.Documents.Operations.Replication
             djv[nameof(AllowedHubToSinkPaths)] = AllowedHubToSinkPaths;
             djv[nameof(AllowedSinkToHubPaths)] = AllowedSinkToHubPaths;
             djv[nameof(AccessName)] = AccessName;
+            djv[nameof(Type)] = Type;
 
             return djv;
         }

--- a/src/Raven.Client/Documents/Replication/ReplicationNode.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationNode.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Documents.Replication
     /// <summary>
     /// Data class for replication destination
     /// </summary>
-    public abstract class ReplicationNode : IEquatable<ReplicationNode>
+    public class ReplicationNode : IEquatable<ReplicationNode>, IDynamicJson
     {
         /// <summary>
         /// The name of the connection string specified in the 
@@ -93,6 +93,6 @@ namespace Raven.Client.Documents.Replication
             return str;
         }
 
-        public abstract string FromString();
+        public virtual string FromString() => $"[{Database} @ {Url}]";
     }
 }

--- a/src/Raven.Client/Documents/Replication/ReplicationNode.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationNode.cs
@@ -49,6 +49,11 @@ namespace Raven.Client.Documents.Replication
         /// </summary>
         public bool Disabled { get; set; }
 
+        /// <summary>
+        /// Replication type
+        /// </summary>
+        public ReplicationType Type => GetReplicationType();
+       
         public enum ReplicationType
         {
             External,
@@ -56,6 +61,8 @@ namespace Raven.Client.Documents.Replication
             Internal,
             Migration
         }
+
+        public abstract ReplicationType GetReplicationType();
 
         public bool Equals(ReplicationNode other) => IsEqualTo(other);
 
@@ -92,7 +99,8 @@ namespace Raven.Client.Documents.Replication
             {
                 [nameof(Database)] = Database,
                 [nameof(Url)] = Url,
-                [nameof(Disabled)] = Disabled
+                [nameof(Disabled)] = Disabled,
+                [nameof(Type)] = Type
             };
         }
 

--- a/src/Raven.Client/Documents/Replication/ReplicationNode.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationNode.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Documents.Replication
     /// <summary>
     /// Data class for replication destination
     /// </summary>
-    public class ReplicationNode : IEquatable<ReplicationNode>, IDynamicJson
+    public abstract class ReplicationNode : IEquatable<ReplicationNode>, IDynamicJson
     {
         /// <summary>
         /// The name of the connection string specified in the 
@@ -49,6 +49,14 @@ namespace Raven.Client.Documents.Replication
         /// </summary>
         public bool Disabled { get; set; }
 
+        public enum ReplicationType
+        {
+            External,
+            PullAsSink,
+            Internal,
+            Migration
+        }
+
         public bool Equals(ReplicationNode other) => IsEqualTo(other);
 
         public virtual bool IsEqualTo(ReplicationNode other)
@@ -58,9 +66,12 @@ namespace Raven.Client.Documents.Replication
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != GetType())
+                return false;
             return Equals((ReplicationNode)obj);
         }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetActiveConnections.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForGetActiveConnections.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Replication;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Replication;
+using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.Stats;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -22,7 +24,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         protected override RavenCommand<ReplicationActiveConnectionsPreview> CreateCommandForNode(string nodeTag) => new GetReplicationActiveConnectionsInfoCommand(nodeTag);
     }
 
-    public sealed class ReplicationActiveConnectionsPreview
+    public sealed class ReplicationActiveConnectionsPreview : IFillFromBlittableJson
     {
         public List<IncomingConnectionInfo> IncomingConnections;
 
@@ -35,6 +37,38 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
                 [nameof(IncomingConnections)] = new DynamicJsonArray(IncomingConnections.Select(i => i.ToJson())),
                 [nameof(OutgoingConnections)] = new DynamicJsonArray(OutgoingConnections.Select(o => o.ToJson()))
             };
+        }
+
+        public void FillFromBlittableJson(BlittableJsonReaderObject json)
+        {
+            FillIncomingConnections(json);
+            FillOutgoingConnections(json);
+        }
+
+        private void FillIncomingConnections(BlittableJsonReaderObject json)
+        {
+            IncomingConnections = new List<IncomingConnectionInfo>();
+            if (json.TryGetMember(nameof(IncomingConnections), out var result) && result is BlittableJsonReaderArray bjra)
+            {
+                foreach (BlittableJsonReaderObject bjro in bjra)
+                {
+                    var incomingConnection = DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<IncomingConnectionInfo>(bjro, "IncomingConnectionInfo");
+                    IncomingConnections.Add(incomingConnection);
+                }
+            }
+        }
+
+        private void FillOutgoingConnections(BlittableJsonReaderObject json)
+        {
+            OutgoingConnections = new List<ReplicationNode>();
+            if (json.TryGetMember(nameof(OutgoingConnections), out var result) && result is BlittableJsonReaderArray bjra)
+            {
+                foreach (BlittableJsonReaderObject bjro in bjra)
+                {
+                    var outgoingConnection = ReplicationHelper.GetReplicationNodeByType(bjro);
+                    OutgoingConnections.Add(outgoingConnection);
+                }
+            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Replication/BucketMigrationReplication.cs
+++ b/src/Raven.Server/Documents/Replication/BucketMigrationReplication.cs
@@ -13,6 +13,7 @@ namespace Raven.Server.Documents.Replication
         public readonly int Shard;
         public readonly string Node;
         public readonly long MigrationIndex;
+        public readonly ReplicationType Type = ReplicationType.Migration;
 
         public BucketMigrationReplication(ShardBucketMigration shardBucketMigration, string destResponsibleNode)
         {
@@ -49,6 +50,8 @@ namespace Raven.Server.Documents.Replication
             json[nameof(Shard)] = Shard;
             json[nameof(MigrationIndex)] = MigrationIndex;
             json[nameof(Node)] = Node;
+            json[nameof(Type)] = Type;
+
             return json;
         }
     }

--- a/src/Raven.Server/Documents/Replication/BucketMigrationReplication.cs
+++ b/src/Raven.Server/Documents/Replication/BucketMigrationReplication.cs
@@ -13,7 +13,6 @@ namespace Raven.Server.Documents.Replication
         public readonly int Shard;
         public readonly string Node;
         public readonly long MigrationIndex;
-        public readonly ReplicationType Type = ReplicationType.Migration;
 
         public BucketMigrationReplication(ShardBucketMigration shardBucketMigration, string destResponsibleNode)
         {
@@ -24,6 +23,8 @@ namespace Raven.Server.Documents.Replication
             Shard = ShardBucketMigration.DestinationShard;
             MigrationIndex = ShardBucketMigration.MigrationIndex;
         }
+
+        public override ReplicationType GetReplicationType() => ReplicationType.Migration;
 
         public bool ForBucketMigration(ShardBucketMigration migration)
         {
@@ -50,8 +51,6 @@ namespace Raven.Server.Documents.Replication
             json[nameof(Shard)] = Shard;
             json[nameof(MigrationIndex)] = MigrationIndex;
             json[nameof(Node)] = Node;
-            json[nameof(Type)] = Type;
-
             return json;
         }
     }

--- a/src/Raven.Server/Documents/Replication/ReplicationHelper.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationHelper.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Replication;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Replication
+{
+    public static class ReplicationHelper
+    {
+        public static ReplicationNode GetReplicationNodeByType(BlittableJsonReaderObject bjro)
+        {
+            if (bjro == null || bjro.TryGet("Type", out ReplicationNode.ReplicationType type) == false)
+                return null;
+            
+            return type switch
+            {
+                ReplicationNode.ReplicationType.PullAsSink => DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<PullReplicationAsSink>(bjro,
+                    "PullReplicationAsSink"),
+                ReplicationNode.ReplicationType.External => DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<ExternalReplication>(bjro,
+                    "ExternalReplication"),
+                ReplicationNode.ReplicationType.Internal => DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<InternalReplication>(bjro,
+                    "InternalReplication"),
+                ReplicationNode.ReplicationType.Migration => DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<BucketMigrationReplication>(bjro,
+                    "BucketMigrationReplication"),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/ReplicationHelper.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationHelper.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.Documents.Replication
     {
         public static ReplicationNode GetReplicationNodeByType(BlittableJsonReaderObject bjro)
         {
-            if (bjro == null || bjro.TryGet("Type", out ReplicationNode.ReplicationType type) == false)
+            if (bjro == null || bjro.TryGet(nameof(ReplicationNode.Type), out ReplicationNode.ReplicationType type) == false)
                 return null;
             
             return type switch

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationEditModel.ts
@@ -56,7 +56,8 @@ class ongoingTaskReplicationEditModel extends ongoingTaskEditModel {
             DelayReplicationFor: this.showDelayReplication() ? generalUtils.formatAsTimeSpan(this.delayReplicationTime() * 1000) : null,
             Url: undefined,
             Disabled: this.taskState() === "Disabled",
-            Database: undefined
+            Database: undefined,
+            Type: "External"
         };
     }
 

--- a/test/SlowTests/Issues/RavenDB_22107.cs
+++ b/test/SlowTests/Issues/RavenDB_22107.cs
@@ -1,0 +1,48 @@
+﻿using System.Threading.Tasks;
+using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Sharding.Replication;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22107 : ReplicationTestBase
+    {
+        public RavenDB_22107(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task GetReplicationActiveConnectionsShouldNotThrow(Options options)
+        {
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            {
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Store(new User { Name = "Shiran" }, "users/1");
+                    s1.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+
+                await SetupReplicationAsync(store2, store1);
+                await EnsureReplicatingAsync(store2, store1);
+
+                var db = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "users/1");
+                var replicationActiveConnections = await store1.Maintenance.ForDatabase(db.Name).SendAsync(new ShardedExternalReplicationTests.GetReplicationActiveConnectionsInfoOperation());
+
+                var expectedConnectionsCount = options.DatabaseMode == RavenDatabaseMode.Single ? 1 : 3;
+                Assert.NotNull(replicationActiveConnections.IncomingConnections);
+                Assert.Equal(expectedConnectionsCount, replicationActiveConnections.IncomingConnections.Count);
+
+                expectedConnectionsCount = 1;
+                Assert.NotNull(replicationActiveConnections.OutgoingConnections);
+                Assert.Equal(expectedConnectionsCount, replicationActiveConnections.OutgoingConnections.Count);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_22107.cs
+++ b/test/SlowTests/Issues/RavenDB_22107.cs
@@ -1,6 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Http;
+using Raven.Server.Documents.Commands.Replication;
+using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Sharding.Replication;
+using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -42,6 +51,107 @@ namespace SlowTests.Issues
                 expectedConnectionsCount = 1;
                 Assert.NotNull(replicationActiveConnections.OutgoingConnections);
                 Assert.Equal(expectedConnectionsCount, replicationActiveConnections.OutgoingConnections.Count);
+
+                var outgoingConnection = replicationActiveConnections.OutgoingConnections.Single();
+
+                Assert.True(outgoingConnection is ExternalReplication);
+                Assert.Equal(TimeSpan.Zero, ((ExternalReplication)outgoingConnection)!.DelayReplicationFor);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task GetReplicationOutgoingsFailureInfoShouldNotThrow(Options options)
+        {
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            {
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Store(new User { Name = "Shiran" }, "users/1");
+                    s1.SaveChanges();
+                }
+
+                await SetupReplicationAsync(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
+
+                await SetupReplicationAsync(store2, store1);
+                await EnsureReplicatingAsync(store2, store1);
+
+
+                var db = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "users/1");
+                await BreakReplication(Server.ServerStore, db.Name);
+
+                var replicationFailureInfo = await store1.Maintenance.ForDatabase(db.Name).SendAsync(new GetReplicationOutgoingsFailureInfoOperation());
+
+                Assert.NotNull(replicationFailureInfo.Stats);
+                Assert.Equal(1, replicationFailureInfo.Stats.Count);
+
+                var info = replicationFailureInfo.Stats.Single();
+
+                Assert.True(info.Key is ExternalReplication);
+                Assert.Equal(TimeSpan.Zero, ((ExternalReplication)info.Key)!.DelayReplicationFor);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task GetReplicationOutgoingReconnectionQueueShouldNotThrow(Options options)
+        {
+            using (var store1 = GetDocumentStore(options))
+            using (var store2 = GetDocumentStore(options))
+            {
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Store(new User { Name = "Shiran" }, "users/1");
+                    s1.SaveChanges();
+                }
+
+                var delay = TimeSpan.FromSeconds(5);
+                var externalTask = new ExternalReplication(store2.Database, "DelayedExternalReplication")
+                {
+                    DelayReplicationFor = delay
+                };
+                await AddWatcherToReplicationTopology(store1, externalTask);
+                await EnsureReplicatingAsync(store1, store2);
+
+                var source = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "users/1");
+                var destination = await GetDocumentDatabaseInstanceForAsync(store2, options.DatabaseMode, "users/1");
+
+                destination.Dispose();
+
+                using (var s1 = store1.OpenSession())
+                {
+                    s1.Store(new User { Name = "Shiran 2" }, "users/2$users/1");
+                    s1.SaveChanges();
+                }
+
+                ReplicationOutgoingReconnectionQueuePreview info = null;
+                await WaitAndAssertForValueAsync(async () =>
+                {
+                    info = await store1.Maintenance.ForDatabase(source.Name).SendAsync(new GetReplicationOutgoingReconnectionQueueOperation());
+                    return info.QueueInfo.Count;
+                }, 1);
+
+                var replicationNode = info.QueueInfo.Single();
+                Assert.True(replicationNode is ExternalReplication);
+                Assert.Equal(delay, ((ExternalReplication)replicationNode)!.DelayReplicationFor);
+            }
+        }
+
+        internal class GetReplicationOutgoingsFailureInfoOperation : IMaintenanceOperation<ReplicationOutgoingsFailurePreview>
+        {
+            public RavenCommand<ReplicationOutgoingsFailurePreview> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new GetReplicationOutgoingsFailureInfoCommand();
+            }
+        }
+
+        internal class GetReplicationOutgoingReconnectionQueueOperation : IMaintenanceOperation<ReplicationOutgoingReconnectionQueuePreview>
+        {
+            public RavenCommand<ReplicationOutgoingReconnectionQueuePreview> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new GetReplicationOutgoingReconnectionQueueCommand();
             }
         }
     }


### PR DESCRIPTION
…s broken

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22107/ReplicationActiveConnectionsPreview-deserialization-is-broken


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
