### PR TITLE
RavenDB-22305 - Missing DirtyMemory from the memory notification

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -538,7 +538,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
             public string EncryptionBuffersPool { get; set; }
             public string EncryptionLockedMemory { get; set; }
             public string MemoryMapped { get; set; }
-            public string ScratchDirtyMemory { get; set; }
             public bool IsHighDirty { get; set; }
             public string DirtyMemory { get; set; }
             public string AvailableMemory { get; set; }

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -745,7 +745,7 @@ namespace Sparrow.Server.LowMemory
 
             return new DirtyMemoryState
             {
-                IsHighDirty = totalScratchMemory > 
+                IsHighDirty = totalScratchMemory >
                               TotalPhysicalMemory * LowMemoryNotification.Instance.TemporaryDirtyMemoryAllowedPercentage,
                 TotalDirty = totalScratchMemory
             };

--- a/test/Tests.Infrastructure/TestMetrics/TestResourceSnapshotWriter.cs
+++ b/test/Tests.Infrastructure/TestMetrics/TestResourceSnapshotWriter.cs
@@ -97,7 +97,6 @@ namespace Tests.Infrastructure.TestMetrics
                 AvailableMemoryInMb = memoryInfo.AvailableMemory.GetValue(SizeUnit.Megabytes),
                 CurrentCommitChargeInMb = memoryInfo.CurrentCommitCharge.GetValue(SizeUnit.Megabytes),
                 SharedCleanMemoryInMb = memoryInfo.SharedCleanMemory.GetValue(SizeUnit.Megabytes),
-                TotalScratchDirtyMemory = MemoryInformation.GetDirtyMemoryState().TotalDirty.GetValue(SizeUnit.Megabytes),
                 CurrentIpv4Connections = tcpConnections.CurrentIpv4,
                 CurrentIpv6Connections = tcpConnections.CurrentIpv6
             };
@@ -140,8 +139,6 @@ namespace Tests.Infrastructure.TestMetrics
             public long CurrentCommitChargeInMb { get; set; }
             
             public long SharedCleanMemoryInMb { get; set; }
-            
-            public long TotalScratchDirtyMemory { get; set; }
             
             public long TotalScratchAllocatedMemory { get; set; }
             


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22305/Missing-DirtyMemory-from-the-memory-notification

Merge from 5.4 changes.

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
