### PR TITLE
 RavenDB-22257 Making the transaction owner check on tx dispose to be Debug only. 

### DIFF
--- a/src/Raven.Server/Documents/ReplayTxCommandHelper.cs
+++ b/src/Raven.Server/Documents/ReplayTxCommandHelper.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.Documents
                 await using (var readersItr = readers.GetAsyncEnumerator())
                 {
                     await ReadStartRecordingDetailsAsync(readersItr, context, peepingTomStream);
-                    while (await readersItr.MoveNextAsync())
+                    while (await readersItr.MoveNextAsync().ConfigureAwait(true))
                     {
                         using (readersItr.Current)
                         {

--- a/test/RachisTests/BasicTests.cs
+++ b/test/RachisTests/BasicTests.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.ServerWide;
+using Raven.Client.Util;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -59,10 +60,10 @@ namespace RachisTests
         }
 
         [Fact]
-        public async Task RavenDB_13659()
+        public void RavenDB_13659()
         {
-            var leader = await CreateNetworkAndGetLeader(1);
-            var mre = new AsyncManualResetEvent();
+            var leader = AsyncHelpers.RunSync(() => CreateNetworkAndGetLeader(1));
+            var mre = new ManualResetEventSlim();
             var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var currentThread = NativeMemory.CurrentThreadStats.ManagedThreadId;
 
@@ -90,12 +91,12 @@ namespace RachisTests
             using (leader.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenWriteTransaction())
             {
-                await mre.WaitAsync();
+                mre.Wait();
                 leader.SetNewStateInTx(context, RachisState.Follower, null, leader.CurrentTerm, "deadlock");
                 context.Transaction.Commit();
             }
 
-            await tcs.Task;
+            AsyncHelpers.RunSync(() => tcs.Task);
         }
     }
 }


### PR DESCRIPTION
Removing the usage of await in the scope of a write transaction in the test and making it sync. Added ConfigureAwait(true) to the transaction replay code to in order to try to get to the original thread (that opened the write tx) so the tests for the tx recorder won't fail in debug.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22257/Voron-InvalidJournalException-in-System-storage-on-5.4.117

### Additional description

Continuation of https://github.com/ravendb/ravendb/pull/18482. Details in the comment: https://github.com/ravendb/ravendb/pull/18482#discussion_r1593993688


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
