### PR TITLE
RavenDB-22316: Fixed the case where the last symbol has to be skipped.

### DIFF
--- a/src/Sparrow.Server/Compression/Encoder3Gram.cs
+++ b/src/Sparrow.Server/Compression/Encoder3Gram.cs
@@ -458,12 +458,13 @@ namespace Sparrow.Server.Compression
             int maxBitSequenceLength = 1;
             int minBitSequenceLength = int.MaxValue;
 
+            int tableI = 0;
             for (int i = 0; i < dictSize; i++)
             {
                 var symbol = symbolCodeList[i];
                 int symbolLength = symbol.Length;
 
-                ref var entry = ref EncodingTable[i];
+                var entry = EncodingTable[tableI];
 
                 // We update the size first to avoid getting a zero size start key.
                 entry.KeyLength = (byte)symbolLength;
@@ -496,24 +497,20 @@ namespace Sparrow.Server.Compression
                     entry.PrefixLength = (byte)symbolLength;
                 }
 
-                if (entry.PrefixLength == 0)
-                {
-                    i--;
-                    continue;
-                }
-                    
-                Debug.Assert(entry.PrefixLength > 0);
-
                 entry.Code = symbolCodeList[i].Code;
 
                 maxBitSequenceLength = Math.Max(maxBitSequenceLength, entry.Code.Length);
                 minBitSequenceLength = Math.Min(minBitSequenceLength, entry.Code.Length);
 
                 tree.Add((uint)entry.Code.Value, entry.Code.Length, (short)i);
+
+                // We update the table.
+                EncodingTable[tableI] = entry;
+                tableI++;
             }
 
-            _entries = dictSize;
-            NumberOfEntries = dictSize;
+            _entries = tableI;
+            NumberOfEntries = tableI;
             MaxBitSequenceLength = maxBitSequenceLength;
             MinBitSequenceLength = minBitSequenceLength;
         }

--- a/test/FastTests/Sparrow/Encoder3GramTests.cs
+++ b/test/FastTests/Sparrow/Encoder3GramTests.cs
@@ -571,6 +571,7 @@ namespace FastTests.Sparrow
         [Theory]
         [MemberData("RandomSeed")]
         [InlineData(7157)]
+        [InlineData(50407)]
         public void VerifyCorrectDecodingWithNulls(int randomSeed)
         {
             State state = new(64000);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22316

### Additional description

When the last symbol has to be skipped, encoder table creation process will enter into an infinite loop. It is a very rare condition, but it could happen in the wild.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
