### PR TITLE
RavenDB-22331 - Cache isn't invaildated after Changes API reconnection

### DIFF
--- a/src/Raven.Client/Documents/Changes/AggressiveCacheDatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/AggressiveCacheDatabaseChanges.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Raven.Client.Http;
+
+namespace Raven.Client.Documents.Changes;
+
+internal class AggressiveCacheDatabaseChanges : DatabaseChanges
+{
+    internal AggressiveCacheDatabaseChanges(RequestExecutor requestExecutor, string databaseName) : base(requestExecutor, databaseName, onDispose: null, nodeTag: null)
+    {
+    }
+
+    internal override void NotifyAboutReconnection(Exception e)
+    {
+        NotifyAboutError(e);
+    }
+}

--- a/src/Raven.Client/Documents/Changes/AggressiveCacheDatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/AggressiveCacheDatabaseChanges.cs
@@ -5,7 +5,7 @@ namespace Raven.Client.Documents.Changes;
 
 internal class AggressiveCacheDatabaseChanges : DatabaseChanges
 {
-    internal AggressiveCacheDatabaseChanges(RequestExecutor requestExecutor, string databaseName) : base(requestExecutor, databaseName, onDispose: null, nodeTag: null)
+    internal AggressiveCacheDatabaseChanges(RequestExecutor requestExecutor, string databaseName, Action onDispose) : base(requestExecutor, databaseName, onDispose: onDispose, nodeTag: null)
     {
     }
 

--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -584,10 +584,12 @@ namespace Raven.Client.Documents.Changes
                 }
                 catch (Exception e)
                 {
-                    //We don't report this error since we can automatically recover from it and we can't
-                    // recover from the OnError accessing the faulty WebSocket.
+                    // we don't report this error since we can automatically recover from it,
+                    // and we can't recover from the OnError accessing the faulty WebSocket.
                     try
                     {
+                        NotifyAboutReconnection(e);
+
                         if (wasConnected)
                             ConnectionStatusChanged?.Invoke(this, EventArgs.Empty);
 
@@ -608,7 +610,7 @@ namespace Raven.Client.Documents.Changes
                         }
                         catch (Exception)
                         {
-                            //We don't want to stop observe for changes if server down. we will wait for one to be up
+                            // we don't want to stop observing for changes if the server is down. we will wait for it to be up.
                         }
 
                         if (ReconnectClient() == false)
@@ -817,7 +819,11 @@ namespace Raven.Client.Documents.Changes
             }
         }
 
-        private void NotifyAboutError(Exception e)
+        internal virtual void NotifyAboutReconnection(Exception e)
+        {
+        }
+
+        internal void NotifyAboutError(Exception e)
         {
             if (_cts.Token.IsCancellationRequested)
                 return;

--- a/src/Raven.Client/Documents/Changes/DatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseConnectionState.cs
@@ -100,8 +100,9 @@ namespace Raven.Client.Documents.Changes
 
         public void Dispose()
         {
-            if(_connected?.Exception == null)
+            if (_connected?.Exception == null)
                 Set(Task.FromException(new ObjectDisposedException(nameof(DatabaseConnectionState))));
+
             OnDocumentChangeNotification = null;
             OnCounterChangeNotification = null;
             OnTimeSeriesChangeNotification = null;

--- a/src/Raven.Client/Documents/Changes/EvictItemsFromCacheBasedOnChanges.cs
+++ b/src/Raven.Client/Documents/Changes/EvictItemsFromCacheBasedOnChanges.cs
@@ -24,7 +24,7 @@ namespace Raven.Client.Documents.Changes
         public EvictItemsFromCacheBasedOnChanges(DocumentStore store, string databaseName)
         {
             _requestExecutor = store.GetRequestExecutor(databaseName);
-            _changes = new AggressiveCacheDatabaseChanges(_requestExecutor, databaseName);
+            _changes = new AggressiveCacheDatabaseChanges(_requestExecutor, databaseName, onDispose: () => store._aggressiveCacheChanges.TryRemove(databaseName, out _));
             _taskConnected = EnsureConnectedInternalAsync();
         }
 

--- a/src/Raven.Client/Documents/Changes/EvictItemsFromCacheBasedOnChanges.cs
+++ b/src/Raven.Client/Documents/Changes/EvictItemsFromCacheBasedOnChanges.cs
@@ -14,7 +14,6 @@ namespace Raven.Client.Documents.Changes
 {
     internal class EvictItemsFromCacheBasedOnChanges : IObserver<DocumentChange>, IObserver<IndexChange>, IObserver<AggressiveCacheChange>, IDisposable
     {
-        private readonly string _databaseName;
         private readonly DatabaseChanges _changes;
         private IDisposable _documentsSubscription;
         private IDisposable _indexesSubscription;
@@ -24,7 +23,6 @@ namespace Raven.Client.Documents.Changes
 
         public EvictItemsFromCacheBasedOnChanges(DocumentStore store, string databaseName)
         {
-            _databaseName = databaseName;
             _requestExecutor = store.GetRequestExecutor(databaseName);
             _changes = new AggressiveCacheDatabaseChanges(_requestExecutor, databaseName);
             _taskConnected = EnsureConnectedInternalAsync();

--- a/src/Raven.Client/Documents/Changes/EvictItemsFromCacheBasedOnChanges.cs
+++ b/src/Raven.Client/Documents/Changes/EvictItemsFromCacheBasedOnChanges.cs
@@ -26,7 +26,7 @@ namespace Raven.Client.Documents.Changes
         {
             _databaseName = databaseName;
             _requestExecutor = store.GetRequestExecutor(databaseName);
-            _changes = new DatabaseChanges(_requestExecutor, databaseName, onDispose: null, nodeTag: null);
+            _changes = new AggressiveCacheDatabaseChanges(_requestExecutor, databaseName);
             _taskConnected = EnsureConnectedInternalAsync();
         }
 
@@ -81,6 +81,8 @@ namespace Raven.Client.Documents.Changes
 
         public void OnError(Exception error)
         {
+            // any error means that the changes connection was disconnected, and we must invalidate the cache
+            Interlocked.Increment(ref _requestExecutor.Cache.Generation);
         }
 
         public void OnCompleted()

--- a/src/Raven.Client/Documents/DocumentStore.cs
+++ b/src/Raven.Client/Documents/DocumentStore.cs
@@ -31,7 +31,7 @@ namespace Raven.Client.Documents
     {
         private readonly ConcurrentDictionary<DatabaseChangesOptions, IDatabaseChanges> _databaseChanges = new ConcurrentDictionary<DatabaseChangesOptions, IDatabaseChanges>();
 
-        private readonly ConcurrentDictionary<string, Lazy<EvictItemsFromCacheBasedOnChanges>> _aggressiveCacheChanges = new ConcurrentDictionary<string, Lazy<EvictItemsFromCacheBasedOnChanges>>();
+        internal readonly ConcurrentDictionary<string, Lazy<EvictItemsFromCacheBasedOnChanges>> _aggressiveCacheChanges = new ConcurrentDictionary<string, Lazy<EvictItemsFromCacheBasedOnChanges>>();
 
         private readonly ConcurrentDictionary<string, Lazy<RequestExecutor>> _requestExecutors = new ConcurrentDictionary<string, Lazy<RequestExecutor>>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Raven.Server/Documents/ChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/ChangesClientConnection.cs
@@ -599,6 +599,8 @@ namespace Raven.Server.Documents
                                 if (value == null || _disposeToken.IsCancellationRequested)
                                     break;
 
+                                _documentDatabase.ForTestingPurposes?.OnNextMessageChangesApi?.Invoke(value, _webSocket);
+
                                 if (first == false)
                                     writer.WriteComma();
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Net.WebSockets;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
@@ -1986,6 +1987,8 @@ namespace Raven.Server.Documents
             internal Action BeforeSnapshotOfDocuments;
 
             internal Action AfterSnapshotOfDocuments;
+
+            internal Action<DynamicJsonValue, WebSocket> OnNextMessageChangesApi;
 
             internal bool SkipDrainAllRequests = false;
 

--- a/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
+++ b/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
@@ -280,6 +281,71 @@ namespace SlowTests.Server.Documents.Notifications
             }
         }
 
+        [Fact]
+        public async Task CacheIsUpdatedAfterChangesApiReconnection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var database = await GetDatabase(Server, store.Database);
+                var count = 0;
+                database.ForTestingPurposesOnly().OnNextMessageChangesApi = (djv, webSocket) =>
+                {
+                    var nameValue = djv.Properties.FirstOrDefault(x => x.Name == "Type");
+                    if (nameValue.Name == null || (string)nameValue.Value != nameof(AggressiveCacheChange))
+                        return;
+
+                    if (++count == 1)
+                    {
+                        webSocket.Abort();
+                    }
+                };
+
+                const string oldName = "Grisha";
+                const string newName = "Grisha Kotler";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = oldName
+                    }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                using (await store.AggressivelyCacheForAsync(TimeSpan.MaxValue))
+                using (var session = store.OpenAsyncSession())
+                {
+                    var loaded = await session.LoadAsync<User>("users/1");
+                    Assert.Equal(oldName, loaded.Name);
+                }
+
+                using (var updateStore = new DocumentStore
+                {
+                    Urls = store.Urls,
+                    Database = store.Database
+                }.Initialize())
+                {
+                    using (var session = updateStore.OpenAsyncSession())
+                    {
+                        var loaded = await session.LoadAsync<User>("users/1");
+                        loaded.Name = newName;
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                var value = await WaitForValueAsync(async () =>
+                {
+                    using (await store.AggressivelyCacheForAsync(TimeSpan.MaxValue))
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var loaded = await session.LoadAsync<User>("users/1");
+                        return loaded.Name;
+                    }
+                }, newName);
+
+                Assert.Equal(newName, value);
+            }
+        }
+
         private class UsersIndex : AbstractIndexCreationTask<User>
         {
             public override string IndexName => "Users/All";
@@ -302,10 +368,7 @@ namespace SlowTests.Server.Documents.Notifications
                 Map = users =>
                     from user in users
                     select new { user.Name, user.LastName, user.Age, user.AddressId, user.Id };
-
-
             }
         }
-        
     }
 }

--- a/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
+++ b/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
@@ -318,18 +318,11 @@ namespace SlowTests.Server.Documents.Notifications
                     Assert.Equal(oldName, loaded.Name);
                 }
 
-                using (var updateStore = new DocumentStore
+                using (var session = store.OpenAsyncSession())
                 {
-                    Urls = store.Urls,
-                    Database = store.Database
-                }.Initialize())
-                {
-                    using (var session = updateStore.OpenAsyncSession())
-                    {
-                        var loaded = await session.LoadAsync<User>("users/1");
-                        loaded.Name = newName;
-                        await session.SaveChangesAsync();
-                    }
+                    var loaded = await session.LoadAsync<User>("users/1");
+                    loaded.Name = newName;
+                    await session.SaveChangesAsync();
                 }
 
                 var value = await WaitForValueAsync(async () =>

--- a/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
+++ b/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
@@ -281,7 +281,7 @@ namespace SlowTests.Server.Documents.Notifications
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi)]
         public async Task CacheIsUpdatedAfterChangesApiReconnection()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22331/Cache-isnt-invaildated-after-Changes-API-reconnection

### Additional description

In the event of a disruption in the Changes API connection, it's essential to invalidate the cache. This is necessary because there could potentially be some changes during the downtime.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
