### PR TITLE
RavenDB-22193 - Improve the performance of indexes with LoadDocument from different collections

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -428,12 +428,10 @@ namespace Raven.Server.Documents.Indexes.Workers
             foreach (var key in _referencesStorage.GetItemKeysFromCollectionThatReference(collection, referencedItem.Key, indexContext.Transaction, lastProcessedItemId))
             {
                 // we check if we already indexed the document BEFORE we fetch it from the disk.
-                var clonedKey = key.Clone(queryContext.Documents.Allocator);
-                if (indexed.Add(clonedKey) == false)
-                {
-                    clonedKey.Release(queryContext.Documents.Allocator);
+                if (indexed.Contains(key))
                     continue;
-                }
+
+                indexed.Add(key.Clone(queryContext.Documents.Allocator));
 
                 var item = GetItem(queryContext.Documents, key);
                 if (item == null)

--- a/test/SlowTests/Issues/RavenDB-15754.cs
+++ b/test/SlowTests/Issues/RavenDB-15754.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Session;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes;
 using Sparrow.Platform;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -90,6 +91,73 @@ namespace SlowTests.Issues
                 await AssertCount(store, _companyName2, _employeesCount);
                 Assert.True(await Task.WhenAny(tcs.Task, Task.Delay(10_000)) == tcs.Task);
                 Assert.True(batchCount > 1);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task CanIndexReferencedDocumentWithMultipleReferences()
+        {
+            using (var store = GetDocumentStore(new Options()))
+            {
+                const string oldManagerName = "Grisha";
+                const string newManagerName = "Grisha Kotler";
+
+                var company = new Company
+                {
+                    Name = _companyName1
+                };
+
+                var manager = new Manager
+                {
+                    Name = oldManagerName
+                };
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(company);
+                    await session.StoreAsync(manager);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var bulk = store.BulkInsert())
+                {
+                    for (var i = 0; i < _employeesCount; i++)
+                    {
+                        await bulk.StoreAsync(new Employee
+                        {
+                            CompanyId = company.Id,
+                            ManagerId = manager.Id
+                        });
+                    }
+                }
+
+                var index = new DocumentsIndex();
+                await index.ExecuteAsync(store);
+
+                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await AssertCount(store, _companyName1, _employeesCount, managerName: oldManagerName);
+                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+                Assert.Equal(_employeesCount, indexStats.MapAttempts);
+                Assert.Equal(_employeesCount, indexStats.MapSuccesses);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    company.Name = _companyName2;
+                    manager.Name = newManagerName;
+                    await session.StoreAsync(company, company.Id);
+                    await session.StoreAsync(manager, manager.Id);
+                    await session.SaveChangesAsync();
+                }
+
+                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(10));
+                await AssertCount(store, _companyName1, 0);
+                await AssertCount(store, _companyName2, _employeesCount, managerName: newManagerName);
+
+                indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+
+                // we expect the parent document to be indexed only once
+                Assert.Equal(_employeesCount, indexStats.MapReferenceAttempts);
+                Assert.Equal(_employeesCount, indexStats.MapReferenceSuccesses);
             }
         }
 
@@ -814,7 +882,7 @@ namespace SlowTests.Issues
             }
         }
 
-        private static async Task AssertCount(DocumentStore store, string companyName, int expectedCount)
+        private static async Task AssertCount(DocumentStore store, string companyName, int expectedCount, string managerName = null)
         {
             using (var session = store.OpenAsyncSession())
             {
@@ -822,6 +890,14 @@ namespace SlowTests.Issues
                     .Where(x => x.CompanyName == companyName).CountAsync();
 
                 Assert.Equal(expectedCount, itemsCount);
+
+                if (managerName != null)
+                {
+                    itemsCount = await session.Query<DocumentsIndex.Result, DocumentsIndex>()
+                        .Where(x => x.ManagerName == managerName).CountAsync();
+
+                    Assert.Equal(expectedCount, itemsCount);
+                }
             }
         }
 
@@ -892,6 +968,14 @@ namespace SlowTests.Issues
             public string Id { get; set; }
 
             public string CompanyId { get; set; }
+
+            public string ManagerId { get; set; }
+        }
+
+        private class Manager
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
         }
 
         private class DocumentsIndex : AbstractIndexCreationTask<Employee>
@@ -899,6 +983,7 @@ namespace SlowTests.Issues
             public class Result
             {
                 public string CompanyName { get; set; }
+                public string ManagerName { get; set; }
             }
 
             public DocumentsIndex()
@@ -907,7 +992,8 @@ namespace SlowTests.Issues
                     from employee in employees
                     select new Result
                     {
-                        CompanyName = LoadDocument<Company>(employee.CompanyId).Name
+                        CompanyName = LoadDocument<Company>(employee.CompanyId).Name,
+                        ManagerName = LoadDocument<Manager>(employee.ManagerId).Name
                     };
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22193/Improve-the-performance-of-indexes-with-LoadDocument-from-different-collections

### Additional description

- When references from different collections are being changed, we might index the same document more than once, we now identify that and skip it (this is valid since we are in the same read transaction).
- Renewing a transaction will clear the already indexed documents (same as the previous behaviour).
- Check if we already indexed the document BEFORE we fetch it from the disk.
- Use `Slice` instead of materializing the item key to a `string`.

In the provided test we have `20K` documents with 2 references each (to the same 2 documents).
When those 2 are being changed, we would index all parent documents twice (`40K` map reference attemps), now we do it only once (`20K` map reference attemps).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
