### PR TITLE
RavenDB-22036 Allow resetting an index Side-by-side (studio work)

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/index/resetIndexCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/resetIndexCommand.ts
@@ -1,31 +1,35 @@
 import commandBase = require("commands/commandBase");
-import database = require("models/resources/database");
 import endpoints = require("endpoints");
 import genUtils = require("common/generalUtils");
+
+type IndexResetMode = Raven.Client.Documents.Indexes.IndexResetMode;
 
 class resetIndexCommand extends commandBase {
 
     private readonly indexName: string;
-    private readonly db: database | string;
+    private readonly databaseName: string;
+    private readonly mode: IndexResetMode;
     private readonly location: databaseLocationSpecifier;
 
-    constructor(indexName: string, db: database | string, location: databaseLocationSpecifier) {
+    constructor(indexName: string, databaseName: string, mode: IndexResetMode, location: databaseLocationSpecifier) {
         super();
         this.location = location;
-        this.db = db;
+        this.databaseName = databaseName;
+        this.mode = mode;
         this.indexName = indexName;
     }
 
     execute(): JQueryPromise<{ IndexId: number }> {
         const args = {
-            name: this.indexName, 
+            name: this.indexName,
+            mode: this.mode,
             ...this.location
         };
         const url = endpoints.databases.index.indexes + this.urlEncodeArgs(args);
 
         const locationText = genUtils.formatLocation(this.location);
 
-        return this.reset<{ IndexId: number }>(url, null, this.db)
+        return this.reset<{ IndexId: number }>(url, null, this.databaseName)
             .fail((response: JQueryXHR) => this.reportError(`Failed to reset index ${this.indexName} for ${locationText}`, response.responseText, response.statusText));
     }
 }

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmResetIndex.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmResetIndex.tsx
@@ -9,29 +9,30 @@ import ActionContextUtils from "components/utils/actionContextUtils";
 
 interface ConfirmResetIndexProps {
     indexName: string;
-    toggle: () => void;
     allActionContexts: DatabaseActionContexts[];
+    mode?: Raven.Client.Documents.Indexes.IndexResetMode;
+    closeConfirm: () => void;
     onConfirm: (contexts: DatabaseActionContexts[]) => void;
 }
 
 export function ConfirmResetIndex(props: ConfirmResetIndexProps) {
-    const { toggle, indexName, allActionContexts, onConfirm } = props;
+    const { indexName, mode, allActionContexts, onConfirm, closeConfirm } = props;
 
     const [selectedActionContexts, setSelectedActionContexts] = useState<DatabaseActionContexts[]>(allActionContexts);
 
     const onSubmit = () => {
         onConfirm(selectedActionContexts);
-        toggle();
+        closeConfirm();
     };
 
     return (
-        <Modal isOpen toggle={toggle} wrapClassName="bs5" centered contentClassName="modal-border bulge-warning">
+        <Modal isOpen toggle={closeConfirm} wrapClassName="bs5" centered contentClassName="modal-border bulge-warning">
             <ModalBody className="vstack gap-4 position-relative">
                 <div className="text-center">
                     <Icon icon="index" color="warning" addon="reset-index" className="fs-1" margin="m-0" />
                 </div>
                 <div className="position-absolute m-2 end-0 top-0">
-                    <Button close onClick={toggle} />
+                    <Button close onClick={closeConfirm} />
                 </div>
                 <div className="text-center lead">
                     You&apos;re about to <span className="text-warning">reset</span> following index
@@ -52,6 +53,13 @@ export function ConfirmResetIndex(props: ConfirmResetIndexProps) {
                     <br />
                     <small>All items matched by the index definition will be re-indexed.</small>
                 </Alert>
+                {mode && (
+                    <Alert color="info">
+                        <strong>Reset mode: </strong>
+                        {mode === "InPlace" && <span>In place</span>}
+                        {mode === "SideBySide" && <span>Side by side</span>}
+                    </Alert>
+                )}
                 {ActionContextUtils.showContextSelector(allActionContexts) && (
                     <div>
                         <h4>Select context</h4>
@@ -64,7 +72,7 @@ export function ConfirmResetIndex(props: ConfirmResetIndexProps) {
                 )}
             </ModalBody>
             <ModalFooter>
-                <Button color="link" onClick={toggle} className="link-muted">
+                <Button color="link" onClick={closeConfirm} className="link-muted">
                     Cancel
                 </Button>
                 <Button

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -250,11 +250,11 @@ export function IndexesPage(props: IndexesPageProps) {
             {bulkOperationConfirm && (
                 <BulkIndexOperationConfirm {...bulkOperationConfirm} toggle={() => setBulkOperationConfirm(null)} />
             )}
-            {resetIndexData.indexName && (
+            {resetIndexData.confirmData && (
                 <ConfirmResetIndex
-                    indexName={resetIndexData.indexName}
-                    toggle={() => resetIndexData.setIndexName(null)}
-                    onConfirm={(x) => resetIndexData.onConfirm(x)}
+                    {...resetIndexData.confirmData}
+                    closeConfirm={resetIndexData.closeConfirm}
+                    onConfirm={resetIndexData.onConfirm}
                     allActionContexts={allActionContexts}
                 />
             )}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
@@ -56,7 +56,9 @@ export default function IndexesPageList({
                             setPriority={(p) => setIndexPriority(index, p)}
                             setLockMode={(l) => setIndexLockMode(index, l)}
                             globalIndexingStatus={globalIndexingStatus}
-                            resetIndex={() => resetIndexData.setIndexName(index.name)}
+                            resetIndex={(mode?: Raven.Client.Documents.Indexes.IndexResetMode) =>
+                                resetIndexData.openConfirm(index.name, mode)
+                            }
                             openFaulty={(location: databaseLocationSpecifier) => openFaulty(index, location)}
                             startIndexing={() => startIndexes([index])}
                             disableIndexing={() => disableIndexes([index])}
@@ -90,10 +92,11 @@ export default function IndexesPageList({
                         )}
                         {replacement && (
                             <IndexPanel
+                                isReplacement={true}
                                 setPriority={(p) => setIndexPriority(replacement, p)}
                                 setLockMode={(l) => setIndexLockMode(replacement, l)}
                                 globalIndexingStatus={globalIndexingStatus}
-                                resetIndex={() => resetIndexData.setIndexName(replacement.name)}
+                                resetIndex={() => resetIndexData.openConfirm(replacement.name, "InPlace")}
                                 openFaulty={(location: databaseLocationSpecifier) => openFaulty(replacement, location)}
                                 startIndexing={() => startIndexes([replacement])}
                                 disableIndexing={() => disableIndexes([replacement])}

--- a/src/Raven.Studio/typescript/components/services/IndexesService.ts
+++ b/src/Raven.Studio/typescript/components/services/IndexesService.ts
@@ -35,8 +35,8 @@ export default class IndexesService {
         return new getIndexesStatsCommand(databaseName, location).execute();
     }
 
-    async resetIndex(indexName: string, databaseName: string, location: databaseLocationSpecifier) {
-        await new resetIndexCommand(indexName, databaseName, location).execute();
+    async resetIndex(...args: ConstructorParameters<typeof resetIndexCommand>) {
+        await new resetIndexCommand(...args).execute();
     }
 
     async pauseAllIndexes(databaseName: string, location: databaseLocationSpecifier) {

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -326,6 +326,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(IndexOptimizeResult));
             scripter.AddType(typeof(TestIndexParameters));
             scripter.AddType(typeof(TestIndexResult));
+            scripter.AddType(typeof(IndexResetMode));
 
             // cluster
             scripter.AddType(typeof(ClusterTopology));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22036/Allow-resetting-an-index-Side-by-side

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
