### PR TITLE
RavenDB-22183 / RavenDB-10493 Fixing translation of DateTime.MaxValue to JS date when building RQL with JS projection

### DIFF
--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -1646,7 +1646,7 @@ namespace Raven.Client.Util
                         break;
 
                     case "MaxValue":
-                        writer.Write("new Date(253402297199999)");
+                        writer.Write("new Date(253402300799999)");
                         break;
 
                     case "Now":

--- a/test/SlowTests/Issues/RavenDB-10493.cs
+++ b/test/SlowTests/Issues/RavenDB-10493.cs
@@ -43,7 +43,7 @@ namespace SlowTests.Issues
                                 };
 
                     var expectedQuery =
-                        $"declare function output(x) {{{Environment.NewLine}\tvar test = 1;{Environment.NewLine}\treturn {{ DateTime : x.DateTime, DateTimeMinValue : new Date(-62135596800000), DateTimeMaxValue : new Date(253402297199999) }};{Environment.NewLine}}}{Environment.NewLine}from 'Articles' as x select output(x)";
+                        $"declare function output(x) {{{Environment.NewLine}\tvar test = 1;{Environment.NewLine}\treturn {{ DateTime : x.DateTime, DateTimeMinValue : new Date(-62135596800000), DateTimeMaxValue : new Date(253402300799999) }};{Environment.NewLine}}}{Environment.NewLine}from 'Articles' as x select output(x)";
 
                     Assert.Equal(expectedQuery, query.ToString());
 
@@ -51,8 +51,7 @@ namespace SlowTests.Issues
 
                     Assert.Equal(DateTime.MinValue, result[0].DateTimeMinValue);
 
-                    // Only missing 0.9999 ms, but with additional timezone
-                    var epsilon = 1 + Math.Abs((DateTime.UtcNow - DateTime.Now).TotalSeconds); // Lower than 1 ms
+                    var epsilon = 0.001; // Only missing 0.0009999 ms due to the precision of JS Date implementation
                     var val = (DateTime.MaxValue - result[0].DateTimeMaxValue).TotalSeconds;
                     Assert.True(Math.Abs(val) < epsilon, $"Math.Abs({val}) < ({epsilon})");
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22183/CanTranslateDateTimeMinValueMaxValue-fails-when-run-on-UTC0000

Relates to: https://issues.hibernatingrhinos.com/issue/RavenDB-10493/Linq-to-RQL-DateTime.MinValue-MaxValue

### Additional description

We have found recently that `RavenDB_10493.CanTranslateDateTimeMinValueMaxValue` test fails _consistently_ on machines which have time zone set to UTC+00:00:

```
Math.Abs(3600.0009999) < (1.0000002)
Expected: True
Actual:   False
```

After the investigation it appeared that the ticks value provided here:
https://github.com/ravendb/ravendb/pull/5438/files#diff-061a975a775a0a6ce3bf677cfd6f74822425ca320b4efd237acb828a497a8fa6R997

was off by 1 hour:

https://github.com/ravendb/ravendb/blob/2715b366a2f934b1f351c2a8ed4effc434bb2a66/src/Raven.Client/Util/JavascriptConversionExtensions.cs#L1648-L1650

- C#
  - `DateTime.MaxValue` -> "9999-12-31T23:59:59.9999999"

- What we had:
  - new Date(253402297199999) -> "9999-12-31T22:59:59.9990000Z" (note **22:59:59** instead of **23:59:59**)
  
- What we'll have:
  -   new Date(253402300799999) -> "9999-12-31T23:59:59.9990000Z" 

#### Why it didn't fail earlier?

Because the assertion that we had with epsilon (necessary for lower precision of dates in JS) was also adding the time zone difference:

https://github.com/ravendb/ravendb/blob/2715b366a2f934b1f351c2a8ed4effc434bb2a66/test/SlowTests/Issues/RavenDB-10493.cs#L54-L55

According to description in https://github.com/ravendb/ravendb/pull/5438

> MaxValue is off by timezone + 0.9999ms

This made that instead of 1 sec tolerance when comparing `DateTime.MaxValue` with value returned from projection we added 3600 sec when running in UTC+1. 7200 sec in UTC+2 etc. This made that assertion was always passing - except when running on UTC+0.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate - see "Backward compatibility" below
- [ ] High
- [ ] Not relevant

### Backward compatibility

I'm concerned whether that might be a breaking change for someone. We were never returning a correct value so we might treat it as a regular bug fix.

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Verified by existing test

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
