### PR TITLE
RavenDB-17593 Clarify text for Reset index

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmResetIndex.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmResetIndex.tsx
@@ -42,7 +42,12 @@ export function ConfirmResetIndex(props: ConfirmResetIndexProps) {
                 </span>
                 <Alert color="warning">
                     <small>
-                        Clicking <strong>Reset</strong> will remove all existing indexed data.
+                        <strong>Reset</strong> will remove all existing indexed data
+                        {ActionContextUtils.showContextSelector(allActionContexts) ? (
+                            <span> from the selected context.</span>
+                        ) : (
+                            <span> from node {allActionContexts[0].nodeTag}.</span>
+                        )}
                     </small>
                     <br />
                     <small>All items matched by the index definition will be re-indexed.</small>
@@ -62,7 +67,12 @@ export function ConfirmResetIndex(props: ConfirmResetIndexProps) {
                 <Button color="link" onClick={toggle} className="link-muted">
                     Cancel
                 </Button>
-                <Button color="warning" onClick={onSubmit} className="rounded-pill">
+                <Button
+                    color="warning"
+                    onClick={onSubmit}
+                    className="rounded-pill"
+                    disabled={selectedActionContexts.length === 0}
+                >
                     <Icon icon="reset-index" />
                     Reset
                 </Button>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17593

### Additional description

* Added text to explain where the reset action takes place 
  (either on the selected context, or on the local node)
  
* Disabled the 'reset' btn if no context is selected
  
### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
