### PR TITLE
RavenDB-21644: handle usage of resource cancellation token after it was disposed

### DIFF
--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -105,6 +105,11 @@ namespace Raven.Server.Documents
             return new OperationCancelToken(Database.DatabaseShutdown, HttpContext.RequestAborted);
         }
 
+        public override OperationCancelToken CreateHttpRequestBoundOperationToken(CancellationToken token)
+        {
+            return new OperationCancelToken(Database.DatabaseShutdown, HttpContext.RequestAborted, token);
+        }
+
         public override OperationCancelToken CreateTimeLimitedBackgroundOperationTokenForQueryOperation()
         {
             return new OperationCancelToken(Database.Configuration.Databases.QueryOperationTimeout.AsTimeSpan, Database.DatabaseShutdown);

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -80,7 +80,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public override bool IsShutdownRequested() => base.IsShutdownRequested() || Database.DatabaseShutdown.IsCancellationRequested;
+        public override bool IsShutdownRequested() => base.IsShutdownRequested() || Database.IsShutdownRequested();
 
         [DoesNotReturn]
         public override void ThrowShutdownException(Exception inner = null) => throw new DatabaseDisabledException("The database " + DatabaseName + " is shutting down", inner);

--- a/src/Raven.Server/Documents/Handlers/Processors/Changes/AbstractChangesHandlerProcessorForGetChanges.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Changes/AbstractChangesHandlerProcessorForGetChanges.cs
@@ -76,6 +76,10 @@ internal abstract class AbstractChangesHandlerProcessorForGetChanges<TRequestHan
                             await webSocket.SendAsync(bytes, WebSocketMessageType.Text, true, token.Token);
                         }
                     }
+                    catch (ObjectDisposedException)
+                    {
+                        // disposing
+                    }
                     catch (Exception exception)
                     {
                         if (Logger.IsInfoEnabled)

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedDatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedDatabaseRequestHandler.cs
@@ -119,7 +119,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
             }
         }
 
-        public override bool IsShutdownRequested() => base.IsShutdownRequested() || DatabaseContext.DatabaseShutdown.IsCancellationRequested;
+        public override bool IsShutdownRequested() => base.IsShutdownRequested() || DatabaseContext.IsShutdownRequested();
 
         [DoesNotReturn]
         public override void ThrowShutdownException(Exception inner = null) => throw new DatabaseDisabledException("The database " + DatabaseName + " is shutting down", inner);

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -225,6 +225,11 @@ namespace Raven.Server.Documents.Sharding
             Configuration = DatabasesLandlord.CreateDatabaseConfiguration(ServerStore, DatabaseName, settings);
         }
 
+        public bool IsShutdownRequested()
+        {
+            return _databaseShutdown.IsCancellationRequested;
+        }
+
         public void Dispose()
         {
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "RavenDB-19086 needs an ExceptionAggregator like DocumentDatabase");

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2570,6 +2570,11 @@ namespace Raven.Server.ServerWide
 
         public Guid ServerId => GetServerId();
 
+        public bool IsShutdownRequested()
+        {
+            return _shutdownNotification.IsCancellationRequested;
+        }
+
         public void Dispose()
         {
             if (_shutdownNotification.IsCancellationRequested || _disposed)

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -775,7 +775,7 @@ namespace Raven.Server.Web
             HttpContext.Response.Headers["Location"] = leaderLocation;
         }
 
-        public virtual bool IsShutdownRequested() => ServerStore.ServerShutdown.IsCancellationRequested;
+        public virtual bool IsShutdownRequested() => ServerStore.IsShutdownRequested();
 
         [DoesNotReturn]
         public virtual void ThrowShutdownException(Exception inner = null) => throw new OperationCanceledException($"Server on node {ServerStore.NodeTag} is shutting down", inner);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21644

### Additional description

use `CancellationTokenSource` and not its `.Token` property when resource is getting disposed, so we won't get `ObjectDisposedException`

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
