### PR TITLE
RavenDB-22261: Inconsistency in Tree external API

### DIFF
--- a/bench/Micro.Benchmark/Benchmarks/ThrowingAllocation.cs
+++ b/bench/Micro.Benchmark/Benchmarks/ThrowingAllocation.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿#nullable enable 
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Analysers;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
@@ -13,7 +14,6 @@ using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Validators;
-using Sparrow;
 
 namespace Micro.Benchmark.Benchmarks
 {
@@ -193,9 +193,7 @@ namespace Micro.Benchmark.Benchmarks
 
         public static void ThrowIf(
             bool condition,
-            string message,
-            [CallerArgumentExpression(nameof(condition))]
-            string paramName = null)
+            string message)
         {
             if (condition)
             {
@@ -209,11 +207,11 @@ namespace Micro.Benchmark.Benchmarks
         public readonly ref struct ThrowInterpolatedStringHandler
         {
             // Storage for the built-up string
-            private readonly List<object> _strings;
+            private readonly List<object?> _strings;
 
             public ThrowInterpolatedStringHandler(int literalLength, int formattedCount)
             {
-                _strings = new List<object>(literalLength);
+                _strings = new List<object?>(literalLength);
             }
 
             public void AppendLiteral(string s)
@@ -238,9 +236,7 @@ namespace Micro.Benchmark.Benchmarks
 
         public static void ThrowIfInterpolated(
             bool condition,
-            ThrowInterpolatedStringHandler message,
-            [CallerArgumentExpression(nameof(condition))]
-            string paramName = null)
+            ThrowInterpolatedStringHandler message)
         {
             if (condition)
             {
@@ -266,9 +262,7 @@ namespace Micro.Benchmark.Benchmarks
         public static void ThrowIfInterpolatedEfficient(
             bool condition,
             [InterpolatedStringHandlerArgument(nameof(condition))]
-            ThrowInterpolatedStringEfficientHandler message,
-            [CallerArgumentExpression(nameof(condition))]
-            string paramName = null)
+            ThrowInterpolatedStringEfficientHandler message)
         {
             if (condition)
             {

--- a/bench/Micro.Benchmark/Benchmarks/ThrowingAllocation.cs
+++ b/bench/Micro.Benchmark/Benchmarks/ThrowingAllocation.cs
@@ -1,0 +1,265 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnostics.Windows.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Validators;
+using Sparrow;
+
+namespace Micro.Benchmark.Benchmarks
+{
+    [Config(typeof(ThrowingAllocationConfig))]
+    [InliningDiagnoser(true, true)]
+    [MemoryDiagnoser]
+    
+    public class ThrowingAllocationBench
+    {
+        private class ThrowingAllocationConfig : ManualConfig
+        {
+            public ThrowingAllocationConfig()
+            {
+                AddJob(new Job
+                {
+                    Environment =
+                    {
+                        Runtime = CoreRuntime.Core80,
+                        Platform = Platform.X64,
+                        Jit = Jit.RyuJit,
+                    },
+                    Run =
+                    {
+                        // TODO: Next line is just for testing. Fine tune parameters.
+                        //RunStrategy = RunStrategy.Monitoring,
+                    }
+                });
+
+                // Exporters for data
+                AddExporter(GetExporters().ToArray());
+                // Generate plots using R if %R_HOME% is correctly set
+                AddExporter(RPlotExporter.Default);
+
+                AddValidator(BaselineValidator.FailOnError);
+                AddValidator(JitOptimizationsValidator.FailOnError);
+
+                AddAnalyser(EnvironmentAnalyser.Default);
+            }
+        }
+
+        private int location;
+        
+        [GlobalSetup]
+        public void Setup()
+        {
+            var rnd = new Random();
+            location = rnd.Next(1) + 998;
+        }
+
+        [Benchmark]
+        public void Naked()
+        {
+
+            for (int i = 0; i < 1000; i++)
+            {
+                try
+                {
+                    if (location == i)
+                        throw new InvalidOperationException($"We are constructing this based on the i value = {i}");
+                }
+                catch { }
+            }
+        }
+
+        [DoesNotReturn]
+        private void ThrowMethod(int i)
+        {
+            throw new InvalidOperationException($"We are constructing this based on the i value = {i}");
+        }
+
+        [Benchmark]
+        public void NakedWithThrow()
+        {
+
+            for (int i = 0; i < 1000; i++)
+            {
+                try
+                {
+                    if (location == i)
+                        ThrowMethod(i);
+                }
+                catch { }
+            }
+        }
+
+        [Benchmark]
+        public void PortableIfNoInterpolation()
+        {
+
+            for (int i = 0; i < 1000; i++)
+            {
+                try
+                {
+                    ThrowIf(location == i, $"We are constructing this based on the i value = i");
+                }
+                catch { }
+            }
+        }
+
+        [Benchmark]
+        public void PortableIfWithNoInlining()
+        {
+
+            for (int i = 0; i < 1000; i++)
+            {
+                try
+                {
+                    ThrowIf(location == i, $"We are constructing this based on the i value = {i}");
+                }
+                catch { }
+            }
+        }
+
+        [Benchmark]
+        public void PortableIfWithCondition()
+        {
+
+            for (int i = 0; i < 1000; i++)
+            {
+                try
+                {
+                    ThrowIfWithCondition(location == i, $"We are constructing this based on the i value = {i}");
+                }
+                catch { }
+            }
+        }
+
+        [Benchmark]
+        public void PortableIfDelegate()
+        {
+
+            for (int i = 0; i < 1000; i++)
+            {
+                try
+                {
+                    ThrowIf(location == i, () => $"We are constructing this based on the i value = {i}");
+                }
+                catch { }
+            }
+        }
+
+        [Benchmark]
+        public void OutOfRange()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                try
+                {
+                    ArgumentOutOfRangeException.ThrowIfEqual(i, location);
+                }
+                catch { }
+            }
+        }
+
+
+        public delegate string ThrowMessage();
+        
+        public static void ThrowIf(
+            bool condition,
+            ThrowMessage message)
+        {
+            if (condition)
+            {
+                throw new InvalidOperationException(message());
+            }
+        }
+
+        public static void ThrowIfWithCondition(
+            [DoesNotReturnIf(true)] bool condition,
+            string message)
+        {
+            if (condition)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+
+        public static void ThrowIf(
+            bool condition,
+            string message,
+            [CallerArgumentExpression(nameof(condition))]
+            string paramName = null)
+        {
+            if (condition)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+        
+        
+
+        [InterpolatedStringHandler]
+        public readonly ref struct ThrowInterpolatedStringHandler
+        {
+            // Storage for the built-up string
+            private readonly List<object> _strings;
+
+            public ThrowInterpolatedStringHandler(int literalLength, int formattedCount)
+            {
+                _strings = new List<object>(literalLength);
+            }
+
+            public void AppendLiteral(string s)
+            {
+                _strings.Add(s);
+            }
+
+            public void AppendFormatted<T>(T t)
+            {
+                _strings.Add(t);
+            }
+
+            internal string GetFormattedText()
+            {
+                var builder = new StringBuilder();
+                foreach (var obj in _strings)
+                    builder.Append(obj);
+                
+                return builder.ToString();
+            }
+        }
+
+        public static void ThrowIfInterpolated(
+            bool condition,
+            ThrowInterpolatedStringHandler message,
+            [CallerArgumentExpression(nameof(condition))]
+            string paramName = null)
+        {
+            if (condition)
+            {
+                throw new InvalidOperationException(message.GetFormattedText());
+            }
+        }
+
+        [Benchmark]
+        public void PortableIfInterpolated()
+        {
+
+            for (int i = 0; i < 1000; i++)
+            {
+                try
+                {
+                    ThrowIfInterpolated(location == i,  $"We are constructing this based on the i value = {i}");
+                }
+                catch { }
+            }
+        }
+    }
+}

--- a/bench/Voron.Benchmark/BTree/BTreeReadAndIterate.cs
+++ b/bench/Voron.Benchmark/BTree/BTreeReadAndIterate.cs
@@ -121,7 +121,7 @@ namespace Voron.Benchmark.BTree
                         {
                             var reader = tree.Read(key).Reader;
 
-                            while (reader.Read(buffer, 0, buffer.Length) != 0) { }
+                            while (reader.Read(buffer, buffer.Length) != 0) { }
                         }
 
                         tx.Commit();
@@ -154,7 +154,7 @@ namespace Voron.Benchmark.BTree
                         {
                             var reader = tree.Read(key).Reader;
 
-                            while (reader.Read(buffer, 0, buffer.Length) != 0) { }
+                            while (reader.Read(buffer, buffer.Length) != 0) { }
                         }
 
                         tx.Commit();

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -634,7 +634,9 @@ namespace Corax.Indexing
             if (_indexedEntries.Contains(termSlice) == false)
             {
                 _compactKeyScope.Key.Set(termSlice);
-                var exists = _fieldsTree.CompactTreeFor(_fieldsMapping.GetByFieldId(Constants.IndexWriter.PrimaryKeyFieldId).FieldName).TryGetValue(_compactKeyScope.Key, out var containerId);
+                var exists = _fieldsTree.CompactTreeFor(_fieldsMapping.GetByFieldId(Constants.IndexWriter.PrimaryKeyFieldId).FieldName)
+                                             .TryGetValue(_compactKeyScope.Key, out var containerId);
+                
                 if (exists)
                 {
                     // note that the containerId may be a single value or many(!), if it is many items

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -304,7 +304,7 @@ namespace Corax.Indexing
 
                 if (persistedAnalyzer != null)
                 {
-                    var originalIndexingMode = (FieldIndexingMode)persistedAnalyzer.Reader.ReadByte();
+                    var originalIndexingMode = (FieldIndexingMode)persistedAnalyzer.Reader.Read<byte>();
                     if (binding.FieldIndexingMode != originalIndexingMode) 
                         ThrowInconsistentDynamicFieldCreation(binding, originalIndexingMode);
                 }
@@ -325,7 +325,7 @@ namespace Corax.Indexing
                 }
                 else
                 {
-                    mode = (FieldIndexingMode)persistedAnalyzer.Reader.ReadByte();
+                    mode = (FieldIndexingMode)persistedAnalyzer.Reader.Read<byte>();
                 }
 
                 Analyzer analyzer = mode switch
@@ -1542,21 +1542,23 @@ namespace Corax.Indexing
             {
                 // In the case where the field does not have any null values, we will create a *large* posting list (an empty one)
                 // then we'll insert data to it as if it was any other term
-                var entry = _writer._nullEntriesPostingLists.Read(_indexedField.Name);
-
-                if (entry != null)
+                if (_writer._nullEntriesPostingLists.TryRead(_indexedField.Name, out var reader))
                 {
                     Debug.Assert(sizeof(long) * 2 == sizeof((long, long)));
-                    Debug.Assert(entry.Reader.Length == sizeof((long, long)));
-                    return *((long,long)*)entry.Reader.Base;
+                    Debug.Assert(reader.Length == sizeof((long, long)));
+                    return *((long, long)*)reader.Base;
                 }
 
-                long setId = Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._postingListContainerId, sizeof(PostingListState), out var setSpace);
+                long setId = Container.Allocate(_writer._transaction.LowLevelTransaction,
+                    _writer._postingListContainerId, 
+                    sizeof(PostingListState), out var setSpace);
 
                 _writer.InitializeFieldRootPage(_indexedField);
                 
-                long nullMarkerId = Container.Allocate(_writer._transaction.LowLevelTransaction, _writer._entriesTermsContainerId,
+                long nullMarkerId = Container.Allocate(
+                    _writer._transaction.LowLevelTransaction, _writer._entriesTermsContainerId,
                     1, _indexedField.FieldRootPage, out var nullBuffer);
+                
                 nullBuffer.Clear();
                 
                 // we need to account for the size of the posting lists, once a term has been switch to a posting list

--- a/src/Corax/Querying/IndexSearcher.PhraseMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.PhraseMatch.cs
@@ -10,6 +10,7 @@ using Sparrow.Compression;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.CompactTrees;
+using static Voron.Global.Constants;
 
 namespace Corax.Querying;
 
@@ -18,8 +19,7 @@ public partial class IndexSearcher
     public IQueryMatch PhraseQuery<TInner>(TInner inner, in FieldMetadata field, ReadOnlySpan<Slice> terms)
         where TInner : IQueryMatch
     {
-        var compactTree = _fieldsTree?.CompactTreeFor(field.FieldName);
-        if (compactTree == null)
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out var compactTree) == false)
             return default;
 
         Allocator.Allocate(terms.Length * sizeof(long), out var sequenceBuffer);

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -157,7 +157,7 @@ public partial class IndexSearcher
     {
         double termRatioToWholeCollection;
         var totalTerms = tree.NumberOfEntries;
-        var totalSum = _metadataTree.Read(field.TermLengthSumName)?.Reader.ReadLittleEndianInt64() ?? totalTerms;
+        var totalSum = _metadataTree.Read(field.TermLengthSumName)?.Reader.Read<long>() ?? totalTerms;
 
         if (totalTerms == 0 || totalSum == 0)
             termRatioToWholeCollection = 1;

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -98,8 +98,8 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         _entriesToTermsTree = _transaction.ReadTree(Constants.IndexWriter.EntriesToTermsSlice);
         _metadataTree = _transaction.ReadTree(Constants.IndexMetadataSlice);
         _multipleTermsInField = _transaction.ReadTree(Constants.IndexWriter.MultipleTermsInField);
-        _entryIdToLocation = _transaction.LookupFor<Int64LookupKey>(Constants.IndexWriter.EntryIdToLocationSlice);
-        _dictionaryId = CompactTree.GetDictionaryId(_transaction.LowLevelTransaction);
+        _transaction.TryGetLookupFor(Constants.IndexWriter.EntryIdToLocationSlice, out _entryIdToLocation);
+        _dictionaryId = GetDictionaryId(_transaction.LowLevelTransaction);
         FieldCache = new FieldsCache(_transaction, _fieldsTree);
     }
 
@@ -212,7 +212,9 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     //Function used to generate Slice from query parameters.
     //We cannot dispose them before the whole query is executed because they are an integral part of IQueryMatch.
     //We know that the Slices are automatically disposed when the transaction is closed so we don't need to track them.
+#if !DEBUG
     [SkipLocalsInit]
+#endif
     public Slice EncodeAndApplyAnalyzer(in FieldMetadata binding, string term)
     {
         if (term is null)
@@ -325,15 +327,18 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
    public long GetDictionaryIdFor(Slice field)
    {
-       var terms = _fieldsTree?.CompactTreeFor(field);
-       return terms?.DictionaryId ?? -1;
+       if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field, out var terms) == false)
+            return -1;
+
+       return terms.DictionaryId;
    }
    
     public long GetTermAmountInField(in FieldMetadata field)
     {
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-
-        return terms?.NumberOfEntries ?? 0;
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out var terms) == false)
+            return 0;
+        
+        return terms.NumberOfEntries;
     }
 
     public bool TryGetTermsOfField(in FieldMetadata field, out ExistsTermProvider<Lookup<CompactKeyLookup>.ForwardIterator> existsTermProvider)
@@ -344,14 +349,12 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     public bool TryGetTermsOfField<TLookupIterator>(in FieldMetadata field, out ExistsTermProvider<TLookupIterator> existsTermProvider)
         where TLookupIterator : struct, ILookupIterator
     {
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-
-        if (terms == null)
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out var terms) == false)
         {
             existsTermProvider = default;
             return false;
         }
-
+        
         existsTermProvider = new ExistsTermProvider<TLookupIterator>(this, terms, field);
         return true;
     }

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -389,11 +389,11 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     public FieldIndexingMode GetFieldIndexingModeForDynamic(Slice name)
     {
         _persistedDynamicTreeAnalyzer ??= _transaction.ReadTree(Constants.IndexWriter.DynamicFieldsAnalyzersSlice);
-        var readResult = _persistedDynamicTreeAnalyzer?.Read(name);
-        if (readResult == null)
+
+        if (_persistedDynamicTreeAnalyzer.TryRead(name, out var reader) == false)
             return FieldIndexingMode.Normal;
 
-        var mode = (FieldIndexingMode)readResult.Reader.ReadByte();
+        var mode = (FieldIndexingMode)reader.Read<byte>();
         return mode;
     }
 
@@ -568,7 +568,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
             {
                 do
                 {
-                    (_, long nullTermId) = it.CreateReaderForCurrent().ReadStructure<(long, long)>();
+                    (_, long nullTermId) = it.CreateReaderForCurrent().Read<(long, long)>();
                     nullTermsMarkers.Add(nullTermId);
                 } while (it.MoveNext());
             }
@@ -578,11 +578,11 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     private long GetRootPageByFieldName(Slice fieldName)
     {
         var it = _fieldsTree.Iterate(false);
-        var result = _fieldsTree.Read(fieldName);
-        if (result is null)
+
+        if (_fieldsTree.TryRead(fieldName, out var reader) == false)
             return -1;
         
-        var state = (LookupState*)result.Reader.Base;
+        var state = (LookupState*)reader.Base;
         Debug.Assert(state->RootObjectType is RootObjectType.Lookup, "state->RootObjectType is RootObjectType.Lookup");
         return state->RootPage;
     }

--- a/src/Corax/Querying/Matches/SuggestionTermProvider.cs
+++ b/src/Corax/Querying/Matches/SuggestionTermProvider.cs
@@ -169,8 +169,7 @@ namespace Corax.Querying.Matches
 
             // We initialize the iterator and store it in the stack memory.
             Slice.From(allocator, $"{Constants.IndexWriter.SuggestionsTreePrefix}{_fieldId}", out var treeName);
-            var tree = _searcher.Transaction.CompactTreeFor(treeName);
-            if (tree == null)
+            if (_searcher.Transaction.TryGetCompactTreeFor(treeName, out var tree) == false)
                 goto NoResults;
 
             var iter = tree.Iterate();

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
@@ -88,8 +88,7 @@ public partial class IndexSearcher
 
     public MultiTermMatch RegexQuery(in FieldMetadata field, Regex regex, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
     {
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-        if (terms == null)
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out var terms) == false)
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);
 
         return forward

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Common.cs
@@ -17,8 +17,7 @@ public partial class IndexSearcher
     private MultiTermMatch MultiTermMatchBuilder<TTermProvider>(in FieldMetadata field, Slice term, bool streamingEnabled = false, bool validatePostfixLen = false, in CancellationToken token = default)
         where TTermProvider : struct, ITermProvider
     {
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-        if (terms == null)
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out var terms) == false)
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);
         
         CompactKey termKey;
@@ -48,8 +47,7 @@ public partial class IndexSearcher
     private MultiTermMatch MultiTermMatchBuilder<TTermProvider>(in FieldMetadata field, string term, bool streamingEnabled, CancellationToken token)
         where TTermProvider : struct, ITermProvider
     {
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-        if (terms == null)
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out var terms) == false)
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);
 
         var slicedTerm = EncodeAndApplyAnalyzer(field, term);

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.In.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.In.cs
@@ -28,9 +28,8 @@ public partial class IndexSearcher
             throw new NotSupportedException($"Type {typeof(TTermType)} is not supported.");
         
         var exactField = field.ChangeAnalyzer(FieldIndexingMode.Exact);
-        
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-        if (terms == null)
+
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out var terms) == false)
         {
             // If either the term or the field does not exist the request will be empty. 
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);
@@ -113,9 +112,7 @@ public partial class IndexSearcher
         
         const int maximumTermMatchesHandledAsTermMatches = 4;
         var canUseUnaryMatch = field.HasBoost == false;
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-
-        if (terms == null)
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out var terms) == false)
         {
             // If either the term or the field does not exist the request will be empty. 
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Ranges.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.Ranges.cs
@@ -151,8 +151,7 @@ public partial class IndexSearcher
         where TLow : struct, Range.Marker
         where THigh : struct, Range.Marker
     {
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-        if (terms == null)
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out var terms) == false)
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);
         
         return forward == true
@@ -170,12 +169,11 @@ public partial class IndexSearcher
         where TLow : struct, Range.Marker
         where THigh : struct, Range.Marker
     {
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-        if (terms == null)
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out _) == false)
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);
 
         field = field.GetNumericFieldMetadata<long>(Allocator);
-        var set = _fieldsTree?.LookupFor<Int64LookupKey>(field.FieldName);
+        var set = _fieldsTree.LookupFor<Int64LookupKey>(field.FieldName);
 
         return forward 
             ? MultiTermMatch.Create(new MultiTermMatch<TermNumericRangeProvider<Lookup<Int64LookupKey>.ForwardIterator, TLow, THigh, Int64LookupKey>>(this, field, _transaction.Allocator, new TermNumericRangeProvider<Lookup<Int64LookupKey>.ForwardIterator, TLow, THigh, Int64LookupKey>(this, set, field, low, high), streamingEnabled, maxNumberOfTerms,  token: token)) 
@@ -186,13 +184,12 @@ public partial class IndexSearcher
         where TLow : struct, Range.Marker
         where THigh : struct, Range.Marker
     {
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-        if (terms == null)
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out _) == false)
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);
- 
         
         field = field.GetNumericFieldMetadata<double>(Allocator);
-        var set = _fieldsTree?.LookupFor<DoubleLookupKey>(field.FieldName); 
+        
+        var set = _fieldsTree.LookupFor<DoubleLookupKey>(field.FieldName); 
         return forward
             ? MultiTermMatch.Create(new MultiTermMatch<TermNumericRangeProvider<Lookup<DoubleLookupKey>.ForwardIterator, TLow, THigh, DoubleLookupKey>>(this, field,
                 _transaction.Allocator, new TermNumericRangeProvider<Lookup<DoubleLookupKey>.ForwardIterator, TLow, THigh, DoubleLookupKey>(this, set, field, low, high), streamingEnabled, maxNumberOfTerms, token: token))

--- a/src/Corax/Querying/Spatials/IndexSearcher.Spatial.cs
+++ b/src/Corax/Querying/Spatials/IndexSearcher.Spatial.cs
@@ -12,8 +12,7 @@ public partial class IndexSearcher
 {
     public IQueryMatch SpatialQuery(in FieldMetadata field, double error, IShape shape, SpatialContext spatialContext, Utils.Spatial.SpatialRelation spatialRelation, bool isNegated = false, in CancellationToken token = default)
     {
-        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
-        if (terms == null)
+        if (_fieldsTree == null || _fieldsTree.TryGetCompactTreeFor(field.FieldName, out var terms) == false)
         {
             // If either the term or the field does not exist the request will be empty. 
             return TermMatch.CreateEmpty(this, Allocator);
@@ -22,6 +21,7 @@ public partial class IndexSearcher
         IQueryMatch match = field.HasBoost 
             ? new SpatialMatch<HasBoosting>(this, _transaction.Allocator, spatialContext, field, shape, terms, error, spatialRelation, token)
             : new SpatialMatch<NoBoosting>(this, _transaction.Allocator, spatialContext, field, shape, terms, error, spatialRelation, token);
+        
         if (isNegated)
         {
             return AndNot(AllEntries(), match);

--- a/src/Corax/Querying/TermsReader.cs
+++ b/src/Corax/Querying/TermsReader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Sparrow;
 using Sparrow.Server;
 using Voron;
@@ -22,14 +23,16 @@ public unsafe struct TermsReader : IDisposable
     private Page _lastPage;
     private readonly long _dictionaryId;
 
-    public TermsReader(LowLevelTransaction llt, Tree entriesToTermsTree, Slice name)
+    public TermsReader([NotNull] LowLevelTransaction llt, [NotNull] Tree entriesToTermsTree, Slice name)
     {
         _llt = llt;
         _cacheScope = _llt.Allocator.Allocate(sizeof((long, UnmanagedSpan)) * CacheSize, out var bs);
         bs.Clear();
         _lastPage = new();
         _cache = ((long, UnmanagedSpan)*)bs.Ptr;
-        _lookup = entriesToTermsTree.LookupFor<Int64LookupKey>(name);
+        
+        entriesToTermsTree.TryGetLookupFor(name, out _lookup);
+        
         _xKeyScope = new CompactKeyCacheScope(_llt);
         _yKeyScope = new CompactKeyCacheScope(_llt);
         _dictionaryId = CompactTree.GetDictionaryId(llt);

--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -75,7 +75,7 @@ public abstract unsafe class AbstractBackgroundWorkStorage
 
             do
             {
-                var entryTicks = it.CurrentKey.CreateReader().ReadBigEndianInt64();
+                var entryTicks = it.CurrentKey.CreateReader().ReadBigEndian<long>();
                 if (entryTicks > currentTicks)
                     break;
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -588,10 +588,10 @@ namespace Raven.Server.Documents
             }
 
             var tree = tx.CreateTree(EtagsSlice);
-            var readResult = tree.Read(LastEtagSlice);
+
             long lastEtag = 0;
-            if (readResult != null)
-                lastEtag = readResult.Reader.ReadLittleEndianInt64();
+            if (tree.TryRead(LastEtagSlice, out var reader))
+                lastEtag = reader.Read<long>();
 
             var lastDocumentEtag = ReadLastDocumentEtag(tx);
             if (lastDocumentEtag > lastEtag)
@@ -639,7 +639,7 @@ namespace Raven.Server.Documents
                 return 0;
             }
 
-            return readResult.Reader.ReadLittleEndianInt64();
+            return readResult.Reader.Read<long>();
         }
 
         public void SetLastCompletedClusterTransactionIndex(DocumentsOperationContext context, long index)
@@ -2520,7 +2520,7 @@ namespace Raven.Server.Documents
                 do
                 {
                     var dbId = it.CurrentKey.ToString();
-                    yield return new KeyValuePair<string, long>(dbId, it.CreateReaderForCurrent().ReadLittleEndianInt64());
+                    yield return new KeyValuePair<string, long>(dbId, it.CreateReaderForCurrent().Read<long>());
                 }
                 while (it.MoveNext());
             }
@@ -2533,7 +2533,7 @@ namespace Raven.Server.Documents
             if (readResult == null)
                 return 0;
 
-            return readResult.Reader.ReadLittleEndianInt64();
+            return readResult.Reader.Read<long>();
         }
 
         public static void SetLastReplicatedEtagFrom(DocumentsOperationContext context, string dbId, long etag)

--- a/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
+++ b/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
@@ -121,7 +121,7 @@ namespace Raven.Server.Documents.Indexes
         {
             var read = tree.Read(VersionSlice);
             if (read != null)
-                return read.Reader.ReadLittleEndianInt64();
+                return read.Reader.Read<long>();
 
             return isNew
                 ? BloomFilterVersion.CurrentVersion
@@ -132,13 +132,13 @@ namespace Raven.Server.Documents.Indexes
         {
             var read = tree.Read(mode == Mode.X64 ? Count64Slice : Count32Slice);
             if (read != null)
-                return read.Reader.ReadLittleEndianInt64();
+                return read.Reader.Read<long>();
 
             read = tree.Read(mode == Mode.X64 ? Count32Slice : Count64Slice);
             if (read != null)
             {
                 mode = mode == Mode.X64 ? Mode.X86 : Mode.X64;
-                return read.Reader.ReadLittleEndianInt64();
+                return read.Reader.Read<long>();
             }
 
             return 0;
@@ -383,7 +383,7 @@ namespace Raven.Server.Documents.Indexes
                 if (read == null)
                     return 0;
 
-                return read.Reader.ReadLittleEndianInt64();
+                return read.Reader.Read<long>();
             }
 
             internal bool Add(LazyStringValue key)

--- a/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
+++ b/src/Raven.Server/Documents/Indexes/Debugging/IndexDebugExtensions.cs
@@ -208,14 +208,10 @@ namespace Raven.Server.Documents.Indexes.Debugging
             {
                 MapReduceResultsStore store;
 
-                var mapReduceIndex = self as MapReduceIndex;
-
-                if (mapReduceIndex != null)
-                    store = mapReduceIndex.CreateResultsStore(typePerHash,
-                        reduceKeyHash, indexContext, false);
+                if (self is MapReduceIndex mapReduceIndex)
+                    store = mapReduceIndex.CreateResultsStore(typePerHash, reduceKeyHash, indexContext, false);
                 else
-                    store = ((AutoMapReduceIndex)self).CreateResultsStore(typePerHash,
-                        reduceKeyHash, indexContext, false);
+                    store = ((AutoMapReduceIndex)self).CreateResultsStore(typePerHash, reduceKeyHash, indexContext, false);
 
                 using (store)
                 {

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
@@ -304,9 +304,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
 
                     numberOfReduceTrees++;
 
-                    if (aggregatedTree == null)
-                        aggregatedTree = new TreeReport();
-
+                    aggregatedTree ??= new TreeReport();
                     aggregatedTree.AllocatedSpaceInBytes += treeReport.AllocatedSpaceInBytes;
                     aggregatedTree.BranchPages += treeReport.BranchPages;
                     aggregatedTree.Density = calculateExactSizes ? aggregatedTree.Density + treeReport.Density : -1;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneSuggestionIndexReader.cs
@@ -121,10 +121,10 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             int freq = (ir != null && field != null) ? ir.DocFreq(new Term(FWord, word), _state) : 0;
             int goalFreq = (morePopular && ir != null && field != null) ? freq : 0;
 
-            // if the word exists in the real index and we don't care for word frequency, return the word itself
+            // if the word exists in the real index, and we don't care for word frequency, return the word itself
             if (!morePopular && freq > 0)
             {
-                return new[] { new SuggestWord { Term = word } };
+                return [new SuggestWord { Term = word }];
             }
 
             var query = new BooleanQuery();
@@ -153,7 +153,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 if (BoostEnd > 0)
                 {
                     // should we boost suffixes
-                    Add(query, table[ng].End, grams[grams.Length - 1], BoostEnd); // matches end of word
+                    Add(query, table[ng].End, grams[^1], BoostEnd); // matches end of word
                 }
 
                 for (int i = 0; i < grams.Length; i++)
@@ -197,7 +197,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                         continue;
                 }
 
-                if (alreadySeen.Add(suggestedWord.Term) == false) // we already seen this word, no point returning it twice
+                if (alreadySeen.Add(suggestedWord.Term) == false) // we have already seen this word, no point returning it twice
                     continue;
 
                 queue.InsertWithOverflow(suggestedWord);

--- a/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
+++ b/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
@@ -14,6 +14,7 @@ using Sparrow.Json;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
+using Voron.Data.Fixed;
 
 namespace Raven.Server.Documents.Indexes
 {
@@ -377,8 +378,9 @@ namespace Raven.Server.Documents.Indexes
 
                 foreach (var key in toDelete)
                 {
-                    index.MapReduceWorkContext.DocumentMapEntries.RepurposeInstance(key, clone: false);
-
+                    if (FixedSizeTree.TryRepurposeInstance(index.MapReduceWorkContext.DocumentMapEntries, key, clone: false) == false)
+                        continue;
+                    
                     if (index.MapReduceWorkContext.DocumentMapEntries.NumberOfEntries == 0)
                         continue;
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1531,7 +1531,7 @@ namespace Raven.Server.Documents.Revisions
         private static long CountOfRevisions(DocumentsOperationContext context, Slice prefix)
         {
             var numbers = context.Transaction.InnerTransaction.ReadTree(RevisionsCountSlice);
-            return numbers.Read(prefix)?.Reader.ReadLittleEndianInt64() ?? 0;
+            return numbers.Read(prefix)?.Reader.Read<long>() ?? 0;
         }
 
         public Document GetRevisionBefore(DocumentsOperationContext context, string id, DateTime max)

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -112,7 +112,7 @@ namespace Raven.Server.Documents.TimeSeries
 
                     do
                     {
-                        var etag = it.CurrentKey.CreateReader().ReadBigEndianInt64();
+                        var etag = it.CurrentKey.CreateReader().ReadBigEndian<long>();
                         if (etag > upto)
                         {
                             hasMore = false;

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -528,7 +528,7 @@ namespace Raven.Server.Rachis
                 return 0L;
             }
 
-            return read.Reader.ReadLittleEndianInt64();
+            return read.Reader.Read<long>();
         }
 
         public string ReadNodeTag(ClusterOperationContext context)
@@ -1735,8 +1735,8 @@ namespace Raven.Server.Rachis
                 return;
             }
             var reader = read.Reader;
-            lastTruncatedIndex = reader.ReadLittleEndianInt64();
-            lastTruncatedTerm = reader.ReadLittleEndianInt64();
+            lastTruncatedIndex = reader.Read<long>();
+            lastTruncatedTerm = reader.Read<long>();
         }
 
         public unsafe BlittableJsonReaderObject GetEntry(ClusterOperationContext context, long index,
@@ -1770,7 +1770,7 @@ namespace Raven.Server.Rachis
             var read = state.Read(LastCommitSlice);
             if (read == null)
                 return 0;
-            return read.Reader.ReadLittleEndianInt64();
+            return read.Reader.Read<long>();
         }
 
         public void GetLastCommitIndex(ClusterOperationContext context, out long index, out long term)
@@ -1786,8 +1786,8 @@ namespace Raven.Server.Rachis
                 return;
             }
             var reader = read.Reader;
-            index = reader.ReadLittleEndianInt64();
-            term = reader.ReadLittleEndianInt64();
+            index = reader.Read<long>();
+            term = reader.Read<long>();
         }
 
         public void GetLastCommitIndex(out long index, out long term)
@@ -1810,13 +1810,13 @@ namespace Raven.Server.Rachis
             if (read != null)
             {
                 var reader = read.Reader;
-                var oldIndex = reader.ReadLittleEndianInt64();
+                var oldIndex = reader.Read<long>();
                 if (oldIndex > index)
                     throw new InvalidOperationException(
                         $"Cannot reduce the last commit index (is {oldIndex:#,#;;0} but was requested to reduce to {index:#,#;;0})");
                 if (oldIndex == index)
                 {
-                    var oldTerm = reader.ReadLittleEndianInt64();
+                    var oldTerm = reader.Read<long>();
                     if (oldTerm != term)
                         throw new InvalidOperationException(
                             $"Cannot change just the last commit index (at {oldIndex:#,#;;0} index, was {oldTerm:#,#;;0} but was requested to change it to {term:#,#;;0})");
@@ -2045,7 +2045,7 @@ namespace Raven.Server.Rachis
             var state = context.Transaction.InnerTransaction.CreateTree(GlobalStateSlice);
             var read = state.Read(CurrentTermSlice);
 
-            var votedTerm = read?.Reader.ReadLittleEndianInt64();
+            var votedTerm = read?.Reader.Read<long>();
 
             if (votedTerm != term && votedTerm.HasValue)
                 return (null, votedTerm.Value);
@@ -2372,7 +2372,7 @@ namespace Raven.Server.Rachis
             if (reader == null)
                 return false;
 
-            return Convert.ToBoolean(reader.Reader.ReadByte());
+            return Convert.ToBoolean(reader.Reader.Read<byte>());
         }
 
         public void LeaderElectToLeaderChanged()

--- a/src/Raven.Server/ServerWide/CompareExchangeExpirationStorage.cs
+++ b/src/Raven.Server/ServerWide/CompareExchangeExpirationStorage.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.ServerWide
                 if (it.Seek(Slices.BeforeAllKeys) == false)
                     return false;
 
-                var entryTicks = it.CurrentKey.CreateReader().ReadBigEndianInt64();
+                var entryTicks = it.CurrentKey.CreateReader().ReadBigEndian<long>();
                 return entryTicks <= currentTicks;
             }
         }
@@ -56,7 +56,7 @@ namespace Raven.Server.ServerWide
 
                 do
                 {
-                    var entryTicks = it.CurrentKey.CreateReader().ReadBigEndianInt64();
+                    var entryTicks = it.CurrentKey.CreateReader().ReadBigEndian<long>();
                     if (entryTicks > currentTicks)
                         yield break;
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1826,7 +1826,7 @@ namespace Raven.Server.ServerWide
                 return null;
 
             var protectedData = new byte[readResult.Reader.Length];
-            readResult.Reader.Read(protectedData, 0, protectedData.Length);
+            readResult.Reader.Read(protectedData, protectedData.Length);
 
             return Secrets.Unprotect(protectedData);
         }

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -503,7 +503,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             var buffer = new byte[16];
             Debug.Assert(dbId != null);
             // ReSharper disable once PossibleNullReferenceException
-            var dbIdBytes = dbId.Reader.Read(buffer, 0, 16);
+            var dbIdBytes = dbId.Reader.Read(buffer, 16);
             if (dbIdBytes != 16)
                 VoronUnrecoverableErrorException.Raise(step.WriteTx.LowLevelTransaction,
                     "The db id value in metadata tree wasn't 16 bytes in size, possible mismatch / corruption?");
@@ -697,7 +697,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
                     while (true)
                     {
-                        long id = it.CreateReaderForCurrent().ReadLittleEndianInt64();
+                        long id = it.CreateReaderForCurrent().Read<long>();
 
                         if (shouldSkip != null)
                         {

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42013/From42012.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42013/From42012.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
                                 {
                                     var key = it.CurrentKey;
                                     var keyAsString = key.ToString();   // old identity key
-                                    var value = it.CreateReaderForCurrent().ReadLittleEndianInt64();
+                                    var value = it.CreateReaderForCurrent().Read<long>();
 
                                     var newKey = keyAsString.Substring(identityPrefix.ToString().Length);
 

--- a/src/Sparrow.Server/Binary/Bit.cs
+++ b/src/Sparrow.Server/Binary/Bit.cs
@@ -1,14 +1,9 @@
 ﻿namespace Sparrow.Server.Binary
 {
-    public readonly struct Bit
+    public readonly struct Bit(byte value)
     {
-        public readonly byte Value;
+        public readonly byte Value = (byte) (value & 1);
 
         public bool IsSet => Value == 1;
-
-        public Bit(byte value)
-        {
-            Value = (byte) (value & 1);
-        }
     }
 }

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -14,7 +14,12 @@ using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Threading;
 using Sparrow.Utils;
+
 using NativeMemory = Sparrow.Utils.NativeMemory;
+
+using static Sparrow.DisposableExceptions;
+using static Sparrow.PortableExceptions;
+
 
 namespace Sparrow.Server
 {
@@ -121,12 +126,12 @@ namespace Sparrow.Server
 #if DEBUG
         public int Generation;
 #endif
-        public ByteStringType Flags
+        public readonly ByteStringType Flags
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Debug.Assert(HasValue, "ByteString.HasValue");
+                ThrowIfOnDebug<InvalidOperationException>(HasValue == false, $"{nameof(HasValue)} is false.");
                 EnsureIsNotBadPointer();
 
                 return _pointer->Flags;
@@ -138,7 +143,7 @@ namespace Sparrow.Server
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Debug.Assert(HasValue, "ByteString.HasValue");
+                ThrowIfOnDebug<InvalidOperationException>(HasValue == false, $"{nameof(HasValue)} is false.");
                 EnsureIsNotBadPointer();
 
                 return _pointer->Ptr;
@@ -154,33 +159,27 @@ namespace Sparrow.Server
                 return;
             }
 
-            ThrowFlagsWithReservedBits();
+            Throw<ArgumentException>("The flags passed contains reserved bits.");
         }
 
-        [DoesNotReturn]
-        private void ThrowFlagsWithReservedBits()
-        {
-            throw new ArgumentException("The flags passed contains reserved bits.");
-        }
-
-        public bool IsMutable
+        public readonly bool IsMutable
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Debug.Assert(HasValue, "ByteString.HasValue");
+                ThrowIfOnDebug<InvalidOperationException>(HasValue == false, $"{nameof(HasValue)} is false.");
                 EnsureIsNotBadPointer();
 
                 return (_pointer->Flags & ByteStringType.Mutable) != 0;
             }
         }
 
-        public bool IsExternal
+        public readonly bool IsExternal
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Debug.Assert(HasValue, "ByteString.HasValue");
+                ThrowIfOnDebug<InvalidOperationException>(HasValue == false, $"{nameof(HasValue)} is false.");
                 EnsureIsNotBadPointer();
 
                 return (_pointer->Flags & ByteStringType.External) != 0;
@@ -201,7 +200,7 @@ namespace Sparrow.Server
             }
         }
 
-        public int Size
+        public readonly int Size
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -224,7 +223,7 @@ namespace Sparrow.Server
             }
         }
 
-        public byte this[int index]
+        public readonly byte this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
@@ -238,10 +237,8 @@ namespace Sparrow.Server
 
         public void CopyTo(int from, byte* dest, int offset, int count)
         {
-            Debug.Assert(HasValue, "ByteString.HasValue");
-
-            if (from + count > _pointer->Length)
-                throw new ArgumentOutOfRangeException(nameof(from), "Cannot copy data after the end of the slice");
+            ThrowIfOnDebug<InvalidOperationException>(HasValue == false, $"{nameof(HasValue)} is false.");
+            ThrowIf<ArgumentOutOfRangeException>(from + count > _pointer->Length, "Cannot copy data after the end of the slice");
 
             EnsureIsNotBadPointer();
             Memory.Copy(dest + offset, _pointer->Ptr + from, count);
@@ -254,7 +251,7 @@ namespace Sparrow.Server
 
         public void CopyTo(byte* dest)
         {
-            Debug.Assert(HasValue, "ByteString.HasValue");
+            ThrowIfOnDebug<InvalidOperationException>(HasValue == false, $"{nameof(HasValue)} is false.");
 
             EnsureIsNotBadPointer();
             Memory.Copy(dest, _pointer->Ptr, _pointer->Length);
@@ -262,7 +259,7 @@ namespace Sparrow.Server
 
         public void CopyTo(byte[] dest)
         {
-            Debug.Assert(HasValue, "ByteString.HasValue");
+            ThrowIfOnDebug<InvalidOperationException>(HasValue == false, $"{nameof(HasValue)} is false.");
 
             EnsureIsNotBadPointer();
             new Span<byte>(_pointer->Ptr, _pointer->Length).CopyTo(dest);
@@ -301,7 +298,7 @@ namespace Sparrow.Server
         
         public void CopyTo(int from, byte[] dest, int offset, int count)
         {
-            Debug.Assert(HasValue, "ByteString.HasValue");
+            ThrowIfOnDebug<InvalidOperationException>(HasValue == false, $"{nameof(HasValue)} is false.");
 
             if (from + count > _pointer->Length)
                 throw new ArgumentOutOfRangeException(nameof(from), "Cannot copy data after the end of the slice");
@@ -359,18 +356,10 @@ namespace Sparrow.Server
         {
             EnsureIsNotBadPointer();
 
-            if (_pointer->Size < newSize || newSize < 0)
-                ThrowInvalidSize();
+            ThrowIf<ArgumentOutOfRangeException>(_pointer->Size < newSize || newSize < 0, $"{nameof(newSize)} must be within the existing string limit.");
 
             _pointer->Length = newSize;
         }
-
-        [DoesNotReturn]
-        private static void ThrowInvalidSize()
-        {
-            throw new ArgumentOutOfRangeException("newSize", "must be within the existing string limits");
-        }
-
 
         public string ToString(Encoding encoding)
         {
@@ -692,7 +681,7 @@ namespace Sparrow.Server
         { }
     }
 
-    public unsafe class ByteStringContext<TAllocator> : IDisposable 
+    public unsafe class ByteStringContext<TAllocator> : IDisposable, IDisposableQueryable
         where TAllocator : struct, IByteStringAllocator
     {
         private static readonly long DefragmentationSegmentsThresholdInBytes = (PlatformDetails.Is32Bits ? 32 : 128) * Sparrow.Global.Constants.Size.Megabyte;
@@ -816,10 +805,7 @@ namespace Sparrow.Server
 
         public void Reset()
         {
-            if (_disposed)
-            {
-                ThrowObjectDisposed();
-            }
+            ThrowIfDisposed();
 
 #if DEBUG
             Generation++;
@@ -1077,8 +1063,7 @@ namespace Sparrow.Server
 
         private ByteString AllocateInternal(int length, ByteStringType type)
         {
-            if (_disposed)
-                ThrowObjectDisposed();
+            ThrowIfDisposed();
 
             Debug.Assert((type & ByteStringType.External) == 0, "This allocation routine is only for use with internal storage byte strings.");
             type &= ~ByteStringType.External; // We are allocating internal, so we will force it (even if we are checking for it in debug).
@@ -1304,8 +1289,7 @@ namespace Sparrow.Server
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ReleaseExternal(ref ByteString value)
         {
-            if (_disposed)
-                ThrowObjectDisposed();
+            ThrowIfDisposed();
 
             Debug.Assert(value._pointer != null, "Pointer cannot be null. You have a defect in your code.");
 
@@ -1348,8 +1332,7 @@ namespace Sparrow.Server
 
         public void Release(ref ByteString value)
         {
-            if (_disposed)
-                ThrowObjectDisposed();
+            ThrowIfDisposed();
 
 #if DEBUG
             Debug.Assert(value.Generation == Generation, "value.Generation == Generation");
@@ -1424,14 +1407,16 @@ namespace Sparrow.Server
         private void ThrowInvalidMemorySegmentOnAllocation()
         {
             AllocationFailed?.Invoke();
-            throw new InvalidOperationException("Allocate gave us a segment that was already disposed.");
+            PortableExceptions.Throw<InvalidOperationException>("Allocate gave us a segment that was already disposed.");
         }
 
-        [DoesNotReturn]
-        private void ThrowObjectDisposed()
+        private void ThrowIfDisposed()
         {
-            AllocationFailed?.Invoke();
-            throw new ObjectDisposedException("ByteStringContext");
+            if (IsDisposed)
+            {
+                AllocationFailed?.Invoke();
+                Throw(this, $"The {nameof(ByteStringContext)} has been disposed.");
+            }
         }
 
         private void AllocateExternalSegment(int size)
@@ -1453,8 +1438,7 @@ namespace Sparrow.Server
         {
             Debug.Assert(value._pointer != null, "ByteString cant be null.");
 
-            if (_disposed)
-                ThrowObjectDisposed();
+            ThrowIfDisposed();
 
             if (bytesToSkip < 0)
                 throw new ArgumentException($"'{nameof(bytesToSkip)}' cannot be smaller than 0.");
@@ -1472,11 +1456,9 @@ namespace Sparrow.Server
 
         public ByteString Slice(ByteString value, int offset, int size, ByteStringType type = ByteStringType.Mutable)
         {
-            Debug.Assert(value._pointer != null, "ByteString cant be null.");
-
-            if (_disposed)
-                ThrowObjectDisposed();
-
+            PortableExceptions.ThrowIfNull(value._pointer);
+            ThrowIfDisposed();
+            
             if (offset < 0)
                 throw new ArgumentException($"'{nameof(offset)}' cannot be smaller than 0.");
 
@@ -1768,16 +1750,10 @@ namespace Sparrow.Server
             }
         }
 
-        public struct InternalScope : IDisposable
+        public struct InternalScope(ByteStringContext<TAllocator> parent, ByteString str) : IDisposable
         {
-            private ByteStringContext<TAllocator> _parent;
-            private ByteString _str;
-
-            public InternalScope(ByteStringContext<TAllocator> parent, ByteString str)
-            {
-                _parent = parent;
-                _str = str;
-            }
+            private ByteStringContext<TAllocator> _parent = parent;
+            private ByteString _str = str;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void Dispose()
@@ -1804,16 +1780,10 @@ namespace Sparrow.Server
             }
         }
 
-        public struct ExternalScope : IDisposable
+        public struct ExternalScope(ByteStringContext<TAllocator> parent, ByteString str) : IDisposable
         {
-            private ByteStringContext<TAllocator> _parent;
-            private ByteString _str;
-
-            public ExternalScope(ByteStringContext<TAllocator> parent, ByteString str)
-            {
-                _parent = parent;
-                _str = str;
-            }
+            private ByteStringContext<TAllocator> _parent = parent;
+            private ByteString _str = str;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void Dispose()
@@ -1830,9 +1800,7 @@ namespace Sparrow.Server
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ExternalScope FromPtr(byte* valuePtr, int size,
-            ByteStringType type,
-            out ByteString str)
+        public ExternalScope FromPtr(byte* valuePtr, int size, ByteStringType type, out ByteString str)
         {
             Debug.Assert(valuePtr != null || size == 0, $"{nameof(valuePtr)} cant be null if the size is not zero");
             Debug.Assert(size >= 0, $"{nameof(size)} cannot be negative.");
@@ -1930,18 +1898,21 @@ namespace Sparrow.Server
 
 #endif
 
-        private bool _disposed;
+        private bool _isDisposed;
+
+        public bool IsDisposed => _isDisposed;
+        
 
         public void Dispose()
         {
             lock (this)
             {
-                if (_disposed)
+                if (_isDisposed)
                     return;
 
                 GC.SuppressFinalize(this);
 
-                _disposed = true;
+                _isDisposed = true;
 
 
                 foreach (var segment in _wholeSegments)
@@ -1964,8 +1935,7 @@ namespace Sparrow.Server
             _totalAllocated -= segment.Size;
 
             // Check if we can release this memory segment back to the pool.
-            if (segment.Memory.Size > ByteStringContext.MaxAllocationBlockSizeInBytes ||
-                _lowMemoryFlag)
+            if (segment.Memory.Size > ByteStringContext.MaxAllocationBlockSizeInBytes || _lowMemoryFlag)
             {
                 segment.Memory.Dispose();
             }

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -353,8 +353,11 @@ namespace Sparrow.Server
         {
             EnsureIsNotBadPointer();
 
-            ThrowIf<ArgumentOutOfRangeException>(_pointer->Size < newSize || newSize < 0, $"{nameof(newSize)} must be within the existing string limit.");
-
+            if (_pointer->Size < newSize || newSize < 0)
+            {
+                Throw<ArgumentOutOfRangeException>( $"{nameof(newSize)} must be within the existing string limit.");
+            }
+            
             _pointer->Length = newSize;
         }
 

--- a/src/Sparrow/DisposableException.cs
+++ b/src/Sparrow/DisposableException.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Sparrow;
+
+public static class DisposableException
+{
+    [Conditional("DEBUG")]
+    public static void ThrowIfDisposedOnDebug<T>(
+        T disposable, string message = "The object has already been disposed.",
+#if NET6_0_OR_GREATER
+        [CallerArgumentExpression(nameof(disposable))]
+#endif
+        string paramName = null) where T : IDisposableQueryable
+    {
+        ThrowIfDisposed(disposable, message, paramName);
+    }
+
+
+    public static void ThrowIfDisposed<T>(
+        T disposable, string message = "The object has already been disposed.",
+#if NET6_0_OR_GREATER        
+        [CallerArgumentExpression(nameof(disposable))]
+#endif
+        string paramName = null) where T : IDisposableQueryable
+    {
+        if (disposable.IsDisposed)
+        {
+#if !NET6_0_OR_GREATER
+            paramName ??= disposable.GetType().Name;
+#endif
+            Throw(paramName, message);
+        }
+    }
+
+    public static void Throw<T>(
+        T disposable, string message = "The object has already been disposed.",
+#if NET6_0_OR_GREATER
+        [CallerArgumentExpression(nameof(disposable))]
+#endif
+        string paramName = null) where T : IDisposableQueryable
+    {
+#if !NET6_0_OR_GREATER
+        paramName ??= disposable.GetType().Name;
+#endif
+        Throw(paramName, message);
+    }
+
+#if NET6_0_OR_GREATER
+    [DoesNotReturn]
+#endif
+    private static void Throw(string paramName, string message) => throw new ObjectDisposedException(paramName, message);
+}

--- a/src/Sparrow/DisposableExceptions.cs
+++ b/src/Sparrow/DisposableExceptions.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Diagnostics;
+
+#if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+#endif
 
 namespace Sparrow;
 
-public static class DisposableException
+internal static class DisposableExceptions
 {
     [Conditional("DEBUG")]
     public static void ThrowIfDisposedOnDebug<T>(
@@ -26,7 +29,7 @@ public static class DisposableException
 #endif
         string paramName = null) where T : IDisposableQueryable
     {
-        if (disposable.IsDisposed)
+        if (disposable?.IsDisposed ?? false)
         {
 #if !NET6_0_OR_GREATER
             paramName ??= disposable.GetType().Name;
@@ -35,6 +38,9 @@ public static class DisposableException
         }
     }
 
+#if NET6_0_OR_GREATER
+    [DoesNotReturn]
+#endif
     public static void Throw<T>(
         T disposable, string message = "The object has already been disposed.",
 #if NET6_0_OR_GREATER

--- a/src/Sparrow/IDisposableQueryable.cs
+++ b/src/Sparrow/IDisposableQueryable.cs
@@ -2,7 +2,7 @@
 
 namespace Sparrow
 {
-    public interface IDisposableQueryable
+    internal interface IDisposableQueryable
     {
         bool IsDisposed { get; }
     }

--- a/src/Sparrow/IDisposableQueryable.cs
+++ b/src/Sparrow/IDisposableQueryable.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Sparrow
+{
+    public interface IDisposableQueryable
+    {
+        bool IsDisposed { get; }
+    }
+}

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -160,7 +160,7 @@ namespace Sparrow.Json
         private void GrowArena(int requestedSize)
         {
             ThrowIf<ArgumentOutOfRangeException>(requestedSize > MaxArenaSize, 
-                () => $"Requested arena resize to {requestedSize} while current size is {_allocated} and maximum size is {MaxArenaSize}");
+                $"Requested arena resize to {requestedSize} while current size is {_allocated} and maximum size is {MaxArenaSize}");
             
             long newSize = GetPreferredSize(requestedSize);
             if (newSize > MaxArenaSize)

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -119,7 +119,9 @@ namespace Sparrow.Json
 
             ThrowIfNull<InvalidOperationException>(_ptrStart, "Attempt to allocate from reset arena without calling renew");
             ThrowIf<ArgumentOutOfRangeException>(size < 0, "Size cannot be negative");
-            ThrowIf<ArgumentOutOfRangeException>(size > MaxArenaSize, $"Requested size {size} while maximum size is {MaxArenaSize}");
+            
+            if (size > MaxArenaSize)
+                Throw<ArgumentOutOfRangeException>($"Requested size {size} while maximum size is {MaxArenaSize}");
             
 #if MEM_GUARD
             return new AllocatedMemoryData
@@ -158,7 +160,7 @@ namespace Sparrow.Json
         private void GrowArena(int requestedSize)
         {
             ThrowIf<ArgumentOutOfRangeException>(requestedSize > MaxArenaSize, 
-                $"Requested arena resize to {requestedSize} while current size is {_allocated} and maximum size is {MaxArenaSize}");
+                () => $"Requested arena resize to {requestedSize} while current size is {_allocated} and maximum size is {MaxArenaSize}");
             
             long newSize = GetPreferredSize(requestedSize);
             if (newSize > MaxArenaSize)

--- a/src/Sparrow/Json/ArenaMemoryAllocator.cs
+++ b/src/Sparrow/Json/ArenaMemoryAllocator.cs
@@ -17,7 +17,7 @@ using Sparrow.Utils;
 
 namespace Sparrow.Json
 {
-    public sealed unsafe class ArenaMemoryAllocator : IDisposable
+    public sealed unsafe class ArenaMemoryAllocator : IDisposableQueryable, IDisposable
     {
         internal const int MaxArenaSize = 1024 * 1024 * 1024;
         private static readonly int? SingleAllocationSizeLimit = PlatformDetails.Is32Bits ? 8 * Constants.Size.Megabyte : (int?)null;
@@ -40,15 +40,13 @@ namespace Sparrow.Json
 
         private readonly FreeSection*[] _freed = new FreeSection*[32];
 
-        private readonly SingleUseFlag _isDisposed = new SingleUseFlag();
+        private readonly SingleUseFlag _isDisposed = new();
         private NativeMemory.ThreadStats _allocatingThread;
         private readonly int _initialSize;
 
         public long TotalUsed;
 
         public bool AvoidOverAllocation;
-
-        private readonly SharedMultipleUseFlag _lowMemoryFlag;
 
         public long Allocated
         {
@@ -73,7 +71,6 @@ namespace Sparrow.Json
             _allocated = initialSize;
             _used = 0;
             TotalUsed = 0;
-            _lowMemoryFlag = lowMemoryFlag;
         }
 
         public bool GrowAllocation(AllocatedMemoryData allocation, int sizeIncrease)
@@ -115,11 +112,9 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public AllocatedMemoryData Allocate(int size)
         {
-            if (_isDisposed ?? true)
-                goto ErrorDisposed;
+            DisposableException.ThrowIfDisposed(this);
 
-            if (_ptrStart == null)
-                goto ErrorResetted;
+            PortableExceptions.ThrowIfNull<InvalidOperationException>(_ptrStart, "Attempt to allocate from reset arena without calling renew");
 
 #if MEM_GUARD
             return new AllocatedMemoryData
@@ -128,17 +123,11 @@ namespace Sparrow.Json
                 SizeInBytes = size
             };
 #else
-            if (size < 0)
-                throw new ArgumentOutOfRangeException(nameof(size), size,
-                    $"Size cannot be negative");
 
-            if (size > MaxArenaSize)
-                throw new ArgumentOutOfRangeException(nameof(size), size,
-                    $"Requested size {size} while maximum size is {MaxArenaSize}");
+            PortableExceptions.ThrowIf<ArgumentOutOfRangeException>(size < 0, "Size cannot be negative");
+            PortableExceptions.ThrowIf<ArgumentOutOfRangeException>(size > MaxArenaSize, $"Requested size {size} while maximum size is {MaxArenaSize}");
 
             size = Bits.PowerOf2(Math.Max(sizeof(FreeSection), size));
-
-            AllocatedMemoryData allocation;
 
             var index = Bits.MostSignificantBit(size) - 1;
             if (_freed[index] != null)
@@ -146,8 +135,7 @@ namespace Sparrow.Json
                 var section = _freed[index];
                 _freed[index] = section->Previous;
 
-                allocation = new AllocatedMemoryData((byte*)section, section->SizeInBytes);
-                goto Return;
+                return new AllocatedMemoryData((byte*)section, section->SizeInBytes);
             }
 
             if (_used + size > _allocated)
@@ -155,31 +143,14 @@ namespace Sparrow.Json
                 GrowArena(size);
             }
 
-            allocation = new AllocatedMemoryData(_ptrCurrent, size);
+            AllocatedMemoryData allocation = new(_ptrCurrent, size);
 
             _ptrCurrent += size;
             _used += size;
             TotalUsed += size;
 
-        Return:
             return allocation;
 #endif
-
-        ErrorDisposed:
-            ThrowAlreadyDisposedException();
-        ErrorResetted:
-            ThrowInvalidAllocateFromResetWithoutRenew();
-            return null; // Will never happen.
-        }
-
-        private static void ThrowInvalidAllocateFromResetWithoutRenew()
-        {
-            throw new InvalidOperationException("Attempt to allocate from reset arena without calling renew");
-        }
-
-        private void ThrowAlreadyDisposedException()
-        {
-            throw new ObjectDisposedException("This ArenaMemoryAllocator is already disposed");
         }
 
         private void GrowArena(int requestedSize)
@@ -208,8 +179,7 @@ namespace Sparrow.Json
             }
 
             // Save the old buffer pointer to be released when the arena is reset
-            if (_olderBuffers == null)
-                _olderBuffers = new List<Tuple<IntPtr, long, NativeMemory.ThreadStats>>();
+            _olderBuffers ??= new List<Tuple<IntPtr, long, NativeMemory.ThreadStats>>();
             _olderBuffers.Add(Tuple.Create(new IntPtr(_ptrStart), _allocated, _allocatingThread));
 
             _allocatingThread = thread;
@@ -367,11 +337,12 @@ namespace Sparrow.Json
             }
         }
 
+        public bool IsDisposed => _isDisposed ?? true;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Return(AllocatedMemoryData allocation)
         {
-            if (_isDisposed ?? true)
-                return;
+            if (IsDisposed) return;
 
             var address = allocation.Address;
 
@@ -436,7 +407,7 @@ namespace Sparrow.Json
         }
     }
 
-    public sealed unsafe class AllocatedMemoryData
+    public sealed unsafe class AllocatedMemoryData : IDisposableQueryable
     {
         public int SizeInBytes;
         public int ContextGeneration;
@@ -461,40 +432,31 @@ namespace Sparrow.Json
 
 #if !DEBUG
         public readonly byte* Address;
+        bool IDisposableQueryable.IsDisposed => false;
 #else
         public bool IsLongLived;
         public bool IsReturned;
 
         private byte* _address;
 
+        bool IDisposableQueryable.IsDisposed => IsLongLived == false &&
+                                                Parent != null &&
+                                                ContextGeneration != Parent.Generation ||
+                                                IsReturned;
+
         public byte* Address
         {
             get
             {
-                if (IsLongLived == false &&
-                    Parent != null &&
-                    ContextGeneration != Parent.Generation ||
-                    IsReturned)
-                    ThrowObjectDisposedException();
-
+                DisposableException.ThrowIfDisposed(this);
                 return _address;
             }
 
             private set
             {
-                if (IsLongLived == false &&
-                    Parent != null &&
-                    ContextGeneration != Parent.Generation ||
-                    IsReturned)
-                    ThrowObjectDisposedException();
-
+                DisposableException.ThrowIfDisposed(this);
                 _address = value;
             }
-        }
-
-        private void ThrowObjectDisposedException()
-        {
-            throw new ObjectDisposedException(nameof(AllocatedMemoryData));
         }
 
 #endif
@@ -513,7 +475,7 @@ namespace Sparrow.Json
 
         public override Memory<byte> Memory => CreateMemory(_length);
 
-        public override Span<byte> GetSpan() => new Span<byte>(_address, _length);
+        public override Span<byte> GetSpan() => new(_address, _length);
 
         public override MemoryHandle Pin(int elementIndex = 0)
         {

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -9,7 +9,7 @@ namespace Sparrow.Json
 {
     public sealed class BlittableJsonDocumentBuilder : AbstractBlittableJsonDocumentBuilder
     {
-        private static readonly StringSegment UnderscoreSegment = new StringSegment("_");
+        private static readonly StringSegment UnderscoreSegment = new("_");
 
         private readonly JsonOperationContext _context;
         private UsageMode _mode;
@@ -19,7 +19,7 @@ namespace Sparrow.Json
         private readonly JsonParserState _state;
         private LazyStringValue _fakeFieldName;
 
-        private readonly SingleUseFlag _disposed = new SingleUseFlag();
+        private readonly SingleUseFlag _disposed = new();
 
         private WriteToken _writeToken;
         private string _debugTag;

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -7,7 +7,7 @@ using Sparrow.Threading;
 
 namespace Sparrow.Json
 {
-    public sealed class BlittableJsonDocumentBuilder : AbstractBlittableJsonDocumentBuilder
+    public sealed class BlittableJsonDocumentBuilder : AbstractBlittableJsonDocumentBuilder, IDisposableQueryable
     {
         private static readonly StringSegment UnderscoreSegment = new("_");
 
@@ -49,6 +49,8 @@ namespace Sparrow.Json
         {
             Renew(debugTag, mode);
         }
+
+        bool IDisposableQueryable.IsDisposed => _disposed.IsRaised();
 
         public void Reset()
         {
@@ -106,6 +108,9 @@ namespace Sparrow.Json
 
         public override void Dispose()
         {
+            // We may not want to execute `.Dispose()` more than once in release, but we want to fail fast in debug if it happens.
+            DisposableExceptions.ThrowIfDisposedOnDebug(this);
+            
             if (_disposed.Raise() == false)
                 return;
 

--- a/src/Sparrow/Json/BlittableJsonReaderArray.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderArray.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Sparrow.Json.Parsing;
+using static Sparrow.DisposableExceptions;
 
 namespace Sparrow.Json
 {
@@ -45,7 +46,7 @@ namespace Sparrow.Json
             if (_parent._mem == null)
                 return "Disposed";
 
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
 
             using (var memoryStream = new MemoryStream())
             {
@@ -67,14 +68,15 @@ namespace Sparrow.Json
 
         public void BlittableValidation()
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
             _parent?.BlittableValidation();
         }
 
         //Todo Fixing the clone implementation to support this situation or throw clear error
         public BlittableJsonReaderArray Clone(JsonOperationContext context, BlittableJsonDocumentBuilder.UsageMode usageMode = BlittableJsonDocumentBuilder.UsageMode.None)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
+            
             using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
             {
                 builder.Reset(usageMode);
@@ -121,7 +123,7 @@ namespace Sparrow.Json
 
         public void Dispose()
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
 
             // this is required only in cases that we get a BlittableJsonReaderArray, which is an only child of an BlittableJsonReaderObject and we lose track of it's parent,
             // like in BlittableJsonDocumentBuilder.CreateArrayReader.
@@ -131,7 +133,8 @@ namespace Sparrow.Json
 
         public BlittableJsonToken GetArrayType()
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
+            
             var blittableJsonToken = (BlittableJsonToken)(*(_metadataPtr + _currentOffsetSize)) & TypesMask;
             Debug.Assert(blittableJsonToken != 0);
             return blittableJsonToken;
@@ -141,7 +144,8 @@ namespace Sparrow.Json
 
         public int BinarySearch(string key, StringComparison comparison)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
+            
             int min = 0;
             int max = Length - 1;
 
@@ -168,7 +172,8 @@ namespace Sparrow.Json
 
         public T GetByIndex<T>(int index)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
+            
             var obj = GetValueTokenTupleByIndex(index).Item1;
             BlittableJsonReaderObject.ConvertType(obj, out T result);
             return result;
@@ -176,7 +181,8 @@ namespace Sparrow.Json
 
         public string GetStringByIndex(int index)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
+            
             var obj = GetValueTokenTupleByIndex(index).Item1;
             if (obj == null)
                 return null;
@@ -191,7 +197,8 @@ namespace Sparrow.Json
 
         public void AddItemsToStream<T>(ManualBlittableJsonDocumentBuilder<T> writer) where T : struct, IUnmanagedWriteBuffer
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
+            
             for (var i = 0; i < _count; i++)
             {
                 var (value, token) = GetValueTokenTupleByIndex(i);
@@ -201,7 +208,7 @@ namespace Sparrow.Json
 
         public (object, BlittableJsonToken) GetValueTokenTupleByIndex(int index)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
 
             // try get value from cache, works only with Blittable types, other objects are not stored for now
             if (NoCache == false && _cache != null && _cache.TryGetValue(index, out (object, BlittableJsonToken) result))
@@ -234,7 +241,8 @@ namespace Sparrow.Json
         {
             get
             {
-                AssertContextNotDisposed();
+                ThrowIfDisposedOnDebug(this);
+                
                 return new BlittableJsonArrayEnumerator(this);
             }
         }
@@ -302,14 +310,14 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         BlittableJsonArrayEnumerator GetEnumerator()
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
 
             return new BlittableJsonArrayEnumerator(this);
         }
 
         public override bool Equals(object obj)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
 
             if (ReferenceEquals(null, obj))
                 return false;
@@ -325,7 +333,7 @@ namespace Sparrow.Json
 
         public bool Equals(BlittableJsonReaderArray other)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
 
             if (_count != other._count)
                 return false;
@@ -347,7 +355,8 @@ namespace Sparrow.Json
 
         public override int GetHashCode()
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
+            
             return _count;
         }
 

--- a/src/Sparrow/Json/BlittableJsonReaderBase.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderBase.cs
@@ -236,7 +236,7 @@ namespace Sparrow.Json
         [Conditional("DEBUG")]
         protected void AssertContextNotDisposed()
         {
-            if (_context?.Disposed ?? false)
+            if (_context?.IsDisposed ?? false)
             {
                 throw new ObjectDisposedException("blittable's context has been disposed, blittable should not be used now in that case!");
             }
@@ -245,7 +245,7 @@ namespace Sparrow.Json
         [Conditional("DEBUG")]
         protected void AssertContextNotDisposed(JsonOperationContext context)
         {
-            if (context?.Disposed ?? false)
+            if (context?.IsDisposed ?? false)
             {
                 throw new ObjectDisposedException("blittable's context has been disposed, blittable should not be used now in that case!");
             }

--- a/src/Sparrow/Json/BlittableJsonReaderBase.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderBase.cs
@@ -2,10 +2,11 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Sparrow.Compression;
+using static Sparrow.DisposableExceptions;
 
 namespace Sparrow.Json
 {
-    public abstract unsafe class BlittableJsonReaderBase
+    public abstract unsafe class BlittableJsonReaderBase : IDisposableQueryable
     {
         protected BlittableJsonReaderObject _parent;
         protected internal byte* _mem;
@@ -14,14 +15,18 @@ namespace Sparrow.Json
         protected BlittableJsonReaderBase(JsonOperationContext context)
         {
             _context = context;
-            AssertContextNotDisposed();
+
+            ThrowIfDisposedOnDebug(this);
         }
 
         public bool BelongsToContext(JsonOperationContext context)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
             return context == _context;
         }
+
+        bool IDisposableQueryable.IsDisposed => _context?.IsDisposed ?? false;
+
 
         public bool HasParent => _parent != null;
 
@@ -138,7 +143,8 @@ namespace Sparrow.Json
 
         public BlittableJsonReaderObject ReadNestedObject(int pos)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
+            
             var size = VariableSizeEncoding.Read<int>(_mem + pos, out var offset);
             return new BlittableJsonReaderObject(_mem + pos + offset, size, _context)
             {
@@ -149,7 +155,8 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LazyStringValue ReadStringLazily(int pos)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
+            
             var size = VariableSizeEncoding.Read<int>(_mem + pos, out var offset);
 
             return _context.AllocateStringValue(null, _mem + pos + offset, size);
@@ -158,7 +165,8 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LazyCompressedStringValue ReadCompressStringLazily(int pos)
         {
-            AssertContextNotDisposed();
+            ThrowIfDisposedOnDebug(this);
+            
             var uncompressedSize = VariableSizeEncoding.Read<int>(_mem + pos, out var offset);
             pos += offset;
             var compressedSize = VariableSizeEncoding.Read<int>(_mem + pos, out offset);
@@ -231,15 +239,6 @@ namespace Sparrow.Json
         protected long ReadVariableSizeLong(int pos)
         {
             return ZigZagEncoding.Decode<long>(_mem, out _, pos: pos);
-        }
-
-        [Conditional("DEBUG")]
-        protected void AssertContextNotDisposed()
-        {
-            if (_context?.IsDisposed ?? false)
-            {
-                throw new ObjectDisposedException("blittable's context has been disposed, blittable should not be used now in that case!");
-            }
         }
 
         [Conditional("DEBUG")]

--- a/src/Sparrow/Json/JsonOperationContext.Sync.cs
+++ b/src/Sparrow/Json/JsonOperationContext.Sync.cs
@@ -1,4 +1,5 @@
 ﻿using Sparrow.Json.Parsing;
+using static Sparrow.DisposableExceptions;
 
 namespace Sparrow.Json
 {
@@ -22,7 +23,7 @@ namespace Sparrow.Json
 
             internal void EnsureNotDisposed()
             {
-                Context.EnsureNotDisposed();
+                ThrowIfDisposed(Context);
             }
 
             internal JsonParserState JsonParserState => Context._jsonParserState;

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -12,6 +12,8 @@ using Sparrow.Global;
 using Sparrow.Json.Parsing;
 using Sparrow.Threading;
 using Sparrow.Utils;
+using static Sparrow.DisposableExceptions;
+using static Sparrow.PortableExceptions;
 
 #if VALIDATE
 
@@ -24,7 +26,7 @@ namespace Sparrow.Json
     /// <summary>
     /// Single threaded for contexts
     /// </summary>
-    public partial class JsonOperationContext : PooledItem
+    public partial class JsonOperationContext : PooledItem, IDisposableQueryable
     {
         private int _generation;
         internal long PoolGeneration;
@@ -175,7 +177,7 @@ namespace Sparrow.Json
 
         public unsafe MemoryBuffer.ReturnBuffer GetMemoryBuffer(int size, out MemoryBuffer buffer)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
 
             var rawMemory = GetMemory(size);
             buffer = new MemoryBuffer(rawMemory.Address, rawMemory.SizeInBytes, rawMemory.ContextGeneration, this);
@@ -381,15 +383,10 @@ namespace Sparrow.Json
             if (requestedSize <= 0)
                 throw new ArgumentException(nameof(requestedSize));
 #endif
-            //we should use JsonOperationContext in single thread
-            if (_arenaAllocatorForLongLivedValues == null)
-            {
-                //_arenaAllocatorForLongLivedValues == null when the context is after Reset() but before Renew()
-                ThrowAlreadyDisposedForLongLivedAllocator();
 
-                //make compiler happy, previous row will throw
-                return null;
-            }
+            // we should use JsonOperationContext in single thread
+            // _arenaAllocatorForLongLivedValues == null when the context is after Reset() but before Renew()
+            ThrowIf<ObjectDisposedException>(_arenaAllocatorForLongLivedValues == null, "Could not allocated long lived memory, because the context is after Reset() but before Renew(). Is it possible that you have tried to use the context AFTER it was returned to the context pool?");
 
             var allocatedMemory = _arenaAllocatorForLongLivedValues.Allocate(requestedSize);
             allocatedMemory.ContextGeneration = Generation;
@@ -398,11 +395,6 @@ namespace Sparrow.Json
             allocatedMemory.IsLongLived = true;
 #endif
             return allocatedMemory;
-        }
-
-        private static void ThrowAlreadyDisposedForLongLivedAllocator()
-        {
-            throw new ObjectDisposedException("Could not allocated long lived memory, because the context is after Reset() but before Renew(). Is it possible that you have tried to use the context AFTER it was returned to the context pool?");
         }
 
         /// <summary>
@@ -425,7 +417,7 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LazyStringValue GetLazyStringForFieldWithCaching(StringSegment key)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
 
             if (_fieldNames.TryGetValue(key, out LazyStringValue value))
             {
@@ -440,7 +432,8 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LazyStringValue GetLazyStringForFieldWithCaching(string field)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
+            
             if (_fieldNames.TryGetValue(field, out LazyStringValue value))
             {
                 // PERF: This is usually the most common scenario, so actually being contiguous improves the behavior.
@@ -457,13 +450,14 @@ namespace Sparrow.Json
             using (new SingleThreadAccessAssertion(_threadId, "GetLazyStringForFieldWithCachingUnlikely"))
             {
 #endif
-            EnsureNotDisposed();
-            LazyStringValue value = GetLazyString(key, longLived: true);
-            _fieldNames[key.Value] = value;
+                ThrowIfDisposed(this);
+                
+                LazyStringValue value = GetLazyString(key, longLived: true);
+                _fieldNames[key.Value] = value;
 
-            //sanity check, in case the 'value' is manually disposed outside of this function
-            Debug.Assert(value.IsDisposed == false);
-            return value;
+                //sanity check, in case the 'value' is manually disposed outside of this function
+                Debug.Assert(value.IsDisposed == false);
+                return value;
 #if DEBUG || VALIDATE
             }
 #endif
@@ -471,7 +465,7 @@ namespace Sparrow.Json
 
         public LazyStringValue GetLazyString(string field)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
 
             if (field == null)
                 return null;
@@ -595,9 +589,8 @@ namespace Sparrow.Json
             string debugTag,
             CancellationToken token)
         {
-            if (IsDisposed)
-                ThrowObjectDisposed();
-
+            ThrowIfDisposed(this);
+            
             _jsonParserState.Reset();
             UnmanagedJsonParser parser = null;
             BlittableJsonDocumentBuilder builder = null;
@@ -616,7 +609,7 @@ namespace Sparrow.Json
                     var result = await webSocket.ReceiveAsync(bytes.Memory.Memory, token).ConfigureAwait(false);
 
                     token.ThrowIfCancellationRequested();
-                    EnsureNotDisposed();
+                    ThrowIfDisposed(this);
 
                     if (result.MessageType == WebSocketMessageType.Close)
                         return null;
@@ -631,8 +624,10 @@ namespace Sparrow.Json
                         if (read)
                             break;
                         result = await webSocket.ReceiveAsync(bytes.Memory.Memory, token).ConfigureAwait(false);
+                        
                         token.ThrowIfCancellationRequested();
-                        EnsureNotDisposed();
+                        ThrowIfDisposed(this);
+                        
                         bytes.Valid = result.Count;
                         bytes.Used = 0;
                         parser.SetBuffer(bytes);
@@ -657,7 +652,7 @@ namespace Sparrow.Json
         public unsafe BlittableJsonReaderObject ParseBuffer(byte* buffer, int length, string debugTag,
             BlittableJsonDocumentBuilder.UsageMode mode, IBlittableDocumentModifier modifier = null)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
 
             _jsonParserState.Reset();
             using (var parser = new UnmanagedJsonParser(this, _jsonParserState, debugTag))
@@ -680,7 +675,7 @@ namespace Sparrow.Json
         public BlittableJsonReaderArray ParseBufferToArray(string value, string debugTag,
             BlittableJsonDocumentBuilder.UsageMode mode, IBlittableDocumentModifier modifier = null)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
 
             _jsonParserState.Reset();
             using (var parser = new UnmanagedJsonParser(this, _jsonParserState, debugTag))
@@ -719,7 +714,7 @@ namespace Sparrow.Json
             IBlittableDocumentModifier modifier = null,
             CancellationToken token = default)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
 
             _jsonParserState.Reset();
             UnmanagedJsonParser parser = null;
@@ -736,11 +731,10 @@ namespace Sparrow.Json
                     if (bytes.Valid == bytes.Used)
                     {
                         var read = await webSocket.ReceiveAsync(bytes.Memory.Memory, token).ConfigureAwait(false);
+                        ThrowIfDisposed(this);
 
-                        EnsureNotDisposed();
-
-                        if (read.Count == 0)
-                            throw new EndOfStreamException("Stream ended without reaching end of json content");
+                        ThrowIf<EndOfStreamException>(read.Count == 0, "Stream ended without reaching end of json content");
+                        
                         bytes.Valid = read.Count;
                         bytes.Used = 0;
                     }
@@ -761,12 +755,6 @@ namespace Sparrow.Json
             }
         }
 
-        private void EnsureNotDisposed()
-        {
-            if (IsDisposed)
-                ThrowObjectDisposed();
-        }
-
         public async ValueTask<BlittableJsonReaderObject> ParseToMemoryAsync(
             Stream stream,
             string documentId,
@@ -776,7 +764,7 @@ namespace Sparrow.Json
             CancellationToken? token = null,
             int maxSize = int.MaxValue)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
 
             _jsonParserState.Reset();
             UnmanagedJsonParser parser = null;
@@ -798,16 +786,16 @@ namespace Sparrow.Json
                         var read = token.HasValue
                             ? await stream.ReadAsync(bytes.Memory.Memory, token.Value).ConfigureAwait(false)
                             : await stream.ReadAsync(bytes.Memory.Memory).ConfigureAwait(false);
+                        
+                        ThrowIfDisposed(this);
 
-                        EnsureNotDisposed();
+                        ThrowIf<EndOfStreamException>(read == 0, "Stream ended without reaching end of json content");
 
-                        if (read == 0)
-                            throw new EndOfStreamException("Stream ended without reaching end of json content");
                         bytes.Valid = read;
                         bytes.Used = 0;
                         maxSize -= read;
-                        if (maxSize < 0)
-                            throw new ArgumentException($"The maximum size allowed for {documentId} ({maxSize}) has been exceeded, aborting");
+                        
+                        ThrowIf<ArgumentException>(maxSize < 0, $"The maximum size allowed for {documentId} ({maxSize}) has been exceeded, aborting");
                     }
 
                     parser.SetBuffer(bytes);
@@ -842,15 +830,9 @@ namespace Sparrow.Json
             }
         }
 
-        private void ThrowObjectDisposed()
-        {
-            throw new ObjectDisposedException(nameof(JsonOperationContext));
-        }
-
         protected internal virtual void Renew()
         {
-            if (IsDisposed)
-                ThrowObjectDisposed();
+            ThrowIfDisposed(this);
 
             if (_activeAllocatePathCaches == null)
             {
@@ -906,10 +888,10 @@ namespace Sparrow.Json
 
                 _arenaAllocatorForLongLivedValues = null;
                 CachedProperties = null;
-                // at this point, the long lived section is far too large, this is something that can happen
+                // at this point, the long-lived section is far too large, this is something that can happen
                 // if we have dynamic properties. A back of the envelope calculation gives us roughly 32K
                 // property names before this kicks in, which is a true abuse of the system. In this case,
-                // in order to avoid unlimited growth, we'll reset the long lived section
+                // in order to avoid unlimited growth, we'll reset the long-lived section
                 allocatorForLongLivedValues.Dispose();
 
                 _fieldNames.Clear();
@@ -970,7 +952,8 @@ namespace Sparrow.Json
 
         public async ValueTask WriteAsync(Stream stream, BlittableJsonReaderObject json, CancellationToken token = default)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
+            
             await using (AsyncBlittableJsonTextWriter.Create(this, stream, out var writer))
             {
                 writer.WriteObject(json);
@@ -981,7 +964,7 @@ namespace Sparrow.Json
         public void Write<TWriter>(TWriter writer, BlittableJsonReaderObject json)
             where TWriter : IBlittableJsonTextWriter
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
             WriteInternal(writer, json);
         }
 
@@ -1001,14 +984,16 @@ namespace Sparrow.Json
         public void Write<TWriter>(TWriter writer, DynamicJsonValue json)
             where TWriter : IBlittableJsonTextWriter
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
+            
             WriteInternal(writer, json);
         }
 
         public void Write<TWriter>(TWriter writer, DynamicJsonArray json)
             where TWriter : IBlittableJsonTextWriter
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
+            
             _jsonParserState.Reset();
             _objectJsonParser.Reset(json);
 
@@ -1022,7 +1007,8 @@ namespace Sparrow.Json
         public void WriteObject<TWriter>(TWriter writer, JsonParserState state, ObjectJsonParser parser)
             where TWriter : IBlittableJsonTextWriter
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
+            
             if (state.CurrentTokenType != JsonParserToken.StartObject)
                 throw new InvalidOperationException("StartObject expected, but got " + state.CurrentTokenType);
 
@@ -1129,7 +1115,8 @@ namespace Sparrow.Json
         public void WriteArray<TWriter>( TWriter writer, JsonParserState state, ObjectJsonParser parser)
             where TWriter : IBlittableJsonTextWriter
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
+            
             if (state.CurrentTokenType != JsonParserToken.StartArray)
                 throw new InvalidOperationException("StartArray expected, but got " + state.CurrentTokenType);
 
@@ -1154,13 +1141,15 @@ namespace Sparrow.Json
 
         public bool GrowAllocation(AllocatedMemoryData allocation, int sizeIncrease)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
+            
             return _arenaAllocator.GrowAllocation(allocation, sizeIncrease);
         }
 
         public MemoryStream CheckoutMemoryStream()
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
+            
             if (_cachedMemoryStreams.Count == 0)
             {
                 return new MemoryStream();
@@ -1185,7 +1174,7 @@ namespace Sparrow.Json
                 return;
             }
 
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
 
             stream.SetLength(0);
             _cachedMemoryStreams.Push(stream);
@@ -1194,7 +1183,8 @@ namespace Sparrow.Json
 
         public void ReturnMemory(AllocatedMemoryData allocation)
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
+            
             if (_generation != allocation.ContextGeneration)
                 ThrowUseAfterFree(allocation);
 
@@ -1214,7 +1204,8 @@ namespace Sparrow.Json
 
         public AvoidOverAllocationScope AvoidOverAllocation()
         {
-            EnsureNotDisposed();
+            ThrowIfDisposed(this);
+            
             _arenaAllocator.AvoidOverAllocation = true;
             return new AvoidOverAllocationScope(this);
         }

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -339,7 +339,7 @@ namespace Sparrow.Json
 
                     //_parent disposal sets _managedBuffers to null,
                     //throwing ObjectDisposedException() to make it more visible
-                    if (_parent.Disposed)
+                    if (_parent.IsDisposed)
                         ThrowParentWasDisposed();
 
                     if (_allocatedMemory != null)
@@ -415,7 +415,7 @@ namespace Sparrow.Json
         }
 
         private readonly DisposeOnce<SingleAttempt> _disposeOnceRunner;
-        public bool Disposed => _disposeOnceRunner.Disposed;
+        public bool IsDisposed => _disposeOnceRunner.Disposed;
 
         public override void Dispose()
         {
@@ -595,7 +595,7 @@ namespace Sparrow.Json
             string debugTag,
             CancellationToken token)
         {
-            if (Disposed)
+            if (IsDisposed)
                 ThrowObjectDisposed();
 
             _jsonParserState.Reset();
@@ -763,7 +763,7 @@ namespace Sparrow.Json
 
         private void EnsureNotDisposed()
         {
-            if (Disposed)
+            if (IsDisposed)
                 ThrowObjectDisposed();
         }
 
@@ -849,7 +849,7 @@ namespace Sparrow.Json
 
         protected internal virtual void Renew()
         {
-            if (Disposed)
+            if (IsDisposed)
                 ThrowObjectDisposed();
 
             if (_activeAllocatePathCaches == null)

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -794,8 +794,11 @@ namespace Sparrow.Json
                         bytes.Valid = read;
                         bytes.Used = 0;
                         maxSize -= read;
-                        
-                        ThrowIf<ArgumentException>(maxSize < 0, $"The maximum size allowed for {documentId} ({maxSize}) has been exceeded, aborting");
+
+                        if (maxSize < 0)
+                        {
+                            Throw<ArgumentException>($"The maximum size allowed for {documentId} ({maxSize}) has been exceeded, aborting");
+                        }
                     }
 
                     parser.SetBuffer(bytes);

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -203,7 +203,7 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(string other)
         {
-            DisposableException.ThrowIfDisposedOnDebug(this);
+            DisposableExceptions.ThrowIfDisposedOnDebug(this);
 
             if (_string != null)
                 return string.Equals(_string, other, StringComparison.Ordinal);
@@ -231,7 +231,7 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(LazyStringValue other)
         {
-            DisposableException.ThrowIfDisposedOnDebug(this);
+            DisposableExceptions.ThrowIfDisposedOnDebug(this);
 
             int size = Size;
             if (other.Size != size)
@@ -269,7 +269,7 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(byte* other, int otherSize)
         {
-            DisposableException.ThrowIfDisposedOnDebug(this);
+            DisposableExceptions.ThrowIfDisposedOnDebug(this);
             
             int size = Size;
             var result = Memory.CompareInline(Buffer, other, Math.Min(size, otherSize));
@@ -307,7 +307,7 @@ namespace Sparrow.Json
             if (self == null)
                 return null;
             
-            DisposableException.ThrowIfDisposedOnDebug(self);
+            DisposableExceptions.ThrowIfDisposedOnDebug(self);
             
             return self._string ??
                    (self._string = Encodings.Utf8.GetString(self._buffer, self._size));
@@ -386,7 +386,7 @@ namespace Sparrow.Json
 
         public override bool Equals(object other)
         {
-            DisposableException.ThrowIfDisposedOnDebug(this);
+            DisposableExceptions.ThrowIfDisposedOnDebug(this);
             
             if (ReferenceEquals(other, this))
                 return true;
@@ -413,7 +413,7 @@ namespace Sparrow.Json
 
         public override int GetHashCode()
         {
-            DisposableException.ThrowIfDisposedOnDebug(this);
+            DisposableExceptions.ThrowIfDisposedOnDebug(this);
             
             if (_hashCode.HasValue)
                 return _hashCode.Value;
@@ -432,7 +432,7 @@ namespace Sparrow.Json
 
         public int CompareTo(object obj)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (obj == null)
                 return 1;
@@ -452,7 +452,7 @@ namespace Sparrow.Json
 
         public void Dispose()
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             ReturnAllocatedMemory();
 
@@ -474,7 +474,7 @@ namespace Sparrow.Json
 
         public bool Contains(char value)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (_string != null)
                 return _string.Contains(value);
@@ -486,7 +486,7 @@ namespace Sparrow.Json
 
         public bool Contains(char value, StringComparison comparisonType)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (_string != null)
                 return _string.Contains(value, comparisonType);
@@ -498,7 +498,7 @@ namespace Sparrow.Json
 
         public bool Contains(string value)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (_string != null)
                 return _string.Contains(value);
@@ -510,7 +510,7 @@ namespace Sparrow.Json
 
         public bool Contains(string value, StringComparison comparisonType)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (_string != null)
                 return _string.Contains(value, comparisonType);
@@ -522,7 +522,7 @@ namespace Sparrow.Json
 
         public bool EndsWith(string value)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (_string != null)
                 return _string.EndsWith(value);
@@ -542,7 +542,7 @@ namespace Sparrow.Json
 
         public bool EndsWith(LazyStringValue value)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
             
             if (value.Size > Size)
                 return false;
@@ -578,7 +578,7 @@ namespace Sparrow.Json
 
         public int IndexOf(char value, StringComparison comparisonType)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (_string != null)
                 return _string.IndexOf(value, comparisonType);
@@ -608,7 +608,7 @@ namespace Sparrow.Json
 
         public int IndexOf(char value, int startIndex, int count)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (_string != null)
                 return _string.IndexOf(value, startIndex, count);
@@ -672,7 +672,7 @@ namespace Sparrow.Json
 
         public int IndexOfAny(char[] anyOf, int startIndex, int count)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (_string != null)
                 return _string.IndexOfAny(anyOf, startIndex, count);
@@ -711,7 +711,7 @@ namespace Sparrow.Json
 
         public int LastIndexOf(char value, int startIndex, int count)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (_string != null)
                 return _string.LastIndexOf(value, startIndex, count);
@@ -778,7 +778,7 @@ namespace Sparrow.Json
 
         public int LastIndexOfAny(char[] anyOf, int startIndex, int count)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
             
             if (_string != null)
                 return _string.LastIndexOfAny(anyOf, startIndex, count);
@@ -932,7 +932,7 @@ namespace Sparrow.Json
 
         public bool StartsWith(string value)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (_string != null)
                 return _string.StartsWith(value);
@@ -952,7 +952,7 @@ namespace Sparrow.Json
 
         public bool StartsWith(LazyStringValue value)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (value.Size > Size)
                 return false;
@@ -962,7 +962,7 @@ namespace Sparrow.Json
 
         public bool StartsWith(ReadOnlySpan<byte> value)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (value.Length > Size)
                 return false;
@@ -973,7 +973,7 @@ namespace Sparrow.Json
 
         public bool StartsWith(string value, StringComparison comparisionType)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (value.Length > Size)
                 return false;
@@ -985,7 +985,7 @@ namespace Sparrow.Json
 
         public bool StartsWith(string value, bool ignoreCase, CultureInfo culture)
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             if (value.Length > Size)
                 return false;
@@ -1100,7 +1100,7 @@ namespace Sparrow.Json
 
         public string Reverse()
         {
-            DisposableException.ThrowIfDisposed(this);
+            DisposableExceptions.ThrowIfDisposed(this);
 
             var maxCharCount = Encodings.Utf8.GetMaxCharCount(Length);
             if (_lazyStringTempBuffer == null || _lazyStringTempBuffer.Length < maxCharCount)

--- a/src/Sparrow/Json/UnmanagedWriteBuffer.cs
+++ b/src/Sparrow/Json/UnmanagedWriteBuffer.cs
@@ -293,8 +293,10 @@ namespace Sparrow.Json
         {
             Debug.Assert(required > 0);
 
-            ThrowIf<InvalidOperationException>(required > ArenaMemoryAllocator.MaxArenaSize, 
-                $"Tried to allocate {new Size(required, SizeUnit.Bytes)}, which exceeds maximum allocation size of {new Size(ArenaMemoryAllocator.MaxArenaSize, SizeUnit.Bytes)}");
+            if (required > ArenaMemoryAllocator.MaxArenaSize)
+            {
+                Throw<InvalidOperationException>($"Tried to allocate {new Size(required, SizeUnit.Bytes)}, which exceeds maximum allocation size of {new Size(ArenaMemoryAllocator.MaxArenaSize, SizeUnit.Bytes)}");
+            }
             
             // Grow by doubling segment size until we get to 1 MB, then just use 1 MB segments
             // otherwise a document with 17 MB will waste 15 MB and require very big allocations
@@ -315,8 +317,11 @@ namespace Sparrow.Json
             // mutate it to ensure all copies have the same allocations.
             var allocation = _context.GetMemory(segmentSize);
 
-            ThrowIf<InvalidOperationException>(allocation.SizeInBytes < required,
-                $"Allocated {new Size(allocation.SizeInBytes, SizeUnit.Bytes)} but we requested at least {new Size(required, SizeUnit.Bytes)}");
+            if (allocation.SizeInBytes < required)
+            {
+                Throw<InvalidOperationException>($"Allocated {new Size(allocation.SizeInBytes, SizeUnit.Bytes)} but we requested at least {new Size(required, SizeUnit.Bytes)}");
+            }
+
 
             // Copy the head
             Segment previousHead = _head.ShallowCopy();

--- a/src/Sparrow/PortableExceptions.cs
+++ b/src/Sparrow/PortableExceptions.cs
@@ -11,6 +11,14 @@ namespace Sparrow
 {
     internal class PortableExceptions
     {
+        // In order to differ the allocation of interpolations we need to do it through a delegate.
+        // More details in the following issue: https://github.com/dotnet/runtime/issues/101996
+        // We could remove all the API when this is solved at the JIT level. 
+        internal delegate string ThrowMessage();
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void ThrowIfNull(
 #if NET6_0_OR_GREATER              
             [NotNull]
@@ -30,7 +38,10 @@ namespace Sparrow
 #endif
             }
         }
-        
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static void ThrowIfNullOnDebug(
 #if NET6_0_OR_GREATER              
@@ -44,7 +55,10 @@ namespace Sparrow
         {
             ThrowIfNull(argument, paramName);
         }
-        
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void ThrowIfNotNull(
 #if NET6_0_OR_GREATER              
             [NotNull]
@@ -65,6 +79,9 @@ namespace Sparrow
             }
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static void ThrowIfNotNullOnDebug(
 #if NET6_0_OR_GREATER              
@@ -78,7 +95,7 @@ namespace Sparrow
         {
             ThrowIfNotNull(argument, paramName);
         }
-        
+
         public static void ThrowIfNull<T>(
 #if NET6_0_OR_GREATER
             [NotNull]
@@ -99,7 +116,31 @@ namespace Sparrow
 #endif
             }
         }
-        
+
+        public static void ThrowIfNull<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            object argument,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (argument == null)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message());
+#else
+                Throw<T>(message());
+#endif
+            }
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static void ThrowIfNullOnDebug<T>(
 #if NET6_0_OR_GREATER
@@ -114,6 +155,9 @@ namespace Sparrow
             ThrowIfNull<T>(argument, paramName);
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void ThrowIfNotNull<T>(
 #if NET6_0_OR_GREATER
             [NotNull]
@@ -135,6 +179,33 @@ namespace Sparrow
             }
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static void ThrowIfNotNull<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            object argument,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (argument != null)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message());
+#else
+                Throw<T>(message());
+#endif
+            }
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static void ThrowIfNotNullOnDebug<T>(
 #if NET6_0_OR_GREATER
@@ -150,13 +221,34 @@ namespace Sparrow
             ThrowIfNotNull<T>(argument, message, paramName);
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        [Conditional("DEBUG")]
+        public static void ThrowIfNotNullOnDebug<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            object argument,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIfNotNull<T>(argument, message, paramName);
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static unsafe void ThrowIfNull(
 #if NET6_0_OR_GREATER
-    [NotNull]
+            [NotNull]
 #endif
             void* argument,
 #if NET6_0_OR_GREATER
-    [CallerArgumentExpression(nameof(argument))]
+            [CallerArgumentExpression(nameof(argument))]
 #endif
             string paramName = null)
         {
@@ -170,6 +262,9 @@ namespace Sparrow
             }
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNullOnDebug(
 #if NET6_0_OR_GREATER
@@ -184,6 +279,9 @@ namespace Sparrow
             ThrowIfNull(argument, paramName);
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static unsafe void ThrowIfNotNull(
 #if NET6_0_OR_GREATER
             [NotNull]
@@ -204,6 +302,9 @@ namespace Sparrow
             }
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNotNullOnDebug(
 #if NET6_0_OR_GREATER
@@ -218,6 +319,9 @@ namespace Sparrow
             ThrowIfNotNull(argument, paramName);
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNullOnDebug<T>(
 #if NET6_0_OR_GREATER
@@ -231,7 +335,10 @@ namespace Sparrow
         {
             ThrowIfNull<T>(argument, paramName);
         }
-        
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static unsafe void ThrowIfNull<T>(
 #if NET6_0_OR_GREATER
             [NotNull]
@@ -253,6 +360,34 @@ namespace Sparrow
             }
         }
 
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static unsafe void ThrowIfNull<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (argument == null)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message());
+#else
+                Throw<T>(message());
+#endif
+            }
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNullOnDebug<T>(
 #if NET6_0_OR_GREATER
@@ -268,6 +403,27 @@ namespace Sparrow
             ThrowIfNull<T>(argument, message, paramName);
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        [Conditional("DEBUG")]
+        public static unsafe void ThrowIfNullOnDebug<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIfNull<T>(argument, message(), paramName);
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static unsafe void ThrowIfNotNull<T>(
 #if NET6_0_OR_GREATER
             [NotNull]
@@ -289,6 +445,33 @@ namespace Sparrow
             }
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static unsafe void ThrowIfNotNull<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (argument != null)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message());
+#else
+                Throw<T>(message());
+#endif
+            }
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNotNullOnDebug<T>(
 #if NET6_0_OR_GREATER
@@ -304,6 +487,27 @@ namespace Sparrow
             ThrowIfNotNull<T>(argument, message, paramName);
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        [Conditional("DEBUG")]
+        public static unsafe void ThrowIfNotNullOnDebug<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIfNotNull<T>(argument, message, paramName);
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void ThrowIf<T>(
             bool condition,
             string message = null,
@@ -322,6 +526,30 @@ namespace Sparrow
             }
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static void ThrowIf<T>(
+            bool condition,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(condition))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (condition)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message());
+#else
+                Throw<T>(message());
+#endif
+            }
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static void ThrowIfOnDebug<T>(
             bool condition,
@@ -334,6 +562,24 @@ namespace Sparrow
             ThrowIf<T>(condition, message, paramName);
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        [Conditional("DEBUG")]
+        public static void ThrowIfOnDebug<T>(
+            bool condition,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(condition))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIf<T>(condition, message, paramName);
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void ThrowIfNot<T>(
             bool condition,
             string message = null,
@@ -352,6 +598,30 @@ namespace Sparrow
             }
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static void ThrowIfNot<T>(
+            bool condition,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(condition))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (condition == false)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message());
+#else
+                Throw<T>(message());
+#endif
+            }
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static void ThrowIfNotOnDebug<T>(
             bool condition,
@@ -364,6 +634,24 @@ namespace Sparrow
             ThrowIfNot<T>(condition, message, paramName);
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        [Conditional("DEBUG")]
+        public static void ThrowIfNotOnDebug<T>(
+            bool condition,
+            ThrowMessage message,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(condition))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIfNot<T>(condition, message, paramName);
+        }
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
 #if NET6_0_OR_GREATER
         [DoesNotReturn]
 #endif
@@ -388,12 +676,18 @@ namespace Sparrow
             throw new NotSupportedException($"Exception type '{typeof(T).Name}' is not supported by this {nameof(Throw)} statement.");
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static void ThrowOnDebug<T>(string paramName, string message)
         {
             Throw<T>(paramName, message);
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
 #if NET6_0_OR_GREATER
         [DoesNotReturn]
 #endif
@@ -416,6 +710,9 @@ namespace Sparrow
             throw new NotSupportedException($"Exception type '{typeof(T).Name}' is not supported by this {nameof(Throw)} statement.");
         }
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         [Conditional("DEBUG")]
         public static void ThrowOnDebug<T>(string message) where T : Exception
         {
@@ -423,11 +720,17 @@ namespace Sparrow
         }
 
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
 #if NET6_0_OR_GREATER
         [DoesNotReturn]
 #endif
         private static void Throw(string paramName) => Throw<ArgumentNullException>(paramName);
 
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
 #if NET6_0_OR_GREATER
         [DoesNotReturn]
 #endif

--- a/src/Sparrow/PortableExceptions.cs
+++ b/src/Sparrow/PortableExceptions.cs
@@ -44,7 +44,7 @@ namespace Sparrow
         {
             ThrowIfNull(argument, paramName);
         }
-
+        
         public static void ThrowIfNotNull(
 #if NET6_0_OR_GREATER              
             [NotNull]
@@ -78,7 +78,7 @@ namespace Sparrow
         {
             ThrowIfNotNull(argument, paramName);
         }
-
+        
         public static void ThrowIfNull<T>(
 #if NET6_0_OR_GREATER
             [NotNull]
@@ -99,7 +99,7 @@ namespace Sparrow
 #endif
             }
         }
-
+        
         [Conditional("DEBUG")]
         public static void ThrowIfNullOnDebug<T>(
 #if NET6_0_OR_GREATER
@@ -150,6 +150,88 @@ namespace Sparrow
             ThrowIfNotNull<T>(argument, message, paramName);
         }
 
+        public static unsafe void ThrowIfNull(
+#if NET6_0_OR_GREATER
+    [NotNull]
+#endif
+            void* argument,
+#if NET6_0_OR_GREATER
+    [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null)
+        {
+            if (argument == null)
+            {
+#if NET6_0_OR_GREATER
+                Throw(paramName);
+#else
+                Throw();
+#endif
+            }
+        }
+
+        [Conditional("DEBUG")]
+        public static unsafe void ThrowIfNullOnDebug(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null)
+        {
+            ThrowIfNull(argument, paramName);
+        }
+
+        public static unsafe void ThrowIfNotNull(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null)
+        {
+            if (argument != null)
+            {
+#if NET6_0_OR_GREATER
+                Throw(paramName);
+#else
+                Throw();
+#endif
+            }
+        }
+
+        [Conditional("DEBUG")]
+        public static unsafe void ThrowIfNotNullOnDebug(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null)
+        {
+            ThrowIfNotNull(argument, paramName);
+        }
+
+        [Conditional("DEBUG")]
+        public static unsafe void ThrowIfNullOnDebug<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIfNull<T>(argument, paramName);
+        }
+        
         public static unsafe void ThrowIfNull<T>(
 #if NET6_0_OR_GREATER
             [NotNull]

--- a/src/Sparrow/PortableExceptions.cs
+++ b/src/Sparrow/PortableExceptions.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Sparrow
+{
+    internal class PortableExceptions
+    {
+        public static void ThrowIfNull(
+#if NET6_0_OR_GREATER              
+            [NotNull]
+#endif
+            object argument,
+#if NET6_0_OR_GREATER        
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null)
+        {
+            if (argument == null)
+            {
+#if NET6_0_OR_GREATER
+                Throw(paramName);
+#else
+                Throw();
+#endif
+            }
+        }
+
+        public static void ThrowIfNotNull(
+#if NET6_0_OR_GREATER              
+            [NotNull]
+#endif
+            object argument,
+#if NET6_0_OR_GREATER        
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null)
+        {
+            if (argument != null)
+            {
+#if NET6_0_OR_GREATER
+                Throw(paramName);
+#else
+                Throw();
+#endif
+            }
+        }
+
+        public static void ThrowIfNull<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            object argument,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (argument == null)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message);
+#else
+                Throw<T>(message);
+#endif
+            }
+        }
+
+        public static void ThrowIfNotNull<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            object argument,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (argument != null)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message);
+#else
+                Throw<T>(message);
+#endif
+            }
+        }
+
+        public static unsafe void ThrowIfNull<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (argument == null)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message);
+#else
+                Throw<T>(message);
+#endif
+            }
+        }
+
+        public static unsafe void ThrowIfNotNull<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (argument != null)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message);
+#else
+                Throw<T>(message);
+#endif
+            }
+        }
+
+        public static void ThrowIf<T>(
+            bool condition,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(condition))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (condition)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message);
+#else
+                Throw<T>(message);
+#endif
+            }
+        }
+
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
+        public static void Throw<T>(string paramName, string message)
+        {
+            if (typeof(T) == typeof(ArgumentException))
+                throw new ArgumentException(message, paramName);
+            if (typeof(T) == typeof(ArgumentNullException))
+                throw new ArgumentNullException(paramName, message);
+            if (typeof(T) == typeof(ArgumentOutOfRangeException))
+                throw new ArgumentOutOfRangeException(paramName, message);
+            if (typeof(T) == typeof(InvalidOperationException))
+                throw new InvalidOperationException(message);
+
+            // We will still throw but in a way that we can look
+            throw new NotSupportedException($"Exception type '{typeof(T).Name}' is not supported by this {nameof(Throw)} statement.");
+        }
+
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
+        public static void Throw<T>(string message)
+        {
+            if (typeof(T) == typeof(ArgumentException))
+                throw new ArgumentException(message);
+            if (typeof(T) == typeof(ArgumentNullException))
+                throw new ArgumentNullException(null, message);
+            if (typeof(T) == typeof(ArgumentOutOfRangeException))
+                throw new ArgumentOutOfRangeException(null, message);
+            if (typeof(T) == typeof(InvalidOperationException))
+                throw new InvalidOperationException(message);
+
+            // We will still throw but in a way that we can look
+            throw new NotSupportedException($"Exception type '{typeof(T).Name}' is not supported by this {nameof(Throw)} statement.");
+        }
+
+
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
+        private static void Throw(string paramName) => Throw<ArgumentNullException>(paramName);
+
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
+        private static void Throw() => throw new ArgumentNullException();
+    }
+}

--- a/src/Sparrow/PortableExceptions.cs
+++ b/src/Sparrow/PortableExceptions.cs
@@ -1,6 +1,11 @@
-﻿using System;
+using System;
+using System.Diagnostics;
+using System.IO;
+
+#if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+#endif
 
 namespace Sparrow
 {
@@ -25,6 +30,20 @@ namespace Sparrow
 #endif
             }
         }
+        
+        [Conditional("DEBUG")]
+        public static void ThrowIfNullOnDebug(
+#if NET6_0_OR_GREATER              
+            [NotNull]
+#endif
+            object argument,
+#if NET6_0_OR_GREATER        
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null)
+        {
+            ThrowIfNull(argument, paramName);
+        }
 
         public static void ThrowIfNotNull(
 #if NET6_0_OR_GREATER              
@@ -44,6 +63,20 @@ namespace Sparrow
                 Throw();
 #endif
             }
+        }
+
+        [Conditional("DEBUG")]
+        public static void ThrowIfNotNullOnDebug(
+#if NET6_0_OR_GREATER              
+            [NotNull]
+#endif
+            object argument,
+#if NET6_0_OR_GREATER        
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null)
+        {
+            ThrowIfNotNull(argument, paramName);
         }
 
         public static void ThrowIfNull<T>(
@@ -67,6 +100,20 @@ namespace Sparrow
             }
         }
 
+        [Conditional("DEBUG")]
+        public static void ThrowIfNullOnDebug<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            object argument,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIfNull<T>(argument, paramName);
+        }
+
         public static void ThrowIfNotNull<T>(
 #if NET6_0_OR_GREATER
             [NotNull]
@@ -86,6 +133,21 @@ namespace Sparrow
                 Throw<T>(message);
 #endif
             }
+        }
+
+        [Conditional("DEBUG")]
+        public static void ThrowIfNotNullOnDebug<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            object argument,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIfNotNull<T>(argument, message, paramName);
         }
 
         public static unsafe void ThrowIfNull<T>(
@@ -109,6 +171,21 @@ namespace Sparrow
             }
         }
 
+        [Conditional("DEBUG")]
+        public static unsafe void ThrowIfNullOnDebug<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIfNull<T>(argument, message, paramName);
+        }
+
         public static unsafe void ThrowIfNotNull<T>(
 #if NET6_0_OR_GREATER
             [NotNull]
@@ -130,6 +207,21 @@ namespace Sparrow
             }
         }
 
+        [Conditional("DEBUG")]
+        public static unsafe void ThrowIfNotNullOnDebug<T>(
+#if NET6_0_OR_GREATER
+            [NotNull]
+#endif
+            void* argument,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(argument))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIfNotNull<T>(argument, message, paramName);
+        }
+
         public static void ThrowIf<T>(
             bool condition,
             string message = null,
@@ -148,6 +240,18 @@ namespace Sparrow
             }
         }
 
+        [Conditional("DEBUG")]
+        public static void ThrowIfOnDebug<T>(
+            bool condition,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(condition))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIf<T>(condition, message, paramName);
+        }
+
 #if NET6_0_OR_GREATER
         [DoesNotReturn]
 #endif
@@ -161,9 +265,21 @@ namespace Sparrow
                 throw new ArgumentOutOfRangeException(paramName, message);
             if (typeof(T) == typeof(InvalidOperationException))
                 throw new InvalidOperationException(message);
+            if (typeof(T) == typeof(ObjectDisposedException))
+                throw new ObjectDisposedException(message);
+            if (typeof(T) == typeof(EndOfStreamException))
+                throw new EndOfStreamException(message);
+            if (typeof(T) == typeof(InvalidDataException))
+                throw new InvalidDataException(message);
 
             // We will still throw but in a way that we can look
             throw new NotSupportedException($"Exception type '{typeof(T).Name}' is not supported by this {nameof(Throw)} statement.");
+        }
+
+        [Conditional("DEBUG")]
+        public static void ThrowOnDebug<T>(string paramName, string message)
+        {
+            Throw<T>(paramName, message);
         }
 
 #if NET6_0_OR_GREATER
@@ -179,9 +295,19 @@ namespace Sparrow
                 throw new ArgumentOutOfRangeException(null, message);
             if (typeof(T) == typeof(InvalidOperationException))
                 throw new InvalidOperationException(message);
+            if (typeof(T) == typeof(ObjectDisposedException))
+                throw new ObjectDisposedException(message);
+            if (typeof(T) == typeof(InvalidDataException))
+                throw new InvalidDataException(message);
 
             // We will still throw but in a way that we can look
             throw new NotSupportedException($"Exception type '{typeof(T).Name}' is not supported by this {nameof(Throw)} statement.");
+        }
+
+        [Conditional("DEBUG")]
+        public static void ThrowOnDebug<T>(string message)
+        {
+            Throw<T>(message);
         }
 
 

--- a/src/Sparrow/PortableExceptions.cs
+++ b/src/Sparrow/PortableExceptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -11,10 +12,121 @@ namespace Sparrow
 {
     internal class PortableExceptions
     {
-        // In order to differ the allocation of interpolations we need to do it through a delegate.
+
+#if NET6_0_OR_GREATER         
+        // In order to defer the allocation of interpolations we need to do it through a InterpolatedStringHandler.
         // More details in the following issue: https://github.com/dotnet/runtime/issues/101996
         // We could remove all the API when this is solved at the JIT level. 
-        internal delegate string ThrowMessage();
+
+        [InterpolatedStringHandler]
+        public readonly ref struct ConditionalThrowInterpolatedStringHandler
+        {
+            private readonly StringBuilder? _builder;
+
+            public ConditionalThrowInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool isEnabled)
+            {
+                isEnabled = condition;
+                _builder = condition ? new StringBuilder(literalLength + formattedCount * 2 + 1) : null;
+            }
+
+            public void AppendLiteral(string s)
+            {
+                _builder!.Append(s);
+            }
+
+            public void AppendFormatted<T>(T t)
+            {
+                _builder!.Append(t);
+            }
+
+            internal string? GetFormattedText()
+            {
+                return _builder!.ToString();
+            }
+        }
+
+        [InterpolatedStringHandler]
+        public readonly ref struct NotConditionalThrowInterpolatedStringHandler
+        {
+            private readonly StringBuilder? _builder;
+
+            public NotConditionalThrowInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool isEnabled)
+            {
+                isEnabled = condition == false;
+                _builder = condition == false ? new StringBuilder(literalLength + formattedCount * 2 + 1) : null;
+            }
+
+            public void AppendLiteral(string s)
+            {
+                _builder!.Append(s);
+            }
+
+            public void AppendFormatted<T>(T t)
+            {
+                _builder!.Append(t);
+            }
+
+            internal string? GetFormattedText()
+            {
+                return _builder!.ToString();
+            }
+        }
+
+        [InterpolatedStringHandler]
+        public readonly ref struct NullThrowInterpolatedStringHandler
+        {
+            private readonly StringBuilder? _builder;
+
+            public NullThrowInterpolatedStringHandler(int literalLength, int formattedCount, object condition, out bool isEnabled)
+            {
+                isEnabled = condition == null;
+                _builder = condition == null ? new StringBuilder(literalLength + formattedCount * 2 + 1) : null;
+            }
+
+            public void AppendLiteral(string s)
+            {
+                _builder!.Append(s);
+            }
+
+            public void AppendFormatted<T>(T t)
+            {
+                _builder!.Append(t);
+            }
+
+            internal string? GetFormattedText()
+            {
+                return _builder!.ToString();
+            }
+        }
+
+        [InterpolatedStringHandler]
+        public readonly ref struct NotNullThrowInterpolatedStringHandler
+        {
+            private readonly StringBuilder? _builder;
+
+            public NotNullThrowInterpolatedStringHandler(int literalLength, int formattedCount, object condition, out bool isEnabled)
+            {
+                isEnabled = condition != null;
+                _builder = condition != null ? new StringBuilder(literalLength + formattedCount * 2 + 1) : null;
+            }
+
+            public void AppendLiteral(string s)
+            {
+                _builder!.Append(s);
+            }
+
+            public void AppendFormatted<T>(T t)
+            {
+                _builder!.Append(t);
+            }
+
+            internal string? GetFormattedText()
+            {
+                return _builder!.ToString();
+            }
+        }
+
+#endif        
 
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -117,26 +229,22 @@ namespace Sparrow
             }
         }
 
+
+#if NET6_0_OR_GREATER         
         public static void ThrowIfNull<T>(
-#if NET6_0_OR_GREATER
             [NotNull]
-#endif
             object argument,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(argument))]
+            NullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-#endif
             string paramName = null) where T : Exception
         {
             if (argument == null)
             {
-#if NET6_0_OR_GREATER
-                Throw<T>(paramName, message());
-#else
-                Throw<T>(message());
-#endif
+                Throw<T>(paramName, message.GetFormattedText());
             }
         }
+#endif
 
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -179,29 +287,22 @@ namespace Sparrow
             }
         }
 
-#if NETCOREAPP2_0_OR_GREATER
+#if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static void ThrowIfNotNull<T>(
-#if NET6_0_OR_GREATER
             [NotNull]
-#endif
             object argument,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(argument))]
+            NotNullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-#endif
             string paramName = null) where T : Exception
         {
             if (argument != null)
             {
-#if NET6_0_OR_GREATER
-                Throw<T>(paramName, message());
-#else
-                Throw<T>(message());
-#endif
+                Throw<T>(paramName, message.GetFormattedText());
             }
         }
+#endif
 
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -221,23 +322,20 @@ namespace Sparrow
             ThrowIfNotNull<T>(argument, message, paramName);
         }
 
-#if NETCOREAPP2_0_OR_GREATER
+#if NET6_0_OR_GREATER         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         [Conditional("DEBUG")]
         public static void ThrowIfNotNullOnDebug<T>(
-#if NET6_0_OR_GREATER
             [NotNull]
-#endif
             object argument,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(argument))]
+            NotNullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-#endif
             string paramName = null) where T : Exception
         {
             ThrowIfNotNull<T>(argument, message, paramName);
         }
+#endif
 
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -361,29 +459,23 @@ namespace Sparrow
         }
 
 
-#if NETCOREAPP2_0_OR_GREATER
+#if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static unsafe void ThrowIfNull<T>(
-#if NET6_0_OR_GREATER
+
             [NotNull]
-#endif
             void* argument,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(argument))]
+            NullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-#endif
             string paramName = null) where T : Exception
         {
             if (argument == null)
             {
-#if NET6_0_OR_GREATER
-                Throw<T>(paramName, message());
-#else
-                Throw<T>(message());
-#endif
+                Throw<T>(paramName, message.GetFormattedText());
             }
         }
+#endif
 
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -403,24 +495,21 @@ namespace Sparrow
             ThrowIfNull<T>(argument, message, paramName);
         }
 
-#if NETCOREAPP2_0_OR_GREATER
+#if NET6_0_OR_GREATER         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNullOnDebug<T>(
-#if NET6_0_OR_GREATER
             [NotNull]
-#endif
             void* argument,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(argument))]
+            NullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-#endif
             string paramName = null) where T : Exception
         {
-            ThrowIfNull<T>(argument, message(), paramName);
+            ThrowIfNull<T>(argument, message.GetFormattedText(), paramName);
         }
-
+#endif
+        
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
@@ -445,29 +534,22 @@ namespace Sparrow
             }
         }
 
-#if NETCOREAPP2_0_OR_GREATER
+#if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static unsafe void ThrowIfNotNull<T>(
-#if NET6_0_OR_GREATER
             [NotNull]
-#endif
             void* argument,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(argument))]
+            NotNullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-#endif
             string paramName = null) where T : Exception
         {
             if (argument != null)
             {
-#if NET6_0_OR_GREATER
-                Throw<T>(paramName, message());
-#else
-                Throw<T>(message());
-#endif
+                Throw<T>(paramName, message.GetFormattedText());
             }
         }
+#endif
 
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -487,23 +569,20 @@ namespace Sparrow
             ThrowIfNotNull<T>(argument, message, paramName);
         }
 
-#if NETCOREAPP2_0_OR_GREATER
+#if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNotNullOnDebug<T>(
-#if NET6_0_OR_GREATER
             [NotNull]
-#endif
             void* argument,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(argument))]
+            NotNullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-#endif
             string paramName = null) where T : Exception
         {
             ThrowIfNotNull<T>(argument, message, paramName);
         }
+#endif
 
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -526,27 +605,22 @@ namespace Sparrow
             }
         }
 
-#if NETCOREAPP2_0_OR_GREATER
+#if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static void ThrowIf<T>(
             bool condition,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(condition))]
+            ConditionalThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(condition))]
-#endif
             string paramName = null) where T : Exception
         {
             if (condition)
             {
-#if NET6_0_OR_GREATER
-                Throw<T>(paramName, message());
-#else
-                Throw<T>(message());
-#endif
+                Throw<T>(paramName, message.GetFormattedText());
             }
         }
-
+#endif
+        
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
@@ -562,20 +636,19 @@ namespace Sparrow
             ThrowIf<T>(condition, message, paramName);
         }
 
-#if NETCOREAPP2_0_OR_GREATER
+#if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         [Conditional("DEBUG")]
         public static void ThrowIfOnDebug<T>(
             bool condition,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(condition))]
+            ConditionalThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(condition))]
-#endif
             string paramName = null) where T : Exception
         {
             ThrowIf<T>(condition, message, paramName);
         }
+#endif
 
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -598,27 +671,22 @@ namespace Sparrow
             }
         }
 
-#if NETCOREAPP2_0_OR_GREATER
+#if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static void ThrowIfNot<T>(
             bool condition,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(condition))]
+            NotConditionalThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(condition))]
-#endif
             string paramName = null) where T : Exception
         {
             if (condition == false)
             {
-#if NET6_0_OR_GREATER
-                Throw<T>(paramName, message());
-#else
-                Throw<T>(message());
-#endif
+                Throw<T>(paramName, message.GetFormattedText());
             }
         }
-
+#endif
+        
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
@@ -634,21 +702,20 @@ namespace Sparrow
             ThrowIfNot<T>(condition, message, paramName);
         }
 
-#if NETCOREAPP2_0_OR_GREATER
+#if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         [Conditional("DEBUG")]
         public static void ThrowIfNotOnDebug<T>(
             bool condition,
-            ThrowMessage message,
-#if NET6_0_OR_GREATER
+            [InterpolatedStringHandlerArgument(nameof(condition))]
+            NotConditionalThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(condition))]
-#endif
             string paramName = null) where T : Exception
         {
             ThrowIfNot<T>(condition, message, paramName);
         }
-
+#endif
+        
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif

--- a/src/Sparrow/PortableExceptions.cs
+++ b/src/Sparrow/PortableExceptions.cs
@@ -397,7 +397,7 @@ namespace Sparrow
 #if NET6_0_OR_GREATER
         [DoesNotReturn]
 #endif
-        public static void Throw<T>(string message)
+        public static T Throw<T>(string message) where T : Exception
         {
             if (typeof(T) == typeof(ArgumentException))
                 throw new ArgumentException(message);
@@ -417,7 +417,7 @@ namespace Sparrow
         }
 
         [Conditional("DEBUG")]
-        public static void ThrowOnDebug<T>(string message)
+        public static void ThrowOnDebug<T>(string message) where T : Exception
         {
             Throw<T>(message);
         }

--- a/src/Sparrow/PortableExceptions.cs
+++ b/src/Sparrow/PortableExceptions.cs
@@ -334,6 +334,36 @@ namespace Sparrow
             ThrowIf<T>(condition, message, paramName);
         }
 
+        public static void ThrowIfNot<T>(
+            bool condition,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(condition))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            if (condition == false)
+            {
+#if NET6_0_OR_GREATER
+                Throw<T>(paramName, message);
+#else
+                Throw<T>(message);
+#endif
+            }
+        }
+
+        [Conditional("DEBUG")]
+        public static void ThrowIfNotOnDebug<T>(
+            bool condition,
+            string message = null,
+#if NET6_0_OR_GREATER
+            [CallerArgumentExpression(nameof(condition))]
+#endif
+            string paramName = null) where T : Exception
+        {
+            ThrowIfNot<T>(condition, message, paramName);
+        }
+
 #if NET6_0_OR_GREATER
         [DoesNotReturn]
 #endif

--- a/src/Sparrow/PortableExceptions.cs
+++ b/src/Sparrow/PortableExceptions.cs
@@ -1,9 +1,12 @@
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 
 #if NET6_0_OR_GREATER
+using System.ComponentModel.Design;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 #endif
@@ -77,7 +80,7 @@ namespace Sparrow
         {
             private readonly StringBuilder? _builder;
 
-            public NullThrowInterpolatedStringHandler(int literalLength, int formattedCount, object condition, out bool isEnabled)
+            public NullThrowInterpolatedStringHandler(int literalLength, int formattedCount, object? condition, out bool isEnabled)
             {
                 isEnabled = condition == null;
                 _builder = condition == null ? new StringBuilder(literalLength + formattedCount * 2 + 1) : null;
@@ -104,7 +107,7 @@ namespace Sparrow
         {
             private readonly StringBuilder? _builder;
 
-            public NotNullThrowInterpolatedStringHandler(int literalLength, int formattedCount, object condition, out bool isEnabled)
+            public NotNullThrowInterpolatedStringHandler(int literalLength, int formattedCount, object? condition, out bool isEnabled)
             {
                 isEnabled = condition != null;
                 _builder = condition != null ? new StringBuilder(literalLength + formattedCount * 2 + 1) : null;
@@ -132,14 +135,11 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
         public static void ThrowIfNull(
-#if NET6_0_OR_GREATER              
-            [NotNull]
-#endif
-            object argument,
+            object? argument,
 #if NET6_0_OR_GREATER        
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null)
+            string? paramName = null)
         {
             if (argument == null)
             {
@@ -156,14 +156,11 @@ namespace Sparrow
 #endif
         [Conditional("DEBUG")]
         public static void ThrowIfNullOnDebug(
-#if NET6_0_OR_GREATER              
-            [NotNull]
-#endif
-            object argument,
+            object? argument,
 #if NET6_0_OR_GREATER        
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null)
+            string? paramName = null)
         {
             ThrowIfNull(argument, paramName);
         }
@@ -172,14 +169,11 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
         public static void ThrowIfNotNull(
-#if NET6_0_OR_GREATER              
-            [NotNull]
-#endif
-            object argument,
+            object? argument,
 #if NET6_0_OR_GREATER        
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null)
+            string? paramName = null)
         {
             if (argument != null)
             {
@@ -196,28 +190,22 @@ namespace Sparrow
 #endif
         [Conditional("DEBUG")]
         public static void ThrowIfNotNullOnDebug(
-#if NET6_0_OR_GREATER              
-            [NotNull]
-#endif
             object argument,
 #if NET6_0_OR_GREATER        
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null)
+            string? paramName = null)
         {
             ThrowIfNotNull(argument, paramName);
         }
 
         public static void ThrowIfNull<T>(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
-            object argument,
-            string message = null,
+            object? argument,
+            string? message = null,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (argument == null)
             {
@@ -232,12 +220,11 @@ namespace Sparrow
 
 #if NET6_0_OR_GREATER         
         public static void ThrowIfNull<T>(
-            [NotNull]
-            object argument,
+            object? argument,
             [InterpolatedStringHandlerArgument(nameof(argument))]
             NullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (argument == null)
             {
@@ -251,14 +238,11 @@ namespace Sparrow
 #endif
         [Conditional("DEBUG")]
         public static void ThrowIfNullOnDebug<T>(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
-            object argument,
+            object? argument,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIfNull<T>(argument, paramName);
         }
@@ -267,15 +251,12 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
         public static void ThrowIfNotNull<T>(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
-            object argument,
-            string message = null,
+            object? argument,
+            string? message = null,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (argument != null)
             {
@@ -290,12 +271,11 @@ namespace Sparrow
 #if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfNotNull<T>(
-            [NotNull]
-            object argument,
+            object? argument,
             [InterpolatedStringHandlerArgument(nameof(argument))]
             NotNullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (argument != null)
             {
@@ -309,15 +289,12 @@ namespace Sparrow
 #endif
         [Conditional("DEBUG")]
         public static void ThrowIfNotNullOnDebug<T>(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
-            object argument,
-            string message = null,
+            object? argument,
+            string? message = null,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIfNotNull<T>(argument, message, paramName);
         }
@@ -326,12 +303,11 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [Conditional("DEBUG")]
         public static void ThrowIfNotNullOnDebug<T>(
-            [NotNull]
-            object argument,
+            object? argument,
             [InterpolatedStringHandlerArgument(nameof(argument))]
             NotNullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIfNotNull<T>(argument, message, paramName);
         }
@@ -341,14 +317,11 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
         public static unsafe void ThrowIfNull(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
             void* argument,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null)
+            string? paramName = null)
         {
             if (argument == null)
             {
@@ -365,14 +338,11 @@ namespace Sparrow
 #endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNullOnDebug(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
             void* argument,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null)
+            string? paramName = null)
         {
             ThrowIfNull(argument, paramName);
         }
@@ -381,14 +351,11 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
         public static unsafe void ThrowIfNotNull(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
             void* argument,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null)
+            string? paramName = null)
         {
             if (argument != null)
             {
@@ -405,14 +372,11 @@ namespace Sparrow
 #endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNotNullOnDebug(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
             void* argument,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null)
+            string? paramName = null)
         {
             ThrowIfNotNull(argument, paramName);
         }
@@ -422,14 +386,11 @@ namespace Sparrow
 #endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNullOnDebug<T>(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
             void* argument,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIfNull<T>(argument, paramName);
         }
@@ -438,15 +399,12 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
         public static unsafe void ThrowIfNull<T>(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
             void* argument,
-            string message = null,
+            string? message = null,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (argument == null)
             {
@@ -462,40 +420,18 @@ namespace Sparrow
 #if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void ThrowIfNull<T>(
-
-            [NotNull]
             void* argument,
             [InterpolatedStringHandlerArgument(nameof(argument))]
             NullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (argument == null)
             {
                 Throw<T>(paramName, message.GetFormattedText());
             }
         }
-#endif
 
-#if NETCOREAPP2_0_OR_GREATER
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
-        [Conditional("DEBUG")]
-        public static unsafe void ThrowIfNullOnDebug<T>(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
-            void* argument,
-            string message = null,
-#if NET6_0_OR_GREATER
-            [CallerArgumentExpression(nameof(argument))]
-#endif
-            string paramName = null) where T : Exception
-        {
-            ThrowIfNull<T>(argument, message, paramName);
-        }
-
-#if NET6_0_OR_GREATER         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNullOnDebug<T>(
@@ -504,25 +440,40 @@ namespace Sparrow
             [InterpolatedStringHandlerArgument(nameof(argument))]
             NullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIfNull<T>(argument, message.GetFormattedText(), paramName);
         }
+#else
+
+#if NETCOREAPP2_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-        
+        [Conditional("DEBUG")]
+        public static unsafe void ThrowIfNullOnDebug<T>(
+            void* argument,
+            string? message = null,
+            string? paramName = null) where T : Exception
+        {
+            ThrowIfNull<T>(argument, message, paramName);
+        }
+
+#endif
+
+
+
+
+
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
         public static unsafe void ThrowIfNotNull<T>(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
             void* argument,
-            string message = null,
+            string? message = null,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (argument != null)
             {
@@ -537,12 +488,11 @@ namespace Sparrow
 #if NET6_0_OR_GREATER 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void ThrowIfNotNull<T>(
-            [NotNull]
             void* argument,
             [InterpolatedStringHandlerArgument(nameof(argument))]
             NotNullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (argument != null)
             {
@@ -556,15 +506,12 @@ namespace Sparrow
 #endif
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNotNullOnDebug<T>(
-#if NET6_0_OR_GREATER
-            [NotNull]
-#endif
             void* argument,
-            string message = null,
+            string?message = null,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(argument))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIfNotNull<T>(argument, message, paramName);
         }
@@ -573,12 +520,11 @@ namespace Sparrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [Conditional("DEBUG")]
         public static unsafe void ThrowIfNotNullOnDebug<T>(
-            [NotNull]
             void* argument,
             [InterpolatedStringHandlerArgument(nameof(argument))]
             NotNullThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(argument))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIfNotNull<T>(argument, message, paramName);
         }
@@ -589,11 +535,11 @@ namespace Sparrow
 #endif
         public static void ThrowIf<T>(
             bool condition,
-            string message = null,
+            string? message = null,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(condition))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (condition)
             {
@@ -612,7 +558,7 @@ namespace Sparrow
             [InterpolatedStringHandlerArgument(nameof(condition))]
             ConditionalThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(condition))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (condition)
             {
@@ -627,11 +573,11 @@ namespace Sparrow
         [Conditional("DEBUG")]
         public static void ThrowIfOnDebug<T>(
             bool condition,
-            string message = null,
+            string? message = null,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(condition))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIf<T>(condition, message, paramName);
         }
@@ -644,7 +590,7 @@ namespace Sparrow
             [InterpolatedStringHandlerArgument(nameof(condition))]
             ConditionalThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(condition))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIf<T>(condition, message, paramName);
         }
@@ -655,11 +601,11 @@ namespace Sparrow
 #endif
         public static void ThrowIfNot<T>(
             bool condition,
-            string message = null,
+            string? message = null,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(condition))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (condition == false)
             {
@@ -678,7 +624,7 @@ namespace Sparrow
             [InterpolatedStringHandlerArgument(nameof(condition))]
             NotConditionalThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(condition))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             if (condition == false)
             {
@@ -693,11 +639,11 @@ namespace Sparrow
         [Conditional("DEBUG")]
         public static void ThrowIfNotOnDebug<T>(
             bool condition,
-            string message = null,
+            string? message = null,
 #if NET6_0_OR_GREATER
             [CallerArgumentExpression(nameof(condition))]
 #endif
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIfNot<T>(condition, message, paramName);
         }
@@ -710,7 +656,7 @@ namespace Sparrow
             [InterpolatedStringHandlerArgument(nameof(condition))]
             NotConditionalThrowInterpolatedStringHandler message,
             [CallerArgumentExpression(nameof(condition))]
-            string paramName = null) where T : Exception
+            string? paramName = null) where T : Exception
         {
             ThrowIfNot<T>(condition, message, paramName);
         }
@@ -722,7 +668,7 @@ namespace Sparrow
 #if NET6_0_OR_GREATER
         [DoesNotReturn]
 #endif
-        public static void Throw<T>(string paramName, string message)
+        public static void Throw<T>(string? paramName, string? message)
         {
             if (typeof(T) == typeof(ArgumentException))
                 throw new ArgumentException(message, paramName);
@@ -758,7 +704,7 @@ namespace Sparrow
 #if NET6_0_OR_GREATER
         [DoesNotReturn]
 #endif
-        public static T Throw<T>(string message) where T : Exception
+        public static T Throw<T>(string? message) where T : Exception
         {
             if (typeof(T) == typeof(ArgumentException))
                 throw new ArgumentException(message);
@@ -793,7 +739,7 @@ namespace Sparrow
 #if NET6_0_OR_GREATER
         [DoesNotReturn]
 #endif
-        private static void Throw(string paramName) => Throw<ArgumentNullException>(paramName);
+        private static void Throw(string? paramName) => Throw<ArgumentNullException>(paramName);
 
 #if NETCOREAPP2_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Sparrow/UnmanagedMemory.cs
+++ b/src/Sparrow/UnmanagedMemory.cs
@@ -3,13 +3,12 @@ using Sparrow.Json;
 
 namespace Sparrow
 {
-    public sealed unsafe class UnmanagedMemory
+    public sealed unsafe class UnmanagedMemory(byte* address, int size)
     {
         private Memory<byte>? _memory;
 
-        public readonly byte* Address;
-
-        public readonly int Size;
+        public readonly byte* Address = address;
+        public readonly int Size = size;
 
         public Memory<byte> Memory
         {
@@ -23,12 +22,6 @@ namespace Sparrow
 
                 return _memory.Value;
             }
-        }
-
-        public UnmanagedMemory(byte* address, int size)
-        {
-            Address = address;
-            Size = size;
         }
     }
 }

--- a/src/Voron/Data/BTrees/Tree.Extensions.cs
+++ b/src/Voron/Data/BTrees/Tree.Extensions.cs
@@ -14,8 +14,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public long Increment(string key, long delta)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 return Increment(keySlice, delta);
             }
@@ -24,8 +23,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Add(string key, Stream value)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 Add(keySlice, value);
             }
@@ -34,8 +32,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Add(string key, byte[] value)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 Add(keySlice, value);
             }
@@ -44,10 +41,8 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Add(string key, string value)
         {
-            Slice keySlice;
-            Slice valueSlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
-            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out Slice valueSlice))
             {
                 Add(keySlice, valueSlice);
             }
@@ -62,8 +57,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public DirectAddScope DirectAdd(string key, int len, TreeNodeFlags nodeType, out byte* ptr)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 return DirectAdd(keySlice, len, nodeType, out ptr);
             }
@@ -72,8 +66,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void Delete(string key)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 Delete(keySlice);
             }
@@ -82,8 +75,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public ReadResult Read(string key)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 return Read(keySlice);
             }
@@ -92,8 +84,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public bool Exists(string key)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 return Exists(keySlice);
             }
@@ -102,10 +93,8 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiAdd(string key, string value)
         {
-            Slice keySlice;
-            Slice valueSlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
-            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out Slice valueSlice))
             {
                 MultiAdd(keySlice, valueSlice);
             }
@@ -114,8 +103,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiAdd(string key, Slice value)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 MultiAdd(keySlice, value);
             }
@@ -124,8 +112,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiAdd(Slice key, string value)
         {
-            Slice valueSlice;
-            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out Slice valueSlice))
             {
                 MultiAdd(key, valueSlice);
             }
@@ -134,10 +121,8 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiDelete(string key, string value)
         {
-            Slice keySlice;
-            Slice valueSlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
-            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out Slice valueSlice))
             {
                 MultiDelete(keySlice, valueSlice);
             }
@@ -146,8 +131,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiDelete(Slice key, string value)
         {
-            Slice valueSlice;
-            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out Slice valueSlice))
             {
                 MultiDelete(key, valueSlice);
             }
@@ -156,8 +140,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiDelete(string key, Slice value)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 MultiDelete(keySlice, value);
             }
@@ -166,8 +149,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.NoInlining)]
         public IIterator MultiRead(string key)
         {
-            Slice keySlice;
-            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out Slice keySlice))
             {
                 return MultiRead(keySlice);
             }
@@ -210,12 +192,13 @@ namespace Voron.Data.BTrees
 
         public long GetLookupRootPage(Slice name)
         {
-            var result = Read(name);
-            if (result == null)
+            if (TryRead(name, out var reader) == false)
                 return -1;
-            var header = (LookupState*)result.Reader.Base;
+            
+            var header = (LookupState*)reader.Base;
             if (header->RootObjectType != RootObjectType.Lookup)
                 return -1;
+            
             return header->RootPage;
         }
 

--- a/src/Voron/Data/BTrees/Tree.Extensions.cs
+++ b/src/Voron/Data/BTrees/Tree.Extensions.cs
@@ -173,23 +173,6 @@ namespace Voron.Data.BTrees
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public FixedSizeTree<TVal> FixedSizeTree<TVal>(Tree fieldsTree, Slice fieldName, byte valSize = 0)
-            where TVal : unmanaged, IBinaryNumber<TVal>, IMinMaxValue<TVal>
-        {
-            if (typeof(TVal) == typeof(long))
-            {
-                return (FixedSizeTree<TVal>)(object)fieldsTree.FixedTreeFor(fieldName, valSize);
-            }
-
-            if (typeof(TVal) == typeof(double))
-            {
-                return (FixedSizeTree<TVal>)(object)fieldsTree.FixedTreeForDouble(fieldName, valSize);
-            }
-
-            throw new NotSupportedException();
-        }
-
         public long GetLookupRootPage(Slice name)
         {
             if (TryRead(name, out var reader) == false)

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -220,9 +220,8 @@ namespace Voron.Data.BTrees
             
             long currentValue = 0;
 
-            var read = Read(key);
-            if (read != null)
-                currentValue = *(long*)read.Reader.Base;
+            if (TryRead(key, out var reader))
+                currentValue = *(long*)reader.Base;
 
             var value = currentValue + delta;
             using (DirectAdd(key, sizeof(long), out byte* ptr))
@@ -236,11 +235,11 @@ namespace Voron.Data.BTrees
         /// </summary>
         public long? ReadInt64(Slice key)
         {
-            var read = Read(key);
-            if (read == null)
+            if (TryRead(key, out var reader) == false)
                 return null;
-            Debug.Assert(read.Reader.Length == sizeof(long));
-            return *(long*)read.Reader.Base;
+
+            Debug.Assert(reader.Length == sizeof(long));
+            return *(long*)reader.Base;
         }
 
         /// <summary>
@@ -248,11 +247,11 @@ namespace Voron.Data.BTrees
         /// </summary>
         public int? ReadInt32(Slice key)
         {
-            var read = Read(key);
-            if (read == null) 
+            if (TryRead(key, out var reader) == false)
                 return null;
-            Debug.Assert(read.Reader.Length == sizeof(int));
-            return *(int*)read.Reader.Base;
+
+            Debug.Assert(reader.Length == sizeof(int));
+            return *(int*)reader.Base;
 
         }
         
@@ -262,11 +261,11 @@ namespace Voron.Data.BTrees
         public T? ReadStructure<T>(Slice key)
             where T : unmanaged
         {
-            var read = Read(key);
-            if (read == null) 
+            if (TryRead(key, out var reader) == false)
                 return null;
-            Debug.Assert(read.Reader.Length == sizeof(T));
-            return *(T*)read.Reader.Base;
+
+            Debug.Assert(reader.Length == sizeof(T));
+            return *(T*)reader.Base;
 
         }
 
@@ -1098,6 +1097,22 @@ namespace Voron.Data.BTrees
                 return null;
 
             return new ReadResult(GetValueReaderFromHeader(node));
+        }
+
+        public bool TryRead(Slice key, out ValueReader reader)
+        {
+            ThrowIfDisposedOnDebug(_llt);
+
+            var p = FindPageFor(key, out TreeNodeHeader* node);
+
+            if (p.LastMatch != 0)
+            {
+                Unsafe.SkipInit(out reader);
+                return false;
+            }
+
+            reader = GetValueReaderFromHeader(node);
+            return true;
         }
 
         public bool Exists(Slice key)

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -142,8 +142,7 @@ namespace Voron.Data.BTrees
             if (type != RootObjectType.VariableSizeTree && type != RootObjectType.Table)
                 ThrowInvalidTreeCreateType();
 
-            if (llt.Flags != TransactionFlags.ReadWrite)
-                ThrowCannotCreateTreeInReadTx();
+            VoronExceptions.ThrowIfReadOnly(llt);
 
             var newPage = newPageAllocator?.AllocateSinglePage(0) ?? llt.AllocatePage(1);
 
@@ -162,12 +161,6 @@ namespace Voron.Data.BTrees
 
             tree.RecordNewPage(newRootPage, 1);
             return tree;
-        }
-
-        [DoesNotReturn]
-        private static void ThrowCannotCreateTreeInReadTx()
-        {
-            throw new ArgumentException("Cannot create a tree in a read only transaction");
         }
 
         [DoesNotReturn]
@@ -313,9 +306,8 @@ namespace Voron.Data.BTrees
 
         private static void ValidateValueLength(Stream value)
         {
-            if (value == null)
-                ThrowNullReferenceException();
-            Debug.Assert(value != null);
+            ArgumentNullException.ThrowIfNull(value);
+
             if (value.Length > int.MaxValue)
                 ThrowValueTooLarge();
         }
@@ -326,29 +318,20 @@ namespace Voron.Data.BTrees
             throw new ArgumentException("Cannot add a value that is over 2GB in size");
         }
 
-        [DoesNotReturn]
-        private static void ThrowNullReferenceException()
-        {
-            throw new ArgumentNullException();
-        }
-
         public void Add(Slice key, ReadOnlySpan<byte> value)
         {
-            if (value == null)
-                ThrowNullReferenceException();
-
-            Debug.Assert(value != null);
-
             using (DirectAdd(key, value.Length, out byte* ptr))
                 value.CopyTo(new Span<byte>(ptr, value.Length));
         }
 
         public void Add(Slice key, Slice value)
         {
-            Debug.Assert((State.Header.Flags & TreeFlags.MultiValue) == TreeFlags.None,"(State.Flags & TreeFlags.MultiValue) == TreeFlags.None");
+            VoronExceptions.ThrowIfNull(value);
             
+            Debug.Assert((State.Header.Flags & TreeFlags.MultiValue) == TreeFlags.None,"(State.Flags & TreeFlags.MultiValue) == TreeFlags.None");
+
             if (!value.HasValue)
-                ThrowNullReferenceException();
+                throw new NullReferenceException();
 
             using (DirectAdd(key, value.Size, out byte* ptr))
                 value.CopyTo(ptr);
@@ -370,8 +353,7 @@ namespace Voron.Data.BTrees
         {
             AssertNotDisposed();
 
-            if (_llt.Flags is TransactionFlags.Read)
-                ThrowCannotAddInReadTx();
+            VoronExceptions.ThrowIfReadOnly(_llt);
 
             if (AbstractPager.IsKeySizeValid(key.Size) == false)
                 ThrowInvalidKeySize(key);
@@ -526,6 +508,7 @@ namespace Voron.Data.BTrees
 
         }
 
+        [DoesNotReturn]
         private static void ThrowUnknownNodeTypeAddOperation(TreeNodeFlags nodeType)
         {
             throw new NotSupportedException("Unknown node type for direct add operation: " + nodeType);
@@ -537,11 +520,6 @@ namespace Voron.Data.BTrees
             throw new ArgumentException(
                 $"Key size is too big, must be at most {AbstractPager.MaxKeySize} bytes, but was {(key.Size + AbstractPager.RequiredSpaceForNewNode)}",
                 nameof(key));
-        }
-
-        private void ThrowCannotAddInReadTx()
-        {
-            throw new ArgumentException("Cannot add a value in a read only transaction on " + Name + " in " + _llt.Flags);
         }
 
         public TreePage ModifyPage(TreePage page)
@@ -617,8 +595,6 @@ namespace Voron.Data.BTrees
 
         public void ValidateTree_Forced(long rootPageNumber)
         {
-
-
             var pages = new HashSet<long>();
             var stack = new Stack<TreePage>();
             var root = GetReadOnlyTreePage(rootPageNumber);
@@ -721,9 +697,7 @@ namespace Voron.Data.BTrees
 
         internal TreePage FindPageFor(Slice key, out TreeNodeHeader* node, out TreeCursorConstructor cursor, bool allowCompressed = false)
         {
-            TreePage p;
-
-            if (TryUseRecentTransactionPage(key, out cursor, out p, out node))
+            if (TryUseRecentTransactionPage(key, out cursor, out TreePage p, out node))
             {
                 if (allowCompressed == false && p.IsCompressed)
                     ThrowOnCompressedPage(p);
@@ -1090,8 +1064,7 @@ namespace Voron.Data.BTrees
         {
             AssertNotDisposed();
 
-            if (_llt.Flags == (TransactionFlags.ReadWrite) == false)
-                throw new ArgumentException("Cannot delete a value in a read only transaction");
+            VoronExceptions.ThrowIfReadOnly(_llt, "Cannot delete a value in a read only transaction");
 
             var page = FindPageFor(key, node: out TreeNodeHeader* _, cursor: out var cursorConstructor, allowCompressed: true);
             if (page.IsCompressed)

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -1489,7 +1489,9 @@ namespace Voron.Data.BTrees
             // RavenDB-22261: It may happen that the FixedSizeTree requested does not exist, and if it does not
             // it would still return an instance. This is a workaround because the check in debug is correct.
             // https://issues.hibernatingrhinos.com/issue/RavenDB-22261/Inconsistency-in-Tree-external-API
-            Debug.Assert(fixedTree.NumberOfEntries == 0 || State.Header.Flags.HasFlag(TreeFlags.FixedSizeTrees));
+            Debug.Assert(fixedTree.NumberOfEntries == 0 || 
+                         fixedTree.Type == RootObjectType.EmbeddedFixedSizeTree || 
+                         State.Header.Flags.HasFlag(TreeFlags.FixedSizeTrees));
 
             return fixedTree;
         }

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -92,10 +92,9 @@ namespace Voron.Data.BTrees
             llt.RegisterDisposable(new TreeDisposable(this));
         }
 
-        public Tree(LowLevelTransaction llt, Transaction tx, Slice name, TreeMutableState state)
+        private Tree(LowLevelTransaction llt, Slice name, TreeMutableState state)
         {
             _llt = llt;
-            _tx = tx;
             Name = name;
 
             _recentlyFoundPages = FoundPagesPool.Allocate();
@@ -122,6 +121,11 @@ namespace Voron.Data.BTrees
 
         public bool HasNewPageAllocator { get; private set; }
 
+        public static Tree GetRoot(LowLevelTransaction llt, Slice name, TreeMutableState parentState)
+        {
+            return new Tree(llt, name, parentState);
+        }
+        
         public static Tree Open(LowLevelTransaction llt, Transaction tx, Slice name, in TreeRootHeader header, bool isIndexTree = false, NewPageAllocator newPageAllocator = null)
         {
             var tree = new Tree(llt, tx, header, name, isIndexTree, newPageAllocator);
@@ -172,7 +176,7 @@ namespace Voron.Data.BTrees
             throw new ArgumentException($"Only valid types are {nameof(RootObjectType.VariableSizeTree)} or {nameof(RootObjectType.Table)}.");
         }
 
-        internal void RecordNewPage(TreePage p, int num)
+        private void RecordNewPage(TreePage p, int num)
         {
             ref var header = ref State.Modify();
 
@@ -192,7 +196,7 @@ namespace Voron.Data.BTrees
             }
         }
 
-        internal void RecordFreedPage(TreePage p, int num)
+        private void RecordFreedPage(TreePage p, int num)
         {
             ref var header = ref State.Modify();
 

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -13,15 +13,16 @@ using Voron.Impl;
 using Voron.Impl.Paging;
 using Sparrow.Collections;
 using Sparrow.Server;
-using Voron.Data.CompactTrees;
 using Voron.Data.Lookups;
 using Constants = Voron.Global.Constants;
 using System.Diagnostics.CodeAnalysis;
-using Sparrow.Json;
 
 using static Sparrow.DisposableExceptions;
 using static Sparrow.PortableExceptions;
 using static Voron.VoronExceptions;
+
+using CompactTree = Voron.Data.CompactTrees.CompactTree;
+using FixedSizeTree = Voron.Data.Fixed.FixedSizeTree;
 
 namespace Voron.Data.BTrees
 {
@@ -1380,10 +1381,10 @@ namespace Voron.Data.BTrees
             using var _ = Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out var keySlice);
             return CompactTreeFor(keySlice);
         }
-        
+
         // RavenDB-21678: If you're keeping a reference to CompactTree, it may happen that you can actually override the prepareLocator and 
         // have more than one object of the same tree in memory but with different states. It's dangerous to mix usage since the object retains states.
-        public CompactTree CompactTreeFor(Slice key)
+        public bool TryGetCompactTreeFor(Slice key, out CompactTree tree)
         {
             // RavenDB-21678: Indexes with dynamic fields can generate a lot of fields, which can lead to overflow in the locator.
             // We've observed indexes with more than ~150 fields, and since performance is crucial, we increased it by one order of magnitude.
@@ -1395,22 +1396,39 @@ namespace Voron.Data.BTrees
 
             if (_prepareLocator.TryGetValue(key, out var prep) == false)
             {
-                var compactTree = CompactTree.InternalCreate(this, key);
-                if (compactTree == null) // missing value on read transaction
-                    return null;
+                tree = CompactTree.InternalCreate(this, key);
+                if (tree == null) // missing value on read transaction
+                    return false;
 
                 var keyClone = key.Clone(_llt.Allocator);
-                _prepareLocator.Add(keyClone, compactTree);
-                prep = compactTree;
+                _prepareLocator.Add(keyClone, tree);
+                prep = tree;
             }
 
             Debug.Assert(State.Header.Flags.HasFlag(TreeFlags.CompactTrees));
 
-            return (CompactTree)prep;
+            tree = (CompactTree)prep;
+            return true;
         }
 
+        public CompactTree CompactTreeFor(Slice key)
+        {
+            if (TryGetCompactTreeFor(key, out var tree))
+                return tree;
+
+            throw new InvalidOperationException($"{nameof(CompactTree)} with key '{key}' does not exist.");
+        }
 
         public Lookup<TKey> LookupFor<TKey>(Slice key)
+            where TKey : struct, ILookupKey
+        {
+            if (TryGetLookupFor<TKey>(key, out var lookup))
+                return lookup;
+
+            throw new InvalidOperationException($"{nameof(Lookup<TKey>)} with key '{key}' does not exist.");
+        }
+
+        public bool TryGetLookupFor<TKey>(Slice key, out Lookup<TKey> lookup)
             where TKey : struct, ILookupKey
         {
             if (_prepareLocator == null)
@@ -1421,10 +1439,10 @@ namespace Voron.Data.BTrees
 
             if (_prepareLocator.TryGetValue(key, out var prep) == false)
             {
-                var lookup = Lookup<TKey>.InternalCreate(this, key);
-                if (lookup == null) // missing value on read transaction
-                    return null;
-
+                lookup = Lookup<TKey>.InternalCreate(this, key);
+                if (lookup == null)
+                    return false;
+                
                 var keyClone = key.Clone(_llt.Allocator);
                 _prepareLocator.Add(keyClone, lookup);
                 prep = lookup;
@@ -1432,7 +1450,8 @@ namespace Voron.Data.BTrees
 
             Debug.Assert(State.Header.Flags.HasFlag(TreeFlags.Lookups));
 
-            return (Lookup<TKey>)prep;
+            lookup = (Lookup<TKey>)prep;
+            return true;
         }
 
         public FixedSizeTree FixedTreeFor(Slice key, byte valSize = 0)

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -20,6 +20,7 @@ using System.Diagnostics.CodeAnalysis;
 using Sparrow.Json;
 
 using static Sparrow.DisposableExceptions;
+using static Sparrow.PortableExceptions;
 using static Voron.VoronExceptions;
 
 namespace Voron.Data.BTrees
@@ -85,7 +86,7 @@ namespace Voron.Data.BTrees
 
             if (newPageAllocator != null)
             {
-                Debug.Assert(isIndexTree, "If newPageAllocator is set, we must be in a isIndexTree = true");
+                ThrowIfNullOnDebug(isIndexTree, "If newPageAllocator is set, we must be in a isIndexTree = true");
                 SetNewPageAllocator(newPageAllocator);
             }
 
@@ -124,9 +125,9 @@ namespace Voron.Data.BTrees
 
         public bool HasNewPageAllocator { get; private set; }
 
-        public static Tree GetRoot(LowLevelTransaction llt, Slice name, TreeMutableState parentState)
+        public static Tree GetRoot(LowLevelTransaction llt, TreeMutableState parentState)
         {
-            return new Tree(llt, name, parentState);
+            return new Tree(llt, Constants.RootTreeNameSlice, parentState);
         }
         
         public static Tree Open(LowLevelTransaction llt, Transaction tx, Slice name, in TreeRootHeader header, bool isIndexTree = false, NewPageAllocator newPageAllocator = null)
@@ -142,10 +143,9 @@ namespace Voron.Data.BTrees
         public static Tree Create(LowLevelTransaction llt, Transaction tx, Slice name, TreeFlags flags = TreeFlags.None, RootObjectType type = RootObjectType.VariableSizeTree,
             bool isIndexTree = false, NewPageAllocator newPageAllocator = null)
         {
-            if (type != RootObjectType.VariableSizeTree && type != RootObjectType.Table)
-                ThrowInvalidTreeCreateType();
-
-            VoronExceptions.ThrowIfReadOnly(llt);
+            ThrowIfReadOnly(llt);
+            ThrowIf<ArgumentException>(type != RootObjectType.VariableSizeTree && type != RootObjectType.Table,
+                $"Only valid types are {nameof(RootObjectType.VariableSizeTree)} or {nameof(RootObjectType.Table)}.");
 
             var newPage = newPageAllocator?.AllocateSinglePage(0) ?? llt.AllocatePage(1);
 
@@ -164,12 +164,6 @@ namespace Voron.Data.BTrees
 
             tree.RecordNewPage(newRootPage, 1);
             return tree;
-        }
-
-        [DoesNotReturn]
-        private static void ThrowInvalidTreeCreateType()
-        {
-            throw new ArgumentException($"Only valid types are {nameof(RootObjectType.VariableSizeTree)} or {nameof(RootObjectType.Table)}.");
         }
 
         private void RecordNewPage(TreePage p, int num)
@@ -297,7 +291,8 @@ namespace Voron.Data.BTrees
 
         public void Add(Slice key, Stream value)
         {
-            ValidateValueLength(value);
+            ThrowIfNull(value);
+            ThrowIf<ArgumentException>(value.Length > int.MaxValue, "Cannot add a value that is over 2GB in size");
 
             var length = (int)value.Length;
 
@@ -305,20 +300,6 @@ namespace Voron.Data.BTrees
             {
                 value.ReadExactly(new Span<byte>(ptr, length));
             }
-        }
-
-        private static void ValidateValueLength(Stream value)
-        {
-            ArgumentNullException.ThrowIfNull(value);
-
-            if (value.Length > int.MaxValue)
-                ThrowValueTooLarge();
-        }
-
-        [DoesNotReturn]
-        private static void ThrowValueTooLarge()
-        {
-            throw new ArgumentException("Cannot add a value that is over 2GB in size");
         }
 
         public void Add(Slice key, ReadOnlySpan<byte> value)
@@ -408,7 +389,9 @@ namespace Voron.Data.BTrees
             }
             
             nodeType &= ~TreeNodeFlags.NewOnly;
-            Debug.Assert(nodeType == TreeNodeFlags.Data || nodeType == TreeNodeFlags.MultiValuePageRef);
+            
+            ThrowIfOnDebug<InvalidOperationException>(nodeType != TreeNodeFlags.Data && nodeType != TreeNodeFlags.MultiValuePageRef,
+                $"Node should be either {nameof(TreeNodeFlags.Data)} or {nameof(TreeNodeFlags.MultiValuePageRef)}");
 
             var lastSearchPosition = page.LastSearchPosition; // searching for overflow pages might change this
             byte* overFlowPos = null;
@@ -499,7 +482,7 @@ namespace Voron.Data.BTrees
             private void ThrowScopeAlreadyOpen()
             {
                 var message = $"Write operation already requested on a tree name: {_parent}. " +
-                              $"{nameof(Tree.DirectAdd)} method cannot be called recursively while the scope is already opened.";
+                              $"{nameof(DirectAdd)} method cannot be called recursively while the scope is already opened.";
 
 #if VALIDATE_DIRECT_ADD_STACKTRACE
                 message += Environment.NewLine + _parent._allocationStacktrace;

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -68,7 +68,6 @@ namespace Voron.Data.BTrees
             }
 
             _recentlyFoundPages = FoundPagesPool.Allocate();
-
             _state = new TreeMutableState(llt, in header);
 
             llt.RegisterDisposable(new TreeDisposable(this));
@@ -100,9 +99,6 @@ namespace Voron.Data.BTrees
             Name = name;
 
             _recentlyFoundPages = FoundPagesPool.Allocate();
-
-
-            _state = new TreeMutableState(llt, state);
             _state = state;
 
             llt.RegisterDisposable(new TreeDisposable(this));

--- a/src/Voron/Data/BTrees/TreeMutableState.cs
+++ b/src/Voron/Data/BTrees/TreeMutableState.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using Voron.Global;
+﻿using Voron.Global;
 using Voron.Impl;
 
 namespace Voron.Data.BTrees
@@ -35,17 +33,10 @@ namespace Voron.Data.BTrees
 
         internal ref TreeRootHeader Modify()
         {
-            if (_tx.Flags != TransactionFlags.ReadWrite)
-                ThrowCanOnlyModifyInWriteTransaction();
-
+            VoronExceptions.ThrowIfReadOnly(_tx);
+            
             _stateIsModified = true;
             return ref _header;
-        }
-
-        [DoesNotReturn]
-        private static void ThrowCanOnlyModifyInWriteTransaction()
-        {
-            throw new InvalidOperationException("Invalid operation outside of a write transaction");
         }
 
         public void CopyTo(TreeRootHeader* header)

--- a/src/Voron/Data/BTrees/TreeNodeHeader.cs
+++ b/src/Voron/Data/BTrees/TreeNodeHeader.cs
@@ -41,10 +41,15 @@ namespace Voron.Data.BTrees
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<byte> ToReadOnlySpan(TreeNodeHeader* node, ByteStringType type)
+        {
+            return new ReadOnlySpan<byte>((byte*)node + Constants.Tree.NodeHeaderSize, node->KeySize);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ByteStringContext.InternalScope ToSlice(ByteStringContext context, TreeNodeHeader* node, ByteStringType type, out Slice str)
         {
-            ByteString byteString;
-            var scope = context.From((byte*)node + Constants.Tree.NodeHeaderSize, node->KeySize, type | (ByteStringType) SliceOptions.Key, out byteString);
+            var scope = context.From((byte*)node + Constants.Tree.NodeHeaderSize, node->KeySize, type | (ByteStringType) SliceOptions.Key, out ByteString byteString);
             str = new Slice(byteString);
             return scope;
         }
@@ -60,8 +65,7 @@ namespace Voron.Data.BTrees
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ByteStringContext.ExternalScope ToSlicePtr(ByteStringContext context, TreeNodeHeader* node, ByteStringType type, out Slice slice)
         {
-            ByteString str;
-            var scope = context.FromPtr((byte*)node + Constants.Tree.NodeHeaderSize, node->KeySize, type, out str);
+            var scope = context.FromPtr((byte*)node + Constants.Tree.NodeHeaderSize, node->KeySize, type, out ByteString str);
             slice = new Slice(str);
             return scope;
         }

--- a/src/Voron/Data/BTrees/TreePage.cs
+++ b/src/Voron/Data/BTrees/TreePage.cs
@@ -10,6 +10,7 @@ using Sparrow.Server;
 using Voron.Data.Compression;
 using Voron.Debugging;
 using Voron.Impl;
+using static Sparrow.PortableExceptions;
 using Constants = Voron.Global.Constants;
 
 namespace Voron.Data.BTrees
@@ -323,8 +324,10 @@ namespace Voron.Data.BTrees
         {
             Debug.Assert(index <= NumberOfEntries && index >= 0);
             Debug.Assert(IsBranch == false || index != 0 || key.Size == 0);// branch page's first item must be the implicit ref
-            if (HasSpaceFor(key, len) == false)
-                throw new InvalidOperationException(string.Format("The page is full and cannot add an entry, this is probably a bug. Key: {0}, data length: {1}, size left: {2}", key, len, SizeLeft));
+            
+            ThrowIf<InvalidOperationException>(HasSpaceFor(key, len) == false,
+                $"The page is full and cannot add an entry, this is probably a bug. Key: {key}, data length: {len}, size left: {SizeLeft}");
+                
 
             // move higher pointers up one slot
             ushort* offsets = KeysOffsets;

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -308,69 +308,60 @@ public sealed partial class CompactTree : IPrepareForCommit
 
     public static unsafe CompactTree InternalCreate(Tree parent, Slice name)
     {
-        Lookup<CompactKeyLookup> inner;
+        if (parent.TryRead(name, out _))
+            return new CompactTree(Lookup<CompactKeyLookup>.InternalCreate(parent, name));
+
         var llt = parent.Llt;
-        var existing = parent.Read(name);
-        if (existing == null)
+        if (llt.Flags != TransactionFlags.ReadWrite)
+            return null;
+
+        if ((parent.State.Header.Flags & TreeFlags.CompactTrees) != TreeFlags.CompactTrees)
         {
-            if (llt.Flags != TransactionFlags.ReadWrite)
-                return null;
+            // We will modify the parent tree state because there are Compact Trees in it.
+            ref var parentState = ref parent.State.Modify();
+            parentState.Flags |= TreeFlags.CompactTrees;
+        }
 
-            if ((parent.State.Header.Flags & TreeFlags.CompactTrees) != TreeFlags.CompactTrees)
+        long dictionaryId;
+
+        // This will be created a single time and stored in the root page.
+        using var scoped = Slice.From(llt.Allocator, PersistentDictionary.DictionaryKey, out var defaultKey);
+        var existingDictionary = llt.RootObjects.DirectRead(defaultKey);
+        if (existingDictionary == null)
+        {
+            dictionaryId = PersistentDictionary.CreateDefault(llt);
+
+            using var scope = llt.RootObjects.DirectAdd(defaultKey, sizeof(PersistentDictionaryRootHeader), out var ptr);
+            *(PersistentDictionaryRootHeader*)ptr = new PersistentDictionaryRootHeader()
             {
-                // We will modify the parent tree state because there are Compact Trees in it.
-                ref var parentState = ref parent.State.Modify();
-                parentState.Flags |= TreeFlags.CompactTrees;
-            }
-
-            long dictionaryId;
-
-            // This will be created a single time and stored in the root page.
-            using var scoped = Slice.From(llt.Allocator, PersistentDictionary.DictionaryKey, out var defaultKey);
-            var existingDictionary = llt.RootObjects.DirectRead(defaultKey);
-            if (existingDictionary == null)
-            {
-                dictionaryId = PersistentDictionary.CreateDefault(llt);
-
-                using var scope = llt.RootObjects.DirectAdd(defaultKey, sizeof(PersistentDictionaryRootHeader), out var ptr);
-                *(PersistentDictionaryRootHeader*)ptr = new PersistentDictionaryRootHeader()
-                {
-                    RootObjectType = RootObjectType.PersistentDictionary,
-                    PageNumber = dictionaryId
-                };
-            }
-            else
-            {
-                dictionaryId = ((PersistentDictionaryRootHeader*)existingDictionary)->PageNumber;
-            }
-
-            long containerId = Container.Create(llt);
-            inner = Lookup<CompactKeyLookup>.InternalCreate(parent, name, dictionaryId, containerId);
+                RootObjectType = RootObjectType.PersistentDictionary, PageNumber = dictionaryId
+            };
         }
         else
         {
-            inner = Lookup<CompactKeyLookup>.InternalCreate(parent, name);
+            dictionaryId = ((PersistentDictionaryRootHeader*)existingDictionary)->PageNumber;
         }
 
-        return new CompactTree(inner);
+        long containerId = Container.Create(llt);
+        return new CompactTree(
+            Lookup<CompactKeyLookup>.InternalCreate(parent, name, dictionaryId, containerId));
     }
 
     public static bool HasDictionary(LowLevelTransaction llt)
     {
         using var scoped = Slice.From(llt.Allocator, PersistentDictionary.DictionaryKey, out var dictionarySlice);
-        var existingDictionary = llt.RootObjects.Read(dictionarySlice);
-        return existingDictionary != null;
+
+        return llt.RootObjects.TryRead(dictionarySlice, out _);
     }
     
     public static unsafe long GetDictionaryId(LowLevelTransaction llt)
     {
         using var scoped = Slice.From(llt.Allocator, PersistentDictionary.DictionaryKey, out var dictionarySlice);
-        var read = llt.RootObjects.Read(dictionarySlice);
-        if (read != null)
-        {
-            return ((PersistentDictionaryRootHeader*)read.Reader.Base)->PageNumber;
-        }
-        return -1;
+
+        if (llt.RootObjects.TryRead(dictionarySlice, out var reader) == false)
+            return -1;
+
+        return ((PersistentDictionaryRootHeader*)reader.Base)->PageNumber;
     }
 
     public bool TryGetValue(string key, out long value)

--- a/src/Voron/Data/Compression/DecompressedReadResult.cs
+++ b/src/Voron/Data/Compression/DecompressedReadResult.cs
@@ -2,18 +2,11 @@
 
 namespace Voron.Data.Compression
 {
-    public sealed class DecompressedReadResult : ReadResult, IDisposable
+    public sealed class DecompressedReadResult(ValueReader reader, DecompressedLeafPage page) : ReadResult(reader), IDisposable
     {
-        private readonly DecompressedLeafPage _page;
-
-        public DecompressedReadResult(ValueReader reader, DecompressedLeafPage page) : base(reader)
-        {
-            _page = page;
-        }
-
         public void Dispose()
         {
-            _page?.Dispose();
+            page?.Dispose();
         }
     }
 }

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -274,8 +274,7 @@ namespace Voron.Data.Fixed
 
         public DirectAddScope DirectAdd(TVal key, out bool isNew, out byte* ptr)
         {
-            if (_tx.Flags == TransactionFlags.Read)
-                throw new InvalidOperationException("Cannot add a value in a read only transaction");
+            VoronExceptions.ThrowIfReadOnly(_tx, "Cannot add a value in a read only transaction");
 
             _changes++;
 
@@ -880,8 +879,7 @@ namespace Voron.Data.Fixed
 
         public DeletionResult Delete(TVal key)
         {
-            if (_tx.Flags == TransactionFlags.Read)
-                throw new InvalidOperationException("Cannot delete a value in a read only transaction");
+            VoronExceptions.ThrowIfReadOnly(_tx, "Cannot delete a value in a read only transaction");
 
             _changes++;
             switch (Type)
@@ -907,31 +905,30 @@ namespace Voron.Data.Fixed
 
         public DeletionResult DeleteRange(TVal start, TVal end)
         {
-            if (_tx.Flags == TransactionFlags.Read)
-                throw new InvalidOperationException("Cannot delete a range in a read only transaction");
+            VoronExceptions.ThrowIfReadOnly(_tx, "Cannot delete a range in a read only transaction");
 
             _changes++;
             if (start > end)
                 throw new InvalidOperationException("Start range cannot be greater than the end of the range");
 
-            long entriedDeleted;
+            long entriesDeleted;
             switch (Type)
             {
                 case null:
-                    entriedDeleted = 0;
+                    entriesDeleted = 0;
                     break;
                 case RootObjectType.EmbeddedFixedSizeTree:
-                    entriedDeleted = DeleteRangeEmbedded(start, end);
+                    entriesDeleted = DeleteRangeEmbedded(start, end);
                     break;
                 case RootObjectType.FixedSizeTree:
-                    entriedDeleted = DeleteRangeLarge(start, end);
+                    entriesDeleted = DeleteRangeLarge(start, end);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(Type?.ToString());
             }
             return new DeletionResult
             {
-                NumberOfEntriesDeleted = entriedDeleted,
+                NumberOfEntriesDeleted = entriesDeleted,
                 TreeRemoved = Type == null
             };
         }

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="FixedSizeTree.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -31,7 +31,7 @@ namespace Voron.Data.Fixed
             NewPageAllocator newPageAllocator = null)
         : FixedSizeTree<long>(tx, parent, treeName, valSize, clone, isIndexTree, newPageAllocator); 
     
-    public unsafe partial class FixedSizeTree<TVal> 
+    public unsafe partial class FixedSizeTree<TVal> : IDisposable
         where TVal: unmanaged, IBinaryNumber<TVal>, IMinMaxValue<TVal>
     {
 #if VALIDATE_DIRECT_ADD_STACKTRACE
@@ -48,7 +48,10 @@ namespace Voron.Data.Fixed
         private readonly int _maxEmbeddedEntries;
 
         private NewPageAllocator _newPageAllocator;
+
+        private static readonly ObjectPool<FastStack<FixedSizeTreePage<TVal>>> CursorObjectPool = new(() => new FastStack<FixedSizeTreePage<TVal>>(8));
         private FastStack<FixedSizeTreePage<TVal>> _cursor;
+        
         private int _changes;
 
         public LowLevelTransaction Llt => _tx;
@@ -420,7 +423,7 @@ namespace Voron.Data.Fixed
             var header = (FixedSizeTreeHeader.Large*)_parent.DirectRead(_treeName);
             var page = GetReadOnlyPage(header->RootPageNumber);
             if (_cursor == null)
-                _cursor = new FastStack<FixedSizeTreePage<TVal>>();
+                _cursor = CursorObjectPool.Allocate();
             else
                 _cursor.WeakClear();
 
@@ -1813,6 +1816,18 @@ namespace Voron.Data.Fixed
             System.Diagnostics.Debug.Assert(newPageAllocator != null);
 
             _newPageAllocator = newPageAllocator;
+        }
+
+        void IDisposable.Dispose()
+        {
+            if (_cursor != null)
+            {
+                var cursor = _cursor;
+                _cursor = null;
+                
+                cursor.Clear();
+                CursorObjectPool.Free(cursor);
+            }
         }
     }
 }

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -120,52 +120,60 @@ namespace Voron.Data.Fixed
 
         }
 
-        public void RepurposeInstance(Slice treeName, bool clone)
+        public static bool TryRepurposeInstance(FixedSizeTree<TVal> tree, Slice treeName, bool clone)
         {
-            new DirectAddScope(this).Dispose();// verifying that we aren't holding a ptr out
+            new DirectAddScope(tree).Dispose();// verifying that we aren't holding a ptr out
 
+            // Setting the name of the tree has to happen before returning even if the return is null
+            // TODO: Make sure that is no longer the case by prohibiting the direct creation of trees.
             if (clone)
             {
-                if (_treeName.HasValue)
-                    _tx.Allocator.Release(ref _treeName.Content);
+                if (tree._treeName.HasValue)
+                    tree._tx.Allocator.Release(ref tree._treeName.Content);
 
-                _treeName = treeName.Clone(_tx.Allocator);
+                tree._treeName = treeName.Clone(tree._tx.Allocator);
             }
             else
             {
-                _treeName = treeName;
+                tree._treeName = treeName;
             }
 
-            var header = (FixedSizeTreeHeader.Embedded*)_parent.DirectRead(_treeName);
+            var header = (FixedSizeTreeHeader.Embedded*)tree._parent.DirectRead(treeName);
             if (header == null)
-                return;
+                return false;
 
             switch (header->RootObjectType)
             {
                 case RootObjectType.EmbeddedFixedSizeTree:
                 case RootObjectType.FixedSizeTree:
-                    break;
+                    if (header->ValueSize != tree._valSize)
+                        ThrowInvalidFixedSizeTreeSize(tree, header);
+
+                    if (tree._tx.Flags == TransactionFlags.ReadWrite && (tree._parent.State.Header.Flags & TreeFlags.FixedSizeTrees) != TreeFlags.FixedSizeTrees)
+                    {
+                        ref var state = ref tree._parent.State.Modify();
+                        state.Flags |= TreeFlags.FixedSizeTrees;
+                    }
+
+                    return true;
                 default:
                     ThrowInvalidFixedSizeTree(treeName, header);
                     break; // will never get here
             }
 
-            if (header->ValueSize != _valSize)
-                ThrowInvalidFixedSizeTreeSize(header);
+            return false;
         }
 
         [DoesNotReturn]
-        private void ThrowInvalidFixedSizeTreeSize(FixedSizeTreeHeader.Embedded* header)
+        private static void ThrowInvalidFixedSizeTreeSize(FixedSizeTree<TVal> tree, FixedSizeTreeHeader.Embedded* header)
         {
-            throw new InvalidFixedSizeTree("The expected value len " + _valSize + " does not match actual value len " +
-                                                header->ValueSize + " for " + _treeName);
+            throw new InvalidFixedSizeTree($"The expected value len {tree._valSize} does not match actual value len {header->ValueSize} for {tree._treeName}");
         }
 
         [DoesNotReturn]
         private static void ThrowInvalidFixedSizeTree(Slice treeName, FixedSizeTreeHeader.Embedded* header)
         {
-            throw new InvalidFixedSizeTree("Tried to open '" + treeName + "' as FixedSizeTree, but is actually " +
-                                                  header->RootObjectType);
+            throw new InvalidFixedSizeTree($"Tried to open '{treeName}' as FixedSizeTree, but is actually {header->RootObjectType}");
         }
 
         static FixedSizeTree()
@@ -189,13 +197,13 @@ namespace Voron.Data.Fixed
             if (_maxEmbeddedEntries == 0)
                 ThrowInvalidFixedTreeValueSize();
 
-            RepurposeInstance(treeName, clone);
+            TryRepurposeInstance(this, treeName, clone);
         }
 
         [DoesNotReturn]
         private static void ThrowInvalidFixedTreeValueSize()
         {
-            throw new InvalidFixedSizeTree("The value size must be small than " + (Constants.Storage.PageSize / 8));
+            throw new InvalidFixedSizeTree($"The value size must be small than {Constants.Storage.PageSize / 8}");
         }
 
         public long[] Debug(FixedSizeTreePage<TVal> p)
@@ -270,26 +278,25 @@ namespace Voron.Data.Fixed
                 throw new InvalidOperationException("Cannot add a value in a read only transaction");
 
             _changes++;
-            byte* pos;
+
+            isNew = false;
             switch (Type)
             {
                 case null:
-                    pos = AddNewEntry(key);
+                    ptr = AddNewEntry(key);
                     isNew = true;
                     break;
                 case RootObjectType.EmbeddedFixedSizeTree:
-                    pos = AddEmbeddedEntry(key, out isNew);
+                    ptr = AddEmbeddedEntry(key, out isNew);
                     break;
                 case RootObjectType.FixedSizeTree:
-                    pos = AddLargeEntry(key, out isNew);
+                    ptr = AddLargeEntry(key, out isNew);
                     break;
                 default:
                     ThrowInvalidFixedSizeTreeType();
-                    pos = null; // never happens
-                    isNew = false;
+                    ptr = null; // Never happens
                     break;
             }
-            ptr = pos;
             return new DirectAddScope(this);
         }
 
@@ -566,8 +573,7 @@ namespace Voron.Data.Fixed
                 newPage.ValueSize = _valSize;
                 newPage.NumberOfEntries = 0;
 
-                FixedSizeTreeHeader.Large* largePtr;
-                using (ModifyLargeHeader(out largePtr))
+                using (ModifyLargeHeader(out FixedSizeTreeHeader.Large* largePtr))
                 {
                     largePtr->PageCount++;
                 }
@@ -1217,12 +1223,12 @@ namespace Voron.Data.Fixed
             var parentPage = _cursor.Pop();
             parentPage = ModifyPage(parentPage);
 
-            if (page.NumberOfEntries == 0)// empty page, delete it and fixup the parent
+            if (page.NumberOfEntries == 0)// empty page, delete it and fix the parent
             {
-                // fixup the implicit less than ref
+                // fix the implicit less than ref
                 if (parentPage.LastSearchPosition == 0
-                    // if we are 2 or less, we'll remove our entry and the parent page 
-                    // page will rebalance in turn, so we shouldn't modify the relevant
+                    // if we are 2 or less, we'll remove our entry and the parent page
+                    // will be rebalanced in turn, so we shouldn't modify the relevant
                     // entry
                     && parentPage.NumberOfEntries > 2) 
                 {
@@ -1325,7 +1331,7 @@ namespace Voron.Data.Fixed
 
                 // we need to set the leftmost key in the entries we
                 // moved to the key of the page we are going to remove
-                // to avoid smallest being injected into the sibling
+                // to avoid the smallest being injected into the sibling
                 // page, see RavenDB-9916
                 if (page.IsBranch)
                 {
@@ -1360,7 +1366,7 @@ namespace Voron.Data.Fixed
                     siblingPage.NumberOfEntries += page.NumberOfEntries;
                     // we need to set the leftmost key in the entries we
                     // moved to the key of the page we are going to remove
-                    // to avoid smallest being injected into the sibling
+                    // to avoid the smallest being injected into the sibling
                     // page, see RavenDB-9916
                     if (siblingPage.IsBranch)
                     {
@@ -1381,9 +1387,9 @@ namespace Voron.Data.Fixed
 
                 if (page.IsBranch)
                 {
-                    // if we are a branch page and we copy items from our left we need to make
+                    // if we are a branch page, we copy items from our left we need to make
                     // sure that the implicit left entry is fixed. We do that by copying the
-                    // entry our parent has for us as the leftmost entry for our current state
+                    // entry our parent has for us as the leftmost entry for our current state,
                     // and then we copy the entries to our left
                     page.SetKey(parentPage.GetKey(parentPage.LastSearchPosition),0);
                 }
@@ -1398,7 +1404,7 @@ namespace Voron.Data.Fixed
                     entriesToTake * sizeOfEntryInPage
                     );
 
-                // we don't need to do any fixup of the values themselves, because we take only the rightmost half
+                // we don't need to do any fix of the values themselves, because we take only the rightmost half
                 // of the values from the left sibling and that doesn't include the [smallest] value by definition
                 // RavenDB-9916
 
@@ -1462,9 +1468,9 @@ namespace Voron.Data.Fixed
                         (_entrySize * page.NumberOfEntries));
                 }
 
-                // side affect, this updates the number of pages in the 
+                // side effect, this updates the number of pages in the 
                 // large fixed size tree header, so we disable this to avoid 
-                // reverting to an large (and empty) fixed size tree
+                // reverting to a large (and empty) fixed size tree
                 FreePage(page.PageNumber, modifyPageCount: false);
             }
             return null;
@@ -1497,8 +1503,7 @@ namespace Voron.Data.Fixed
 
                 var newDataSize = sizeof(FixedSizeTreeHeader.Embedded) + ((startingEntryCount - 1) * _entrySize);
 
-                byte* addPtr;
-                using (_parent.DirectAdd(_treeName, newDataSize, out addPtr))
+                using (_parent.DirectAdd(_treeName, newDataSize, out byte* addPtr))
                 {
                     Memory.Copy(addPtr, tmpPtr, newDataSize);
 

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -127,7 +127,8 @@ namespace Voron.Data.Fixed
             new DirectAddScope(tree).Dispose();// verifying that we aren't holding a ptr out
 
             // Setting the name of the tree has to happen before returning even if the return is null
-            // TODO: Make sure that is no longer the case by prohibiting the direct creation of trees.
+            // because we are repurposing the tree and we dont want the tree to be returned with the wrong
+            // name.
             if (clone)
             {
                 if (tree._treeName.HasValue)

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -1556,6 +1556,19 @@ namespace Voron.Data.Fixed
             return ptr;
         }
 
+        public bool TryRead(TVal key, out ReadOnlySpan<byte> data)
+        {
+            var ptr = ReadPtr(key, out int size);
+            if (ptr == null)
+            {
+                data = ReadOnlySpan<byte>.Empty;
+                return false;
+            }
+
+            data = new ReadOnlySpan<byte>(ptr, size);
+            return true;
+        }
+
         public ByteStringContext.ExternalScope Read(TVal key, out Slice slice)
         {
             var ptr = ReadPtr(key, out int size);

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -255,8 +255,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
 
         LookupState header;
 
-        var existing = parent.Read(name);
-        if (existing == null)
+        if (parent.TryRead(name, out var reader) == false)
         {
             if (llt.Flags != TransactionFlags.ReadWrite)
                 return null;
@@ -273,7 +272,7 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
         }
         else
         {
-            header = *(LookupState*)existing.Reader.Base;
+            header = *(LookupState*)reader.Base;
         }
 
         if (header.RootObjectType != RootObjectType.Lookup)

--- a/src/Voron/Data/RawData/RawDataSection.cs
+++ b/src/Voron/Data/RawData/RawDataSection.cs
@@ -186,8 +186,7 @@ namespace Voron.Data.RawData
 
         public bool TryWriteDirect(long id, int size, bool compressed, out byte* writePos)
         {
-            if (_llt.Flags == TransactionFlags.Read)
-                ThrowReadOnlyTransaction(id);
+            VoronExceptions.ThrowIfReadOnly(_llt, $"Attempted to modify page {id} in a read only transaction");
 
             var posInPage = (int)(id % Constants.Storage.PageSize);
             var pageNumberInSection = (id - posInPage) / Constants.Storage.PageSize;
@@ -277,8 +276,7 @@ namespace Voron.Data.RawData
 
         public void DeleteSection(long sectionPageNumber)
         {
-            if (_llt.Flags == TransactionFlags.Read)
-                ThrowReadOnlyTransaction(sectionPageNumber);
+            VoronExceptions.ThrowIfReadOnly(_llt, $"Attempted to modify page {sectionPageNumber} in a read only transaction");
 
             if (sectionPageNumber != _sectionHeader->PageNumber)
             {
@@ -302,8 +300,7 @@ namespace Voron.Data.RawData
 
         public RawDataSection Free(long id)
         {
-            if (_llt.Flags == TransactionFlags.Read)
-                ThrowReadOnlyTransaction(id);
+            VoronExceptions.ThrowIfReadOnly(_llt, $"Attempted to modify page {id} in a read only transaction");
 
             var posInPage = (int)(id % Constants.Storage.PageSize);
             var pageNumberInSection = (id - posInPage) / Constants.Storage.PageSize;

--- a/src/Voron/Data/Tables/NewPageAllocator.cs
+++ b/src/Voron/Data/Tables/NewPageAllocator.cs
@@ -71,7 +71,7 @@ namespace Voron.Data.Tables
             {
                 if (slice.HasValue)
                 {
-                    _numberOfPagesToAllocate = slice.CreateReader().ReadLittleEndianInt32();
+                    _numberOfPagesToAllocate = slice.CreateReader().Read<int>();
                 }
             }
         }
@@ -108,7 +108,7 @@ namespace Voron.Data.Tables
             {
                 using (fixedSizeTreeSize.Read(0, out var slice))
                 {
-                    _numberOfPagesToAllocate = slice.CreateReader().ReadLittleEndianInt32();
+                    _numberOfPagesToAllocate = slice.CreateReader().Read<int>();
                 }
             }
 

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -91,17 +91,16 @@ namespace Voron.Data.Tables
         {
             get
             {
-                if (_activeDataSmallSection == null)
-                {
-                    var readResult = _tableTree.Read(TableSchema.ActiveSectionSlice);
-                    if (readResult == null)
-                        throw new VoronErrorException($"Could not find active sections for {Name}");
+                if (_activeDataSmallSection != null) 
+                    return _activeDataSmallSection;
+                
+                if (_tableTree.TryRead(TableSchema.ActiveSectionSlice, out var reader) == false)
+                    throw new VoronErrorException($"Could not find active sections for {Name}");
 
-                    long pageNumber = readResult.Reader.ReadLittleEndianInt64();
+                long pageNumber = reader.Read<long>();
 
-                    _activeDataSmallSection = new ActiveRawDataSmallSection(_tx, pageNumber);
-                    _activeDataSmallSection.DataMoved += OnDataMoved;
-                }
+                _activeDataSmallSection = new ActiveRawDataSmallSection(_tx, pageNumber);
+                _activeDataSmallSection.DataMoved += OnDataMoved;
                 return _activeDataSmallSection;
             }
         }
@@ -198,7 +197,7 @@ namespace Voron.Data.Tables
                     return false;
                 }
 
-                var storageId = read.CreateReader().ReadLittleEndianInt64();
+                var storageId = read.CreateReader().Read<long>();
 
                 ReadById(storageId, out reader);
                 return true;
@@ -208,19 +207,23 @@ namespace Voron.Data.Tables
         public bool VerifyKeyExists(Slice key)
         {
             var pkTree = GetTree(_schema.Key);
-            var readResult = pkTree?.Read(key);
-            return readResult != null;
+            if (pkTree == null)
+                return false;
+
+            return pkTree.TryRead(key, out _);
         }
 
         private bool TryFindIdFromPrimaryKey(Slice key, out long id)
         {
             id = -1;
             var pkTree = GetTree(_schema.Key);
-            var readResult = pkTree?.Read(key);
-            if (readResult == null)
+            if (pkTree == null)
                 return false;
 
-            id = readResult.Reader.ReadLittleEndianInt64();
+            if (pkTree.TryRead(key, out var reader) == false)
+                return false;
+            
+            id = reader.Read<long>();
             return true;
         }
 
@@ -814,7 +817,7 @@ namespace Voron.Data.Tables
 
                     do
                     {
-                        var id = iterator.CurrentKey.CreateReader().ReadBigEndianInt32();
+                        var id = iterator.CurrentKey.CreateReader().ReadBigEndian<int>();
                         var dict = CreateCompressionDictionary(tx, id);
                         yield return dict;
                     } while (iterator.MoveNext());
@@ -1246,13 +1249,11 @@ namespace Voron.Data.Tables
             AssertWritableTable();
 
             var pkTree = GetTree(_schema.Key);
-
-            var readResult = pkTree.Read(key);
-            if (readResult == null)
+            if (pkTree.TryRead(key, out var reader) == false)
                 return false;
 
             // This is an implementation detail. We read the absolute location pointer (absolute offset on the file)
-            var id = readResult.Reader.ReadLittleEndianInt64();
+            var id = reader.Read<long>();
 
             // And delete the element accordingly.
             Delete(id);
@@ -1671,7 +1672,7 @@ namespace Voron.Data.Tables
 
                         while (true)
                         {
-                            var id = it.CreateReaderForCurrent().ReadLittleEndianInt64();
+                            var id = it.CreateReaderForCurrent().Read<long>();
                             var ptr = DirectRead(id, out int size);
 
                             tableValueHolder ??= new TableValueHolder();
@@ -2043,7 +2044,7 @@ namespace Voron.Data.Tables
 
         private void GetTableValueReader(IIterator it, out TableValueReader reader)
         {
-            var id = it.CreateReaderForCurrent().ReadLittleEndianInt64();
+            var id = it.CreateReaderForCurrent().Read<long>();
             var ptr = DirectRead(id, out int size);
             reader = new TableValueReader(id, ptr, size);
         }
@@ -2093,7 +2094,7 @@ namespace Voron.Data.Tables
                     if (it.CurrentKey > value)
                         return deleted;
 
-                    Delete(it.CreateReaderForCurrent().ReadLittleEndianInt64());
+                    Delete(it.CreateReaderForCurrent().Read<long>());
                     deleted++;
                 }
             }
@@ -2133,7 +2134,7 @@ namespace Voron.Data.Tables
                 if (it.CurrentKey != value)
                     return false;
 
-                Delete(it.CreateReaderForCurrent().ReadLittleEndianInt64());
+                Delete(it.CreateReaderForCurrent().Read<long>());
                 return true;
             }
         }
@@ -2154,7 +2155,7 @@ namespace Voron.Data.Tables
                     if (it.Seek(it.RequiredPrefix) == false)
                         return deleted;
 
-                    long id = it.CreateReaderForCurrent().ReadLittleEndianInt64();
+                    long id = it.CreateReaderForCurrent().Read<long>();
 
                     if (beforeDelete != null || shouldAbort != null)
                     {
@@ -2242,7 +2243,7 @@ namespace Voron.Data.Tables
                     if (it.Seek(it.RequiredPrefix) == false)
                         return false;
 
-                    var id = it.CreateReaderForCurrent().ReadLittleEndianInt64();
+                    var id = it.CreateReaderForCurrent().Read<long>();
                     var ptr = DirectRead(id, out int size);
 
                     if (tableValueHolder == null)

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1226,6 +1226,8 @@ namespace Voron.Data.Tables
 
         internal Tree GetTree(AbstractTreeIndexDef idx)
         {
+            DisposableExceptions.ThrowIfDisposedOnDebug(_tx);
+            
             Tree tree;
             if (idx.IsGlobal)
             {
@@ -1235,8 +1237,7 @@ namespace Voron.Data.Tables
             {
                 tree = GetTree(idx.Name, true);
             }
-                
-            tree?.AssertNotDisposed();
+
             return tree;
         }
 

--- a/src/Voron/Data/Tables/TableValueCompressor.cs
+++ b/src/Voron/Data/Tables/TableValueCompressor.cs
@@ -169,7 +169,7 @@ namespace Voron.Data.Tables
 
                     do
                     {
-                        long id = it.CreateReaderForCurrent().ReadLittleEndianInt64();
+                        long id = it.CreateReaderForCurrent().Read<long>();
                         var size = table.GetSize(id);
 
                         if (size > 32 * 1024)
@@ -365,7 +365,7 @@ namespace Voron.Data.Tables
 
                     do
                     {
-                        var dicId = it.CurrentKey.CreateReader().ReadBigEndianInt32();
+                        var dicId = it.CurrentKey.CreateReader().ReadBigEndian<int>();
                         var entry = zip.CreateEntry($"{dicId:D8}.dic",
                             obj.Environment.Options.Encryption.IsEnabled ? CompressionLevel.NoCompression : CompressionLevel.Optimal);
 

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -125,7 +125,7 @@ namespace Voron.Debugging
                         do
                         {
                             ReadResult readResult = tree.Read(it.CurrentKey);
-                            RootObjectType rootObjectType = (RootObjectType)readResult.Reader.ReadByte();
+                            RootObjectType rootObjectType = (RootObjectType)readResult.Reader.Read<byte>();
                             switch (rootObjectType)
                             {
                                 case RootObjectType.Lookup:

--- a/src/Voron/Exceptions/VoronUnrecoverableErrorException.cs
+++ b/src/Voron/Exceptions/VoronUnrecoverableErrorException.cs
@@ -13,6 +13,7 @@ namespace Voron.Exceptions
 {
     public class VoronUnrecoverableErrorException : Exception
     {
+        [DoesNotReturn]
         public static void Raise(LowLevelTransaction tx, string message)
         {
             try
@@ -43,6 +44,7 @@ namespace Voron.Exceptions
             }
         }
 
+        [DoesNotReturn]
         public static void Raise(StorageEnvironmentOptions options, string message)
         {
             try
@@ -57,6 +59,7 @@ namespace Voron.Exceptions
             }
         }
 
+        [DoesNotReturn]
         public static void Raise(StorageEnvironment env, string message, Exception inner)
         {
             try
@@ -70,7 +73,8 @@ namespace Voron.Exceptions
                 throw;
             }
         }
-        
+
+        [DoesNotReturn]
         public static void Raise(StorageEnvironmentOptions options, string message, Exception inner)
         {
             try
@@ -85,7 +89,7 @@ namespace Voron.Exceptions
             }
         }
 
-
+        [DoesNotReturn]
         public static void Raise(string message, Exception inner)
         {
             throw new VoronUnrecoverableErrorException(message, inner);
@@ -100,6 +104,5 @@ namespace Voron.Exceptions
             : base(message, inner)
         {
         }
-
     }
 }

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -55,7 +55,7 @@ namespace Voron.Impl.FreeSpace
             if (!BitConverter.IsLittleEndian)
                 throw new NotSupportedException("Big endian conversion is not supported yet.");
 
-            SetCount = reader.ReadLittleEndianInt32();
+            SetCount = reader.Read<int>();
 
             unsafe
             {

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -468,7 +468,7 @@ namespace Voron.Impl
         {
             if (_state.Root != null)
             {
-                _root = Tree.GetRoot(this, Constants.RootTreeNameSlice, _state.Root);
+                _root = Tree.GetRoot(this, _state.Root);
             }
         }
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -34,7 +34,7 @@ using Constants = Voron.Global.Constants;
 
 namespace Voron.Impl
 {
-    public sealed unsafe class LowLevelTransaction : IPagerLevelTransactionState
+    public sealed unsafe class LowLevelTransaction : IPagerLevelTransactionState, IDisposableQueryable
     {
         public readonly AbstractPager DataPager;
         private readonly StorageEnvironment _env;

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -468,7 +468,7 @@ namespace Voron.Impl
         {
             if (_state.Root != null)
             {
-                _root = new Tree(this, null, Constants.RootTreeNameSlice, _state.Root);
+                _root = Tree.GetRoot(this, Constants.RootTreeNameSlice, _state.Root);
             }
         }
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -202,7 +202,7 @@ namespace Voron.Impl
             {
                 CopyPagerStatesFromPreviousTx(previous);
 
-                _pageLocator = transactionPersistentContext.AllocatePageLocator(this);
+                _pageLocator = transactionPersistentContext.AllocatePageLocator();
 
                 _scratchPagerStates = previous._scratchPagerStates;
 
@@ -301,7 +301,7 @@ namespace Voron.Impl
 
                 _state = previous._state.Clone();
 
-                _pageLocator = PersistentContext.AllocatePageLocator(this);
+                _pageLocator = PersistentContext.AllocatePageLocator();
                 InitializeRoots();
                 InitTransactionHeader();
             }
@@ -372,7 +372,7 @@ namespace Voron.Impl
                     EnsurePagerStateReference(ref pagerState);
                 }
 
-                _pageLocator = transactionPersistentContext.AllocatePageLocator(this);
+                _pageLocator = transactionPersistentContext.AllocatePageLocator();
 
                 switch (flags)
                 {

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -482,7 +482,6 @@ namespace Voron.Impl
             UncompressedSize = 0
         };
 
-
         private void InitTransactionHeader()
         {
             if (_id > 1 && _state.NextPageNumber <= 1)

--- a/src/Voron/Impl/PagerState.cs
+++ b/src/Voron/Impl/PagerState.cs
@@ -26,7 +26,7 @@ namespace Voron.Impl
 
             public override string ToString()
             {
-                return $"{nameof(BaseAddress)}: {new IntPtr(BaseAddress).ToString("x")} - {new IntPtr(BaseAddress + Size).ToString("x")} {nameof(Size)}: {Size}";
+                return $"{nameof(BaseAddress)}: {new IntPtr(BaseAddress):x} - {new IntPtr(BaseAddress + Size):x} {nameof(Size)}: {Size}";
             }
         }
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -156,11 +156,17 @@ namespace Voron.Impl
                 return LookupFor<TKey>(nameSlice);
             }
         }
+        
         public Lookup<TKey> LookupFor<TKey>(Slice name) where TKey : struct, ILookupKey
         {
             return LowLevelTransaction.RootObjects.LookupFor<TKey>(name);
         }
 
+        public bool TryGetLookupFor<TKey>(Slice name, out Lookup<TKey> lookup) where TKey : struct, ILookupKey
+        {
+            return LowLevelTransaction.RootObjects.TryGetLookupFor(name, out lookup);
+        }
+        
         public long OpenContainer(Slice name)
         {
             var exists = LowLevelTransaction.RootObjects.DirectRead(name);
@@ -507,6 +513,11 @@ namespace Voron.Impl
             return CompactTreeFor(treeNameSlice);
         }
 
+        public bool TryGetCompactTreeFor(Slice treeName, out CompactTree tree)
+        {
+            return _lowLevelTransaction.RootObjects.TryGetCompactTreeFor(treeName, out tree);
+        }
+        
         public CompactTree CompactTreeFor(Slice treeName)
         {
             return _lowLevelTransaction.RootObjects.CompactTreeFor(treeName);

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -453,10 +453,10 @@ namespace Voron.Impl
                 Throw<InvalidOperationException>($"Cannot create a tree with reserved name: {toName}");
 
             var existingTree = ReadTree(toName);
-            ThrowIfNotNull<ArgumentException>(existingTree,() => $"Cannot rename a tree with the name of an existing tree: {toName}");
+            ThrowIfNotNull<ArgumentException>(existingTree,$"Cannot rename a tree with the name of an existing tree: {toName}");
 
             Tree fromTree = ReadTree(fromName);
-            ThrowIfNull<ArgumentException>(fromTree, () => $"Tree {fromName} does not exists");
+            ThrowIfNull<ArgumentException>(fromTree, $"Tree {fromName} does not exists");
 
             _lowLevelTransaction.RootObjects.Delete(fromName);
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -17,6 +17,8 @@ using Voron.Data.RawData;
 using Voron.Data.PostingLists;
 using Constants = Voron.Global.Constants;
 using System.Diagnostics.CodeAnalysis;
+using static Sparrow.PortableExceptions;
+using static Voron.VoronExceptions;
 
 namespace Voron.Impl
 {
@@ -99,9 +101,8 @@ namespace Voron.Impl
             var header = (TreeRootHeader*)_lowLevelTransaction.RootObjects.DirectRead(treeName);
             if (header != null)
             {
-                if (header->RootObjectType != type)
-                    ThrowInvalidTreeType(treeName, type, header);
-
+                ThrowIf<InvalidOperationException>(header->RootObjectType != type, $"Tried to open {treeName} as a {type}, but it is actually a {header->RootObjectType}");
+                    
                 tree = Tree.Open(_lowLevelTransaction, this, treeName, *header, isIndexTree, newPageAllocator);
 
                 _trees.Add(treeName, tree);
@@ -111,13 +112,6 @@ namespace Voron.Impl
 
             _trees.Add(treeName, null);
             return null;
-        }
-
-        [DoesNotReturn]
-        private static void ThrowInvalidTreeType(Slice treeName, RootObjectType type, TreeRootHeader* header)
-        {
-            throw new InvalidOperationException($"Tried to open {treeName} as a {type}, but it is actually a " +
-                                                header->RootObjectType);
         }
 
         public void Commit()
@@ -132,7 +126,7 @@ namespace Voron.Impl
 
         public Transaction BeginAsyncCommitAndStartNewTransaction(TransactionPersistentContext persistentContext)
         {
-            VoronExceptions.ThrowIfReadOnly(_lowLevelTransaction, "Cannot call begin async commit on read tx");
+            ThrowIfReadOnly(_lowLevelTransaction, "Cannot call begin async commit on read tx");
 
             PrepareForCommit();
             
@@ -393,7 +387,7 @@ namespace Voron.Impl
 
         public void DeleteTree(Slice name)
         {
-            VoronExceptions.ThrowIfReadOnly(_lowLevelTransaction, "Cannot create a new newRootTree with a read only transaction");
+            ThrowIfReadOnly(_lowLevelTransaction, "Cannot create a new newRootTree with a read only transaction");
 
             Tree tree = ReadTree(name);
             if (tree == null)
@@ -445,17 +439,16 @@ namespace Voron.Impl
 
         public void RenameTree(Slice fromName, Slice toName)
         {
-            VoronExceptions.ThrowIfReadOnly(_lowLevelTransaction, "Cannot rename a new tree with a read only transaction");
+            ThrowIfReadOnly(_lowLevelTransaction, "Cannot rename a new tree with a read only transaction");
 
             if (SliceComparer.Equals(toName, Constants.RootTreeNameSlice))
-                throw new InvalidOperationException("Cannot create a tree with reserved name: " + toName);
+                Throw<InvalidOperationException>($"Cannot create a tree with reserved name: {toName}");
 
-            if (ReadTree(toName) != null)
-                throw new ArgumentException("Cannot rename a tree with the name of an existing tree: " + toName);
+            var existingTree = ReadTree(toName);
+            ThrowIfNotNull<ArgumentException>(existingTree,$"Cannot rename a tree with the name of an existing tree: {toName}");
 
             Tree fromTree = ReadTree(fromName);
-            if (fromTree == null)
-                throw new ArgumentException("Tree " + fromName + " does not exists");
+            ThrowIfNull<ArgumentException>(fromTree, $"Tree {fromName} does not exists");
 
             _lowLevelTransaction.RootObjects.Delete(fromName);
 
@@ -484,7 +477,7 @@ namespace Voron.Impl
             if (tree != null)
                 return tree;
 
-            VoronExceptions.ThrowIfReadOnly(_lowLevelTransaction, $"No such tree: '{name}' and cannot create trees in read transactions");
+            ThrowIfReadOnly(_lowLevelTransaction, $"No such tree: '{name}' and cannot create trees in read transactions");
 
             tree = Tree.Create(_lowLevelTransaction, this, name, flags, type, isIndexTree, newPageAllocator);
             ref var state = ref tree.State.Modify();

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -452,10 +452,10 @@ namespace Voron.Impl
                 Throw<InvalidOperationException>($"Cannot create a tree with reserved name: {toName}");
 
             var existingTree = ReadTree(toName);
-            ThrowIfNotNull<ArgumentException>(existingTree,$"Cannot rename a tree with the name of an existing tree: {toName}");
+            ThrowIfNotNull<ArgumentException>(existingTree,() => $"Cannot rename a tree with the name of an existing tree: {toName}");
 
             Tree fromTree = ReadTree(fromName);
-            ThrowIfNull<ArgumentException>(fromTree, $"Tree {fromName} does not exists");
+            ThrowIfNull<ArgumentException>(fromTree, () => $"Tree {fromName} does not exists");
 
             _lowLevelTransaction.RootObjects.Delete(fromName);
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -2,27 +2,28 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Sparrow;
+using Sparrow.Json;
+using Sparrow.Server;
 using Voron.Data;
 using Voron.Data.BTrees;
 using Voron.Data.Fixed;
 using Voron.Data.Tables;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using Sparrow.Json;
-using Sparrow.Server;
 using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Voron.Data.RawData;
 using Voron.Data.PostingLists;
 using Constants = Voron.Global.Constants;
-using System.Diagnostics.CodeAnalysis;
+
 using static Sparrow.PortableExceptions;
 using static Voron.VoronExceptions;
 
 namespace Voron.Impl
 {
-    public sealed unsafe class Transaction : IDisposable
+    public sealed unsafe class Transaction : IDisposable, IDisposableQueryable
     {
         public LowLevelTransaction LowLevelTransaction
         {
@@ -490,6 +491,8 @@ namespace Voron.Impl
 
             return tree;
         }
+
+        bool IDisposableQueryable.IsDisposed => _lowLevelTransaction == null || _lowLevelTransaction.IsDisposed;
         
         public void Dispose()
         {
@@ -694,16 +697,10 @@ namespace Voron.Impl
             return state;
         }
 
-        private readonly struct TableKey
+        private readonly struct TableKey(Slice tableName, bool compressed)
         {
-            private readonly Slice _tableName;
-            private readonly bool _compressed;
-
-            public TableKey(Slice tableName, bool compressed)
-            {
-                _tableName = tableName;
-                _compressed = compressed;
-            }
+            private readonly Slice _tableName = tableName;
+            private readonly bool _compressed = compressed;
 
             private bool Equals(TableKey other) =>
                 SliceComparer.Equals(_tableName, other._tableName) && _compressed == other._compressed;

--- a/src/Voron/ReadResult.cs
+++ b/src/Voron/ReadResult.cs
@@ -1,12 +1,7 @@
 namespace Voron
 {
-    public class ReadResult
+    public class ReadResult(ValueReader reader)
     {
-        public ReadResult(ValueReader reader)
-        {
-            Reader = reader;
-        }
-         
-        public ValueReader Reader { get; private set; }
+        public ValueReader Reader { get; private set; } = reader;
     }
 }

--- a/src/Voron/Slice.cs
+++ b/src/Voron/Slice.cs
@@ -301,18 +301,6 @@ namespace Voron
             return new ValueReader(Content.Ptr, Size);
         }
 
-        public long ReadInt64()
-        {
-            Debug.Assert(Size == sizeof(long));
-            return *(long*)Content.Ptr;
-        }
-        
-        public double ReadDouble()
-        {
-            Debug.Assert(Size == sizeof(double));
-            return *(double*)Content.Ptr;
-        }
-
         public override int GetHashCode()
         {
             return this.Content.GetHashCode();

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -330,7 +330,7 @@ namespace Voron
                 var buffer = new byte[16];
                 Debug.Assert(dbId != null);
                 // ReSharper disable once PossibleNullReferenceException
-                var dbIdBytes = dbId.Reader.Read(buffer, 0, 16);
+                var dbIdBytes = dbId.Reader.Read(buffer, 16);
                 if (dbIdBytes != 16)
                     VoronUnrecoverableErrorException.Raise(tx,
                         "The db id value in metadata tree wasn't 16 bytes in size, possible mismatch / corruption?");
@@ -369,7 +369,7 @@ namespace Voron
                     if (schemaVersion == null)
                         SchemaErrorException.Raise(this, "Could not find schema version in metadata tree, possible mismatch / corruption?");
 
-                    schemaVersionVal = schemaVersion.Reader.ReadLittleEndianInt32();
+                    schemaVersionVal = schemaVersion.Reader.Read<int>();
                     Options.OnVersionReadingTransaction?.Invoke(readTx);
                 }
 
@@ -1150,7 +1150,7 @@ namespace Voron
                                     {
                                         do
                                         {
-                                            var rootObjectType = (RootObjectType)it.CreateReaderForCurrent().ReadByte();
+                                            var rootObjectType = (RootObjectType)it.CreateReaderForCurrent().Read<byte>();
                                             switch (rootObjectType)
                                             {
                                                 case RootObjectType.Lookup:
@@ -1216,7 +1216,7 @@ namespace Voron
                                 RegisterTableSection(tableTree, name, TableSchema.ActiveCandidateSectionSlice);
                                 RegisterTableSection(tableTree, name, TableSchema.InactiveSectionSlice);
                                 var readResult = tableTree.Read(TableSchema.ActiveSectionSlice);
-                                long pageNumber = readResult.Reader.ReadLittleEndianInt64();
+                                long pageNumber = readResult.Reader.Read<long>();
                                 var activeDataSmallSection = new ActiveRawDataSmallSection(tx, pageNumber);
                                 // off by one here because of the section header
                                 r.Add(activeDataSmallSection.PageNumber, name + "/" + TableSchema.ActiveSectionSlice + "/header");

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -906,18 +906,11 @@ namespace Voron
             return false;
         }
 
-        public struct ExitWriteLock : IDisposable
+        public readonly struct ExitWriteLock(ReaderWriterLockSlim rwls) : IDisposable
         {
-            private readonly ReaderWriterLockSlim _rwls;
-
-            public ExitWriteLock(ReaderWriterLockSlim rwls)
-            {
-                _rwls = rwls;
-            }
-
             public void Dispose()
             {
-                _rwls?.ExitWriteLock();
+                rwls?.ExitWriteLock();
             }
         }
 

--- a/src/Voron/TransactionPersistentContext.cs
+++ b/src/Voron/TransactionPersistentContext.cs
@@ -5,28 +5,16 @@ using Voron.Impl;
 
 namespace Voron
 {
-    public sealed class TransactionPersistentContext
+    public sealed class TransactionPersistentContext(bool longLivedTransactions = false)
     {
-        private bool _longLivedTransaction;
+        public bool LongLivedTransactions { get; set; } = longLivedTransactions;
+        
 
-        public bool LongLivedTransactions
-        {
-            get { return _longLivedTransaction; }
-            set
-            {
-                _longLivedTransaction = value;
-            }
-        }
-
-        private readonly Stack<PageLocator> _pageLocators = new Stack<PageLocator>();
-
-        public TransactionPersistentContext(bool longLivedTransactions = false)
-        {
-            LongLivedTransactions = longLivedTransactions;
-        }
+        private readonly Stack<PageLocator> _pageLocators = new();
+        
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public PageLocator AllocatePageLocator(LowLevelTransaction tx)
+        public PageLocator AllocatePageLocator()
         {
             PageLocator locator;
             if (_pageLocators.Count != 0)

--- a/src/Voron/Util/DataCopier.cs
+++ b/src/Voron/Util/DataCopier.cs
@@ -76,7 +76,7 @@ namespace Voron.Util
             }
 
             var totalSecElapsed = Math.Max((double)totalSw.ElapsedMilliseconds / 1000, 0.0001);
-            infoNotify?.Invoke($"Finshed copying {new Size(totalCopied, SizeUnit.Bytes)}, " +
+            infoNotify?.Invoke($"Finished copying {new Size(totalCopied, SizeUnit.Bytes)}, " +
                                 $"{new Size((long)(totalCopied / totalSecElapsed), SizeUnit.Bytes)}/sec");
         }
 
@@ -126,7 +126,7 @@ namespace Voron.Util
             }
 
             var totalSecElapsed = Math.Max((double)totalSw.ElapsedMilliseconds / 1000, 0.0001);
-            infoNotify?.Invoke($"Finshed copying {new Size(totalCopied, SizeUnit.Bytes)}, " +
+            infoNotify?.Invoke($"Finished copying {new Size(totalCopied, SizeUnit.Bytes)}, " +
                                 $"{new Size((long)(totalCopied / totalSecElapsed), SizeUnit.Bytes)}/sec");
 
             Debug.Assert(numberOf4KbsToCopy == 0);

--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -16,10 +16,10 @@ namespace Voron.Util;
 /// ContextBoundNativeList of T is the high level primitive that should be used for most uses and purposes. For example, there are cases where the
 /// NativeList has to contain other native lists, therefore, the requirement of NativeList of T to be completely unmanaged is important for those uses.
 /// </summary>
-public unsafe struct NativeList<T>
-    where T: unmanaged
+public unsafe struct NativeList<T>()
+    where T : unmanaged
 {
-    private ByteString _storage;
+    private ByteString _storage = default;
 
     public T* RawItems => Capacity > 0 ? (T*)_storage.Ptr : null;
 
@@ -29,11 +29,6 @@ public unsafe struct NativeList<T>
     public readonly Span<T> ToSpan() => Count == 0 ? Span<T>.Empty : new Span<T>(_storage.Ptr, Count);
     
     public bool IsValid => RawItems != null;
-
-    public NativeList()
-    {
-        _storage = default;
-    }
 
     public ref T this[int index]
     {

--- a/src/Voron/Util/PFor/MaskEntries.cs
+++ b/src/Voron/Util/PFor/MaskEntries.cs
@@ -2,14 +2,10 @@
 
 namespace Voron.Util.PFor;
 
-public struct MaskEntries : ISimdTransform
+public readonly struct MaskEntries(uint mask) : ISimdTransform
 {
-    private readonly Vector256<uint> _mask;
+    private readonly Vector256<uint> _mask = Vector256.Create(mask);
 
-    public MaskEntries(uint mask)
-    {
-        _mask = Vector256.Create(mask);
-    }
     public Vector256<uint> Decode(Vector256<uint> curr, ref Vector256<uint> prev)
     {
         return curr;

--- a/src/Voron/VoronExceptions.cs
+++ b/src/Voron/VoronExceptions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Voron.Impl;
+
+namespace Voron
+{
+    public static class VoronExceptions
+    {
+        public static void ThrowIfReadOnly(LowLevelTransaction tx, string message = "A write transaction is required for this operation")
+        {
+            if (tx.Flags == TransactionFlags.Read)
+                throw new InvalidOperationException(message);
+        }
+
+        public static void ThrowIfReadOnly(Transaction tx, string message = "A write transaction is required for this operation")
+        {
+            if (tx.LowLevelTransaction.Flags == TransactionFlags.Read)
+                throw new InvalidOperationException(message);
+        }
+
+        public static void ThrowIfNull(Slice argument, [CallerArgumentExpression(nameof(argument))] string paramName = null)
+        {
+            if (argument.HasValue == false)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+        }
+    }
+}

--- a/test/FastTests/Voron/FixedSize/SimpleFixedSizeTrees.cs
+++ b/test/FastTests/Voron/FixedSize/SimpleFixedSizeTrees.cs
@@ -268,7 +268,7 @@ namespace FastTests.Voron.FixedSize
                     {
                         Assert.True(fst.Contains(i), i.ToString());
                         using (fst.Read(i, out read))
-                            Assert.Equal(i + 10L, read.CreateReader().ReadLittleEndianInt64());
+                            Assert.Equal(i + 10L, read.CreateReader().Read<long>());
                     }
                 }
                 tx.Commit();
@@ -326,7 +326,7 @@ namespace FastTests.Voron.FixedSize
                     {
                         Assert.True(fst.Contains(i), i.ToString());
                         using (fst.Read(i, out read))
-                            Assert.Equal(i + 10L, read.CreateReader().ReadLittleEndianInt64());
+                            Assert.Equal(i + 10L, read.CreateReader().Read<long>());
                     }
                 }
                 for (int i = 30; i <= 40; i++)
@@ -341,7 +341,7 @@ namespace FastTests.Voron.FixedSize
                     {
                         Assert.True(fst.Contains(i), i.ToString());
                         using (fst.Read(i, out read))
-                            Assert.Equal(i + 10L, read.CreateReader().ReadLittleEndianInt64());
+                            Assert.Equal(i + 10L, read.CreateReader().Read<long>());
                     }
                 }
                 tx.Commit();
@@ -415,10 +415,10 @@ namespace FastTests.Voron.FixedSize
                 Slice read;
 
                 using (fst.Read(1, out read))
-                    Assert.Equal(1L, read.CreateReader().ReadLittleEndianInt64());
+                    Assert.Equal(1L, read.CreateReader().Read<long>());
 
                 using (fst.Read(2, out read))
-                    Assert.Equal(2L, read.CreateReader().ReadLittleEndianInt64());
+                    Assert.Equal(2L, read.CreateReader().Read<long>());
                 using (fst.Read(3, out read))
                     Assert.False(read.HasValue);
                 tx.Commit();
@@ -460,11 +460,11 @@ namespace FastTests.Voron.FixedSize
 
                 Slice read;
                 using (fst.Read(1, out read))
-                    Assert.Equal(1L, read.CreateReader().ReadLittleEndianInt64());
+                    Assert.Equal(1L, read.CreateReader().Read<long>());
                 using (fst.Read(2, out read))
                     Assert.False(read.HasValue);
                 using (fst.Read(3, out read))
-                    Assert.Equal(3L, read.CreateReader().ReadLittleEndianInt64());
+                    Assert.Equal(3L, read.CreateReader().Read<long>());
                 tx.Commit();
             }
         }

--- a/test/FastTests/Voron/Tables/CompositeIndex.cs
+++ b/test/FastTests/Voron/Tables/CompositeIndex.cs
@@ -44,7 +44,7 @@ namespace FastTests.Voron.Tables
 
                     var valueReader = reader.Key.CreateReader();
                     Assert.Equal("Users", valueReader.ReadString(5));
-                    Assert.Equal(1L, valueReader.ReadBigEndianInt64());
+                    Assert.Equal(1L, valueReader.ReadBigEndian<long>());
                     var handle = reader.Result.Reader;
                     int size;
                     Assert.Equal("{'Name': 'Oren'}", Encoding.UTF8.GetString(handle.Read(3, out size), size));
@@ -54,7 +54,7 @@ namespace FastTests.Voron.Tables
 
                     valueReader = reader.Key.CreateReader();
                     Assert.Equal("Users", valueReader.ReadString(5));
-                    Assert.Equal(2L, valueReader.ReadBigEndianInt64());
+                    Assert.Equal(2L, valueReader.ReadBigEndian<long>());
                     handle = reader.Result.Reader;
                     Assert.Equal("{'Name': 'Eini'}", Encoding.UTF8.GetString(handle.Read(3, out size), size));
 
@@ -147,7 +147,7 @@ namespace FastTests.Voron.Tables
                     {
                         var valueReader = reader.Key.CreateReader();
                         Assert.Equal("Users", valueReader.ReadString(5));
-                        Assert.Equal(2L, valueReader.ReadBigEndianInt64());
+                        Assert.Equal(2L, valueReader.ReadBigEndian<long>());
 
                         var handle = reader.Result;
                         int size;

--- a/test/FastTests/Voron/Tables/SecondayIndex.cs
+++ b/test/FastTests/Voron/Tables/SecondayIndex.cs
@@ -42,7 +42,7 @@ namespace FastTests.Voron.Tables
                 {
                     foreach (var reader in docs.SeekForwardFrom(DocsSchema.Indexes[EtagsSlice], etag, 0))
                     {
-                        Assert.Equal(1L, reader.Key.CreateReader().ReadBigEndianInt64());
+                        Assert.Equal(1L, reader.Key.CreateReader().ReadBigEndian<long>());
                         var handle = reader.Result.Reader;
                         int size;
                         Assert.Equal("{'Name': 'Oren'}", Encoding.UTF8.GetString(handle.Read(3, out size), size));
@@ -136,7 +136,7 @@ namespace FastTests.Voron.Tables
                 {
                     foreach (var reader in docs.SeekForwardFrom(DocsSchema.Indexes[EtagsSlice], etag, 0))
                     {
-                        Assert.Equal(2L, reader.Key.CreateReader().ReadBigEndianInt64());
+                        Assert.Equal(2L, reader.Key.CreateReader().ReadBigEndian<long>());
 
                         var handle = reader.Result;
                         int size;

--- a/test/FastTests/Voron/Trees/TreeRenaming.cs
+++ b/test/FastTests/Voron/Trees/TreeRenaming.cs
@@ -5,20 +5,17 @@
 // -----------------------------------------------------------------------
 
 using System;
+using Tests.Infrastructure;
 using Xunit;
 using Voron.Global;
 using Xunit.Abstractions;
-using Elastic.Clients.Elasticsearch;
+
 
 namespace FastTests.Voron.Trees
 {
-    public class TreeRenaming : StorageTest
+    public class TreeRenaming(ITestOutputHelper output) : StorageTest(output)
     {
-        public TreeRenaming(ITestOutputHelper output) : base(output)
-        {
-        }
-
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void CanRenameTree()
         {
             using (var tx = Env.WriteTransaction())
@@ -54,7 +51,7 @@ namespace FastTests.Voron.Trees
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldNotAllowToRenameTreeIfTreeAlreadyExists()
         {
             using (var tx = Env.WriteTransaction())
@@ -68,7 +65,7 @@ namespace FastTests.Voron.Trees
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldThrowIfTreeDoesNotExist()
         {
             using (var tx = Env.WriteTransaction())
@@ -79,7 +76,7 @@ namespace FastTests.Voron.Trees
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void MustNotRenameToRootAndFreeSpaceRootTrees()
         {
             using (var tx = Env.WriteTransaction())
@@ -89,7 +86,7 @@ namespace FastTests.Voron.Trees
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void ShouldPreventFromRenamingTreeInReadTransaction()
         {
             using (var tx = Env.ReadTransaction())

--- a/test/FastTests/Voron/Trees/TreeRenaming.cs
+++ b/test/FastTests/Voron/Trees/TreeRenaming.cs
@@ -93,7 +93,7 @@ namespace FastTests.Voron.Trees
         {
             using (var tx = Env.ReadTransaction())
             {
-                var ae = Assert.Throws<ArgumentException>(() => tx.RenameTree( "tree_1", "tree_2"));
+                var ae = Assert.Throws<InvalidOperationException>(() => tx.RenameTree( "tree_1", "tree_2"));
 
                 Assert.Equal("Cannot rename a new tree with a read only transaction", ae.Message);
             }

--- a/test/FastTests/Voron/Trees/TreeRenaming.cs
+++ b/test/FastTests/Voron/Trees/TreeRenaming.cs
@@ -8,6 +8,7 @@ using System;
 using Xunit;
 using Voron.Global;
 using Xunit.Abstractions;
+using Elastic.Clients.Elasticsearch;
 
 namespace FastTests.Voron.Trees
 {
@@ -63,7 +64,7 @@ namespace FastTests.Voron.Trees
 
                 var ae = Assert.Throws<ArgumentException>(() => tx.RenameTree("tree_1", "tree_2"));
 
-                Assert.Equal("Cannot rename a tree with the name of an existing tree: tree_2", ae.Message);
+                Assert.StartsWith("Cannot rename a tree with the name of an existing tree: tree_2", ae.Message);
             }
         }
 
@@ -74,7 +75,7 @@ namespace FastTests.Voron.Trees
             {
                 var ae = Assert.Throws<ArgumentException>(() => tx.RenameTree( "tree_1", "tree_2"));
 
-                Assert.Equal("Tree tree_1 does not exists", ae.Message);
+                Assert.StartsWith("Tree tree_1 does not exists", ae.Message);
             }
         }
 

--- a/test/SlowTests/Voron/LargeFixedSizeTrees.cs
+++ b/test/SlowTests/Voron/LargeFixedSizeTrees.cs
@@ -104,7 +104,7 @@ namespace SlowTests.Voron
                     Assert.True(it.Seek(long.MinValue));
                     do
                     {
-                        Assert.Equal(total++, it.CreateReaderForCurrent().ReadLittleEndianInt64());
+                        Assert.Equal(total++, it.CreateReaderForCurrent().Read<long>());
                     }
                     while (it.MoveNext());
                 }
@@ -230,7 +230,7 @@ namespace SlowTests.Voron
                         Slice read;
                         using (fst.Read(i, out read))
                         {
-                            Assert.Equal(i, read.CreateReader().ReadLittleEndianInt64());
+                            Assert.Equal(i, read.CreateReader().Read<long>());
                         }
                     }
                 }

--- a/test/SlowTests/Voron/Storage/Increments.cs
+++ b/test/SlowTests/Voron/Storage/Increments.cs
@@ -46,7 +46,7 @@ namespace SlowTests.Voron.Storage
                 var read = tx.ReadTree("tree0").Read("key/1");
 
                 Assert.NotNull(read);
-                Assert.Equal(12, read.Reader.ReadLittleEndianInt64());
+                Assert.Equal(12, read.Reader.Read<long>());
             }
         }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22261

### Additional description

This is a series of commits aimed at homogenizing the external API of Voron data structures in order to simplify the code and avoid edge cases that arise from inconsistent usage patterns along the codebase.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
