### PR TITLE
RavenDB-21877 Ace editor's full screen command doesn't work in read-only mode

### DIFF
--- a/src/Raven.Studio/typescript/components/common/AceEditor.tsx
+++ b/src/Raven.Studio/typescript/components/common/AceEditor.tsx
@@ -2,7 +2,7 @@ import React, { LegacyRef, useEffect, useState } from "react";
 import { AceEditorMode, LanguageService } from "components/models/aceEditor";
 import { Ace } from "ace-builds";
 import { setCompleters } from "ace-builds/src-noconflict/ext-language_tools";
-import ReactAce, { IAceEditorProps, IAceOptions, ICommand } from "react-ace";
+import ReactAce, { IAceEditorProps, IAceOptions, ICommand as CommandFromReactAce } from "react-ace";
 import "./AceEditor.scss";
 import classNames from "classnames";
 
@@ -75,7 +75,7 @@ export default function AceEditor(props: AceEditorProps) {
 
     const errorMessage = validationErrorMessage ?? aceErrorMessage;
 
-    const commands = execute
+    const commands: Command[] = execute
         ? [
               ...defaultCommands,
               {
@@ -120,7 +120,12 @@ export default function AceEditor(props: AceEditorProps) {
     );
 }
 
-const defaultCommands: ICommand[] = [
+// Can be removed after https://github.com/securingsincity/react-ace/pull/1881 is merged
+interface Command extends CommandFromReactAce {
+    readOnly?: boolean;
+}
+
+const defaultCommands: Command[] = [
     {
         name: "Open Fullscreen",
         bindKey: {
@@ -130,5 +135,6 @@ const defaultCommands: ICommand[] = [
         exec: function (editor: Ace.Editor) {
             editor.container.requestFullscreen();
         },
+        readOnly: true,
     },
 ];


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21877/Ace-editors-full-screen-command-doesnt-work-in-read-only-mode

### Additional description

The readOnly property was missing in type. I also made a pr to the react-ace library.

https://github.com/securingsincity/react-ace/pull/1881

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
