### PR TITLE
RavenDB-22305 - Missing DirtyMemory from the memory notification

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/MemoryUsageNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/MemoryUsageNotificationSender.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
                 EncryptionBuffersInUse = encryptionBuffers.CurrentlyInUseSize,
                 EncryptionBuffersPool = encryptionBuffers.TotalPoolSize,
                 MemoryMapped = totalMapping,
-                DirtyMemory = dirtyMemoryState.TotalDirtyInBytes,
+                DirtyMemory = dirtyMemoryState.TotalDirty.GetValue(SizeUnit.Bytes),
                 AvailableMemory = memoryInfo.AvailableMemory.GetValue(SizeUnit.Bytes),
                 AvailableMemoryForProcessing = memoryInfo.AvailableMemoryForProcessing.GetValue(SizeUnit.Bytes),
                 TotalSwapUsage = memoryInfo.TotalSwapUsage.GetValue(SizeUnit.Bytes)

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -9,13 +9,11 @@ using System.Threading.Tasks;
 using Raven.Server.Routing;
 using Raven.Server.Utils;
 using Raven.Server.Web;
-using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Platform.Posix;
-using Sparrow.Server;
 using Sparrow.Server.Platform.Win32;
 using Sparrow.Utils;
 using Voron.Impl;
@@ -331,10 +329,9 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(MemoryInfo.EncryptionBuffersPool)] = Size.Humane(encryptionBuffers.TotalPoolSize),
                 [nameof(MemoryInfo.EncryptionLockedMemory)] = Size.Humane(Sodium.LockedBytes),
                 [nameof(MemoryInfo.MemoryMapped)] = Size.Humane(totalMapping),
-                [nameof(MemoryInfo.ScratchDirtyMemory)] = memInfo.TotalScratchDirtyMemory.ToString(),
                 [nameof(MemoryInfo.IsHighDirty)] = dirtyMemoryState.IsHighDirty,
-                [nameof(MemoryInfo.DirtyMemory)] = Size.Humane(dirtyMemoryState.TotalDirtyInBytes),
-                [nameof(MemoryInfo.AvailableMemory)] = Size.Humane(memInfo.AvailableMemory.GetValue(SizeUnit.Bytes)),
+                [nameof(MemoryInfo.DirtyMemory)] = dirtyMemoryState.TotalDirty.ToString(),
+                [nameof(MemoryInfo.AvailableMemory)] = memInfo.AvailableMemory.ToString(),
                 [nameof(MemoryInfo.AvailableMemoryForProcessing)] = memInfo.AvailableMemoryForProcessing.ToString(),
             };
             if (memInfo.Remarks != null)

--- a/src/Raven.Server/Documents/TransactionOperationsMerger.cs
+++ b/src/Raven.Server/Documents/TransactionOperationsMerger.cs
@@ -882,7 +882,7 @@ namespace Raven.Server.Documents
                         $"Operation was cancelled by the transaction merger for transaction #{llt.Id} due to high dirty memory in scratch files." +
                         $" This might be caused by a slow IO storage. Current memory usage: " +
                         $"Total Physical Memory: {MemoryInformation.TotalPhysicalMemory}, " +
-                        $"Total Scratch Allocated Memory: {new Size(dirtyMemoryState.TotalDirtyInBytes, SizeUnit.Bytes)} " +
+                        $"Total Scratch Allocated Memory: {dirtyMemoryState.TotalDirty} " +
                         $"(which is above {_parent.Configuration.Memory.TemporaryDirtyMemoryAllowedPercentage * 100}%)");
                 }
 

--- a/src/Raven.Server/Monitoring/MetricsProvider.cs
+++ b/src/Raven.Server/Monitoring/MetricsProvider.cs
@@ -154,8 +154,7 @@ public class MetricsProvider
         result.TotalSwapUsageInMb = memoryInfoResult.TotalSwapUsage.GetValue(SizeUnit.Megabytes);
         result.WorkingSetSwapUsageInMb = memoryInfoResult.WorkingSetSwapUsage.GetValue(SizeUnit.Megabytes);
 
-        var totalDirtyInBytes = MemoryInformation.GetDirtyMemoryState().TotalDirtyInBytes;
-        result.TotalDirtyInMb = new Size(totalDirtyInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
+        result.TotalDirtyInMb = MemoryInformation.GetDirtyMemoryState().TotalDirty.GetValue(SizeUnit.Megabytes);
 
         return result;
     }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/ServerDirtyMemory.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.6/ServerDirtyMemory.cs
@@ -13,8 +13,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
 
         protected override Gauge32 GetData()
         {
-            var totalDirtyInBytes = MemoryInformation.GetDirtyMemoryState().TotalDirtyInBytes;
-            return new Gauge32(new Size(totalDirtyInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes));
+            return new Gauge32(MemoryInformation.GetDirtyMemoryState().TotalDirty.GetValue(SizeUnit.Megabytes));
         }
     }
 }

--- a/src/Raven.Server/NotificationCenter/OutOfMemoryNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/OutOfMemoryNotifications.cs
@@ -76,7 +76,7 @@ namespace Raven.Server.NotificationCenter
 
             return new MessageDetails
             {
-                Message = $"{MemoryUtils.GetExtendedMemoryInfo(memoryInfo)} {Environment.NewLine}" +
+                Message = $"{MemoryUtils.GetExtendedMemoryInfo(memoryInfo, MemoryInformation.GetDirtyMemoryState())} {Environment.NewLine}" +
                           $"Error: {exception}"
             };
         }

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -584,13 +584,15 @@ namespace Raven.Server.Utils.Cli
         public static string GetInfoText()
         {
             var memoryInfo = MemoryInformation.GetMemoryInformationUsingOneTimeSmapsReader();
+            var dirtyMemoryState = MemoryInformation.GetDirtyMemoryState();
+
             using (var currentProcess = Process.GetCurrentProcess())
             {
                 return $" Build {ServerVersion.Build}, Version {ServerVersion.Version}, SemVer {ServerVersion.FullVersion}, Commit {ServerVersion.CommitHash}" +
                        Environment.NewLine +
                        $" PID {currentProcess.Id}, {IntPtr.Size * 8} bits, {ProcessorInfo.ProcessorCount} Cores, Arch: {RuntimeInformation.OSArchitecture}" +
                        Environment.NewLine +
-                       $" {memoryInfo.TotalPhysicalMemory} Physical Memory, {memoryInfo.AvailableMemory} Available Memory, {memoryInfo.AvailableMemoryForProcessing} Calculated Available Memory, {memoryInfo.TotalScratchDirtyMemory} Scratch Dirty Memory" +
+                       $" {memoryInfo.TotalPhysicalMemory} Physical Memory, {memoryInfo.AvailableMemory} Available Memory, {memoryInfo.AvailableMemoryForProcessing} Calculated Available Memory, {dirtyMemoryState.TotalDirty} Scratch Dirty Memory" +
                        Environment.NewLine +
                        $" {RuntimeSettings.Describe()}" +
                        Environment.NewLine +
@@ -1118,7 +1120,7 @@ namespace Raven.Server.Utils.Cli
                 SizeClient.Humane(MemoryInformation.GetWorkingSetInBytes()),
                 SizeClient.Humane(AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes()),
                 SizeClient.Humane(AbstractLowMemoryMonitor.GetManagedMemoryInBytes()),
-                SizeClient.Humane(MemoryInformation.GetTotalScratchAllocatedMemory()),
+                SizeClient.Humane(MemoryInformation.GetTotalScratchAllocatedMemoryInBytes()),
                 SizeClient.Humane(totalMemoryMapped));
         }
 

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -179,7 +179,7 @@ namespace Sparrow.LowMemory
             LowMemoryNotification.Instance.SimulateLowMemoryNotification();
 
             throw new EarlyOutOfMemoryException($"The amount of available memory to commit on the system is low. " +
-                                                MemoryUtils.GetExtendedMemoryInfo(memInfo), memInfo);
+                                                MemoryUtils.GetExtendedMemoryInfo(memInfo, GetDirtyMemoryState()), memInfo);
 
         }
 
@@ -423,7 +423,7 @@ namespace Sparrow.LowMemory
             }
         }
 
-        public static long GetTotalScratchAllocatedMemory()
+        public static long GetTotalScratchAllocatedMemoryInBytes()
         {
             long totalScratchAllocated = 0;
             foreach (var scratchGetAllocated in DirtyMemoryObjects)
@@ -740,13 +740,13 @@ namespace Sparrow.LowMemory
 
         public static DirtyMemoryState GetDirtyMemoryState()
         {
-            var totalScratchMemory = GetTotalScratchAllocatedMemory();
+            var totalScratchMemory = new Size(GetTotalScratchAllocatedMemoryInBytes(), SizeUnit.Bytes);
 
             return new DirtyMemoryState
             {
-                IsHighDirty = totalScratchMemory > TotalPhysicalMemory.GetValue(SizeUnit.Bytes) *
-                              LowMemoryNotification.Instance.TemporaryDirtyMemoryAllowedPercentage,
-                TotalDirtyInBytes = totalScratchMemory
+                IsHighDirty = totalScratchMemory > 
+                              TotalPhysicalMemory * LowMemoryNotification.Instance.TemporaryDirtyMemoryAllowedPercentage,
+                TotalDirty = totalScratchMemory
             };
         }
     }

--- a/src/Sparrow/LowMemory/DirtyMemoryState.cs
+++ b/src/Sparrow/LowMemory/DirtyMemoryState.cs
@@ -4,6 +4,6 @@
     {
         public bool IsHighDirty;
 
-        public long TotalDirtyInBytes;
+        public Size TotalDirty;
     }
 }

--- a/src/Sparrow/LowMemory/MemoryInfoResult.cs
+++ b/src/Sparrow/LowMemory/MemoryInfoResult.cs
@@ -29,7 +29,6 @@ namespace Sparrow.LowMemory
         public Size AvailableMemory;
         public Size AvailableMemoryForProcessing;
         public Size SharedCleanMemory;
-        public Size TotalScratchDirtyMemory;
 
         public Size TotalSwapSize;
         public Size TotalSwapUsage;

--- a/src/Sparrow/Utils/MemoryUtils.cs
+++ b/src/Sparrow/Utils/MemoryUtils.cs
@@ -11,7 +11,7 @@ public static class MemoryUtils
     private static readonly InvertedComparer InvertedComparerInstance = new InvertedComparer();
     private const int MinAllocatedThresholdInBytes = 10 * 1024 * 1024;
 
-    public static string GetExtendedMemoryInfo(MemoryInfoResult memoryInfo)
+    public static string GetExtendedMemoryInfo(MemoryInfoResult memoryInfo, DirtyMemoryState dirtyState)
     {
         try
         {
@@ -19,7 +19,7 @@ public static class MemoryUtils
             TryAppend(() => sb.Append("Commit charge: ").Append(memoryInfo.CurrentCommitCharge).Append(" / ").Append(memoryInfo.TotalCommittableMemory).Append(", "));
             TryAppend(() => sb.Append("Memory: ").Append(memoryInfo.TotalPhysicalMemory - memoryInfo.AvailableMemory).Append(" / ").Append(memoryInfo.TotalPhysicalMemory).Append(", "));
             TryAppend(() => sb.Append("Available memory for processing: ").Append(memoryInfo.AvailableMemoryForProcessing).Append(", "));
-            TryAppend(() => sb.Append("Dirty memory: ").Append(memoryInfo.TotalScratchDirtyMemory).Append(", "));
+            TryAppend(() => sb.Append("Dirty memory: ").Append(dirtyState.TotalDirty).Append(", "));
             TryAppend(() => sb.Append("Managed memory: ").Append(new Size(AbstractLowMemoryMonitor.GetManagedMemoryInBytes(), SizeUnit.Bytes)).Append(", "));
             TryAppend(() => sb.Append("Unmanaged allocations: ").Append(new Size(AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes(), SizeUnit.Bytes)).Append(", "));
             TryAppend(() => sb.Append("Lucene managed: ").Append(new Size(NativeMemory.TotalLuceneManagedAllocationsForTermCache, SizeUnit.Bytes)).Append(", "));

--- a/test/Tests.Infrastructure/TestMetrics/TestResourceSnapshotWriter.cs
+++ b/test/Tests.Infrastructure/TestMetrics/TestResourceSnapshotWriter.cs
@@ -79,12 +79,13 @@ namespace Tests.Infrastructure.TestMetrics
             var cpuUsage = _metricCacher.GetCpuUsage();
             var memoryInfo = _metricCacher.GetMemoryInfoExtended();
             var tcpConnections = TcpStatisticsProvider.GetConnections();
+            var dirtyMemoryState = MemoryInformation.GetDirtyMemoryState();
 
             var snapshot = new TestResourceSnapshot
             {
-                TotalScratchAllocatedMemory = new Size(MemoryInformation.GetTotalScratchAllocatedMemory(), SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
-                TotalDirtyMemory = new Size(MemoryInformation.GetDirtyMemoryState().TotalDirtyInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
-                IsHighDirty = MemoryInformation.GetDirtyMemoryState().IsHighDirty,
+                TotalScratchAllocatedMemory = new Size(MemoryInformation.GetTotalScratchAllocatedMemoryInBytes(), SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
+                TotalDirtyMemory = dirtyMemoryState.TotalDirty.GetValue(SizeUnit.Megabytes),
+                IsHighDirty = dirtyMemoryState.IsHighDirty,
                 TestStage = testStage,
                 Timestamp = timeStamp.ToString("o"),
                 AssemblyName = assemblyName,
@@ -96,7 +97,7 @@ namespace Tests.Infrastructure.TestMetrics
                 AvailableMemoryInMb = memoryInfo.AvailableMemory.GetValue(SizeUnit.Megabytes),
                 CurrentCommitChargeInMb = memoryInfo.CurrentCommitCharge.GetValue(SizeUnit.Megabytes),
                 SharedCleanMemoryInMb = memoryInfo.SharedCleanMemory.GetValue(SizeUnit.Megabytes),
-                TotalScratchDirtyMemory = memoryInfo.TotalScratchDirtyMemory.GetValue(SizeUnit.Megabytes),
+                TotalScratchDirtyMemory = MemoryInformation.GetDirtyMemoryState().TotalDirty.GetValue(SizeUnit.Megabytes),
                 CurrentIpv4Connections = tcpConnections.CurrentIpv4,
                 CurrentIpv6Connections = tcpConnections.CurrentIpv6
             };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22305/Missing-DirtyMemory-from-the-memory-notification

### Additional description



### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
