### PR TITLE
RavenDB-20986 Set responsible node select list control is empty on Edit replication sink

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
@@ -53,7 +53,7 @@
                             <div class="form-group">
                                 <label class="control-label">&nbsp;</label>
                                 <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                    <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                                    <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                                     <label for="responsibleNode">Set responsible node</label>
                                 </div>
                             </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editExternalReplicationTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editExternalReplicationTask.html
@@ -75,7 +75,7 @@
                         <div class="form-group">
                             <label class="control-label">&nbsp;</label>
                             <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                                 <label for="responsibleNode">Set responsible node</label>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
@@ -51,7 +51,7 @@
                         <div class="form-group">
                             <label class="control-label">&nbsp;</label>
                             <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                                 <label for="responsibleNode">Set responsible node</label>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
@@ -53,7 +53,7 @@
                             <div class="form-group">
                                 <label class="control-label">&nbsp;</label>
                                 <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                    <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor" />
+                                    <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0" />
                                     <label for="responsibleNode">Set responsible node</label>
                                 </div>
                             </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editPeriodicBackupTask.html
@@ -98,7 +98,7 @@
                     <div class="col-sm-4 col-sm-offset-4 col-lg-offset-2">
                         <div class="toggle">
                             <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                                 <label for="responsibleNode">Set responsible node</label>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
@@ -51,7 +51,7 @@
                         <div class="form-group">
                             <label class="control-label">&nbsp;</label>
                             <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                                 <label for="responsibleNode">Set responsible node</label>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
@@ -51,7 +51,7 @@
                         <div class="form-group">
                             <label class="control-label">&nbsp;</label>
                             <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                                 <label for="responsibleNode">Set responsible node</label>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationHubTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationHubTask.html
@@ -58,7 +58,7 @@
                             <div class="form-group margin-bottom margin-bottom-xs">
                                 <label class="control-label">&nbsp;</label>
                                 <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                    <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor" />
+                                    <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0" />
                                     <label for="responsibleNode">Set responsible node</label>
                                 </div>
                             </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationSinkTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editReplicationSinkTask.html
@@ -54,7 +54,7 @@
                         <div class="form-group margin-bottom margin-bottom-xs">
                             <label class="control-label">&nbsp;</label>
                             <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                <input id="manualMentorNode" type="checkbox" data-bind="checked: manualChooseMentor" />
+                                <input id="manualMentorNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0" />
                                 <label for="manualMentorNode">Set responsible node</label>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
@@ -53,7 +53,7 @@
                             <div class="form-group">
                                 <label class="control-label">&nbsp;</label>
                                 <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                    <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                                    <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                                     <label for="responsibleNode">Set responsible node</label>
                                 </div>
                             </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSubscriptionTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSubscriptionTask.html
@@ -102,7 +102,7 @@
                             </div>
                             <div class="form-group">
                                 <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                    <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                                    <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                                     <label for="responsibleNode">Set responsible node</label>
                                 </div>
                             </div>

--- a/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/editServerWideBackup.html
@@ -98,7 +98,7 @@
                 <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4">
                     <div class="toggle">
                         <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                            <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                            <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                             <label for="responsibleNode">Set responsible node</label>
                         </div>
                     </div>

--- a/src/Raven.Studio/wwwroot/App/views/manage/editServerWideExternalReplication.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/editServerWideExternalReplication.html
@@ -62,7 +62,7 @@
                         <div class="form-group">
                             <label class="control-label">&nbsp;</label>
                             <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to set a responsible node for the task" data-animation="true">
-                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                                <input id="responsibleNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                                 <label for="responsibleNode">Set responsible node</label>
                             </div>
                         </div>

--- a/src/Raven.Studio/wwwroot/App/views/partial/taskResponsibleNodeSection.html
+++ b/src/Raven.Studio/wwwroot/App/views/partial/taskResponsibleNodeSection.html
@@ -1,32 +1,48 @@
-<div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
-    <div class="form-group" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
-        <div>
-            <label class="control-label">Responsible Node</label>
-        </div>
-        <div class="flex-grow">
-            <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
-                <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
-                <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
-            </ul>
-            <span class="help-block" data-bind="validationMessage: mentorNode"></span>
-        </div>
-    </div>
-    <div data-bind="visible: mentorNode">
-        <div class="form-group small">
-            <label class="control-label">&nbsp;</label>
-            <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to pin selected node" data-animation="true">
-                <input id="pinMentorNode" type="checkbox" data-bind="checked: pinMentorNode">
-                <label for="pinMentorNode">Pin node</label>
+<div>
+    <div class="form-group small" data-bind="visible: $root.possibleMentors().length === 0">
+        <label class="control-label">&nbsp;</label>
+        <div class="text-warning bg-warning padding padding-xs">
+            <div class="flex-horizontal">
+                <small>
+                    <i class="icon-warning"></i>
+                </small>
+                <small class="margin-left margin-left-sm">
+                    Currently, the responsible node cannot be selected because there are no nodes available.
+                </small>
             </div>
         </div>
     </div>
-    <div data-bind="visible: mentorNode">
-        <div class="form-group small">
-            <label class="control-label">&nbsp;</label>
-            <div class="flex-grow" data-bind="compose: $root.pinResponsibleNodeTextScriptView"></div>
+
+    <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
+        <div class="form-group" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
+            <div>
+                <label class="control-label">Responsible Node</label>
+            </div>
+            <div class="flex-grow">
+                <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
+                    <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
+                    <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
+                </ul>
+                <span class="help-block" data-bind="validationMessage: mentorNode"></span>
+            </div>
+        </div>
+        <div data-bind="visible: mentorNode">
+            <div class="form-group small">
+                <label class="control-label">&nbsp;</label>
+                <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to pin selected node" data-animation="true">
+                    <input id="pinMentorNode" type="checkbox" data-bind="checked: pinMentorNode">
+                    <label for="pinMentorNode">Pin node</label>
+                </div>
+            </div>
+        </div>
+        <div data-bind="visible: mentorNode">
+            <div class="form-group small">
+                <label class="control-label">&nbsp;</label>
+                <div class="flex-grow" data-bind="compose: $root.pinResponsibleNodeTextScriptView"></div>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Raven.Studio/wwwroot/App/views/partial/taskResponsibleNodeSection_ForBackup.html
+++ b/src/Raven.Studio/wwwroot/App/views/partial/taskResponsibleNodeSection_ForBackup.html
@@ -1,30 +1,47 @@
-<div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
-    <div class="row" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
-        <label class="control-label col-sm-4 col-lg-2">Responsible Node</label>
-        <div class="col-sm-4 flex-horizontal">
-            <div class="dropdown btn-block">
-                <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
-                    <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
-                    <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
-                    <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
-                </ul>
-                <span class="help-block" data-bind="validationMessage: mentorNode"></span>
+<div>
+    <div class="row margin-bottom small">
+        <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4" data-bind="visible: $root.possibleMentors().length === 0">
+            <div class="text-warning bg-warning padding padding-xs">
+                <div class="flex-horizontal">
+                    <small>
+                        <i class="icon-warning"></i>
+                    </small>
+                    <small class="margin-left margin-left-sm">
+                        Currently, the responsible node cannot be selected because there are no nodes available.
+                    </small>
+                </div>
             </div>
         </div>
     </div>
-    <div class="row margin-bottom small">
-        <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4" data-bind="visible: mentorNode">
-            <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to pin selected node" data-animation="true">
-            <input id="pinMentorNode" type="checkbox" data-bind="checked: pinMentorNode">
-            <label for="pinMentorNode">Pin node</label>
+
+    <div data-bind="validationElement: mentorNode, collapse: manualChooseMentor">
+        <div class="row" data-bind="css: { 'margin-bottom-xs': mentorNode() }">
+            <label class="control-label col-sm-4 col-lg-2">Responsible Node</label>
+            <div class="col-sm-4 flex-horizontal">
+                <div class="dropdown btn-block">
+                    <button class="btn btn-block dropdown-toggle text-left" data-toggle="dropdown">
+                        <span data-bind="text: mentorNode() ? 'Node ' + mentorNode() : 'Select responsible node'"></span>
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" data-bind="foreach: $root.possibleMentors">
+                        <li><a href="#" data-bind="text: 'Node ' + $data, click: $parent.mentorNode.bind($parent.mentorNode, $data)"></a></li>
+                    </ul>
+                    <span class="help-block" data-bind="validationMessage: mentorNode"></span>
+                </div>
+            </div>
         </div>
+        <div class="row margin-bottom small">
+            <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4" data-bind="visible: mentorNode">
+                <div class="toggle" data-placement="right" data-toggle="tooltip" title="Toggle on to pin selected node" data-animation="true">
+                <input id="pinMentorNode" type="checkbox" data-bind="checked: pinMentorNode">
+                <label for="pinMentorNode">Pin node</label>
+            </div>
+            </div>
         </div>
-    </div>
-    <div class="row margin-bottom small">
-        <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4" data-bind="visible: mentorNode">
-            <div data-bind="compose: $root.pinResponsibleNodeTextScriptView"></div>
+        <div class="row margin-bottom small">
+            <div class="col-sm-offset-4 col-lg-offset-2 col-sm-4" data-bind="visible: mentorNode">
+                <div data-bind="compose: $root.pinResponsibleNodeTextScriptView"></div>
+            </div>
         </div>
-    </div>
+    </div>    
 </div>

--- a/src/Raven.Studio/wwwroot/App/views/resources/addNewNodeToDatabaseGroup.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/addNewNodeToDatabaseGroup.html
@@ -33,7 +33,7 @@
                     <label class="control-label">&nbsp;</label>
                     <div class="toggle">
                         <div data-placement="right" data-toggle="tooltip" title="Mentor node is responsible for replicating data to the newly added node" data-animation="true">
-                            <input id="manualMentorNode" type="checkbox" data-bind="checked: manualChooseMentor">
+                            <input id="manualMentorNode" type="checkbox" data-bind="checked: manualChooseMentor, disable: $root.possibleMentors().length === 0">
                             <label for="manualMentorNode">Set preferred mentor node</label>
                         </div>
                     </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20986/Set-responsible-node-select-list-control-is-empty-on-Edit-replication-sink

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
