### PR TITLE
RavenDB-22158 Unwrap aggregated exception to check if socket was closed and ignore exception.

### DIFF
--- a/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
+using Raven.Client.Extensions;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -154,13 +155,21 @@ namespace Raven.Server.NotificationCenter.Handlers
                     if (Logger.IsInfoEnabled)
                         Logger.Info($"Websocket proxy got disconnected ({_remoteWebSocketUri} to local)", ex);
                 }
+                catch (AggregateException ae)
+                {
+                    if (IsSocketClosed(ae.ExtractSingleInnerException()))
+                    {
+                        //ignore
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                    
+                }
                 catch (Exception ex)
                 {
-                    // if we received close from the client, we want to ignore it and close the websocket (dispose does it)
-                    if (ex is WebSocketException webSocketException
-                        && (webSocketException.WebSocketErrorCode == WebSocketError.InvalidState)
-                        && (_localWebSocket.State == WebSocketState.Closed || _remoteWebSocket.State == WebSocketState.Closed ||
-                            _localWebSocket.State == WebSocketState.CloseReceived || _remoteWebSocket.State == WebSocketState.CloseReceived))
+                    if (IsSocketClosed(ex))
                     {
                         // ignore
                     }
@@ -169,6 +178,15 @@ namespace Raven.Server.NotificationCenter.Handlers
                         throw;
                     }
                 }
+            }
+
+            bool IsSocketClosed(Exception ex)
+            {
+                // if we received close from the client, we want to ignore it and close the websocket (dispose does it)
+                return ex is WebSocketException webSocketException
+                       && (webSocketException.WebSocketErrorCode == WebSocketError.InvalidState)
+                       && (_localWebSocket.State == WebSocketState.Closed || _remoteWebSocket.State == WebSocketState.Closed ||
+                           _localWebSocket.State == WebSocketState.CloseReceived || _remoteWebSocket.State == WebSocketState.CloseReceived);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22158 

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
