### PR TITLE
RavenDB-22207 Failed to get the debug package for a shareded database

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -330,9 +330,19 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 {
                     using (var rawRecord = ServerStore.Cluster.ReadRawDatabaseRecord(context, databaseName))
                     {
-                        if (rawRecord == null ||
-                            rawRecord.Topology.RelevantFor(ServerStore.NodeTag) == false)
+                        if (rawRecord == null)
                             continue;
+
+                        if (rawRecord.IsSharded)
+                        {
+                            if (rawRecord.Sharding.Orchestrator.Topology.RelevantFor(ServerStore.NodeTag) == false)
+                                continue;
+                        }
+                        else
+                        {
+                            if (rawRecord.Topology.RelevantFor(ServerStore.NodeTag) == false)
+                                continue;
+                        }
 
                         await WriteDatabaseRecord(archive, databaseName, jsonOperationContext, context);
 
@@ -352,7 +362,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     if (databases.Count > 0)
                     {
                         return allDatabases.Intersect(databases).ToHashSet();
-            }
+                    }
 
                     return allDatabases.ToHashSet();
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22207

### Additional description

When we have shared DB, we need to check the topology differently than regular DB 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
