### PR TITLE
RavenDB-22232 Failed to delete Filtered replication Access

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractPullReplicationHandlerProcessorForUnregisterHubAccess.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractPullReplicationHandlerProcessorForUnregisterHubAccess.cs
@@ -14,6 +14,19 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         protected AbstractPullReplicationHandlerProcessorForUnregisterHubAccess([NotNull] TRequestHandler requestHandler) : base(requestHandler)
         {
         }
+        public override async ValueTask ExecuteAsync()
+        {
+            using (RequestHandler.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                await AssertCanExecuteAsync();
+
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+                {
+                    await UpdateConfigurationAsync(context, writer);
+                }
+            }
+        }
+
 
         protected override async Task<(long Index, object Result)> OnUpdateConfiguration(TransactionOperationContext context, BlittableJsonReaderObject configuration, string raftRequestId)
         {

--- a/test/SlowTests/Server/Replication/PullReplicationWithAuthenticationTest.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationWithAuthenticationTest.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Replication
+{
+    public class PullReplicationWithAuthenticationTest : ReplicationTestBase
+    {
+        public PullReplicationWithAuthenticationTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Replication)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task DeleteReplicationAccess(Options options)
+        {
+            var certificates = Certificates.SetupServerAuthentication();
+            var dbNameA = GetDatabaseName();
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates
+                .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            using var store = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseName = s => dbNameA
+            });
+
+            var pullCert = certificates.ClientCertificate2.Value;
+            await store.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "Yard Replication Hub",
+                WithFiltering = true
+            }));
+            await store.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("Yard Replication Hub",
+                new ReplicationHubAccess
+                {
+                    Name = "Test",
+                    CertificateBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert)),
+                    AllowedHubToSinkPaths = new[] { "*" }
+                }));
+
+            await store.Maintenance.SendAsync(new UnregisterReplicationHubAccessOperation("Yard Replication Hub", pullCert.Thumbprint));
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22232

### Additional description

We were failing when we tried to read from the empty request body.
We don't have any configuration. All the info we need is in that request query string. 
I override ExecuteAsync to skip that
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
