### PR TITLE
RavenDB-22229 - fix legacy index replication

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AbstractAdminIndexHandlerProcessorForPut.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AbstractAdminIndexHandlerProcessorForPut.cs
@@ -2,14 +2,11 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
-using Esprima.Ast;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
 using Raven.Client.Documents.Changes;
-using Raven.Client.Documents.DataArchival;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations.DataArchival;
 using Raven.Server.Documents.Handlers.Processors;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Json;

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AbstractAdminIndexHandlerProcessorForStaticPut.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AbstractAdminIndexHandlerProcessorForStaticPut.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
@@ -11,19 +10,5 @@ internal abstract class AbstractAdminIndexHandlerProcessorForStaticPut<TRequestH
     protected AbstractAdminIndexHandlerProcessorForStaticPut([NotNull] TRequestHandler requestHandler)
         : base(requestHandler, validatedAsAdmin: true)
     {
-    }
-
-    protected abstract ValueTask HandleLegacyIndexesAsync();
-
-    public override async ValueTask ExecuteAsync()
-    {
-        var isReplicated = RequestHandler.GetBoolValueQueryString("is-replicated", required: false) ?? false;
-        if (isReplicated)
-        {
-            await HandleLegacyIndexesAsync();
-            return;
-        }
-
-        await base.ExecuteAsync();
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForJavaScriptPut.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForJavaScriptPut.cs
@@ -1,7 +1,15 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http.Features.Authentication;
+using Raven.Client.Documents.Smuggler;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Smuggler.Documents;
+using Raven.Server.Smuggler.Documents.Data;
+using Raven.Server.Smuggler.Migration;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
 
@@ -14,4 +22,27 @@ internal sealed class AdminIndexHandlerProcessorForJavaScriptPut : AbstractAdmin
     protected override AbstractIndexCreateController GetIndexCreateProcessor() => RequestHandler.Database.IndexStore.Create;
 
     protected override RavenConfiguration GetDatabaseConfiguration() => RequestHandler.Database.Configuration;
+
+    protected override async ValueTask HandleIndexesFromLegacyReplicationAsync()
+    {
+        if (HttpContext.Features.Get<IHttpAuthenticationFeature>() is RavenServer.AuthenticateConnection feature &&
+            feature.CanAccess(RequestHandler.DatabaseName, requireAdmin: true, requireWrite: true) == false)
+        {
+            throw new UnauthorizedAccessException("Deploying indexes from legacy replication requires admin privileges.");
+        }
+
+        using (ContextPool.AllocateOperationContext(out JsonOperationContext jsonOperationContext))
+        await using (var stream = new ArrayStream(RequestHandler.RequestBodyStream(), nameof(DatabaseItemType.Indexes)))
+        using (var source = new StreamSource(stream, jsonOperationContext, RequestHandler.DatabaseName))
+        {
+            var destination = RequestHandler.Database.Smuggler.CreateDestination();
+            var options = new DatabaseSmugglerOptionsServerSide
+            {
+                OperateOnTypes = DatabaseItemType.Indexes
+            };
+
+            var smuggler = RequestHandler.Database.Smuggler.Create(source, destination, jsonOperationContext, options);
+            await smuggler.ExecuteAsync();
+        }
+    }
 }

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForStaticPut.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForStaticPut.cs
@@ -1,12 +1,6 @@
-﻿using System.Threading.Tasks;
-using JetBrains.Annotations;
-using Raven.Client.Documents.Smuggler;
+﻿using JetBrains.Annotations;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.ServerWide.Context;
-using Raven.Server.Smuggler.Documents;
-using Raven.Server.Smuggler.Documents.Data;
-using Raven.Server.Smuggler.Migration;
-using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
 
@@ -17,21 +11,4 @@ internal sealed class AdminIndexHandlerProcessorForStaticPut : AbstractAdminInde
     }
 
     protected override AbstractIndexCreateController GetIndexCreateProcessor() => RequestHandler.Database.IndexStore.Create;
-
-    protected override async ValueTask HandleLegacyIndexesAsync()
-    {
-        using (ContextPool.AllocateOperationContext(out JsonOperationContext jsonOperationContext))
-        await using (var stream = new ArrayStream(RequestHandler.RequestBodyStream(), nameof(DatabaseItemType.Indexes)))
-        using (var source = new StreamSource(stream, jsonOperationContext, RequestHandler.DatabaseName))
-        {
-            var destination = RequestHandler.Database.Smuggler.CreateDestination();
-            var options = new DatabaseSmugglerOptionsServerSide
-            {
-                OperateOnTypes = DatabaseItemType.Indexes
-            };
-
-            var smuggler = RequestHandler.Database.Smuggler.Create(source, destination, jsonOperationContext, options);
-            await smuggler.ExecuteAsync();
-        }
-    }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Indexes/ShardedAdminIndexHandlerProcessorForJavaScriptPut.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Indexes/ShardedAdminIndexHandlerProcessorForJavaScriptPut.cs
@@ -1,4 +1,6 @@
-﻿using JetBrains.Annotations;
+﻿using System.Threading.Tasks;
+using System;
+using JetBrains.Annotations;
 using Raven.Server.Config;
 using Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
 using Raven.Server.Documents.Indexes;
@@ -15,4 +17,9 @@ internal sealed class ShardedAdminIndexHandlerProcessorForJavaScriptPut : Abstra
     protected override AbstractIndexCreateController GetIndexCreateProcessor() => RequestHandler.DatabaseContext.Indexes.Create;
 
     protected override RavenConfiguration GetDatabaseConfiguration() => RequestHandler.DatabaseContext.Configuration;
+
+    protected override ValueTask HandleIndexesFromLegacyReplicationAsync()
+    {
+        throw new NotSupportedException("Legacy replication of indexes isn't supported in a sharded environment");
+    }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Indexes/ShardedAdminIndexHandlerProcessorForStaticPut.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Admin/Processors/Indexes/ShardedAdminIndexHandlerProcessorForStaticPut.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 using Raven.Server.Documents.Handlers.Admin.Processors.Indexes;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.ServerWide.Context;
@@ -14,9 +12,4 @@ internal sealed class ShardedAdminIndexHandlerProcessorForStaticPut : AbstractAd
     }
 
     protected override AbstractIndexCreateController GetIndexCreateProcessor() => RequestHandler.DatabaseContext.Indexes.Create;
-
-    protected override ValueTask HandleLegacyIndexesAsync()
-    {
-        throw new NotSupportedException("Legacy replication of indexes isn't supported in a sharded environment");
-    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22229/Legacy-replication-for-indexes-doesnt-work

### Additional description

The endpoint that the legacy replication is using is `/databases/*/indexes` and not `/databases/*/admin/indexes`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
