### PR TITLE
RavenDB-21636 ShouldUpdateBackupInfoIfDatabaseUnloaded - remove local…

### DIFF
--- a/test/SlowTests/Issues/RavenDB_20084.cs
+++ b/test/SlowTests/Issues/RavenDB_20084.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.OngoingTasks;
-using Raven.Client.Util;
+using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -47,7 +47,7 @@ public class RavenDB_20084 : ClusterTestBase
             leaderStore.Conventions = new DocumentConventions { DisableTopologyUpdates = true };
             leaderStore.Database = databaseName;
             leaderStore.Initialize();
-            var debugInfo = new ConcurrentBag<string> { $"Started at: {SystemTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}" };
+            var debugInfo = new List<string> { $"Started at: {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}" };
 
             leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().OnFailedRescheduleNextScheduledActivity = (exception, erroredDatabaseName) =>
                 debugInfo.Add($"Failed to schedule the next activity for the idle database '{erroredDatabaseName}': {exception}");
@@ -137,24 +137,10 @@ public class RavenDB_20084 : ClusterTestBase
                     timeout: Convert.ToInt32(TimeSpan.FromMinutes(3).TotalMilliseconds),
                     interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
 
-                debugInfo.Add($"'lastBackupTime': {lastBackupTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
-                debugInfo.Add($"'expectedTime':   {expectedTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
-
-                var backupInfoUpdated = lastBackupTime >= expectedTime;
-                if (backupInfoUpdated == false)
-                {
-                    var response = await client.GetAsync($"{leaderServer.WebUrl}/admin/debug/databases/idle");
-                    debugInfo.Add($"{leaderServer.WebUrl}/admin/debug/databases/idle");
-                    debugInfo.Add(await response.Content.ReadAsStringAsync());
-
-                    response = await client.GetAsync($"{leaderServer.WebUrl}/admin/debug/periodic-backup/timers");
-                    debugInfo.Add($"{leaderServer.WebUrl}/admin/debug/periodic-backup/timers");
-                    debugInfo.Add(await response.Content.ReadAsStringAsync());
-                }
+                bool backupInfoUpdated = await AddInfo(debugInfo, lastBackupTime, expectedTime, leaderStore, taskId, client, leaderServer);
 
                 Assert.True(backupInfoUpdated, $"lastBackupTime >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
-                Assert.True(leaderServer.ServerStore.IdleDatabases.Count == 1,
-                    $"leaderServer.ServerStore.IdleDatabases.Count == 1: Count is {leaderServer.ServerStore.IdleDatabases.Count}{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
+
 
                 // Verifying that the cluster storage contains the same value for consistency
                 var operation = new GetPeriodicBackupStatusOperation(taskId);
@@ -174,5 +160,33 @@ public class RavenDB_20084 : ClusterTestBase
                     $"lastInternalBackupTimeInClusterStorage >= expectedTime: false{Environment.NewLine}{string.Join(Environment.NewLine, debugInfo)}");
             }
         }
+    }
+
+    private static async Task<bool> AddInfo(List<string> debugInfo, DateTime lastBackupTime, DateTime expectedTime, DocumentStore leaderStore, long taskId, HttpClient client,
+        RavenServer leaderServer)
+    {
+        OngoingTaskBackup onGoingTaskBackup;
+        debugInfo.Add($"'lastBackupTime': {lastBackupTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
+        debugInfo.Add($"'expectedTime':   {expectedTime:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
+        debugInfo.Add($"'Now':   {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
+        onGoingTaskBackup = await leaderStore.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
+        debugInfo.Add($"'LastIncrementalBackup':   {onGoingTaskBackup?.LastIncrementalBackup:yyyy-MM-ddTHH:mm:ss.ffffffZ}");
+        debugInfo.Add($"'Error':   {onGoingTaskBackup?.Error}");
+        debugInfo.Add($"'TaskConnectionStatus':   {onGoingTaskBackup?.TaskConnectionStatus}");
+        debugInfo.Add($"'LastFullBackup':   {onGoingTaskBackup?.LastFullBackup}");
+        debugInfo.Add($"'TaskState':   {onGoingTaskBackup?.TaskState}");
+        var backupInfoUpdated = lastBackupTime >= expectedTime;
+        if (backupInfoUpdated == false)
+        {
+            var response = await client.GetAsync($"{leaderServer.WebUrl}/admin/debug/databases/idle");
+            debugInfo.Add($"{leaderServer.WebUrl}/admin/debug/databases/idle");
+            debugInfo.Add(await response.Content.ReadAsStringAsync());
+
+            response = await client.GetAsync($"{leaderServer.WebUrl}/admin/debug/periodic-backup/timers");
+            debugInfo.Add($"{leaderServer.WebUrl}/admin/debug/periodic-backup/timers");
+            debugInfo.Add(await response.Content.ReadAsStringAsync());
+        }
+
+        return backupInfoUpdated;
     }
 }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2965,7 +2965,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.NotNull(taskBackupInfo.OnGoingBackup.StartTime);
 
                     var delayDuration = TimeSpan.FromMinutes(delayDurationInMinutes);
-                    var delayUntil = DateTime.Now + delayDuration;
+                    var delayUntil = DateTime.UtcNow + delayDuration;
                     await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
 
                     // There should be no OnGoingBackup operation in the OngoingTaskBackup
@@ -2991,7 +2991,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(backupStatus.OriginalBackupTime,
                         delayUntil < nextFullBackup
                             ? taskBackupInfo.OnGoingBackup.StartTime    // until the next scheduled backup time.
-                            : nextFullBackup.Value.ToUniversalTime());  // after the next scheduled backup.
+                            : nextFullBackup.Value);  // after the next scheduled backup.
                 }, tcs: new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
             }
         }
@@ -3082,7 +3082,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.NotNull(taskBackupInfo);
                     Assert.NotNull(taskBackupInfo.OnGoingBackup);
 
-                    var expectedNextBackupDateTime = new DateTime(DateTime.Now.Year + 1, 1, 1, 0, 0, 0, DateTimeKind.Local).ToUniversalTime();
+                    var expectedNextBackupDateTime = new DateTime(DateTime.UtcNow.Year + 1, 1, 1, 0, 0, 0, DateTimeKind.Utc);
                     Assert.Equal(expectedNextBackupDateTime, taskBackupInfo.NextBackup.DateTime);
 
                     // Let's delay the backup task to next occurence + 1 hour


### PR DESCRIPTION
… time

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21636

### Additional description
The issue arises from our reliance on local time for calculating the next backup time, during the transition to winter time in Israel.

On October 29, 2023, the period from 1 AM to 2 AM occurs twice due to the time change, resulting in two possible times: one before and one after the transition. When we converted 22:17:30 to local time, it became 1:17:30. consequently, we calculated the next backup time as 1:18:00 (the correct answer). However, upon reverting to UTC, the time became 23:18:00 instead.
V6.0 PR : https://github.com/ravendb/ravendb/pull/18234

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
