### PR TITLE
RavenDB-21050 - When restoring from incremental backup with atomic guard, a tombstone can be handled before creating the document (v5.4)

### DIFF
--- a/src/Raven.Server/Documents/Handlers/LegacyReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/LegacyReplicationHandler.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.Handlers
                 SkipRevisionCreation = true
             };
 
-            await using (destination.InitializeAsync(options, null, buildVersion: default))
+            await using (destination.InitializeAsync(options, result: null, onProgress: null, buildVersion: default))
             await using (var documentActions = destination.Documents())
             await using (var buffered = new BufferedStream(RequestBodyStream()))
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -433,7 +433,7 @@ namespace Raven.Server.ServerWide.Commands
             return result;
         }
 
-        private static long GetPrevCount(ClusterOperationContext context, Tree commandsCountPerDatabase, string databaseName)
+        internal static long GetPrevCount(ClusterOperationContext context, Tree commandsCountPerDatabase, string databaseName)
         {
             using (GetPrefix(context, databaseName, out var databaseSlice))
             {

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Smuggler;
@@ -19,7 +20,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 {
     public interface ISmugglerDestination
     {
-        IAsyncDisposable InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result, long buildVersion);
+        IAsyncDisposable InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result, Action<IOperationProgress> onProgress, long buildVersion);
 
         IDatabaseRecordActions DatabaseRecord();
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -88,7 +88,7 @@ namespace Raven.Server.Smuggler.Documents
 
             using (_patcher?.Initialize())
             using (var initializeResult = await _source.InitializeAsync(_options, result))
-            await using (_destination.InitializeAsync(_options, result, initializeResult.BuildNumber))
+            await using (_destination.InitializeAsync(_options, result, _onProgress, initializeResult.BuildNumber))
             {
                 ModifyV41OperateOnTypes(initializeResult.BuildNumber, isLastFile);
 

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Analysis;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Configuration;
@@ -66,7 +67,7 @@ namespace Raven.Server.Smuggler.Documents
             _compressionLevel = compressionLevel;
         }
 
-        public IAsyncDisposable InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result, long buildVersion)
+        public IAsyncDisposable InitializeAsync(DatabaseSmugglerOptionsServerSide options, SmugglerResult result, Action<IOperationProgress> onProgress, long buildVersion)
         {
             _outputStream = BackupUtils.GetCompressionStream(_stream, _compressionAlgorithm, _compressionLevel);
             _writer = new AsyncBlittableJsonTextWriter(_context, _outputStream);

--- a/src/Raven.Server/Smuggler/Migration/Migrator_V2.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator_V2.cs
@@ -100,7 +100,7 @@ namespace Raven.Server.Smuggler.Migration
                 SkipRevisionCreation = true
             };
 
-            destination.InitializeAsync(options, parametersResult, buildVersion: default);
+            destination.InitializeAsync(options, parametersResult, onProgress: null, buildVersion: default);
 
             using (Parameters.Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext transactionOperationContext))
             await using (var documentActions = destination.Documents())

--- a/src/Raven.Server/Smuggler/Migration/Migrator_V3.cs
+++ b/src/Raven.Server/Smuggler/Migration/Migrator_V3.cs
@@ -123,7 +123,7 @@ namespace Raven.Server.Smuggler.Migration
                 SkipRevisionCreation = true
             };
 
-            destination.InitializeAsync(options, parametersResult, _buildVersion);
+            destination.InitializeAsync(options, parametersResult, onProgress: null, _buildVersion);
             using (Parameters.Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext transactionOperationContext))
             using (Parameters.Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             await using (var documentActions = destination.Documents())

--- a/test/SlowTests/Issues/RavenDB-21050.cs
+++ b/test/SlowTests/Issues/RavenDB-21050.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21050 : RavenTestBase
+{
+    public RavenDB_21050(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.BackupExportImport)]
+    public async Task ClusterWideTransaction_WhenRestoreFromIncrementalBackupAfterStoreAndDelete_ShouldDeleteInTheDestination()
+    {
+        var backupPath = NewDataPath(suffix: "BackupFolder");
+        const string id = "TestObjs/0";
+
+        using (var source = GetDocumentStore())
+        using (var destination = new DocumentStore { Urls = new[] { Server.WebUrl }, Database = $"restored_{source.Database}" }.Initialize())
+        {
+            var config = new PeriodicBackupConfiguration { LocalSettings = new LocalSettings { FolderPath = backupPath }, IncrementalBackupFrequency = "0 0 */12 * *" };
+            var backupTaskId = (await source.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+
+            using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new TestObj(), id);
+                await session.SaveChangesAsync();
+            }
+
+            var backupStatus = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
+            await backupStatus.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+            using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                session.Delete(id);
+                await session.SaveChangesAsync();
+            }
+
+            var backupStatus2 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
+            await backupStatus2.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+            var restoreConfig = new RestoreBackupConfiguration { BackupLocation = Directory.GetDirectories(backupPath).First(), DatabaseName = destination.Database };
+            using (Backup.RestoreDatabase(destination, restoreConfig))
+            {
+                using (var session = destination.OpenAsyncSession())
+                {
+                    var shouldBeDeleted = await session.LoadAsync<TestObj>(id);
+                    Assert.Null(shouldBeDeleted); //Fails here
+                }
+            }
+
+
+        }
+    }
+
+    private class TestObj
+    {
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21050/When-restoring-from-incremental-backup-with-atomic-guard-a-tombstone-can-be-handled-before-creating-the-document

### Additional description

To create a document with atomic guard we send a ClusterWideTransaction.

This is done in two steps:

The atomic guard is created in the cluster state machine
The database creates the document.
If we have a full backup with an atomic-guarded document and an incremental backup with a tombstone to this document
The actual creation of the document can be after the tombstone is applied.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
