### PR TITLE
RavenDB-22289 Fixing test issue which assumed the order of paths returned by Directory.GetDirectories()

### DIFF
--- a/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
+++ b/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
@@ -354,11 +354,14 @@ namespace SlowTests.Sharding.Backup
                 var dirs = Directory.GetDirectories(backupPath);
                 Assert.Equal(2, dirs.Length);
 
-                // should have one root folder for all shards 
-                Assert.Contains(store1.Database, dirs[0]);
-                Assert.DoesNotContain('$', dirs[0]);
+                var shardedBackupPath = dirs.First(x => x.Contains(store1.Database));
+                var nonShardedBackupPath = dirs.First(x => x.Contains(store2.Database));
 
-                var store1Backups = Directory.GetDirectories(Path.Combine(backupPath, store1.Database));
+                // should have one root folder for all shards 
+                Assert.Contains(store1.Database, shardedBackupPath);
+                Assert.DoesNotContain('$', nonShardedBackupPath);
+
+                var store1Backups = Directory.GetDirectories(Path.Combine(backupPath, store1.Database)).OrderBy(x => x).ToArray();
                 var store2Backup = Directory.GetDirectories(Path.Combine(backupPath, store2.Database));
 
                 Assert.Equal(3, store1Backups.Length); // one per shard


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22289

### Additional description

Test issue

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
