### PR TITLE
RavenDB-22312 adjust the test to be more consistent

### DIFF
--- a/src/Raven.Server/Rachis/Elector.cs
+++ b/src/Raven.Server/Rachis/Elector.cs
@@ -256,8 +256,7 @@ namespace Raven.Server.Rachis
                                 continue;
                             }
 
-
-                            _engine.ForTestingPurposes?.BeforeCastingForRealElection();
+                            _engine.ForTestingPurposes?.ReleaseOnLeaderElect();
 
                             HandleVoteResult result;
                             using (context.OpenWriteTransaction())

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -985,7 +985,7 @@ namespace Raven.Server.Rachis
                     if (_leaderLongRunningWork != null && _leaderLongRunningWork.ManagedThreadId != Thread.CurrentThread.ManagedThreadId)
                         _leaderLongRunningWork.Join(int.MaxValue);
 
-                    _engine.ForTestingPurposes?.LeaderDispose();
+                    _engine.ForTestingPurposes?.ReleaseOnLeaderElect();
 
                     var ae = new ExceptionAggregator("Could not properly dispose Leader");
                     foreach (var ambassador in _nonVoters)

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -1191,8 +1191,11 @@ namespace RachisTests.DatabaseCluster
                     DeletePrevious = false,
                     DataDirectory = down1.DataDirectory
                 });
-                nodes[1].ServerStore.Engine.ForTestingPurposesOnly().NodeTagsToDisconnect.Add(nodes[0].ServerStore.NodeTag);
-                nodes[1].ServerStore.Engine.ForTestingPurposesOnly().NodeTagsToDisconnect.Add(nodes[2].ServerStore.NodeTag);
+                nodes[1].ServerStore.Engine.ForTestingPurposesOnly().NodeTagsToDisconnect =
+                [
+                    nodes[0].ServerStore.NodeTag,
+                    nodes[2].ServerStore.NodeTag
+                ];
                 Servers.Add(nodes[1]);
 
                 //make sure leader and follower [2] disconnected

--- a/test/RachisTests/ElectionTests.cs
+++ b/test/RachisTests/ElectionTests.cs
@@ -40,38 +40,53 @@ namespace RachisTests
             DebuggerAttachedTimeout.DisableLongTimespan = true;
             var leader = await CreateNetworkAndGetLeader(2);
             var follower = GetFollowers().Single();
-
-            leader.ForTestingPurposesOnly();
-            follower.ForTestingPurposesOnly();
-
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            
             DisconnectBiDirectionalFromNode(leader);
 
-            await leader.WaitForState(RachisState.Candidate, CancellationToken.None);
-            await follower.WaitForState(RachisState.Candidate, CancellationToken.None);
+            using (leader.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+            using (var tx = ctx.OpenWriteTransaction())
+            {
+                leader.SetNewStateInTx(ctx, RachisState.LeaderElect, null, leader.CurrentTerm, "append an extra entry so only me can be leader");
+                tx.Commit();
+            }
+            
+            var mre1 = new ManualResetEventSlim(false);
+            var mre2 = new ManualResetEventSlim(false);
 
-            var le1 = leader.WaitForState(RachisState.LeaderElect, CancellationToken.None);
-            var le2 = follower.WaitForState(RachisState.LeaderElect, CancellationToken.None);
+            leader.ForTestingPurposesOnly().HoldOnLeaderElect = mre1;
+            follower.ForTestingPurposesOnly().HoldOnLeaderElect = mre2;
+
+            await leader.WaitForState(RachisState.Candidate, cts.Token);
+            await follower.WaitForState(RachisState.Candidate, cts.Token);
+
+            var le1 = leader.WaitForState(RachisState.LeaderElect, cts.Token);
+            var le2 = follower.WaitForState(RachisState.LeaderElect, cts.Token);
 
             ReconnectBiDirectionalFromNode(leader);
+            
+            while (le1.IsCompleted == false && le2.IsCompleted == false)
+            {
+                mre1.Set();
+                mre2.Set();
+                await Task.Delay(100, cts.Token);
+            }
 
             await Task.WhenAny(le1, le2);
 
-            await leader.WaitForState(RachisState.Candidate, CancellationToken.None);
-            await follower.WaitForState(RachisState.Candidate, CancellationToken.None);
+            await leader.WaitForState(RachisState.Candidate, cts.Token);
+            await follower.WaitForState(RachisState.Candidate, cts.Token);
 
-
-            var mre1 = leader.ForTestingPurposesOnly().Mre;
-            leader.ForTestingPurposesOnly().Mre = null;
+            leader.ForTestingPurposesOnly().HoldOnLeaderElect = null;
             mre1.Set();
 
-            var mre2 = follower.ForTestingPurposesOnly().Mre;
-            follower.ForTestingPurposesOnly().Mre = null;
+            follower.ForTestingPurposesOnly().HoldOnLeaderElect = null;
             mre2.Set();
 
             var lastIndex = await IssueCommandsAndWaitForCommit(3, "test", 1);
 
-            var t1 = leader.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, lastIndex);
-            var t2 = follower.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, lastIndex);
+            var t1 = leader.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, lastIndex, token: cts.Token);
+            var t2 = follower.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, lastIndex, token: cts.Token);
             if (await Task.WhenAll(t1, t2).WaitWithoutExceptionAsync(5000) == false)
             {
                 throw new TimeoutException();
@@ -248,7 +263,6 @@ namespace RachisTests
             foreach (var follower in RachisConsensuses)
             {
                 follower.ForTestingPurposesOnly().CreateLeaderLock(flag);
-                follower.ForTestingPurposes.Mre = null;
             }
 
             firstLeader.CurrentLeader.StepDown(forceElection: false);

--- a/test/SlowTests/Issues/RavenDB-17347.cs
+++ b/test/SlowTests/Issues/RavenDB-17347.cs
@@ -41,9 +41,9 @@ namespace SlowTests.Issues
 
             (var nodes, var leader) = await CreateRaftCluster(3, shouldRunInMemory: false, watcherCluster: true);
 
-            leader.ServerStore.Engine.ForTestingPurposes = new RachisConsensus.TestingStuff()
+            leader.ServerStore.Engine.ForTestingPurposes = new RachisConsensus.TestingStuff
             {
-                Mre = null
+                NodeTagsToDisconnect = new List<string>()
             };
 
             using var store = GetDocumentStore(new Options { RunInMemory = false, Server = leader, ReplicationFactor = 2 });


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22312

### Additional description

Adjust the test to fix an artificial hang of `ForTestingPurposes` when one of the nodes was prematurely elected 

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
