### PR TITLE
RavenDB-20225 Use moving avg to calculate the speed of the import

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/common/timeAwareEWMA.spec.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/timeAwareEWMA.spec.ts
@@ -1,0 +1,89 @@
+import { timeAwareEWMA } from "./timeAwareEWMA";
+
+describe("timeAwareEWMA", () => {
+    beforeAll(() => {
+        jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+
+    it("can calculate ewma when server doesn't responds for more than 4 seconds", () => {
+        const ewma = new timeAwareEWMA(2_000);
+        
+        ewma.handleServerTick(10_000);
+
+        // after 3 seconds no change
+        jest.advanceTimersByTime(3_000);
+        expect(ewma.value()).toBe(10_000);
+
+        // after 4 seconds
+        jest.advanceTimersByTime(1_000);
+        expect(ewma.value()).toBe(2_500);
+
+        // after 5 seconds
+        jest.advanceTimersByTime(1_000);
+        expect(ewma.value()).toBe(1_767);
+
+        // after 6 seconds
+        jest.advanceTimersByTime(1_000);
+        expect(ewma.value()).toBe(1_249);
+
+        // after 7 seconds
+        jest.advanceTimersByTime(1_000);
+        expect(ewma.value()).toBe(883);
+
+        // after 8 seconds
+        jest.advanceTimersByTime(1_000);
+        expect(ewma.value()).toBe(624);
+
+        // after 9 seconds
+        jest.advanceTimersByTime(1_000);
+        expect(ewma.value()).toBe(441);
+
+        // after 10 seconds
+        jest.advanceTimersByTime(1_000);
+        expect(ewma.value()).toBe(0);
+    });
+
+    it("can calculate value when server responds every second", () => {
+        const ewma = new timeAwareEWMA(2_000);
+
+        ewma.handleServerTick(10_000);
+
+        // after 1 second
+        jest.advanceTimersByTime(1_000);
+        ewma.handleServerTick(15_000);
+        expect(ewma.value()).toBe(15_000);
+
+        // after 2 seconds
+        jest.advanceTimersByTime(1_000);
+        ewma.handleServerTick(5_000);
+        expect(ewma.value()).toBe(5_000);
+    });
+
+    it("can calculate value when server responds at irregular timestamps", () => {
+        const ewma = new timeAwareEWMA(2_000);
+
+        ewma.handleServerTick(10_000);
+
+        // after 0.5 second (value / 0.5)
+        jest.advanceTimersByTime(500);
+        ewma.handleServerTick(10_000);
+        expect(ewma.value()).toBe(20_000);
+
+        // after 3 seconds (value / 3)
+        jest.advanceTimersByTime(3_000);
+        ewma.handleServerTick(9_000);
+        expect(ewma.value()).toBe(3_000);
+    });
+
+    it("can calculate value right away", () => {
+        const ewma = new timeAwareEWMA(2_000);
+
+        ewma.handleServerTick(10_000);
+        expect(ewma.value()).toBe(10_000);
+    });
+});
+

--- a/src/Raven.Studio/typescript/viewmodels/common/timeAwareEWMA.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/timeAwareEWMA.ts
@@ -1,0 +1,84 @@
+// This is modified version of EWMA (exponentially weighted moving average)
+
+export class timeAwareEWMA {
+    private prevTime: number;
+    private prevEwma: number;
+
+    private noServerValueInterval: NodeJS.Timeout;
+    private msSinceLastServerValue: number = 0;
+
+    private readonly halfLife: number;
+
+    value = ko.observable<number>(null);
+
+    constructor(halfLife: number) {
+        this.halfLife = halfLife;
+    }
+
+    private tick(value: number, time: Date = new Date()) {
+        if (this.prevEwma == null || this.prevTime == null) {
+            this.prevEwma = value;
+            this.prevTime = time.getTime();
+
+            this.value(Math.floor(value));
+            this.startNoServerValueInterval();
+            return;
+        }
+
+        const timeAsNumber = time.getTime();
+        const timeDecay = timeAsNumber - this.prevTime;
+
+        const alpha = 1 - Math.exp(Math.log(0.5) * timeDecay / this.halfLife);
+        const ewma = alpha * value + (1 - alpha) * this.prevEwma;
+
+        this.prevEwma = ewma;
+        this.prevTime = timeAsNumber;
+
+        this.value(Math.floor(ewma));
+    }
+
+    private startNoServerValueInterval() {
+        this.noServerValueInterval = setInterval(() => {
+            this.msSinceLastServerValue += 100;
+
+            if (this.value() === 0) {
+                return;
+            }
+
+            // If the server doesn't send any value for 10 seconds, the value will be set to 0
+            if (this.msSinceLastServerValue >= 10_000) {
+                this.value(0);
+                return;
+            }
+
+            // If the server doesn't send any value for 4 seconds, ewma will be calculated with 0 value
+            if (this.msSinceLastServerValue >= 4_000 && this.msSinceLastServerValue % 1_000 === 0) {
+                this.tick(0);
+            }
+        }, 100);
+    }
+
+    private clearData() {
+        this.prevEwma = null;
+        this.prevTime = null;
+        this.msSinceLastServerValue = 0;
+
+        if (this.noServerValueInterval) {
+            clearInterval(this.noServerValueInterval);
+        }
+    }
+
+    handleServerTick(value: number) {
+        // If the server sends a value, it will be set to (value / secondsSinceLastValue)
+        const secondsSinceLastValue = this.msSinceLastServerValue / 1_000;
+        const calculatedValue = secondsSinceLastValue ? (value / secondsSinceLastValue) : value;
+
+        this.clearData();
+        this.tick(calculatedValue);
+    }
+    
+    reset() {
+        this.clearData();
+        this.value(null);
+    }
+}

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
@@ -59,7 +59,13 @@
                             <i class="icon-skip"></i> <span>Skipped</span>
                         </div>
                         <div class="status status-processing" data-bind="visible: stage === 'processing'">
-                            <span class="global-spinner spinner-sm"></span> <span data-bind="text: processingSpeedText"></span>
+                            <span class="global-spinner spinner-sm"></span>
+                            <span data-bind="visible: $root.getProcessingSpeed(name) == null">
+                                Processing
+                            </span>
+                            <span data-bind="visible: $root.getProcessingSpeed(name) != null">
+                                <span data-bind="text: $root.getProcessingSpeed(name)"></span> items/sec
+                            </span>
                         </div>
                         <div class="status status-waiting" data-bind="visible: stage === 'pending'">
                             <i class="icon-waiting"></i> <span>Pending</span>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20225/Use-moving-avg-to-calculate-the-speed-of-the-import

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
