### PR TITLE
RavenDB-21250 Reset selected indexes

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmResetIndexes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/ConfirmResetIndexes.tsx
@@ -7,16 +7,16 @@ import {
 } from "components/common/MultipleDatabaseLocationSelector";
 import ActionContextUtils from "components/utils/actionContextUtils";
 
-interface ConfirmResetIndexProps {
-    indexName: string;
+interface ConfirmResetIndexesProps {
+    indexNames: string[];
     allActionContexts: DatabaseActionContexts[];
     mode?: Raven.Client.Documents.Indexes.IndexResetMode;
     closeConfirm: () => void;
     onConfirm: (contexts: DatabaseActionContexts[]) => void;
 }
 
-export function ConfirmResetIndex(props: ConfirmResetIndexProps) {
-    const { indexName, mode, allActionContexts, onConfirm, closeConfirm } = props;
+export function ConfirmResetIndexes(props: ConfirmResetIndexesProps) {
+    const { indexNames, mode, allActionContexts, onConfirm, closeConfirm } = props;
 
     const [selectedActionContexts, setSelectedActionContexts] = useState<DatabaseActionContexts[]>(allActionContexts);
 
@@ -35,12 +35,14 @@ export function ConfirmResetIndex(props: ConfirmResetIndexProps) {
                     <Button close onClick={closeConfirm} />
                 </div>
                 <div className="text-center lead">
-                    You&apos;re about to <span className="text-warning">reset</span> following index
+                    You&apos;re about to <span className="text-warning">reset</span> following{" "}
+                    {indexNames.length === 1 ? "index" : `indexs`}
                 </div>
-                <span className="d-flex align-items-center word-break bg-faded-primary py-1 px-3 w-fit-content rounded-pill mx-auto">
-                    <Icon icon="index" />
-                    {indexName}
-                </span>
+                <ul className="overflow-auto" style={{ maxHeight: "200px" }}>
+                    {indexNames.map((indexName) => (
+                        <li key={indexName}>{indexName}</li>
+                    ))}
+                </ul>
                 <Alert color="warning">
                     <small>
                         <strong>Reset</strong> will remove all existing indexed data

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -41,6 +41,7 @@ import { Icon } from "components/common/Icon";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import ResetIndexesButton from "components/pages/database/indexes/list/partials/ResetIndexesButton";
 
 export interface IndexPanelProps {
     index: IndexSharedInfo;
@@ -55,7 +56,6 @@ export interface IndexPanelProps {
     openFaulty: (location: databaseLocationSpecifier) => Promise<void>;
     selected: boolean;
     hasReplacement?: boolean;
-    isReplacement?: boolean;
     toggleSelection: () => void;
     ref?: any;
 }
@@ -366,7 +366,7 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                         )}
                         {hasDatabaseWriteAccess && (
                             <>
-                                <ResetButton resetIndex={resetIndex} isReplacement={isReplacement} />
+                                <ResetIndexesButton resetIndex={resetIndex} isDropdownVisible={!isReplacement} />
                                 <Button color="danger" onClick={deleteIndex} title="Delete the index">
                                     <Icon icon="trash" margin="m-0" />
                                 </Button>
@@ -540,33 +540,3 @@ function InlineDetails(props: InlineDetailsProps) {
 }
 
 const indexUniqueId = (index: IndexSharedInfo) => "index_" + index.name;
-
-interface ResetButtonProps {
-    resetIndex: (mode?: Raven.Client.Documents.Indexes.IndexResetMode) => void;
-    isReplacement?: boolean;
-}
-
-function ResetButton({ resetIndex, isReplacement }: ResetButtonProps) {
-    return (
-        <UncontrolledDropdown group>
-            <Button color="warning" onClick={() => resetIndex()} title="Reset index (rebuild)">
-                <Icon icon="reset-index" margin="m-0" />
-            </Button>
-            {!isReplacement && (
-                <>
-                    <DropdownToggle className="dropdown-toggle" color="warning" />
-                    <DropdownMenu end>
-                        <DropdownItem onClick={() => resetIndex("InPlace")} title="Reset index in place">
-                            <Icon icon="reset-index" addon="arrow-down" />
-                            Reset in place
-                        </DropdownItem>
-                        <DropdownItem onClick={() => resetIndex("SideBySide")} title="Reset index side by side">
-                            <Icon icon="reset-index" addon="swap" />
-                            Reset side by side
-                        </DropdownItem>
-                    </DropdownMenu>
-                </>
-            )}
-        </UncontrolledDropdown>
-    );
-}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexSelectActions.tsx
@@ -1,26 +1,22 @@
 ﻿import React, { useState } from "react";
 import IndexLockMode = Raven.Client.Documents.Indexes.IndexLockMode;
-import {
-    Button,
-    ButtonGroup,
-    DropdownItem,
-    DropdownMenu,
-    DropdownToggle,
-    Spinner,
-    UncontrolledDropdown,
-} from "reactstrap";
+import { Button, DropdownItem, DropdownMenu, DropdownToggle, Spinner, UncontrolledDropdown } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import { Checkbox } from "components/common/Checkbox";
 import { SelectionActions } from "components/common/SelectionActions";
 import genUtils = require("common/generalUtils");
+import ResetIndexesButton from "components/pages/database/indexes/list/partials/ResetIndexesButton";
+import { IndexSharedInfo } from "components/models/indexes";
 
 interface IndexSelectActionProps {
     indexNames: string[];
     selectedIndexes: string[];
+    replacements: IndexSharedInfo[];
     deleteSelectedIndexes: () => Promise<void>;
     startSelectedIndexes: () => Promise<void>;
     disableSelectedIndexes: () => Promise<void>;
     pauseSelectedIndexes: () => Promise<void>;
+    resetSelectedIndexes: (mode?: Raven.Client.Documents.Indexes.IndexResetMode) => void;
     setLockModeSelectedIndexes: (lockMode: IndexLockMode) => Promise<void>;
     toggleSelectAll: () => void;
     onCancel: () => void;
@@ -30,10 +26,12 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
     const {
         indexNames,
         selectedIndexes,
+        replacements,
         deleteSelectedIndexes,
         startSelectedIndexes,
         disableSelectedIndexes,
         pauseSelectedIndexes,
+        resetSelectedIndexes,
         setLockModeSelectedIndexes,
         toggleSelectAll,
         onCancel,
@@ -43,6 +41,8 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
     // TODO: IDK I just wanted it to compile
 
     const selectionState = genUtils.getSelectionState(indexNames, selectedIndexes);
+
+    const isResetDropdownVisible = !replacements.some((x) => selectedIndexes.includes(x.name));
 
     return (
         <div className="position-relative">
@@ -63,7 +63,7 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
                     <div className="lead text-nowrap">
                         <strong className="text-emphasis me-1">{selectedIndexes.length}</strong> selected
                     </div>
-                    <ButtonGroup className="gap-2 flex-wrap justify-content-center">
+                    <div className="hstack gap-2 flex-wrap justify-content-center">
                         <UncontrolledDropdown>
                             <DropdownToggle
                                 title="Set the indexing state for the selected indexes"
@@ -124,6 +124,13 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
                                 </DropdownItem>
                             </DropdownMenu>
                         </UncontrolledDropdown>
+
+                        <ResetIndexesButton
+                            resetIndex={resetSelectedIndexes}
+                            isDropdownVisible={isResetDropdownVisible}
+                            isRounded
+                        />
+
                         <Button
                             color="danger"
                             disabled={selectedIndexes.length === 0}
@@ -133,7 +140,7 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
                             <Icon icon="trash" />
                             <span>Delete</span>
                         </Button>
-                    </ButtonGroup>
+                    </div>
                     <Button onClick={onCancel} color="link">
                         Cancel
                     </Button>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -8,7 +8,7 @@ import { Button, Col, Row, UncontrolledPopover } from "reactstrap";
 import { LoadingView } from "components/common/LoadingView";
 import { StickyHeader } from "components/common/StickyHeader";
 import { BulkIndexOperationConfirm } from "components/pages/database/indexes/list/BulkIndexOperationConfirm";
-import { ConfirmResetIndex } from "components/pages/database/indexes/list/ConfirmResetIndex";
+import { ConfirmResetIndexes } from "components/pages/database/indexes/list/ConfirmResetIndexes";
 import { getAllIndexes, useIndexesPage } from "components/pages/database/indexes/list/useIndexesPage";
 import { useEventsCollector } from "hooks/useEventsCollector";
 import { NoIndexes } from "components/pages/database/indexes/list/partials/NoIndexes";
@@ -81,6 +81,9 @@ export function IndexesPage(props: IndexesPageProps) {
     const startSelectedIndexes = () => startIndexes(getSelectedIndexes());
     const disableSelectedIndexes = () => disableIndexes(getSelectedIndexes());
     const pauseSelectedIndexes = () => pauseIndexes(getSelectedIndexes());
+    const resetSelectedIndexes = (mode?: Raven.Client.Documents.Indexes.IndexResetMode) => {
+        return resetIndexData.openConfirm(selectedIndexes, mode);
+    };
 
     const indexNames = getAllIndexes(groups, replacements).map((x) => x.name);
 
@@ -217,10 +220,12 @@ export function IndexesPage(props: IndexesPageProps) {
                         <IndexSelectActions
                             indexNames={indexNames}
                             selectedIndexes={selectedIndexes}
+                            replacements={replacements}
                             deleteSelectedIndexes={deleteSelectedIndexes}
                             startSelectedIndexes={startSelectedIndexes}
                             disableSelectedIndexes={disableSelectedIndexes}
                             pauseSelectedIndexes={pauseSelectedIndexes}
+                            resetSelectedIndexes={resetSelectedIndexes}
                             setLockModeSelectedIndexes={confirmSetLockModeSelectedIndexes}
                             toggleSelectAll={toggleSelectAll}
                             onCancel={onSelectCancel}
@@ -251,7 +256,7 @@ export function IndexesPage(props: IndexesPageProps) {
                 <BulkIndexOperationConfirm {...bulkOperationConfirm} toggle={() => setBulkOperationConfirm(null)} />
             )}
             {resetIndexData.confirmData && (
-                <ConfirmResetIndex
+                <ConfirmResetIndexes
                     {...resetIndexData.confirmData}
                     closeConfirm={resetIndexData.closeConfirm}
                     onConfirm={resetIndexData.onConfirm}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
@@ -5,7 +5,7 @@ import { Card } from "reactstrap";
 import { IndexPanel } from "./IndexPanel";
 import { IndexSharedInfo } from "components/models/indexes";
 import { Icon } from "components/common/Icon";
-import { ResetIndexData, SwapSideBySideData } from "./useIndexesPage";
+import { ResetIndexesData, SwapSideBySideData } from "./useIndexesPage";
 import IndexPriority = Raven.Client.Documents.Indexes.IndexPriority;
 import IndexLockMode = Raven.Client.Documents.Indexes.IndexLockMode;
 
@@ -15,7 +15,7 @@ export interface IndexesPageListProps {
     selectedIndexes: string[];
     indexToHighlight: string;
     globalIndexingStatus: "Running";
-    resetIndexData: ResetIndexData;
+    resetIndexData: ResetIndexesData;
     swapSideBySideData: SwapSideBySideData;
     setIndexPriority: (index: IndexSharedInfo, priority: IndexPriority) => Promise<void>;
     setIndexLockMode: (index: IndexSharedInfo, lockMode: IndexLockMode) => Promise<void>;
@@ -57,7 +57,7 @@ export default function IndexesPageList({
                             setLockMode={(l) => setIndexLockMode(index, l)}
                             globalIndexingStatus={globalIndexingStatus}
                             resetIndex={(mode?: Raven.Client.Documents.Indexes.IndexResetMode) =>
-                                resetIndexData.openConfirm(index.name, mode)
+                                resetIndexData.openConfirm([index.name], mode)
                             }
                             openFaulty={(location: databaseLocationSpecifier) => openFaulty(index, location)}
                             startIndexing={() => startIndexes([index])}
@@ -92,11 +92,10 @@ export default function IndexesPageList({
                         )}
                         {replacement && (
                             <IndexPanel
-                                isReplacement={true}
                                 setPriority={(p) => setIndexPriority(replacement, p)}
                                 setLockMode={(l) => setIndexLockMode(replacement, l)}
                                 globalIndexingStatus={globalIndexingStatus}
-                                resetIndex={() => resetIndexData.openConfirm(replacement.name, "InPlace")}
+                                resetIndex={() => resetIndexData.openConfirm([replacement.name], "InPlace")}
                                 openFaulty={(location: databaseLocationSpecifier) => openFaulty(replacement, location)}
                                 startIndexing={() => startIndexes([replacement])}
                                 disableIndexing={() => disableIndexes([replacement])}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/partials/ResetIndexesButton.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/partials/ResetIndexesButton.tsx
@@ -1,0 +1,40 @@
+import classNames from "classnames";
+import { Icon } from "components/common/Icon";
+import React from "react";
+import { UncontrolledDropdown, Button, DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
+
+interface ResetIndexesButtonProps {
+    resetIndex: (mode?: Raven.Client.Documents.Indexes.IndexResetMode) => void;
+    isDropdownVisible?: boolean;
+    isRounded?: boolean;
+}
+
+export default function ResetIndexesButton({ resetIndex, isDropdownVisible, isRounded }: ResetIndexesButtonProps) {
+    return (
+        <UncontrolledDropdown group>
+            <Button
+                onClick={() => resetIndex()}
+                title="Reset index (rebuild)"
+                color="warning"
+                className={classNames({ "rounded-pill": isRounded && !isDropdownVisible })}
+            >
+                <Icon icon="reset-index" margin="m-0" />
+            </Button>
+            {isDropdownVisible && (
+                <>
+                    <DropdownToggle className="dropdown-toggle" color="warning" />
+                    <DropdownMenu end>
+                        <DropdownItem onClick={() => resetIndex("InPlace")} title="Reset index in place">
+                            <Icon icon="reset-index" addon="arrow-down" />
+                            Reset in place
+                        </DropdownItem>
+                        <DropdownItem onClick={() => resetIndex("SideBySide")} title="Reset index side by side">
+                            <Icon icon="reset-index" addon="swap" />
+                            Reset side by side
+                        </DropdownItem>
+                    </DropdownMenu>
+                </>
+            )}
+        </UncontrolledDropdown>
+    );
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21250/Reset-indexes-for-selected-indexes-is-not-available.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
