### PR TITLE
RavenDB-22239 Add test for "GetCompareExchangeValuesOperation"

### DIFF
--- a/test/SlowTests/Client/UniqueValues.cs
+++ b/test/SlowTests/Client/UniqueValues.cs
@@ -106,6 +106,42 @@ namespace SlowTests.Client
         }
 
         [Fact]
+        public async Task CanGetMultipleCompareExchangeItemsByKeys()
+        {
+            DoNotReuseServer();
+            var store = GetDocumentStore();
+            var res1 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/1", new User
+            {
+                Name = "Name1"
+            }, 0));
+            
+            var res2 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/2", new User
+            {
+                Name = "Name2"
+            }, 0));
+            
+            var res3 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/3", new User
+            {
+                Name = "Name3"
+            }, 0));
+            
+            Assert.True(res1.Successful);
+            Assert.True(res2.Successful);
+            Assert.True(res3.Successful);
+            
+            Assert.Equal("Name1", res1.Value.Name);
+            Assert.Equal("Name2", res2.Value.Name);
+            Assert.Equal("Name3", res3.Value.Name);
+
+            var values = await store.Operations
+                .SendAsync(new GetCompareExchangeValuesOperation<User>(new string[] {"users/1", "users/3"}));
+            
+            Assert.Equal(2, values.Count);
+            Assert.Equal("Name1", values["users/1"].Value.Name);
+            Assert.Equal("Name3", values["users/3"].Value.Name);
+        }
+        
+        [Fact]
         public async Task CanListCompareExchange()
         {
             DoNotReuseServer();

--- a/test/SlowTests/Client/UniqueValues.cs
+++ b/test/SlowTests/Client/UniqueValues.cs
@@ -16,6 +16,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -105,7 +106,7 @@ namespace SlowTests.Client
             Assert.True(res.Successful);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.CompareExchange)]
         public async Task CanGetMultipleCompareExchangeItemsByKeys()
         {
             DoNotReuseServer();


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22239/Add-test-for-GetCompareExchangeValuesOperation

### Additional description
Added a test to test `GetCompareExchangeValuesOperation` with the overload that only passes `keys`.

### Type of change
- [x] Bug fix / task
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] Documentation will add this in RDoc-2724
- [ ] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
