### PR TITLE
RavenDB-22304 Fixing test which started to fail after the update to .NET 8 because the stacktrace of an exception was different

### DIFF
--- a/test/SlowTests/Issues/RavenDB-12564.cs
+++ b/test/SlowTests/Issues/RavenDB-12564.cs
@@ -81,12 +81,10 @@ namespace SlowTests.Issues
                     var e = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<JObject>(@"
                         match (Dogs as d2)-[Likes]->(Dogs as d2)-[Likes]->(d2)").ToArray());
                     
-                    Assert.DoesNotContain("implicit", e.Message,StringComparison.OrdinalIgnoreCase);
-                    Assert.Contains("duplicate", e.Message, StringComparison.OrdinalIgnoreCase);
-                    Assert.Contains("alias", e.Message, StringComparison.OrdinalIgnoreCase);
+                    Assert.False(e.Message.Contains("implicit",StringComparison.OrdinalIgnoreCase));
+                    Assert.True(e.Message.Contains("Found redefinition of alias", StringComparison.OrdinalIgnoreCase));
                 }
             }
-
         }
 
         [Fact]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22304/Failing-test-SlowTests.Issues.RavenDB12564.Shouldthrowwhenquerywithoutrecursivehasduplicatealiases

### Additional description

Previously the term "duplicate" that the test is checking was found in the _stacktrace_ (not in the exception message) so the test was passing (because of `ThrowIfDuplicateAlias`):

```
Raven.Client.Exceptions.InvalidQueryException: Found redefinition of alias 'd2', this is not allowed. The correct syntax is to have only single alias definition in the form of '(Employees as e)'
Query: 
   at Raven.Server.Documents.Queries.AST.GraphQuerySyntaxValidatorVisitor.ThrowIfDuplicateAlias(MatchPath path) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\AST\GraphQuerySyntaxValidatorVisitor.cs:line 43
   at Raven.Server.Documents.Queries.AST.GraphQuerySyntaxValidatorVisitor.VisitPatternMatchElementExpression(PatternMatchElementExpression elementExpression) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\AST\GraphQuerySyntaxValidatorVisitor.cs:line 88
   at Raven.Server.Documents.Queries.AST.QueryVisitor.VisitExpression(QueryExpression expr) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\AST\QueryVisitor.cs:line 248
   at Raven.Server.Documents.Queries.AST.QueryVisitor.VisitMatchExpression(QueryExpression expr) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\AST\QueryVisitor.cs:line 79
   at Raven.Server.Documents.Queries.AST.QueryVisitor.VisitGraph(GraphQuery q) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\AST\QueryVisitor.cs:line 89
   at Raven.Server.Documents.Queries.AST.QueryVisitor.Visit(Query q) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\AST\QueryVisitor.cs:line 24
   at Raven.Server.Documents.Queries.Graph.GraphQueryPlan.BuildQueryPlan() in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\Graph\GraphQueryPlan.cs:line 47
   at Raven.Server.Documents.Queries.GraphQueryRunner.GetQueryResults(IndexQueryServerSide query, QueryOperationContext queryContext, Nullable`1 existingResultEtag, OperationCancelToken token, Boolean collectIntermediateResults) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\GraphQueryRunner.cs:line 236
   at Raven.Server.Documents.Queries.GraphQueryRunner.ExecuteQuery[TResult](TResult final, IndexQueryServerSide query, QueryOperationContext queryContext, Nullable`1 existingResultEtag, OperationCancelToken token) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\GraphQueryRunner.cs:line 125
   at Raven.Server.Documents.Queries.GraphQueryRunner.ExecuteQuery(IndexQueryServerSide query, QueryOperationContext queryContext, Nullable`1 existingResultEtag, OperationCancelToken token) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\GraphQueryRunner.cs:line 107
   at Raven.Server.Documents.Queries.QueryRunner.ExecuteQuery(IndexQueryServerSide query, QueryOperationContext queryContext, Nullable`1 existingResultEtag, OperationCancelToken token) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Queries\QueryRunner.cs:line 79
   at Raven.Server.Documents.Handlers.QueriesHandler.Query(QueryOperationContext queryContext, OperationCancelToken token, RequestTimeTracker tracker, HttpMethod method) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Handlers\QueriesHandler.cs:line 152
   at Raven.Server.Documents.Handlers.QueriesHandler.HandleQuery(HttpMethod httpMethod) in D:\workspace\ravendb-5.4\src\Raven.Server\Documents\Handlers\QueriesHandler.cs:line 63
   at Raven.Server.Routing.RequestRouter.HandlePath(RequestHandlerContext reqCtx) in D:\workspace\ravendb-5.4\src\Raven.Server\Routing\RequestRouter.cs:line 407
   at Raven.Server.RavenServerStartup.RequestHandler(HttpContext context) in D:\workspace\ravendb-5.4\src\Raven.Server\RavenServerStartup.cs:line 184
   ```
   
   After the update the stacktrace is a bit different (some method got inlined) so the assertion started to fail:
   
   ```
   Raven.Client.Exceptions.InvalidQueryException: Found redefinition of alias 'd2', this is not allowed. The correct syntax is to have only single alias definition in the form of '(Employees as e)'
Query: 
   at Raven.Server.Documents.Queries.AST.GraphQuerySyntaxValidatorVisitor.VisitPatternMatchElementExpression(PatternMatchElementExpression elementExpression) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/Documents/Queries/AST/GraphQuerySyntaxValidatorVisitor.cs:line 88
   at Raven.Server.Documents.Queries.AST.QueryVisitor.VisitGraph(GraphQuery q) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs:line 89
   at Raven.Server.Documents.Queries.AST.QueryVisitor.Visit(Query q) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/Documents/Queries/AST/QueryVisitor.cs:line 24
   at Raven.Server.Documents.Queries.GraphQueryRunner.GetQueryResults(IndexQueryServerSide query, QueryOperationContext queryContext, Nullable`1 existingResultEtag, OperationCancelToken token, Boolean collectIntermediateResults) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs:line 236
   at Raven.Server.Documents.Queries.GraphQueryRunner.ExecuteQuery[TResult](TResult final, IndexQueryServerSide query, QueryOperationContext queryContext, Nullable`1 existingResultEtag, OperationCancelToken token) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs:line 125
   at Raven.Server.Documents.Queries.GraphQueryRunner.ExecuteQuery(IndexQueryServerSide query, QueryOperationContext queryContext, Nullable`1 existingResultEtag, OperationCancelToken token) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs:line 107
   at Raven.Server.Documents.Queries.QueryRunner.ExecuteQuery(IndexQueryServerSide query, QueryOperationContext queryContext, Nullable`1 existingResultEtag, OperationCancelToken token) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/Documents/Queries/QueryRunner.cs:line 79
   at Raven.Server.Documents.Handlers.QueriesHandler.Query(QueryOperationContext queryContext, OperationCancelToken token, RequestTimeTracker tracker, HttpMethod method) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/Documents/Handlers/QueriesHandler.cs:line 152
   at Raven.Server.Documents.Handlers.QueriesHandler.HandleQuery(HttpMethod httpMethod) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/Documents/Handlers/QueriesHandler.cs:line 63
   at Raven.Server.Routing.RequestRouter.HandlePath(RequestHandlerContext reqCtx) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/Routing/RequestRouter.cs:line 407
   at Raven.Server.RavenServerStartup.RequestHandler(HttpContext context) in /home/eagle-4/Jenkins/workspace/Testsv54_Linx64/s/src/Raven.Server/RavenServerStartup.cs:line 184
   ```

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
