### PR TITLE
RavenDB-22129 - Remove Client API code that checks if Cluster Transaction is supported

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1157,23 +1157,6 @@ namespace Raven.Client.Http
 
             LastServerVersion = chosenNode.LastServerVersion;
 
-            if (sessionInfo?.LastClusterTransactionIndex != null)
-            {
-                // if we reach here it means that sometime a cluster transaction has occurred against this database.
-                // Since the current executed command can be dependent on that, we have to wait for the cluster transaction.
-                // But we can't do that if the server is an old one.
-
-                if (LastServerVersion == null || string.Compare(LastServerVersion, "4.1", StringComparison.Ordinal) < 0)
-                {
-                    using (response)
-                    {
-                        throw new ClientVersionMismatchException(
-                            $"The server on {chosenNode.Url} has an old version and can't perform the command '{command.GetType()}', " +
-                            "since this command dependent on a cluster transaction which this node doesn't support");
-                    }
-                }
-            }
-
             return response;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22129/Remove-Client-API-code-that-checks-if-Cluster-Transaction-is-supported

### Additional description

Remove Client API code that checks if Cluster Transaction is supported.

### Type of change

- [x] Task
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
