### PR TITLE
RavenDB-17593 Clarify that reset index is done on the current node

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexes.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexes.ts
@@ -547,7 +547,7 @@ class indexes extends viewModelBase {
                     <small><i class="icon-warning"></i></small>
                 </div>
                 <div>
-                    <small>Clicking <strong>Reset</strong> will remove all existing indexed data.</small><br>
+                    <small>Clicking <strong>Reset</strong> will remove all existing indexed data from node ${this.localNodeTag()}.</small><br>
                     <small>All items matched by the index definition will be re-indexed.</small>
                 </div>
              </div>`,


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-17593

### Additional description
Added the 'node' tag to the description text to clarify that Reset index applies to the current node.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
