### PR TITLE
RavenDB-22237 - add transaction limits to DeleteBucketCommand

### DIFF
--- a/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
+++ b/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Documents
         private readonly Func<T, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> _commandToExecute;
         private readonly RateGate _rateGate;
         private readonly OperationCancelToken _token;
-        private readonly int? _maxTransactionSizeInPages;
+        private readonly Size? _maxTransactionSize;
         private readonly int? _batchSize;
         private readonly CancellationToken _cancellationToken;
 
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents
             _rateGate = rateGate;
             _token = token;
             if (maxTransactionSize != null)
-                _maxTransactionSizeInPages = Math.Max(1, maxTransactionSize.Value / Constants.Storage.PageSize);
+                _maxTransactionSize = new Size(maxTransactionSize.Value, SizeUnit.Bytes);
             _batchSize = batchSize;
             _cancellationToken = token.Token;
         }
@@ -73,8 +73,8 @@ namespace Raven.Server.Documents
                 if (_batchSize != null && Processed >= _batchSize)
                     break;
 
-                if (_maxTransactionSizeInPages != null &&
-                    context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSizeInPages > _maxTransactionSizeInPages)
+                if (_maxTransactionSize != null &&
+                    context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSize > _maxTransactionSize)
                     break;
 
                 if (context.CachedProperties.NeedClearPropertiesCache())

--- a/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
+++ b/src/Raven.Server/Documents/ExecuteRateLimitedOperations.cs
@@ -74,8 +74,7 @@ namespace Raven.Server.Documents
                     break;
 
                 if (_maxTransactionSizeInPages != null &&
-                    context.Transaction.InnerTransaction.LowLevelTransaction.NumberOfModifiedPages +
-                    context.Transaction.InnerTransaction.LowLevelTransaction.AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes) / Constants.Storage.PageSize > _maxTransactionSizeInPages)
+                    context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSizeInPages > _maxTransactionSizeInPages)
                     break;
 
                 if (context.CachedProperties.NeedClearPropertiesCache())

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -231,6 +231,7 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
                     return;
                 // we have more docs, batch limit reached.
                 case DeleteBucketCommand.DeleteBucketResult.FullBatch:
+                case DeleteBucketCommand.DeleteBucketResult.ReachedTransactionLimit:
                     continue;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -304,7 +305,8 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
         {
             Empty,
             Skipped,
-            FullBatch
+            FullBatch,
+            ReachedTransactionLimit
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -336,7 +336,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
 
     private const long MaxDocumentsToDeleteInBucket = 1024;
 
-    private const long MaxTransactionSize = 16 * Constants.Size.Megabyte;
+    private const long MaxTransactionSizeInPages = 16 * Constants.Size.Megabyte / Constants.Storage.PageSize;
 
     public ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult DeleteBucket(DocumentsOperationContext context, int bucket, ChangeVector upTo)
     {
@@ -368,7 +368,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
             RevisionsStorage.ForceDeleteAllRevisionsFor(context, document.Id);
             deleted++;
 
-            if (context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSizeInPages > MaxTransactionSize)
+            if (context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSizeInPages > MaxTransactionSizeInPages)
                 return ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult.ReachedTransactionLimit;
         }
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -336,7 +336,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
 
     private const long MaxDocumentsToDeleteInBucket = 1024;
 
-    private const long MaxTransactionSizeInPages = 16 * Constants.Size.Megabyte / Constants.Storage.PageSize;
+    private readonly Size _maxTransactionSize = new Size(16 * Constants.Size.Megabyte, SizeUnit.Bytes);
 
     public ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult DeleteBucket(DocumentsOperationContext context, int bucket, ChangeVector upTo)
     {
@@ -368,7 +368,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
             RevisionsStorage.ForceDeleteAllRevisionsFor(context, document.Id);
             deleted++;
 
-            if (context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSizeInPages > MaxTransactionSizeInPages)
+            if (context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSize > _maxTransactionSize)
                 return ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult.ReachedTransactionLimit;
         }
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -368,8 +368,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
             RevisionsStorage.ForceDeleteAllRevisionsFor(context, document.Id);
             deleted++;
 
-            if (context.Transaction.InnerTransaction.LowLevelTransaction.NumberOfModifiedPages +
-                context.Transaction.InnerTransaction.LowLevelTransaction.AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes) / Constants.Storage.PageSize > MaxTransactionSize)
+            if (context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSizeInPages > MaxTransactionSize)
                 return ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult.ReachedTransactionLimit;
         }
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -96,7 +96,7 @@ namespace Voron.Impl
 
         public event Action<LowLevelTransaction> LastChanceToReadFromWriteTransactionBeforeCommit;
 
-        public long TransactionSizeInPages => NumberOfModifiedPages + AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes) / Constants.Storage.PageSize;
+        public Size TransactionSize => new Size(NumberOfModifiedPages * Constants.Storage.PageSize, SizeUnit.Bytes) + AdditionalMemoryUsageSize;
 
         public Size AdditionalMemoryUsageSize
         {

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -96,6 +96,8 @@ namespace Voron.Impl
 
         public event Action<LowLevelTransaction> LastChanceToReadFromWriteTransactionBeforeCommit;
 
+        public long TransactionSizeInPages => NumberOfModifiedPages + AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes) / Constants.Storage.PageSize;
+
         public Size AdditionalMemoryUsageSize
         {
             get


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22237/DeleteBucketCommand-is-running-with-no-transaction-limits

### Additional description

`DeleteBucketCommand` can delete up to 1024 documents in a single batch, however this doesn't take into account the size of the transaction (deleting a document which has a few million timeseries).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
