### PR TITLE
RavenDB-21926 Modify the state and the flags of a tree only if they aren't aleady set. Otherwise we force the write to journal of the pages where tree states are kept because we recognize that they were modified (even if the state did not change).

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
@@ -43,8 +43,11 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             MapReduceWorkContext.ReducePhaseTree = GetReducePhaseTree(indexContext.Transaction.InnerTransaction);
             MapReduceWorkContext.ResultsStoreTypes = MapReduceWorkContext.ReducePhaseTree.FixedTreeFor(ResultsStoreTypesTreeName, sizeof(byte));
 
-            ref var state = ref MapReduceWorkContext.MapPhaseTree.State.Modify();
-            state.Flags |= TreeFlags.FixedSizeTrees;
+            if ((MapReduceWorkContext.MapPhaseTree.State.Header.Flags & TreeFlags.FixedSizeTrees) != TreeFlags.FixedSizeTrees)
+            {
+                ref var state = ref MapReduceWorkContext.MapPhaseTree.State.Modify();
+                state.Flags |= TreeFlags.FixedSizeTrees;
+            }
 
             MapReduceWorkContext.DocumentMapEntries = new FixedSizeTree(
                    indexContext.Transaction.InnerTransaction.LowLevelTransaction,

--- a/src/Voron/Data/BTrees/Tree.MultiTree.cs
+++ b/src/Voron/Data/BTrees/Tree.MultiTree.cs
@@ -43,8 +43,11 @@ namespace Voron.Data.BTrees
             if (value.Size == 0)
                 throw new ArgumentException("Cannot add empty value to child tree");
 
-            ref var state = ref State.Modify();
-            state.Flags |= TreeFlags.MultiValueTrees;
+            if ((State.Header.Flags & TreeFlags.MultiValueTrees) != TreeFlags.MultiValueTrees)
+            {
+                ref var state = ref State.Modify();
+                state.Flags |= TreeFlags.MultiValueTrees;
+            }
 
             var page = FindPageFor(key, out _);
             if (page == null || page.LastMatch != 0)

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -233,8 +233,11 @@ namespace Voron.Data.BTrees
             writer.Init(this, key, tag, initialNumberOfPagesPerChunk);
             writer.Write(stream);
 
-            ref var state = ref State.Modify();
-            state.Flags |= TreeFlags.Streams;
+            if ((State.Header.Flags & TreeFlags.Streams) != TreeFlags.Streams)
+            {
+                ref var state = ref State.Modify();
+                state.Flags |= TreeFlags.Streams;
+            }
         }
 
         public VoronStream ReadStream(string key)

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -1493,7 +1493,7 @@ namespace Voron.Data.BTrees
             {
                 fixedTree = new FixedSizeTree(_llt, this, key, valSize);
 
-                if (_llt.Flags is TransactionFlags.ReadWrite)
+                if (_llt.Flags is TransactionFlags.ReadWrite && (State.Header.Flags & TreeFlags.FixedSizeTrees) != TreeFlags.FixedSizeTrees)
                 {
                     ref var state = ref State.Modify();
                     state.Flags |= TreeFlags.FixedSizeTrees;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -316,9 +316,12 @@ public sealed partial class CompactTree : IPrepareForCommit
             if (llt.Flags != TransactionFlags.ReadWrite)
                 return null;
 
-            // We will modify the parent tree state because there are Compact Trees in it.
-            ref var parentState = ref parent.State.Modify();
-            parentState.Flags |= TreeFlags.CompactTrees;
+            if ((parent.State.Header.Flags & TreeFlags.CompactTrees) != TreeFlags.CompactTrees)
+            {
+                // We will modify the parent tree state because there are Compact Trees in it.
+                ref var parentState = ref parent.State.Modify();
+                parentState.Flags |= TreeFlags.CompactTrees;
+            }
 
             long dictionaryId;
 

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -261,8 +261,11 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
             if (llt.Flags != TransactionFlags.ReadWrite)
                 return null;
 
-            ref var state = ref parent.State.Modify();
-            state.Flags |= TreeFlags.Lookups;
+            if ((parent.State.Header.Flags & TreeFlags.Lookups) != TreeFlags.Lookups)
+            {
+                ref var state = ref parent.State.Modify();
+                state.Flags |= TreeFlags.Lookups;
+            }
 
             Create(llt, out header, dictionaryId, termsContainerId);
             using var _ = parent.DirectAdd(name, sizeof(LookupState), out var p);

--- a/test/SlowTests/Voron/RavenDB_21926.cs
+++ b/test/SlowTests/Voron/RavenDB_21926.cs
@@ -1,0 +1,43 @@
+﻿using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron.Data.Fixed;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron;
+
+public class RavenDB_21926 : StorageTest
+{
+    public RavenDB_21926(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void MustNotCommitTreeStateIfItWasNotModified()
+    {
+        var lastCommitedTx = -1L;
+
+        using (var txw = Env.WriteTransaction())
+        {
+            FixedSizeTree fst = txw.CreateTree("foo").FixedTreeFor("bar", sizeof(long));
+
+            fst.Add(1, 1L);
+
+            txw.Commit();
+
+            lastCommitedTx = txw.LowLevelTransaction.Id;
+        }
+
+        using (var txw = Env.WriteTransaction())
+        {
+            FixedSizeTree fst = txw.CreateTree("foo").FixedTreeFor("bar", sizeof(long));
+
+            txw.Commit(); // should be no op because nothing was changed in this transaction
+        }
+
+        using (var txw = Env.WriteTransaction())
+        {
+            Assert.Equal(lastCommitedTx + 1, txw.LowLevelTransaction.Id);
+        }
+    }
+}


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22297/Tombstonecleanermustnotpreventfromunloadingidledatabase-failure-after-commit-2de28d9

### Additional description

The fix for the failing test is in `Tree.FixedTreeFor()`. Although I have applied the same to other places where we modify the tree state flags by doing `state.Flags |=`. I think in other places it might not be needed because we're in methods like `MultiAdd`, `AddStream`, `CompactTree.InternalCreate`, `Lookup.InternalCreate` so we're pretty sure that the state will be modified anyway.  For the sake of consistency I have added the check if the flag isn't already applied in other places as well. Although if this might be performance sensitive I'm fine with dropping it there. @redknightlois Thoughts?

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
