### PR TITLE
RavenDB-22201 Custom sorters - new sorters have the same key

### DIFF
--- a/src/Raven.Studio/typescript/components/common/customSorters/useCustomSorters.ts
+++ b/src/Raven.Studio/typescript/components/common/customSorters/useCustomSorters.ts
@@ -1,11 +1,15 @@
 import { CustomSorterFormData } from "components/common/customSorters/editCustomSorterValidation";
 import { useState } from "react";
 
+export interface CustomSorter extends CustomSorterFormData {
+    id: string;
+}
+
 export function useCustomSorters() {
-    const [sorters, setSorters] = useState<CustomSorterFormData[]>([]);
+    const [sorters, setSorters] = useState<CustomSorter[]>([]);
 
     const addNewSorter = () => {
-        setSorters((prev) => [{ name: "", code: "" } satisfies CustomSorterFormData, ...prev]);
+        setSorters((prev) => [{ id: createId(), name: "", code: "" } satisfies CustomSorter, ...prev]);
     };
 
     const removeSorter = (idx: number) => {
@@ -21,6 +25,10 @@ export function useCustomSorters() {
     };
 }
 
-function mapFromDto(dto: Raven.Client.Documents.Queries.Sorting.SorterDefinition[]): CustomSorterFormData[] {
-    return dto.map((x) => ({ code: x.Code, name: x.Name }) satisfies CustomSorterFormData);
+function mapFromDto(dto: Raven.Client.Documents.Queries.Sorting.SorterDefinition[]): CustomSorter[] {
+    return dto.map((x) => ({ id: createId(), code: x.Code, name: x.Name }) satisfies CustomSorter);
+}
+
+function createId() {
+    return _.uniqueId("custom-sorter");
 }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorters.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorters.stories.tsx
@@ -1,6 +1,11 @@
 ﻿import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
-import { withStorybookContexts, withBootstrap5, databaseAccessArgType } from "test/storybookTestUtils";
+import {
+    withStorybookContexts,
+    withBootstrap5,
+    databaseAccessArgType,
+    withForceRerender,
+} from "test/storybookTestUtils";
 import DatabaseCustomSorters from "./DatabaseCustomSorters";
 import { DatabasesStubs } from "test/stubs/DatabasesStubs";
 import { mockStore } from "test/mocks/store/MockStore";
@@ -9,7 +14,7 @@ import { ManageServerStubs } from "test/stubs/ManageServerStubs";
 
 export default {
     title: "Pages/Database/Settings/Custom Sorters",
-    decorators: [withStorybookContexts, withBootstrap5],
+    decorators: [withStorybookContexts, withBootstrap5, withForceRerender],
 } satisfies Meta;
 
 interface DefaultDatabaseCustomSortersProps {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersList.tsx
@@ -2,12 +2,12 @@ import { EmptySet } from "components/common/EmptySet";
 import { LoadError } from "components/common/LoadError";
 import { LoadingView } from "components/common/LoadingView";
 import DatabaseCustomSortersListItem from "components/pages/database/settings/customSorters/DatabaseCustomSortersListItem";
-import { CustomSorterFormData } from "components/common/customSorters/editCustomSorterValidation";
 import React from "react";
 import { AsyncStateStatus } from "react-async-hook";
+import { CustomSorter } from "components/common/customSorters/useCustomSorters";
 
 interface DatabaseCustomSortersListProps {
-    sorters: CustomSorterFormData[];
+    sorters: CustomSorter[];
     fetchStatus: AsyncStateStatus;
     reload: () => void;
     serverWideSorterNames: string[];
@@ -29,16 +29,12 @@ export default function DatabaseCustomSortersList(props: DatabaseCustomSortersLi
         return <EmptySet>No custom sorters have been defined</EmptySet>;
     }
 
-    return (
-        <div>
-            {sorters.map((sorter, idx) => (
-                <DatabaseCustomSortersListItem
-                    key={sorter.name + idx}
-                    initialSorter={sorter}
-                    serverWideSorterNames={serverWideSorterNames}
-                    remove={() => remove(idx)}
-                />
-            ))}
-        </div>
-    );
+    return sorters.map((sorter, idx) => (
+        <DatabaseCustomSortersListItem
+            key={sorter.id}
+            initialSorter={sorter}
+            serverWideSorterNames={serverWideSorterNames}
+            remove={() => remove(idx)}
+        />
+    ));
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSorters.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSorters.stories.tsx
@@ -1,6 +1,6 @@
 ﻿import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
-import { withStorybookContexts, withBootstrap5 } from "test/storybookTestUtils";
+import { withStorybookContexts, withBootstrap5, withForceRerender } from "test/storybookTestUtils";
 import ServerWideCustomSorters from "./ServerWideCustomSorters";
 import { mockServices } from "test/mocks/services/MockServices";
 import { mockStore } from "test/mocks/store/MockStore";
@@ -8,7 +8,7 @@ import { ManageServerStubs } from "test/stubs/ManageServerStubs";
 
 export default {
     title: "Pages/ManageServer/Server-Wide Sorters",
-    decorators: [withStorybookContexts, withBootstrap5],
+    decorators: [withStorybookContexts, withBootstrap5, withForceRerender],
 } satisfies Meta;
 
 interface DefaultServerWideCustomSortersProps {

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSortersList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSortersList.tsx
@@ -3,11 +3,11 @@ import { LoadError } from "components/common/LoadError";
 import { LoadingView } from "components/common/LoadingView";
 import React from "react";
 import { AsyncStateStatus } from "react-async-hook";
-import { CustomSorterFormData } from "components/common/customSorters/editCustomSorterValidation";
 import ServerWideCustomSortersListItem from "components/pages/resources/manageServer/serverWideSorters/ServerWideCustomSortersListItem";
+import { CustomSorter } from "components/common/customSorters/useCustomSorters";
 
 interface ServerWideCustomSortersListProps {
-    sorters: CustomSorterFormData[];
+    sorters: CustomSorter[];
     fetchStatus: AsyncStateStatus;
     reload: () => void;
     remove: (idx: number) => void;
@@ -28,15 +28,7 @@ export default function ServerWideCustomSortersList(props: ServerWideCustomSorte
         return <EmptySet>No server-wide custom sorters have been defined</EmptySet>;
     }
 
-    return (
-        <div>
-            {sorters.map((sorter, idx) => (
-                <ServerWideCustomSortersListItem
-                    key={sorter.name + idx}
-                    initialSorter={sorter}
-                    remove={() => remove(idx)}
-                />
-            ))}
-        </div>
-    );
+    return sorters.map((sorter, idx) => (
+        <ServerWideCustomSortersListItem key={sorter.id} initialSorter={sorter} remove={() => remove(idx)} />
+    ));
 }

--- a/src/Raven.Studio/typescript/test/storybookTestUtils.tsx
+++ b/src/Raven.Studio/typescript/test/storybookTestUtils.tsx
@@ -50,6 +50,10 @@ export function withBootstrap5(storyFn: any) {
     );
 }
 
+export function withForceRerender(storyFn: any) {
+    return <React.Fragment {...forceStoryRerender()}>{storyFn()}</React.Fragment>;
+}
+
 export const licenseArgType = {
     control: {
         type: "select",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22201/Custom-sorters-new-sorters-have-the-same-key

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
