### PR TITLE
RavenDB-22309 notifying the database should propagate to the rachis notifier as well

### DIFF
--- a/src/Raven.Server/Documents/DatabaseRaftIndexNotifications.cs
+++ b/src/Raven.Server/Documents/DatabaseRaftIndexNotifications.cs
@@ -1,16 +1,7 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.ExceptionServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Server.ServerWide;
-using Sparrow.Logging;
-using Sparrow.Server;
-using Sparrow.Utils;
-using static Raven.Server.Documents.DatabasesLandlord;
 
 namespace Raven.Server.Documents;
 
@@ -31,6 +22,8 @@ public class DatabaseRaftIndexNotifications : AbstractRaftIndexNotifications<Raf
 
     public override void NotifyListenersAbout(long index, Exception e)
     {
+        _clusterStateMachineLogIndexNotifications.NotifyListenersAbout(index, e);
+
         RecordNotification(new RaftIndexNotification
         {
             Index = index,
@@ -39,5 +32,4 @@ public class DatabaseRaftIndexNotifications : AbstractRaftIndexNotifications<Raf
 
         base.NotifyListenersAbout(index, e);
     }
-
 }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1347,7 +1347,6 @@ namespace Raven.Server.ServerWide
                                 finally
                                 {
                                     _rachisLogIndexNotifications.NotifyListenersAbout(index, error);
-                                    _rachisLogIndexNotifications.SetTaskCompleted(index, error);
                                 }
                             }
                         });
@@ -1361,11 +1360,10 @@ namespace Raven.Server.ServerWide
             try
             {
                 _rachisLogIndexNotifications.NotifyListenersAbout(index, null);
-                _rachisLogIndexNotifications.SetTaskCompleted(index, null);
             }
             catch (OperationCanceledException e)
             {
-                _rachisLogIndexNotifications.SetTaskCompleted(index, e);
+                _rachisLogIndexNotifications.NotifyListenersAbout(index, e);
             }
         }
 
@@ -2395,7 +2393,6 @@ namespace Raven.Server.ServerWide
                 finally
                 {
                     _rachisLogIndexNotifications.NotifyListenersAbout(index, error);
-                    _rachisLogIndexNotifications.SetTaskCompleted(index, error);
                 }
             });
         }

--- a/src/Raven.Server/ServerWide/RachisLogIndexNotifications.cs
+++ b/src/Raven.Server/ServerWide/RachisLogIndexNotifications.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Sparrow.Logging;
@@ -85,7 +82,7 @@ public class RachisLogIndexNotifications : AbstractRaftIndexNotifications<Recent
         return false;
     }
 
-    public void SetTaskCompleted(long index, Exception e)
+    private void SetTaskCompleted(long index, Exception e)
     {
         if (_tasksDictionary.TryGetValue(index, out var tcs))
         {
@@ -109,6 +106,12 @@ public class RachisLogIndexNotifications : AbstractRaftIndexNotifications<Recent
         }
 
         _tasksDictionary.TryRemove(index, out _);
+    }
+
+    public override void NotifyListenersAbout(long index, Exception e)
+    {
+        SetTaskCompleted(index, e);
+        base.NotifyListenersAbout(index, e);
     }
 
     public void AddTask(long index)

--- a/test/SlowTests/Issues/RavenDB-22217.cs
+++ b/test/SlowTests/Issues/RavenDB-22217.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using FastTests;
 using Nito.AsyncEx;
@@ -13,7 +10,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues;
-public class RavenDB_22217: RavenTestBase
+public class RavenDB_22217 : RavenTestBase
 {
     public RavenDB_22217(ITestOutputHelper output) : base(output)
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22309

### Additional description

Notifying a database should also notify the cluster

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
