### PR TITLE
RavenDB-21693 - fix race in resource cache

### DIFF
--- a/src/Raven.Server/Documents/ResourceCache.cs
+++ b/src/Raven.Server/Documents/ResourceCache.cs
@@ -72,8 +72,23 @@ namespace Raven.Server.Documents
             if (_caseInsensitive.TryGetValue(resourceName, out resourceTask) == false)
                 return false;
 
+            _forTestingPurposes?.OnUnlikelyTryGet?.Invoke();
+
             lock (this)
             {
+                if (_caseInsensitive.TryGetValue(resourceName, out var resourceTaskUnderLock) == false)
+                {
+                    // database was deleted
+                    return false;
+                }
+
+                if (resourceTask != resourceTaskUnderLock)
+                {
+                    // we have a case in sensitive match, but it is not the same instance
+                    resourceTask = resourceTaskUnderLock;
+                    return true;
+                }
+
                 //we have a case insensitive match, let us optimize that
                 if (_mappings.TryGetValue(resourceName, out ConcurrentSet<StringSegment> mappingsForResource))
                 {
@@ -271,6 +286,7 @@ namespace Raven.Server.Documents
             }
 
             internal Action<ResourceCache<TResource>> OnRemoveLockAndReturnDispose;
+            internal Action OnUnlikelyTryGet;
 
             public Task<TResource> Replace(string databaseName, Task<TResource> task)
             {

--- a/test/SlowTests/Issues/RavenDB-21693.cs
+++ b/test/SlowTests/Issues/RavenDB-21693.cs
@@ -1,0 +1,68 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Documents;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using static SlowTests.Issues.RavenDB_19033;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21693 : NoDisposalNeeded
+    {
+        public RavenDB_21693(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task ShouldNotLockDatabaseForever()
+        {
+            var dbsCache = new ResourceCache<MyDb>();
+
+            var dbName = "foo";
+
+            var task1 = new Task<MyDb>(() =>
+            {
+                var myDb = new MyDb(dbName);
+
+                myDb.Run();
+
+                return myDb;
+            }, TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var database1 = dbsCache.GetOrAdd(dbName, task1);
+
+            if (database1 == task1)
+            {
+                task1.Start();
+                await task1;
+            }
+
+            var mre = new AsyncManualResetEvent();
+            var mre2 = new AsyncManualResetEvent();
+            Task t = null;
+            dbsCache.ForTestingPurposesOnly().OnUnlikelyTryGet = () =>
+            {
+                mre2.Set();
+                mre.WaitAsync().GetAwaiter().GetResult();
+            };
+
+            using (dbsCache.RemoveLockAndReturn(dbName, x =>
+                   {
+                       x.Dispose();
+                       t = Task.Run(() => dbsCache.TryGetValue(dbName, out _));
+                   }, out _))
+            {
+
+                await mre2.WaitAsync();
+            }
+
+            mre.Set();
+
+            await t;
+
+            Assert.False(dbsCache.TryGetValue(dbName, out var task));
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_19033.cs
+++ b/test/SlowTests/Issues/RavenDB_19033.cs
@@ -18,7 +18,7 @@ public class RavenDB_19033 : NoDisposalNeeded
     {
     }
 
-    private class MyDb : IDisposable
+    internal class MyDb : IDisposable
     {
         public static List<MyDb> RunningDatabases = new List<MyDb>();
 

--- a/test/Tests.Infrastructure/RavenTestCategory.cs
+++ b/test/Tests.Infrastructure/RavenTestCategory.cs
@@ -57,4 +57,5 @@ public enum RavenTestCategory : long
     Lucene = 1L << 42,
     Security = 1L << 43,
     Monitoring = 1L << 44,
+    Core = 1L << 45,
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21693

### Additional description

Fix race in `ResourceCache`:
in case we would call `TryGetValue()` while `RemoveLockAndReturn()` is running, we might repopulate the cache with failed task created in `RemoveLockAndReturn()`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
