### PR TITLE
RavenDB-22323 Wrap where clause in parentheses when search clause is also used

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1700,6 +1700,11 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 target = search.Arguments[0];
             }
 
+            // This has to be set in order to have correct parentheses
+            // when using both search and where clause, e.g.
+            // where (Category = $p0 or Category = $p1) and search(Name, $p2)
+            _chainedWhere = true;
+            
             VisitExpression(target);
 
             if (expressions.Count > 1)

--- a/test/FastTests/Issues/RavenDB_12235.cs
+++ b/test/FastTests/Issues/RavenDB_12235.cs
@@ -24,7 +24,7 @@ namespace FastTests.Issues
                     q = q.Where(x => x.Name == "123");
                     q = q.Search(x => x.Age, "123");
 
-                    Assert.Equal("from 'Users' where Name = $p0 and search(Age, $p1)", q.ToString());
+                    Assert.Equal("from 'Users' where (Name = $p0) and search(Age, $p1)", q.ToString());
                     Assert.Equal("from 'Users'", docQuery.ToString());
                 }
 
@@ -35,7 +35,7 @@ namespace FastTests.Issues
                     q = q.Where(x => x.Name == "123");
                     q = q.Search(x => x.Age, "123");
 
-                    Assert.Equal("from 'Users' where Name = $p0 and search(Age, $p1)", q.ToString());
+                    Assert.Equal("from 'Users' where (Name = $p0) and search(Age, $p1)", q.ToString());
                     Assert.Equal("from 'Users'", docQuery.ToString());
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-22323.cs
+++ b/test/SlowTests/Issues/RavenDB-22323.cs
@@ -1,0 +1,128 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22323 : RavenTestBase
+{
+    public RavenDB_22323(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void TestParenthesesWhenUsingSearchAndWhereClause()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A" || d.Category == "B")
+                    .Search(d => d.Name, "Peter*")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where (Category = $p0 or Category = $p1) and search(Name, $p2)", query);
+                
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Search(d => d.Name, "Peter*")
+                    .Where(d => d.Category == "A" || d.Category == "B")
+                    .ToString();
+                
+                Assert.Equal("from index 'DummyIndex' where search(Name, $p0) and (Category = $p1 or Category = $p2)", query);
+                
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A" || d.Category == "B")
+                    .ToString();
+                
+                Assert.Equal("from index 'DummyIndex' where Category = $p0 or Category = $p1", query);
+                
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A")
+                    .ToString();
+                
+                Assert.Equal("from index 'DummyIndex' where Category = $p0", query);
+                
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A")
+                    .Where(d => d.Name == "aaa")
+                    .ToString();
+                
+                Assert.Equal("from index 'DummyIndex' where (Category = $p0) and (Name = $p1)", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A")
+                    .Search(d => d.Name, "Peter*")
+                    .ToString();
+                
+                Assert.Equal("from index 'DummyIndex' where (Category = $p0) and search(Name, $p1)", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Search(d => d.Name, "Peter*")
+                    .Search(d => d.Category, "A", options: SearchOptions.Or)
+                    .Where(d => d.Category == "A" || d.Category == "B")
+                    .Search(d => d.Surname, "DDD", options: SearchOptions.And)
+                    .ToString();
+                
+                Assert.Equal("from index 'DummyIndex' where search(Name, $p0) or search(Category, $p1) and (Category = $p2 or Category = $p3) and search(Surname, $p4)", query);
+                
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A" || d.Category == "B")
+                    .Search(d => d.Name, "Peter*")
+                    .Search(d => d.Category, "A", options: SearchOptions.Or)
+                    .Search(d => d.Surname, "DDD", options: SearchOptions.And)
+                    .ToString();
+                
+                Assert.Equal("from index 'DummyIndex' where (Category = $p0 or Category = $p1) and search(Name, $p2) or search(Category, $p3) and search(Surname, $p4)", query);
+                
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Search(d => d.Name, "Peter*")
+                    .Where(d => d.Category == "A")
+                    .Search(d => d.Category, "A")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where search(Name, $p0) and (Category = $p1) and search(Category, $p2)", query);
+                
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Name == "Peter")
+                    .Search(d => d.Name, "Peter*")
+                    .Where(d => d.Category == "A")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where (Name = $p0) and search(Name, $p1) and (Category = $p2)", query);
+            }
+        }
+    }
+
+    private class Dto
+    { 
+        public string Category { get; set; }
+        public string Name { get; set; }
+        public string Surname { get; set; }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public class Result
+        {
+            public string Category { get; set; }
+            public string Name { get; set; }
+            public string Surname { get; set; }
+        }
+        
+        public DummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new Result()
+                {
+                    Category = dto.Category, 
+                    Name = dto.Name, 
+                    Surname = dto.Surname
+                };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22323/Parentheses-missing-when-combining-Where-and-Search-clause

### Additional description

We want to treat usage of both `search` and `where` clause similarly to the usage of `where` clause twice and wrap the `where` clause in parentheses.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
