### PR TITLE
RavenDB-22311 Alphanumerical sorter - index out of range exception fix

### DIFF
--- a/src/Raven.Server/Documents/Queries/Sorting/AlphaNumeric/AlphaNumericFieldComparator.cs
+++ b/src/Raven.Server/Documents/Queries/Sorting/AlphaNumeric/AlphaNumericFieldComparator.cs
@@ -150,7 +150,7 @@ namespace Raven.Server.Documents.Queries.Sorting.AlphaNumeric
             {
                 CurrentSequenceStartPosition = GetStartPosition();
                 Span<char> characters = stackalloc char[4];
-                var (usedBytes, usedChars) = ReadCharacter(CurrentPositionInString, characters);
+                var (usedBytes, usedChars) = ReadCharacter(StringBufferOffset, characters);
                 _currentSequenceIsNumber =  usedChars == 1 && char.IsDigit(characters[0]);
                 NumberLength = 0;
 
@@ -180,7 +180,7 @@ namespace Raven.Server.Documents.Queries.Sorting.AlphaNumeric
 
                     if (CurrentPositionInString < _stringLength)
                     {
-                        (usedBytes, usedChars) = ReadCharacter(CurrentPositionInString, characters);
+                        (usedBytes, usedChars) = ReadCharacter(StringBufferOffset, characters);
                         currentCharacterIsDigit = usedChars == 1 && char.IsDigit(characters[0]);
                     }
                     else

--- a/test/SlowTests/Issues/RavenDB-22311.cs
+++ b/test/SlowTests/Issues/RavenDB-22311.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22311 : RavenTestBase
+{
+    public RavenDB_22311(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Lucene | RavenTestCategory.Querying)]
+    public void AlphanumericalWillShiftWithGoodOffsetSize()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Lucene));
+        using var session = store.OpenSession();
+        session.Store(new Order(){Company = "🚀1t"});
+        session.Store(new Order(){Company = "🚀1"});
+        session.SaveChanges();
+
+        var result = session.Query<Order>()
+            .Customize(c => c.WaitForNonStaleResults())
+            .OrderBy(x => x.Company, OrderingType.AlphaNumeric)
+            .ToList();
+        
+        Assert.Equal("🚀1", result[0].Company);
+        Assert.Equal("🚀1t", result[1].Company);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22311 

### Additional description

Surrogate characters may affect the amount of characters required to represent it. It may happen that a single character (what we see) is represented by a few char objects.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
