### PR TITLE
RavenDB-22110 CollectionQuery count 

### DIFF
--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -170,7 +170,7 @@ namespace Raven.Server.Documents
 
                 isStartsWithOrIdQuery = true;
 
-                return new CollectionQueryEnumerable(Database, Database.DocumentsStorage, SearchEngineType.None, new FieldsToFetch(_operationQuery, null, IndexType.None),
+                return new CollectionQueryEnumerable(Database, Database.DocumentsStorage, new FieldsToFetch(_operationQuery, null, IndexType.None),
                     collectionName, _operationQuery, null, context, null, null, null, new Reference<long>(), new Reference<int>(), new Reference<long>(), token)
                 {
                     Fields = fields, StartAfterId = startAfterId, AlreadySeenIdsCount = alreadySeenIdsCount

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -979,7 +979,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<Slice> ids, long start, long take, Reference<long> totalCount)
+        public IEnumerable<Document>  GetDocuments(DocumentsOperationContext context, IEnumerable<Slice> ids, long start, long take, Reference<long> totalCount)
         {
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -979,7 +979,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<Document>  GetDocuments(DocumentsOperationContext context, IEnumerable<Slice> ids, long start, long take, Reference<long> totalCount)
+        public IEnumerable<Document>  GetDocuments(DocumentsOperationContext context, IEnumerable<Slice> ids, long start, long take)
         {
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 
@@ -988,9 +988,7 @@ namespace Raven.Server.Documents
                 // id must be lowercased
                 if (table.ReadByKey(id, out TableValueReader reader) == false)
                     continue;
-
-                totalCount.Value++;
-
+                
                 if (start > 0)
                 {
                     start--;
@@ -1004,7 +1002,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<string> ids, long start, long take, Reference<long> totalCount)
+        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<string> ids, long start, long take)
         {
             var listOfIds = new List<Slice>();
             foreach (var id in ids)
@@ -1013,13 +1011,13 @@ namespace Raven.Server.Documents
                 listOfIds.Add(slice);
             }
 
-            return GetDocuments(context, listOfIds, start, take, totalCount);
+            return GetDocuments(context, listOfIds, start, take);
         }
 
-        public IEnumerable<Document> GetDocumentsForCollection(DocumentsOperationContext context, IEnumerable<Slice> ids, string collection, long start, long take, Reference<long> totalCount)
+        public IEnumerable<Document> GetDocumentsForCollection(DocumentsOperationContext context, IEnumerable<Slice> ids, string collection, long start, long take)
         {
             // we'll fetch all documents and do the filtering here since we must check the collection name
-            foreach (var doc in GetDocuments(context, ids, start, int.MaxValue, totalCount))
+            foreach (var doc in GetDocuments(context, ids, start, int.MaxValue))
             {
                 if (collection == Constants.Documents.Collections.AllDocumentsCollection)
                 {
@@ -1029,17 +1027,14 @@ namespace Raven.Server.Documents
 
                 if (doc.TryGetMetadata(out var metadata) == false)
                 {
-                    totalCount.Value--;
                     continue;
                 }
                 if (metadata.TryGet(Constants.Documents.Metadata.Collection, out string c) == false)
                 {
-                    totalCount.Value--;
                     continue;
                 }
                 if (string.Equals(c, collection, StringComparison.OrdinalIgnoreCase) == false)
                 {
-                    totalCount.Value--;
                     continue;
                 }
 

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -1077,11 +1077,7 @@ namespace Raven.Server.Documents.Handlers
                     else
                     {
                         var listOfIds = ids.Select(x => x.ToString());
-                        var _ = new Reference<long>
-                        {
-                            Value = 0
-                        };
-                        var docs = Database.DocumentsStorage.GetDocuments(context, listOfIds, 0, long.MaxValue, _);
+                        var docs = Database.DocumentsStorage.GetDocuments(context, listOfIds, 0, long.MaxValue);
                         foreach (var doc in docs)
                         {
                             if (doc.TryGetMetadata(out var metadata) && metadata.TryGet(Constants.Documents.Metadata.Collection, out string collectionStr))

--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -9,6 +9,7 @@ using Raven.Client.Exceptions;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Queries.AST;
+using Raven.Server.Documents.Queries.Dynamic;
 using Raven.Server.Documents.Queries.Results;
 using Raven.Server.Documents.Queries.Timings;
 using Raven.Server.ServerWide.Context;
@@ -144,6 +145,7 @@ namespace Raven.Server.Documents.Queries
             private readonly ScriptRunner.SingleRun _filterScriptRun;
             private ScriptRunner.ReturnRun _releaseFilterScriptRunner;
             private bool _totalResultsCalculated;
+            private bool _isCountQuery;
 
             public Enumerator(DocumentDatabase database, DocumentsStorage documents, FieldsToFetch fieldsToFetch, string collection, bool isAllDocsCollection,
                 IndexQueryServerSide query, QueryTimingsScope queryTimings, DocumentsOperationContext context, IncludeDocumentsCommand includeDocumentsCommand,
@@ -165,7 +167,7 @@ namespace Raven.Server.Documents.Queries
                 _fields = fields;
                 _skippedResults = skippedResults;
                 _token = token;
-                
+                _isCountQuery = _query.PageSize == 0;
                 if (_fieldsToFetch.IsDistinct)
                     _alreadySeenProjections = new HashSet<ulong>();
 
@@ -217,15 +219,22 @@ namespace Raven.Server.Documents.Queries
 
             public bool MoveNext()
             {
-                if (_initialized == false) 
-                    Initialize();
-
-                if (_query.PageSize == 0) // .Count() query
+                if (_initialized == false)
                 {
-                    CountDocumentsInEnumerator();
+                    Initialize(out var processedAllDocuments);
+                    
+                    // When our query skipped all documents from underlying stream
+                    if (processedAllDocuments)
+                        return false;
+                    
+                    ConfigureStreamForUnboundedQueries();
+                }
+
+                if (_isCountQuery)
+                {
+                    CountDocumentsInEnumerator(countQuery: true);
                     return false;
                 }
-                
                 
                 while (_returnedResults < _query.PageSize)
                 {
@@ -256,43 +265,57 @@ namespace Raven.Server.Documents.Queries
                     _skippedResults.Value++;
                 }
 
+                //In' (or 'equal') is an unbounded query like `startsWith'. However, there are not as many documents to check (since it requires sending list of ids) compared to startsWith
+                // where the query can match the whole collection (and more). For this scenario, we'll count the rest of the documents in the underlying enumerator
+                // in order to return exact totalResults count.
+                if (_ids != null)
+                    CountDocumentsInEnumerator(countQuery: false);
+                
                 return false;
             }
 
-            private void CountDocumentsInEnumerator()
+            private void CountDocumentsInEnumerator(bool countQuery)
             {
                 // If we know how many documents we have, and we do not have a DISTINCT clause, we can simply return the current value from memory.
-                if (_totalResultsCalculated && _query.Metadata.IsDistinct == false)
+                if (_totalResultsCalculated && _query.Metadata.IsDistinct == false && _filterScriptRun == null)
                     return;
                 
-                // We need to disable calculating totalResults in the enumerator, so let's set _totalResultsCalculated to true.
+                // For count(): We need to disable calculating totalResults in the enumerator, so let's set _totalResultsCalculated to true.
                 _totalResultsCalculated = true;
-                _totalResults.Value = 0;
+                
+                if (countQuery)
+                    _totalResults.Value = 0;
+
                 while (true)
                 {
                     var (hasNext, doc) = GetNextDocument();
-                    if (doc == null)
+                    using (doc)
                     {
-                        if (hasNext == false)
-                            return;
-                        _skippedResults.Value++;
-                        break;
+                        if (doc == null)
+                        {
+                            if (hasNext == false)
+                                return;
+                            _skippedResults.Value++;
+                            continue;
+                        }
+
+                        if (_query.SkipDuplicateChecking || _fieldsToFetch.IsDistinct == false)
+                        {
+                            _totalResults.Value++;
+                            continue;
+                        }
+
+                        if (_alreadySeenProjections.Add(doc.DataHash))
+                        {
+                            _totalResults.Value++;
+                        }
+                        else
+                        {
+                            _skippedResults.Value++; 
+                        }
                     }
                     
-                    if (_query.SkipDuplicateChecking || _fieldsToFetch.IsDistinct == false)
-                    {
-                        _totalResults.Value++;
-                        continue;
-                    }
-
-                    if (_alreadySeenProjections.Add(doc.DataHash))
-                    {
-                        _totalResults.Value++;
-                    }
-                    else
-                    {
-                        _skippedResults.Value++;
-                    }
+                    _context.Transaction.ForgetAbout(doc);
                 }
             }
 
@@ -381,94 +404,131 @@ namespace Raven.Server.Documents.Queries
                     }
                     else if (_alreadySeenIdsCount != null)
                     {
-                        documents = _isAllDocsCollection
-                            ? _documents.GetDocuments(_context, _ids, skip, take, _totalResults)
-                            : _documents.GetDocumentsForCollection(_context, _ids, _collection, skip, take, _totalResults);
-                        
+                        var idsLeft = _ids.Count - _alreadySeenIdsCount.Value;
+                        if (idsLeft == 0)
+                        {
+                            documents = Enumerable.Empty<Document>();
+                        }
+                        else
+                        {
+                            var count = idsLeft >= _query.PageSize ? _query.PageSize : idsLeft;
+                            var ids = _ids.Skip((int)_alreadySeenIdsCount.Value).Take((int)count);
+                            _alreadySeenIdsCount.Value += count;
+
+                            documents = _isAllDocsCollection
+                                ? _documents.GetDocuments(_context, ids, 0, take)
+                                : _documents.GetDocumentsForCollection(_context, ids, _collection, 0, take);
+                        }
                     }
                     else
                     {
                         documents = _isAllDocsCollection
-                            ? _documents.GetDocuments(_context, _ids, skip, take, _totalResults)
-                            : _documents.GetDocumentsForCollection(_context, _ids, _collection, skip, take, _totalResults);
+                            ? _documents.GetDocuments(_context, _ids, skip, take)
+                            : _documents.GetDocumentsForCollection(_context, _ids, _collection, skip, take);
+                        
                     }
                 }
                 else if (_isAllDocsCollection)
                 {
                     documents = _documents.GetDocumentsFrom(_context, 0, skip, take);
-                    totalResultsCalculated = true; 
-                    _totalResults.Value = (int)_documents.GetNumberOfDocuments(_context);
+                    if (_filterScriptRun == null)
+                    {
+                        totalResultsCalculated = true;
+                        _totalResults.Value = (int)_documents.GetNumberOfDocuments(_context);
+                    }
                 }
                 else
                 {
                     documents = _documents.GetDocumentsFrom(_context, _collection, 0, skip, take);
-                    totalResultsCalculated = true;
-                    _totalResults.Value = (int)_documents.GetCollection(_collection, _context).Count;
+                    if (_filterScriptRun == null)
+                    {
+                        totalResultsCalculated = true;
+                        _totalResults.Value = (int)_documents.GetCollection(_collection, _context).Count;
+                    }
                 }
 
                 return documents;
             }
+            
+            private void ConfigureStreamForUnboundedQueries()
+            {
+                // This is the scenario when we have an unbounded query (which basically means we don't know how many elements are in the underlying enumerable). 
+                // We want to avoid materializing just for the correct value of TotalResults and tell Studio that it is unbounded and count it on the front end.
+                // To do this, we'll need to disable totalResults incrementation and set totalResults to 'CollectionQueryRunner.UnboundedQueryResultMarker' (0). See more in `CollectionQueryRunner`.
+                //However, for count queries we will evaluate it to the end.
+                if (_startsWith != null && _isCountQuery == false)
+                {
+                    _totalResults.Value = CollectionQueryRunner.UnboundedQueryResultMarker;
+                    _totalResultsCalculated = true;
+                }
+            }
 
-            private void Initialize()
+            private void Initialize(out bool processedAllDocuments)
             {
                 _initialized = true;
+                var start = _query.Start;
+                var isInSkip = _ids != null && start > 0;
+                processedAllDocuments = false;
                 
-                if (_query.Start == 0 || _query.SkipDuplicateChecking || _fieldsToFetch.IsDistinct == false)
+                if (start == 0)
                 {
-                    _inner = GetDocuments(out _totalResultsCalculated, _query.Start).GetEnumerator();
+                    _inner = GetDocuments(out _totalResultsCalculated, start).GetEnumerator();
                     return;
                 }
 
+                if (_query.SkipDuplicateChecking)
+                {
+                    _inner = GetDocuments(out _totalResultsCalculated, start).GetEnumerator();
+                    return;
+                }
+
+                if (isInSkip == false && _fieldsToFetch.IsDistinct == false)
+                {
+                    _inner = GetDocuments(out _totalResultsCalculated, start).GetEnumerator();
+                    return;
+                }
+                
                 _inner = GetDocuments(out _totalResultsCalculated, amountToSkip: 0).GetEnumerator();
                 var count = 0;
                 while (true)
                 {
-                    if (_inner.MoveNext() == false)
-                        return;
+                    var (hasNextDocument, document) = GetNextDocument();
                     
-                    var document = _inner.Current;
-                    if (_fieldsToFetch.IsProjection)
+                    if (document == null && hasNextDocument == false)
+                        break;
+                    
+                    if (IsStartingPoint(document) || hasNextDocument == false)
                     {
-                        RetrieverInput retrieverInput = new(null, QueryResultRetrieverBase.ZeroScore, null);
-                        var result = _resultsRetriever.GetProjectionFromDocument(document, ref retrieverInput, _fieldsToFetch, _context, _token);
-                        if (result.Document != null)
-                        {
-                            if (IsStartingPoint(result.Document))
-                                break;
-                        }
-                        else if (result.List != null)
-                        {
-                            bool match = false;
-                            foreach (Document item in result.List)
-                            {
-                                if (IsStartingPoint(item))
-                                {
-                                    match = true;
-                                    _projections = result.List.GetEnumerator();
-                                    _hasProjections = true;
-                                    break;
-                                }
-                            }
+                        ReleaseDocument();
+                        break;
+                    }
 
-                            if (match)
-                                break;
-                        }
-
-                        bool IsStartingPoint(Document d)
+                    ReleaseDocument();
+                    
+                    
+                    void ReleaseDocument()
+                    {
+                        if (document != null)
                         {
-                            count++;
-                            
-                            if (_totalResultsCalculated == false)
-                                _totalResults.Value++;
-                            
-                            if (d.Data.Count > 0)
-                                _alreadySeenProjections.Add(d.DataHash);
-                            
-                            // We have to seek to the point where we previously ended.
-                            return count == _query.Start;
+                            document.Dispose();
+                            _context.Transaction.ForgetAbout(document);
                         }
                     }
                 }
+                
+                bool IsStartingPoint(Document d)
+                {
+                    count++;
+                    
+                    if (_fieldsToFetch.IsDistinct && d.Data.Count > 0)
+                        _alreadySeenProjections.Add(d.DataHash);
+                            
+                    // We have to seek to the point where we previously ended.
+                    return count == _query.Start;
+                }
+
+                if (count < _query.Start)
+                    processedAllDocuments = true;
             }
 
             public void Reset()

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -153,7 +153,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 var lastRaftId = Database.RachisLogIndexNotifications.LastModifiedIndex;
                 if (pulseReadingTransaction == false)
                 {
-                    var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, SearchEngineType.None, fieldsToFetch, collection, query, queryScope, context.Documents,
+                    var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope, context.Documents,
                         includeDocumentsCommand, includeRevisionsCommand: includeRevisionsCommand,
                         includeCompareExchangeValuesCommand: includeCompareExchangeValuesCommand, totalResults: totalResults, scannedResults, skippedResults, token);
 
@@ -166,7 +166,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                         {
                             query.Start = state.Start;
                             query.PageSize = state.Take;
-                            var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, SearchEngineType.None, fieldsToFetch, collection, query, queryScope,
+                            var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope,
                                 context.Documents, includeDocumentsCommand, includeRevisionsCommand, includeCompareExchangeValuesCommand, totalResults, scannedResults,
                                 skippedResults, token);
 

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -23,6 +23,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 {
     public class CollectionQueryRunner : AbstractQueryRunner
     {
+        public const int UnboundedQueryResultMarker = 0;
         public const string CollectionIndexPrefix = "collection/";
 
         public CollectionQueryRunner(DocumentDatabase database) : base(database)
@@ -260,7 +261,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                     resultToFill.AddRevisionIncludes(includeRevisionsCommand);
 
                 resultToFill.RegisterTimeSeriesFields(query, fieldsToFetch);
-                resultToFill.LongTotalResults = (totalResults.Value == 0 && resultToFill.Results.Count != 0) ? -1 : totalResults.Value;
+                resultToFill.LongTotalResults = (totalResults.Value == UnboundedQueryResultMarker && resultToFill.Results.Count != 0) ? -1 : totalResults.Value;
                 resultToFill.TotalResults = (int)resultToFill.LongTotalResults;
                 resultToFill.SkippedResults = Convert.ToInt32(skippedResults.Value);
                 resultToFill.ScannedResults = scannedResults.Value;

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -259,8 +259,7 @@ namespace RachisTests.DatabaseCluster
                         using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                         using (context.OpenReadTransaction())
                         {
-                            var _ = new Reference<long> { Value = 0 };
-                            var docs = database.DocumentsStorage.GetDocuments(context, new List<string>() { "foo/bar2" }, 0, long.MaxValue, _).ToList();
+                            var docs = database.DocumentsStorage.GetDocuments(context, new List<string>() { "foo/bar2" }, 0, long.MaxValue).ToList();
                             return docs.Exists(x => x.Id == "foo/bar2");
                         }
                     }

--- a/test/SlowTests/Issues/RavenDB_22110.cs
+++ b/test/SlowTests/Issues/RavenDB_22110.cs
@@ -18,12 +18,12 @@ public class RavenDB_22110 : RavenTestBase
 {
     private Random _random;
     private const string MyIndexName = nameof(DistinctCountOnCollectionQuery);
-    
+
     public RavenDB_22110(ITestOutputHelper output) : base(output)
     {
         _random = new(1337);
     }
-    
+
     [RavenTheory(RavenTestCategory.Querying)]
     [InlineData(true)]
     [InlineData(false)]
@@ -33,7 +33,8 @@ public class RavenDB_22110 : RavenTestBase
         var indexName = useIndex ? MyIndexName : null;
 
         using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
-        var databaseStatistics = session.Query<Order>(indexName).Where(x => x.Id.StartsWith("Order")).Select(x => x.Company).ToList().GroupBy(x => x).ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
+        var databaseStatistics = session.Query<Order>(indexName).Where(x => x.Id.StartsWith("Order")).Select(x => x.Company).ToList().GroupBy(x => x)
+            .ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
 
         var concanatedResults = new List<string>();
         List<string> pagedResults;
@@ -42,8 +43,8 @@ public class RavenDB_22110 : RavenTestBase
         int totalUniqueResults = 0;
         int pageNumber = 0;
         int pageSize = 10;
-        
-        
+
+
         do
         {
             pagedResults = session
@@ -53,28 +54,27 @@ public class RavenDB_22110 : RavenTestBase
                 .Select(x => x.Company)
                 .Distinct()
                 .Skip((pageNumber * pageSize) + (int)skippedResults)
-                // Define how many items to return
+// Define how many items to return
                 .Take(pageSize)
                 .ToList();
-            
+
             if (useIndex == false)
                 Assert.Equal("collection/Orders", stats.IndexName);
-            
-            totalResults = stats.TotalResults;        // Number of total matching documents (includes duplicates)
-            skippedResults += stats.SkippedResults;   // Number of duplicate results that were skipped
+
+            totalResults = stats.TotalResults; // Number of total matching documents (includes duplicates)
+            skippedResults += stats.SkippedResults; // Number of duplicate results that were skipped
             totalUniqueResults += pagedResults.Count; // Number of unique results returned in this server call
             concanatedResults.AddRange(pagedResults);
             pageNumber++;
-        }
-        while (pagedResults.Count > 0); // Fetch next results
-        
+        } while (pagedResults.Count > 0); // Fetch next results
+
         Assert.Equal(databaseStatistics.Count, concanatedResults.Count);
         Assert.Equal(databaseStatistics.Select(x => x.Key).OrderBy(x => x), concanatedResults.OrderBy(x => x));
-        
+
         Assert.Equal(1024, totalResults);
         Assert.Equal(databaseStatistics.Select(x => x.Value).Sum() - databaseStatistics.Count, skippedResults);
     }
-    
+
     [RavenTheory(RavenTestCategory.Querying)]
     [InlineData(true)]
     [InlineData(false)]
@@ -83,8 +83,9 @@ public class RavenDB_22110 : RavenTestBase
         using var store = GetDatabaseWithDocuments(useIndex);
         using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
         var indexName = useIndex ? MyIndexName : null;
-        
-        var databaseStatistics = session.Query<Order>(indexName).Where(x => x.Id.StartsWith("Order")).Select(x => x.Company).ToList().GroupBy(x => x).ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
+
+        var databaseStatistics = session.Query<Order>(indexName).Where(x => x.Id.StartsWith("Order")).Select(x => x.Company).ToList().GroupBy(x => x)
+            .ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
 
         var count = session.Query<Order>(indexName).Where(x => x.Id.StartsWith("Order")).Statistics(out var statistics).Select(x => x.Company).Distinct().Count();
         Assert.Equal(databaseStatistics.Count, count);
@@ -100,15 +101,16 @@ public class RavenDB_22110 : RavenTestBase
         using var store = GetDatabaseWithDocuments(useIndex);
         using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
         var indexName = useIndex ? MyIndexName : null;
-        
-        var databaseStatistics = session.Query<Order>(indexName).Select(x => x.Company).ToList().GroupBy(x => x).ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
+
+        var databaseStatistics = session.Query<Order>(indexName).Select(x => x.Company).ToList().GroupBy(x => x)
+            .ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
 
         var count = session.Query<Order>(indexName).Statistics(out var statistics).Select(x => x.Company).Distinct().Count();
         Assert.Equal(databaseStatistics.Count, count);
         Assert.Equal(databaseStatistics.Count, statistics.TotalResults);
         Assert.Equal(databaseStatistics.Select(x => x.Value).Sum() - databaseStatistics.Count, statistics.SkippedResults);
     }
-    
+
     [RavenTheory(RavenTestCategory.Querying)]
     [InlineData(true)]
     [InlineData(false)]
@@ -118,7 +120,8 @@ public class RavenDB_22110 : RavenTestBase
         var indexName = useIndex ? MyIndexName : null;
 
         using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
-        var databaseStatistics = session.Query<Order>(indexName).Select(x => x.Company).ToList().GroupBy(x => x).ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
+        var databaseStatistics = session.Query<Order>(indexName).Select(x => x.Company).ToList().GroupBy(x => x)
+            .ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
 
         var concanatedResults = new List<string>();
         List<string> pagedResults;
@@ -127,8 +130,8 @@ public class RavenDB_22110 : RavenTestBase
         int totalUniqueResults = 0;
         int pageNumber = 0;
         int pageSize = 10;
-        
-        
+
+
         do
         {
             pagedResults = session
@@ -137,20 +140,19 @@ public class RavenDB_22110 : RavenTestBase
                 .Select(x => x.Company)
                 .Distinct()
                 .Skip((pageNumber * pageSize) + (int)skippedResults)
-                // Define how many items to return
+// Define how many items to return
                 .Take(pageSize)
                 .ToList();
-            totalResults = stats.TotalResults;        // Number of total matching documents (includes duplicates)
-            skippedResults += stats.SkippedResults;   // Number of duplicate results that were skipped
+            totalResults = stats.TotalResults; // Number of total matching documents (includes duplicates)
+            skippedResults += stats.SkippedResults; // Number of duplicate results that were skipped
             totalUniqueResults += pagedResults.Count; // Number of unique results returned in this server call
             concanatedResults.AddRange(pagedResults);
             pageNumber++;
-        }
-        while (pagedResults.Count > 0); // Fetch next results
-        
+        } while (pagedResults.Count > 0); // Fetch next results
+
         Assert.Equal(databaseStatistics.Count, concanatedResults.Count);
         Assert.Equal(databaseStatistics.Select(x => x.Key).OrderBy(x => x), concanatedResults.OrderBy(x => x));
-        
+
         Assert.Equal(1024, totalResults);
         Assert.Equal(databaseStatistics.Select(x => x.Value).Sum() - databaseStatistics.Count, skippedResults);
     }
@@ -168,11 +170,11 @@ public class RavenDB_22110 : RavenTestBase
         session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
         var databaseStatistics = session.Query<Order>(indexName).Where(x => x.Id.StartsWith(prefix)).ToList();
         var results = GetResultsInPagingManner(session.Query<Order>(indexName).Where(x => x.Id.StartsWith(prefix)), out var totalResults, out _);
-        
+
         Assert.Equal(databaseStatistics.Count, totalResults);
         Assert.Equal(databaseStatistics.Select(x => x.Id), results.Select(x => x.Id));
     }
-    
+
     [RavenTheory(RavenTestCategory.Querying)]
     [InlineData(true)]
     [InlineData(false)]
@@ -187,20 +189,21 @@ public class RavenDB_22110 : RavenTestBase
         var databaseStatistics = session.Query<Order>(indexName).Where(x => x.Id.StartsWith(prefix)).ToList();
         databaseStatistics.Shuffle();
         databaseStatistics = databaseStatistics.Take(128).ToList();
-        
-        
-        var results = GetResultsInPagingManner(session.Query<Order>(indexName).Where(x => x.Id.In(databaseStatistics.Select(y => y.Id).ToArray())), out var totalResults, out _);
 
-        //In-memory sorting for assert purposes. In this case we do not care about order returned by underlying enumerator but correctness of whole result.
+
+        var results = GetResultsInPagingManner(session.Query<Order>(indexName).Where(x => x.Id.In(databaseStatistics.Select(y => y.Id).ToArray())), out var totalResults,
+            out _);
+
+//In-memory sorting for assert purposes. In this case we do not care about order returned by underlying enumerator but correctness of whole result.
         databaseStatistics = databaseStatistics.OrderBy(x => x.Id).ToList();
         results = results.OrderBy(x => x.Id).ToList();
-        
+
         Assert.Equal(databaseStatistics.Count, totalResults);
         Assert.Equal(databaseStatistics.Select(x => x.Id), results.Select(x => x.Id));
     }
 
     private List<TOut> GetResultsInPagingManner<TOut>(IRavenQueryable<TOut> baseQuery, out long totalResults, out long skippedResults)
-    { 
+    {
         var results = new List<TOut>();
         List<TOut> pagedResults;
         totalResults = 0;
@@ -213,19 +216,20 @@ public class RavenDB_22110 : RavenTestBase
         {
             pagedResults = baseQuery.Statistics(out QueryStatistics stats)
                 .Skip((pageNumber * pageSize) + (int)skippedResults)
-                // Define how many items to return
+// Define how many items to return
                 .Take(pageSize)
                 .ToList();
-            totalResults = stats.TotalResults;        // Number of total matching documents (includes duplicates)
-            skippedResults += stats.SkippedResults;   // Number of duplicate results that were skipped
+            totalResults = stats.TotalResults; // Number of total matching documents (includes duplicates)
+            skippedResults += stats.SkippedResults; // Number of duplicate results that were skipped
             totalUniqueResults += pagedResults.Count; // Number of unique results returned in this server call
             results.AddRange(pagedResults);
             pageNumber++;
         } while (pagedResults.Count > 0); // Fetch next results
+
         totalResults = totalUniqueResults;
         return results;
     }
-    
+
     private IDocumentStore GetDatabaseWithDocuments(bool useIndex)
     {
         var store = GetDocumentStore();
@@ -235,11 +239,8 @@ public class RavenDB_22110 : RavenTestBase
             "test", "library", "database", "issues"
         };
 
-        List<Order> orders = Enumerable.Range(0, 1024).Select(x => new Order()
-        {
-            Company = stringTable[_random.Next(stringTable.Length)],
-            Freight = _random.Next(0, 16)
-        }).ToList();
+        List<Order> orders = Enumerable.Range(0, 1024).Select(x => new Order() { Company = stringTable[_random.Next(stringTable.Length)], Freight = _random.Next(0, 16) })
+            .ToList();
 
         using (var bulk = store.BulkInsert())
         {
@@ -254,7 +255,7 @@ public class RavenDB_22110 : RavenTestBase
             new Index().Execute(store);
             Indexes.WaitForIndexing(store);
         }
-        
+
         return store;
     }
 
@@ -263,14 +264,14 @@ public class RavenDB_22110 : RavenTestBase
     public void CollectionQueryCountWithFilter(bool useIndex)
     {
         var indexName = useIndex ? MyIndexName : null;
-        
+
         using var store = GetDatabaseWithDocuments(useIndex);
         using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
         var result = session.Query<Order>(indexName).Filter(x => x.Freight == 5).ToList();
         var count = session.Query<Order>(indexName).Filter(x => x.Freight == 5).Count();
         Assert.Equal(result.Count, count);
     }
-    
+
     private class Index : AbstractIndexCreationTask<Order>
     {
         public override string IndexName => MyIndexName;
@@ -278,6 +279,6 @@ public class RavenDB_22110 : RavenTestBase
         public Index()
         {
             Map = orders => orders.Select(x => new { Company = x.Company });
-        }    
+        }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_22110.cs
+++ b/test/SlowTests/Issues/RavenDB_22110.cs
@@ -1,0 +1,268 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22110 : RavenTestBase
+{
+    private Random _random;
+    private const string MyIndexName = nameof(DistinctCountOnCollectionQuery);
+    
+    public RavenDB_22110(ITestOutputHelper output) : base(output)
+    {
+        _random = new(1337);
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DistinctOnStartsWithCollectionQueryWithPaging(bool useIndex)
+    {
+        using var store = GetDatabaseWithDocuments(useIndex);
+        var indexName = useIndex ? MyIndexName : null;
+
+        using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
+        var databaseStatistics = session.Query<Order>(indexName).Where(x => x.Id.StartsWith("Order")).Select(x => x.Company).ToList().GroupBy(x => x).ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
+
+        var concanatedResults = new List<string>();
+        List<string> pagedResults;
+        long totalResults = 0;
+        long skippedResults = 0;
+        int totalUniqueResults = 0;
+        int pageNumber = 0;
+        int pageSize = 10;
+        
+        
+        do
+        {
+            pagedResults = session
+                .Query<Order>(indexName)
+                .Where(x => x.Id.StartsWith("Order"))
+                .Statistics(out QueryStatistics stats)
+                .Select(x => x.Company)
+                .Distinct()
+                .Skip((pageNumber * pageSize) + (int)skippedResults)
+                // Define how many items to return
+                .Take(pageSize)
+                .ToList();
+            
+            if (useIndex == false)
+                Assert.Equal("collection/Orders", stats.IndexName);
+            
+            totalResults = stats.TotalResults;        // Number of total matching documents (includes duplicates)
+            skippedResults += stats.SkippedResults;   // Number of duplicate results that were skipped
+            totalUniqueResults += pagedResults.Count; // Number of unique results returned in this server call
+            concanatedResults.AddRange(pagedResults);
+            pageNumber++;
+        }
+        while (pagedResults.Count > 0); // Fetch next results
+        
+        Assert.Equal(databaseStatistics.Count, concanatedResults.Count);
+        Assert.Equal(databaseStatistics.Select(x => x.Key).OrderBy(x => x), concanatedResults.OrderBy(x => x));
+        
+        Assert.Equal(1024, totalResults);
+        Assert.Equal(databaseStatistics.Select(x => x.Value).Sum() - databaseStatistics.Count, skippedResults);
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DistinctCountOnCollectionQueryStartsWith(bool useIndex)
+    {
+        using var store = GetDatabaseWithDocuments(useIndex);
+        using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
+        var indexName = useIndex ? MyIndexName : null;
+        
+        var databaseStatistics = session.Query<Order>(indexName).Where(x => x.Id.StartsWith("Order")).Select(x => x.Company).ToList().GroupBy(x => x).ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
+
+        var count = session.Query<Order>(indexName).Where(x => x.Id.StartsWith("Order")).Statistics(out var statistics).Select(x => x.Company).Distinct().Count();
+        Assert.Equal(databaseStatistics.Count, count);
+        Assert.Equal(databaseStatistics.Count, statistics.TotalResults);
+        Assert.Equal(databaseStatistics.Select(x => x.Value).Sum() - databaseStatistics.Count, statistics.SkippedResults);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DistinctCountOnCollectionQuery(bool useIndex)
+    {
+        using var store = GetDatabaseWithDocuments(useIndex);
+        using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
+        var indexName = useIndex ? MyIndexName : null;
+        
+        var databaseStatistics = session.Query<Order>(indexName).Select(x => x.Company).ToList().GroupBy(x => x).ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
+
+        var count = session.Query<Order>(indexName).Statistics(out var statistics).Select(x => x.Company).Distinct().Count();
+        Assert.Equal(databaseStatistics.Count, count);
+        Assert.Equal(databaseStatistics.Count, statistics.TotalResults);
+        Assert.Equal(databaseStatistics.Select(x => x.Value).Sum() - databaseStatistics.Count, statistics.SkippedResults);
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DistinctOnCollectionQueryWithPaging(bool useIndex)
+    {
+        using var store = GetDatabaseWithDocuments(useIndex);
+        var indexName = useIndex ? MyIndexName : null;
+
+        using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
+        var databaseStatistics = session.Query<Order>(indexName).Select(x => x.Company).ToList().GroupBy(x => x).ToDictionary(grouping => grouping.Key, grouping => grouping.Count());
+
+        var concanatedResults = new List<string>();
+        List<string> pagedResults;
+        long totalResults = 0;
+        long skippedResults = 0;
+        int totalUniqueResults = 0;
+        int pageNumber = 0;
+        int pageSize = 10;
+        
+        
+        do
+        {
+            pagedResults = session
+                .Query<Order>(indexName)
+                .Statistics(out QueryStatistics stats)
+                .Select(x => x.Company)
+                .Distinct()
+                .Skip((pageNumber * pageSize) + (int)skippedResults)
+                // Define how many items to return
+                .Take(pageSize)
+                .ToList();
+            totalResults = stats.TotalResults;        // Number of total matching documents (includes duplicates)
+            skippedResults += stats.SkippedResults;   // Number of duplicate results that were skipped
+            totalUniqueResults += pagedResults.Count; // Number of unique results returned in this server call
+            concanatedResults.AddRange(pagedResults);
+            pageNumber++;
+        }
+        while (pagedResults.Count > 0); // Fetch next results
+        
+        Assert.Equal(databaseStatistics.Count, concanatedResults.Count);
+        Assert.Equal(databaseStatistics.Select(x => x.Key).OrderBy(x => x), concanatedResults.OrderBy(x => x));
+        
+        Assert.Equal(1024, totalResults);
+        Assert.Equal(databaseStatistics.Select(x => x.Value).Sum() - databaseStatistics.Count, skippedResults);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CollectionQueryStartsWithPagination(bool useIndex)
+    {
+        using var store = GetDatabaseWithDocuments(useIndex);
+        var prefix = "orders/1";
+        var indexName = useIndex ? MyIndexName : null;
+
+        using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        var databaseStatistics = session.Query<Order>(indexName).Where(x => x.Id.StartsWith(prefix)).ToList();
+        var results = GetResultsInPagingManner(session.Query<Order>(indexName).Where(x => x.Id.StartsWith(prefix)), out var totalResults, out _);
+        
+        Assert.Equal(databaseStatistics.Count, totalResults);
+        Assert.Equal(databaseStatistics.Select(x => x.Id), results.Select(x => x.Id));
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CollectionQueryInPagination(bool useIndex)
+    {
+        using var store = GetDatabaseWithDocuments(useIndex);
+        var prefix = "orders/1";
+        var indexName = useIndex ? MyIndexName : null;
+
+        using var session = store.OpenSession(new SessionOptions() { NoCaching = true, NoTracking = true });
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        var databaseStatistics = session.Query<Order>(indexName).Where(x => x.Id.StartsWith(prefix)).ToList();
+        databaseStatistics.Shuffle();
+        databaseStatistics = databaseStatistics.Take(128).ToList();
+        
+        
+        var results = GetResultsInPagingManner(session.Query<Order>(indexName).Where(x => x.Id.In(databaseStatistics.Select(y => y.Id).ToArray())), out var totalResults, out _);
+
+        //In-memory sorting for assert purposes. In this case we do not care about order returned by underlying enumerator but correctness of whole result.
+        databaseStatistics = databaseStatistics.OrderBy(x => x.Id).ToList();
+        results = results.OrderBy(x => x.Id).ToList();
+        
+        Assert.Equal(databaseStatistics.Count, totalResults);
+        Assert.Equal(databaseStatistics.Select(x => x.Id), results.Select(x => x.Id));
+    }
+
+    private List<TOut> GetResultsInPagingManner<TOut>(IRavenQueryable<TOut> baseQuery, out long totalResults, out long skippedResults)
+    { 
+        var results = new List<TOut>();
+        List<TOut> pagedResults;
+        totalResults = 0;
+        skippedResults = 0;
+        int totalUniqueResults = 0;
+        int pageNumber = 0;
+        int pageSize = 10;
+
+        do
+        {
+            pagedResults = baseQuery.Statistics(out QueryStatistics stats)
+                .Skip((pageNumber * pageSize) + (int)skippedResults)
+                // Define how many items to return
+                .Take(pageSize)
+                .ToList();
+            totalResults = stats.TotalResults;        // Number of total matching documents (includes duplicates)
+            skippedResults += stats.SkippedResults;   // Number of duplicate results that were skipped
+            totalUniqueResults += pagedResults.Count; // Number of unique results returned in this server call
+            results.AddRange(pagedResults);
+            pageNumber++;
+        } while (pagedResults.Count > 0); // Fetch next results
+        totalResults = totalUniqueResults;
+        return results;
+    }
+    
+    private IDocumentStore GetDatabaseWithDocuments(bool useIndex)
+    {
+        var store = GetDocumentStore();
+        var stringTable = new[]
+        {
+            "class", "struct", "readonly", "final", "task", "select", "query", "index", "memory", "cpu", "counter", "timeseries", "attachment", "javascript", "C#",
+            "test", "library", "database", "issues"
+        };
+
+        List<Order> orders = Enumerable.Range(0, 1024).Select(x => new Order() { Company = stringTable[_random.Next(stringTable.Length)] }).ToList();
+
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (Order order in orders)
+            {
+                bulk.Store(order);
+            }
+        }
+
+        if (useIndex)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+        
+        return store;
+    }
+    
+   
+    
+    private class Index : AbstractIndexCreationTask<Order>
+    {
+        public override string IndexName => MyIndexName;
+
+        public Index()
+        {
+            Map = orders => orders.Select(x => new { Company = x.Company });
+        }    
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22110

### Additional description

PR includes fixes to count, distinct, and paging for very specific cases.
In addition, it contains cleanup for the previous collection query flow to make it more straightforward.
 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
