### PR TITLE
RavenDB-22178 Added better exception handling for index cleanup and fixed issue with ConditionalAccessExpressionSyntax

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexData.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexData.cs
@@ -29,7 +29,6 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
 
         public string IndexName { get; set; }
         public bool IsAlreadyMerged { get; set; }
-        public bool IsSuitedForMerge { get; set; }
         public string Comment { get; set; }
 
         public bool IsFanout { get; set; }

--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMergeResults.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMergeResults.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
     {
         public Dictionary<string, string> Unmergables = new Dictionary<string, string>(); // index name, reason
         public List<MergeSuggestions> Suggestions = new List<MergeSuggestions>();
-        public Dictionary<string, string> Errors = new Dictionary<string, string>();
+        public List<MergeError> Errors = new List<MergeError>();
 
         public DynamicJsonValue ToJson()
         {
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
             {
                 [nameof(Unmergables)] = DynamicJsonValue.Convert(Unmergables),
                 [nameof(Suggestions)] = new DynamicJsonArray(Suggestions.Select(x=>x.ToJson())),
-                [nameof(Errors)] = DynamicJsonValue.Convert(Errors)
+                [nameof(Errors)] = new DynamicJsonArray(Errors.Select(x => x.ToJson()))
             };
         }
     }
@@ -64,6 +64,17 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
     {
         public string IndexName { get; set; }
         public string Message { get; set; }
+        public string StackTrace { get; set; }
+        
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(IndexName)] = IndexName,
+                [nameof(Message)] = Message,
+                [nameof(StackTrace)] = StackTrace,
+            };
+        }
     }
 
 }

--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMergeResults.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMergeResults.cs
@@ -11,13 +11,15 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
     {
         public Dictionary<string, string> Unmergables = new Dictionary<string, string>(); // index name, reason
         public List<MergeSuggestions> Suggestions = new List<MergeSuggestions>();
+        public Dictionary<string, string> Errors = new Dictionary<string, string>();
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
                 [nameof(Unmergables)] = DynamicJsonValue.Convert(Unmergables),
-                [nameof(Suggestions)] = new DynamicJsonArray(Suggestions.Select(x=>x.ToJson()))
+                [nameof(Suggestions)] = new DynamicJsonArray(Suggestions.Select(x=>x.ToJson())),
+                [nameof(Errors)] = DynamicJsonValue.Convert(Errors)
             };
         }
     }
@@ -56,6 +58,12 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
         public List<IndexData> ProposedForMerge = new List<IndexData>();
         public IndexData MergedData { get; set; }
         public string IndexMergeSuggestion { get; set; }
+    }
+
+    public class MergeError
+    {
+        public string IndexName { get; set; }
+        public string Message { get; set; }
     }
 
 }

--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMerger.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMerger.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
 using Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters;
 
 namespace Raven.Server.Documents.Indexes.IndexMerging
@@ -16,6 +17,23 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
     {
         private readonly Dictionary<string, IndexDefinition> _indexDefinitions;
         private static readonly IdentifierNameSyntax DefaultDocumentIdentifier = SyntaxFactory.IdentifierName("doc");
+        
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (_forTestingPurposes != null)
+                return _forTestingPurposes;
+
+            return _forTestingPurposes = new TestingStuff();
+        }
+        
+        public class TestingStuff
+        {
+            internal List<string> IndexNamesToThrowOn { get; set; }
+            internal Action<List<string>, string> OnTryMergeSelectExpressionsAndFields { get; set; }
+        }
+        
+        private TestingStuff _forTestingPurposes;
+        
         public IndexMerger(Dictionary<string, IndexDefinition> indexDefinitions)
         {
             _indexDefinitions = indexDefinitions
@@ -36,7 +54,6 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
                 if (failComments.Count != 0)
                 {
                     indexData.Comment = string.Join(Environment.NewLine, failComments);
-                    indexData.IsSuitedForMerge = false;
                     mergeData.MergedData = indexData;
                     mergedIndexesData.Add(mergeData);
                     continue;
@@ -54,7 +71,6 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
                     if (AreSelectClausesCompatible(current, indexData) == false)
                         continue;
 
-                    current.IsSuitedForMerge = true;
                     mergeData.ProposedForMerge.Add(current);
                 }
 
@@ -69,42 +85,42 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
             var failComments = new List<string>();
             if (indexData.Index.Type == IndexType.MapReduce)
             {
-                failComments.Add("Cannot merge map/reduce indexes");
+                failComments.Add("Cannot merge map/reduce indexes.");
             }
 
             if (indexData.Index.Maps.Count > 1)
             {
-                failComments.Add("Cannot merge multi map indexes");
+                failComments.Add("Cannot merge multi map indexes.");
             }
 
             if (indexData.NumberOfFromClauses > 1)
             {
-                failComments.Add("Cannot merge indexes that have more than a single from clause");
+                failComments.Add("Cannot merge indexes that have more than a single from clause.");
             }
 
             if (indexData.NumberOfSelectClauses > 1)
             {
-                failComments.Add("Cannot merge indexes that have more than a single select clause");
+                failComments.Add("Cannot merge indexes that have more than a single select clause.");
             }
 
             if (indexData.HasWhere)
             {
-                failComments.Add("Cannot merge indexes that have a where clause");
+                failComments.Add("Cannot merge indexes that have a where clause.");
             }
 
             if (indexData.HasGroup)
             {
-                failComments.Add("Cannot merge indexes that have a group by clause");
+                failComments.Add("Cannot merge indexes that have a group by clause.");
             }
 
             if (indexData.HasLet)
             {
-                failComments.Add("Cannot merge indexes that are using a let clause");
+                failComments.Add("Cannot merge indexes that are using a let clause.");
             }
 
             if (indexData.HasOrder)
             {
-                failComments.Add("Cannot merge indexes that have an order by clause");
+                failComments.Add("Cannot merge indexes that have an order by clause.");
             }
 
             if (indexData.IsFanout)
@@ -299,40 +315,42 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
                 var mergeSuggestion = new MergeSuggestions();
                 var selectExpressionDict = new Dictionary<string, ExpressionSyntax>();
 
-                if (TryMergeSelectExpressionsAndFields(mergeProposal, selectExpressionDict, mergeSuggestion, out var mergingComment) == false)
-                {
-                    indexMergeResults.Unmergables.Add(mergeProposal.MergedData.IndexName, mergingComment); 
+                var isMergeSuccessful = TryMergeSelectExpressionsAndFields(mergeProposal, selectExpressionDict, mergeSuggestion, out var errors);
+
+                AddMergeErrors(indexMergeResults, errors);
+                
+                if (isMergeSuccessful == false)
                     continue;
-                }
 
-                TrySetCollectionName(mergeProposal, mergeSuggestion);
+                var firstMergeableIndexData = mergeProposal.ProposedForMerge.First(x => x.IndexName.In(mergeSuggestion.CanMerge));
 
-                var map = mergeProposal.ProposedForMerge[0].BuildExpression(selectExpressionDict);
+                TrySetCollectionName(firstMergeableIndexData, mergeSuggestion);
+                
+                const string comment = "Can't find any other index to merge this index with.";
+
+                var map = firstMergeableIndexData.BuildExpression(selectExpressionDict);
                 if (map is null)
                 {
-                    indexMergeResults.Unmergables.Add(mergeProposal.ProposedForMerge[0].IndexName, "No other index to merge.");
+                    indexMergeResults.Unmergables.Add(firstMergeableIndexData.IndexName, comment);
                     continue;
                 } 
 
                 mergeSuggestion.MergedIndex.Maps.Add(SourceCodeBeautifier.FormatIndex(map).Expression);
-                RemoveMatchingIndexes(mergeProposal, selectExpressionDict, mergeSuggestion, indexMergeResults);
+                SuggestIndexesToDelete(mergeProposal, selectExpressionDict, mergeSuggestion, indexMergeResults);
 
-                if (mergeProposal.ProposedForMerge.Count == 1 && mergeProposal.ProposedForMerge[0].IsSuitedForMerge == false)
-                {
-                    const string comment = "Can't find any other index to merge this with";
-                    indexMergeResults.Unmergables.Add(mergeProposal.ProposedForMerge[0].IndexName, comment);
-                }
+                if (mergeSuggestion.CanMerge.Count == 1)
+                    indexMergeResults.Unmergables[firstMergeableIndexData.IndexName] = comment;
             }
 
             indexMergeResults = ExcludePartialResults(indexMergeResults);
             return indexMergeResults;
         }
 
-        private static void RemoveMatchingIndexes(MergeProposal mergeProposal, Dictionary<string, ExpressionSyntax> selectExpressionDict,
+        private static void SuggestIndexesToDelete(MergeProposal mergeProposal, Dictionary<string, ExpressionSyntax> selectExpressionDict,
             MergeSuggestions mergeSuggestion,
             IndexMergeResults indexMergeResults)
         {
-            if (mergeProposal.ProposedForMerge.Count > 1)
+            if (mergeProposal.ProposedForMerge.Count > 1 && mergeSuggestion.CanMerge.Count > 1)
             {
                 var matchingExistingIndexes = mergeProposal.ProposedForMerge.Where(x =>
                         AreSelectClausesTheSame(x, selectExpressionDict) &&
@@ -355,19 +373,27 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
             }
         }
 
-        private static void TrySetCollectionName(MergeProposal mergeProposal, MergeSuggestions mergeSuggestion)
+        private static void AddMergeErrors(IndexMergeResults indexMergeResults, List<MergeError> errors)
         {
-            if (mergeProposal.ProposedForMerge[0].Collections != null)
+            foreach (var error in errors)
             {
-                mergeSuggestion.Collection = mergeProposal.ProposedForMerge[0].Collections[0];
+                indexMergeResults.Errors[error.IndexName] = error.Message;
+            }
+        }
+
+        private static void TrySetCollectionName(IndexData indexData, MergeSuggestions mergeSuggestion)
+        {
+            if (indexData.Collections != null)
+            {
+                mergeSuggestion.Collection = indexData.Collections[0];
             }
 
-            else if (mergeProposal.ProposedForMerge[0].FromExpression is SimpleNameSyntax name)
+            else if (indexData.FromExpression is SimpleNameSyntax name)
             {
                 mergeSuggestion.Collection = name.Identifier.ValueText;
             }
 
-            else if (mergeProposal.ProposedForMerge[0].FromExpression is MemberAccessExpressionSyntax member)
+            else if (indexData.FromExpression is MemberAccessExpressionSyntax member)
             {
                 var identifier = ExtractIdentifierFromExpression(member);
                 if (identifier == "docs")
@@ -375,24 +401,35 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
             }
         }
 
-        private static bool TryMergeSelectExpressionsAndFields(MergeProposal mergeProposal, Dictionary<string, ExpressionSyntax> selectExpressionDict,
-            MergeSuggestions mergeSuggestion, out string message)
+        private bool TryMergeSelectExpressionsAndFields(MergeProposal mergeProposal, Dictionary<string, ExpressionSyntax> selectExpressionDict,
+            MergeSuggestions mergeSuggestion, out List<MergeError> mergeErrors)
         {
-            message = null;
+            mergeErrors = new List<MergeError>();
+            
             foreach (var curProposedData in mergeProposal.ProposedForMerge)
             {
-                foreach (var curExpr in curProposedData.SelectExpressions)
+                try
                 {
-                    var expr =  curExpr.Value;
-                    var rewritten = RewriteExpressionSyntax(curProposedData, expr, out message);
-                    selectExpressionDict[curExpr.Key] = rewritten ?? expr;
-                }
+                    _forTestingPurposes?.OnTryMergeSelectExpressionsAndFields?.Invoke(_forTestingPurposes.IndexNamesToThrowOn, curProposedData.IndexName);
+                    
+                    foreach (var curExpr in curProposedData.SelectExpressions)
+                    {
+                        var expr = curExpr.Value;
+                        var rewritten = RewriteExpressionSyntax(curProposedData, expr, out var message);
+                        selectExpressionDict[curExpr.Key] = rewritten ?? expr;
+                    }
 
-                mergeSuggestion.CanMerge.Add(curProposedData.IndexName);
-                DataDictionaryMerge(mergeSuggestion.MergedIndex.Fields, curProposedData.Index.Fields);
+                    mergeSuggestion.CanMerge.Add(curProposedData.IndexName);
+                    DataDictionaryMerge(mergeSuggestion.MergedIndex.Fields, curProposedData.Index.Fields);
+                }
+                catch (Exception ex)
+                {
+                    var mergeError = new MergeError() { IndexName = curProposedData.IndexName, Message = ex.Message };
+                    mergeErrors.Add(mergeError);
+                }
             }
 
-            return true;
+            return mergeSuggestion.CanMerge.Count > 0;
         }
 
         private static InvocationExpressionSyntax RecursivelyTransformInvocationExpressionSyntax(IndexData curProposedData, InvocationExpressionSyntax ies, out string message)
@@ -592,6 +629,8 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
             }
 
             resultingIndexMerge.Unmergables = originalIndexes.Unmergables;
+            resultingIndexMerge.Errors = originalIndexes.Errors;
+            
             return resultingIndexMerge;
         }
 

--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMerger.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMerger.cs
@@ -375,9 +375,12 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
 
         private static void AddMergeErrors(IndexMergeResults indexMergeResults, List<MergeError> errors)
         {
-            foreach (var error in errors)
+            var alreadyAddedIndexNames = indexMergeResults.Errors.Select(x => x.IndexName).ToList();
+            
+            foreach (var error in errors) 
             {
-                indexMergeResults.Errors[error.IndexName] = error.Message;
+                if (alreadyAddedIndexNames.Contains(error.IndexName) == false)
+                    indexMergeResults.Errors.Add(error);
             }
         }
 
@@ -424,7 +427,7 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
                 }
                 catch (Exception ex)
                 {
-                    var mergeError = new MergeError() { IndexName = curProposedData.IndexName, Message = ex.Message };
+                    var mergeError = new MergeError() { IndexName = curProposedData.IndexName, Message = ex.Message, StackTrace = ex.StackTrace };
                     mergeErrors.Add(mergeError);
                 }
             }

--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMerger.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMerger.cs
@@ -482,6 +482,7 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
                 PrefixUnaryExpressionSyntax pues => pues,
                 CastExpressionSyntax ces => RewriteCastExpressionSyntax(indexData, ces, out message),
                 ElementAccessExpressionSyntax eaes => RewriteElementAccessExpressionSyntax(indexData, eaes, out message),
+                ConditionalAccessExpressionSyntax caes => caes,
                 _ => null
             };
             

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/indexCleanup.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/indexCleanup.html
@@ -214,7 +214,59 @@
             </div>
         </div>
 
-        
+        <div class="panel index-group panel-danger" data-bind="visible: mergeSuggestionsErrors().length > 0">
+            <div class="panel-heading">
+                <h4 class="panel-title">
+                    <a href="#collapseMergeSuggestionsErrors" data-toggle="collapse">
+                        <i class="icon-danger"></i>
+                        <span>
+                            Merge suggestions errors (<span data-bind="text: mergeSuggestionsErrors().length"></span>)
+                        </span>
+                    </a>
+                </h4>
+            </div>
+            <div class="panel-collapse collapse" id="collapseMergeSuggestionsErrors">
+                <div class="panel-default panel-body">    
+                    <div class="padding padding-sm flex-horizontal margin-left">
+                        <div>
+                            <i class="icon-info"></i>
+                        </div>
+                        <div class="small">
+                            The following errors have been encountered when trying to create index merge suggestions.
+                        </div>
+                    </div>
+
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Index name</th>
+                                <th>Error</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody data-bind="foreach: mergeSuggestionsErrors()">
+                            <tr class="well well-sm">
+                                <td>
+                                    <a href="#" target="_blank" data-bind="text: indexName, attr: { href: $root.indexUrl(indexName) }"></a>
+                                </td>
+                                <td class="w-100">
+                                    <pre><code data-bind="text: isStackTraceVisible() ? (message + stackTrace) : message"></code></pre>
+                                    <div class="text-right">
+                                        <a href="#" data-bind="click: toggleIsStackTraceVisible, text: isStackTraceVisible() ? 'hide details' : 'show details'"></a>
+                                    </div>
+                                </td>
+                                <td>
+                                    <button class="btn btn-default" title="Copy error to clipboard" data-bind="click: copyErrorToClipboard">
+                                        <i class="icon-copy-to-clipboard"></i>
+                                    </button>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
     </div>
 </div>
 

--- a/test/SlowTests/Issues/RavenDB-22178.cs
+++ b/test/SlowTests/Issues/RavenDB-22178.cs
@@ -78,7 +78,8 @@ public class RavenDB_22178 : RavenTestBase
             Assert.Equal(1, indexMergeSuggestions.Suggestions.Count);
             Assert.Equal(0, indexMergeSuggestions.Unmergables.Count);
 
-            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[secondIndex.IndexName]);
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors.First(x => x.IndexName == secondIndex.IndexName).Message);
+            Assert.NotNull(indexMergeSuggestions.Errors.First(x => x.IndexName == secondIndex.IndexName).StackTrace);
             Assert.Equal(2, indexMergeSuggestions.Suggestions.First().CanMerge.Count);
             
             Assert.True(indexMergeSuggestions.Suggestions.First().CanMerge.Contains(firstIndex.IndexName));
@@ -111,8 +112,11 @@ public class RavenDB_22178 : RavenTestBase
             Assert.Equal(0, indexMergeSuggestions.Suggestions.Count);
             Assert.Equal(1, indexMergeSuggestions.Unmergables.Count);
 
-            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[firstIndex.IndexName]);
-            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[thirdIndex.IndexName]);
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors.First(x => x.IndexName == firstIndex.IndexName).Message);
+            Assert.NotNull(indexMergeSuggestions.Errors.First(x => x.IndexName == firstIndex.IndexName).StackTrace);
+            
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors.First(x => x.IndexName == thirdIndex.IndexName).Message);
+            Assert.NotNull(indexMergeSuggestions.Errors.First(x => x.IndexName == thirdIndex.IndexName).StackTrace);
             
             Assert.True(indexMergeSuggestions.Unmergables.ContainsKey(secondIndex.IndexName));
         }
@@ -143,9 +147,14 @@ public class RavenDB_22178 : RavenTestBase
             Assert.Equal(0, indexMergeSuggestions.Suggestions.Count);
             Assert.Equal(0, indexMergeSuggestions.Unmergables.Count);
 
-            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[firstIndex.IndexName]);
-            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[secondIndex.IndexName]);
-            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[thirdIndex.IndexName]);
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors.First(x => x.IndexName == firstIndex.IndexName).Message);
+            Assert.NotNull(indexMergeSuggestions.Errors.First(x => x.IndexName == firstIndex.IndexName).StackTrace);
+            
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors.First(x => x.IndexName == secondIndex.IndexName).Message);
+            Assert.NotNull(indexMergeSuggestions.Errors.First(x => x.IndexName == secondIndex.IndexName).StackTrace);
+            
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors.First(x => x.IndexName == thirdIndex.IndexName).Message);
+            Assert.NotNull(indexMergeSuggestions.Errors.First(x => x.IndexName == thirdIndex.IndexName).StackTrace);
         }
     }
 

--- a/test/SlowTests/Issues/RavenDB-22178.cs
+++ b/test/SlowTests/Issues/RavenDB-22178.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Indexes.IndexMerging;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22178 : RavenTestBase
+{
+    private const string ExceptionMessage = "Intentionally caused for testing.";
+    
+    public RavenDB_22178(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task TestThreeIndexesNoMergingErrors()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var firstIndex = new FirstIndex();
+            var secondIndex = new SecondIndex();
+            var thirdIndex = new ThirdIndex();
+            
+            await firstIndex.ExecuteAsync(store);
+            await secondIndex.ExecuteAsync(store);
+            await thirdIndex.ExecuteAsync(store);
+            
+            Indexes.WaitForIndexing(store);
+            
+            var database = await GetDatabase(store.Database);
+
+            var indexMerger = PrepareIndexMerger(database, new List<string>(), ExceptionMessage);
+
+            var indexMergeSuggestions = indexMerger.ProposeIndexMergeSuggestions();
+            
+            Assert.Equal(0, indexMergeSuggestions.Errors.Count);
+            Assert.Equal(1, indexMergeSuggestions.Suggestions.Count);
+            Assert.Equal(0, indexMergeSuggestions.Unmergables.Count);
+            
+            Assert.Equal(3, indexMergeSuggestions.Suggestions.First().CanMerge.Count);
+            
+            Assert.True(indexMergeSuggestions.Suggestions.First().CanMerge.Contains(firstIndex.IndexName));
+            Assert.True(indexMergeSuggestions.Suggestions.First().CanMerge.Contains(secondIndex.IndexName));
+            Assert.True(indexMergeSuggestions.Suggestions.First().CanMerge.Contains(thirdIndex.IndexName));
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task TestThreeIndexesWithMergingError()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var firstIndex = new FirstIndex();
+            var secondIndex = new SecondIndex();
+            var thirdIndex = new ThirdIndex();
+            
+            await firstIndex.ExecuteAsync(store);
+            await secondIndex.ExecuteAsync(store);
+            await thirdIndex.ExecuteAsync(store);
+            
+            Indexes.WaitForIndexing(store);
+            
+            var database = await GetDatabase(store.Database);
+
+            var indexMerger = PrepareIndexMerger(database, new List<string>(){ secondIndex.IndexName }, ExceptionMessage);
+
+            var indexMergeSuggestions = indexMerger.ProposeIndexMergeSuggestions();
+            
+            Assert.Equal(1, indexMergeSuggestions.Errors.Count);
+            Assert.Equal(1, indexMergeSuggestions.Suggestions.Count);
+            Assert.Equal(0, indexMergeSuggestions.Unmergables.Count);
+
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[secondIndex.IndexName]);
+            Assert.Equal(2, indexMergeSuggestions.Suggestions.First().CanMerge.Count);
+            
+            Assert.True(indexMergeSuggestions.Suggestions.First().CanMerge.Contains(firstIndex.IndexName));
+            Assert.True(indexMergeSuggestions.Suggestions.First().CanMerge.Contains(thirdIndex.IndexName));
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task TestThreeIndexesWithTwoMergingErrors()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var firstIndex = new FirstIndex();
+            var secondIndex = new SecondIndex();
+            var thirdIndex = new ThirdIndex();
+            
+            await firstIndex.ExecuteAsync(store);
+            await secondIndex.ExecuteAsync(store);
+            await thirdIndex.ExecuteAsync(store);
+            
+            Indexes.WaitForIndexing(store);
+            
+            var database = await GetDatabase(store.Database);
+
+            var indexMerger = PrepareIndexMerger(database, new List<string>(){ firstIndex.IndexName, thirdIndex.IndexName }, ExceptionMessage);
+
+            var indexMergeSuggestions = indexMerger.ProposeIndexMergeSuggestions();
+            
+            Assert.Equal(2, indexMergeSuggestions.Errors.Count);
+            Assert.Equal(0, indexMergeSuggestions.Suggestions.Count);
+            Assert.Equal(1, indexMergeSuggestions.Unmergables.Count);
+
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[firstIndex.IndexName]);
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[thirdIndex.IndexName]);
+            
+            Assert.True(indexMergeSuggestions.Unmergables.ContainsKey(secondIndex.IndexName));
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task TestThreeIndexesWithThreeMergingErrors()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var firstIndex = new FirstIndex();
+            var secondIndex = new SecondIndex();
+            var thirdIndex = new ThirdIndex();
+            
+            await firstIndex.ExecuteAsync(store);
+            await secondIndex.ExecuteAsync(store);
+            await thirdIndex.ExecuteAsync(store);
+            
+            Indexes.WaitForIndexing(store);
+            
+            var database = await GetDatabase(store.Database);
+
+            var indexMerger = PrepareIndexMerger(database, new List<string>(){ firstIndex.IndexName, secondIndex.IndexName, thirdIndex.IndexName }, ExceptionMessage);
+
+            var indexMergeSuggestions = indexMerger.ProposeIndexMergeSuggestions();
+            
+            Assert.Equal(3, indexMergeSuggestions.Errors.Count);
+            Assert.Equal(0, indexMergeSuggestions.Suggestions.Count);
+            Assert.Equal(0, indexMergeSuggestions.Unmergables.Count);
+
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[firstIndex.IndexName]);
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[secondIndex.IndexName]);
+            Assert.Equal(ExceptionMessage, indexMergeSuggestions.Errors[thirdIndex.IndexName]);
+        }
+    }
+
+    private static IndexMerger PrepareIndexMerger(DocumentDatabase database, List<string> indexNamesToThrowOn, string exceptionMessage)
+    {
+        var dic = new Dictionary<string, IndexDefinition>();
+
+        foreach (var index in database.IndexStore.GetIndexes())
+        {
+            dic[index.Name] = index.GetIndexDefinition();
+        }
+        
+        var indexMerger = new IndexMerger(dic);
+        
+        indexMerger.ForTestingPurposesOnly().IndexNamesToThrowOn = indexNamesToThrowOn;
+        indexMerger.ForTestingPurposesOnly().OnTryMergeSelectExpressionsAndFields = (indexNames, currentIndexName) =>
+        {
+            if (indexNames.Contains(currentIndexName))
+                throw new Exception(exceptionMessage);
+        };
+
+        return indexMerger;
+    }
+    
+    private class FirstIndex : AbstractIndexCreationTask
+    {
+        public override IndexDefinition CreateIndexDefinition()
+        {
+            return new IndexDefinition() { Maps = new HashSet<string>() { "from u in docs.Users\nselect new\n{\n    FirstName = u.Details.FirstName\n}" } };
+        }
+    }
+    
+    private class SecondIndex : AbstractIndexCreationTask
+    {
+        public override IndexDefinition CreateIndexDefinition()
+        {
+            return new IndexDefinition() { Maps = new HashSet<string>() { "from u in docs.Users\nselect new\n{\n    LastName = u.Details.LastName\n}" } };
+        }
+    }
+    
+    private class ThirdIndex : AbstractIndexCreationTask
+    {
+        public override IndexDefinition CreateIndexDefinition()
+        {
+            return new IndexDefinition() { Maps = new HashSet<string>() { "from u in docs.Users\nselect new\n{\n    Age = u.Details.Age\n}" } };
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/Indexing/IndexMerging.cs
+++ b/test/SlowTests/Server/Documents/Indexing/IndexMerging.cs
@@ -374,7 +374,7 @@ select new
             var results = GetMergeReportOfTwoIndexes(index1, index2);
 
             Assert.Equal(0, results.Suggestions.Count);
-            Assert.Equal("Cannot merge indexes that have a where clause", results.Unmergables[index1.Name]);
+            Assert.Equal("Cannot merge indexes that have a where clause.", results.Unmergables[index1.Name]);
         }
 
         [Fact]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22178/ArgumentNullException-in-index-cleanup

### Additional description

This PR introduces two changes:
1. When encountering an exception in `TryMergeSelectExpressionsAndFields()`, we want to mark index we're currently attempting to merge as errored (only in context of index merging) and continue with remaining indexes. Also adjusted the logic to match implemented changes.
2. Index definition containing `ConditionalAccessExpressionSyntax` shouldn't fail to be merged.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
