### PR TITLE
RavenDB-22275 Updated to .NET 8

### DIFF
--- a/.github/workflows/FastTests.yml
+++ b/.github/workflows/FastTests.yml
@@ -10,7 +10,7 @@ on:
         - v5.4
 
 env:
-  DOTNET_VERSION: 7.0.408
+  DOTNET_VERSION: 8.0.204
   
 
 jobs:

--- a/.github/workflows/FastTestsARM.yml
+++ b/.github/workflows/FastTestsARM.yml
@@ -7,7 +7,7 @@ on:
     - cron: '30 6 * * *'
 
 env:
-  DOTNET_VERSION: 7.0.408
+  DOTNET_VERSION: 8.0.204
 
 jobs:
   release:

--- a/.github/workflows/StudioTests.yml
+++ b/.github/workflows/StudioTests.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup .NET Core
+    - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '7.0'
+        dotnet-version: '8.0'
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '7.0'
+        dotnet-version: '8.0'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.x
-      - name: Setup .NET 7
+      - name: Setup .NET 8
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - name: Restore
         run: |
           git clean -xfd

--- a/bench/BulkInsert.Benchmark/BulkInsert.Benchmark.csproj
+++ b/bench/BulkInsert.Benchmark/BulkInsert.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AssemblyName>BulkInsert.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>BulkInsert.Benchmark</PackageId>

--- a/bench/Directory.Build.props
+++ b/bench/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Version></Version>
 
-    <LangVersion>11</LangVersion>
+    <LangVersion>preview</LangVersion>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <GenerateRequiresPreviewFeaturesAttribute>True</GenerateRequiresPreviewFeaturesAttribute>
     

--- a/bench/Indexing.Benchmark/Indexing.Benchmark.csproj
+++ b/bench/Indexing.Benchmark/Indexing.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AssemblyName>Indexing.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Indexing.Benchmark</PackageId>

--- a/bench/Micro.Benchmark/Micro.Benchmark.csproj
+++ b/bench/Micro.Benchmark/Micro.Benchmark.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Micro.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Micro.Benchmark</PackageId>
-    <RuntimeIdentifiers>win7-x64;win8-x64;win10-x64;ubuntu.14.04-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64</RuntimeIdentifiers>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/bench/Regression.Benchmark/Regression.Benchmark.csproj
+++ b/bench/Regression.Benchmark/Regression.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Regression.Benchmark</AssemblyName>
     <PackageId>Regression.Benchmark</PackageId>

--- a/bench/SubscriptionFailover.Benchmark/SubscriptionFailover.Benchmark.csproj
+++ b/bench/SubscriptionFailover.Benchmark/SubscriptionFailover.Benchmark.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/bench/Subscriptions.Benchmark/Subscriptions.Benchmark.csproj
+++ b/bench/Subscriptions.Benchmark/Subscriptions.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AssemblyName>Subscriptions.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Subscriptions.Benchmark</PackageId>

--- a/bench/TimeSeries.Benchmark/TimeSeries.Benchmark.csproj
+++ b/bench/TimeSeries.Benchmark/TimeSeries.Benchmark.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/bench/Voron.Benchmark/Voron.Benchmark.csproj
+++ b/bench/Voron.Benchmark/Voron.Benchmark.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Voron.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Voron.Benchmark</PackageId>
-    <RuntimeIdentifiers>win7-x64;win8-x64;win10-x64;ubuntu.14.04-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64</RuntimeIdentifiers>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/bench/VxSort.Benchmark/VxSort.Benchmark.csproj
+++ b/bench/VxSort.Benchmark/VxSort.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM mcr.microsoft.com/dotnet/core/sdk:7.0 AS build
+﻿FROM mcr.microsoft.com/dotnet/core/sdk:8.0 AS build
 WORKDIR /app
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
@@ -13,11 +13,11 @@ RUN ls && du -sh ./src/* && du -sh ./src/Raven.Server/*
 
 RUN dotnet restore ./src/Raven.Server/Raven.Server.csproj
 RUN dotnet build ./src/Raven.Server/Raven.Server.csproj && \
-    echo '{}' > ./src/Raven.Server/bin/Debug/net7.0/settings.json
+    echo '{}' > ./src/Raven.Server/bin/Debug/net8.0/settings.json
 
 COPY tools/ ./tools
 RUN dotnet build ./tools/TypingsGenerator/TypingsGenerator.csproj \
     && cd src/Raven.Studio \
     && npm install && npm run gulp restore && npm run gulp compile
 
-ENTRYPOINT [ "dotnet", "./src/Raven.Server/bin/Debug/net7.0/Raven.Server.dll" ]
+ENTRYPOINT [ "dotnet", "./src/Raven.Server/bin/Debug/net8.0/Raven.Server.dll" ]

--- a/docker/ravendb-ubuntu/Dockerfile.arm32v7
+++ b/docker/ravendb-ubuntu/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-jammy-arm32v7
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-arm32v7
 
 RUN apt-get update \
     && apt-get install -y \

--- a/docker/ravendb-ubuntu/Dockerfile.arm64v8
+++ b/docker/ravendb-ubuntu/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-jammy-arm64v8
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-arm64v8
 
 RUN apt-get update \
     && apt-get install -y \

--- a/docker/ravendb-ubuntu/Dockerfile.x64
+++ b/docker/ravendb-ubuntu/Dockerfile.x64
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-jammy
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy
 
 RUN apt-get update \
     && apt-get install -y \

--- a/scripts/certificates/powershell/dev-create-authenticated-cluster-with-subdomains.ps1
+++ b/scripts/certificates/powershell/dev-create-authenticated-cluster-with-subdomains.ps1
@@ -34,7 +34,7 @@ dotnet build -c $conf
 popd
 
 # load servers with a certificate
-pushd "$serverDir\src\Raven.Server\bin\$conf\net7.0"
+pushd "$serverDir\src\Raven.Server\bin\$conf\net8.0"
 
 # clean old directoty
 for($i=1; $i -le $nodeCount; $i++){
@@ -50,7 +50,7 @@ $commonArgs = "--Cluster.TimeBeforeAddingReplicaInSec=15"
 $authArgs = "--Security.Certificate.Path=$serverDir\scripts\certificates\powershell\server.pfx --Security.Certificate.Password=$CertificatePassword"
 
 for($i=1; $i -le $nodeCount; $i++){
-    start powershell "-NoExit -NoProfile dotnet run -p .\src\Raven.Server\Raven.Server.csproj --ServerUrl=https://rvn$i.hrhinos.local:8080 DataDir=$serverDir\src\Raven.Server\bin\$conf\net7.0\$i --Logs.Path=$serverDir\src\Raven.Server\bin\$conf\net7.0\$i --License.Path=$licensePath $commonArgs $authArgs"
+    start powershell "-NoExit -NoProfile dotnet run -p .\src\Raven.Server\Raven.Server.csproj --ServerUrl=https://rvn$i.hrhinos.local:8080 DataDir=$serverDir\src\Raven.Server\bin\$conf\net8.0\$i --Logs.Path=$serverDir\src\Raven.Server\bin\$conf\net8.0\$i --License.Path=$licensePath $commonArgs $authArgs"
 }
 popd
 

--- a/scripts/certificates/powershell/dev-create-authenticated-cluster.ps1
+++ b/scripts/certificates/powershell/dev-create-authenticated-cluster.ps1
@@ -23,7 +23,7 @@ dotnet build -c $conf
 popd 
 
 # load servers with a certificate 
-pushd "$serverDir\src\Raven.Server\bin\$conf\net7.0" 
+pushd "$serverDir\src\Raven.Server\bin\$conf\net8.0" 
 
 # clean old directoty
 for($i=1; $i -le $nodeCount; $i++){
@@ -40,7 +40,7 @@ $commonArgs = "--Cluster.TimeBeforeAddingReplicaInSec=15"
 $authArgs = "--Security.Certificate.Path=$serverDir\scripts\certificates\powershell\server.pfx --Security.Certificate.Password=$CertificatePassword" 
 
 for($i=1; $i -le $nodeCount; $i++){    
-    start powershell "-NoExit -NoProfile dotnet run -p .\src\Raven.Server\Raven.Server.csproj --ServerUrl=https://localhost:808$i --DataDir=$serverDir\src\Raven.Server\bin\$conf\net7.0\$i --Logs.Path=$serverDir\src\Raven.Server\bin\$conf\net7.0\$i --License.Path=$licensePath $commonArgs $authArgs" 
+    start powershell "-NoExit -NoProfile dotnet run -p .\src\Raven.Server\Raven.Server.csproj --ServerUrl=https://localhost:808$i --DataDir=$serverDir\src\Raven.Server\bin\$conf\net8.0\$i --Logs.Path=$serverDir\src\Raven.Server\bin\$conf\net8.0\$i --License.Path=$licensePath $commonArgs $authArgs" 
     sleep -Milliseconds 500
 } 
 popd 

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -76,8 +76,8 @@ function LayoutServerPackage ( $packageDir, $projectDir, $packOpts ) {
     CopyStudioPackageToServerOutputDirectory $packOpts
 
     #if ($target.IsUnix -and $global:isPublishBundlingEnabled) {
-    #    # TODO get 'net7.0' from somewhere
-    #    $buildDir = [io.path]::Combine($projectDir, "src", "Raven.Server", "bin", "Release", "net7.0", $target.Runtime)
+    #    # TODO get 'net8.0' from somewhere
+    #    $buildDir = [io.path]::Combine($projectDir, "src", "Raven.Server", "bin", "Release", "net8.0", $target.Runtime)
     #    CopyNativeBinariesRequiredForDebugging $buildDir "$($packOpts.OutDirs.Server)" $target.NativeBinExtension
     #}
 

--- a/scripts/updateTargetFramework.ps1
+++ b/scripts/updateTargetFramework.ps1
@@ -1,0 +1,20 @@
+param($Version)
+
+function UpdateCsprojTargetFramework ( $csproj, $version ) {
+    $versionPattern = [regex]'(?sm)<TargetFramework>[A-Za-z0-9-\.\r\n\s]*</TargetFramework>'
+    $result = [System.IO.File]::ReadAllText($csproj)
+    $result = $versionPattern.Replace($result, "<TargetFramework>$version</TargetFramework>")
+    [System.IO.File]::WriteAllText($csproj, $result, [System.Text.Encoding]::UTF8)
+}
+
+if ([string]::IsNullOrEmpty($Version)) {
+    throw "Version is required."
+}
+
+$csprojs = Get-ChildItem -Recurse "*.csproj"
+
+foreach ($csproj in $csprojs) {
+    write-host "Update TargetFramework in $csproj"
+    UpdateCsprojTargetFramework $csproj $Version
+}
+

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -5,9 +5,9 @@ using System.Resources;
 
 [assembly: AssemblyCopyright("© Hibernating Rhinos 2009 - 2024 All rights reserved.")]
 
-[assembly: AssemblyVersion("5.4.118")]
-[assembly: AssemblyFileVersion("5.4.118.54")]
-[assembly: AssemblyInformationalVersion("5.4.118")]
+[assembly: AssemblyVersion("5.4.200")]
+[assembly: AssemblyFileVersion("5.4.200.54")]
+[assembly: AssemblyInformationalVersion("5.4.200")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]

--- a/src/Corax/Corax.csproj
+++ b/src/Corax/Corax.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Description>Corax - Low level indexing engine</Description>
     <Authors>Hibernating Rhinos</Authors>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Corax</AssemblyName>
     <PackageId>Corax</PackageId>

--- a/src/Corax/IndexEntry/IndexEntryWriter.cs
+++ b/src/Corax/IndexEntry/IndexEntryWriter.cs
@@ -382,7 +382,7 @@ public unsafe struct IndexEntryWriter : IDisposable
         geohashPtrTableLocation = dataLocation; // We write the current location.
         for (int i = 0; i < entries.Length; ++i)
         {
-            ref var entry = ref Unsafe.AsRef(entries[i]);
+            ref var entry = ref Unsafe.AsRef(in entries[i]);
             latitudesList[i] = entry.Latitude;
             longitudesList[i] = entry.Longitude;
 

--- a/src/Corax/IndexOpenException.cs
+++ b/src/Corax/IndexOpenException.cs
@@ -21,9 +21,5 @@ namespace Corax
         public IndexOpenException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
-        protected IndexOpenException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <Version></Version>
-    <LangVersion>11</LangVersion>
+    <LangVersion>preview</LangVersion>
     <DebugType>embedded</DebugType>
     <PackageIconUrl>http://static.ravendb.net/logo-for-nuget.png</PackageIconUrl>
     <PackageIcon>icon.png</PackageIcon>
@@ -28,7 +28,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0'">
     <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">
     <DefineConstants>$(DefineConstants);NETCOREAPP;FEATURE_DATEONLY_TIMEONLY_SUPPORT</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == ''">

--- a/src/Raven.Client/Properties/VersionInfo.cs
+++ b/src/Raven.Client/Properties/VersionInfo.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using Raven.Client.Extensions;
 using Raven.Client.Properties;
 
-[assembly: RavenVersion(Build = "54", CommitHash = "a377982", Version = "5.4", FullVersion = "5.4.118-custom-54", ReleaseDateString = "2024-03-19")]
+[assembly: RavenVersion(Build = "54", CommitHash = "a377982", Version = "5.4", FullVersion = "5.4.200-custom-54", ReleaseDateString = "2024-03-19")]
 
 namespace Raven.Client.Properties
 {

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -84,6 +84,15 @@
       <PackagePath>lib/net7.0/</PackagePath>
       <Pack>true</Pack>
     </Content>
+	<!-- this is required for the nuget build to properly include the right files -->
+    <Content Include="..\Sparrow\bin\Release\net8.0\Sparrow.dll">
+      <PackagePath>lib/net8.0/</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="..\Sparrow\bin\Release\net8.0\Sparrow.xml">
+      <PackagePath>lib/net8.0/</PackagePath>
+      <Pack>true</Pack>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\libs\libzstd\libzstd.win.x64.dll" Link="libzstd.win.x64.dll">
@@ -134,7 +143,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Lambda2Js.Signed" Version="3.1.4" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="7.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageReference Include="Raven.CodeAnalysis" Version="1.0.11" PrivateAssets="All" />
@@ -146,7 +155,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.5" />

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -11,7 +11,7 @@ namespace Raven.Embedded
 
         internal static string AltServerDirectory = Path.Combine(AppContext.BaseDirectory, "bin", "RavenDBServer");
 
-        public string FrameworkVersion { get; set; } = "7.0.18+";
+        public string FrameworkVersion { get; set; } = "8.0.4+";
 
         public string LogsPath { get; set; } = Path.Combine(AppContext.BaseDirectory, "RavenDB", "Logs");
 

--- a/src/Raven.Server/Documents/Handlers/MultiGetHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/MultiGetHandler.cs
@@ -225,7 +225,7 @@ namespace Raven.Server.Documents.Handlers
                     if (string.IsNullOrWhiteSpace(value))
                         continue;
 
-                    httpContext.Request.Headers.Add(header, value);
+                    httpContext.Request.Headers[header] = value;
                 }
             }
             // initiated to use it at the end of for

--- a/src/Raven.Server/Exceptions/MissingAttachmentException.cs
+++ b/src/Raven.Server/Exceptions/MissingAttachmentException.cs
@@ -17,9 +17,5 @@ namespace Raven.Server.Exceptions
         public MissingAttachmentException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
-        protected MissingAttachmentException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
     }
 }

--- a/src/Raven.Server/Https/HttpsConnectionMiddleware.cs
+++ b/src/Raven.Server/Https/HttpsConnectionMiddleware.cs
@@ -26,7 +26,9 @@ namespace Raven.Server.Https
         {
             _server = server;
             CipherSuitesPolicy = server.Configuration.Security.TlsCipherSuites != null && server.Configuration.Security.TlsCipherSuites.Length > 0
+#pragma warning disable CA1416
                 ? new CipherSuitesPolicy(server.Configuration.Security.TlsCipherSuites)
+#pragma warning restore CA1416
                 : null;
 
             _originalServerCertificate = originalServerCertificate;

--- a/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
+++ b/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.NotificationCenter
             {
                 _sw.Stop();
                 var httpContext = (HttpContext)state;
-                httpContext.Response.Headers.Add(Constants.Headers.RequestTime, _sw.ElapsedMilliseconds.ToString());
+                httpContext.Response.Headers[Constants.Headers.RequestTime] = _sw.ElapsedMilliseconds.ToString();
                 return Task.CompletedTask;
             }, _context);
         }

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -2,15 +2,15 @@
   <PropertyGroup>
     <Description>Raven.Server is the database server for RavenDB</Description>
     <Authors>Hibernating Rhinos</Authors>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Raven.Server</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Raven.Server</PackageId>
     <UserSecretsId>aspnet5-Raven.Server-20160308043041</UserSecretsId>
     <PackageTags>database;nosql;doc db</PackageTags>
-    <RuntimeIdentifiers>win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;Validate</Configurations>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
@@ -173,12 +173,13 @@
     <PackageReference Include="Lucene.Net" Version="3.0.54011" />
     <PackageReference Include="Lucene.Net.Contrib.Spatial.NTS" Version="3.0.54011" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="MySqlConnector" Version="2.3.6" />
     <PackageReference Include="NCrontab.Advanced" Version="1.3.28" />
@@ -196,11 +197,11 @@
     <PackageReference Include="Raven.CodeAnalysis" Version="1.0.11">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="System.Reflection.Metadata" Version="7.0.2" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
+    <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="ZstdSharp.Port" Version="0.7.6" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -451,7 +451,7 @@ namespace Raven.Server
             if (exception is DatabaseNotRelevantException)
             {
                 response.StatusCode = (int)HttpStatusCode.Gone;
-                response.Headers.Add("Cache-Control", new Microsoft.Extensions.Primitives.StringValues(new[] { "must-revalidate", "no-cache" }));
+                response.Headers["Cache-Control"] = new Microsoft.Extensions.Primitives.StringValues(new[] { "must-revalidate", "no-cache" });
                 return;
             }
 

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -652,7 +652,7 @@ namespace Raven.Server.Web
         
         public static void SetupCORSHeaders(HttpContext httpContext, ServerStore serverStore, CorsMode corsMode)
         {
-            httpContext.Response.Headers.Add("Vary", "Origin");
+            httpContext.Response.Headers["Vary"] = "Origin";
 
             var requestedOrigin = httpContext.Request.Headers["Origin"];
 
@@ -675,10 +675,10 @@ namespace Raven.Server.Web
                     break;
             }
 
-            httpContext.Response.Headers.Add("Access-Control-Allow-Origin", allowedOrigin);
-            httpContext.Response.Headers.Add("Access-Control-Allow-Methods", "PUT, POST, GET, OPTIONS, DELETE");
-            httpContext.Response.Headers.Add("Access-Control-Allow-Headers", httpContext.Request.Headers["Access-Control-Request-Headers"]);
-            httpContext.Response.Headers.Add("Access-Control-Max-Age", "86400");
+            httpContext.Response.Headers["Access-Control-Allow-Origin"] = allowedOrigin;
+            httpContext.Response.Headers["Access-Control-Allow-Methods"] = "PUT, POST, GET, OPTIONS, DELETE";
+            httpContext.Response.Headers["Access-Control-Allow-Headers"] = httpContext.Request.Headers["Access-Control-Request-Headers"];
+            httpContext.Response.Headers["Access-Control-Max-Age"] = "86400";
         }
 
         private static bool IsOriginAllowed(string origin, ServerStore serverStore)
@@ -734,7 +734,7 @@ namespace Raven.Server.Web
             var leaderLocation = url + HttpContext.Request.Path + HttpContext.Request.QueryString;
             HttpContext.Response.StatusCode = (int)HttpStatusCode.TemporaryRedirect;
             HttpContext.Response.Headers.Remove("Content-Type");
-            HttpContext.Response.Headers.Add("Location", leaderLocation);
+            HttpContext.Response.Headers["Location"] = leaderLocation;
         }
 
         protected virtual OperationCancelToken CreateHttpRequestBoundOperationToken()

--- a/src/Raven.Server/Web/System/BuildVersionHandler.cs
+++ b/src/Raven.Server/Web/System/BuildVersionHandler.cs
@@ -50,7 +50,7 @@ namespace Raven.Server.Web.System
         [RavenAction("/build/version", "GET", AuthorizationStatus.ValidUser, EndpointType.Read, IsDebugInformationEndpoint = true)]
         public async Task Get()
         {
-            HttpContext.Response.Headers.Add(Constants.Headers.ServerStartupTime, ServerStore.Server.Statistics.StartUpTime.GetDefaultRavenFormat(isUtc: true));
+            HttpContext.Response.Headers[Constants.Headers.ServerStartupTime] = ServerStore.Server.Statistics.StartUpTime.GetDefaultRavenFormat(isUtc: true);
 
             var versionBuffer = VersionBuffer.Value;
             await ResponseBodyStream().WriteAsync(versionBuffer, 0, versionBuffer.Length);

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -455,7 +455,7 @@ namespace Raven.Server.Web.System
             var location = url + HttpContext.Request.Path + HttpContext.Request.QueryString;
             HttpContext.Response.StatusCode = (int)HttpStatusCode.TemporaryRedirect;
             HttpContext.Response.Headers.Remove("Content-Type");
-            HttpContext.Response.Headers.Add("Location", location);
+            HttpContext.Response.Headers["Location"] = location;
         }
 
         private static int _oneTimeBackupCounter;

--- a/src/Raven.Studio/Raven.Studio.csproj
+++ b/src/Raven.Studio/Raven.Studio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Raven.Studio</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/Raven.Studio/scripts/typings.js
+++ b/src/Raven.Studio/scripts/typings.js
@@ -4,8 +4,8 @@ const fsUtils = require("./fsUtils");
 const exec = require('child_process').execSync;
 
 const possibleTypingsGenPaths = [
-    '../../tools/TypingsGenerator/bin/Debug/net7.0/TypingsGenerator.dll',
-    '../../tools/TypingsGenerator/bin/Release/net7.0/TypingsGenerator.dll' ];
+    '../../tools/TypingsGenerator/bin/Debug/net8.0/TypingsGenerator.dll',
+    '../../tools/TypingsGenerator/bin/Release/net8.0/TypingsGenerator.dll' ];
 
 const dllPath = fsUtils.getLastRecentlyModifiedFile(possibleTypingsGenPaths);
 if (!dllPath) {

--- a/src/Sparrow.Server/Collections/Persistent/BinaryTree.cs
+++ b/src/Sparrow.Server/Collections/Persistent/BinaryTree.cs
@@ -55,7 +55,7 @@ namespace Sparrow.Server.Collections.Persistent
         private ushort FreeNodes
         {
             get { return MemoryMarshal.Read<ushort>(_storage); }
-            set { MemoryMarshal.Write(_storage, ref value); }
+            set { MemoryMarshal.Write(_storage, in value); }
         }
 
         public int MaxNodes => _nodes.Length - 1;

--- a/src/Sparrow.Server/Compression/Encoder3Gram.cs
+++ b/src/Sparrow.Server/Compression/Encoder3Gram.cs
@@ -395,7 +395,7 @@ namespace Sparrow.Server.Compression
         public int NumberOfEntries
         {
             get { return ReadNumberOfEntries(_state); }
-            set { MemoryMarshal.Write(_state.EncodingTable, ref value);}
+            set { MemoryMarshal.Write(_state.EncodingTable, in value);}
         }
 
         private static int ReadNumberOfEntries(in TEncoderState encoderState)
@@ -411,7 +411,7 @@ namespace Sparrow.Server.Compression
             set
             {
                 byte valueAsByte = (byte)value;
-                MemoryMarshal.Write(_state.EncodingTable.Slice(4, 1), ref valueAsByte);
+                MemoryMarshal.Write(_state.EncodingTable.Slice(4, 1), in valueAsByte);
             }
         }
 
@@ -421,7 +421,7 @@ namespace Sparrow.Server.Compression
             set
             {
                 byte valueAsByte = (byte)value;
-                MemoryMarshal.Write(_state.EncodingTable.Slice(5, 1), ref valueAsByte);
+                MemoryMarshal.Write(_state.EncodingTable.Slice(5, 1), in valueAsByte);
             }
         }
 

--- a/src/Sparrow.Server/LowMemory/CheckPageFileOnHdd.cs
+++ b/src/Sparrow.Server/LowMemory/CheckPageFileOnHdd.cs
@@ -333,7 +333,7 @@ namespace Sparrow.Server.LowMemory
         private struct VOLUME_DISK_EXTENTS
         {
             private readonly uint NumberOfDiskExtents;
-            [MarshalAs(UnmanagedType.ByValArray)] public readonly DISK_EXTENT[] Extents;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1)] public readonly DISK_EXTENT[] Extents;
         }
 
         // DeviceIoControl to get disk extents

--- a/src/Sparrow.Server/Sparrow.Server.csproj
+++ b/src/Sparrow.Server/Sparrow.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Sparrow.Server</AssemblyName>
     <PackageId>Sparrow.Server</PackageId>
@@ -47,7 +47,7 @@
     <PackageReference Include="Raven.CodeAnalysis" Version="1.0.11">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="7.0.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sparrow\Sparrow.csproj" />

--- a/src/Sparrow/Sparrow.csproj
+++ b/src/Sparrow/Sparrow.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;netstandard2.1;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Sparrow</AssemblyName>
     <PackageId>Sparrow</PackageId>
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/Voron/Data/CompactTrees/CompactKey.cs
+++ b/src/Voron/Data/CompactTrees/CompactKey.cs
@@ -307,7 +307,7 @@ public unsafe class CompactKey : IDisposable
         currentPtr += sizeof(int);
 
         // PERF: Between pinning the pointer and just execute the Unsafe.CopyBlock unintuitively it is faster to just copy. 
-        Unsafe.CopyBlock(ref Unsafe.AsRef<byte>(currentPtr), ref Unsafe.AsRef<byte>(key[0]), (uint)keyLength);
+        Unsafe.CopyBlock(ref Unsafe.AsRef<byte>(currentPtr), ref Unsafe.AsRef<byte>(in key[0]), (uint)keyLength);
 
         currentPtr += keyLength; // We update the new pointer. 
         _currentPtr = currentPtr;

--- a/src/Voron/Util/ActiveTransactions.cs
+++ b/src/Voron/Util/ActiveTransactions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading;
 using Sparrow.Threading;
@@ -129,9 +130,9 @@ namespace Voron.Util
             return list;
         }
 
-        private static LowLevelTransaction InvalidLowLevelTransaction = (LowLevelTransaction)FormatterServices.GetUninitializedObject(typeof(LowLevelTransaction));
+        private static readonly LowLevelTransaction InvalidLowLevelTransaction = (LowLevelTransaction)RuntimeHelpers.GetUninitializedObject(typeof(LowLevelTransaction));
 
-        private MultipleUseFlag _compactionInProgress = new MultipleUseFlag();
+        private readonly MultipleUseFlag _compactionInProgress = new MultipleUseFlag();
 
         public bool Remove(LowLevelTransaction tx)
         {

--- a/src/Voron/Voron.csproj
+++ b/src/Voron/Voron.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <Description>Voron - Low level storage engine</Description>
     <Authors>Hibernating Rhinos</Authors>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Voron</AssemblyName>
     <PackageId>Voron</PackageId>

--- a/test/BenchmarkTests/BenchmarkTests.csproj
+++ b/test/BenchmarkTests/BenchmarkTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>BenchmarkTests</AssemblyName>
     <PackageId>BenchmarkTests</PackageId>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Version></Version>
 
-    <LangVersion>11</LangVersion>
+    <LangVersion>preview</LangVersion>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <GenerateRequiresPreviewFeaturesAttribute>True</GenerateRequiresPreviewFeaturesAttribute>
     

--- a/test/EmbeddedTests/EmbeddedTestBase.cs
+++ b/test/EmbeddedTests/EmbeddedTestBase.cs
@@ -39,13 +39,13 @@ namespace EmbeddedTests
                 Directory.CreateDirectory(dataDirectory);
 
 #if DEBUG
-            var runtimeConfigPath = @"../../../../../src/Raven.Server/bin/x64/Debug/net7.0/Raven.Server.runtimeconfig.json";
+            var runtimeConfigPath = @"../../../../../src/Raven.Server/bin/x64/Debug/net8.0/Raven.Server.runtimeconfig.json";
             if (File.Exists(runtimeConfigPath) == false) // this can happen when running directly from CLI e.g. dotnet xunit
-                runtimeConfigPath = @"../../../../../src/Raven.Server/bin/Debug/net7.0/Raven.Server.runtimeconfig.json";
+                runtimeConfigPath = @"../../../../../src/Raven.Server/bin/Debug/net8.0/Raven.Server.runtimeconfig.json";
 #else
-                var runtimeConfigPath = @"../../../../../src/Raven.Server/bin/x64/Release/net7.0/Raven.Server.runtimeconfig.json";
+                var runtimeConfigPath = @"../../../../../src/Raven.Server/bin/x64/Release/net8.0/Raven.Server.runtimeconfig.json";
                 if (File.Exists(runtimeConfigPath) == false) // this can happen when running directly from CLI e.g. dotnet xunit
-                    runtimeConfigPath = @"../../../../../src/Raven.Server/bin/Release/net7.0/Raven.Server.runtimeconfig.json";
+                    runtimeConfigPath = @"../../../../../src/Raven.Server/bin/Release/net8.0/Raven.Server.runtimeconfig.json";
 #endif
 
             var runtimeConfigFileInfo = new FileInfo(runtimeConfigPath);

--- a/test/EmbeddedTests/EmbeddedTests.csproj
+++ b/test/EmbeddedTests/EmbeddedTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>EmbeddedTests</AssemblyName>
     <PackageId>EmbeddedTests</PackageId>

--- a/test/EmbeddedTests/TestDriver/TestDriverExampleTest.cs
+++ b/test/EmbeddedTests/TestDriver/TestDriverExampleTest.cs
@@ -35,13 +35,13 @@ namespace EmbeddedTests.TestDriver
                 throw new InvalidOperationException($"Could not find '{testDllFile.FullName}'.");
 
 #if DEBUG
-            var serverDirectory = @"../../../../../src/Raven.Server/bin/x64/Debug/net7.0";
+            var serverDirectory = @"../../../../../src/Raven.Server/bin/x64/Debug/net8.0";
             if (Directory.Exists(serverDirectory) == false) // this can happen when running directly from CLI e.g. dotnet xunit
-                serverDirectory = @"../../../../../src/Raven.Server/bin/Debug/net7.0";
+                serverDirectory = @"../../../../../src/Raven.Server/bin/Debug/net8.0";
 #else
-            var serverDirectory = @"../../../../../src/Raven.Server/bin/x64/Release/net7.0";
+            var serverDirectory = @"../../../../../src/Raven.Server/bin/x64/Release/net8.0";
             if (Directory.Exists(serverDirectory) == false) // this can happen when running directly from CLI e.g. dotnet xunit
-                serverDirectory = @"../../../../../src/Raven.Server/bin/Release/net7.0";
+                serverDirectory = @"../../../../../src/Raven.Server/bin/Release/net8.0";
 #endif
 
             var path = Path.Combine(testDllFile.DirectoryName, serverDirectory);

--- a/test/FastTests/FastTests.csproj
+++ b/test/FastTests/FastTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>FastTests</AssemblyName>
     <PackageId>FastTests</PackageId>

--- a/test/FastTests/Server/DebugMemoryTests.cs
+++ b/test/FastTests/Server/DebugMemoryTests.cs
@@ -14,7 +14,7 @@ public class DebugMemoryTests : NoDisposalNeeded
     [Fact]
     public void Allocation_Debug_Event()
     {
-        Assert.True(Environment.Version.Major == 7 && AdminGcDebugHandler.GcAllocationsEventListener.AllocationEventName == "GCAllocationTick_V4",
+        Assert.True(Environment.Version.Major == 8 && AdminGcDebugHandler.GcAllocationsEventListener.AllocationEventName == "GCAllocationTick_V4",
             "Check if GCAllocationTick event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
     }
 }

--- a/test/InterversionTests/InterversionTests.csproj
+++ b/test/InterversionTests/InterversionTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>InterversionTests</AssemblyName>
     <PackageId>InterversionTests</PackageId>

--- a/test/LicenseTests/LicenseTests.csproj
+++ b/test/LicenseTests/LicenseTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AssemblyName>LicenseTests</AssemblyName>
     <PackageId>LicenseTests</PackageId>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>

--- a/test/RachisTests/RachisTests.csproj
+++ b/test/RachisTests/RachisTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>RachisTests</AssemblyName>
     <PackageId>RachisTests</PackageId>

--- a/test/SlowTests/Issues/RavenDB-11980.cs
+++ b/test/SlowTests/Issues/RavenDB-11980.cs
@@ -53,7 +53,9 @@ namespace SlowTests.Issues
                         Reverse = e.CustomFields.Reverse(),
                         Take = e.CustomFields.Take(1),
                         Skip = e.CustomFields.Skip(1),
+#pragma warning disable CA2021
                         OfType = e.CustomFields.OfType<KeyValuePair<object, object>>()
+#pragma warning restore CA2021
                     };
             }
         }

--- a/test/SlowTests/SlowTests.csproj
+++ b/test/SlowTests/SlowTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>SlowTests</AssemblyName>
     <PackageId>SlowTests</PackageId>
@@ -152,7 +152,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="7.0.1" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="8.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/StressTests/StressTests.csproj
+++ b/test/StressTests/StressTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>StressTests</AssemblyName>
     <PackageId>StressTests</PackageId>

--- a/test/Tests.Infrastructure/Tests.Infrastructure.csproj
+++ b/test/Tests.Infrastructure/Tests.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AssemblyName>Tests.Infrastructure</AssemblyName>
     <PackageId>Tests.Infrastructure</PackageId>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>

--- a/test/Tryouts/Tryouts.csproj
+++ b/test/Tryouts/Tryouts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Tryouts</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/tools/Raven.Debug/Raven.Debug.csproj
+++ b/tools/Raven.Debug/Raven.Debug.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
-    <RuntimeIdentifiers>win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64</RuntimeIdentifiers>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -16,13 +16,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.510501" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.77" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
-    <PackageReference Include="System.Reflection.Metadata" Version="7.0.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Raven.Migrator/Raven.Migrator.csproj
+++ b/tools/Raven.Migrator/Raven.Migrator.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
-    <RuntimeIdentifiers>win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64</RuntimeIdentifiers>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
@@ -20,11 +20,11 @@
     <PackageReference Include="MongoDB.Driver" Version="2.24.0" />
     <PackageReference Include="MongoDB.Driver.GridFS" Version="2.24.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Data.HashFunction.Blake2" Version="2.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
-    <PackageReference Include="System.Reflection.Metadata" Version="7.0.2" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageReference Include="ZstdSharp.Port" Version="0.7.6" />
   </ItemGroup>
 </Project>

--- a/tools/TypingsGenerator/TypingsGenerator.csproj
+++ b/tools/TypingsGenerator/TypingsGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AssemblyName>TypingsGenerator</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>TypingsGenerator</PackageId>

--- a/tools/Voron.Dictionary.Generator/Voron.Dictionary.Generator.csproj
+++ b/tools/Voron.Dictionary.Generator/Voron.Dictionary.Generator.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tools/Voron.Recovery/Voron.Recovery.csproj
+++ b/tools/Voron.Recovery/Voron.Recovery.csproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <Description>Voron Recovery Tool</Description>
     <Authors>Hibernating Rhinos</Authors>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Voron.Recovery</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Voron.Recovery</PackageId>
-    <RuntimeIdentifiers>win7-x64;win8-x64;win10-x64;ubuntu.14.04-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -19,8 +19,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\src\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
-    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="7.0.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
     <ProjectReference Include="..\..\src\Raven.Server\Raven.Server.csproj" />
     <ProjectReference Include="..\..\src\Voron\Voron.csproj" />
   </ItemGroup>

--- a/tools/rvn/rvn.csproj
+++ b/tools/rvn/rvn.csproj
@@ -3,12 +3,12 @@
     <Description>rvn is a CLI utility for RavenDB</Description>
     <Authors>Hibernating Rhinos</Authors>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <RuntimeFrameworkVersion>7.0.18</RuntimeFrameworkVersion>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeFrameworkVersion>8.0.4</RuntimeFrameworkVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>database;nosql;doc db</PackageTags>
     <PackageProjectUrl>https://ravendb.net</PackageProjectUrl>
-    <RuntimeIdentifiers>win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64</RuntimeIdentifiers>
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
     <DefineConstants>$(DefineConstants);RVN</DefineConstants>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
@@ -156,11 +156,11 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="DasMulli.Win32.ServiceUtils.Signed" Version="1.1.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="7.0.1" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22275/Update-v5.4-to-.NET-8

### Additional description

```
1. Run script (from the main directory):
> .\updateFrameworkVersion.ps1 8.0.4

2. Run script (from the main directory):
> .\updateTargetFramework.ps1 net8.0

3. Github actions - *.yml files

a) update DOTNET_VERSION (DOTNET_VERSION: 7.0.408 -> DOTNET_VERSION: 8.0.204) b) update dotnet-version ('7.0' -> '8.0' / '7.0.x' -> '8.0.x')

4. Update Directory.Build.props

a) <LangVersion>11</LangVersion> -> <LangVersion>preview</LangVersion> b) <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0'"> -> <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'">

5. Update <RuntimeIdentifiers> in .csproj files

a) Micro.Benchmark.csproj: win7-x64;win8-x64;win10-x64;ubuntu.14.04-x64 -> win-x64;win-x86;linux-x64
b) Voron.Benchmark.csproj: win7-x64;win8-x64;win10-x64;ubuntu.14.04-x64 -> win-x64;win-x86;linux-x64
c) Raven.Server.csproj: win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64 -> win-x64;win-x86;linux-x64;osx-x64
d) Raven.Debug.csproj: win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64 -> win-x64;win-x86;linux-x64;osx-x64
d) Raven.Migrator.csproj: win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64 -> win-x64;win-x86;linux-x64;osx-x64
e) Voron.Recovery.csproj: win7-x64;win8-x64;win10-x64;ubuntu.14.04-x64 -> win-x64;win-x86;linux-x64
f) rvn.csproj: win7-x64;win8-x64;win81-x64;win10-x64;win7-x86;win8-x86;win81-x86;win10-x86;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.18.04-x64 -> win-x64;win-x86;linux-x64

6. Update files in docker/ directory: 7.0 -> 8.0

7. Update debug.Dockerfile file: 7.0 -> 8.0

8. Update scripts/certificates/powershell/dev-create-authenticated-cluster-with-subdomains.ps1: net7.0 -> net8.0

9. Update scripts/certificates/powershell/dev-create-authenticated-cluster.ps1: net7.0 -> net8.0

10. Update scripts/package.ps1: net7.0 -> net8.0

11. Update src/CommonAssemblyInfo.cs

12. Update src/Raven.Client/Properties/VersionInfo.cs

13. Update Raven.Client.csproj and

a) Add net8.0 to <TargetFrameworks>
b) Add new 'this is required for the nuget build to properly include the right files' section

14. Update Sparrow.csproj and

a) Add net8.0 to <TargetFrameworks>

15. Update src/Raven.Studio/scripts/typings.js: net7.0 -> net8.0

16. Update test/EmbeddedTests/EmbeddedTestBase.cs: net7.0 -> net8.0

17. Update test/EmbeddedTests/TestDriver/TestDriverExampleTest.cs: net7.0 -> net8.0
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
