### PR TITLE
RavenDB-22253 Hooking up NewTransactionCreated and AfterCommitWhenNewTransactionsPrevented events to transactions created on async commit

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1123,6 +1123,8 @@ namespace Voron.Impl
                 _env.ActiveTransactions.Add(nextTx);
                 _env.WriteTransactionStarted();
 
+                nextTx.AfterCommitWhenNewTransactionsPrevented += _env.InvokeAfterCommitWhenNewTransactionsPrevented;
+                _env.InvokeNewTransactionCreated(nextTx);
 
                 return nextTx;
             }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -770,6 +770,16 @@ namespace Voron
             }
         }
 
+        internal void InvokeNewTransactionCreated(LowLevelTransaction tx)
+        {
+            NewTransactionCreated?.Invoke(tx);
+        }
+
+        internal void InvokeAfterCommitWhenNewTransactionsPrevented(LowLevelTransaction tx)
+        {
+            AfterCommitWhenNewTransactionsPrevented?.Invoke(tx);
+        }
+
         [Conditional("DEBUG")]
         private void ThrowOnWriteTransactionOpenedByTheSameThread()
         {

--- a/test/SlowTests/Issues/RavenDB_22253.cs
+++ b/test/SlowTests/Issues/RavenDB_22253.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Sparrow.Collections;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22253 : RavenTestBase
+{
+    public RavenDB_22253(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Voron)]
+    public async Task QueryMustNotReturnNoResultsAfterWaitForIndexesAfterSaveChanges()
+    {
+        using var store = GetDocumentStore();
+
+        store.ExecuteIndex(new PupilsIndex());
+
+        var tasks = new List<Task>();
+        var failures = new ConcurrentSet<string>();
+
+        WaitForUserToContinueTheTest(store);
+
+        // Run 10 concurrent tasks:
+        for (int i = 0; i < 10; i++)
+        {
+            var taskId = i.ToString() + "-";
+
+            tasks.Add(Task.Run(async () =>
+            {
+                // Add 1 pupil to each of 1000 schools:
+                foreach (var schoolId in Enumerable
+                    .Range(1, 100)
+                    .Select(j => $"Schools/{taskId}{j}"))
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new Pupil
+                        {
+                            SchoolId = schoolId,
+                            FirstName = "John"
+                        }, $"pupils/{schoolId}");
+                        session.Advanced.WaitForIndexesAfterSaveChanges();
+                        await session.SaveChangesAsync();
+                    }
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        // Given the previous step uses WaitForIndexesAfterSaveChanges,
+                        // we'd assume that the index contains the new pupil.
+                        var pupils = await session.Query<Pupil, PupilsIndex>()
+                            .Where(x => x.SchoolId == schoolId)
+                            .ToListAsync();
+
+                        if (pupils.Count == 0)
+                        {
+                            failures.Add($"No pupils found for {schoolId}");
+                        }
+                    }
+                }
+            }));
+        }
+
+        await Task.WhenAll(tasks);
+        Assert.True(failures.Count == 0, string.Join('\n', failures));
+    }
+
+    class Pupil
+    {
+        public string Id { get; set; }
+        public string SchoolId { get; set; }
+        public string FirstName { get; set; }
+    }
+
+    class PupilsIndex : AbstractIndexCreationTask<Pupil>
+    {
+
+        public PupilsIndex()
+        {
+            Map = pupils => from pupil in pupils
+                            select new
+                            {
+                                pupil.SchoolId
+                            };
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22253/The-result-of-a-query-for-stored-value-when-the-store-was-marked-for-WaitForIndexesAfterSaveChanges-is-not-up-to-date.

### Additional description

This ensure that we'll be setting and updating DocumentsStorage.DocumentTransactionCache on commit of those transactions. This is important for read transactions calling methods like DocumentsStorage.ReadLastXXXEtag because they use that cache.

The origin of the issue was the invalid calculation of `IsStale()` when `WaitForIndexesAfterSaveChanges()` was used. The investigation has revealed that the problem was that we calculated it for the wrong cuttofEtag here:

https://github.com/ravendb/ravendb/blob/26ded91a6aba3f87de688839dbcf97a5e873500e/src/Raven.Server/Documents/Indexes/Index.cs#L1382

`cutoff.Value` that we passed from the batch handler (`command.LastChangeVector`):

https://github.com/ravendb/ravendb/blob/26ded91a6aba3f87de688839dbcf97a5e873500e/src/Raven.Server/Documents/Handlers/BatchHandler.cs#L129-L131

was greater than `lastItemEtag` that we got during `IsStale()` calculation:

https://github.com/ravendb/ravendb/blob/26ded91a6aba3f87de688839dbcf97a5e873500e/src/Raven.Server/Documents/Indexes/Index.cs#L1335

So effectively we checked the staleness for lower etag than we just inserted.

It was because we read it from `DocumentTransactionCache` object:

https://github.com/ravendb/ravendb/blob/26ded91a6aba3f87de688839dbcf97a5e873500e/src/Raven.Server/Documents/DocumentsStorage.cs#L1421-L1424

which wasn't updated after the commit of a transaction created in `BeginAsyncCommitAndStartNewTransaction()`


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
