### PR TITLE
RavenDB-20446 Fixing occassionally failing. Let's wait explicitly for index to be non stale before issuing a query so we will be sure we won't wait for the replacement to complete the swap.

### DIFF
--- a/test/SlowTests/Issues/RavenDB_12269.cs
+++ b/test/SlowTests/Issues/RavenDB_12269.cs
@@ -80,6 +80,8 @@ namespace SlowTests.Issues
 
                     await session.SaveChangesAsync();
 
+                    Indexes.WaitForIndexing(store);
+
                     // this will ensure that index isn't in error state
                     try
                     {


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20446

### Additional description

https://github.com/ravendb/ravendb/pull/18383 applied to 5.4

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
