### PR TITLE
RavenDB-22329 avoid deadlock in LoggingSource

### DIFF
--- a/src/Raven.Server/Commercial/SetupWizard/LetsEncryptSetupUtils.cs
+++ b/src/Raven.Server/Commercial/SetupWizard/LetsEncryptSetupUtils.cs
@@ -54,7 +54,7 @@ public static class LetsEncryptSetupUtils
                 try
                 {
                     var content = new StringContent(serializeObject, Encoding.UTF8, "application/json");
-                    var response = await ApiHttpClient.Instance.PostAsync($"/api/v1/dns-n-cert/claim", content, CancellationToken.None).ConfigureAwait(false);
+                    var response = await ApiHttpClient.Instance.PostAsync($"/api/v1/dns-n-cert/claim", content, token).ConfigureAwait(false);
                     response.EnsureSuccessStatusCode();
                     progress?.AddInfo($"Successfully claimed this domain: {setupInfo.Domain}.");
                 }
@@ -67,7 +67,7 @@ public static class LetsEncryptSetupUtils
                     Challenge = challengeResult.Challenge,
                     SetupInfo = setupInfo,
                     Progress = progress,
-                    Token = CancellationToken.None,
+                    Token = token,
                     RegisterTcpDnsRecords = registerTcpDnsRecords
                 });
                 progress?.AddInfo($"Updating DNS record(s) and challenge(s) in {setupInfo.Domain.ToLower()}.{setupInfo.RootDomain.ToLower()}.");
@@ -92,8 +92,7 @@ public static class LetsEncryptSetupUtils
                 SetupInfo = setupInfo,
                 Client = acmeClient,
                 ChallengeResult = challengeResult,
-                Token = CancellationToken.None
-                
+                Token = token
             });
 
             progress.Processed++;

--- a/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
+++ b/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
@@ -35,6 +35,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
     public async Task Should_Create_Secured_Cluster_Generating_Self_Singed_Cert_And_Setup_Zip_File_From_Rvn_Three_Nodes()
     {
         DoNotReuseServerAndUseStagingLetsEncrypt();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 
         var license = Environment.GetEnvironmentVariable("RAVEN_LICENSE");
         Assert.True(license != null, nameof(license) + " != null");
@@ -72,7 +73,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
             {
                 Output.WriteLine(tuple.Exception.Message);
             }
-        }), CancellationToken.None);
+        }), cts.Token);
 
 
         var settingsJsonObject = SetupManager.ExtractCertificatesAndSettingsJsonFromZip(zipBytes, "A",
@@ -220,6 +221,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
     public async Task Should_Create_Secured_Cluster_Generating_Self_Singed_Cert_And_Setup_Zip_File_From_Rvn_One_Node()
     {
         DoNotReuseServerAndUseStagingLetsEncrypt();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 
         var license = Environment.GetEnvironmentVariable("RAVEN_LICENSE");
         Assert.True(license != null, nameof(license) + " != null");
@@ -256,7 +258,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
             {
                 Output.WriteLine(tuple.Exception.Message);
             }
-        }), CancellationToken.None);
+        }), cts.Token);
 
 
         var settingsJsonObject = SetupManager.ExtractCertificatesAndSettingsJsonFromZip(zipBytes, "A",
@@ -324,6 +326,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
     public async Task Should_Create_Secured_Cluster_From_Rvn_Using_Lets_Encrypt_Mode_One_Node()
     {
         DoNotReuseServerAndUseStagingLetsEncrypt();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 
         var license = Environment.GetEnvironmentVariable("RAVEN_LICENSE");
         Assert.True(license != null, nameof(license) + " != null");
@@ -333,7 +336,6 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
         const string rootDomain = "development.run";
         const string publicTcpServerUrl1 = $"tcp://a.{domain}.{rootDomain}:38879";
         const string tcpServerUrl1 = "tcp://127.0.0.1:38879";
-
 
         var setupInfo = new SetupInfo
         {
@@ -369,7 +371,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
         },
             false,
             StagingAcmeClientUrl,
-            CancellationToken.None);
+            cts.Token);
 
         X509Certificate2 serverCert;
         X509Certificate2 clientCert;
@@ -454,6 +456,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
     public async Task Should_Create_Secured_Cluster_From_Rvn_Using_Lets_Encrypt_Mode_Three_Nodes()
     {
         DoNotReuseServerAndUseStagingLetsEncrypt();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 
         var license = Environment.GetEnvironmentVariable("RAVEN_LICENSE");
         Assert.True(license != null, nameof(license) + " != null");
@@ -506,7 +509,7 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
         },
             false,
             StagingAcmeClientUrl,
-            CancellationToken.None);
+            cts.Token);
 
         X509Certificate2 serverCert;
         X509Certificate2 clientCert;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22329

### Additional description

Here is one of the relevant stack traces
![image](https://github.com/ravendb/ravendb/assets/6377808/e7c7d885-51b3-4b6c-8fd0-c9d235908dcb)

What happened here is that the test acquired the lock and waiting for the logging thread to exit.
But the logging thread can't exit, because he also tries to acquire the lock.
-> Deadlock!

The fix is to not trying to acquire the lock if you are the logging thread

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
