### PR TITLE
RavenDB-22225 avoid opening write tx in the same test thread

### DIFF
--- a/test/RachisTests/BasicTests.cs
+++ b/test/RachisTests/BasicTests.cs
@@ -6,6 +6,7 @@ using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Server;
+using Sparrow.Utils;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -63,9 +64,13 @@ namespace RachisTests
             var leader = await CreateNetworkAndGetLeader(1);
             var mre = new AsyncManualResetEvent();
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var currentThread = NativeMemory.CurrentThreadStats.ManagedThreadId;
 
             leader.Timeout.Start(() =>
             {
+                if (currentThread == NativeMemory.CurrentThreadStats.ManagedThreadId)
+                    throw new InvalidOperationException("Can't use same thread as the xUnit test");
+
                 mre.Set();
                 try
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22225

### Additional description

It is possible that the timer callback will be executed at the same thread as the xUnit one, so in this test it might happened that we tried to open the write tx in the same thread.

I can't explain why we start to see this exception just now.. :/

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
