### PR TITLE
RavenDB-22192: Updated tests when CurrentCulture is set to invariant.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-11795.cs
+++ b/test/SlowTests/Issues/RavenDB-11795.cs
@@ -130,9 +130,12 @@ namespace SlowTests.Issues
                             StartDate = x.Start.ToString(CultureInfo.CurrentCulture)
                         });
 
+                    var cultureString = CultureInfo.CurrentCulture.Equals(CultureInfo.InvariantCulture) == false
+                                            ? $", \"{culture.Name}\""
+                                            : "";
+
                     Assert.Equal("from 'Bookings' as x where x.FirstName = $p0 " +
-                                 $"select {{ StartDate : toStringWithFormat(x.Start, \"{culture.Name}\") }}"
-                        , query.ToString());
+                                         $"select {{ StartDate : toStringWithFormat(x.Start{cultureString}) }}", query.ToString());
 
                     var result = query.Single();
 
@@ -170,8 +173,12 @@ namespace SlowTests.Issues
                             StartDate = x.Start.ToString("dd.MM.yyyy", CultureInfo.CurrentCulture)
                         });
 
+                    var cultureString = CultureInfo.CurrentCulture.Equals(CultureInfo.InvariantCulture) == false
+                        ? $", \"{CultureInfo.CurrentCulture.Name}\""
+                        : "";
+
                     Assert.Equal("from 'Bookings' as x where x.FirstName = $p0 " +
-                                 $"select {{ StartDate : toStringWithFormat(x.Start, \"dd.MM.yyyy\", \"{CultureInfo.CurrentCulture.Name}\") }}"
+                                 $"select {{ StartDate : toStringWithFormat(x.Start, \"dd.MM.yyyy\"{cultureString}) }}"
                         , query.ToString());
 
                     var result = query.Single();
@@ -330,8 +337,12 @@ namespace SlowTests.Issues
                             Number = x.Number.ToString(CultureInfo.CurrentCulture)
                         });
 
+                    var cultureString = CultureInfo.CurrentCulture.Equals(CultureInfo.InvariantCulture) == false
+                        ? $", \"{CultureInfo.CurrentCulture.Name}\""
+                        : "";
+
                     Assert.Equal("from 'Bookings' as x where x.FirstName = $p0 " +
-                                 $"select {{ Number : toStringWithFormat(x.Number, \"{CultureInfo.CurrentCulture.Name}\") }}"
+                                 $"select {{ Number : toStringWithFormat(x.Number{cultureString}) }}"
                         , query.ToString());
 
                     var result = query.Single();
@@ -370,8 +381,12 @@ namespace SlowTests.Issues
                             Number = x.Number.ToString("000", CultureInfo.CurrentCulture)
                         });
 
+                    var cultureString = CultureInfo.CurrentCulture.Equals(CultureInfo.InvariantCulture) == false
+                        ? $", \"{CultureInfo.CurrentCulture.Name}\""
+                        : "";
+
                     Assert.Equal("from 'Bookings' as x where x.FirstName = $p0 " +
-                                 $"select {{ Number : toStringWithFormat(x.Number, \"000\", \"{CultureInfo.CurrentCulture.Name}\") }}"
+                                 $"select {{ Number : toStringWithFormat(x.Number, \"000\"{cultureString}) }}"
                         , query.ToString());
 
                     var result = query.Single();


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22192

### Additional description
Tests would fail when Current Culture is set to invariant. Recommend to ensure in automated tests to setup current culture randomization to ensure proper coverage.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
