### PR TITLE
RavenDB-22320 JavaScript error breaking Certificates view

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/certificates.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/certificates.ts
@@ -660,7 +660,10 @@ class certificates extends viewModelBase {
                 secondaryCertificates.forEach(cert => {
                     const thumbprint = cert.CollectionPrimaryKey;
                     const primaryCert = mergedCertificates.find(x => x.Thumbprint === thumbprint);
-                    primaryCert.Thumbprints.push(cert.Thumbprint);
+                    
+                    if (primaryCert) {
+                        primaryCert.Thumbprints.push(cert.Thumbprint);
+                    }
                 });
                 
                 const orderedCertificates = this.sortByDefaultInternal(mergedCertificates);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22320/JavaScript-error-breaking-Certificates-view

### Additional description

Fixes case when primary cert doesn't exist

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
