### PR TITLE
RavenDB-22190 - use the verifier from BouncyCastle

### DIFF
--- a/src/Raven.Server/Commercial/LicenseValidator.cs
+++ b/src/Raven.Server/Commercial/LicenseValidator.cs
@@ -95,13 +95,13 @@ namespace Raven.Server.Commercial
                     binaryWriter.Write(licenseKey.Id.ToByteArray());
                     binaryWriter.Write(licenseKey.Name);
 
-                    RsaKeyParameters publicKey = new(false,
+                    RsaKeyParameters publicKey = new(isPrivate: false,
                         new BigInteger(1, rsaParameters.Modulus),
                         new BigInteger(1, rsaParameters.Exponent));
 
                     var dataToVerify = ms.ToArray();
                     ISigner verifier = SignerUtilities.GetSigner("SHA1withRSA");
-                    verifier.Init(false, publicKey);
+                    verifier.Init(forSigning: false, publicKey);
                     verifier.BlockUpdate(dataToVerify, 0, dataToVerify.Length);
 
                     if (verifier.VerifySignature(keys.Signature) == false)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22190

### Additional description

Use the signature verifier from `BouncyCastle`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
