### PR TITLE
RavenDB-22233 - change the test batch count

### DIFF
--- a/test/SlowTests/Issues/RavenDB-15754.cs
+++ b/test/SlowTests/Issues/RavenDB-15754.cs
@@ -102,6 +102,8 @@ namespace SlowTests.Issues
                 const string oldManagerName = "Grisha";
                 const string newManagerName = "Grisha Kotler";
 
+                const int employeesCount = 128;
+
                 var company = new Company
                 {
                     Name = _companyName1
@@ -121,7 +123,7 @@ namespace SlowTests.Issues
 
                 using (var bulk = store.BulkInsert())
                 {
-                    for (var i = 0; i < _employeesCount; i++)
+                    for (var i = 0; i < employeesCount; i++)
                     {
                         await bulk.StoreAsync(new Employee
                         {
@@ -135,10 +137,10 @@ namespace SlowTests.Issues
                 await index.ExecuteAsync(store);
 
                 Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
-                await AssertCount(store, _companyName1, _employeesCount, managerName: oldManagerName);
+                await AssertCount(store, _companyName1, employeesCount, managerName: oldManagerName);
                 var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
-                Assert.Equal(_employeesCount, indexStats.MapAttempts);
-                Assert.Equal(_employeesCount, indexStats.MapSuccesses);
+                Assert.Equal(employeesCount, indexStats.MapAttempts);
+                Assert.Equal(employeesCount, indexStats.MapSuccesses);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -151,13 +153,13 @@ namespace SlowTests.Issues
 
                 Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(10));
                 await AssertCount(store, _companyName1, 0);
-                await AssertCount(store, _companyName2, _employeesCount, managerName: newManagerName);
+                await AssertCount(store, _companyName2, employeesCount, managerName: newManagerName);
 
                 indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
 
                 // we expect the parent document to be indexed only once
-                Assert.Equal(_employeesCount, indexStats.MapReferenceAttempts);
-                Assert.Equal(_employeesCount, indexStats.MapReferenceSuccesses);
+                Assert.Equal(employeesCount, indexStats.MapReferenceAttempts); // was employeesCount * 2
+                Assert.Equal(employeesCount, indexStats.MapReferenceSuccesses); // was employeesCount * 2
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22233

### Additional description

Since the test is checking if the optimization works, we can reduce the batch size to 128.
Before the optimization the `MapReferenceAttempts` was 256, now we expect it to be 128.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
