### PR TITLE
RavenDB-22226 - Fix updating value in dynamic index

### DIFF
--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -654,19 +654,9 @@ namespace Voron.Data.Tables
                 using (dynamicKeyIndexDef.GetValue(_tx, ref value, out Slice val))
                 {
                     dynamicKeyIndexDef.OnIndexEntryChanged(_tx, val, oldValue: ref value, newValue: ref TableValueReaderUtils.EmptyReader);
+
                     var tree = GetTree(dynamicKeyIndexDef);
-
-                    if (dynamicKeyIndexDef.SupportDuplicateKeys == false)
-                    {
-                        tree.Delete(val);
-                        continue;
-                    }
-
-                    var fst = GetFixedSizeTree(tree, val.Clone(_tx.Allocator), 0, dynamicKeyIndexDef.IsGlobal);
-                    if (fst.Delete(id).NumberOfEntriesDeleted == 0)
-                    {
-                        ThrowInvalidAttemptToRemoveValueFromIndexAndNotFindingIt(id, dynamicKeyIndexDef.Name);
-                    }
+                    RemoveValueFromDynamicIndex(id, dynamicKeyIndexDef, tree, val);
                 }
             }
 
@@ -954,7 +944,7 @@ namespace Voron.Data.Tables
                             forceUpdate)
                         {
                             var indexTree = GetTree(dynamicKeyIndexDef);
-                            indexTree.Delete(oldVal);
+                            RemoveValueFromDynamicIndex(id, dynamicKeyIndexDef, indexTree, oldVal);
 
                             AddValueToDynamicIndex(id, dynamicKeyIndexDef, indexTree, newVal, TreeNodeFlags.Data);
                         }
@@ -990,6 +980,22 @@ namespace Voron.Data.Tables
             {
                 var index = GetFixedSizeTree(indexTree, newVal, 0, dynamicKeyIndexDef.IsGlobal);
                 index.Add(id);
+            }
+        }
+
+        private void RemoveValueFromDynamicIndex(long id, DynamicKeyIndexDef dynamicKeyIndexDef, Tree tree, Slice val)
+        {
+            if (dynamicKeyIndexDef.SupportDuplicateKeys == false)
+            {
+                tree.Delete(val);
+            }
+            else
+            {
+                var fst = GetFixedSizeTree(tree, val.Clone(_tx.Allocator), 0, dynamicKeyIndexDef.IsGlobal);
+                if (fst.Delete(id).NumberOfEntriesDeleted == 0)
+                {
+                    ThrowInvalidAttemptToRemoveValueFromIndexAndNotFindingIt(id, dynamicKeyIndexDef.Name);
+                }
             }
         }
 

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -955,10 +955,8 @@ namespace Voron.Data.Tables
                         {
                             var indexTree = GetTree(dynamicKeyIndexDef);
                             indexTree.Delete(oldVal);
-                            using (indexTree.DirectAdd(newVal, sizeof(long), TreeNodeFlags.Data, out var ptr))
-                            {
-                                *(long*)ptr = id;
-                            }
+
+                            AddValueToDynamicIndex(id, dynamicKeyIndexDef, indexTree, newVal, TreeNodeFlags.Data);
                         }
                     }
                 }
@@ -976,6 +974,22 @@ namespace Voron.Data.Tables
                             ThrowInvalidDuplicateFixedSizeTreeKey(newKey, indexDef);
                     }
                 }
+            }
+        }
+
+        private void AddValueToDynamicIndex(long id, DynamicKeyIndexDef dynamicKeyIndexDef, Tree indexTree, Slice newVal, TreeNodeFlags flags)
+        {
+            if (dynamicKeyIndexDef.SupportDuplicateKeys == false)
+            {
+                using (indexTree.DirectAdd(newVal, sizeof(long), flags, out var ptr))
+                {
+                    *(long*)ptr = id;
+                }
+            }
+            else
+            {
+                var index = GetFixedSizeTree(indexTree, newVal, 0, dynamicKeyIndexDef.IsGlobal);
+                index.Add(id);
             }
         }
 
@@ -1085,18 +1099,7 @@ namespace Voron.Data.Tables
                         dynamicKeyIndexDef.OnIndexEntryChanged(_tx, dynamicKey, oldValue: ref TableValueReaderUtils.EmptyReader, newValue: ref value);
                         
                         var dynamicIndex = GetTree(dynamicKeyIndexDef);
-                        if (dynamicKeyIndexDef.SupportDuplicateKeys == false)
-                        {
-                            using (dynamicIndex.DirectAdd(dynamicKey, sizeof(long), TreeNodeFlags.Data | TreeNodeFlags.NewOnly, out var ptr))
-                            {
-                                *(long*)ptr = id;
-                            }
-
-                            continue;
-                        }
-
-                        var index = GetFixedSizeTree(dynamicIndex, dynamicKey, 0, dynamicKeyIndexDef.IsGlobal);
-                        index.Add(id);
+                        AddValueToDynamicIndex(id, dynamicKeyIndexDef, dynamicIndex, dynamicKey, TreeNodeFlags.Data | TreeNodeFlags.NewOnly);
                     }
                 }
 

--- a/test/FastTests/Voron/Tables/RavenDB_22226.cs
+++ b/test/FastTests/Voron/Tables/RavenDB_22226.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Sparrow.Server;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data.Tables;
 using Voron.Impl;
@@ -25,12 +27,13 @@ namespace FastTests.Voron.Tables
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanInsertUpdateThenReadByDynamic()
         {
             using (var tx = Env.WriteTransaction())
             {
                 Slice.From(tx.Allocator, "RevisionsChangeVector", ByteStringType.Immutable, out var changeVectorSlice);
+                Slice.From(tx.Allocator, "DocumentsChangeVector", ByteStringType.Immutable, out var documentsSlice);
                 Slice.From(tx.Allocator, "Etag", ByteStringType.Immutable, out var etag);
                 var revisionsSchema = new TableSchema();
                 revisionsSchema.DefineKey(new TableSchema.IndexDef
@@ -43,46 +46,83 @@ namespace FastTests.Voron.Tables
                 var index = new TableSchema.DynamicKeyIndexDef { IsGlobal = true, GenerateKey = IndexCvEtagKeyGenerator, Name = IndexName, SupportDuplicateKeys = true };
                 revisionsSchema.DefineIndex(index);
 
-                var cv = Guid.NewGuid().ToString();
+                var cv1 = Guid.NewGuid().ToString();
+                var cv2 = Guid.NewGuid().ToString();
+                var cv3 = Guid.NewGuid().ToString();
+                var shared = Guid.NewGuid().ToString();
 
                 revisionsSchema.Create(tx, "users", 32);
 
                 var usersTbl = tx.OpenTable(revisionsSchema, "users");
 
-                using (usersTbl.Allocate(out var builder))
-                using (Slice.From(tx.Allocator, cv, out var key))
-                {
-                    builder.Add(key);
-                    builder.Add(0L);
-
-                    usersTbl.Insert(builder);
-                }
+                PopulateTable(tx, usersTbl, cv1, shared, 0L);
+                PopulateTable(tx, usersTbl, cv2, shared, 0L);
+                PopulateTable(tx, usersTbl, cv3, shared, 228L);
 
                 using (usersTbl.Allocate(out var builder))
-                using (Slice.From(tx.Allocator, cv, out var key))
+                using (Slice.From(tx.Allocator, cv1, out var key))
                 {
                     usersTbl.ReadByKey(key, out var tvr);
+                    var ptr = tvr.Read(1, out int size);
+                    using var x = Slice.From(tx.Allocator, ptr, size, ByteStringType.Immutable, out var sharedSlice);
+
                     builder.Add(key);
+                    builder.Add(sharedSlice);
                     builder.Add(322L);
                     usersTbl.Update(tvr.Id, builder);
                 }
 
+                var results = new List<(string key, string shared, long etag)>();
                 foreach (var x in usersTbl.SeekForwardFrom(index, Slices.BeforeAllKeys, 0))
                 {
-                    var cv1 = x.Result.Reader.ReadString(0);
-                    var etag1 = x.Result.Reader.ReadLong(1);
-
-                    Assert.Equal(cv, cv1);
-                    Assert.Equal(322, etag1);
+                    results.Add((x.Result.Reader.ReadString(0), x.Result.Reader.ReadString(1), x.Result.Reader.ReadLong(2)));
                 }
+
+                //Assert results
+                Assert.Equal(3, results.Count);
+
+                Assert.Contains(results, x=> x.key == cv1 && x.shared == shared && x.etag == 322L);
+                Assert.Contains(results, x=> x.key == cv2 && x.shared == shared && x.etag == 0L);
+                Assert.Contains(results, x=> x.key == cv3 && x.shared == shared && x.etag == 228L);
+
+                using (Slice.From(tx.Allocator, cv1, out var key))
+                {
+                    usersTbl.ReadByKey(key, out var tvr);
+                    usersTbl.Delete(tvr.Id);
+                }
+
+                results = new List<(string key, string shared, long etag)>();
+                foreach (var x in usersTbl.SeekForwardFrom(index, Slices.BeforeAllKeys, 0))
+                {
+                    results.Add((x.Result.Reader.ReadString(0), x.Result.Reader.ReadString(1), x.Result.Reader.ReadLong(2)));
+                }
+
+                //Assert results
+                Assert.Equal(2, results.Count);
+                Assert.Contains(results, x => x.key == cv2 && x.shared == shared && x.etag == 0L);
+                Assert.Contains(results, x => x.key == cv3 && x.shared == shared && x.etag == 228L);
+            }
+        }
+
+        private void PopulateTable(Transaction tx, Table usersTbl, string cv, string shared, long etag)
+        {
+            using (usersTbl.Allocate(out var builder))
+            using (Slice.From(tx.Allocator, cv, out var key))
+            using (Slice.From(tx.Allocator, shared, out var sharedSlice))
+            {
+                builder.Add(key);
+                builder.Add(sharedSlice);
+                builder.Add(etag);
+
+                usersTbl.Insert(builder);
             }
         }
 
         [StorageIndexEntryKeyGenerator]
         internal static ByteStringContext.Scope IndexCvEtagKeyGenerator(Transaction tx, ref TableValueReader tvr, out Slice slice)
         {
-            var cvPtr = tvr.Read(0, out var cvSize);
-            var etag = tvr.ReadLong(1);
+            var cvPtr = tvr.Read(1, out var cvSize);
+            var etag = tvr.ReadLong(2);
 
             var scope = tx.Allocator.Allocate(sizeof(long) + cvSize, out var buffer);
 
@@ -93,7 +133,5 @@ namespace FastTests.Voron.Tables
             slice = new Slice(buffer);
             return scope;
         }
-
-
     }
 }

--- a/test/FastTests/Voron/Tables/RavenDB_22226.cs
+++ b/test/FastTests/Voron/Tables/RavenDB_22226.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+using Voron.Impl;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron.Tables
+{
+    public unsafe class RavenDB_22226 : TableStorageTest
+    {
+        public static readonly Slice IndexName;
+
+        public RavenDB_22226(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        static RavenDB_22226()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "DynamicKeyIndex", ByteStringType.Immutable, out IndexName);
+            }
+        }
+
+        [Fact]
+        public void CanInsertUpdateThenReadByDynamic()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                Slice.From(tx.Allocator, "RevisionsChangeVector", ByteStringType.Immutable, out var changeVectorSlice);
+                Slice.From(tx.Allocator, "Etag", ByteStringType.Immutable, out var etag);
+                var revisionsSchema = new TableSchema();
+                revisionsSchema.DefineKey(new TableSchema.IndexDef
+                {
+                    StartIndex = 0,
+                    Count = 1,
+                    Name = changeVectorSlice,
+                    IsGlobal = false
+                });
+                var index = new TableSchema.DynamicKeyIndexDef { IsGlobal = true, GenerateKey = IndexCvEtagKeyGenerator, Name = IndexName, SupportDuplicateKeys = true };
+                revisionsSchema.DefineIndex(index);
+
+                var cv = Guid.NewGuid().ToString();
+
+                revisionsSchema.Create(tx, "users", 32);
+
+                var usersTbl = tx.OpenTable(revisionsSchema, "users");
+
+                using (usersTbl.Allocate(out var builder))
+                using (Slice.From(tx.Allocator, cv, out var key))
+                {
+                    builder.Add(key);
+                    builder.Add(0L);
+
+                    usersTbl.Insert(builder);
+                }
+
+                using (usersTbl.Allocate(out var builder))
+                using (Slice.From(tx.Allocator, cv, out var key))
+                {
+                    usersTbl.ReadByKey(key, out var tvr);
+                    builder.Add(key);
+                    builder.Add(322L);
+                    usersTbl.Update(tvr.Id, builder);
+                }
+
+                foreach (var x in usersTbl.SeekForwardFrom(index, Slices.BeforeAllKeys, 0))
+                {
+                    var cv1 = x.Result.Reader.ReadString(0);
+                    var etag1 = x.Result.Reader.ReadLong(1);
+
+                    Assert.Equal(cv, cv1);
+                    Assert.Equal(322, etag1);
+                }
+            }
+        }
+
+        [StorageIndexEntryKeyGenerator]
+        internal static ByteStringContext.Scope IndexCvEtagKeyGenerator(Transaction tx, ref TableValueReader tvr, out Slice slice)
+        {
+            var cvPtr = tvr.Read(0, out var cvSize);
+            var etag = tvr.ReadLong(1);
+
+            var scope = tx.Allocator.Allocate(sizeof(long) + cvSize, out var buffer);
+
+            var span = new Span<byte>(buffer.Ptr, buffer.Length);
+            MemoryMarshal.AsBytes(new Span<long>(ref etag)).CopyTo(span);
+            new ReadOnlySpan<byte>(cvPtr, cvSize).CopyTo(span[sizeof(long)..]);
+
+            slice = new Slice(buffer);
+            return scope;
+        }
+
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22226

### Additional description

in case of updating the dynamic index with `SupportDuplicateKeys` we should add values to `FixedSizeTree`  but it was adding directly using `DirectAdd` 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
