### PR TITLE
RavenDB-7070 Fixing warnings

### DIFF
--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -81,6 +81,10 @@ namespace Raven.Embedded
                     var thumbprint = options.Security.ServerCertificateThumbprint;
                     RequestExecutor.RemoteCertificateValidationCallback += (sender, certificate, chain, errors) =>
                     {
+#if NET6_0_OR_GREATER
+                        if (certificate == null)
+                            return false;
+#endif
                         var certificate2 = certificate as X509Certificate2 ?? new X509Certificate2(certificate);
                         return certificate2.Thumbprint == thumbprint;
                     };

--- a/src/Raven.Embedded/ProcessHelper.cs
+++ b/src/Raven.Embedded/ProcessHelper.cs
@@ -14,7 +14,7 @@ namespace Raven.Embedded
         {
             var sb = new StringBuilder();
 
-            Task<string>? readLineTask = null;
+            Task<string?>? readLineTask = null;
             while (true)
             {
                 readLineTask ??= output.ReadLineAsync();

--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/BlittableJsonElasticSerializer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/BlittableJsonElasticSerializer.cs
@@ -38,9 +38,24 @@ internal class BlittableJsonElasticSerializer : Serializer
         }
     }
 
-    public override Task SerializeAsync<T>(T data, Stream stream,
-        SerializationFormatting formatting = SerializationFormatting.None, CancellationToken cancellationToken = default) =>
-        throw new NotSupportedException();
+    public override async Task SerializeAsync<T>(T data, Stream stream,
+        SerializationFormatting formatting = SerializationFormatting.None, CancellationToken cancellationToken = default)
+    {
+        if (_context is null)
+        {
+            throw new InvalidOperationException("Context cannot be null");
+        }
+        if (data is not BlittableJsonReaderObject json)
+        {
+            throw new NotSupportedException(
+                $"Blittable elastic serializer cannot serialize object of type '{data.GetType()}'. Object type needs to be '{typeof(BlittableJsonReaderObject)}'");
+        }
+
+        await using (var writer = new AsyncBlittableJsonTextWriter(_context, stream))
+        {
+            writer.WriteObject(json);
+        }
+    }
         
     public override object Deserialize(Type type, Stream stream) =>
         throw new NotSupportedException();

--- a/test/FastTests/Corax/Bugs/RavenDB-22285.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-22285.cs
@@ -47,7 +47,6 @@ public class RavenDB_22285 : StorageTest
         using (var indexSearcher = new IndexSearcher(Env, mapping))
         {
             var termsReader =  indexSearcher.TermsReaderFor(nameof(Id));
-            Page p = default;
             var exists = indexSearcher.ExistsQuery(mapping.GetByFieldId(Content).Metadata);
             var termMatch = indexSearcher.TermQuery(mapping.GetByFieldId(Content2).Metadata, "common0");
             var buffer = new long[512];

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using FastTests;
 using Elastic.Clients.Elasticsearch;
 using Raven.Client.Documents;
@@ -104,22 +105,22 @@ loadToOrders" + IndexSuffix + @"(orderData);";
                 ElasticSearchHelper.CreateClient(new ElasticSearchConnectionString {Nodes = ElasticSearchTestNodes.Instance.VerifiedNodes.Value},
                     useCustomBlittableSerializer: false);
             
-            CleanupIndexes(localClient);
+            AsyncHelpers.RunSync(() => CleanupIndexes(localClient));
 
             return new DisposableAction(() =>
             {
-                CleanupIndexes(localClient);
+                AsyncHelpers.RunSync(() => CleanupIndexes(localClient));
             });
         }
 
-        private void CleanupIndexes(ElasticsearchClient client)
+        private async Task CleanupIndexes(ElasticsearchClient client)
         {
             if (_definedIndexes.Count <= 0)
                 return;
 
             foreach (var indexName in _definedIndexes)
             {
-                var response = client.Indices.Delete(Indices.Index(indexName.ToLower()));
+                var response = await client.Indices.DeleteAsync(Indices.Index(indexName.ToLower()));
 
                 if (response.IsValidResponse)
                     continue;

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTests.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         };
 
         [RequiresElasticSearchRetryFact]
-        public void SimpleScript()
+        public async Task SimpleScript()
         {
             using (var store = GetDocumentStore())
             using (GetElasticClient(out var client))
@@ -59,8 +59,8 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                var ordersCount = client.Count<object>(descriptor => descriptor.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCount = client.Count<object>(descriptor => descriptor.Indices(Indices.Index(OrderLinesIndexName)));
+                var ordersCount = await client.CountAsync<object>(descriptor => descriptor.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCount = await client.CountAsync<object>(descriptor => descriptor.Indices(Indices.Index(OrderLinesIndexName)));
 
                 Assert.Equal(1, ordersCount.Count);
                 Assert.Equal(2, orderLinesCount.Count);
@@ -76,8 +76,8 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                var ordersCountAfterDelete = client.Count<object>(descriptor => descriptor.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCountAfterDelete = client.Count<object>(descriptor => descriptor.Indices(Indices.Index(OrderLinesIndexName)));
+                var ordersCountAfterDelete = await client.CountAsync<object>(descriptor => descriptor.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCountAfterDelete = await client.CountAsync<object>(descriptor => descriptor.Indices(Indices.Index(OrderLinesIndexName)));
 
                 Assert.True(ordersCount.IsValidResponse);
                 Assert.True(orderLinesCount.IsValidResponse);
@@ -88,7 +88,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         }
 
         [RequiresElasticSearchRetryFact]
-        public void SimpleScriptWithManyDocuments()
+        public async Task SimpleScriptWithManyDocuments()
         {
             using (var store = GetDocumentStore())
             using (GetElasticClient(out var client))
@@ -121,8 +121,8 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                var ordersCount = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCount = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
+                var ordersCount = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCount = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
                 
                 Assert.Equal(numberOfOrders, ordersCount.Count);
                 Assert.Equal(numberOfOrders * numberOfLinesPerOrder, orderLinesCount.Count);
@@ -141,8 +141,8 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                var ordersCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
+                var ordersCountAfterDelete = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCountAfterDelete = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
 
                 Assert.Equal(0, ordersCountAfterDelete.Count);
                 Assert.Equal(0, orderLinesCountAfterDelete.Count);
@@ -196,7 +196,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         }
 
         [RequiresElasticSearchRetryFact]
-        public void Can_get_document_id()
+        public async Task Can_get_document_id()
         {
             using (var store = GetDocumentStore())
             using (GetElasticClient(out var client))
@@ -219,10 +219,10 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                client.Indices.Refresh(OrdersIndexName);
-                client.Indices.Refresh(OrderLinesIndexName);
+                await client.Indices.RefreshAsync(OrdersIndexName);
+                await client.Indices.RefreshAsync(OrderLinesIndexName);
 
-                var orderResponse = client.Search<object>(d => d
+                var orderResponse = await client.SearchAsync<object>(d => d
                     .Index(OrdersIndexName)
                     .Query(q => q
                         .Term(p => p
@@ -231,7 +231,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
                     )
                 );
 
-                var orderLineResponse = client.Search<object>(d => d
+                var orderLineResponse = await client.SearchAsync<object>(d => d
                     .Index(OrderLinesIndexName)
                     .Query(q => q
                         .Term(p => p
@@ -261,12 +261,12 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                client.Indices.Refresh(OrdersIndexName);
-                client.Indices.Refresh(OrderLinesIndexName);
+                await client.Indices.RefreshAsync(OrdersIndexName);
+                await client.Indices.RefreshAsync(OrderLinesIndexName);
 
 
-                var ordersCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
+                var ordersCountAfterDelete = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCountAfterDelete = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
 
                 Assert.Equal(0, ordersCountAfterDelete.Count);
                 Assert.Equal(0, orderLinesCountAfterDelete.Count);
@@ -274,7 +274,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         }
 
         [RequiresElasticSearchRetryFact]
-        public void Can_Update_To_Be_No_Items_In_Child_TTable()
+        public async Task Can_Update_To_Be_No_Items_In_Child_TTable()
         {
             using (var store = GetDocumentStore())
             using (GetElasticClient(out var client))
@@ -296,11 +296,11 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                client.Indices.Refresh(OrdersIndexName);
-                client.Indices.Refresh(OrderLinesIndexName);
+                await client.Indices.RefreshAsync(OrdersIndexName);
+                await client.Indices.RefreshAsync(OrderLinesIndexName);
 
-                var ordersCount = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCount = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
+                var ordersCount = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCount = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
 
                 Assert.Equal(1, ordersCount.Count);
                 Assert.Equal(2, orderLinesCount.Count);
@@ -316,11 +316,11 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                client.Indices.Refresh(OrdersIndexName);
-                client.Indices.Refresh(OrderLinesIndexName);
+                await client.Indices.RefreshAsync(OrdersIndexName);
+                await client.Indices.RefreshAsync(OrderLinesIndexName);
 
-                var ordersCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
+                var ordersCountAfterDelete = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCountAfterDelete = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
 
                 Assert.Equal(1, ordersCountAfterDelete.Count);
                 Assert.Equal(0, orderLinesCountAfterDelete.Count);
@@ -328,7 +328,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         }
 
         [RequiresElasticSearchRetryFact]
-        public void Update_of_disassembled_document()
+        public async Task Update_of_disassembled_document()
         {
             using (var store = GetDocumentStore())
             using (GetElasticClient(out var client))
@@ -350,9 +350,9 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                client.Indices.Refresh(OrdersIndexName);
+                await client.Indices.RefreshAsync(OrdersIndexName);
 
-                var orderResponse = client.Search<object>(d => d
+                var orderResponse = await client.SearchAsync<object>(d => d
                     .Index(OrdersIndexName)
                     .Query(q => q
                         .Term(p => p
@@ -387,9 +387,9 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(2), store.Database, config);
 
-                client.Indices.Refresh(OrdersIndexName);
+                await client.Indices.RefreshAsync(OrdersIndexName);
 
-                var orderResponse1 = client.Search<object>(d => d
+                var orderResponse1 = await client.SearchAsync<object>(d => d
                     .Index(OrdersIndexName)
                     .Query(q => q
                         .Term(p => p
@@ -410,7 +410,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         }
 
         [RequiresElasticSearchRetryFact]
-        public void Docs_from_two_collections_loaded_to_single_one()
+        public async Task Docs_from_two_collections_loaded_to_single_one()
         {
             using (var store = GetDocumentStore())
             using (GetElasticClient(out var client))
@@ -429,9 +429,9 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                client.Indices.Refresh(UsersIndexName);
+                await client.Indices.RefreshAsync(UsersIndexName);
 
-                var userResponse1 = client.Search<object>(d => d
+                var userResponse1 = await client.SearchAsync<object>(d => d
                     .Index(UsersIndexName)
                     .Query(q => q
                         .Term(p => p
@@ -446,9 +446,9 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
                 Assert.NotNull(userObject1);
                 Assert.Equal("Joe Doe", ((JsonElement)userObject1).GetProperty("Name").ToString());
 
-                client.Indices.Refresh(UsersIndexName);
+                await client.Indices.RefreshAsync(UsersIndexName);
 
-                var userResponse2 = client.Search<object>(d => d
+                var userResponse2 = await client.SearchAsync<object>(d => d
                     .Index(UsersIndexName)
                     .Query(q => q
                         .Term(p => p
@@ -477,9 +477,9 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                client.Indices.Refresh(UsersIndexName);
+                await client.Indices.RefreshAsync(UsersIndexName);
 
-                var userResponse3 = client.Search<object>(d => d
+                var userResponse3 = await client.SearchAsync<object>(d => d
                     .Index(UsersIndexName)
                     .Query(q => q
                         .Term(p => p
@@ -493,9 +493,9 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
                 Assert.NotNull(userObject3);
                 Assert.Equal("Doe Joe", ((JsonElement)userObject3).GetProperty("Name").ToString());
 
-                client.Indices.Refresh(UsersIndexName);
+                await client.Indices.RefreshAsync(UsersIndexName);
 
-                var userResponse4 = client.Search<object>(d => d
+                var userResponse4 = await client.SearchAsync<object>(d => d
                     .Index(UsersIndexName)
                     .Query(q => q
                         .Term(p => p
@@ -513,7 +513,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         }
 
         [RequiresElasticSearchRetryFact]
-        public void Can_load_to_specific_collection_when_applying_to_all_docs()
+        public async Task Can_load_to_specific_collection_when_applying_to_all_docs()
         {
             using (var src = GetDocumentStore())
             using (GetElasticClient(out var client))
@@ -534,7 +534,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), src.Database, config);
 
-                var userResponse = client.Search<object>(d => d
+                var userResponse = await client.SearchAsync<object>(d => d
                     .Index(UsersIndexName)
                     .Query(q => q
                         .Term(p => p
@@ -548,7 +548,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         }
 
         [RequiresElasticSearchRetryFact]
-        public void Should_delete_existing_document_when_filtered_by_script()
+        public async Task Should_delete_existing_document_when_filtered_by_script()
         {
             using (var src = GetDocumentStore())
             using (GetElasticClient(out var client))
@@ -569,7 +569,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), src.Database, config);
 
-                var userResponse = client.Search<object>(d => d
+                var userResponse = await client.SearchAsync<object>(d => d
                     .Index(UsersIndexName)
                     .Query(q => q
                         .Term(p => p
@@ -591,7 +591,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), src.Database, config);
 
-                userResponse = client.Search<object>(d => d
+                userResponse = await client.SearchAsync<object>(d => d
                     .Index("users")
                     .Query(q => q
                         .Term(p => p
@@ -645,7 +645,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
         }
 
         [RequiresElasticSearchRetryFact]
-        public void Etl_from_encrypted_to_non_encrypted_db_will_work()
+        public async Task Etl_from_encrypted_to_non_encrypted_db_will_work()
         {
             var certificates = Certificates.SetupServerAuthentication();
             var dbName = GetDatabaseName();
@@ -714,7 +714,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), src.Database, config);
 
-                var userResponse1 = client.Search<object>(d => d
+                var userResponse1 = await client.SearchAsync<object>(d => d
                     .Index(UsersIndexName)
                     .Query(q => q
                         .Term(p => p

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17476.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17476.cs
@@ -44,7 +44,7 @@ loadTo" + OrdersIndexName + @"(orderData);
 ";
 
         [RequiresElasticSearchRetryFact]
-        public void CanOmitDocumentIdPropertyInJsonPassedToLoadTo()
+        public async Task CanOmitDocumentIdPropertyInJsonPassedToLoadTo()
         {
             using (var store = GetDocumentStore())
             using (GetElasticClient(out var client))
@@ -68,8 +68,8 @@ loadTo" + OrdersIndexName + @"(orderData);
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                var ordersCount = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCount = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
+                var ordersCount = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCount = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
 
                 Assert.True(ordersCount.IsValidResponse);
                 Assert.True(orderLinesCount.IsValidResponse);
@@ -88,8 +88,8 @@ loadTo" + OrdersIndexName + @"(orderData);
 
                 AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-                var ordersCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
-                var orderLinesCountAfterDelete = client.Count<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
+                var ordersCountAfterDelete = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
+                var orderLinesCountAfterDelete = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
 
                 Assert.True(ordersCount.IsValidResponse);
                 Assert.True(orderLinesCount.IsValidResponse);

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Server.Documents.ETL.ElasticSearch
             using (var store = GetDocumentStore())
             using (GetElasticClient(out var client))
             {
-                client.Indices.Create(OrdersIndexName, c => c
+                await client.Indices.CreateAsync(OrdersIndexName, c => c
                     .Mappings(m => m
                         .Properties<object>(p => p
                             .MatchOnlyText("Id"))));

--- a/test/Tests.Infrastructure/ConnectionString/ElasticSearchTestNodes.cs
+++ b/test/Tests.Infrastructure/ConnectionString/ElasticSearchTestNodes.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Elastic.Clients.Elasticsearch;
 using Raven.Client.Documents.Operations.ETL.ElasticSearch;
+using Raven.Client.Util;
 using Raven.Server.Documents.ETL.Providers.ElasticSearch;
 
 namespace Tests.Infrastructure.ConnectionString
@@ -72,7 +73,7 @@ namespace Tests.Infrastructure.ConnectionString
                 {
                     var client = ElasticSearchHelper.CreateClient(new ElasticSearchConnectionString { Nodes = nodes }, requestTimeout: TimeSpan.FromSeconds(1), pingTimeout: TimeSpan.FromSeconds(1));
 
-                    response = client.Ping();
+                    response = AsyncHelpers.RunSync(() => client.PingAsync());
 
                     return response.IsValidResponse;
                 }


### PR DESCRIPTION

### Additional description

Warnings on 6.0 branch. Mostly related to marking sync API of Elasticsearch client deprecated.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
