### PR TITLE
RavenDB-22280 Fix  GetNotification endpoint tests in debug mode 

### DIFF
--- a/test/SlowTests/Issues/RavenDB_22176.cs
+++ b/test/SlowTests/Issues/RavenDB_22176.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Http;
@@ -117,7 +116,7 @@ public sealed class RavenDB_22176 : RavenDB_17068_Base
             result = store.Maintenance.Send(new GetNotifications(pageSize: 0, alertType: notificationTypeParameter, testAsNumber: flagAsInt));
             Assert.Equal(5, result.TotalResults);
             Assert.Empty(result.Results);
-            
+
             //paging
             {
                 result = store.Maintenance.Send(new GetNotifications(pageStart: 0, pageSize: 2, alertType: notificationTypeParameter, testAsNumber: flagAsInt));
@@ -177,8 +176,12 @@ public sealed class RavenDB_22176 : RavenDB_17068_Base
 
         public override string Id { get; }
     }
-    private record NotificationEndpointDto(int TotalResults, List<SerializableNotification> Results);
-    
+    private class NotificationEndpointDto
+    {
+        public int TotalResults { get; set; }
+        public List<SerializableNotification> Results { get; set; } 
+    }
+
     [Flags]
     private enum NotificationTypeParameter : short
     {
@@ -254,7 +257,7 @@ public sealed class RavenDB_22176 : RavenDB_17068_Base
                 if (response == null)
                     ThrowInvalidResponse();
 
-                Result = JsonConvert.DeserializeObject<NotificationEndpointDto>(response!.ToString());
+                Result = DocumentConventions.DefaultForServer.Serialization.DeserializeEntityFromBlittable<NotificationEndpointDto>(response);
             }
 
             public override bool IsReadRequest => true;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22280

### Additional description

There was an issue with debug deserialization of server results when DTO was a record.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
