### PR TITLE
RavenDB-22346 Remove the take parameter for `SortingMultiMatch`

### DIFF
--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -322,11 +322,6 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             }
 
             Sort.Run(buffer);
-
-            if (match._take >= 0 &&
-                buffer.Length > match._take)
-                buffer = buffer[..match._take];
-
             MaybeBreakTies(buffer, tieBreaker, isDescending);
 
             return ExtractIndexes(buffer, isDescending);

--- a/test/SlowTests/Issues/RavenDB_22346.cs
+++ b/test/SlowTests/Issues/RavenDB_22346.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using Raven.Client.Documents.Indexes;
+using System.Linq;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22346 : RavenTestBase
+{
+    public RavenDB_22346(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void CoraxMultipleOrder_SearchEngine_Test2()
+    {
+        using var store = GetDocumentStore();
+
+        store.ExecuteIndex(new OrderByIndexCorax());
+
+        using (var session = store.OpenSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                session.Store(new TestDocument { Name = "Name_" + i.ToString(), DateCreated = new DateTime(2000, 1, 1).AddDays(i), Archived = i % 2 == 0 });
+            }
+
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var page1 = session.Query<TestDocument, OrderByIndexCorax>()
+                .OrderBy(x => x.Archived).ThenByDescending(x => x.DateCreated).Skip(0).Take(10)
+                .ToList();
+
+            var page2 = session.Query<TestDocument, OrderByIndexCorax>()
+                .OrderBy(x => x.Archived).ThenByDescending(x => x.DateCreated).Skip(10).Take(10)
+                .ToList();
+
+            Assert.NotEqual(page1.First().Id, page2.First().Id);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void CoraxMultipleOrder_SearchEngine_Test()
+    {
+        using var store = GetDocumentStore();
+        store.ExecuteIndex(new OrderByIndexLucene());
+        store.ExecuteIndex(new OrderByIndexCorax());
+        using (var session = store.OpenSession())
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                var obj = new TestDocument { Name = "Name_" + i.ToString(), DateCreated = new DateTime(2000, 1, 1).AddDays(i), Archived = i % 2 == 0 };
+                session.Store(obj);
+            }
+
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var luceneDocs = session.Query<TestDocument, OrderByIndexLucene>()
+                .OrderBy(x => x.Archived)
+                .ThenByDescending(x => x.DateCreated)
+                .Skip(10)
+                .Take(10)
+                .Select(x => x.Id)
+                .ToList();
+
+            var coraxDocs = session.Query<TestDocument, OrderByIndexCorax>()
+                .OrderBy(x => x.Archived).ThenByDescending(x => x.DateCreated).Skip(10).Take(10)
+                .Select(x => x.Id)
+                .ToList();
+
+            Assert.Equal(luceneDocs, coraxDocs);
+
+        }
+
+    }
+    
+    private class OrderByIndexLucene : AbstractIndexCreationTask<TestDocument>
+    {
+        public OrderByIndexLucene()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Lucene;
+
+            Map = entities => from entity in entities
+                select new
+                {
+                    entity.Id,
+                    entity.Name,
+                    entity.Archived,
+                    entity.DateCreated
+                };
+
+        }
+    }
+    
+    private class OrderByIndexCorax : AbstractIndexCreationTask<TestDocument>
+    {
+        public OrderByIndexCorax()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+
+            Map = entities => from entity in entities
+                select new { entity.Id, entity.Name, entity.Archived, entity.DateCreated };
+        }
+    }
+
+    private class TestDocument
+    {
+        public string Id { get; set; } = null!;
+        public bool Archived { get; set; }
+        public DateTime DateCreated { get; set; }
+        public string Name { get; set; } = null!;
+    }
+}

--- a/test/SlowTests/Server/Documents/Queries/Dynamic/Map/DynamicQueriesEnumsNestedFieldsAndCollections.cs
+++ b/test/SlowTests/Server/Documents/Queries/Dynamic/Map/DynamicQueriesEnumsNestedFieldsAndCollections.cs
@@ -47,8 +47,8 @@ namespace SlowTests.Server.Documents.Queries.Dynamic.Map
                     var privateCompanies = session.Query<Company>().Customize(x => x.WaitForNonStaleResults()).Where(x => x.Type == Company.CompanyType.Private).ToList();
 
                     Assert.Equal(2, privateCompanies.Count);
-                    Assert.Equal("companies/1", privateCompanies[0].Id);
-                    Assert.Equal("companies/3", privateCompanies[1].Id);
+                    Assert.Contains("companies/1", privateCompanies.Select(x => x.Id));
+                    Assert.Contains("companies/3", privateCompanies.Select(x => x.Id));
                 }
             }
         }
@@ -164,8 +164,8 @@ namespace SlowTests.Server.Documents.Queries.Dynamic.Map
                     var orders = session.Query<Order>().Customize(x => x.WaitForNonStaleResults()).Where(x => x.Lines.Any(y => y.ProductName == "Keyboard")).ToList();
 
                     Assert.Equal(2, orders.Count);
-                    Assert.Equal("orders/1", orders[0].Id);
-                    Assert.Equal("orders/3", orders[1].Id);
+                    Assert.Contains("orders/1", orders.Select(x => x.Id));
+                    Assert.Contains("orders/3", orders.Select(x => x.Id));
 
                     orders = session.Query<Order>().Customize(x => x.WaitForNonStaleResults()).Where(x => x.Lines.Any(y => y.PricePerUnit >= 10)).ToList();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22346 

### Additional description

Remove the take parameter for `SortingMultiMatch` since we've to do a sort on the whole set using all comparers to get the result.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
