### PR TITLE
RavenDB-21801 - dont fail test on failing delete temp file

### DIFF
--- a/test/InterversionTests/SmugglerTests.cs
+++ b/test/InterversionTests/SmugglerTests.cs
@@ -16,6 +16,7 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Smuggler.Migration;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -558,7 +559,7 @@ namespace InterversionTests
             }
             finally
             {
-                File.Delete(file);
+                IOExtensions.DeleteFile(file);
             }
         }
 


### PR DESCRIPTION
https://issues.hibernatingrhinos.com/issue/RavenDB-21801/InterversionTests.SmugglerTests.CanExportFrom54XAndImportToCurrentoptions-DatabaseMode-Single-SearchEngineMode-Lucene