### PR TITLE
RavenDB-22313 Checking cancellation token during the load phase of Elasticsearch, Kafka and RabbitMQ ETLs.

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/ElasticSearchEtl.cs
@@ -109,6 +109,8 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch
 
                 EnsureIndexExistsAndValidateIfNeeded(indexName, index);
 
+                CancellationToken.ThrowIfCancellationRequested();
+
                 if (index.InsertOnlyMode == false)
                     count += DeleteByQueryOnIndexIdProperty(index);
 

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Kafka/KafkaEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Kafka/KafkaEtl.cs
@@ -159,6 +159,8 @@ public class KafkaEtl : QueueEtl<KafkaItem>
             {
                 foreach (var queueItem in topic.Items)
                 {
+                    CancellationToken.ThrowIfCancellationRequested();
+
                     var cloudEvent = CreateCloudEvent(queueItem);
 
                     var kafkaMessage = cloudEvent.ToKafkaMessage(ContentMode.Binary, formatter);

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/RabbitMq/RabbitMqEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/RabbitMq/RabbitMqEtl.cs
@@ -67,6 +67,8 @@ public class RabbitMqEtl : QueueEtl<RabbitMqItem>
 
             foreach (var queueItem in exchange.Items)
             {
+                CancellationToken.ThrowIfCancellationRequested();
+
                 var properties = producer.CreateBasicProperties();
 
                 properties.Headers = new Dictionary<string, object>();


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22313/Elasticsearch-ETL-doesnt-seem-to-respect-cancellation

### Additional description

This should prevent the long running disposals of those tasks.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
