### PR TITLE
RavenDB-22156 - MixedClusterTests.UpgradeDirectlyFrom42X is failing when updating from 4.2.0

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
@@ -117,7 +117,7 @@ public abstract class AbstractClusterTransactionRequestProcessor<TRequestHandler
         }
 
         throw new InvalidOperationException(
-            "Cluster-transaction was succeeded, but Leader is outdated and its results are inaccessible (the command has been already deleted from the history log).  We recommend you to update all nodes in the cluster to the last stable version.");
+            "We are not able to verify that the cluster-wide transaction was succeeded. please consider to upgrade your leader to the latest stable version.");
     }
 
     public abstract Task WaitForDatabaseCompletion(Task<HashSet<string>> onDatabaseCompletionTask, long index, ClusterTransactionOptions options, CancellationToken token);

--- a/test/InterversionTests/MixedClusterTests.cs
+++ b/test/InterversionTests/MixedClusterTests.cs
@@ -177,7 +177,13 @@ namespace InterversionTests
                         foreach (var node in nodes)
                         {
                             await UpgradeServerAsync(nextVersion, node);
-                            await during.TestClustering(stores, $"during/{nextVersion}/{node.Url}");
+                            var versions = nodes.Select(x => x.Version).ToArray();
+
+                            if (ShouldTestClustering(versions))
+                            {
+                                await during.TestClustering(stores, $"during/{nextVersion}/{node.Url}");
+                            }
+
                             await during.TestReplication(stores);
                         }
                     }
@@ -191,6 +197,33 @@ namespace InterversionTests
                     throw;
                 }
             }
+        }
+
+
+        private static bool ShouldTestClustering(string[] versions)
+        {
+            var last = IsGreaterOrEqual421(versions[0]);
+
+            foreach (var version in versions)
+            {
+                var current = IsGreaterOrEqual421(version);
+                if (last != current)
+                    return false;
+            }
+
+            return true;
+        }
+
+        public static bool IsGreaterOrEqual421(string version)
+        {
+            if (version == "current")
+                return true;
+
+            const string threshold = "4.2.1";
+            Version inputVersion = Version.Parse(version);
+            Version thresholdVersion = Version.Parse(threshold);
+
+            return inputVersion >= thresholdVersion;
         }
 
         private static async Task CreateDatabase(List<DocumentStore> stores, string database, int size)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22156/InterversionTests.MixedClusterTests.UpgradeDirectlyFrom42XinitialVersions-4.2.0-4.2.0-4.2.0

### Additional description

The test fails when there is a leader in version 4.2.0 and a follower in version 6.0. 
When the follower receives a null result from the non-updated leader for the cluster transaction raft command (in batch handler), it attempts to locate the cluster transaction command result in the local history log.
However, the follower doesn't find it because the raft command received from the leader lacks a UniqueRequestId, a feature introduced only in version 4.2.1 (and therefore does not add the command to the history log at all from the first place).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
