### PR TITLE
RavenDB-22225 avoid holding write tx while performing network calls

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Raven/Handlers/Processors/AbstractDatabaseEtlHandlerProcessorForTest.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/Handlers/Processors/AbstractDatabaseEtlHandlerProcessorForTest.cs
@@ -20,9 +20,9 @@ internal abstract class AbstractDatabaseEtlHandlerProcessorForTest<TTestEtlScrip
 
     protected override bool SupportsCurrentNode => true;
 
-    protected override IDisposable TestScript(DocumentsOperationContext context, TTestEtlScript testScript, out TestEtlScriptResult testResult)
+    protected override TestEtlScriptResult TestScript(DocumentsOperationContext context, TTestEtlScript testScript)
     {
-        return RavenEtl.TestScript(testScript, RequestHandler.Database, RequestHandler.ServerStore, context, out testResult);
+        return RavenEtl.TestScript(testScript, RequestHandler.Database, RequestHandler.ServerStore, context);
     }
 
     protected override ValueTask HandleRemoteNodeAsync(DocumentsOperationContext context, TTestEtlScript testScript, BlittableJsonReaderObject testScriptJson)

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/Handlers/Processors/AbstractEtlHandlerProcessorForTest.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/Handlers/Processors/AbstractEtlHandlerProcessorForTest.cs
@@ -24,17 +24,15 @@ namespace Raven.Server.Documents.ETL.Providers.Raven.Handlers.Processors
 
         protected abstract TTestEtlScript GetTestEtlScript(BlittableJsonReaderObject json);
 
-        protected abstract IDisposable TestScript(TOperationContext context, TTestEtlScript testScript, out TestEtlScriptResult testResult);
+        protected abstract TestEtlScriptResult TestScript(TOperationContext context, TTestEtlScript testScript);
 
         private async ValueTask HandleCurrentNodeAsync(TOperationContext context, TTestEtlScript testScript)
         {
-            using (TestScript(context, testScript, out var testResult))
+            var testResult = TestScript(context, testScript);
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
             {
-                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
-                {
-                    var djv = testResult.ToJson(context);
-                    writer.WriteObject(context.ReadObject(djv, "et/sql/test"));
-                }
+                var djv = testResult.ToJson(context);
+                writer.WriteObject(context.ReadObject(djv, "et/sql/test"));
             }
         }
 

--- a/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
+++ b/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
@@ -415,10 +415,10 @@ public abstract class QueueSinkProcess : IDisposable, ILowMemoryHandler
         if (string.IsNullOrEmpty(testScript.Message))
             throw new InvalidOperationException("Sample message in JSON format must be provided");
 
+        using var messageDoc = context.Sync.ReadForMemory(new MemoryStream(Encoding.UTF8.GetBytes(testScript.Message)), "queue-sink-test-message");
+
         using (context.OpenWriteTransaction())
         {
-            using var messageDoc = context.Sync.ReadForMemory(new MemoryStream(Encoding.UTF8.GetBytes(testScript.Message)), "queue-sink-test-message");
-
             var script = new PatchRequest(testScript.Configuration.Scripts[0].Script, PatchRequestType.QueueSink);
 
             var command = new TestQueueMessageCommand(context, script, messageDoc);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/AbstractShardedEtlHandlerProcessorForTest.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/ETL/AbstractShardedEtlHandlerProcessorForTest.cs
@@ -24,7 +24,7 @@ internal abstract class AbstractShardedEtlHandlerProcessorForTest<TTestEtlScript
 
     protected override bool SupportsCurrentNode => false;
 
-    protected override IDisposable TestScript(TransactionOperationContext context, TTestEtlScript testScript, out TestEtlScriptResult testResult)
+    protected override TestEtlScriptResult TestScript(TransactionOperationContext context, TTestEtlScript testScript)
     {
         throw new NotSupportedException();
     }

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -439,6 +439,9 @@ namespace Raven.Server.Rachis
             try
             {
                 _persistentState = env;
+#if DEBUG
+                _persistentState.CaptureTransactionStackTrace = ServerStore.EnableCaptureWriteTransactionStackTrace;
+#endif
 
                 OperationTimeout = configuration.Cluster.OperationTimeout.AsTimeSpan;
                 ElectionTimeout = configuration.Cluster.ElectionTimeout.AsTimeSpan;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3858,6 +3858,10 @@ namespace Raven.Server.ServerWide
             internal Action<string, List<ClusterTransactionCommand.SingleClusterDatabaseCommand>> BeforeExecuteClusterTransactionBatch;
         }
 
+#if DEBUG
+        public bool EnableCaptureWriteTransactionStackTrace = false;
+#endif
+
         public readonly MemoryCache QueryClauseCache;
 
         public void LowMemory(LowMemorySeverity lowMemorySeverity)

--- a/src/Sparrow/Utils/NativeMemory.cs
+++ b/src/Sparrow/Utils/NativeMemory.cs
@@ -56,6 +56,8 @@ namespace Sparrow.Utils
             public readonly int ManagedThreadId;
             private string _lastName = "Unknown";
 
+            internal string CapturedStackTrace;
+
             public string Name
             {
                 get

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -787,8 +787,12 @@ namespace Voron
                 currentWriteTransactionHolder == NativeMemory.CurrentThreadStats)
             {
                 throw new InvalidOperationException($"A write transaction is already opened by thread name: " +
-                                                    $"{currentWriteTransactionHolder.Name}, Id: {currentWriteTransactionHolder.ManagedThreadId}");
+                                                    $"{currentWriteTransactionHolder.Name}, Id: {currentWriteTransactionHolder.ManagedThreadId}{Environment.NewLine}" +
+                                                    $"{currentWriteTransactionHolder.CapturedStackTrace}");
             }
+
+            if (currentWriteTransactionHolder != null)
+                currentWriteTransactionHolder.CapturedStackTrace = Environment.StackTrace;
         }
 
         internal void IncrementUsageOnNewTransaction()

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -779,6 +779,10 @@ namespace Voron
             AfterCommitWhenNewTransactionsPrevented?.Invoke(tx);
         }
 
+#if DEBUG
+        public bool CaptureTransactionStackTrace;
+#endif
+
         [Conditional("DEBUG")]
         private void ThrowOnWriteTransactionOpenedByTheSameThread()
         {
@@ -790,9 +794,12 @@ namespace Voron
                                                     $"{currentWriteTransactionHolder.Name}, Id: {currentWriteTransactionHolder.ManagedThreadId}{Environment.NewLine}" +
                                                     $"{currentWriteTransactionHolder.CapturedStackTrace}");
             }
-
-            if (currentWriteTransactionHolder != null)
+#if DEBUG
+            if (currentWriteTransactionHolder != null && CaptureTransactionStackTrace)
+            {
                 currentWriteTransactionHolder.CapturedStackTrace = Environment.StackTrace;
+            }
+#endif
         }
 
         internal void IncrementUsageOnNewTransaction()

--- a/test/RachisTests/BasicTests.cs
+++ b/test/RachisTests/BasicTests.cs
@@ -60,6 +60,8 @@ namespace RachisTests
         [Fact]
         public async Task RavenDB_13659()
         {
+            EnableCaptureWriteTransactionStackTrace = true;
+
             var leader = await CreateNetworkAndGetLeader(1);
             var mre = new AsyncManualResetEvent();
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17476.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17476.cs
@@ -127,45 +127,41 @@ loadTo" + OrdersIndexName + @"(orderData);
 
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
-                    using (ElasticSearchEtl.TestScript(
-                               new TestElasticSearchEtlScript
-                               {
-                                   DocumentId = "orders/1-A",
-                                   Configuration = new ElasticSearchEtlConfiguration
-                                   {
-                                       Name = "simulate",
-                                       ConnectionStringName = "simulate",
-                                       ElasticIndexes =
-                                       {
-                                           new ElasticSearchIndex { IndexName = OrdersIndexName, DocumentIdProperty = "Id" },
-                                           new ElasticSearchIndex { IndexName = OrderLinesIndexName, DocumentIdProperty = "OrderId" },
-                                           new ElasticSearchIndex { IndexName = "NotUsedInScript", DocumentIdProperty = "OrderId" },
-                                       },
-                                       Transforms =
-                                       {
-                                           new Transformation { Collections = { "Orders" }, Name = "OrdersAndLines", Script = ScriptWithNoIdMethodUsage }
-                                       }
-                                   }
-                               }, database, database.ServerStore, context, out var testResult))
-                    {
-                        var result = (ElasticSearchEtlTestScriptResult)testResult;
+                    var testResult = ElasticSearchEtl.TestScript(
+                        new TestElasticSearchEtlScript
+                        {
+                            DocumentId = "orders/1-A",
+                            Configuration = new ElasticSearchEtlConfiguration
+                            {
+                                Name = "simulate",
+                                ConnectionStringName = "simulate",
+                                ElasticIndexes =
+                                {
+                                    new ElasticSearchIndex { IndexName = OrdersIndexName, DocumentIdProperty = "Id" },
+                                    new ElasticSearchIndex { IndexName = OrderLinesIndexName, DocumentIdProperty = "OrderId" },
+                                    new ElasticSearchIndex { IndexName = "NotUsedInScript", DocumentIdProperty = "OrderId" },
+                                },
+                                Transforms = { new Transformation { Collections = { "Orders" }, Name = "OrdersAndLines", Script = ScriptWithNoIdMethodUsage } }
+                            }
+                        }, database, database.ServerStore, context);
+                    
+                    var result = (ElasticSearchEtlTestScriptResult)testResult;
 
-                        Assert.Equal(0, result.TransformationErrors.Count);
+                    Assert.Equal(0, result.TransformationErrors.Count);
 
-                        Assert.Equal(2, result.Summary.Count);
+                    Assert.Equal(2, result.Summary.Count);
 
-                        var orderLines = result.Summary.First(x => x.IndexName == OrderLinesIndexName);
+                    var orderLines = result.Summary.First(x => x.IndexName == OrderLinesIndexName);
 
-                        Assert.Equal(2, orderLines.Commands.Length); // delete by query and bulk
+                    Assert.Equal(2, orderLines.Commands.Length); // delete by query and bulk
 
-                        Assert.Contains(@"""OrderId"":""orders/1-a""", orderLines.Commands[1]);
+                    Assert.Contains(@"""OrderId"":""orders/1-a""", orderLines.Commands[1]);
 
-                        var orders = result.Summary.First(x => x.IndexName == OrdersIndexName);
+                    var orders = result.Summary.First(x => x.IndexName == OrdersIndexName);
 
-                        Assert.Equal(2, orders.Commands.Length); // delete by query and bulk
+                    Assert.Equal(2, orders.Commands.Length); // delete by query and bulk
 
-                        Assert.Contains(@"""Id"":""orders/1-a""", orders.Commands[1]);
-                    }
+                    Assert.Contains(@"""Id"":""orders/1-a""", orders.Commands[1]);
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_17263.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_17263.cs
@@ -84,40 +84,38 @@ namespace SlowTests.Server.Documents.ETL.Olap
 
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
-                    using (OlapEtl.TestScript(new TestOlapEtlScript
+                    var testResult = OlapEtl.TestScript(new TestOlapEtlScript
                     {
                         DocumentId = "orders/1",
                         Configuration = configuration
-                    }, database, database.ServerStore, context, out var testResult))
-                    {
-                        var result = (OlapEtlTestScriptResult)testResult;
+                    }, database, database.ServerStore, context);
+                    
+                    var result = (OlapEtlTestScriptResult)testResult;
 
-                        Assert.Equal(1, result.ItemsByPartition.Count);
+                    Assert.Equal(1, result.ItemsByPartition.Count);
 
-                        Assert.Equal(4, result.ItemsByPartition[0].Columns.Count);
+                    Assert.Equal(4, result.ItemsByPartition[0].Columns.Count);
 
-                        Assert.Equal("Orders/order_date=2020-01-01-00-00/location=USA", result.ItemsByPartition[0].Key);
-                    }
+                    Assert.Equal("Orders/order_date=2020-01-01-00-00/location=USA", result.ItemsByPartition[0].Key);
                 }
 
                 configuration.CustomPartitionValue = null;
 
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
-                    using (OlapEtl.TestScript(new TestOlapEtlScript
+                    var testResult = OlapEtl.TestScript(new TestOlapEtlScript
                     {
                         DocumentId = "orders/1",
                         Configuration = configuration
-                    }, database, database.ServerStore, context, out var testResult))
-                    {
-                        var result = (OlapEtlTestScriptResult)testResult;
+                    }, database, database.ServerStore, context);
+                    
+                    var result = (OlapEtlTestScriptResult)testResult;
 
-                        Assert.Equal(1, result.ItemsByPartition.Count);
+                    Assert.Equal(1, result.ItemsByPartition.Count);
 
-                        Assert.Equal(4, result.ItemsByPartition[0].Columns.Count);
+                    Assert.Equal(4, result.ItemsByPartition[0].Columns.Count);
 
-                        Assert.Equal("Orders/order_date=2020-01-01-00-00/location=undefined", result.ItemsByPartition[0].Key);
-                    }
+                    Assert.Equal("Orders/order_date=2020-01-01-00-00/location=undefined", result.ItemsByPartition[0].Key);
                 }
 
             }

--- a/test/SlowTests/Server/Documents/ETL/Queue/KafkaEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/KafkaEtlTests.cs
@@ -313,23 +313,23 @@ public class KafkaEtlTests : KafkaEtlTestBase
 
             using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                using (QueueEtl<QueueItem>.TestScript(
-                           new TestQueueEtlScript
-                           {
-                               DocumentId = "orders/1-A",
-                               Configuration = new QueueEtlConfiguration
-                               {
-                                   Name = "simulate",
-                                   ConnectionStringName = "simulate",
-                                   Queues = { new EtlQueue() { Name = "Orders" } },
-                                   BrokerType = QueueBrokerType.Kafka,
-                                   Transforms =
-                                   {
-                                       new Transformation
-                                       {
-                                           Collections = { "Orders" },
-                                           Name = "Orders",
-                                           Script = @"
+                var testResult = QueueEtl<QueueItem>.TestScript(
+                    new TestQueueEtlScript
+                    {
+                        DocumentId = "orders/1-A",
+                        Configuration = new QueueEtlConfiguration
+                        {
+                            Name = "simulate",
+                            ConnectionStringName = "simulate",
+                            Queues = { new EtlQueue() { Name = "Orders" } },
+                            BrokerType = QueueBrokerType.Kafka,
+                            Transforms =
+                            {
+                                new Transformation
+                                {
+                                    Collections = { "Orders" },
+                                    Name = "Orders",
+                                    Script = @"
 var orderData = {
     Id: id(this),
     OrderLinesCount: this.OrderLines.length,
@@ -345,19 +345,18 @@ for (var i = 0; i < this.OrderLines.length; i++) {
 loadToOrders(orderData);
 
 output('test output')"
-                                       }
-                                   }
-                               }
-                           }, database, database.ServerStore, context, out var testResult))
-                {
-                    var result = (QueueEtlTestScriptResult)testResult;
+                                }
+                            }
+                        }
+                    }, database, database.ServerStore, context);
+                
+                var result = (QueueEtlTestScriptResult)testResult;
 
-                    Assert.Equal(0, result.TransformationErrors.Count);
+                Assert.Equal(0, result.TransformationErrors.Count);
 
-                    Assert.Equal(1, result.Summary.Count);
+                Assert.Equal(1, result.Summary.Count);
 
-                    Assert.Equal("test output", result.DebugOutput[0]);
-                }
+                Assert.Equal("test output", result.DebugOutput[0]);
             }
         }
     }

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_12011.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_12011.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     {
-                        using (RavenEtl.TestScript(new TestRavenEtlScript
+                        var testResult = RavenEtl.TestScript(new TestRavenEtlScript
                         {
                             DocumentId = docId,
                             IsDelete = true,
@@ -55,7 +55,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                                 {
                                     new Transformation()
                                     {
-                                        Collections = {"Orders"},
+                                        Collections = { "Orders" },
                                         Name = "OrdersAndLines",
                                         Script =
                                             @"
@@ -81,17 +81,16 @@ loadToOrders(orderData);
                                     }
                                 }
                             }
-                        }, database, database.ServerStore, context, out var testResult))
-                        {
-                            var result = (RavenEtlTestScriptResult)testResult;
+                        }, database, database.ServerStore, context);
+                        
+                        var result = (RavenEtlTestScriptResult)testResult;
                             
-                            Assert.Equal(0, result.TransformationErrors.Count);
+                        Assert.Equal(0, result.TransformationErrors.Count);
 
-                            Assert.Equal(2, result.Commands.Count);
+                        Assert.Equal(2, result.Commands.Count);
 
-                            Assert.IsType(typeof(DeletePrefixedCommandData), result.Commands[0]);
-                            Assert.IsType(typeof(DeleteCommandData), result.Commands[1]);
-                        }
+                        Assert.IsType(typeof(DeletePrefixedCommandData), result.Commands[0]);
+                        Assert.IsType(typeof(DeleteCommandData), result.Commands[1]);
                     }
                 }
 
@@ -121,7 +120,7 @@ loadToOrders(orderData);
 
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     {
-                        using (RavenEtl.TestScript(new TestRavenEtlScript
+                        var testResult = RavenEtl.TestScript(new TestRavenEtlScript
                         {
                             DocumentId = docId,
                             IsDelete = true,
@@ -132,7 +131,7 @@ loadToOrders(orderData);
                                 {
                                     new Transformation()
                                     {
-                                        Collections = {"Users"},
+                                        Collections = { "Users" },
                                         Name = "Users",
                                         Script =
                                             @"
@@ -146,16 +145,15 @@ function deleteDocumentsOfUsersBehavior(docId) {
                                     }
                                 }
                             }
-                        }, database, database.ServerStore, context, out var testResult))
-                        {
-                            var result = (RavenEtlTestScriptResult)testResult;
+                        }, database, database.ServerStore, context);
+                        
+                        var result = (RavenEtlTestScriptResult)testResult;
                             
-                            Assert.Equal(0, result.TransformationErrors.Count);
+                        Assert.Equal(0, result.TransformationErrors.Count);
 
-                            Assert.Equal(0, result.Commands.Count);
+                        Assert.Equal(0, result.Commands.Count);
 
-                            Assert.Equal("document: users/1", result.DebugOutput[0]);
-                        }
+                        Assert.Equal("document: users/1", result.DebugOutput[0]);
                     }
                 }
 

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_9072.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_9072.cs
@@ -46,20 +46,20 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     {
-                        using (RavenEtl.TestScript(new TestRavenEtlScript
-                               {
-                                   DocumentId = docId,
-                                   Configuration = new RavenEtlConfiguration()
-                                   {
-                                       Name = "simulate",
-                                       Transforms =
-                                       {
-                                           new Transformation()
-                                           {
-                                               Collections = {"Orders"},
-                                               Name = "OrdersAndLines",
-                                               Script =
-                                                   @"
+                        var testResult = RavenEtl.TestScript(new TestRavenEtlScript
+                        {
+                            DocumentId = docId,
+                            Configuration = new RavenEtlConfiguration()
+                            {
+                                Name = "simulate",
+                                Transforms =
+                                {
+                                    new Transformation()
+                                    {
+                                        Collections = { "Orders" },
+                                        Name = "OrdersAndLines",
+                                        Script =
+                                            @"
 var orderData = {
     Id: id(this),
     LinesCount: this.Lines.length,
@@ -80,22 +80,21 @@ for (var i = 0; i < this.Lines.length; i++) {
 output('test output');
 
 loadToOrders(orderData);"
-                                           }
-                                       }
-                                   }
-                               }, database, database.ServerStore, context, out var testResult))
-                        {
-                            var result = (RavenEtlTestScriptResult)testResult;
+                                    }
+                                }
+                            }
+                        }, database, database.ServerStore, context);
+                        
+                        var result = (RavenEtlTestScriptResult)testResult;
 
-                            Assert.Equal(0, result.TransformationErrors.Count);
+                        Assert.Equal(0, result.TransformationErrors.Count);
 
-                            Assert.Equal(4, result.Commands.Count);
+                        Assert.Equal(4, result.Commands.Count);
 
-                            Assert.Equal(1, result.Commands.OfType<DeletePrefixedCommandData>().Count());
-                            Assert.Equal(3, result.Commands.OfType<PutCommandDataWithBlittableJson>().Count());
+                        Assert.Equal(1, result.Commands.OfType<DeletePrefixedCommandData>().Count());
+                        Assert.Equal(3, result.Commands.OfType<PutCommandDataWithBlittableJson>().Count());
 
-                            Assert.Equal("test output", result.DebugOutput[0]);
-                        }
+                        Assert.Equal("test output", result.DebugOutput[0]);
                     }
                 }
             }
@@ -141,7 +140,7 @@ loadToOrders(this);"
                                     }
                                 }
                         }
-                    }, database, database.ServerStore, context, out _);
+                    }, database, database.ServerStore, context);
                 }
             }
         }
@@ -184,7 +183,7 @@ loadToDifferentCollection(this);"
                                     }
                                 }
                             }
-                        }, database, database.ServerStore, context, out _);
+                        }, database, database.ServerStore, context);
                     });
 
                     Assert.Contains(
@@ -209,25 +208,25 @@ loadToDifferentCollection(this);"
 
                 var database = await Etl.GetDatabaseFor(store, documentId);
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                using (RavenEtl.TestScript(
-                   new TestRavenEtlScript
-                   {
-                       DocumentId = documentId,
-                       Configuration = new RavenEtlConfiguration()
-                       {
-                           Name = "simulate", 
-                           Transforms =
-                           {
-                               new Transformation()
-                               {
-                                   Collections = { "Orders" }, 
-                                   Name = "OrdersAndLines", 
-                                   Script = null
-                               }
-                           }
-                       }
-                   }, database, database.ServerStore, context, out var testResult))
                 {
+                    var testResult = RavenEtl.TestScript(
+                        new TestRavenEtlScript
+                        {
+                            DocumentId = documentId,
+                            Configuration = new RavenEtlConfiguration()
+                            {
+                                Name = "simulate", 
+                                Transforms =
+                                {
+                                    new Transformation()
+                                    {
+                                        Collections = { "Orders" }, 
+                                        Name = "OrdersAndLines", 
+                                        Script = null
+                                    }
+                                }
+                            }
+                        }, database, database.ServerStore, context);
 
                     var result = (RavenEtlTestScriptResult)testResult;
 

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -726,7 +726,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
 
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     {
-                        using (SqlEtl.TestScript(
+                        var testResult = SqlEtl.TestScript(
                             new TestSqlEtlScript
                             {
                                 PerformRolledBackTransaction = performRolledBackTransaction,
@@ -737,37 +737,36 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
                                     ConnectionStringName = "simulate",
                                     SqlTables =
                                     {
-                                        new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id"},
-                                        new SqlEtlTable {TableName = "OrderLines", DocumentIdColumn = "OrderId"},
-                                        new SqlEtlTable {TableName = "NotUsedInScript", DocumentIdColumn = "OrderId"},
+                                        new SqlEtlTable { TableName = "Orders", DocumentIdColumn = "Id" },
+                                        new SqlEtlTable { TableName = "OrderLines", DocumentIdColumn = "OrderId" },
+                                        new SqlEtlTable { TableName = "NotUsedInScript", DocumentIdColumn = "OrderId" },
                                     },
                                     Transforms =
                                     {
                                         new Transformation()
                                         {
-                                            Collections = {"Orders"}, Name = "OrdersAndLines", Script = defaultScript + "output('test output')"
+                                            Collections = { "Orders" }, Name = "OrdersAndLines", Script = defaultScript + "output('test output')"
                                         }
                                     }
                                 }
-                            }, database, database.ServerStore, context, out var testResult))
-                        {
-                            var result = (SqlEtlTestScriptResult)testResult;
-                            Assert.Equal(0, result.TransformationErrors.Count);
-                            Assert.Equal(0, result.LoadErrors.Count);
-                            Assert.Equal(0, result.SlowSqlWarnings.Count);
+                            }, database, database.ServerStore, context);
+                        
+                        var result = (SqlEtlTestScriptResult)testResult;
+                        Assert.Equal(0, result.TransformationErrors.Count);
+                        Assert.Equal(0, result.LoadErrors.Count);
+                        Assert.Equal(0, result.SlowSqlWarnings.Count);
 
-                            Assert.Equal(2, result.Summary.Count);
+                        Assert.Equal(2, result.Summary.Count);
 
-                            var orderLines = result.Summary.First(x => x.TableName == "OrderLines");
+                        var orderLines = result.Summary.First(x => x.TableName == "OrderLines");
 
-                            Assert.Equal(3, orderLines.Commands.Length); // delete and two inserts
+                        Assert.Equal(3, orderLines.Commands.Length); // delete and two inserts
 
-                            var orders = result.Summary.First(x => x.TableName == "Orders");
+                        var orders = result.Summary.First(x => x.TableName == "Orders");
 
-                            Assert.Equal(2, orders.Commands.Length); // delete and insert
+                        Assert.Equal(2, orders.Commands.Length); // delete and insert
 
-                            Assert.Equal("test output", result.DebugOutput[0]);
-                        }
+                        Assert.Equal("test output", result.DebugOutput[0]);
                     }
                 }
             }
@@ -811,7 +810,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
 
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     {
-                        using (SqlEtl.TestScript(
+                        var testResult = SqlEtl.TestScript(
                             new TestSqlEtlScript
                             {
                                 PerformRolledBackTransaction = performRolledBackTransaction,
@@ -823,27 +822,26 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
                                     ConnectionStringName = "simulate",
                                     SqlTables =
                                     {
-                                        new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id"},
-                                        new SqlEtlTable {TableName = "OrderLines", DocumentIdColumn = "OrderId"},
-                                        new SqlEtlTable {TableName = "NotUsedInScript", DocumentIdColumn = "OrderId"},
+                                        new SqlEtlTable { TableName = "Orders", DocumentIdColumn = "Id" },
+                                        new SqlEtlTable { TableName = "OrderLines", DocumentIdColumn = "OrderId" },
+                                        new SqlEtlTable { TableName = "NotUsedInScript", DocumentIdColumn = "OrderId" },
                                     },
                                     Transforms = { new Transformation() { Collections = { "Orders" }, Name = "OrdersAndLines", Script = defaultScript } }
                                 }
-                            }, database, database.ServerStore, context, out var testResult))
-                        {
-                            var result = (SqlEtlTestScriptResult)testResult;
+                            }, database, database.ServerStore, context);
+                        
+                        var result = (SqlEtlTestScriptResult)testResult;
 
-                            Assert.Equal(0, result.TransformationErrors.Count);
-                            Assert.Equal(0, result.LoadErrors.Count);
-                            Assert.Equal(0, result.SlowSqlWarnings.Count);
-                            Assert.Equal(2, result.Summary.Count);
+                        Assert.Equal(0, result.TransformationErrors.Count);
+                        Assert.Equal(0, result.LoadErrors.Count);
+                        Assert.Equal(0, result.SlowSqlWarnings.Count);
+                        Assert.Equal(2, result.Summary.Count);
 
-                            var orderLines = result.Summary.First(x => x.TableName == "OrderLines");
-                            Assert.Equal(1, orderLines.Commands.Length); // delete
+                        var orderLines = result.Summary.First(x => x.TableName == "OrderLines");
+                        Assert.Equal(1, orderLines.Commands.Length); // delete
 
-                            var orders = result.Summary.First(x => x.TableName == "Orders");
-                            Assert.Equal(1, orders.Commands.Length); // delete
-                        }
+                        var orders = result.Summary.First(x => x.TableName == "Orders");
+                        Assert.Equal(1, orders.Commands.Length); // delete
                     }
 
                     using (var session = store.OpenAsyncSession())

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -52,7 +52,6 @@ namespace Tests.Infrastructure
             NativeMemory.GetCurrentUnmanagedThreadId = () => (ulong)Pal.rvn_get_current_thread_id();
             ZstdLib.CreateDictionaryException = message => new VoronErrorException(message);
             RachisStateMachine.EnableDebugLongCommit = true;
-
             Lucene.Net.Util.UnmanagedStringArray.Segment.AllocateMemory = NativeMemory.AllocateMemory;
             Lucene.Net.Util.UnmanagedStringArray.Segment.FreeMemory = NativeMemory.Free;
             JsonDeserializationCluster.Commands.Add(nameof(TestCommand), JsonDeserializationBase.GenerateJsonDeserializationRoutine<TestCommand>());
@@ -205,6 +204,8 @@ namespace Tests.Infrastructure
             return sb.ToString();
         }
 
+        protected bool EnableCaptureWriteTransactionStackTrace = false;
+
         protected RachisConsensus<CountingStateMachine> SetupServer(bool bootstrap = false, int port = 0, int electionTimeout = 300, [CallerMemberName] string caller = null, bool shouldRunInMemory = true, string nodeTag = null)
         {
             var tcpListener = new TcpListener(IPAddress.Loopback, port);
@@ -242,6 +243,9 @@ namespace Tests.Infrastructure
             }
 
             var serverStore = new RavenServer(configuration) { ThrowOnLicenseActivationFailure = true }.ServerStore;
+#if DEBUG
+            serverStore.EnableCaptureWriteTransactionStackTrace = EnableCaptureWriteTransactionStackTrace;
+#endif
             serverStore.Initialize();
             var rachis = new RachisConsensus<CountingStateMachine>(serverStore, seed);
             var storageEnvironment = new StorageEnvironment(server);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22225

### Additional description

It was possible to hold the write lock for a long time when we performed an ETL test for deleting a document.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Assume existing tests cover the fix
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
