### PR TITLE
RavenDB-22322 "Bump version ..." commits should be executed against 'release/v5.4' branch

### DIFF
--- a/scripts/version.ps1
+++ b/scripts/version.ps1
@@ -96,7 +96,7 @@ function BumpVersion ($projectDir, $versionPrefix, $buildType, $dryRun = $False)
     $repo = @{
         "Owner"  = "ravendb"
         "Name"   = "ravendb"
-        "Branch" = "v5.4"
+        "Branch" = "release/v5.4"
     }
 
     $remoteFilePath = 'src/CommonAssemblyInfo.cs'

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -5,9 +5,9 @@ using System.Resources;
 
 [assembly: AssemblyCopyright("© Hibernating Rhinos 2009 - 2024 All rights reserved.")]
 
-[assembly: AssemblyVersion("5.4.119")]
-[assembly: AssemblyFileVersion("5.4.119.54")]
-[assembly: AssemblyInformationalVersion("5.4.119")]
+[assembly: AssemblyVersion("5.4.200")]
+[assembly: AssemblyFileVersion("5.4.200.54")]
+[assembly: AssemblyInformationalVersion("5.4.200")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]

--- a/src/Raven.Client/Properties/VersionInfo.cs
+++ b/src/Raven.Client/Properties/VersionInfo.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using Raven.Client.Extensions;
 using Raven.Client.Properties;
 
-[assembly: RavenVersion(Build = "54", CommitHash = "a377982", Version = "5.4", FullVersion = "5.4.119-custom-54", ReleaseDateString = "2024-04-29")]
+[assembly: RavenVersion(Build = "54", CommitHash = "a377982", Version = "5.4", FullVersion = "5.4.200-custom-54", ReleaseDateString = "2024-04-29")]
 
 namespace Raven.Client.Properties
 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22322
### Additional description


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
