### PR TITLE
RavenDB-21521: Restore PerCoreStatic for storage and key mapping pools.

### DIFF
--- a/src/Sparrow/Json/PerCoreStatic.cs
+++ b/src/Sparrow/Json/PerCoreStatic.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Sparrow.Utils;
+
+namespace Sparrow.Json
+{
+    public sealed class PerCoreStatic<T> where T : class
+    {
+        private readonly T[] _perCoreArrays;
+
+        public PerCoreStatic(Func<T> creationFunc)
+        {
+            _perCoreArrays = new T[Environment.ProcessorCount];
+            for (int i = 0; i < _perCoreArrays.Length; i++)
+                _perCoreArrays[i] = creationFunc();
+        }
+
+        public T Get()
+        {
+            return _perCoreArrays[CurrentProcessorIdHelper.GetCurrentProcessorId() % _perCoreArrays.Length];
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-21521

### Additional description

Restore the usage of PerCoreStatic.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
