### PR TITLE
RavenDB-22156 - MixedClusterTests.UpgradeDirectlyFrom42X is failing when updating from 4.2.0 (v5.4)

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -316,7 +316,7 @@ namespace Raven.Server.Documents.Handlers
             }
 
             throw new InvalidOperationException(
-                "Cluster-transaction was succeeded, but Leader is outdated and its results are inaccessible (the command has been already deleted from the history log).  We recommend you to update all nodes in the cluster to the last stable version.");
+                "We are not able to verify that the cluster-wide transaction was succeeded. please consider to upgrade your leader to the latest stable version.");
         }
 
         private void ThrowClusterTransactionConcurrencyException(List<ClusterTransactionErrorInfo> errors)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22156/InterversionTests.MixedClusterTests.UpgradeDirectlyFrom42XinitialVersions-4.2.0-4.2.0-4.2.0

### Additional description

The test fails when there is a leader in version 4.2.0 and a follower in version 5.4 
When the follower receives a null result from the non-updated leader for the cluster transaction raft command (in batch handler), it attempts to locate the cluster transaction command result in the local history log.
However, the follower doesn't find it because the raft command received from the leader lacks a UniqueRequestId, a feature introduced only in version 4.2.1 (and therefore does not add the command to the history log at all from the first place).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
