### PR TITLE
RavenDB-21818 MultiSortingMatch - allow to use score as secondary comparer.

### DIFF
--- a/src/Corax/Mappings/FieldMetadata.cs
+++ b/src/Corax/Mappings/FieldMetadata.cs
@@ -16,7 +16,7 @@ public readonly struct FieldMetadata
     public readonly Analyzer Analyzer;
     public readonly bool HasBoost;
 
-    private FieldMetadata(Slice fieldName, Slice termLengthSumName, int fieldId, FieldIndexingMode mode, Analyzer analyzer, bool hasBoost = false)
+    private FieldMetadata(Slice fieldName, Slice termLengthSumName, int fieldId, FieldIndexingMode mode, Analyzer analyzer, bool hasBoost)
     {
         TermLengthSumName = termLengthSumName;
         FieldName = fieldName;
@@ -41,7 +41,7 @@ public readonly struct FieldMetadata
         else
             throw new NotSupportedException(typeof(T).FullName);
         
-        return new FieldMetadata(numericTree, default, FieldId, Mode, Analyzer);
+        return new FieldMetadata(numericTree, default, FieldId, Mode, Analyzer, HasBoost);
     }
 
     internal Slice GetPhraseQueryContainerName(ByteStringContext alloc)

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -186,8 +186,6 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         {
             Debug.Assert(_comparerId != 0, "_comparerId != 0");
             return _scores[y].CompareTo(_scores[x]);
-            
-            throw new NotSupportedException(ScoreComparerAsInnerExceptionMessage);
         }
     }
 

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Helpers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Helpers.cs
@@ -113,6 +113,10 @@ public unsafe partial struct SortingMultiMatch<TInner>
             else
                 indexes.Sort(new IndirectComparer<Descending<TComparer1>, TComparer2, TComparer3>(ref match, batchTerms, new(comparer1), comparer2, comparer3, true));
 
+            
+            // Support for including scores in the projection in case the score comparer is not first. 
+            // We only have one chance to copy in the right order before pagination happens
+            // (because we'll lose reference to the buffer holder (the comparer)). 
             if (typeof(TComparer1) != typeof(EntryComparerByScore) || typeof(TComparer1) != typeof(Descending<EntryComparerByScore>))
             {
                 if (match._sortingDataTransfer.IncludeScores && match._scoreBufferHandler != null)

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Helpers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Helpers.cs
@@ -47,6 +47,10 @@ public unsafe partial struct SortingMultiMatch<TInner>
             (MatchCompareFieldType.Spatial, false) => SortBy<TComparer1, Descending<EntryComparerBySpatial>>(orderMetadata),
             (MatchCompareFieldType.Alphanumeric, true) => SortBy<TComparer1, EntryComparerByTermAlphaNumeric>(orderMetadata),
             (MatchCompareFieldType.Alphanumeric, false) => SortBy<TComparer1, Descending<EntryComparerByTermAlphaNumeric>>(orderMetadata),
+            
+            (MatchCompareFieldType.Score, true) => SortBy<TComparer1, EntryComparerByScore>(orderMetadata),
+            (MatchCompareFieldType.Score, false) => SortBy<TComparer1, Descending<EntryComparerByScore>>(orderMetadata),
+            
             _ => &Fill<TComparer1, NullComparer, NullComparer>
         };
     }
@@ -70,6 +74,9 @@ public unsafe partial struct SortingMultiMatch<TInner>
             (MatchCompareFieldType.Spatial, false) => &Fill<TComparer1, TComparer2, Descending<EntryComparerBySpatial>>,
             (MatchCompareFieldType.Alphanumeric, true) => &Fill<TComparer1, TComparer2, EntryComparerByTermAlphaNumeric>,
             (MatchCompareFieldType.Alphanumeric, false) => &Fill<TComparer1, TComparer2, Descending<EntryComparerByTermAlphaNumeric>>,
+            (MatchCompareFieldType.Score, true) => &Fill<TComparer1, TComparer2, EntryComparerByScore>,
+            (MatchCompareFieldType.Score, false) => &Fill<TComparer1, TComparer2, Descending<EntryComparerByScore>>,
+            
             _ => &Fill<TComparer1, TComparer2, NullComparer>
         };
     }
@@ -89,7 +96,7 @@ public unsafe partial struct SortingMultiMatch<TInner>
             }
 
             IndirectSort(ref match, indexes, batchTerms, comparer1, comparer2, comparer3);
-
+            
             return indexes;
         }
 
@@ -106,6 +113,20 @@ public unsafe partial struct SortingMultiMatch<TInner>
             else
                 indexes.Sort(new IndirectComparer<Descending<TComparer1>, TComparer2, TComparer3>(ref match, batchTerms, new(comparer1), comparer2, comparer3, true));
 
+            if (typeof(TComparer1) != typeof(EntryComparerByScore) || typeof(TComparer1) != typeof(Descending<EntryComparerByScore>))
+            {
+                if (match._sortingDataTransfer.IncludeScores && match._scoreBufferHandler != null)
+                {
+                    match._scoresResults.EnsureCapacityFor(indexes.Length);
+                    foreach (var t in indexes)
+                        match._scoresResults.AddByRefUnsafe() = match._secondaryScoreBuffer[t];
+
+                    match._secondaryScoreBuffer = default;
+                    match._scoreBufferHandler.Dispose();
+                    match._scoreBufferHandler = null;
+                }
+                
+            }
         }
     }
 }

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.cs
@@ -10,8 +10,6 @@ using Corax.Utils;
 using Corax.Utils.Spatial;
 using Sparrow;
 using Sparrow.Server;
-using Voron;
-using Voron.Data.PostingLists;
 using Voron.Util;
 
 namespace Corax.Querying.Matches.SortingMatches;
@@ -37,6 +35,11 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
     private SortingDataTransfer _sortingDataTransfer;
     private ContextBoundNativeList<SpatialResult> _distancesResults;
     private ContextBoundNativeList<float> _scoresResults;
+    
+    // This is data persisted for holding score from secondary comparer.
+    private UnmanagedSpan<float> _secondaryScoreBuffer;
+    private IDisposable _scoreBufferHandler;
+    
     private int _alreadyReadIdx;
 
 
@@ -53,7 +56,6 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         _alreadyReadIdx = 0;
         _results = new ContextBoundNativeList<long>(searcher.Allocator);
         TotalResults = NotStarted;
-        AssertNoScoreInnerComparer(orderMetadata);
         _fillFunc = SortBy(orderMetadata);
         
         _nextComparers = orderMetadata.Length > NextComparerOffset 
@@ -82,6 +84,10 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
                     
                     (true, MatchCompareFieldType.Spatial) => new EntryComparerBySpatial(),
                     (false, MatchCompareFieldType.Spatial) => new Descending<EntryComparerBySpatial>(),
+                    
+                    (true, MatchCompareFieldType.Score) => new EntryComparerByScore(),
+                    (false, MatchCompareFieldType.Score) => new Descending<EntryComparerByScore>(),
+                    
                     _ => throw new NotSupportedException($"Ascending: {orderMetadata[metadataId].Ascending} | FieldType: {orderMetadata[metadataId].FieldType}.")
                 };
             }
@@ -97,21 +103,6 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             _distancesResults = new(_searcher.Allocator);
         if (sortingDataTransfer.IncludeScores)
             _scoresResults = new(_searcher.Allocator);
-    }
-
-    private void AssertNoScoreInnerComparer(in OrderMetadata[] orderMetadata)
-    {
-        //In Corax's implementation of ranking, we assume that the IDs in the `Score()` parameter are sorted.
-        //This way, we can perform a BinarySearch to find the pair <Entry, Score> and append the score to it.
-        //In the case of compound sorting, when boosting is not the main comparator, matches are not sorted because the previous comparator may have changed the order.
-        //This would require a linear search, which can be extremely costly. Additionally, this would require changing the API of Scoring to indicate whether it's ordered or not.
-        for (int comparerId = 0; comparerId < orderMetadata.Length; ++comparerId)
-        {
-            if (orderMetadata[comparerId].FieldType is MatchCompareFieldType.Score && comparerId != 0)
-            {
-                throw new NotSupportedException(ScoreComparerAsInnerExceptionMessage);
-            }
-        }
     }
 
     private static int Fill<TComparer1, TComparer2, TComparer3>(ref SortingMultiMatch<TInner> match, Span<long> matches)
@@ -142,7 +133,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         var read = match._results.CopyTo(matches, match._alreadyReadIdx);
         match._distancesResults.CopyTo(match._sortingDataTransfer.DistancesBuffer, match._alreadyReadIdx, read);
         match._scoresResults.CopyTo(match._sortingDataTransfer.ScoresBuffer, match._alreadyReadIdx, read);
-
+        
         if (read != 0)
         {
             match._alreadyReadIdx += read;
@@ -155,7 +146,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         match._scoresResults.Dispose();
         match._distancesResults.Dispose();
         match._entriesBufferScope.Dispose();
-
+        
         return 0;
     }
     

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.cs
@@ -251,5 +251,4 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
     }
 
     string DebugView => Inspect().ToString();
-    private static string ScoreComparerAsInnerExceptionMessage => $"{nameof(SortingMultiMatch)} can compare score only as main property. Queries like 'order by Field, [..], score(), [..] ' etc are not supported.";
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -81,10 +80,25 @@ public static class CoraxQueryBuilder
             DynamicFields = HasDynamics
                 ? new Lazy<List<string>>(() => IndexSearcher.GetFields())
                 : null;
+            
+            // in case when we've implicit boosting we've build primitives with scoring enabled
             HasBoost = index.HasBoostedFields || query.Metadata.HasBoost ||
-                       (index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved && query.Metadata.OrderBy?.Count(x => x.OrderingType == OrderByFieldType.Score) > 0); // in case when we've implicit boosting we've build primitives with scoring enabled
+                       (index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved && 
+                        HasBoostingAsOrderingType(query.Metadata.OrderBy)); 
             Allocator = allocator;
             IndexReadOperation = indexReadOperation;
+        }
+
+        private static bool HasBoostingAsOrderingType(OrderByField[] orderBy)
+        {
+            if (orderBy is null)
+                return false;
+            
+            foreach (var field in orderBy)
+                if (field.OrderingType == OrderByFieldType.Score)
+                    return true;
+
+            return false;
         }
     }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -81,7 +82,7 @@ public static class CoraxQueryBuilder
                 ? new Lazy<List<string>>(() => IndexSearcher.GetFields())
                 : null;
             HasBoost = index.HasBoostedFields || query.Metadata.HasBoost ||
-                       (index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved && query.Metadata.OrderBy is [{OrderingType: OrderByFieldType.Score} _, ..]); // in case when we've implicit boosting we've build primitives with scoring enabled
+                       (index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved && query.Metadata.OrderBy?.Count(x => x.OrderingType == OrderByFieldType.Score) > 0); // in case when we've implicit boosting we've build primitives with scoring enabled
             Allocator = allocator;
             IndexReadOperation = indexReadOperation;
         }

--- a/test/SlowTests/Corax/IncludeScoresAndDistancesCorax.cs
+++ b/test/SlowTests/Corax/IncludeScoresAndDistancesCorax.cs
@@ -78,6 +78,8 @@ public class IncludeScoresAndDistancesCorax : RavenTestBase
     {
         // The tests in this file were designed for a pageSize of 4096. In case the default buffer has changed, please update the number of documents above that limit.
         // These tests need to call .Fill at least twice to ensure that distances/scores can be transferred from Corax to Raven in a streaming manner.
+        //Required also for:
+        //-RavenDB-21818
 
         Type type = typeof(Raven.Server.Documents.Indexes.Persistence.IndexOperationBase);
         FieldInfo field = type.GetField("DefaultBufferSizeForCorax",

--- a/test/SlowTests/Corax/RavenDB_21818.cs
+++ b/test/SlowTests/Corax/RavenDB_21818.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq.Indexing;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_21818 : RavenTestBase
+{
+    public RavenDB_21818(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void ScoreAsSecondaryComparer()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenSession();
+        session.Store(new Dto(1, new []{1, 1}, "Maciej", 2));
+        session.Store(new Dto(1, new []{1, 1, 1}, "Maciej", 1));
+        session.SaveChanges();
+
+        var results = session.Advanced.DocumentQuery<Dto>()
+            .WaitForNonStaleResults()
+            .WhereEquals(nameof(Dto.Numbers), 1)
+            .AndAlso()
+            .WhereEquals(x => x.Name, "maciej")
+            .OrderBy(x => x.SomeNum)
+            .OrderByScore()
+            .ToList();
+        
+        Assert.Equal(2, results.Count);
+        Assert.Equal(1, results[0].ExpectedOrder);
+        Assert.Equal(2, results[1].ExpectedOrder);
+    }
+    
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void ScoreAsBoxedComparer()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenSession();
+        session.Store(new Dto(1, new []{1, 1}, "Maciej", 2));
+        session.Store(new Dto(1, new []{1, 1, 1}, "Maciej", 1));
+        session.SaveChanges();
+
+        var results = session.Advanced.DocumentQuery<Dto>()
+            .WaitForNonStaleResults()
+            .WhereEquals(nameof(Dto.Numbers), 1)
+            .AndAlso()
+            .WhereEquals(x => x.Name, "maciej")
+            .OrderBy(x => x.SomeNum)
+            .OrderBy(x => x.Name)
+            .OrderBy(x => x.SomeNum)
+            .OrderByScore()
+            .ToList();
+        
+        Assert.Equal(2, results.Count);
+        Assert.Equal(1, results[0].ExpectedOrder);
+        Assert.Equal(2, results[1].ExpectedOrder);
+    }
+    
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void ScoreAsSecondaryComparerWithIndexBoost()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenSession();
+        session.Store(new Dto(1, new []{1, 1, 1}, "Maciej", 2));
+        session.Store(new Dto(1, new []{1, 1}, "Maciej", 1));
+        session.SaveChanges();
+
+        var index = new Index();
+        index.Execute(store);
+        
+        var results = session.Advanced.DocumentQuery<Dto>(indexName: index.IndexName)
+            .WaitForNonStaleResults()
+            .WhereEquals(nameof(Dto.Numbers), 1)
+            .AndAlso()
+            .WhereEquals(x => x.Name, "maciej")
+            .OrderBy(x => x.SomeNum)
+            .OrderByScore()
+            .ToList();
+        
+        Assert.Equal(2, results.Count);
+        //Document boost should boost the document
+        Assert.Equal(1, results[0].ExpectedOrder);
+        Assert.Equal(2, results[1].ExpectedOrder);
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void ScoreAsSecondaryComparerWithIndexBoostAndIncludeScore()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        options.ModifyDatabaseRecord += record =>
+        {
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = true.ToString();
+        };
+        
+        using var store = GetDocumentStore(options);
+        {
+            using var session = store.OpenSession();
+            session.Store(new Dto(1, new[] { 1, 1, 1 }, "Maciej", 2));
+            session.Store(new Dto(1, new[] { 1, 1 }, "Maciej", 1));
+            session.SaveChanges();
+        }
+
+        var index = new Index();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+        Span<float> scores = stackalloc float[2];
+
+        {
+            using var session = store.OpenSession();
+            var query = session.Advanced.DocumentQuery<Dto>(indexName: index.IndexName)
+                .WhereEquals(nameof(Dto.Numbers), 1)
+                .AndAlso()
+                .WhereEquals(x => x.Name, "maciej")
+                .OrderByScore();
+            using IEnumerator<StreamResult<Dto>> streamResults = session.Advanced.Stream(query, out _);
+            
+            Assert.True(streamResults.MoveNext());
+            Assert.NotNull(streamResults.Current);
+            Assert.NotNull(streamResults.Current.Metadata[Constants.Documents.Metadata.IndexScore]);
+            scores[0] = (float)streamResults.Current.Metadata.GetDouble(Constants.Documents.Metadata.IndexScore);
+           
+            Assert.True(streamResults.MoveNext());
+            Assert.NotNull(streamResults.Current);
+            Assert.NotNull(streamResults.Current.Metadata[Constants.Documents.Metadata.IndexScore]);
+            scores[1] = (float)streamResults.Current.Metadata.GetDouble(Constants.Documents.Metadata.IndexScore);
+        }
+
+
+
+        {
+            using var session = store.OpenSession();
+            var query = session.Advanced.DocumentQuery<Dto>(indexName: index.IndexName)
+                .WhereEquals(nameof(Dto.Numbers), 1)
+                .AndAlso()
+                .WhereEquals(x => x.Name, "maciej")
+                .OrderBy(x => x.SomeNum)
+                .OrderByScore();
+
+
+
+            using IEnumerator<StreamResult<Dto>> streamResults = session.Advanced.Stream(query, out _);
+            Assert.True(streamResults.MoveNext());
+            Assert.NotNull(streamResults.Current);
+            Assert.NotNull(streamResults.Current.Metadata[Constants.Documents.Metadata.IndexScore]);
+            Assert.Equal(1, streamResults.Current.Document.ExpectedOrder);
+            Assert.Equal(scores[0],(float)streamResults.Current.Metadata.GetDouble(Constants.Documents.Metadata.IndexScore), float.Epsilon);
+            
+            Assert.True(streamResults.MoveNext());
+            Assert.NotNull(streamResults.Current);
+            Assert.NotNull(streamResults.Current.Metadata[Constants.Documents.Metadata.IndexScore]);
+            Assert.Equal(2, streamResults.Current.Document.ExpectedOrder);
+            Assert.Equal(scores[1],(float)streamResults.Current.Metadata.GetDouble(Constants.Documents.Metadata.IndexScore), float.Epsilon);
+            
+            Assert.False(streamResults.MoveNext());
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void ScoreAsSecondaryComparerWithIndexBoostAndIncludeScorePaging()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        options.ModifyDatabaseRecord += record =>
+        {
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = true.ToString();
+        };
+        using var store = GetDocumentStore(options);
+        var rnd = new Random(337);
+        
+        {
+            using var bulkInsert = store.BulkInsert();
+            for (int i = 0; i < 5000; ++i)
+                bulkInsert.Store(new Dto(1, Enumerable.Range(0, rnd.Next(2, 36)).Select(_ => 1).ToArray(), "Maciej", 0));
+        }
+
+        var index = new Index();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+        
+        {
+            using var session = store.OpenSession();
+            var query = session.Advanced.DocumentQuery<Dto>(indexName: index.IndexName)
+                .WhereEquals(nameof(Dto.Numbers), 1)
+                .AndAlso()
+                .WhereEquals(x => x.Name, "maciej")
+                .OrderBy(x => x.SomeNum)
+                .OrderByScore();
+            using IEnumerator<StreamResult<Dto>> streamResults = session.Advanced.Stream(query, out _);
+            while (streamResults.MoveNext())
+            {
+                Assert.NotNull(streamResults.Current);
+                Assert.NotNull(streamResults.Current.Metadata[Constants.Documents.Metadata.IndexScore]);
+            }
+        }
+    }
+    
+    private class Index : AbstractIndexCreationTask<Dto>
+    {
+        public Index()
+        {
+            Map = dtos => from doc in dtos
+                let boostVal = doc.ExpectedOrder == 1 ? 1_000_000 : doc.ExpectedOrder
+                select new { doc.Numbers, doc.Name, doc.SomeNum }.Boost(boostVal); 
+        }
+    }
+
+    private record Dto(int SomeNum, int[] Numbers, string Name, int ExpectedOrder, string Id = null);
+}

--- a/test/SlowTests/Issues/RavenDB_14363.cs
+++ b/test/SlowTests/Issues/RavenDB_14363.cs
@@ -27,11 +27,13 @@ namespace SlowTests.Issues
                     newSession.SaveChanges();
 
                     var queryGood = newSession.Query<User>()
+                        .Customize(x => x.WaitForNonStaleResults())
                         .Where(x => x.Id.StartsWith("users/"))
                         .OrderBy(x => x.Name).ThenBy(x => x.LastName);
 
                     // without select work as expected
                     var queryBad = newSession.Query<User>()
+                        .Customize(x => x.WaitForNonStaleResults())
                         .Where(x => x.Id.StartsWith("users/"))
                         .OrderBy(x => x.Name).ThenBy(x => x.LastName)
                         .Select(x => new UserWithoutId


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21818 

### Additional description

Support queries like
```csharp
from X [...] order by SomeField, [...], score(), [...]
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
