### PR TITLE
RavenDB-22249 Change the link and names for the Cloud instances in the Licensing view

### DIFF
--- a/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.spec.tsx
+++ b/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.spec.tsx
@@ -1,0 +1,28 @@
+import { composeStories } from "@storybook/react";
+import * as stories from "./FeatureAvailabilitySummary.stories";
+import { rtlRender } from "test/rtlTestUtils";
+import React from "react";
+
+const { FeatureAvailabilitySummaryStory } = composeStories(stories);
+
+describe("FeatureAvailabilitySummary", () => {
+    it("can render", () => {
+        const { screen } = rtlRender(<FeatureAvailabilitySummaryStory />);
+
+        expect(screen.getByText(/See which plans offer this and more exciting features/)).toBeInTheDocument();
+    });
+
+    it("can show 'Upgrade Instance' for cloud license", () => {
+        const { screen } = rtlRender(<FeatureAvailabilitySummaryStory isCloud />);
+
+        expect(screen.getByText(/Upgrade Instance/)).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /Cloud pricing/ })).toBeInTheDocument();
+    });
+
+    it("can show 'Upgrade License' for non-cloud license", () => {
+        const { screen } = rtlRender(<FeatureAvailabilitySummaryStory />);
+
+        expect(screen.getByText(/Upgrade License/)).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /Pricing plans/ })).toBeInTheDocument();
+    });
+});

--- a/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.stories.tsx
@@ -1,0 +1,67 @@
+import { licenseArgType, withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
+import { Meta, StoryObj } from "@storybook/react";
+import FeatureAvailabilitySummaryWrapper, { FeatureAvailabilityValueData } from "./FeatureAvailabilitySummary";
+import React from "react";
+import IconName from "typings/server/icons";
+import { AboutViewAnchored } from "components/common/AboutView";
+import { mockStore } from "test/mocks/store/MockStore";
+
+export default {
+    title: "Bits/Feature Availability Summary",
+    decorators: [withStorybookContexts, withBootstrap5],
+} satisfies Meta;
+
+interface FeatureAvailabilitySummaryStoryArgs {
+    licenseType: Raven.Server.Commercial.LicenseType;
+    isCloud: boolean;
+    isUnlimited: boolean;
+    hasFeature: boolean;
+    featureIcon: IconName;
+    featureName: string;
+    community: FeatureAvailabilityValueData;
+    professional: FeatureAvailabilityValueData;
+    enterprise: FeatureAvailabilityValueData;
+}
+
+export const FeatureAvailabilitySummaryStory: StoryObj<FeatureAvailabilitySummaryStoryArgs> = {
+    name: "Feature Availability Summary",
+    render: (args) => {
+        const { license } = mockStore;
+
+        license.with_License({
+            Type: args.licenseType,
+            IsCloud: args.isCloud,
+            CanSetupDefaultRevisionsConfiguration: args.hasFeature,
+        });
+
+        return (
+            <AboutViewAnchored defaultOpen="licensing">
+                <FeatureAvailabilitySummaryWrapper
+                    isUnlimited={args.isUnlimited}
+                    data={[
+                        {
+                            featureName: "Default Policy",
+                            featureIcon: args.featureIcon,
+                            community: args.community,
+                            professional: args.professional,
+                            enterprise: args.enterprise,
+                        },
+                    ]}
+                />
+            </AboutViewAnchored>
+        );
+    },
+    args: {
+        licenseType: "Community",
+        isCloud: false,
+        isUnlimited: false,
+        featureIcon: "default",
+        hasFeature: false,
+        community: { value: false },
+        professional: { value: true },
+        enterprise: { value: true },
+    },
+    argTypes: {
+        licenseType: licenseArgType,
+    },
+};

--- a/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.tsx
+++ b/src/Raven.Studio/typescript/components/common/FeatureAvailabilitySummary.tsx
@@ -12,7 +12,7 @@ import { AccordionItemWrapper } from "./AboutView";
 
 export type AvailabilityValue = boolean | number | string;
 
-interface ValueData {
+export interface FeatureAvailabilityValueData {
     value: AvailabilityValue;
     overwrittenValue?: AvailabilityValue;
 }
@@ -20,9 +20,9 @@ interface ValueData {
 export interface FeatureAvailabilityData {
     featureName?: string;
     featureIcon?: IconName;
-    community: ValueData;
-    professional?: ValueData;
-    enterprise: ValueData;
+    community: FeatureAvailabilityValueData;
+    professional?: FeatureAvailabilityValueData;
+    enterprise: FeatureAvailabilityValueData;
 }
 
 interface FeatureAvailabilitySummaryProps {
@@ -218,25 +218,12 @@ export function FeatureAvailabilitySummary(props: FeatureAvailabilitySummaryProp
                     </a>
                 </div>
             )}
-            {currentLicense !== "Enterprise" && currentLicense !== "None" && (
-                <div className="hstack gap-4 justify-content-center mt-4 flex-wrap">
-                    Upgrade License
-                    <a
-                        href={buyLink}
-                        target="_blank"
-                        color="primary"
-                        className="btn btn-primary btn-lg rounded-pill px-4"
-                    >
-                        <Icon icon="license" margin="me-3" />
-                        Pricing plans
-                    </a>
-                </div>
-            )}
+            {currentLicense !== "Enterprise" && currentLicense !== "None" && <UpgradeLinkSection />}
         </>
     );
 }
 
-function formatAvailabilityValue(data: ValueData, canBeEnabledInCloud?: boolean): ReactNode {
+function formatAvailabilityValue(data: FeatureAvailabilityValueData, canBeEnabledInCloud?: boolean): ReactNode {
     const value = data.overwrittenValue ?? data.value;
 
     let formattedValue: ReactNode = value;
@@ -279,6 +266,45 @@ function formatAvailabilityValue(data: ValueData, canBeEnabledInCloud?: boolean)
                 </UncontrolledTooltip>
             </div>
         </>
+    );
+}
+
+function UpgradeLinkSection() {
+    const isCloud = useAppSelector(licenseSelectors.statusValue("IsCloud"));
+
+    const ravenBuyLink = useRavenLink({ hash: "FLDLO4", isDocs: false });
+    const cloudPricingLink = "https://cloud.ravendb.net/pricing";
+
+    return (
+        <div className="hstack gap-4 justify-content-center mt-4 flex-wrap">
+            {isCloud ? (
+                <>
+                    Upgrade Instance
+                    <a
+                        href={cloudPricingLink}
+                        target="_blank"
+                        color="primary"
+                        className="btn btn-primary btn-lg rounded-pill px-4"
+                    >
+                        <Icon icon="license" margin="me-3" />
+                        Cloud pricing
+                    </a>
+                </>
+            ) : (
+                <>
+                    Upgrade License
+                    <a
+                        href={ravenBuyLink}
+                        target="_blank"
+                        color="primary"
+                        className="btn btn-primary btn-lg rounded-pill px-4"
+                    >
+                        <Icon icon="license" margin="me-3" />
+                        Pricing plans
+                    </a>
+                </>
+            )}
+        </div>
     );
 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22249/Change-the-link-and-names-for-the-Cloud-instances-in-the-Licensing-view

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
