### PR TITLE
RavenDB-22011 Display if a document is compressed

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -1192,7 +1192,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public (int ActualSize, int AllocatedSize)? GetDocumentMetrics(DocumentsOperationContext context, string id)
+        public (int ActualSize, int AllocatedSize, bool IsCompressed)? GetDocumentMetrics(DocumentsOperationContext context, string id)
         {
             using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
             {
@@ -1202,9 +1202,10 @@ namespace Raven.Server.Documents
                 {
                     return null;
                 }
-                var allocated = table.GetAllocatedSize(tvr.Id);
 
-                return (tvr.Size, allocated);
+                var info = table.GetInfoFor(tvr.Id);
+
+                return (tvr.Size, info.AllocatedSize, info.IsCompressed);
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -791,7 +791,8 @@ namespace Raven.Server.Documents.Handlers
                 [nameof(ActualSize)] = ActualSize,
                 [nameof(HumaneActualSize)] = HumaneActualSize,
                 [nameof(AllocatedSize)] = AllocatedSize,
-                [nameof(HumaneAllocatedSize)] = HumaneAllocatedSize
+                [nameof(HumaneAllocatedSize)] = HumaneAllocatedSize,
+                [nameof(IsCompressed)] = IsCompressed
             };
         }
     }

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -99,7 +99,8 @@ namespace Raven.Server.Documents.Handlers
                     ActualSize = document.Value.ActualSize,
                     HumaneActualSize = Sizes.Humane(document.Value.ActualSize),
                     AllocatedSize = document.Value.AllocatedSize,
-                    HumaneAllocatedSize = Sizes.Humane(document.Value.AllocatedSize)
+                    HumaneAllocatedSize = Sizes.Humane(document.Value.AllocatedSize),
+                    IsCompressed = document.Value.IsCompressed
                 };
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
@@ -780,6 +781,7 @@ namespace Raven.Server.Documents.Handlers
         public string HumaneActualSize { get; set; }
         public int AllocatedSize { get; set; }
         public string HumaneAllocatedSize { get; set; }
+        public bool IsCompressed { get; set; }
 
         public virtual DynamicJsonValue ToJson()
         {

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -156,6 +156,7 @@ class editDocument extends viewModelBase {
     sizeOnDiskActual = ko.observable<string>();
     sizeOnDiskAllocated = ko.observable<string>();
     documentSizeHtml: KnockoutComputed<string>;
+    isCompressed = ko.observable<boolean>(false);
     
     editedDocId: KnockoutComputed<string>;
     displayLastModifiedDate: KnockoutComputed<boolean>;
@@ -540,7 +541,7 @@ class editDocument extends viewModelBase {
                 return `Computed Size: ${this.computedDocumentSize()} KB`;
             }
             
-            const text = `<div class="margin-top-sm margin-bottom-sm"><strong>Document Size on Disk</strong></div> Actual Size: ${this.sizeOnDiskActual()} <br/> Allocated Size: ${this.sizeOnDiskAllocated()}`;
+            const text = `<div class="margin-top-sm margin-bottom-sm"><strong>Document Size on Disk</strong></div> Actual Size: ${this.sizeOnDiskActual()} <br/> Allocated Size: ${this.sizeOnDiskAllocated()} <br/> Compressed: ${this.isCompressed() ? "Yes" : "No"}`;
             const hugeSizeText = this.isHugeDocument() ? `<br /><div class="text-warning bg-warning margin-top margin-bottom">Document is huge</div>` : "";
             
             return text + hugeSizeText;
@@ -1144,6 +1145,7 @@ class editDocument extends viewModelBase {
             .done((size) => {
                 this.sizeOnDiskActual(size.HumaneActualSize);
                 this.sizeOnDiskAllocated(size.HumaneAllocatedSize);
+                this.isCompressed(size.IsCompressed)
             })
             .fail(() => {
                 this.sizeOnDiskActual("Failed to get size");

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -279,6 +279,7 @@
                         <span data-placement="left" data-toggle="tooltip" data-html="true" data-animation="true"
                              data-bind="tooltipText: $root.documentSizeHtml()">
                             <span data-bind="text: $root.computedDocumentSize()"></span>
+                            <i class="icon-documents-compression margin-left-xs" data-bind="visible: $root.isCompressed()"></i>
                             <i class="icon-warning text-warning margin-left-xs" data-bind="visible: $root.isHugeDocument"></i>
                         </span>
                     </dd>

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -315,22 +315,23 @@ namespace Voron.Data.Tables
             return internalScope;
         }
 
-        public int GetAllocatedSize(long id)
+        public (int AllocatedSize, bool IsCompressed) GetInfoFor(long id)
         {
             var posInPage = id % Constants.Storage.PageSize;
-            if (posInPage == 0) // large
+            if (posInPage == 0) // large value
             {
                 var page = _tx.LowLevelTransaction.GetPage(id / Constants.Storage.PageSize);
 
                 var allocated = VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(page.OverflowSize);
 
-                return allocated * Constants.Storage.PageSize;
+                return (allocated * Constants.Storage.PageSize, page.Flags.HasFlag(PageFlags.Compressed));
             }
 
             // here we rely on the fact that RawDataSmallSection can
             // read any RawDataSmallSection piece of data, not just something that
             // it exists in its own section, but anything from other sections as well
-            return RawDataSection.GetRawDataEntrySizeFor(_tx.LowLevelTransaction, id)->AllocatedSize;
+            var sizes = RawDataSection.GetRawDataEntrySizeFor(_tx.LowLevelTransaction, id);
+            return (sizes->AllocatedSize, sizes->IsCompressed);
         }
 
         public long Update(long id, TableValueBuilder builder, bool forceUpdate = false)

--- a/test/FastTests/Voron/Tables/Compression.cs
+++ b/test/FastTests/Voron/Tables/Compression.cs
@@ -59,7 +59,9 @@ namespace FastTests.Voron.Tables
                     builder.Add(Bits.SwapBytes(number));
                     builder.Add(val);
                     long id = itemsTable.Insert(builder);
-                    firstAllocatedSize = itemsTable.GetAllocatedSize(id);
+                    var info = itemsTable.GetInfoFor(id);
+                    firstAllocatedSize = info.AllocatedSize;
+                    Assert.True(info.IsCompressed);
                 }
 
                 var minAllocatedSize = 0;
@@ -73,8 +75,9 @@ namespace FastTests.Voron.Tables
                         builder.Add(Bits.SwapBytes(++number));
                         builder.Add(val);
                         long id = itemsTable.Insert(builder);
-                        var allocatedSize = itemsTable.GetAllocatedSize(id);
-                        minAllocatedSize = Math.Min(minAllocatedSize, allocatedSize);
+                        var info = itemsTable.GetInfoFor(id);
+                        minAllocatedSize = Math.Min(minAllocatedSize, info.AllocatedSize);
+                        Assert.True(info.IsCompressed);
                     }
                 }
 
@@ -116,8 +119,9 @@ namespace FastTests.Voron.Tables
                     builder.Add(Bits.SwapBytes(number));
                     builder.Add(val);
                     long id = itemsTable.Insert(builder);
-                    var allocatedSize = itemsTable.GetAllocatedSize(id);
-                    Assert.True(allocatedSize < 128);
+                    var info = itemsTable.GetInfoFor(id);
+                    Assert.True(info.AllocatedSize < 128);
+                    Assert.True(info.IsCompressed);
                 }
 
                 using (Slice.From(tx.Allocator, "val1", out var key))
@@ -174,8 +178,9 @@ namespace FastTests.Voron.Tables
                     builder.Add(Bits.SwapBytes(number));
                     builder.Add(val);
                     long id = itemsTable.Insert(builder);
-                    var allocatedSize = itemsTable.GetAllocatedSize(id);
-                    Assert.True(allocatedSize < 128);
+                    var info = itemsTable.GetInfoFor(id);
+                    Assert.True(info.AllocatedSize < 128);
+                    Assert.True(info.IsCompressed);
                 }
 
                 using (itemsTable.Allocate(out TableValueBuilder builder))
@@ -191,8 +196,9 @@ namespace FastTests.Voron.Tables
                 using (Slice.From(tx.Allocator, "val1", out var key))
                 {
                     Assert.True(itemsTable.ReadByKey(key, out var reader));
-                    Assert.True(itemsTable.GetAllocatedSize(reader.Id) < 128);
-
+                    var info = itemsTable.GetInfoFor(reader.Id);
+                    Assert.True(info.AllocatedSize < 128);
+                    Assert.True(info.IsCompressed);
                 }
             }
         }
@@ -235,8 +241,9 @@ namespace FastTests.Voron.Tables
                     builder.Add(Bits.SwapBytes(number));
                     builder.Add(val);
                     long id = itemsTable.Insert(builder);
-                    long allocatedSize = itemsTable.GetAllocatedSize(id);
-                    Assert.True(allocatedSize > 8192 && allocatedSize < str.Length);
+                    var info = itemsTable.GetInfoFor(id);
+                    Assert.True(info.AllocatedSize > 8192 && info.AllocatedSize < str.Length);
+                    Assert.True(info.IsCompressed);
                 }
 
                 using (Slice.From(tx.Allocator, "val1", out var key))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22011/Display-if-a-document-is-compressed

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
