### PR TITLE
RavenDB-22325 Delete time series: fix explanation of 'to' param

### DIFF
--- a/src/Raven.Client/Documents/Session/ISessionDocumentTimeSeriesBase.cs
+++ b/src/Raven.Client/Documents/Session/ISessionDocumentTimeSeriesBase.cs
@@ -83,7 +83,7 @@ namespace Raven.Client.Documents.Session
         /// For more information on the Time Series Delete operation, see: <inheritdoc cref="DocumentationUrls.Session.TimeSeries.DeleteOperation"/>.
         /// </remarks>
         /// <param name="from">The date and time from which to start deleting time series entries (inclusive). If not specified, the deletion will start from the earliest possible date and time (DateTime.MinValue).</param>
-        /// <param name="to">The date and time indicating the end of the range for deleting time series entries (exclusive). If not specified, the deletion will continue until the latest possible date and time (DateTime.MaxValue).</param>
+        /// <param name="to">The date and time indicating the end of the range for deleting time series entries (inclusive). If not specified, the deletion will continue until the latest possible date and time (DateTime.MaxValue).</param>
         void Delete(DateTime? from = null, DateTime? to = null);
 
         /// <inheritdoc cref="Delete"/>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22325/Delete-time-series-fix-explanation-of-to-param

### Additional description
Fix: `exclusive => inclusive`

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed - Documented in: [RDoc-2749](https://issues.hibernatingrhinos.com/issue/RDoc-2749/Node.js-Document-extensions-Time-series-Client-API-Session-Delete-Replace-C-samples)

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed