### PR TITLE
RavenDB-22036 Added side by side index reset

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -524,6 +524,8 @@ namespace Raven.Client.Documents.Indexes
         /// Define index deployment mode
         /// </summary>
         public IndexDeploymentMode? DeploymentMode { get; set; }
+        
+        internal bool ForceUpdate { get; set; }
 
         public override string ToString()
         {

--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -606,6 +606,12 @@ namespace Raven.Client.Documents.Indexes
         Rolling
     }
 
+    public enum IndexResetMode
+    {
+        InPlace,
+        SideBySide
+    }
+
     [Flags]
     public enum IndexDefinitionCompareDifferences
     {
@@ -622,7 +628,8 @@ namespace Raven.Client.Documents.Indexes
         DeploymentMode = 1 << 12,
         CompoundFields = 1 << 13,
         ArchivedDataProcessingBehavior = 1 << 14,
+        IndexResetMode = 1 << 15,
 
-        All = Maps | Reduce | Fields | Configuration | LockMode | Priority | State | AdditionalSources | AdditionalAssemblies | DeploymentMode | CompoundFields | ArchivedDataProcessingBehavior,
+        All = Maps | Reduce | Fields | Configuration | LockMode | Priority | State | AdditionalSources | AdditionalAssemblies | DeploymentMode | CompoundFields | ArchivedDataProcessingBehavior | IndexResetMode,
     }
 }

--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -628,8 +628,7 @@ namespace Raven.Client.Documents.Indexes
         DeploymentMode = 1 << 12,
         CompoundFields = 1 << 13,
         ArchivedDataProcessingBehavior = 1 << 14,
-        IndexResetMode = 1 << 15,
 
-        All = Maps | Reduce | Fields | Configuration | LockMode | Priority | State | AdditionalSources | AdditionalAssemblies | DeploymentMode | CompoundFields | ArchivedDataProcessingBehavior | IndexResetMode,
+        All = Maps | Reduce | Fields | Configuration | LockMode | Priority | State | AdditionalSources | AdditionalAssemblies | DeploymentMode | CompoundFields | ArchivedDataProcessingBehavior,
     }
 }

--- a/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexDefinition.cs
@@ -524,8 +524,6 @@ namespace Raven.Client.Documents.Indexes
         /// Define index deployment mode
         /// </summary>
         public IndexDeploymentMode? DeploymentMode { get; set; }
-        
-        internal bool ForceUpdate { get; set; }
 
         public override string ToString()
         {

--- a/src/Raven.Client/Documents/Operations/Indexes/ResetIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/ResetIndexOperation.cs
@@ -10,35 +10,40 @@ namespace Raven.Client.Documents.Operations.Indexes
     public sealed class ResetIndexOperation : IMaintenanceOperation
     {
         private readonly string _indexName;
+        private readonly bool _isSideBySide;
 
-        public ResetIndexOperation(string indexName)
+        public ResetIndexOperation(string indexName, bool isSideBySide = false)
         {
             _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
+            _isSideBySide = isSideBySide;
         }
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new ResetIndexCommand(_indexName);
+            return new ResetIndexCommand(_indexName, _isSideBySide);
         }
 
         internal sealed class ResetIndexCommand : RavenCommand
         {
             private readonly string _indexName;
+            private readonly bool _isSideBySide;
 
-            public ResetIndexCommand(string indexName)
-                : this(indexName, nodeTag: null)
+            public ResetIndexCommand(string indexName, bool isSideBySide = false)
+                : this(indexName, isSideBySide: false, nodeTag: null)
             {
+                _isSideBySide = isSideBySide;
             }
 
-            internal ResetIndexCommand(string indexName, string nodeTag)
+            internal ResetIndexCommand(string indexName, bool isSideBySide, string nodeTag)
             {
                 _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
+                _isSideBySide = isSideBySide;
                 SelectedNodeTag = nodeTag;
             }
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
-                url = $"{node.Url}/databases/{node.Database}/indexes?name={Uri.EscapeDataString(_indexName)}";
+                url = $"{node.Url}/databases/{node.Database}/indexes?name={Uri.EscapeDataString(_indexName)}&isSideBySide={(_isSideBySide ? "true" : "false")}";
 
                 return new HttpRequestMessage
                 {

--- a/src/Raven.Client/Documents/Operations/Indexes/ResetIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/ResetIndexOperation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Http;
 using Raven.Client.Util;
 using Sparrow.Json;
@@ -10,45 +11,48 @@ namespace Raven.Client.Documents.Operations.Indexes
     public sealed class ResetIndexOperation : IMaintenanceOperation
     {
         private readonly string _indexName;
-        private readonly bool _asSideBySide;
+        private readonly IndexResetMode? _indexResetMode;
 
         public ResetIndexOperation(string indexName)
         {
             _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
         }
         
-        public ResetIndexOperation(string indexName, bool asSideBySide)
+        public ResetIndexOperation(string indexName, IndexResetMode indexResetMode)
         {
             _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
-            _asSideBySide = asSideBySide;
+            _indexResetMode = indexResetMode;
         }
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new ResetIndexCommand(_indexName, _asSideBySide);
+            return new ResetIndexCommand(_indexName, _indexResetMode);
         }
 
         internal sealed class ResetIndexCommand : RavenCommand
         {
             private readonly string _indexName;
-            private readonly bool _asSideBySide;
+            private readonly IndexResetMode? _indexResetMode;
 
-            public ResetIndexCommand(string indexName, bool asSideBySide = false)
-                : this(indexName, asSideBySide: false, nodeTag: null)
+            public ResetIndexCommand(string indexName, IndexResetMode? indexResetMode)
+                : this(indexName, indexResetMode, nodeTag: null)
             {
-                _asSideBySide = asSideBySide;
+                _indexResetMode = indexResetMode;
             }
 
-            internal ResetIndexCommand(string indexName, bool asSideBySide, string nodeTag)
+            internal ResetIndexCommand(string indexName, IndexResetMode? indexResetMode, string nodeTag)
             {
                 _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
-                _asSideBySide = asSideBySide;
+                _indexResetMode = indexResetMode;
                 SelectedNodeTag = nodeTag;
             }
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
-                url = $"{node.Url}/databases/{node.Database}/indexes?name={Uri.EscapeDataString(_indexName)}&asSideBySide={(_asSideBySide ? "true" : "false")}";
+                url = $"{node.Url}/databases/{node.Database}/indexes?name={Uri.EscapeDataString(_indexName)}";
+
+                if (_indexResetMode is not null)
+                    url += $"&indexResetMode={_indexResetMode.ToString()}";
 
                 return new HttpRequestMessage
                 {

--- a/src/Raven.Client/Documents/Operations/Indexes/ResetIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/ResetIndexOperation.cs
@@ -10,40 +10,45 @@ namespace Raven.Client.Documents.Operations.Indexes
     public sealed class ResetIndexOperation : IMaintenanceOperation
     {
         private readonly string _indexName;
-        private readonly bool _isSideBySide;
+        private readonly bool _asSideBySide;
 
-        public ResetIndexOperation(string indexName, bool isSideBySide = false)
+        public ResetIndexOperation(string indexName)
         {
             _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
-            _isSideBySide = isSideBySide;
+        }
+        
+        public ResetIndexOperation(string indexName, bool asSideBySide)
+        {
+            _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
+            _asSideBySide = asSideBySide;
         }
 
         public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
-            return new ResetIndexCommand(_indexName, _isSideBySide);
+            return new ResetIndexCommand(_indexName, _asSideBySide);
         }
 
         internal sealed class ResetIndexCommand : RavenCommand
         {
             private readonly string _indexName;
-            private readonly bool _isSideBySide;
+            private readonly bool _asSideBySide;
 
-            public ResetIndexCommand(string indexName, bool isSideBySide = false)
-                : this(indexName, isSideBySide: false, nodeTag: null)
+            public ResetIndexCommand(string indexName, bool asSideBySide = false)
+                : this(indexName, asSideBySide: false, nodeTag: null)
             {
-                _isSideBySide = isSideBySide;
+                _asSideBySide = asSideBySide;
             }
 
-            internal ResetIndexCommand(string indexName, bool isSideBySide, string nodeTag)
+            internal ResetIndexCommand(string indexName, bool asSideBySide, string nodeTag)
             {
                 _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
-                _isSideBySide = isSideBySide;
+                _asSideBySide = asSideBySide;
                 SelectedNodeTag = nodeTag;
             }
 
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
-                url = $"{node.Url}/databases/{node.Database}/indexes?name={Uri.EscapeDataString(_indexName)}&isSideBySide={(_isSideBySide ? "true" : "false")}";
+                url = $"{node.Url}/databases/{node.Database}/indexes?name={Uri.EscapeDataString(_indexName)}&asSideBySide={(_asSideBySide ? "true" : "false")}";
 
                 return new HttpRequestMessage
                 {

--- a/src/Raven.Client/Documents/Operations/Indexes/ResetIndexOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Indexes/ResetIndexOperation.cs
@@ -52,7 +52,7 @@ namespace Raven.Client.Documents.Operations.Indexes
                 url = $"{node.Url}/databases/{node.Database}/indexes?name={Uri.EscapeDataString(_indexName)}";
 
                 if (_indexResetMode is not null)
-                    url += $"&indexResetMode={_indexResetMode.ToString()}";
+                    url += $"&mode={_indexResetMode.ToString()}";
 
                 return new HttpRequestMessage
                 {

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -567,6 +567,12 @@ namespace Raven.Server.Config.Categories
         [IndexUpdateType(IndexUpdateType.Reset)]
         [ConfigurationEntry("Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public Size MaxAllocationsAtDictionaryTraining { get; protected set; }
+        
+        [Description("Default index reset mode.")]
+        [ConfigurationEntry("Indexing.DefaultIndexResetMode", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        [DefaultValue(IndexResetMode.InPlace)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        public IndexResetMode DefaultIndexResetMode { get; set; }
 
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -568,11 +568,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public Size MaxAllocationsAtDictionaryTraining { get; protected set; }
         
-        [Description("Default index reset mode.")]
-        [ConfigurationEntry("Indexing.DefaultIndexResetMode", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        [Description("The default mode of the index reset operation.")]
+        [ConfigurationEntry("Indexing.ResetMode", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         [DefaultValue(IndexResetMode.InPlace)]
         [IndexUpdateType(IndexUpdateType.None)]
-        public IndexResetMode DefaultIndexResetMode { get; set; }
+        public IndexResetMode ResetMode { get; set; }
 
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForReset.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForReset.cs
@@ -15,6 +15,8 @@ internal abstract class AbstractIndexHandlerProcessorForReset<TRequestHandler, T
     {
     }
     
+    private const string IndexResetModeQueryStringParamName = "mode";
+    
     protected override RavenCommand CreateCommandForNode(string nodeTag) => new ResetIndexOperation.ResetIndexCommand(GetName(), GetIndexResetMode(), nodeTag);
 
     protected string GetName()
@@ -24,7 +26,7 @@ internal abstract class AbstractIndexHandlerProcessorForReset<TRequestHandler, T
 
     private IndexResetMode? GetIndexResetMode()
     {
-        var indexResetModeQueryParam = RequestHandler.GetStringQueryString(nameof(IndexResetMode), false);
+        var indexResetModeQueryParam = RequestHandler.GetStringQueryString(IndexResetModeQueryStringParamName, false);
 
         if (indexResetModeQueryParam is null)
             return null;

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForReset.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForReset.cs
@@ -12,11 +12,25 @@ internal abstract class AbstractIndexHandlerProcessorForReset<TRequestHandler, T
     protected AbstractIndexHandlerProcessorForReset([NotNull] TRequestHandler requestHandler) : base(requestHandler)
     {
     }
+    
+    private const string SideBySideQueryParameterName = "isSideBySide";
 
-    protected override RavenCommand CreateCommandForNode(string nodeTag) => new ResetIndexOperation.ResetIndexCommand(GetName(), nodeTag);
+    protected override RavenCommand CreateCommandForNode(string nodeTag) => new ResetIndexOperation.ResetIndexCommand(GetName(), IsSideBySide(), nodeTag);
 
     protected string GetName()
     {
         return RequestHandler.GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
+    }
+
+    protected bool IsSideBySide()
+    {
+        var sideBySideQueryParam = RequestHandler.GetBoolValueQueryString(SideBySideQueryParameterName, false);
+        
+        var sideBySide = false;
+        
+        if (sideBySideQueryParam.HasValue)
+            sideBySide = sideBySideQueryParam.Value;
+
+        return sideBySide;
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForReset.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForReset.cs
@@ -13,7 +13,7 @@ internal abstract class AbstractIndexHandlerProcessorForReset<TRequestHandler, T
     {
     }
     
-    private const string SideBySideQueryParameterName = "isSideBySide";
+    private const string SideBySideQueryParameterName = "asSideBySide";
 
     protected override RavenCommand CreateCommandForNode(string nodeTag) => new ResetIndexOperation.ResetIndexCommand(GetName(), IsSideBySide(), nodeTag);
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForReset.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForReset.cs
@@ -1,4 +1,6 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Http;
 using Sparrow.Json;
@@ -13,24 +15,20 @@ internal abstract class AbstractIndexHandlerProcessorForReset<TRequestHandler, T
     {
     }
     
-    private const string SideBySideQueryParameterName = "asSideBySide";
-
-    protected override RavenCommand CreateCommandForNode(string nodeTag) => new ResetIndexOperation.ResetIndexCommand(GetName(), IsSideBySide(), nodeTag);
+    protected override RavenCommand CreateCommandForNode(string nodeTag) => new ResetIndexOperation.ResetIndexCommand(GetName(), GetIndexResetMode(), nodeTag);
 
     protected string GetName()
     {
         return RequestHandler.GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
     }
 
-    protected bool IsSideBySide()
+    private IndexResetMode? GetIndexResetMode()
     {
-        var sideBySideQueryParam = RequestHandler.GetBoolValueQueryString(SideBySideQueryParameterName, false);
-        
-        var sideBySide = false;
-        
-        if (sideBySideQueryParam.HasValue)
-            sideBySide = sideBySideQueryParam.Value;
+        var indexResetModeQueryParam = RequestHandler.GetStringQueryString(nameof(IndexResetMode), false);
 
-        return sideBySide;
+        if (indexResetModeQueryParam is null)
+            return null;
+            
+        return Enum.Parse<IndexResetMode>(indexResetModeQueryParam);
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForReset.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForReset.cs
@@ -14,7 +14,7 @@ internal sealed class IndexHandlerProcessorForReset : AbstractIndexHandlerProces
 
     protected override bool SupportsCurrentNode => true;
 
-    private const string SideBySideQueryParameterName = "isSideBySide";
+    private const string SideBySideQueryParameterName = "asSideBySide";
 
     protected override ValueTask HandleCurrentNodeAsync()
     {

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForReset.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForReset.cs
@@ -14,10 +14,20 @@ internal sealed class IndexHandlerProcessorForReset : AbstractIndexHandlerProces
 
     protected override bool SupportsCurrentNode => true;
 
+    private const string SideBySideQueryParameterName = "isSideBySide";
+
     protected override ValueTask HandleCurrentNodeAsync()
     {
         var name = GetName();
-        RequestHandler.Database.IndexStore.ResetIndex(name);
+
+        var sideBySideQueryParam = RequestHandler.GetBoolValueQueryString(SideBySideQueryParameterName, false);
+
+        var sideBySide = false;
+        
+        if (sideBySideQueryParam.HasValue)
+            sideBySide = sideBySideQueryParam.Value;
+        
+        RequestHandler.Database.IndexStore.ResetIndex(name, sideBySide);
 
         return ValueTask.CompletedTask;
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForReset.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForReset.cs
@@ -13,6 +13,8 @@ internal sealed class IndexHandlerProcessorForReset : AbstractIndexHandlerProces
     public IndexHandlerProcessorForReset([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
     {
     }
+    
+    private const string IndexResetModeQueryStringParamName = "mode";
 
     protected override bool SupportsCurrentNode => true;
 
@@ -20,9 +22,9 @@ internal sealed class IndexHandlerProcessorForReset : AbstractIndexHandlerProces
     {
         var name = GetName();
 
-        var indexResetModeQueryParam = RequestHandler.GetStringQueryString(nameof(IndexResetMode), false);
+        var indexResetModeQueryParam = RequestHandler.GetStringQueryString(IndexResetModeQueryStringParamName, false);
 
-        var indexResetMode = RequestHandler.Database.Configuration.Indexing.DefaultIndexResetMode;
+        var indexResetMode = RequestHandler.Database.Configuration.Indexing.ResetMode;
 
         if (indexResetModeQueryParam is not null)
             indexResetMode = Enum.Parse<IndexResetMode>(indexResetModeQueryParam);

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -44,6 +44,8 @@ namespace Raven.Server.Documents.Indexes
         internal IndexDefinitionClusterState ClusterState;
 
         public IndexDeploymentMode DeploymentMode { get; set; }
+        
+        internal bool ForceUpdate { get; set; }
 
         public virtual bool HasDynamicFields => false;
 

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -44,8 +44,6 @@ namespace Raven.Server.Documents.Indexes
         internal IndexDefinitionClusterState ClusterState;
 
         public IndexDeploymentMode DeploymentMode { get; set; }
-        
-        internal bool ForceUpdate { get; set; }
 
         public virtual bool HasDynamicFields => false;
 

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1161,13 +1161,19 @@ namespace Raven.Server.Documents.Indexes
             return true;
         }
 
-        public Index ResetIndex(string name, bool sideBySide = false)
+        public Index ResetIndex(string name, IndexResetMode indexResetMode = IndexResetMode.InPlace)
         {
             var index = GetIndex(name);
+            
             if (index == null)
                 IndexDoesNotExistException.ThrowFor(name);
 
-            return sideBySide ? ResetIndexSideBySideInternal(index) : ResetIndexInternal(index);
+            return indexResetMode switch
+            {
+                IndexResetMode.InPlace => ResetIndexInternal(index),
+                IndexResetMode.SideBySide => ResetIndexSideBySideInternal(index),
+                _ => throw new Exception($"Unknown {nameof(IndexResetMode)} parameter provided for index reset.")
+            };
         }
 
         public async Task DeleteIndex(string name, string raftRequestId)

--- a/test/SlowTests/Issues/RavenDB-22036.cs
+++ b/test/SlowTests/Issues/RavenDB-22036.cs
@@ -1,0 +1,89 @@
+using System.Linq;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22036 : RavenTestBase
+{
+    public RavenDB_22036(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIfSideBySideIndexIsCreatedOnResetWithQueryParam()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var indexName = "Users/ByName";
+            
+            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            {
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
+                Name = indexName
+            }));
+            
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            store.Maintenance.Send(new ResetIndexOperation(indexName, isSideBySide: true));
+            
+            var database = GetDatabase(store.Database).Result;
+            
+            var replacementIndexInstance = database.IndexStore.GetIndex($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}");
+
+            Assert.NotNull(replacementIndexInstance);
+
+            store.Maintenance.Send(new StartIndexingOperation());
+            
+            Indexes.WaitForIndexing(store);
+
+            var indexesCount = database.IndexStore.GetIndexes().Count();
+            
+            Assert.Equal(1, indexesCount);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIfSideBySideIndexIsNotCreatedOnResetWithoutQueryParam()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var indexName = "Users/ByName";
+            
+            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            {
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
+                Name = indexName
+            }));
+            
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            store.Maintenance.Send(new ResetIndexOperation(indexName, isSideBySide: false));
+            
+            var database = GetDatabase(store.Database).Result;
+            
+            var replacementIndexInstance = database.IndexStore.GetIndex($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}");
+
+            Assert.Null(replacementIndexInstance);
+            
+            var indexesCount = database.IndexStore.GetIndexes().Count();
+            
+            Assert.Equal(1, indexesCount);
+
+            store.Maintenance.Send(new StartIndexingOperation());
+            
+            Indexes.WaitForIndexing(store);
+
+            indexesCount = database.IndexStore.GetIndexes().Count();
+            
+            Assert.Equal(1, indexesCount);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-22036.cs
+++ b/test/SlowTests/Issues/RavenDB-22036.cs
@@ -199,7 +199,7 @@ public class RavenDB_22036 : RavenTestBase
     {
         options.ModifyDatabaseRecord += record =>
         {
-            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.DefaultIndexResetMode)] = IndexResetMode.SideBySide.ToString();
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.ResetMode)] = IndexResetMode.SideBySide.ToString();
         };
         
         using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB-22036.cs
+++ b/test/SlowTests/Issues/RavenDB-22036.cs
@@ -20,7 +20,7 @@ public class RavenDB_22036 : RavenTestBase
     {
         using (var store = GetDocumentStore())
         {
-            var indexName = "Users/ByName";
+            const string indexName = "Users/ByName";
             
             store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
@@ -54,7 +54,7 @@ public class RavenDB_22036 : RavenTestBase
     {
         using (var store = GetDocumentStore())
         {
-            var indexName = "Users/ByName";
+            const string indexName = "Users/ByName";
             
             store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
@@ -81,6 +81,59 @@ public class RavenDB_22036 : RavenTestBase
             
             Indexes.WaitForIndexing(store);
 
+            indexesCount = database.IndexStore.GetIndexes().Count();
+            
+            Assert.Equal(1, indexesCount);
+        }
+    }
+    
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestConsecutiveSideBySideResets()
+    {
+        using (var store = GetDocumentStore())
+        {
+            const string indexName = "Users/ByName";
+            
+            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            {
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
+                Name = indexName
+            }));
+            
+            store.Maintenance.Send(new StopIndexingOperation());
+
+            store.Maintenance.Send(new ResetIndexOperation(indexName, isSideBySide: true));
+            
+            var database = GetDatabase(store.Database).Result;
+            
+            var replacementIndexInstance = database.IndexStore.GetIndex($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}");
+
+            Assert.NotNull(replacementIndexInstance);
+            
+            var indexesCount = database.IndexStore.GetIndexes().Count();
+            
+            Assert.Equal(2, indexesCount);
+            
+            store.Maintenance.Send(new ResetIndexOperation(indexName, isSideBySide: true));
+            
+            replacementIndexInstance = database.IndexStore.GetIndex($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}");
+
+            Assert.NotNull(replacementIndexInstance);
+            
+            indexesCount = database.IndexStore.GetIndexes().Count();
+            
+            Assert.Equal(2, indexesCount);
+
+            store.Maintenance.Send(new StartIndexingOperation());
+            
+            Indexes.WaitForIndexing(store);
+            
+            replacementIndexInstance = database.IndexStore.GetIndex($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}");
+            
+            Assert.Null(replacementIndexInstance);
+            
             indexesCount = database.IndexStore.GetIndexes().Count();
             
             Assert.Equal(1, indexesCount);

--- a/test/SlowTests/Issues/RavenDB-22036.cs
+++ b/test/SlowTests/Issues/RavenDB-22036.cs
@@ -31,7 +31,7 @@ public class RavenDB_22036 : RavenTestBase
             
             store.Maintenance.Send(new StopIndexingOperation());
 
-            store.Maintenance.Send(new ResetIndexOperation(indexName, isSideBySide: true));
+            store.Maintenance.Send(new ResetIndexOperation(indexName, asSideBySide: true));
             
             var database = GetDatabase(store.Database).Result;
             
@@ -65,7 +65,7 @@ public class RavenDB_22036 : RavenTestBase
             
             store.Maintenance.Send(new StopIndexingOperation());
 
-            store.Maintenance.Send(new ResetIndexOperation(indexName, isSideBySide: false));
+            store.Maintenance.Send(new ResetIndexOperation(indexName, asSideBySide: false));
             
             var database = GetDatabase(store.Database).Result;
             
@@ -104,7 +104,7 @@ public class RavenDB_22036 : RavenTestBase
             
             store.Maintenance.Send(new StopIndexingOperation());
 
-            store.Maintenance.Send(new ResetIndexOperation(indexName, isSideBySide: true));
+            store.Maintenance.Send(new ResetIndexOperation(indexName, asSideBySide: true));
             
             var database = GetDatabase(store.Database).Result;
             
@@ -116,7 +116,7 @@ public class RavenDB_22036 : RavenTestBase
             
             Assert.Equal(2, indexesCount);
             
-            store.Maintenance.Send(new ResetIndexOperation(indexName, isSideBySide: true));
+            store.Maintenance.Send(new ResetIndexOperation(indexName, asSideBySide: true));
             
             replacementIndexInstance = database.IndexStore.GetIndex($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}");
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22036/Allow-resetting-an-index-Side-by-side

### Additional description

We want to have an option to reset indexes side by side

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. To reset index side by side it's necessary to set the parameter to `true` (either in query string or reset index operation). The default value of this parameter is `false`, in this case the reset behavior is unchanged.
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
