### PR TITLE
RavenDB-20200: Fix for 'SlowTests.Issues.RavenDB_15409.DoNotCallUpdateLicenseLimitsCommandOnEveryLeaderChange' test

### DIFF
--- a/test/SlowTests/Issues/RavenDB_15409.cs
+++ b/test/SlowTests/Issues/RavenDB_15409.cs
@@ -1,81 +1,44 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net.WebSockets;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
+using Raven.Server;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Commands;
-using Sparrow.Json;
-using Sparrow.Logging;
 using Tests.Infrastructure;
-using Tests.Infrastructure.Utils;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
     public class RavenDB_15409 : ClusterTestBase
     {
-        [Fact]
-        public async Task DoNotCallUpdateLicenseLimitsCommandOnEveryLeaderChange()
+        public RavenDB_15409(ITestOutputHelper output) : base(output)
         {
-            using var socket = new DummyWebSocket();
-
-            var (servers, leader) = await CreateRaftCluster(3);
-            var _ = LoggingSource.Instance.Register(socket, new LoggingSource.WebSocketContext(), CancellationToken.None);
-
-            await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(9, TimeSpan.FromSeconds(15));
-            var expected = new HashSet<long>();
-            foreach (var server in servers)
-            {
-                expected.Add(Cluster.GetRaftCommands(server, nameof(UpdateLicenseLimitsCommand)).Count());
-            }
-
-            if (expected.Count != 1)
-            {
-                using (var ctx = JsonOperationContext.ShortTermSingleUse())
-                {
-                    var massageBuilder = new StringBuilder();
-                    foreach (var server in servers)
-                    {
-                        var serverRaftCommands = Cluster.GetRaftCommands(server).Select(c => ctx.ReadObject(c, "raftCommand").ToString());
-
-                        massageBuilder
-                            .AppendFormat("**** Node {0} ****", server.ServerStore.NodeTag).AppendLine()
-                            .AppendLine(string.Join('\n', serverRaftCommands));
-                    }
-
-                    massageBuilder.Append(await socket.CloseAndGetLogsAsync());
-                    Assert.False(true, massageBuilder.ToString());
-                }
-            }
-            Assert.Single(expected);
-
-            for (int i = 0; i < 10; i++)
-            {
-                await ActionWithLeader(l =>
-                {
-                    l.ServerStore.Engine.CurrentLeader.StepDown();
-                    return l.ServerStore.Engine.WaitForLeaderChange(l.ServerStore.ServerShutdown);
-                });
-            }
-
-            using (var ctx = JsonOperationContext.ShortTermSingleUse())
-            {
-                await RavenTestHelper.AssertAllAsync(async () => await socket.CloseAndGetLogsAsync(), servers.Select(s => (Action)(() =>
-                {
-                    var actual = Cluster.GetRaftCommands(s, nameof(UpdateLicenseLimitsCommand)).Count();
-                    Assert.True(expected.Single() == actual, 
-                        $"{s.ServerStore.NodeTag} expect {expected.Single()} actual {actual} " +
-                                $" {string.Join($"{Environment.NewLine}\t", Cluster.GetRaftCommands(s).Select(c => ctx.ReadObject(c, "raftCommand").ToString()))}");
-                })).ToArray());
-            }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Cluster)]
+        public async Task DoNotCallUpdateLicenseLimitsCommandOnEveryLeaderChange()
+        {
+            const int numberOfNodes = 3;
+            (List<RavenServer> servers, _) = await CreateRaftCluster(numberOfNodes);
+
+            // Verifying that each node in the cluster has issued the same number of `UpdateLicenseLimitsCommand` commands,
+            // as each node is expected to independently send its own details.
+            Cluster.AssertNumberOfCommandsPerNode(expectedNumberOfCommands: numberOfNodes, servers, nameof(UpdateLicenseLimitsCommand));
+
+            // 10 leader changes
+            for (int i = 0; i < 10; i++)
+                await ActionWithLeader(leader =>
+                {
+                    leader.ServerStore.Engine.CurrentLeader.StepDown();
+                    return leader.ServerStore.Engine.WaitForLeaderChange(leader.ServerStore.ServerShutdown);
+                });
+
+            // Nothing should have changed
+            Cluster.AssertNumberOfCommandsPerNode(expectedNumberOfCommands: numberOfNodes, servers, nameof(UpdateLicenseLimitsCommand));
+        }
+
+        [RavenFact(RavenTestCategory.Cluster)]
         public async Task CanWaitForTopologyModification()
         {
             var (servers, leader) = await CreateRaftCluster(3);
@@ -84,10 +47,6 @@ namespace SlowTests.Issues
             // demote node to watcher
             await leader.ServerStore.Engine.ModifyTopologyAsync(follower.ServerStore.NodeTag, follower.WebUrl, Leader.TopologyModification.NonVoter);
             await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(10, TimeSpan.FromSeconds(15));
-        }
-
-        public RavenDB_15409(ITestOutputHelper output) : base(output)
-        {
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_15409.cs
+++ b/test/SlowTests/Issues/RavenDB_15409.cs
@@ -24,7 +24,7 @@ namespace SlowTests.Issues
 
             // Verifying that each node in the cluster has issued the same number of `UpdateLicenseLimitsCommand` commands,
             // as each node is expected to independently send its own details.
-            Cluster.AssertNumberOfCommandsPerNode(expectedNumberOfCommands: numberOfNodes, servers, nameof(UpdateLicenseLimitsCommand));
+            await Cluster.AssertNumberOfCommandsPerNode(expectedNumberOfCommands: numberOfNodes, servers, nameof(UpdateLicenseLimitsCommand));
 
             // 10 leader changes
             for (int i = 0; i < 10; i++)
@@ -35,7 +35,7 @@ namespace SlowTests.Issues
                 });
 
             // Nothing should have changed
-            Cluster.AssertNumberOfCommandsPerNode(expectedNumberOfCommands: numberOfNodes, servers, nameof(UpdateLicenseLimitsCommand));
+            await Cluster.AssertNumberOfCommandsPerNode(expectedNumberOfCommands: numberOfNodes, servers, nameof(UpdateLicenseLimitsCommand));
         }
 
         [RavenFact(RavenTestCategory.Cluster)]

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6433;
+            const int numberToTolerate = 6431;
             if (array.Length == numberToTolerate)
                 return;
 

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -245,7 +245,7 @@ public partial class RavenTestBase
         public async Task AssertNumberOfCommandsPerNode(long expectedNumberOfCommands, List<RavenServer> servers, string commandType, int timeout = 30_000, int interval = 1_000)
         {
             var numberOfCommandsPerNode = new Dictionary<string, long>();
-            var isExpectedNumberOfCommandsPerNode = await WaitForValueAsync(async () =>
+            var isExpectedNumberOfCommandsPerNode = await WaitForValueAsync(() =>
                 {
                     numberOfCommandsPerNode = new Dictionary<string, long>();
 
@@ -257,7 +257,7 @@ public partial class RavenTestBase
                         numberOfCommandsPerNode.Add(nodeTag, numberOfCommands);
                     }
 
-                    return numberOfCommandsPerNode.All(x => x.Value == expectedNumberOfCommands);
+                    return Task.FromResult(numberOfCommandsPerNode.All(x => x.Value == expectedNumberOfCommands));
                 },
                 expectedVal: true,
                 timeout, interval);

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -14,6 +14,7 @@ using Raven.Server;
 using Raven.Server.Monitoring.Snmp;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
 using Xunit;
@@ -239,6 +240,51 @@ public partial class RavenTestBase
             WaitForValue(() => server.ServerStore.Observer != null, true);
 
             server.ServerStore.Observer.Suspended = true;
+        }
+
+        public void AssertNumberOfCommandsPerNode(long expectedNumberOfCommands, List<RavenServer> servers, string commandType, int timeout = 30_000, int interval = 1_000)
+        {
+            var numberOfCommandsPerNode = new Dictionary<string, long>();
+            var isExpectedNumberOfCommandsPerNode = WaitForValue(() =>
+                {
+                    numberOfCommandsPerNode = new Dictionary<string, long>();
+
+                    foreach (var server in servers)
+                    {
+                        var nodeTag = server.ServerStore.NodeTag;
+                        var numberOfCommands = GetRaftCommands(server, commandType).Count();
+
+                        numberOfCommandsPerNode.Add(nodeTag, numberOfCommands);
+                    }
+
+                    return numberOfCommandsPerNode.All(x => x.Value == expectedNumberOfCommands);
+                },
+                expectedVal: true,
+                timeout, interval);
+
+            Assert.True(isExpectedNumberOfCommandsPerNode, BuildErrorMessage());
+            
+            return;
+            string BuildErrorMessage()
+            {
+                var stringBuilder = new StringBuilder();
+
+                using (var context = JsonOperationContext.ShortTermSingleUse())
+                {
+                    stringBuilder.AppendLine($"Expected number of commands per node: {expectedNumberOfCommands}. Actual number of commands per node: ");
+                    foreach ((string nodeTag, long numberOfCommands) in numberOfCommandsPerNode)
+                    {
+                        stringBuilder.AppendLine($"Node tag: '{nodeTag}' with actual number of commands: '{numberOfCommands}'. Commands:");
+
+                        var server = servers.Find(x => x.ServerStore.NodeTag == nodeTag);
+                        var raftCommands = GetRaftCommands(server).Select(djv => context.ReadObject(djv, "raftCommand").ToString()).ToArray();
+
+                        stringBuilder.AppendLine($"{string.Join($"{Environment.NewLine}\t", raftCommands)}");
+                    }
+                }
+
+                return stringBuilder.ToString();
+            }
         }
     }
 }

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -242,10 +242,10 @@ public partial class RavenTestBase
             server.ServerStore.Observer.Suspended = true;
         }
 
-        public void AssertNumberOfCommandsPerNode(long expectedNumberOfCommands, List<RavenServer> servers, string commandType, int timeout = 30_000, int interval = 1_000)
+        public async Task AssertNumberOfCommandsPerNode(long expectedNumberOfCommands, List<RavenServer> servers, string commandType, int timeout = 30_000, int interval = 1_000)
         {
             var numberOfCommandsPerNode = new Dictionary<string, long>();
-            var isExpectedNumberOfCommandsPerNode = WaitForValue(() =>
+            var isExpectedNumberOfCommandsPerNode = await WaitForValueAsync(async () =>
                 {
                     numberOfCommandsPerNode = new Dictionary<string, long>();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20200

### Additional description

The issue with the test was that it explicitly instructed to wait until a raft command with `index 9` appeared, which occasionally led to not all nodes managing to execute this command within `9` indexes. The last command had indices of `10` or `11`, which understated the expected number of commands and caused the test to fail.

I almost completely rebuilt the test, which now checks only two metrics:
1. Each cluster node must execute `UpdateLicenseLimitsCommand` to report its `NodeDetails`.
2. A change in leadership should not lead to the execution of these commands.
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
