### PR TITLE
RavenDB-22036 Added tests and throwing exception on side-by-side reset of replacement index

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1522,6 +1522,9 @@ namespace Raven.Server.Documents.Indexes
 
         private Index ResetIndexSideBySideInternal(Index index)
         {
+            if (index.Name.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix))
+                throw new InvalidOperationException($"Index {index.Name} is already a side-by-side running index.");
+            
             try
             {
                 var definitionClone = new IndexDefinition();

--- a/test/SlowTests/Issues/RavenDB-22036.cs
+++ b/test/SlowTests/Issues/RavenDB-22036.cs
@@ -1,7 +1,9 @@
+using System;
 using FastTests;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
 using Raven.Server.Config;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Extensions;
@@ -240,6 +242,160 @@ public class RavenDB_22036 : RavenTestBase
             {
                 Assert.Equal(1, stats.Length);
             });
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public void TestInPlaceResetOnIndexWithRunningSideBySide(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            const string indexName = "Users/ByName";
+
+            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            {
+                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
+                Type = IndexType.Map, 
+                Name = indexName
+            }));
+            
+            store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            
+            store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, IndexResetMode.SideBySide)).ExecuteOnAll();
+            
+            store.Maintenance.ForTesting(() => new GetIndexOperation($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}")).AssertAll((key, stats) =>
+            {
+                Assert.NotNull(stats);
+            });
+            
+            store.Maintenance.ForTesting(() => new GetIndexNamesOperation(0, int.MaxValue)).AssertAll((key, stats) =>
+            {
+                Assert.Equal(2, stats.Length);
+            });
+            
+            store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName)).ExecuteOnAll();
+            
+            store.Maintenance.ForTesting(() => new GetIndexOperation($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}")).AssertAll((key, stats) =>
+            {
+                Assert.NotNull(stats);
+            });
+            
+            store.Maintenance.ForTesting(() => new GetIndexNamesOperation(0, int.MaxValue)).AssertAll((key, stats) =>
+            {
+                Assert.Equal(2, stats.Length);
+            });
+            
+            store.Maintenance.ForTesting(() => new StartIndexingOperation()).ExecuteOnAll();
+            
+            Indexes.WaitForIndexing(store);
+            
+            store.Maintenance.ForTesting(() => new GetIndexOperation($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}")).AssertAll((key, stats) =>
+            {
+                Assert.Null(stats);
+            });
+            
+            store.Maintenance.ForTesting(() => new GetIndexNamesOperation(0, int.MaxValue)).AssertAll((key, stats) =>
+            {
+                Assert.Equal(1, stats.Length);
+            });
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public void TestInPlaceResetOfRunningSideBySideIndex(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            const string indexName = "Users/ByName";
+
+            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            {
+                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
+                Type = IndexType.Map, 
+                Name = indexName
+            }));
+            
+            store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            
+            store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, IndexResetMode.SideBySide)).ExecuteOnAll();
+            
+            store.Maintenance.ForTesting(() => new GetIndexOperation($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}")).AssertAll((key, stats) =>
+            {
+                Assert.NotNull(stats);
+            });
+            
+            store.Maintenance.ForTesting(() => new GetIndexNamesOperation(0, int.MaxValue)).AssertAll((key, stats) =>
+            {
+                Assert.Equal(2, stats.Length);
+            });
+            
+            store.Maintenance.ForTesting(() => new ResetIndexOperation(Constants.Documents.Indexing.SideBySideIndexNamePrefix + indexName)).ExecuteOnAll();
+            
+            store.Maintenance.ForTesting(() => new GetIndexOperation($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}")).AssertAll((key, stats) =>
+            {
+                Assert.NotNull(stats);
+            });
+            
+            store.Maintenance.ForTesting(() => new GetIndexNamesOperation(0, int.MaxValue)).AssertAll((key, stats) =>
+            {
+                Assert.Equal(2, stats.Length);
+            });
+            
+            store.Maintenance.ForTesting(() => new StartIndexingOperation()).ExecuteOnAll();
+            
+            Indexes.WaitForIndexing(store);
+            
+            store.Maintenance.ForTesting(() => new GetIndexOperation($"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}")).AssertAll((key, stats) =>
+            {
+                Assert.Null(stats);
+            });
+            
+            store.Maintenance.ForTesting(() => new GetIndexNamesOperation(0, int.MaxValue)).AssertAll((key, stats) =>
+            {
+                Assert.Equal(1, stats.Length);
+            });
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public void TestSideBySideResetOfRunningSideBySideIndex(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            const string indexName = "Users/ByName";
+            const string replacementIndexName = $"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}";
+
+            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            {
+                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
+                Type = IndexType.Map, 
+                Name = indexName
+            }));
+            
+            store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            
+            store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, IndexResetMode.SideBySide)).ExecuteOnAll();
+            
+            store.Maintenance.ForTesting(() => new GetIndexOperation(replacementIndexName)).AssertAll((key, stats) =>
+            {
+                Assert.NotNull(stats);
+            });
+            
+            store.Maintenance.ForTesting(() => new GetIndexNamesOperation(0, int.MaxValue)).AssertAll((key, stats) =>
+            {
+                Assert.Equal(2, stats.Length);
+            });
+            
+            var ex = Assert.Throws<RavenException>(() =>
+                store.Maintenance.ForTesting(() => new ResetIndexOperation(replacementIndexName, IndexResetMode.SideBySide)).ExecuteOnAll()
+            );
+
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+
+            Assert.Contains($"Index {replacementIndexName} is already a side-by-side running index.", ex.InnerException.Message);
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22036/Allow-resetting-an-index-Side-by-side

### Additional description

Attempt to reset replacement index in side-by-side mode should result in exception

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
