### PR TITLE
RavenDB-22196 Expose referenced collections in index statistics.

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexStats.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexStats.cs
@@ -149,6 +149,11 @@ namespace Raven.Client.Documents.Indexes
         public int ErrorsCount { get; set; }
         
         public IndexSourceType SourceType { get; set; }
+        
+        /// <summary>
+        /// Returns the names of referenced collections.
+        /// </summary>
+        public HashSet<string> ReferencedCollections { get; set; }
 
 #if FEATURE_TEST_INDEX
         /// <summary>

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -420,6 +420,7 @@ namespace Raven.Server.Documents.Handlers
                                         Status = x.Status,
                                         LockMode = x.Definition.LockMode,
                                         Priority = x.Definition.Priority,
+                                        ReferencedCollections = x.GetReferencedCollectionNames()
                                     };
                                 }
                                 catch (Exception e)
@@ -466,6 +467,7 @@ namespace Raven.Server.Documents.Handlers
                                         Status = x.Status,
                                         LockMode = x.Definition.LockMode,
                                         Priority = x.Definition.Priority,
+                                        ReferencedCollections = x.GetReferencedCollectionNames()
                                     };
                                 }
                             })

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2954,7 +2954,8 @@ namespace Raven.Server.Documents.Indexes
                         Priority = Definition?.Priority ?? IndexPriority.Normal,
                         State = State,
                         Status = Status,
-                        Collections = Collections.ToDictionary(x => x, _ => new IndexStats.CollectionStats())
+                        Collections = Collections.ToDictionary(x => x, _ => new IndexStats.CollectionStats()),
+                        ReferencedCollections = GetReferencedCollectionNames()
                     };
                 }
 
@@ -2982,6 +2983,9 @@ namespace Raven.Server.Documents.Indexes
                         stats.LastBatchStats = _lastStats?.ToIndexingPerformanceLiveStats();
 
                     stats.LastQueryingTime = _lastQueryingTime;
+
+                    stats.ReferencedCollections = GetReferencedCollectionNames();
+
 
                     if (Type == IndexType.MapReduce || Type == IndexType.JavaScriptMapReduce)
                     {
@@ -3024,6 +3028,14 @@ namespace Raven.Server.Documents.Indexes
                     return stats;
                 }
             }
+        }
+
+        internal HashSet<string> GetReferencedCollectionNames()
+        {
+            // multiple maps can reference the same collections, we wants to return distinct names only
+            return GetReferencedCollections()?
+                .SelectMany(p =>  p.Value?.Select(z => z.Name))
+                .ToHashSet();
         }
 
         private IndexStats.MemoryStats GetMemoryStats()

--- a/test/SlowTests/Issues/RavenDB_22196.cs
+++ b/test/SlowTests/Issues/RavenDB_22196.cs
@@ -1,0 +1,178 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22196 : RavenTestBase
+{
+    [RavenTheory(RavenTestCategory.ClientApi)]
+    [MemberData(nameof(TestMatrix))]
+    public void SingleCollectionLoadTest(bool disableIndex, bool turnOffDatabase)
+    {
+        using var store = Arrange<SingleCollectionLoad>(disableIndex, turnOffDatabase);
+        var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(nameof(SingleCollectionLoad)));
+        Assert.NotNull(indexStats);
+        Assert.NotNull(indexStats.ReferencedCollections);
+        Assert.Equal(1, indexStats.ReferencedCollections.Count);
+        Assert.Equal("Item2s", indexStats.ReferencedCollections.First());
+    }
+
+    [RavenTheory(RavenTestCategory.ClientApi)]
+    [MemberData(nameof(TestMatrix))]    
+    public void MultipleCollectionLoadTest(bool disableIndex, bool turnOffDatabase)
+    {
+        using var store = Arrange<MultipleCollectionLoad>(disableIndex, turnOffDatabase);
+        var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(nameof(MultipleCollectionLoad)));
+        Assert.NotNull(indexStats);
+        Assert.NotNull(indexStats.ReferencedCollections);
+        Assert.Equal(2, indexStats.ReferencedCollections.Count);
+        Assert.Contains("Item2s", indexStats.ReferencedCollections);
+        Assert.Contains("Item3s", indexStats.ReferencedCollections);
+    }
+
+    [RavenTheory(RavenTestCategory.ClientApi)]
+    [MemberData(nameof(TestMatrix))]    
+    public void MultiMapLoadTest(bool disableIndex, bool turnOffDatabase)
+    {
+        using var store = Arrange<MultiMapLoad>(disableIndex, turnOffDatabase);
+        var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(nameof(MultiMapLoad)));
+        Assert.NotNull(indexStats);
+        Assert.NotNull(indexStats.ReferencedCollections);
+        Assert.Equal(2, indexStats.ReferencedCollections.Count);
+        Assert.Contains("Item2s", indexStats.ReferencedCollections);
+        Assert.Contains("Item3s", indexStats.ReferencedCollections);
+    }
+
+    [RavenTheory(RavenTestCategory.ClientApi)]
+    [MemberData(nameof(TestMatrix))]    
+    public void MultiMapLoadWithRepetitionTest(bool disableIndex, bool turnOffDatabase)
+    {
+        using var store = Arrange<MultiMapLoadWithRepetition>(disableIndex, turnOffDatabase);
+        var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(nameof(MultiMapLoadWithRepetition)));
+        Assert.NotNull(indexStats);
+        Assert.NotNull(indexStats.ReferencedCollections);
+        Assert.Equal(1, indexStats.ReferencedCollections.Count);
+        Assert.Contains("Item3s", indexStats.ReferencedCollections);
+    }
+
+    private IDocumentStore Arrange<TIndex>(bool disableIndex, bool turnOffDatabase) where TIndex : AbstractIndexCreationTask, new()
+    {
+        var documentsToInsert = new List<(object, string)>()
+        {
+            (new Item1("item2/1", "item3/1", "Item1/1"), "item1/1"), (new Item2("item2/1", "item3/1"), "item2/1"), (new Item3("item2/1", "item3/1"), "item3/1"),
+        };
+        
+        var path = NewDataPath();
+        var store = turnOffDatabase == false 
+                ? GetDocumentStore()
+                : GetDocumentStore(new Options()
+                {
+                    RunInMemory = false,
+                    Path = path,
+                });
+        
+        var index = new TIndex();
+        index.Execute(store);
+
+        using var session = store.OpenSession();
+        foreach (var (doc, id) in documentsToInsert)
+            session.Store(doc, id);
+
+        session.SaveChanges();
+        Indexes.WaitForIndexing(store);
+        if (disableIndex)
+            store.Maintenance.Send(new DisableIndexOperation(index.IndexName));
+
+        if (turnOffDatabase)
+        {
+            var old = Databases.GetDocumentDatabaseInstanceFor(store).Result;
+            Server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+        }
+        
+        
+        return store;
+    }
+
+    private record Item1(string RefId2, string RefId3, string Prop, string Id = null);
+
+    private record Item2(string RefId, string Prop, string Id = null);
+
+    private record Item3(string RefId, string Prop, string Id = null);
+
+    private class SingleCollectionLoad : AbstractIndexCreationTask<Item1>
+    {
+        public SingleCollectionLoad()
+        {
+            Map = item1s => from doc in item1s
+                let loadDocument = LoadDocument<Item2>(doc.RefId2)
+                select new { Current = doc.Prop, Loaded2 = loadDocument.Prop };
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    private class MultipleCollectionLoad : AbstractIndexCreationTask<Item1>
+    {
+        public MultipleCollectionLoad()
+        {
+            Map = item1s => from doc in item1s
+                let loadDocument = LoadDocument<Item2>(doc.RefId2)
+                let loadDocument2 = LoadDocument<Item3>(doc.RefId3)
+                select new { Current = doc.Prop, Loaded2 = loadDocument.Prop, Loaded3 = loadDocument2.Prop };
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    private class MultiMapLoad : AbstractMultiMapIndexCreationTask
+    {
+        public MultiMapLoad()
+        {
+            AddMap<Item1>(item1s => from doc in item1s
+                let loadDocument3 = LoadDocument<Item2>(doc.RefId2)
+                select new { Current = doc.Prop, Loaded = loadDocument3.Prop });
+
+            AddMap<Item2>(item2s => from doc in item2s
+                let loadDocument = LoadDocument<Item3>(doc.RefId)
+                select new { Current = doc.Prop, Loaded = loadDocument.Prop });
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    private class MultiMapLoadWithRepetition : AbstractMultiMapIndexCreationTask
+    {
+        public MultiMapLoadWithRepetition()
+        {
+            AddMap<Item1>(item1s => from doc in item1s
+                let loadDocument3 = LoadDocument<Item3>(doc.RefId2)
+                select new { Current = doc.Prop, Loaded = loadDocument3.Prop });
+
+            AddMap<Item2>(item1s => from doc in item1s
+                let loadDocument = LoadDocument<Item3>(doc.RefId)
+                select new { Current = doc.Prop, Loaded = loadDocument.Prop });
+
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    public RavenDB_22196(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private static IEnumerable<object[]> TestMatrix()
+    {
+        foreach (var disableIndex in new[] { true, false })
+        {
+            foreach (var turnOffDatabase in new[] { true, false })
+            {
+                yield return new object[] { disableIndex, turnOffDatabase };
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22196 

### Additional description

Exposing referenced collections in index statistics.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
