### PR TITLE
RavenDB-22172 Fixing exception message in ClusterTestBase

### DIFF
--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -362,7 +362,7 @@ namespace Tests.Infrastructure
                 await Task.Delay(TimeSpan.FromSeconds(1));
             }
 
-            throw new AggregateException("Failed to get leader after 5 retries. {Environment.NewLine}{GetNodesStatus(servers ?? Servers)}", exceptions);
+            throw new AggregateException($"Failed to get leader after 5 retries. {Environment.NewLine}{GetNodesStatus(servers ?? Servers)}", exceptions);
         }
 
         private string GetNodesStatus(List<RavenServer> servers)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22172

### Additional description

It's an issue only on v6.0 branch.
