### PR TITLE
RavenDB-22245: Implementation of Accelerated Frequency Quantization using Vector256

### DIFF
--- a/bench/Voron.Benchmark/Corax/CoraxEntryIdEncodings.cs
+++ b/bench/Voron.Benchmark/Corax/CoraxEntryIdEncodings.cs
@@ -30,9 +30,9 @@ public class CoraxEntryIdEncodings
     [Benchmark]
     public Span<long> DiscardWithSimd()
     {
-        EntryIdEncodings.DecodeAndDiscardFrequencyAvx2(_idsWithEncodingsForSimd, BufferSize);
-        EntryIdEncodings.DecodeAndDiscardFrequencyAvx2(_idsWithEncodingsForSimd, BufferSize);
-        EntryIdEncodings.DecodeAndDiscardFrequencyAvx2(_idsWithEncodingsForSimd, BufferSize);
+        EntryIdEncodings.DecodeAndDiscardFrequencyVector256(_idsWithEncodingsForSimd, BufferSize);
+        EntryIdEncodings.DecodeAndDiscardFrequencyVector256(_idsWithEncodingsForSimd, BufferSize);
+        EntryIdEncodings.DecodeAndDiscardFrequencyVector256(_idsWithEncodingsForSimd, BufferSize);
 
         return _idsWithEncodingsForSimd;
     }

--- a/src/Corax/Utils/EntryIdEncodings.cs
+++ b/src/Corax/Utils/EntryIdEncodings.cs
@@ -163,13 +163,13 @@ public static class EntryIdEncodings
     {
         return FrequencyReconstructionFromQuantization(FrequencyQuantization(frequency));
     }
-    
+
     internal static long FrequencyQuantization(short frequency)
     {
         if (Lzcnt.IsSupported)
             return LzcntFrequencyQuantization(frequency);
         if (ArmBase.Arm64.IsSupported)
-            ArmLzcntFrequencyQuantization(frequency);
+            return ArmLzcntFrequencyQuantization(frequency);
         
         return FrequencyQuantizationWithoutAcceleration(frequency);
     }

--- a/test/FastTests/Corax/Ranking/QuantizationTest.cs
+++ b/test/FastTests/Corax/Ranking/QuantizationTest.cs
@@ -33,7 +33,7 @@ public class QuantizationTest : RavenTestBase
         }
     }
 
-    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Intrinsics, RavenIntrinsics.Avx2)]
+    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Intrinsics)]
     [InlineData(7)]
     [InlineData(8)]
     [InlineData(16)]
@@ -41,7 +41,7 @@ public class QuantizationTest : RavenTestBase
     [InlineData(32)]
     [InlineData(33)]
     [InlineData(1)]
-    public void Avx2InstructionCorrectlyIgnoresFrequency(int size)
+    public void Vector256InstructionCorrectlyIgnoresFrequency(int size)
     {
         var random = new Random(2337);
         var ids = Enumerable.Range(0, size).Select(i => (long)random.Next(31_111, 59_999)).ToArray();
@@ -50,7 +50,7 @@ public class QuantizationTest : RavenTestBase
         var idsWithShiftedCopy = idsWithShifted.ToArray();
 
         EntryIdEncodings.DecodeAndDiscardFrequencyClassic(idsWithShiftedCopy.AsSpan(), size);
-        EntryIdEncodings.DecodeAndDiscardFrequencyAvx2(idsWithShifted.AsSpan(), size);
+        EntryIdEncodings.DecodeAndDiscardFrequencyVector256(idsWithShifted.AsSpan(), size);
 
         Assert.Equal(ids, idsWithShifted);
         Assert.Equal(idsWithShifted, idsWithShiftedCopy);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22245

### Additional description

With .Net 8.0 we have the instructions necessary to implement frequency quantization with Vector256. PR also fixes a bug that causes the wrongful execution of both ARM and unaccelerated frequency quantization.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
