### PR TITLE
RavenDB-20934 : add debug info to flaky test

### DIFF
--- a/test/SlowTests/Sharding/ETL/ShardedEtlFailoverTests.cs
+++ b/test/SlowTests/Sharding/ETL/ShardedEtlFailoverTests.cs
@@ -861,43 +861,7 @@ loadToOrders(partitionBy(key),
             await GetClusterDebugLogsAsync(sb);
 
             sb.AppendLine().AppendLine($"Debug logs for removed node '{node.ServerStore.NodeTag}':");
-
-            var prevStates = node.ServerStore.Engine.PrevStates;
-            sb.AppendLine($"{Environment.NewLine}States:{Environment.NewLine}-----------------------");
-            foreach (var state in prevStates)
-            {
-                sb.AppendLine($"{state}{Environment.NewLine}");
-            }
-            sb.AppendLine();
-
-            using (node.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext clusterOperationContext))
-            using (clusterOperationContext.OpenReadTransaction())
-            {
-                var historyLogs = node.ServerStore.Engine.LogHistory.GetHistoryLogs(clusterOperationContext);
-                sb.AppendLine($"HistoryLogs:{Environment.NewLine}-----------------------");
-
-                using (var context = JsonOperationContext.ShortTermSingleUse())
-                {
-                    var c = 0;
-                    foreach (var log in historyLogs)
-                    {
-                        var json = context.ReadObject(log, nameof(log) + $"{c++}");
-                        sb.AppendLine(json.ToString());
-                    }
-                }
-                sb.AppendLine();
-
-                var inMemoryDebug = node.ServerStore.Engine.InMemoryDebug.ToJson();
-                if (inMemoryDebug != null)
-                {
-                    sb.AppendLine($"RachisDebug:{Environment.NewLine}-----------------------");
-                    using (var context = JsonOperationContext.ShortTermSingleUse())
-                    {
-                        var json = context.ReadObject(inMemoryDebug, nameof(inMemoryDebug));
-                        sb.AppendLine(json.ToString());
-                    }
-                }
-            }
+            GetDebugLogsForNode(node, sb);
 
             return sb.ToString();
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20934/SlowTests.Sharding.ETL.FailoverEtlTests.ReplicateFromSingleSourcereplicationFactor-2

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [X] Tests stabilization

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [X] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [X] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [X] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [X] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [X] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [X] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [X] No UI work is needed
