### PR TITLE
RavenDB-22292 optimize timeseries retention

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
@@ -238,6 +238,7 @@ namespace Raven.Server.Documents.TimeSeries
         internal class TimeSeriesRetentionCommand : TransactionOperationsMerger.MergedTransactionCommand
         {
             public const int BatchSize = 1024;
+            private static readonly Size MaxTransactionSize = new(16, SizeUnit.Megabytes);
 
             private readonly List<Slice> _keys;
             private readonly string _collection;
@@ -274,6 +275,9 @@ namespace Raven.Server.Documents.TimeSeries
 
                     if (logger.IsInfoEnabled)
                         logger.Info($"{request} was executed (successfully: {done})");
+
+                    if (context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSize > MaxTransactionSize)
+                        break;
                 }
 
                 return retained;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -248,7 +248,7 @@ namespace Raven.Server.Documents.TimeSeries
                 if (previousCount == 0)
                     return false; // if current and previous are zero it means that this time-series was completely deleted
 
-                var readerOfFirstValue = _timeSeriesStorage.GetReader(context, slicer.DocId, slicer.Name, DateTime.MinValue, DateTime.MaxValue);
+                var readerOfFirstValue = _timeSeriesStorage.GetReader(context, slicer.DocId, slicer.Name, start, DateTime.MaxValue);
                 readerOfFirstValue.First();
                 var firstValueInCurrentSegment = readerOfFirstValue.ReadBaselineAsDateTime() == baseline;
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -527,12 +527,12 @@ namespace Raven.Server.Documents.TimeSeries
         {
             var storage = ctx.DocumentDatabase.DocumentsStorage;
 
-            var doc = storage.Get(ctx, docId);
-            if (doc == null)
-                return;
-
             var tss = storage.TimeSeriesStorage;
             if (tss.Stats.GetStats(ctx, docId, tsName).Count > 0)
+                return;
+            
+            var doc = storage.Get(ctx, docId);
+            if (doc == null)
                 return;
 
             var data = doc.Data;

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -95,6 +95,8 @@ namespace Voron.Impl
 
         public event Action<LowLevelTransaction> LastChanceToReadFromWriteTransactionBeforeCommit;
 
+        public Size TransactionSize => new Size(NumberOfModifiedPages * Constants.Storage.PageSize, SizeUnit.Bytes) + AdditionalMemoryUsageSize;
+
         public Size AdditionalMemoryUsageSize
         {
             get


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22292

### Additional description

During a retention we had to find the first live entry, so we did that by scanning the timeseries from `DateTime.MinValue`.
We did this scanning for every segment deletion, so if we need to delete the first 10 segments we would scan 10 times from `DateTime.MinValue`, which is O(N^2).

So the fix is to scan from the last known `Start` point of the time series which is effectively O(N) (when deleting N segments) 

![image](https://github.com/ravendb/ravendb/assets/6377808/e151eb90-fa67-4c3d-a4c1-f283d5ed73ed)

(`EnsureStatsAndDataIntegrity` is a check only in Debug)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
