### PR TITLE
RDBCL-3407 : fix wrong folder name in server-wide sharded backups with script-generated settings

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/PutServerWideBackupConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PutServerWideBackupConfigurationCommand.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -212,7 +213,7 @@ namespace Raven.Server.ServerWide.Commands
             if (str.EndsWith(separator) == false)
                 str += separator;
 
-            return str + databaseName;
+            return str + ShardHelper.ToDatabaseName(databaseName);
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBCL-3407/Restoring-sharded-db-on-the-cloud-from-RavenDB-Cloud-link-does-not-work

### Additional description

- server wide backups that are defined using a backup-script should use the database name (instead of shard names) when generating backup folder name

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [X] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [X] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [X] No documentation update is needed 

### Testing by Contributor

- [X] Tests have been added that prove the fix is effective or that the feature works
- [X] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [X] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [X] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [X] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [X] No UI work is needed
