### PR TITLE
RavenDB-22202 Add index to `AdditionalDebugInformation.AdditionalDebugInformation`

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -810,7 +810,7 @@ namespace Raven.Server.ServerWide.Commands
 
         public override string AdditionalDebugInformation(Exception exception)
         {
-            return $"guid: {UniqueRequestId} {string.Join(", ", ClusterCommands.Select(c => c.Id))}";
+            return $"guid: {UniqueRequestId} {string.Join(", ", ClusterCommands.Select(c => $"({c.Id}, {c.Index})"))}";
         }
 
         public override DynamicJsonValue ToJson(JsonOperationContext context)


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22202

### Additional description
Currently, we don't log the requested index of the cluster transaction.

The output log is:

Apply of ClusterTransactionCommand with index 23 was successful. AdditionalDebugInformation: guid: 94c5a7a3-9520-411c-b3d5-375285075e30 rvn-atomic/user3, rvn-atomic/user4.

I want the log to include the index so the log will be:

Apply of ClusterTransactionCommand with index 23 was successful. AdditionalDebugInformation: guid: 94c5a7a3-9520-411c-b3d5-375285075e30 (rvn-atomic/user3, 16), (rvn-atomic/user4, 0).

### Type of change
- [x] Logs
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Not relevant
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
