### PR TITLE
RavenDB-22257 Prevent from runnnig and committing two write transactions concurrently

### DIFF
--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -484,7 +484,7 @@ namespace Raven.Server.Rachis
             {
                 KeepAliveAndExecuteAction(() =>
                 {
-                    onFullSnapshotInstalledTask = ReadAndCommitSnapshot(context, snapshot, cts.Token);
+                    onFullSnapshotInstalledTask = ReadAndCommitSnapshot(snapshot, cts.Token);
                 }, cts, "ReadAndCommitSnapshot");
             }
 
@@ -555,10 +555,11 @@ namespace Raven.Server.Rachis
             }
         }
 
-        private Task ReadAndCommitSnapshot(ClusterOperationContext context, InstallSnapshot snapshot, CancellationToken token)
+        private Task ReadAndCommitSnapshot(InstallSnapshot snapshot, CancellationToken token)
         {
             Task onFullSnapshotInstalledTask = null;
 
+            using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenWriteTransaction())
             {
                 var lastTerm = _engine.GetTermFor(context, snapshot.LastIncludedIndex);

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1547,6 +1547,7 @@ namespace Voron.Impl
             internal Action ActionToCallDuringEnsurePagerStateReference;
             internal Action ActionToCallJustBeforeWritingToJournal;
             internal Action ActionToCallDuringBeginAsyncCommitAndStartNewTransaction;
+            internal Action ActionToCallOnTransactionAfterCommit;
 
             public TestingStuff(LowLevelTransaction tx)
             {
@@ -1577,6 +1578,13 @@ namespace Voron.Impl
                 ActionToCallDuringBeginAsyncCommitAndStartNewTransaction = action;
 
                 return new DisposableAction(() => ActionToCallDuringBeginAsyncCommitAndStartNewTransaction = null);
+            }
+
+            internal IDisposable CallOnTransactionAfterCommit(Action action)
+            {
+                ActionToCallOnTransactionAfterCommit = action;
+
+                return new DisposableAction(() => ActionToCallOnTransactionAfterCommit = null);
             }
 
             internal HashSet<PagerState> GetPagerStates()

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -912,6 +912,8 @@ namespace Voron
         public event Action<LowLevelTransaction> AfterCommitWhenNewTransactionsPrevented;
         internal void TransactionAfterCommit(LowLevelTransaction tx)
         {
+            tx._forTestingPurposes?.ActionToCallOnTransactionAfterCommit?.Invoke();
+
             if (ActiveTransactions.Contains(tx) == false)
             {
                 if (tx.Committed && tx.FlushedToJournal)

--- a/test/SlowTests/Voron/Issues/RavenDB_22257.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22257.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Impl;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_22257 : StorageTest
+{
+    public RavenDB_22257(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        base.Configure(options);
+
+        options.ManualFlushing = true;
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void MustNotAllowToHaveTwoWriteTransactionsConcurrently()
+    {
+        RequireFileBasedPager();
+
+        using (var txw1 = Env.NewLowLevelTransaction(new TransactionPersistentContext(), TransactionFlags.ReadWrite))
+        {
+            LowLevelTransaction txw2 = null;
+
+            txw1.ModifyPage(0);
+
+            try
+            {
+                txw1.ForTestingPurposesOnly().CallOnTransactionAfterCommit(() =>
+                {
+                    // here we pretend to be running as of a different thread
+
+                    txw1.Dispose(); // dispose of the already running transaction will release the write transaction lock, so we'll be able to create a new write transaction
+
+                    txw2 = Env.NewLowLevelTransaction(new TransactionPersistentContext(), TransactionFlags.ReadWrite);
+
+                    txw2.ModifyPage(0);
+                });
+
+                // both commits below will fail BUT they managed to write to the journal file already
+
+                var notFoundInActiveTransactionsEx = Assert.Throws<InvalidOperationException>(txw1.Commit);
+
+                Assert.Equal("The transaction with ID '2' got committed and flushed but it wasn't found in the ActiveTransactions. (Debug details: tx id of ActiveTransactionNode - 2", notFoundInActiveTransactionsEx.Message);
+
+                var duplicatedKeyEx = Assert.Throws<ArgumentException>(txw2.Commit);
+
+                Assert.Equal("An item with the same key has already been added. Key: 2 (Parameter 'key')", duplicatedKeyEx.Message);
+            }
+            finally
+            {
+                txw2?.Dispose();
+            }
+        }
+
+        // during the recovery will encounter two committed transactions with the same ID
+
+        RestartDatabase();
+
+        using (var txw = Env.WriteTransaction())
+        {
+            txw.CreateTree("foo");
+            txw.Commit();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22257/Voron-InvalidJournalException-in-System-storage-on-5.4.117

### Additional description

This PR fixes a bug which resulted in having two write transactions with the same Id at the same time. They both got written to the journal so it resulted in service restart loop due to the following error:
```
Voron.Exceptions.InvalidJournalException: Transaction has valid(!) hash with invalid transaction id 826408860,
the last valid transaction id is 826408860. Tx diff is: 0
```

The initial errors that we could see in RavenDB logs:

```
System.InvalidOperationException: The transaction with ID '826408860' got committed and flushed but it wasn't found in the ActiveTransactions. (Debug details: tx id of ActiveTransactionNode - 826408860
   at Voron.StorageEnvironment.ThrowCommittedAndFlushedTransactionNotFoundInActiveOnes(LowLevelTransaction llt) in D:\Builds\RavenDB-Stable-5.4\54115\src\Voron\StorageEnvironment.cs:line 804
   at Voron.StorageEnvironment.TransactionAfterCommit(LowLevelTransaction tx) in D:\Builds\RavenDB-Stable-5.4\54115\src\Voron\StorageEnvironment.cs:line 926
   at Voron.Impl.LowLevelTransaction.CommitStage3_DisposeTransactionResources() in D:\Builds\RavenDB-Stable-5.4\54115\src\Voron\Impl\LowLevelTransaction.cs:line 1287
   at Raven.Server.Rachis.Follower.ReadAndCommitSnapshot(ClusterOperationContext context, InstallSnapshot snapshot, CancellationToken token) in D:\Builds\RavenDB-Stable-5.4\54115\src\Raven.Server\Rachis\Follower.cs:line 642
   at Raven.Server.Rachis.Follower.<>c__DisplayClass13_1.<NegotiateWithLeader>b__0() in D:\Builds\RavenDB-Stable-5.4\54115\src\Raven.Server\Rachis\Follower.cs:line 487
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()'
```

```
System.ArgumentException: An item with the same key has already been added. Key: 826408860 (Parameter 'key')
   at System.Collections.Generic.SortedList`2.Add(TKey key, TValue value)
   at Voron.Util.PageTable.SetItems(LowLevelTransaction tx, Dictionary`2 items) in D:\Builds\RavenDB-Stable-5.4\54115\src\Voron\Util\PageTable.cs:line 116
   at Voron.Impl.Journal.JournalFile.UpdatePageTranslationTableAndUnusedPagesAction.ExecuteAfterCommit() in D:\Builds\RavenDB-Stable-5.4\54115\src\Voron\Impl\Journal\JournalFile.cs:line 415
   at Voron.Impl.LowLevelTransaction.CommitStage3_DisposeTransactionResources() in D:\Builds\RavenDB-Stable-5.4\54115\src\Voron\Impl\LowLevelTransaction.cs:line 1285
   at Raven.Server.Rachis.RachisConsensus.FoundAboutHigherTerm(Int64 term, String reason) in D:\Builds\RavenDB-Stable-5.4\54115\src\Raven.Server\Rachis\RachisConsensus.cs:line 1992
   at Raven.Server.Rachis.Follower.CheckIfValidLeader(RachisConsensus engine, RemoteConnection connection, LogLengthNegotiation& negotiation) in D:\Builds\RavenDB-Stable-5.4\54115\src\Raven.Server\Rachis\Follower.cs:line 393
   at Raven.Server.Rachis.RachisConsensus.AcceptNewConnection(RemoteConnection remoteConnection, EndPoint remoteEndpoint, Action`1 sayHello) in D:\Builds\RavenDB-Stable-5.4\54115\src\Raven.Server\Rachis\RachisConsensus.cs:line 1307
   at Raven.Server.ServerWide.ServerStore.ClusterAcceptNewConnection(TcpConnectionOptions tcp, TcpConnectionHeaderMessage header, Action disconnect, EndPoint remoteEndpoint) in D:\Builds\RavenDB-Stable-5.4\54115\src\Raven.Server\ServerWide\ServerStore.cs:line 3324
   at Raven.Server.RavenServer.DispatchServerWideTcpConnection(TcpConnectionOptions tcp, TcpConnectionHeaderMessage header, MemoryBuffer buffer) in D:\Builds\RavenDB-Stable-5.4\54115\src\Raven.Server\RavenServer.cs:line 2430
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Raven.Server.RavenServer.DispatchServerWideTcpConnection(TcpConnectionOptions tcp, TcpConnectionHeaderMessage header, MemoryBuffer buffer)
   at Raven.Server.RavenServer.DispatchTcpConnection(TcpConnectionHeaderMessage header, TcpConnectionOptions tcp, MemoryBuffer buffer, X509Certificate2 certificate) in D:\Builds\RavenDB-Stable-5.4\54115\src\Raven.Server\RavenServer.cs:line 2131
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Raven.Server.RavenServer.DispatchTcpConnection(TcpConnectionHeaderMessage header, TcpConnectionOptions tcp, MemoryBuffer buffer, X509Certificate2 certificate)
   at Raven.Server.RavenServer.<>c__DisplayClass79_0.<<ListenToNewTcpConnection>b__0>d.MoveNext() in D:\Builds\RavenDB-Stable-5.4\54115\src\Raven.Server\RavenServer.cs:line 2069
```

were the result of having two write transactions at the same time. That was possible because the first one got disposed from a different thread while it was being committed. This made that we're able to create another write transaction at the same time because the disposal of the first tx released the write tx lock.

### How did we manage to dispose the transaction while it was active in RavenDB code?

 Here are the relevant pieces of code:

 - we execute `ReadAndCommitSnapshot()` in the background with the usage of a context (`ClusterOperationContext`):
    https://github.com/ravendb/ravendb/blob/0635a94b117afa513a9aeb1dc1fefbefe6b51648/src/Raven.Server/Rachis/Follower.cs#L485-L488

- the context was created here:
    https://github.com/ravendb/ravendb/blob/0635a94b117afa513a9aeb1dc1fefbefe6b51648/src/Raven.Server/Rachis/Follower.cs#L1166-L1169

- we use that context to open a write transaction:
    https://github.com/ravendb/ravendb/blob/0635a94b117afa513a9aeb1dc1fefbefe6b51648/src/Raven.Server/Rachis/Follower.cs#L562

- note that we're running this task in the background but waiting for it in `KeepAliveAndExecuteAction()`:
    https://github.com/ravendb/ravendb/blob/0635a94b117afa513a9aeb1dc1fefbefe6b51648/src/Raven.Server/Rachis/Follower.cs#L524

- BUT what if `WaitForTaskCompletion()` will throw? It might throw due to network issue for example during `MaybeNotifyLeaderThatWeAreStillAlive()`. Then we wait 60 seconds (which might not be enough for `ReadAndCommitSnapshot()`):
    https://github.com/ravendb/ravendb/blob/0635a94b117afa513a9aeb1dc1fefbefe6b51648/src/Raven.Server/Rachis/Follower.cs#L529-L530

- THEN we throw so we return / reset the context and dispose the underlying transaction:
    https://github.com/ravendb/ravendb/blob/0635a94b117afa513a9aeb1dc1fefbefe6b51648/src/Raven.Server/Rachis/Follower.cs#L1169

    We're still running the write transaction but we're releasing the write tx lock. So it was possible to create a new write transaction.

### Fix

- The fix applied to the Follower code makes that instead of using the context created externally (which might got disposed / reset) we create the context on our own in the background thread doing the actual execution of `ReadAndCommitSnapshot()`.

- Additionally in order to detect the disposal of a write transaction from a different thread we have added additional check in `LowLevelTransaction.Dispose()` 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
