### PR TITLE
RavenDB-22310 Edit replication sink broken in v5.4

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationSinkEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationSinkEditModel.ts
@@ -51,7 +51,7 @@ class ongoingTaskReplicationSinkEditModel extends ongoingTaskEditModel {
         this.connectionStringName(dto.ConnectionStringName);
         this.manualChooseMentor(!!dto.MentorNode);
         this.pinMentorNode(dto.PinToMentorNode);
-        this.hubName(dto.HubDefinitionName);
+        this.hubName(dto.HubName);
 
         this.allowReplicationFromHubToSink(dto.Mode.includes("HubToSink"));
         this.allowReplicationFromSinkToHub(dto.Mode.includes("SinkToHub"));
@@ -110,7 +110,7 @@ class ongoingTaskReplicationSinkEditModel extends ongoingTaskEditModel {
         });
         
         this.validationGroup = ko.validatedObservable({
-            hubDefinitionName: this.hubName,
+            hubName: this.hubName,
             mentorNode: this.mentorNode,
             connectionStringName: this.connectionStringName
         });
@@ -124,7 +124,7 @@ class ongoingTaskReplicationSinkEditModel extends ongoingTaskEditModel {
             AccessName: "",
             AllowedHubToSinkPaths: null,
             AllowedSinkToHubPaths: null,
-            HubDefinitionName: "",
+            HubName: "",
             Mode: "HubToSink"
         } as Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskPullReplicationAsSink, serverCertificate);
     }

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationSinkListModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationSinkListModel.ts
@@ -9,7 +9,7 @@ class ongoingTaskReplicationSinkListModel extends ongoingTaskListModel {
     destinationURL = ko.observable<string>();
     connectionStringName = ko.observable<string>();
     topologyDiscoveryUrls = ko.observableArray<string>([]);
-    hubDefinitionName = ko.observable<string>();
+    hubName = ko.observable<string>();
 
     connectionStringDefined: KnockoutComputed<boolean>;
     
@@ -43,7 +43,7 @@ class ongoingTaskReplicationSinkListModel extends ongoingTaskListModel {
         this.destinationURL(dto.DestinationUrl || "N/A");
         this.connectionStringName(dto.ConnectionStringName);
         this.topologyDiscoveryUrls(dto.TopologyDiscoveryUrls);
-        this.hubDefinitionName(dto.HubDefinitionName);
+        this.hubName(dto.HubName);
     }
 
     toggleDetails() {

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/ongoingTasks.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/ongoingTasks.html
@@ -714,8 +714,8 @@
                                 <div class="padding">
                                     <div class="list-properties">
                                         <div class="property-item">
-                                            <div class="property-name">Hub Definition Name:</div>
-                                            <div class="property-value"><span class="text-details" data-bind="text: hubDefinitionName"></span></div>
+                                            <div class="property-name">Hub Name:</div>
+                                            <div class="property-value"><span class="text-details" data-bind="text: hubName"></span></div>
                                         </div>
                                         <div class="property-item">
                                             <div class="property-name">Task Status:</div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22310 

### Additional description

Using non-deprecated property (HubName) instead of (HubDefinionName) 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
