### PR TITLE
RavenDB-20103: ARM support for the different variants of VectorizedAnd

### DIFF
--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -27,6 +27,7 @@ using Voron.Impl;
 using InvalidOperationException = System.InvalidOperationException;
 using static Voron.Data.CompactTrees.CompactTree;
 using Voron.Util;
+using System.Runtime.Intrinsics;
 
 namespace Corax.Querying;
 
@@ -47,7 +48,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     /// </summary>
     public bool ForceNonAccelerated { get; set; }
 
-    public bool IsAccelerated => Avx2.IsSupported && !ForceNonAccelerated;
+    public bool IsAccelerated => Vector256.IsHardwareAccelerated && !ForceNonAccelerated;
 
     public long NumberOfEntries => _numberOfEntries ??= _metadataTree?.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
     

--- a/src/Corax/Querying/Matches/TermMatch.cs
+++ b/src/Corax/Querying/Matches/TermMatch.cs
@@ -477,12 +477,12 @@ namespace Corax.Querying.Matches
 
                                 if (largerEndPtr - largerPtr < N)
                                     break; // boundary guardian for vector load.
-                                
+
                                 Vector256<ulong> value = Vector256.Create((ulong)*smallerPtr);
-                                Vector256<ulong> blockValues = Avx.LoadVector256((ulong*)largerPtr);
+                                Vector256<ulong> blockValues = Vector256.Load((ulong*)largerPtr);
 
                                 // We are going to select which direction we are going to be moving forward. 
-                                if (!Avx2.CompareEqual(value, blockValues).Equals(Vector256<ulong>.Zero))
+                                if (Vector256.EqualsAny(value, blockValues))
                                 {
                                     // We found the value, therefore we need to store this value in the destination.
                                     *dstPtr = *smallerPtr;
@@ -567,7 +567,7 @@ namespace Corax.Querying.Matches
                     term._bm25Relevance.Score(matches, scores, boostFactor);
             }
             
-            if (Avx2.IsSupported == false)
+            if (Vector256.IsHardwareAccelerated == false)
                 useAccelerated = false;
 
             var bm25Relevance = isBoosting
@@ -577,7 +577,7 @@ namespace Corax.Querying.Matches
 
             var isStored = isBoosting && bm25Relevance.IsStored;
             
-            // We will select the AVX version if supported.             
+            // We will select the Vector256 version if supported.             
             return new TermMatch(indexSearcher, ctx, postingList.State.NumberOfEntries, 
                     (isBoosting, isStored) switch
                     {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-20103

### Additional description
Current implementation now uses Vector256 operations instead of AVX making it accessible to be used in ARM hardware when acceleration is available.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
