### PR TITLE
RavenDB-22151 Added support for new types of memory dumps in /admin/debug/dump endpoint

### DIFF
--- a/src/Raven.Server/Web/System/AdminDumpHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDumpHandler.cs
@@ -191,7 +191,9 @@ namespace Raven.Server.Web.System
         private enum DumpType
         {
             Mini,
-            Heap
+            Heap,
+            Full,
+            Triage
         }
     }
 }

--- a/tools/Raven.Debug/CommandLineApp.cs
+++ b/tools/Raven.Debug/CommandLineApp.cs
@@ -131,7 +131,7 @@ namespace Raven.Debug
 
                 var pidOption = cmd.Option("--pid", "Process ID to which the tool will attach to", CommandOptionType.SingleValue);
                 var outputOption = cmd.Option("--output", "Output file path", CommandOptionType.SingleValue);
-                var typeOption = cmd.Option("--type", "Type of dump (Heap or Mini). ", CommandOptionType.SingleValue);
+                var typeOption = cmd.Option("--type", "Type of dump (Full, Heap, Mini or Triage). ", CommandOptionType.SingleValue);
                 var outputOwnerOption = cmd.Option("--output-owner", "The owner of the output file (applicable only to Posix based OS)", CommandOptionType.SingleValue);
 
                 cmd.OnExecute(() =>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22151

### Additional description

Continuation of https://github.com/ravendb/ravendb/pull/18356

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
