### PR TITLE
RavenDB-22242 Support `@AllResults` aggregations in Corax.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Corax;
-using Corax.Querying;
 using Corax.Mappings;
 using Corax.Utils;
 using Raven.Client.Documents.Indexes;
@@ -219,6 +218,12 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         if (facetsByName.TryGetValue(result.Key, out var facetValues) == false)
             facetsByName[result.Key] = facetValues = new Dictionary<string, FacetValues>();
 
+        if (result.Key == Client.Constants.Documents.Querying.Facet.AllResults || result.Value.AggregateBy == Client.Constants.Documents.Querying.Facet.AllResults)
+        {
+            InsertTerm(Encodings.Utf8.GetBytes(result.Value.AggregateBy), ref reader);
+            return;
+        }
+        
         long fieldRootPage = GetFieldRootPage(result.Value.AggregateBy);
 
         var cloned = reader;
@@ -230,7 +235,7 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                 : reader.Current.Decoded();
             
             InsertTerm(key, ref cloned);
-        } 
+        }
 
         void InsertTerm(ReadOnlySpan<byte> term, ref EntryTermsReader reader)
         {

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-            const int numberToTolerate = 4616;
+            const int numberToTolerate = 4615;
 
             if (array.Length == numberToTolerate)
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22242

### Additional description

When we aggregate by `@AllResults` we've to create in-memory term for it since entry terms iterator will return 0 elements when we search for this field.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
