### PR TITLE
RavenDB-22008 - Use a separate semaphore for database record changes and value changes

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -133,6 +133,8 @@ namespace Raven.Server.Documents.Indexes
 
         public int HandleDatabaseRecordChange(DatabaseRecord record, long raftIndex, bool startIndexes = true)
         {
+            ForTestingPurposes?.BeforeHandleDatabaseRecordChange?.Invoke();
+
             try
             {
                 if (record == null)
@@ -2178,6 +2180,8 @@ namespace Raven.Server.Documents.Indexes
 
             internal Action<Index> BeforeIndexThreadExit;
             internal Action<Index> BeforeIndexStart;
+
+            public Action BeforeHandleDatabaseRecordChange;
 
             public TestingStuff(IndexStore parent)
             {

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -2181,7 +2181,7 @@ namespace Raven.Server.Documents.Indexes
             internal Action<Index> BeforeIndexThreadExit;
             internal Action<Index> BeforeIndexStart;
 
-            public Action BeforeHandleDatabaseRecordChange;
+            internal Action BeforeHandleDatabaseRecordChange;
 
             public TestingStuff(IndexStore parent)
             {

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -114,7 +114,7 @@ namespace Raven.Server.Documents.Sharding
             }
         }
 
-        private void OnDatabaseRecordChange(DatabaseRecord record, long index)
+        private Task OnDatabaseRecordChange(DatabaseRecord record, long index)
         {
             UpdateConfiguration(record.Settings);
 
@@ -153,6 +153,8 @@ namespace Raven.Server.Documents.Sharding
             SubscriptionsStorage.Update();
 
             Interlocked.Exchange(ref _record, record);
+
+            return Task.CompletedTask;
         }
 
         private bool CheckForTopologyChangesAndRaiseNotification(DatabaseTopology topology, DatabaseTopology oldTopology)
@@ -172,7 +174,7 @@ namespace Raven.Server.Documents.Sharding
             return false;
         }
 
-        private void OnUrlChange(DatabaseRecord record, long index)
+        private Task OnUrlChange(DatabaseRecord record, long index)
         {
             // we explicitly do not dispose the old executors here to avoid possible memory invalidation and since this is expected to be rare.
             // So we rely on the GC to dispose them via the finalizer
@@ -182,6 +184,8 @@ namespace Raven.Server.Documents.Sharding
 
             AllOrchestratorNodesExecutor.ForgetAbout();
             AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, _record);
+
+            return Task.CompletedTask;
         }
 
         public async ValueTask UpdateUrlsAsync(long index) => await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(_record, index, _urlUpdateStateChange);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1102,6 +1102,14 @@ namespace Raven.Server.ServerWide
                     var database = await completedTask.ConfigureAwait(false);
                     await database.RefreshFeaturesAsync().ConfigureAwait(false);
                 }
+                catch (OperationCanceledException)
+                {
+                    // database shutdown
+                }
+                catch (ObjectDisposedException)
+                {
+                    // database shutdown
+                }
                 catch (Exception e)
                 {
                     if (Logger.IsInfoEnabled)

--- a/test/SlowTests/Issues/RavenDB-22008.cs
+++ b/test/SlowTests/Issues/RavenDB-22008.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Util;
+using Raven.Server.ServerWide.Commands.Subscriptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22008 : RavenTestBase
+    {
+        public RavenDB_22008(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+        public async Task Index_Update_With_Subscription_Update()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var indexDefinition = new Index();
+                await indexDefinition.ExecuteAsync(store);
+
+                var database = await GetDatabase(store.Database);
+                var index = database.IndexStore.GetIndex(indexDefinition.IndexName);
+
+                var subscriptionCreationParams = new SubscriptionCreationOptions
+                {
+                    Query = "from People"
+                };
+
+                var subName = await store.Subscriptions.CreateAsync(subscriptionCreationParams);
+                var subscriptionState = await store.Subscriptions.GetSubscriptionStateAsync(subName);
+
+                var indexDisposeMre = new ManualResetEventSlim(false);
+                var mreBeforeSendingCommand = new ManualResetEventSlim(false);
+
+                var mreWasSet = false;
+
+                using (index.ForTestingPurposesOnly().CallDuringFinallyOfExecuteIndexing(() =>
+                {
+                    // simulating a long indexing batch completion
+                    mreWasSet = indexDisposeMre.Wait(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
+                }))
+                {
+                    var deleteIndexTask = store.Maintenance.SendAsync(new DeleteIndexOperation(indexDefinition.IndexName));
+
+                    database.IndexStore.ForTestingPurposesOnly().BeforeHandleDatabaseRecordChange = () =>
+                    {
+                        mreBeforeSendingCommand.Set();
+                    };
+
+                    mreBeforeSendingCommand.Wait(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
+
+                    var command = new AcknowledgeSubscriptionBatchCommand(store.Database, RaftIdGenerator.NewId())
+                    {
+                        ChangeVector = "A:1",
+                        NodeTag = Server.ServerStore.NodeTag,
+                        HasHighlyAvailableTasks = true,
+                        SubscriptionId = subscriptionState.SubscriptionId,
+                        SubscriptionName = subscriptionState.SubscriptionName,
+                        LastTimeServerMadeProgressWithDocuments = DateTime.UtcNow,
+                        LastKnownSubscriptionChangeVector = null,
+                        DatabaseName = database.Name,
+                    };
+
+                    var (etag, _) = await Server.ServerStore.SendToLeaderAsync(command);
+                    await database.RachisLogIndexNotifications.WaitForIndexNotification(etag, Server.ServerStore.Engine.OperationTimeout);
+
+                    indexDisposeMre.Set();
+                    await deleteIndexTask;
+
+                    Assert.True(mreWasSet);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-22008.cs
+++ b/test/SlowTests/Issues/RavenDB-22008.cs
@@ -7,7 +7,6 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Util;
 using Raven.Server.ServerWide.Commands.Subscriptions;
 using Tests.Infrastructure;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues
@@ -40,12 +39,10 @@ namespace SlowTests.Issues
                 var indexDisposeMre = new ManualResetEventSlim(false);
                 var mreBeforeSendingCommand = new ManualResetEventSlim(false);
 
-                var mreWasSet = false;
-
                 using (index.ForTestingPurposesOnly().CallDuringFinallyOfExecuteIndexing(() =>
                 {
                     // simulating a long indexing batch completion
-                    mreWasSet = indexDisposeMre.Wait(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
+                    indexDisposeMre.Wait(Server.ServerStore.Configuration.Cluster.OperationTimeout.AsTimeSpan);
                 }))
                 {
                     var deleteIndexTask = store.Maintenance.SendAsync(new DeleteIndexOperation(indexDefinition.IndexName));
@@ -74,8 +71,6 @@ namespace SlowTests.Issues
 
                     indexDisposeMre.Set();
                     await deleteIndexTask;
-
-                    Assert.True(mreWasSet);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22008/Large-amount-of-threads-are-waiting-on-NotifyFeaturesAboutValueChange

### Additional description

Port from 5.4 - https://github.com/ravendb/ravendb/pull/18241.
Use a separate semaphore for database record changes and value changes to improve the performance of updating database values.
Index updates that require to deletion of the previous index might take some time. In the current implementation, updating the subscription value will be delayed until the index operation is completed.
(To delete an index, for example, we need to wait until the currently running batch is done - we cannot cancel if we are in the middle of a Voron commit, and delete the index folder, which might take a while).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
