### PR TITLE
RavenDB-22203 `database` object is passed as name in command

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/dbGroup/startReshardingCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/dbGroup/startReshardingCommand.ts
@@ -2,9 +2,21 @@
 import endpoints = require("endpoints");
 import database = require("models/resources/database");
 
+interface Range {
+    from: number;
+    to: number;
+}
+
 class startReshardingCommand extends commandBase {
-    constructor(private db: database | string, private range: { from: number, to: number }, private targetShard: number) {
+    private readonly databaseName: string;
+    private readonly range: Range;
+    private readonly targetShard: number;
+
+    constructor(db: database | string,  range: Range, targetShard: number) {
         super();
+        this.databaseName = (_.isString(db) ? db : db.name);
+        this.range = range;
+        this.targetShard = targetShard;
     }
 
     execute(): JQueryPromise<operationIdDto> {
@@ -12,7 +24,7 @@ class startReshardingCommand extends commandBase {
             fromBucket: this.range.from,
             toBucket: this.range.to,
             toShard: this.targetShard,
-            database: this.db
+            database: this.databaseName
         }
      
         const url = endpoints.global.resharding.adminReshardingStart + this.urlEncodeArgs(args);

--- a/src/Raven.Studio/typescript/commands/database/documents/saveConflictSolverConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/saveConflictSolverConfigurationCommand.ts
@@ -3,18 +3,18 @@ import commandBase = require("commands/commandBase");
 import endpoints = require("endpoints");
 
 class saveConflictSolverConfigurationCommand extends commandBase {
-    private readonly db: database | string;
+    private readonly databaseName: string;
     private readonly configuration: Raven.Client.ServerWide.ConflictSolver;
 
     constructor(db: database | string, configuration: Raven.Client.ServerWide.ConflictSolver) {
         super();
-        this.db = db;
+        this.databaseName = (_.isString(db) ? db : db.name);
         this.configuration = configuration;
     }
 
     execute(): JQueryPromise<updateConflictSolverConfigurationResponse> {
         const urlArgs = {
-            name: (_.isString(this.db) ? this.db : this.db)
+            name: this.databaseName
         };
         const url = endpoints.global.adminDatabases.adminReplicationConflictsSolver + this.urlEncodeArgs(urlArgs);
         const args = ko.toJSON(this.configuration);

--- a/src/Raven.Studio/typescript/commands/database/tasks/delayBackupCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/delayBackupCommand.ts
@@ -2,9 +2,8 @@ import commandBase = require("commands/commandBase");
 import database = require("models/resources/database");
 import endpoints = require("endpoints");
 
-
 class delayBackupCommand extends commandBase {
-    private db: database | string;
+    private databaseName: string;
 
     private readonly taskId: number;
 
@@ -14,14 +13,14 @@ class delayBackupCommand extends commandBase {
         super();
         this.duration = duration;
         this.taskId = taskId;
-        this.db = db;
+        this.databaseName = (_.isString(db) ? db : db.name);
     }
  
     execute(): JQueryPromise<Raven.Client.Documents.Operations.Backups.StartBackupOperationResult> {
         const args = {
             taskId: this.taskId,
             duration: this.duration,
-            database: this.db
+            database: this.databaseName
         }
         const url = endpoints.global.adminDatabases.adminBackupTaskDelay + this.urlEncodeArgs(args);
         

--- a/src/Raven.Studio/typescript/commands/database/tasks/getPeriodicBackupConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/getPeriodicBackupConfigurationCommand.ts
@@ -3,13 +3,18 @@ import database = require("models/resources/database");
 import endpoints = require("endpoints");
 
 class getPeriodicBackupConfigurationCommand extends commandBase {
-    constructor(private db: database | string, private taskId: number) {
+    private readonly databaseName: string;
+    private readonly taskId: number;
+
+    constructor( db: database | string,  taskId: number) {
         super();
+        this.databaseName = (_.isString(db) ? db : db.name);
+        this.taskId = taskId;
     }
  
     execute(): JQueryPromise<Raven.Client.Documents.Operations.Backups.PeriodicBackupConfiguration> {
         const url = endpoints.global.backupDatabase.periodicBackup +
-            this.urlEncodeArgs({ name: this.db, taskId: this.taskId });
+            this.urlEncodeArgs({ name: this.databaseName, taskId: this.taskId });
 
         return this.query<Raven.Client.Documents.Operations.Backups.PeriodicBackupConfiguration>(url, null)
             .fail((response: JQueryXHR) => {

--- a/src/Raven.Studio/typescript/commands/database/tasks/saveSubscriptionTaskCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/saveSubscriptionTaskCommand.ts
@@ -3,9 +3,15 @@ import database = require("models/resources/database");
 import endpoints = require("endpoints");
 
 class saveSubscriptionTaskCommand extends commandBase {
+    private readonly databaseName: string;
+    private readonly taskId: number;
+    private readonly payload: Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions;
 
-    constructor(private db: database | string, private payload: Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions, private taskId?: number) {
+    constructor( db: database | string, payload: Raven.Client.Documents.Subscriptions.SubscriptionCreationOptions,  taskId?: number) {
         super();
+        this.databaseName = (_.isString(db) ? db : db.name);
+        this.taskId = taskId;
+        this.payload = payload;
     }
 
     execute(): JQueryPromise<Raven.Client.Documents.Operations.OngoingTasks.ModifyOngoingTaskResult> {
@@ -14,7 +20,7 @@ class saveSubscriptionTaskCommand extends commandBase {
                 this.reportError("Failed to save subscription task", response.responseText, response.statusText); 
             })
             .done(() => {
-                this.reportSuccess(`Saved subscription task ${this.payload.Name} from database ${this.db}`);
+                this.reportSuccess(`Saved subscription task ${this.payload.Name} from database ${this.databaseName}`);
             });
     }
 
@@ -22,17 +28,17 @@ class saveSubscriptionTaskCommand extends commandBase {
         let args: any;
 
         if (this.taskId) {
-            args = { name: this.db, id: this.taskId };
+            args = { name: this.databaseName, id: this.taskId };
         } else {
             // New task
-            args = { name: this.db };
+            args = { name: this.databaseName };
         }
         
         const url = endpoints.databases.subscriptions.subscriptions + this.urlEncodeArgs(args);
 
         const saveTask = $.Deferred<Raven.Client.Documents.Operations.OngoingTasks.ModifyOngoingTaskResult>();
 
-        this.put(url, JSON.stringify(this.payload), this.db)
+        this.put(url, JSON.stringify(this.payload), this.databaseName)
             .done((results: Raven.Client.Documents.Operations.OngoingTasks.ModifyOngoingTaskResult) => { 
                 saveTask.resolve(results);
             })

--- a/src/Raven.Studio/typescript/commands/resources/getDatabaseRecordCommand.ts
+++ b/src/Raven.Studio/typescript/commands/resources/getDatabaseRecordCommand.ts
@@ -5,30 +5,26 @@ import endpoints = require("endpoints");
 
 class getDatabaseRecordCommand extends commandBase {
 
-    private readonly db: database | string;
+    private readonly databaseName: string;
     private readonly reportRefreshProgress: boolean;
 
     constructor(db: database | string, reportRefreshProgress = false) {
         super();
-        this.db = db;
+        this.databaseName = (_.isString(db) ? db : db.name);
         this.reportRefreshProgress = reportRefreshProgress;
-
-        if (!db) {
-            throw new Error("Must specify database");
-        }
     }
 
     execute(): JQueryPromise<document> {
         const resultsSelector = (queryResult: queryResultDto<documentDto>) => new document(queryResult);
         const args = {
-            name: this.db
+            name: this.databaseName
         };
         const url = endpoints.global.adminDatabases.adminDatabases + this.urlEncodeArgs(args);
 
         const getTask = this.query(url, null, null, resultsSelector);
 
         if (this.reportRefreshProgress) {
-            getTask.done(() => this.reportSuccess("Database Record of '" + this.db + "' was successfully refreshed!"));
+            getTask.done(() => this.reportSuccess("Database Record of '" + this.databaseName + "' was successfully refreshed!"));
             getTask.fail((response: JQueryXHR) => this.reportError("Failed to refresh Database Record!", response.responseText, response.statusText));
         }
         return getTask;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22203/database-object-is-passed-as-name-in-command

### Additional description

Fix after refactor

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
