### PR TITLE
RavenDB-13830 / RavenDB-10621 / RavenDB-21987 Unskipping the test which no longer fails (even on 32 bits)

### DIFF
--- a/test/SlowTests/Issues/RavenDB_10621.cs
+++ b/test/SlowTests/Issues/RavenDB_10621.cs
@@ -14,10 +14,11 @@ namespace SlowTests.Issues
         {
         }
 
-        [Fact(Skip = "Waiting for RavenDB-13830 to be resolved")]
+        [Fact]
         public void ShouldNotErrorIndexOnInvalidProgramException()
         {
-            // if this test fails it's very likely the following issue got fixed: https://github.com/dotnet/coreclr/issues/14672
+            // this test has been added initially to workaround the following issue: https://github.com/dotnet/coreclr/issues/14672
+            // initially it was ShouldErrorIndexOnInvalidProgramException but after some time it got changed to ShouldNotErrorIndexOnInvalidProgramException
 
             using (var store = GetDocumentStore())
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13830/RavenDB10621.ShouldNotErrorIndexOnInvalidProgramException-throws-SO-on-32-bit

Relates to: https://issues.hibernatingrhinos.com/issue/RavenDB-10621


### Additional description

This test has been modified / skipped meanwhile. Related PRs:

https://github.com/ravendb/ravendb/pull/7704/files#diff-c138169c899f9315706bbe80038d4aedd4ac1f2640bf4f88b1cbe7d9aab8b448L14-R75

https://github.com/ravendb/ravendb/pull/9511/files#diff-c138169c899f9315706bbe80038d4aedd4ac1f2640bf4f88b1cbe7d9aab8b448L12

### Type of change

- [ ] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
