### PR TITLE
RavenDB-22211 Detailed database & indexing stats disapper automatically

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/StatsHeader.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/StatsHeader.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, Col, Row, Spinner } from "reactstrap";
+﻿import { Button, Col, Row } from "reactstrap";
 import {
     refresh,
     statisticsViewSelectors,
@@ -8,12 +8,13 @@ import { StickyHeader } from "components/common/StickyHeader";
 import React from "react";
 import { useAppDispatch, useAppSelector } from "components/store";
 import { Icon } from "components/common/Icon";
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 
 export function StatsHeader() {
     const dispatch = useAppDispatch();
 
     const detailsVisible = useAppSelector(statisticsViewSelectors.detailsVisible);
-    const spinnerRefresh = useAppSelector(statisticsViewSelectors.refreshing);
+    const isRefreshing = useAppSelector(statisticsViewSelectors.refreshing);
 
     return (
         <StickyHeader>
@@ -30,15 +31,14 @@ export function StatsHeader() {
                 </Col>
                 <Col />
                 <Col sm="auto">
-                    <Button
+                    <ButtonWithSpinner
                         color="primary"
                         onClick={() => dispatch(refresh())}
-                        disabled={spinnerRefresh}
                         title="Click to refresh stats"
+                        isSpinning={isRefreshing}
                     >
-                        {spinnerRefresh ? <Spinner size="sm" /> : <Icon icon="refresh" margin="m-0" />}
-                        <span>Refresh</span>
-                    </Button>
+                        Refresh
+                    </ButtonWithSpinner>
                 </Col>
             </Row>
         </StickyHeader>

--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/store/statisticsViewSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/store/statisticsViewSlice.ts
@@ -295,11 +295,10 @@ export const statisticsViewSlice = createSlice({
 const { initForDatabase, refreshStarted, refreshFinished } = statisticsViewSlice.actions;
 
 export const initView = (db: DatabaseSharedInfo) => async (dispatch: AppDispatch, getState: () => RootState) => {
-    dispatch(initForDatabase(db.name, DatabaseUtils.getLocations(db)));
-
     const firstTime = selectEssentialStats(getState()).status === "idle";
 
     if (firstTime) {
+        dispatch(initForDatabase(db.name, DatabaseUtils.getLocations(db)));
         dispatch(fetchEssentialStats());
     } else {
         dispatch(refresh());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22211/Detailed-database-indexing-stats-disapper-automatically

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
