### PR TITLE
RavenDB-22174 Adding more debug info if the test fails again

### DIFF
--- a/test/SlowTests/Issues/RavenDB_11255.cs
+++ b/test/SlowTests/Issues/RavenDB_11255.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
+using Parquet.Data.Rows;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.ServerWide.Context;
@@ -58,11 +59,7 @@ namespace SlowTests.Issues
                         }
                         catch (OperationCanceledException)
                         {
-                            // index is being replaced, storage environment is being disposed
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                            // index is being replaced, storage environment is being disposed
+                            throw new InvalidOperationException($"Index is already disposed: {index.IsDisposed}. This is not expected. Database disposed: {database.DatabaseShutdown.IsCancellationRequested}. Index Store disposed: {database.IndexStore.IsDisposed}");
                         }
 
                         Thread.Sleep(1000);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22174/SlowTests.Issues.RavenDB11255.Canupdatelockmodeandpriorityofindexevenifindexingisrunning

### Additional description

Reverting what I did in https://github.com/ravendb/ravendb/pull/18221 because it didn't make sens. Adding more debug info instead

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
