### PR TITLE
RavenDB-21983 - Update our Client API XML documentation [IAbstractTim…

### DIFF
--- a/src/Raven.Client/DocumentationUrls.cs
+++ b/src/Raven.Client/DocumentationUrls.cs
@@ -158,6 +158,9 @@ internal static class DocumentationUrls
             ///<remarks><seealso href="https://ravendb.net/docs/article-page/6.0/csharp/document-extensions/timeseries/client-api/session/get/get-entries#include-parent-and-tagged-documents"/></remarks>
             public const string Include = nameof(Include);
 
+            ///<remarks><seealso href="https://ravendb.net/docs/article-page/6.0/csharp/document-extensions/timeseries/client-api/session/include/with-session-query"/></remarks>
+            public const string IncludeWithQuery = nameof(IncludeWithQuery);
+
             ///<remarks><seealso href="https://ravendb.net/docs/article-page/6.0/csharp/document-extensions/timeseries/client-api/overview"/></remarks>
             public const string ClientApi = nameof(ClientApi);
 

--- a/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
@@ -76,18 +76,42 @@ namespace Raven.Client.Documents.Session.Loaders
         ITimeSeriesIncludeBuilder IncludeDocument();
     }
 
+    /// <summary>
+    /// The server is instructed to pre-load referenced documents concurrently with retrieving the time series data.<br/>
+    /// The time series results are added to the session unit of work, and subsequent requests to load them are served directly from the session cache,
+    /// without requiring any additional requests to the server.
+    /// </summary>
+    /// <remarks><inheritdoc cref="DocumentationUrls.Session.TimeSeries.IncludeWithQuery"/></remarks>
     public interface IAbstractTimeSeriesIncludeBuilder<T, out TBuilder>
     {
+        /// <inheritdoc cref="IAbstractTimeSeriesIncludeBuilder{T, TBuilder}"/>
+        /// <param name="name">The name of the time series to include.</param>
+        /// <param name="type">Indicates how to retrieve the time series entries.
+        /// When set to 'Last', retrieves entries from the end of the time series within the specified time range. <br/>
+        /// <remarks>Note that <typeparamref name="TimeSeriesRangeType"></typeparamref> cannot be 'None' when time is specified.</remarks></param>
+        /// <param name="time">The time range to consider when retrieving time series entries.</param>
         TBuilder IncludeTimeSeries(string name, TimeSeriesRangeType type, TimeValue time);
 
+        /// <inheritdoc cref="IAbstractTimeSeriesIncludeBuilder{T, TBuilder}"/>
+        /// <param name="name">The name of the time series to include.</param>
+        /// <param name="type">Indicates how to retrieve the time series entries.
+        /// When set to 'Last', retrieves the last X entries, where X is determined by the 'count' parameter. <br/>
+        /// <remarks>Note that <typeparamref name="TimeSeriesRangeType"></typeparamref> cannot be 'None' when count is specified.</remarks></param>
+        /// <param name="count">The maximum number of entries to take when retrieving time series entries.</param>
         TBuilder IncludeTimeSeries(string name, TimeSeriesRangeType type, int count);
 
+        /// <inheritdoc cref="IncludeTimeSeries(string, TimeSeriesRangeType, TimeValue)"/>
+        /// <param name="names">The names of the time series to include.</param>
         TBuilder IncludeTimeSeries(string[] names, TimeSeriesRangeType type, TimeValue time);
 
+        /// <inheritdoc cref="IncludeTimeSeries(string, TimeSeriesRangeType, int)"/>
+        /// <param name="names">The names of the time series to include.</param>
         TBuilder IncludeTimeSeries(string[] names, TimeSeriesRangeType type, int count);
 
+        /// <inheritdoc cref="IncludeTimeSeries(string, TimeSeriesRangeType, TimeValue)"/> 
         TBuilder IncludeAllTimeSeries(TimeSeriesRangeType type, TimeValue time);
 
+        /// <inheritdoc cref="IncludeTimeSeries(string, TimeSeriesRangeType, int)"/> 
         TBuilder IncludeAllTimeSeries(TimeSeriesRangeType type, int count);
     }
 
@@ -101,9 +125,14 @@ namespace Raven.Client.Documents.Session.Loaders
     
     public interface ITimeSeriesIncludeBuilder<T, out TBuilder> : IAbstractTimeSeriesIncludeBuilder<T, TBuilder>
     {
+        /// <inheritdoc cref="IAbstractTimeSeriesIncludeBuilder{T, TBuilder}"/>
+        /// <param name="name">The name of the time series to include.</param>
+        /// <param name="from">The date and time from which to start including time series entries (inclusive). If not specified, the collection will start from the earliest possible date and time (DateTime.MinValue).</param>
+        /// <param name="to">The date and time at which to stop including time series entries (inclusive). If not specified, the collection will continue until the latest possible date and time (DateTime.MaxValue).</param>
         TBuilder IncludeTimeSeries(string name, DateTime? from = null, DateTime? to = null);
     }
 
+    /// <inheritdoc cref="IAbstractTimeSeriesIncludeBuilder{T, TBuilder}"/>
     public interface ISubscriptionTimeSeriesIncludeBuilder<T, out TBuilder> : IAbstractTimeSeriesIncludeBuilder<T, TBuilder>
     {
     }


### PR DESCRIPTION
…eSeriesIncludeBuilder, ITimeSeriesIncludeBuilder]

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21983/Update-our-Client-API-XML-documentation-Shiran

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
