### PR TITLE
RavenDB-22318 Missing SliceComparer

### DIFF
--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -76,7 +76,7 @@ public abstract unsafe class AbstractBackgroundWorkStorage
                 return null;
             }
 
-            var toProcess = new Dictionary<Slice, List<(Slice LowerId, string Id)>>();
+            var toProcess = new Dictionary<Slice, List<(Slice LowerId, string Id)>>(SliceComparer.Instance);
             duration = Stopwatch.StartNew();
 
             do

--- a/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
@@ -51,7 +51,7 @@ internal class ArchiveDocumentsCommandDto: IReplayableCommandDto<DocumentsOperat
 {
     public ArchiveDocumentsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
     {
-        var toArchive = new Dictionary<Slice, List<(Slice LowerId, string Id)>>();
+        var toArchive = new Dictionary<Slice, List<(Slice LowerId, string Id)>>(SliceComparer.Instance);
         foreach (var item in ToArchive)
         {
             toArchive[item.Key] = item.Value;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22318 


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
