### PR TITLE
RavenDB-22074 - Add an option to specify max items to process in sing…

### DIFF
--- a/src/Raven.Client/Documents/Operations/DataArchival/DataArchivalConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/DataArchival/DataArchivalConfiguration.cs
@@ -8,11 +8,16 @@ namespace Raven.Client.Documents.Operations.DataArchival
 
         public long? ArchiveFrequencyInSec { get; set; }
 
+        public long? MaxItemsToProcess { get; set; }
+
         public override int GetHashCode()
         {
             unchecked
             {
-                return (Disabled.GetHashCode() * 397) ^ ArchiveFrequencyInSec.GetHashCode();
+                int hashCode = Disabled.GetHashCode();
+                hashCode = (hashCode * 397) ^ (ArchiveFrequencyInSec?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (MaxItemsToProcess?.GetHashCode() ?? 0);
+                return hashCode;
             }
         }
 
@@ -26,7 +31,7 @@ namespace Raven.Client.Documents.Operations.DataArchival
 
         protected bool Equals(DataArchivalConfiguration other)
         {
-            return Disabled == other.Disabled && ArchiveFrequencyInSec == other.ArchiveFrequencyInSec;
+            return Disabled == other.Disabled && ArchiveFrequencyInSec == other.ArchiveFrequencyInSec && MaxItemsToProcess == other.MaxItemsToProcess;
         }
 
         public DynamicJsonValue ToJson()
@@ -34,7 +39,8 @@ namespace Raven.Client.Documents.Operations.DataArchival
             return new DynamicJsonValue
             {
                 [nameof(Disabled)] = Disabled,
-                [nameof(ArchiveFrequencyInSec)] = ArchiveFrequencyInSec
+                [nameof(ArchiveFrequencyInSec)] = ArchiveFrequencyInSec,
+                [nameof(MaxItemsToProcess)] = MaxItemsToProcess
             };
         }
     }

--- a/src/Raven.Client/Documents/Operations/Expiration/ExpirationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Expiration/ExpirationConfiguration.cs
@@ -8,11 +8,16 @@ namespace Raven.Client.Documents.Operations.Expiration
 
         public long? DeleteFrequencyInSec { get; set; }
 
+        public long? MaxItemsToProcess { get; set; }
+
         public override int GetHashCode()
         {
             unchecked
             {
-                return (Disabled.GetHashCode() * 397) ^ DeleteFrequencyInSec.GetHashCode();
+                int hashCode = Disabled.GetHashCode();
+                hashCode = (hashCode * 397) ^ (DeleteFrequencyInSec?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (MaxItemsToProcess?.GetHashCode() ?? 0);
+                return hashCode;
             }
         }
 
@@ -26,7 +31,7 @@ namespace Raven.Client.Documents.Operations.Expiration
 
         private bool Equals(ExpirationConfiguration other)
         {
-            return Disabled == other.Disabled && DeleteFrequencyInSec == other.DeleteFrequencyInSec;
+            return Disabled == other.Disabled && DeleteFrequencyInSec == other.DeleteFrequencyInSec && MaxItemsToProcess == other.MaxItemsToProcess;
         }
 
         public DynamicJsonValue ToJson()
@@ -34,7 +39,8 @@ namespace Raven.Client.Documents.Operations.Expiration
             return new DynamicJsonValue
             {
                 [nameof(Disabled)] = Disabled,
-                [nameof(DeleteFrequencyInSec)] = DeleteFrequencyInSec
+                [nameof(DeleteFrequencyInSec)] = DeleteFrequencyInSec,
+                [nameof(MaxItemsToProcess)] = MaxItemsToProcess
             };
         }
     }

--- a/src/Raven.Client/Documents/Operations/Refresh/RefreshConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/RefreshConfiguration.cs
@@ -8,10 +8,11 @@ namespace Raven.Client.Documents.Operations.Refresh
 
         public long? RefreshFrequencyInSec { get; set; }
 
+        public long? MaxItemsToProcess { get; set; }
 
         private bool Equals(RefreshConfiguration other)
         {
-            return Disabled == other.Disabled && RefreshFrequencyInSec == other.RefreshFrequencyInSec;
+            return Disabled == other.Disabled && RefreshFrequencyInSec == other.RefreshFrequencyInSec && MaxItemsToProcess == other.MaxItemsToProcess;
         }
 
         public override bool Equals(object obj)
@@ -29,8 +30,9 @@ namespace Raven.Client.Documents.Operations.Refresh
         {
             unchecked
             {
-                var hashCode = Disabled.GetHashCode();
-                hashCode = (hashCode * 397) ^ RefreshFrequencyInSec.GetHashCode();
+                int hashCode = Disabled.GetHashCode();
+                hashCode = (hashCode * 397) ^ (RefreshFrequencyInSec?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (MaxItemsToProcess?.GetHashCode() ?? 0);
                 return hashCode;
             }
         }
@@ -42,6 +44,7 @@ namespace Raven.Client.Documents.Operations.Refresh
             {
                 [nameof(Disabled)] = Disabled,
                 [nameof(RefreshFrequencyInSec)] = RefreshFrequencyInSec,
+                [nameof(MaxItemsToProcess)] = MaxItemsToProcess
             };
         }
     }

--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -62,18 +62,7 @@ public abstract unsafe class AbstractBackgroundWorkStorage
             $"The due date format for document '{lowerId}' is not valid: '{expirationDate}'. Use the following format: {Database.Time.GetUtcNow():O}");
     }
 
-    public Dictionary<Slice, List<(Slice LowerId, string Id)>> GetDocuments(BackgroundWorkParameters options, out Stopwatch duration, CancellationToken cancellationToken)
-    {
-        var totalCount = 0;
-        return GetDocumentsInternal(options, ref totalCount, out duration, cancellationToken);
-    }
-
     public Dictionary<Slice, List<(Slice LowerId, string Id)>> GetDocuments(BackgroundWorkParameters options, ref int totalCount, out Stopwatch duration, CancellationToken cancellationToken)
-    {
-        return GetDocumentsInternal(options, ref totalCount, out duration, cancellationToken);
-    }
-
-    private Dictionary<Slice, List<(Slice LowerId, string Id)>> GetDocumentsInternal(BackgroundWorkParameters options, ref int totalCount, out Stopwatch duration, CancellationToken cancellationToken)
     {
         var count = 0;
         var currentTicks = options.CurrentTime.Ticks;
@@ -89,7 +78,6 @@ public abstract unsafe class AbstractBackgroundWorkStorage
 
             var toProcess = new Dictionary<Slice, List<(Slice LowerId, string Id)>>();
             duration = Stopwatch.StartNew();
-            var maxItemsToProcess = options is ExpiredDocumentsParameters expiredOptions ? expiredOptions.MaxItemsToProcess : long.MaxValue;
 
             do
             {
@@ -140,7 +128,7 @@ public abstract unsafe class AbstractBackgroundWorkStorage
                             }
                         } while (multiIt.MoveNext()
                                  && docsToProcess.Count + count < options.AmountToTake 
-                                 && totalCount < maxItemsToProcess);
+                                 && totalCount < options.MaxItemsToProcess);
                     }
                 }
 
@@ -150,7 +138,7 @@ public abstract unsafe class AbstractBackgroundWorkStorage
 
             } while (it.MoveNext() 
                      && count < options.AmountToTake
-                     && totalCount < maxItemsToProcess);
+                     && totalCount < options.MaxItemsToProcess);
 
             return toProcess;
         }

--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -65,10 +65,15 @@ public abstract unsafe class AbstractBackgroundWorkStorage
     public Dictionary<Slice, List<(Slice LowerId, string Id)>> GetDocuments(BackgroundWorkParameters options, out Stopwatch duration, CancellationToken cancellationToken)
     {
         var totalCount = 0;
-        return GetDocuments(options, ref totalCount, out duration, cancellationToken);
+        return GetDocumentsInternal(options, ref totalCount, out duration, cancellationToken);
     }
 
     public Dictionary<Slice, List<(Slice LowerId, string Id)>> GetDocuments(BackgroundWorkParameters options, ref int totalCount, out Stopwatch duration, CancellationToken cancellationToken)
+    {
+        return GetDocumentsInternal(options, ref totalCount, out duration, cancellationToken);
+    }
+
+    private Dictionary<Slice, List<(Slice LowerId, string Id)>> GetDocumentsInternal(BackgroundWorkParameters options, ref int totalCount, out Stopwatch duration, CancellationToken cancellationToken)
     {
         var count = 0;
         var currentTicks = options.CurrentTime.Ticks;

--- a/src/Raven.Server/Documents/BackgroundWorkParameters.cs
+++ b/src/Raven.Server/Documents/BackgroundWorkParameters.cs
@@ -12,3 +12,9 @@ public record BackgroundWorkParameters(DocumentsOperationContext Context, DateTi
     public readonly string NodeTag = NodeTag;
     public readonly long AmountToTake = AmountToTake;
 }
+
+public record ExpiredDocumentsParameters(DocumentsOperationContext Context, DateTime CurrentTime, DatabaseTopology DatabaseTopology, string NodeTag, long AmountToTake, long MaxItemsToProcess) : 
+    BackgroundWorkParameters (Context, CurrentTime, DatabaseTopology, NodeTag, AmountToTake)
+{
+    public readonly long MaxItemsToProcess = MaxItemsToProcess;
+}

--- a/src/Raven.Server/Documents/BackgroundWorkParameters.cs
+++ b/src/Raven.Server/Documents/BackgroundWorkParameters.cs
@@ -4,17 +4,12 @@ using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents;
 
-public record BackgroundWorkParameters(DocumentsOperationContext Context, DateTime CurrentTime, DatabaseTopology DatabaseTopology, string NodeTag, long AmountToTake)
+public record BackgroundWorkParameters(DocumentsOperationContext Context, DateTime CurrentTime, DatabaseTopology DatabaseTopology, string NodeTag, long AmountToTake, long MaxItemsToProcess = int.MaxValue)
 {
     public readonly DocumentsOperationContext Context = Context;
     public readonly DateTime CurrentTime = CurrentTime;
     public readonly DatabaseTopology DatabaseTopology = DatabaseTopology;
     public readonly string NodeTag = NodeTag;
     public readonly long AmountToTake = AmountToTake;
-}
-
-public record ExpiredDocumentsParameters(DocumentsOperationContext Context, DateTime CurrentTime, DatabaseTopology DatabaseTopology, string NodeTag, long AmountToTake, long MaxItemsToProcess) : 
-    BackgroundWorkParameters (Context, CurrentTime, DatabaseTopology, NodeTag, AmountToTake)
-{
     public readonly long MaxItemsToProcess = MaxItemsToProcess;
 }

--- a/src/Raven.Server/Documents/DataArchival/DataArchivalStorage.cs
+++ b/src/Raven.Server/Documents/DataArchival/DataArchivalStorage.cs
@@ -46,7 +46,7 @@ public sealed class DataArchivalStorage : AbstractBackgroundWorkStorage
         }
     }
 
-    protected override void HandleDocumentConflict(BackgroundWorkParameters options, Slice clonedId, ref List<(Slice LowerId, string Id)> docsToProcess)
+    protected override void HandleDocumentConflict(BackgroundWorkParameters options, Slice clonedId, ref int totalCount, ref List<(Slice LowerId, string Id)> docsToProcess)
     {
         // data archival ignores conflicts
     }

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents.Expiration
             }
         }
 
-        protected override void HandleDocumentConflict(BackgroundWorkParameters options, Slice clonedId, ref List<(Slice LowerId, string Id)> expiredDocs)
+        protected override void HandleDocumentConflict(BackgroundWorkParameters options, Slice clonedId, ref int totalCount, ref List<(Slice LowerId, string Id)> expiredDocs)
         {
             if (ShouldHandleWorkOnCurrentNode(options.DatabaseTopology, options.NodeTag) == false)
                 return;
@@ -52,6 +52,7 @@ namespace Raven.Server.Documents.Expiration
             if (allExpired)
             {
                 expiredDocs.Add((clonedId, id));
+                totalCount++;
             }
         }
 

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -158,7 +158,7 @@ namespace Raven.Server.Documents.Expiration
 
                         using (context.OpenReadTransaction())
                         {
-                            var options = new ExpiredDocumentsParameters(context, currentTime, topology, nodeTag, batchSize, maxItemsToProcess);
+                            var options = new BackgroundWorkParameters(context, currentTime, topology, nodeTag, batchSize, maxItemsToProcess);
 
                             var expired =
                                 forExpiration ?

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -31,6 +31,8 @@ namespace Raven.Server.Documents.Expiration
             ? 4096
             : 1024;
 
+        internal static int DefaultMaxItemsToProcessInSingleRun = int.MaxValue;
+
         private readonly DocumentDatabase _database;
         private readonly TimeSpan _refreshPeriod;
         private readonly TimeSpan _expirationPeriod;
@@ -123,15 +125,15 @@ namespace Raven.Server.Documents.Expiration
 
         internal Task CleanupExpiredDocs(int? batchSize = null)
         {
-            return CleanupDocs(batchSize ?? BatchSize, forExpiration: true);
+            return CleanupDocs(batchSize ?? BatchSize, ExpirationConfiguration.MaxItemsToProcess ?? DefaultMaxItemsToProcessInSingleRun, forExpiration: true);
         }
 
         internal Task RefreshDocs(int? batchSize = null)
         {
-            return CleanupDocs(batchSize ?? BatchSize, forExpiration: false);
+            return CleanupDocs(batchSize ?? BatchSize, RefreshConfiguration.MaxItemsToProcess ?? DefaultMaxItemsToProcessInSingleRun, forExpiration: false);
         }
         
-        private async Task CleanupDocs(int batchSize, bool forExpiration)
+        private async Task CleanupDocs(int batchSize, long maxItemsToProcess, bool forExpiration)
         {
             var currentTime = _database.Time.GetUtcNow();
             
@@ -146,21 +148,22 @@ namespace Raven.Server.Documents.Expiration
                     nodeTag = _database.ServerStore.NodeTag;
                 }
 
+                var totalCount = 0;
                 using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
-                    while (true)
+                    while (totalCount < maxItemsToProcess)
                     {
                         context.Reset();
                         context.Renew();
 
                         using (context.OpenReadTransaction())
                         {
-                            var options = new BackgroundWorkParameters(context, currentTime, topology, nodeTag, batchSize);
+                            var options = new ExpiredDocumentsParameters(context, currentTime, topology, nodeTag, batchSize, maxItemsToProcess);
 
                             var expired =
                                 forExpiration ?
-                                    _database.DocumentsStorage.ExpirationStorage.GetDocuments(options, out var duration, CancellationToken) :
-                                    _database.DocumentsStorage.RefreshStorage.GetDocuments(options, out duration, CancellationToken);
+                                    _database.DocumentsStorage.ExpirationStorage.GetDocuments(options, ref totalCount, out var duration, CancellationToken) :
+                                    _database.DocumentsStorage.RefreshStorage.GetDocuments(options, ref totalCount, out duration, CancellationToken);
 
                             if (expired == null || expired.Count == 0)
                                 return;

--- a/src/Raven.Server/Documents/Refresh/RefreshStorage.cs
+++ b/src/Raven.Server/Documents/Refresh/RefreshStorage.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents.Refresh
             }
         }
 
-        protected override void HandleDocumentConflict(BackgroundWorkParameters options, Slice clonedId, ref List<(Slice LowerId, string Id)> expiredDocs)
+        protected override void HandleDocumentConflict(BackgroundWorkParameters options, Slice clonedId, ref int totalCount, ref List<(Slice LowerId, string Id)> expiredDocs)
         {
             if (ShouldHandleWorkOnCurrentNode(options.DatabaseTopology, options.NodeTag) == false)
                 return;
@@ -67,6 +67,7 @@ namespace Raven.Server.Documents.Refresh
             if (allExpired)
             {
                 expiredDocs.Add((clonedId, id));
+                totalCount++;
             }
         }
 

--- a/test/FastTests/Utils/DataArchivalHelper.cs
+++ b/test/FastTests/Utils/DataArchivalHelper.cs
@@ -7,7 +7,7 @@ namespace FastTests.Utils
 {
     public static class DataArchivalHelper
     {
-        public static async Task SetupDataArchival(IDocumentStore store, Raven.Server.ServerWide.ServerStore serverStore, DataArchivalConfiguration configuration)
+        public static async Task SetupDataArchival(IDocumentStore store, Raven.Server.ServerWide.ServerStore serverStore, DataArchivalConfiguration configuration, string database = null)
         {
             if (store == null)
                 throw new ArgumentNullException(nameof(store));
@@ -18,7 +18,7 @@ namespace FastTests.Utils
 
             var result = await store.Maintenance.SendAsync(new ConfigureDataArchivalOperation(configuration));
 
-            var documentDatabase = await serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            var documentDatabase = await serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
             await documentDatabase.RachisLogIndexNotifications.WaitForIndexNotification(result.RaftCommandIndex.Value, serverStore.Engine.OperationTimeout);
         }
     }

--- a/test/FastTests/Utils/ExpirationHelper.cs
+++ b/test/FastTests/Utils/ExpirationHelper.cs
@@ -7,7 +7,7 @@ namespace FastTests.Utils
 {
     public static class ExpirationHelper
     {
-        public static async Task SetupExpiration(IDocumentStore store, Raven.Server.ServerWide.ServerStore serverStore, ExpirationConfiguration configuration)
+        public static async Task SetupExpiration(IDocumentStore store, Raven.Server.ServerWide.ServerStore serverStore, ExpirationConfiguration configuration, string database = null)
         {
             if (store == null)
                 throw new ArgumentNullException(nameof(store));
@@ -18,7 +18,7 @@ namespace FastTests.Utils
 
             var result = await store.Maintenance.SendAsync(new ConfigureExpirationOperation(configuration));
 
-            var documentDatabase = await serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            var documentDatabase = await serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
             await documentDatabase.RachisLogIndexNotifications.WaitForIndexNotification(result.RaftCommandIndex.Value, serverStore.Engine.OperationTimeout);
         }
     }

--- a/test/FastTests/Utils/RefreshHelper.cs
+++ b/test/FastTests/Utils/RefreshHelper.cs
@@ -7,7 +7,7 @@ namespace FastTests.Utils
 {
     public static class RefreshHelper
     {
-        public static async Task SetupExpiration(IDocumentStore store, Raven.Server.ServerWide.ServerStore serverStore, RefreshConfiguration configuration)
+        public static async Task SetupExpiration(IDocumentStore store, Raven.Server.ServerWide.ServerStore serverStore, RefreshConfiguration configuration, string database = null)
         {
             if (store == null)
                 throw new ArgumentNullException(nameof(store));
@@ -18,7 +18,7 @@ namespace FastTests.Utils
 
             var result = await store.Maintenance.SendAsync(new ConfigureRefreshOperation(configuration));
 
-            var documentDatabase = await serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            var documentDatabase = await serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
             await documentDatabase.RachisLogIndexNotifications.WaitForIndexNotification(result.RaftCommandIndex.Value, serverStore.Engine.OperationTimeout);
         }
     }

--- a/test/SlowTests/Issues/RDBS-68.cs
+++ b/test/SlowTests/Issues/RDBS-68.cs
@@ -111,25 +111,11 @@ namespace SlowTests.Issues
                         }
                         
                         var options = new BackgroundWorkParameters(context, currentTime, topology, nodeTag, batchSize);
-                        
-                        var expired = database.DocumentsStorage.ExpirationStorage.GetDocuments(options, out _, CancellationToken.None);
                         var totalCount = 0;
-                        if (expired != null)
-                        {
-                            foreach (var singleExpired in expired)
-                            {
-                                totalCount += singleExpired.Value.Count;
-                            }
-                        }
-
+                        var expired = database.DocumentsStorage.ExpirationStorage.GetDocuments(options, ref totalCount, out _, CancellationToken.None);
                         Assert.Equal(expected, totalCount);
                     }
-
-
-                    
                 }
-
-                
             }
         }
 

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
@@ -191,7 +191,7 @@ namespace SlowTests.Server.Documents.DataArchival
         {
             using (var store = GetDocumentStore(options))
             {
-                // Insert documents with refresh before activating the refresh
+                // Insert documents with ArchiveAt before activating the archival
                 var archiveDateTime = SystemTime.UtcNow.AddMinutes(5);
                 for (int i = 0; i < 10; i++)
                 {

--- a/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
+++ b/test/SlowTests/Server/Documents/DataArchival/DataArchivalTests.cs
@@ -24,6 +24,7 @@ using Raven.Server.Documents.DataArchival;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -75,8 +76,9 @@ namespace SlowTests.Server.Documents.DataArchival
                     }
 
                     var options = new BackgroundWorkParameters(context, SystemTime.UtcNow.AddMinutes(10), topology, nodeTag, 10);
+                    var totalCount = 0;
 
-                    var toArchive = database.DocumentsStorage.DataArchivalStorage.GetDocuments(options, out _, CancellationToken.None);
+                    var toArchive = database.DocumentsStorage.DataArchivalStorage.GetDocuments(options, ref totalCount, out _, CancellationToken.None);
                     Assert.Equal(1, toArchive.Count);
                 }
             }
@@ -145,8 +147,6 @@ namespace SlowTests.Server.Documents.DataArchival
             }
         }
 
-
-
         [Fact]
         public async Task ShouldImportTask()
         {
@@ -167,7 +167,6 @@ namespace SlowTests.Server.Documents.DataArchival
             }
         }
 
-
         [Fact]
         public async Task ThrowsIfUsingWrongArchiveAtDateTimeFormat()
         {
@@ -186,6 +185,70 @@ namespace SlowTests.Server.Documents.DataArchival
             }
         }
 
+        [RavenTheory(RavenTestCategory.Configuration)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ArchiveDocsWithMaxItemsToProcessConfiguredShouldWork(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                // Insert documents with refresh before activating the refresh
+                var archiveDateTime = SystemTime.UtcNow.AddMinutes(5);
+                for (int i = 0; i < 10; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var company = new Company { Name = "Company Name", Id = $"companies/{i}$companies/1" };
+                        await session.StoreAsync(company);
+                        var metadata = session.Advanced.GetMetadataFor(company);
+                        metadata[Constants.Documents.Metadata.ArchiveAt] = archiveDateTime.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                        await session.SaveChangesAsync();
+                    }
+                }
 
+                var config = new DataArchivalConfiguration
+                {
+                    Disabled = false,
+                    ArchiveFrequencyInSec = (long)TimeSpan.FromMinutes(10).TotalSeconds,
+                    MaxItemsToProcess = 9
+                };
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "companies/1");
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+
+                await DataArchivalHelper.SetupDataArchival(store, Server.ServerStore, config, database.Name);
+
+                DatabaseTopology topology;
+                string nodeTag;
+
+                using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverContext))
+                using (serverContext.OpenReadTransaction())
+                {
+                    topology = database.ServerStore.Cluster.ReadDatabaseTopology(serverContext, database.Name);
+                    nodeTag = database.ServerStore.NodeTag;
+                }
+
+                DateTime time = SystemTime.UtcNow.AddMinutes(10);
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenWriteTransaction())
+                {
+                    var archiveOptions = new BackgroundWorkParameters(context, time, topology, nodeTag, AmountToTake: 10, MaxItemsToProcess: 10);
+                    var totalCount = 0;
+                    var toArchive = database.DocumentsStorage.DataArchivalStorage.GetDocuments(archiveOptions, ref totalCount, out _, CancellationToken.None);
+                    Assert.Equal(10, totalCount);
+                }
+
+                var dataArchivist = database.DataArchivist;
+                await dataArchivist.ArchiveDocs();
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenWriteTransaction())
+                {
+                    var archiveOptions = new BackgroundWorkParameters(context, time, topology, nodeTag, AmountToTake: 10, MaxItemsToProcess: 10);
+                    var totalCount = 0;
+                    var toArchive = database.DocumentsStorage.DataArchivalStorage.GetDocuments(archiveOptions, ref totalCount, out _, CancellationToken.None);
+                    Assert.Equal(1, totalCount);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
…le expiration and refresh run for v6.0

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22074/Add-an-option-to-specify-max-items-to-process-in-single-expiration-and-refresh-run

### Additional description

PR for v6.0 (https://github.com/ravendb/ravendb/pull/18223) (https://issues.hibernatingrhinos.com/issue/RavenDB-22074/Add-an-option-to-specify-max-items-to-process-in-single-expiration-and-refresh-run#focus=Comments-67-1049764.0-0)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
