### PR TITLE
RavenDB-22151 Updating dotnet-dump related classes

### DIFF
--- a/tools/Raven.Debug/CommandLineApp.cs
+++ b/tools/Raven.Debug/CommandLineApp.cs
@@ -134,7 +134,7 @@ namespace Raven.Debug
                 var typeOption = cmd.Option("--type", "Type of dump (Heap or Mini). ", CommandOptionType.SingleValue);
                 var outputOwnerOption = cmd.Option("--output-owner", "The owner of the output file (applicable only to Posix based OS)", CommandOptionType.SingleValue);
 
-                cmd.OnExecuteAsync(async (_) =>
+                cmd.OnExecute(() =>
                 {
                     if (pidOption.HasValue() == false)
                         return cmd.ExitWithError("Missing --pid option.");
@@ -159,7 +159,7 @@ namespace Raven.Debug
                     try
                     {
                         var dumper = new Dumper();
-                        await dumper.Collect(cmd, pid, output, outputOwner, diag: false, type).ConfigureAwait(false);
+                        dumper.Collect(cmd, pid, output, outputOwner, diag: false, crashreport: false, type);
                         return 0;
                     }
                     catch (Exception e)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22151/Update-dotnet-dump-related-classes-in-our-code

### Additional description

Updates of dotnet-dump tool sources

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
