### PR TITLE
RavenDB-21993 - don't allow automatic fail over in changes api when tracking node-specific operations

### DIFF
--- a/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
@@ -70,7 +70,8 @@ internal abstract class AbstractDatabaseConnectionState
 
     public virtual void Dispose()
     {
-        Set(Task.FromException(new ObjectDisposedException(nameof(DatabaseConnectionState))));
+        if(_connected?.Exception == null)
+            Set(Task.FromException(new ObjectDisposedException(nameof(DatabaseConnectionState))));
         OnError = null;
     }
 }

--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -59,9 +59,6 @@ namespace Raven.Client.Documents.Changes
         
         public IChangesObservable<OperationStatusChange> ForOperationId(long operationId)
         {
-            if (string.IsNullOrEmpty(_nodeTag))
-                ThrowOperationsNodeTagNeeded();
-
             var counter = GetOrAddConnectionState("operations/" + operationId, "watch-operation", "unwatch-operation", operationId.ToString());
 
             var taskedObservable = new ChangesObservable<OperationStatusChange, DatabaseConnectionState>(
@@ -73,9 +70,6 @@ namespace Raven.Client.Documents.Changes
 
         public IChangesObservable<OperationStatusChange> ForAllOperations()
         {
-            if (string.IsNullOrEmpty(_nodeTag))
-                ThrowOperationsNodeTagNeeded();
-
             var counter = GetOrAddConnectionState("all-operations", "watch-operations", "unwatch-operations", null);
 
             var taskedObservable = new ChangesObservable<OperationStatusChange, DatabaseConnectionState>(
@@ -83,11 +77,6 @@ namespace Raven.Client.Documents.Changes
                 _ => true);
 
             return taskedObservable;
-        }
-
-        private void ThrowOperationsNodeTagNeeded()
-        {
-            throw new InvalidOperationException("Changes API must be provided a node tag in order to track node-specific operations.");
         }
 
         public IChangesObservable<IndexChange> ForIndex(string indexName)

--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -59,6 +59,9 @@ namespace Raven.Client.Documents.Changes
         
         public IChangesObservable<OperationStatusChange> ForOperationId(long operationId)
         {
+            if (string.IsNullOrEmpty(_nodeTag))
+                ThrowOperationsNodeTagNeeded();
+
             var counter = GetOrAddConnectionState("operations/" + operationId, "watch-operation", "unwatch-operation", operationId.ToString());
 
             var taskedObservable = new ChangesObservable<OperationStatusChange, DatabaseConnectionState>(
@@ -70,6 +73,9 @@ namespace Raven.Client.Documents.Changes
 
         public IChangesObservable<OperationStatusChange> ForAllOperations()
         {
+            if (string.IsNullOrEmpty(_nodeTag))
+                ThrowOperationsNodeTagNeeded();
+
             var counter = GetOrAddConnectionState("all-operations", "watch-operations", "unwatch-operations", null);
 
             var taskedObservable = new ChangesObservable<OperationStatusChange, DatabaseConnectionState>(
@@ -77,6 +83,11 @@ namespace Raven.Client.Documents.Changes
                 _ => true);
 
             return taskedObservable;
+        }
+
+        private void ThrowOperationsNodeTagNeeded()
+        {
+            throw new InvalidOperationException("Changes API must be provided a node tag in order to track node-specific operations.");
         }
 
         public IChangesObservable<IndexChange> ForIndex(string indexName)

--- a/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseChanges.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations;
@@ -59,6 +60,8 @@ namespace Raven.Client.Documents.Changes
         
         public IChangesObservable<OperationStatusChange> ForOperationId(long operationId)
         {
+            Debug.Assert(string.IsNullOrEmpty(_nodeTag) == false, "Changes API must be provided a node tag in order to track node-specific operations.");
+
             var counter = GetOrAddConnectionState("operations/" + operationId, "watch-operation", "unwatch-operation", operationId.ToString());
 
             var taskedObservable = new ChangesObservable<OperationStatusChange, DatabaseConnectionState>(
@@ -70,6 +73,8 @@ namespace Raven.Client.Documents.Changes
 
         public IChangesObservable<OperationStatusChange> ForAllOperations()
         {
+            Debug.Assert(string.IsNullOrEmpty(_nodeTag) == false, "Changes API must be provided a node tag in order to track node-specific operations.");
+
             var counter = GetOrAddConnectionState("all-operations", "watch-operations", "unwatch-operations", null);
 
             var taskedObservable = new ChangesObservable<OperationStatusChange, DatabaseConnectionState>(

--- a/src/Raven.Client/Documents/Operations/MaintenanceOperationExecutor.cs
+++ b/src/Raven.Client/Documents/Operations/MaintenanceOperationExecutor.cs
@@ -158,7 +158,8 @@ namespace Raven.Client.Documents.Operations
                 ApplyNodeTagAndShardNumberToCommandIfSet(command);
 
                 await RequestExecutor.ExecuteAsync(command, context, sessionInfo: null, token: token).ConfigureAwait(false);
-                return new Operation<TResult>(RequestExecutor, () => _store.Changes(_databaseName), RequestExecutor.Conventions, command.Result.Result, command.Result.OperationId, command.SelectedNodeTag ?? command.Result.OperationNodeTag);
+                var node = command.SelectedNodeTag ?? command.Result.OperationNodeTag;
+                return new Operation<TResult>(RequestExecutor, () => _store.Changes(_databaseName, node), RequestExecutor.Conventions, command.Result.Result, command.Result.OperationId, node);
             }
         }
 

--- a/src/Raven.Client/Documents/Operations/Operation.cs
+++ b/src/Raven.Client/Documents/Operations/Operation.cs
@@ -113,7 +113,7 @@ namespace Raven.Client.Documents.Operations
                     await observable.EnsureSubscribedNow().ConfigureAwait(false);
 
                     if (_requestExecutor.ForTestingPurposes?.WaitBeforeFetchOperationStatus != null)
-                        await _requestExecutor.ForTestingPurposes.WaitBeforeFetchOperationStatus.WaitAsync().ConfigureAwait(false);
+                        await _requestExecutor.ForTestingPurposes.WaitBeforeFetchOperationStatus.ConfigureAwait(false);
 
                     // We start the operation before we subscribe,
                     // so if we subscribe after the operation was already completed we will miss the notification for it. 

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -15,6 +15,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Nito.AsyncEx;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Configuration;
@@ -2544,6 +2545,8 @@ namespace Raven.Client.Http
             internal Action DelayRequest;
 
             internal Action<GetDatabaseTopologyCommand> SetCommandTimeout;
+
+            internal AsyncManualResetEvent WaitBeforeFetchOperationStatus;
         }
     }
 }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -2546,7 +2546,7 @@ namespace Raven.Client.Http
 
             internal Action<GetDatabaseTopologyCommand> SetCommandTimeout;
 
-            internal AsyncManualResetEvent WaitBeforeFetchOperationStatus;
+            internal Task WaitBeforeFetchOperationStatus;
         }
     }
 }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2098,6 +2098,8 @@ namespace Raven.Server.Documents
 
             internal Action<PathSetting> ActionToCallOnGetTempPath;
 
+            internal AsyncManualResetEvent DelayQueryByPatch;
+
             internal bool EnableWritesToTheWrongShard = false;
 
             internal IDisposable CallDuringDocumentDatabaseInternalDispose(Action action)

--- a/src/Raven.Server/Documents/Operations/AbstractOperations.cs
+++ b/src/Raven.Server/Documents/Operations/AbstractOperations.cs
@@ -173,7 +173,7 @@ public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
 
     public abstract long GetNextOperationId();
 
-    public void Dispose(ExceptionAggregator exceptionAggregator)
+    public virtual void Dispose(ExceptionAggregator exceptionAggregator)
     {
         foreach (var active in Active.Values)
         {

--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -399,6 +399,9 @@ namespace Raven.Server.Documents.Queries
             {
                 try
                 {
+                    if (Database.ForTestingPurposes?.DelayQueryByPatch != null)
+                        await Database.ForTestingPurposes.DelayQueryByPatch.WaitAsync(token.Token);
+
                     return await GetRunner(query).ExecutePatchQuery(query, options, patch, patchArgs, queryContext, onProgress, token)
                                                  .ConfigureAwait(false);
                 }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
@@ -145,5 +145,16 @@ public partial class ShardedDatabaseContext
         }
 
         internal DatabaseChanges GetChanges(ShardedDatabaseIdentifier key) => _changes.GetOrAdd(key, k => new DatabaseChangesForShard(_context.ServerStore, _context.ShardExecutor.GetRequestExecutorAt(k.ShardNumber), ShardHelper.ToShardName(_context.DatabaseName, k.ShardNumber), onDispose: null, k.NodeTag));
+
+
+        public override void Dispose(ExceptionAggregator exceptionAggregator)
+        {
+            foreach (var changes in _changes)
+            {
+                changes.Value.Dispose();
+            }
+
+            base.Dispose(exceptionAggregator);
+        }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -249,6 +249,8 @@ namespace Raven.Server.Documents.Sharding
 
             exceptionAggregator.Execute(() => SubscriptionsStorage.Dispose());
 
+            Operations.Dispose(exceptionAggregator);
+
             exceptionAggregator.Execute(() => _databaseShutdown.Dispose());
 
             exceptionAggregator.Execute(() => NotificationCenter.Dispose());

--- a/test/SlowTests/Client/ChangesApiFailover.cs
+++ b/test/SlowTests/Client/ChangesApiFailover.cs
@@ -509,8 +509,8 @@ update {{
                     database.ForTestingPurposesOnly().DelayQueryByPatch = delayQueryByPatch;
 
                     var re = store.GetRequestExecutor();
-                    var delayFetchOperationStatus = new Nito.AsyncEx.AsyncManualResetEvent();
-                    re.ForTestingPurposesOnly().WaitBeforeFetchOperationStatus = delayFetchOperationStatus;
+                    var delayFetchOperationStatus = new AsyncManualResetEvent();
+                    re.ForTestingPurposesOnly().WaitBeforeFetchOperationStatus = delayFetchOperationStatus.WaitAsync(cts.Token);
 
                     var op = await store.Operations.SendAsync(patch, token: cts.Token);
 

--- a/test/SlowTests/Client/ChangesApiFailover.cs
+++ b/test/SlowTests/Client/ChangesApiFailover.cs
@@ -1,10 +1,24 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents.Changes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions.Database;
+using Raven.Client.Extensions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Raven.Server.Documents;
+using SlowTests.Core.Utils.Entities;
+using Sparrow.Server;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
 using Xunit;
@@ -86,6 +100,642 @@ namespace SlowTests.Client
             foreach (var node in args.Topology.Nodes)
             {
                 Debug.Assert(node.Database.Contains('$') == false, $"{node.Database} must not contain '$' char.");
+            }
+        }
+
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ChangesApiShouldNotFailOverWhenWaitingForCompletionOfOperation(Options options)
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
+            {
+                var (clusterNodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, shouldRunInMemory: false);
+
+                if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+                    options = Sharding.GetOptionsForCluster(leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 3);
+                else
+                    options.ReplicationFactor = 3;
+
+                using (var store = GetDocumentStore(new Options(options)
+                {
+                    Server = leader,
+                    ModifyDocumentStore = (documentStore => documentStore.Conventions.DisableTopologyUpdates = true), // so request executor stays on the same node
+                }))
+                {
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "users/1");
+                        await session.SaveChangesAsync();
+                    }
+
+                    var patch = new PatchByQueryOperation(
+                        new IndexQuery
+                        {
+                            Query =
+                                $@"
+from Users as doc
+update {{
+    var copy = {{}};
+}}
+"
+                        },
+                        new QueryOperationOptions { AllowStale = false, StaleTimeout = TimeSpan.FromSeconds(30) }
+                    );
+
+                    var expectedNode = (await store.GetRequestExecutor().GetPreferredNode()).Node.ClusterTag;
+                    //set up waiting for changes api in WaitForCompletionAsync to set up web socket
+                    DocumentDatabase database;
+                    var delayQueryByPatch = new AsyncManualResetEvent();
+                    
+                    if (options.DatabaseMode == RavenDatabaseMode.Single)
+                        database = await Databases.GetDocumentDatabaseInstanceFor(expectedNode, store.Database);
+                    else
+                        database = await (await Sharding.GetShardsDocumentDatabaseInstancesForDocId(store, "users/1", clusterNodes)).SingleAsync(cts.Token);
+
+                    database.ForTestingPurposesOnly().DelayQueryByPatch = delayQueryByPatch;
+
+                    var op = await store.Operations.SendAsync(patch, token: cts.Token);
+                    Assert.Equal(expectedNode, op.NodeTag);
+
+                    var t = op.WaitForCompletionAsync(cts.Token);
+
+                    var waitWebSocketError = new AsyncManualResetEvent(cts.Token);
+                    var changes = store.Changes(store.Database, op.NodeTag);
+                    changes.ConnectionStatusChanged += (sender, args) => { waitWebSocketError.Set(); };
+
+                    //wait for websocket to connect
+                    await AssertWaitForTrueAsync(() => Task.FromResult(changes.Connected));
+
+                    //bring down server
+                    var serverWithOperation = clusterNodes.Single(x => x.ServerStore.NodeTag == expectedNode);
+                    var result = await DisposeServerAndWaitForFinishOfDisposalAsync(serverWithOperation);
+
+                    //wait for websocket to throw and retry
+                    await waitWebSocketError.WaitAsync(cts.Token);
+
+                    //bring server back up
+                    var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Core.ServerUrls), result.Url } };
+                    var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, DeletePrevious = false, DataDirectory = result.DataDirectory, CustomSettings = settings, NodeTag = result.NodeTag });
+                    Servers.Add(server);
+
+                    delayQueryByPatch.Set();
+
+                    //run the operation again - should work
+                    op = await store.Operations.SendAsync(patch, token: cts.Token);
+
+                    // we reconnect to the same node
+                    Assert.Equal(expectedNode, op.NodeTag);
+                    await op.WaitForCompletionAsync(cts.Token);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ChangesApiForOperationShouldCleanUpFaultyConnection_AfterUnrecoverableError(Options options)
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
+            {
+                var (clusterNodes, leader) = await CreateRaftCluster(1, leaderIndex: 0, shouldRunInMemory: false);
+
+                if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+                    options = Sharding.GetOptionsForCluster(leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 1);
+                else
+                    options.ReplicationFactor = 1;
+
+                using (var store = GetDocumentStore(new Options(options)
+                {
+                    Server = leader,
+                }))
+                {
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "users/1");
+                        await session.SaveChangesAsync();
+                    }
+
+                    var patch = new PatchByQueryOperation(
+                        new IndexQuery
+                        {
+                            Query =
+                                $@"
+from Users as doc
+update {{
+    var copy = {{}};
+}}
+"
+                        },
+                        new QueryOperationOptions { AllowStale = false, StaleTimeout = TimeSpan.FromSeconds(30) }
+                    );
+
+
+                    //set up waiting for changes api in WaitForCompletionAsync to set up web socket
+                    var delayQueryByPatch = new AsyncManualResetEvent();
+                    DocumentDatabase database;
+                    if (options.DatabaseMode == RavenDatabaseMode.Single)
+                        database = await Databases.GetDocumentDatabaseInstanceFor(leader.ServerStore.NodeTag, store.Database);
+                    else
+                        database = await (await Sharding.GetShardsDocumentDatabaseInstancesForDocId(store, "users/1", clusterNodes)).SingleAsync(cts.Token);
+
+                    database.ForTestingPurposesOnly().DelayQueryByPatch = delayQueryByPatch;
+
+                    var op = await store.Operations.SendAsync(patch, token: cts.Token);
+
+                    var waitWebSocketError = new AsyncManualResetEvent(cts.Token);
+                    var changes = store.Changes(store.Database, op.NodeTag);
+
+                    var t = op.WaitForCompletionAsync(cts.Token);
+
+                    //wait for websocket to connect
+                    await AssertWaitForTrueAsync(() => Task.FromResult(changes.Connected));
+
+                    //error in changes api will release the mre
+                    changes.ConnectionStatusChanged += (sender, args) => { waitWebSocketError.Set(); };
+
+                    //the error will bubble up to user - later await it
+                    var waitForCompletionErrorTask = Assert.ThrowsAsync<DatabaseDoesNotExistException>(async () => await t);
+
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+
+                    //delete the database, so when changes api tries reconnecting it will throw db does not exist exception
+                    await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, hardDelete: false));
+
+                    // bring server down - so when it reconnects, api will realize db doesn't exist anymore
+                    var result = await DisposeServerAndWaitForFinishOfDisposalAsync(leader);
+
+                    //wait for the websocket failure
+                    await waitWebSocketError.WaitAsync(cts.Token);
+
+                    //bring server back up
+                    var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Core.ServerUrls), result.Url } };
+                    var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, DeletePrevious = false, DataDirectory = result.DataDirectory, CustomSettings = settings, NodeTag = result.NodeTag });
+                    Servers.Add(server);
+
+                    //wait for websocket to throw upon retry connecting - this should result in DatabaseChanges.Dispose - remove connection from the dict
+                    await waitForCompletionErrorTask;
+
+                    //create the db again
+                    await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(record));
+                    
+                    //run the operation again - the connection should have been removed from the _databaseChanges dictionary and a new one created
+                    op = await store.Operations.SendAsync(patch, token: cts.Token);
+
+                    // we reconnect
+                    await op.WaitForCompletionAsync(cts.Token);
+                }
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ChangesApiShouldNotThrowOnConnectionError(Options options)
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
+            {
+                var (clusterNodes, leader) = await CreateRaftCluster(1, leaderIndex: 0, shouldRunInMemory: false);
+
+                if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+                    options = Sharding.GetOptionsForCluster(leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 1);
+                else
+                    options.ReplicationFactor = 1;
+
+                using (var store = GetDocumentStore(new Options(options)
+                {
+                    Server = leader,
+                }))
+                {
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "users/1");
+                        await session.SaveChangesAsync();
+                    }
+
+                    var patch = new PatchByQueryOperation(
+                        new IndexQuery
+                        {
+                            Query =
+                                $@"
+from Users as doc
+update {{
+    var copy = {{}};
+}}
+"
+                        },
+                        new QueryOperationOptions { AllowStale = false, StaleTimeout = TimeSpan.FromSeconds(30) }
+                    );
+
+                    DocumentDatabase database = options.DatabaseMode == RavenDatabaseMode.Single
+                        ? await Databases.GetDocumentDatabaseInstanceFor(leader.ServerStore.NodeTag, store.Database)
+                        : await (await Sharding.GetShardsDocumentDatabaseInstancesForDocId(store, "users/1", clusterNodes)).SingleAsync(cts.Token);
+
+                    //set up waiting for changes api in WaitForCompletionAsync to set up web socket
+                    var delayQueryByPatch = new AsyncManualResetEvent();
+                    database.ForTestingPurposesOnly().DelayQueryByPatch = delayQueryByPatch;
+
+                    var op = await store.Operations.SendAsync(patch, token: cts.Token);
+
+                    var changes = store.Changes(store.Database, op.NodeTag);
+                    
+                    //this error should not bubble up to user
+                    var waitForCompletionErrorTask = Assert.ThrowsAsync<WebSocketException>(async () =>
+                    {
+                        await op.WaitForCompletionAsync(cts.Token);
+                    });
+
+                    //wait for websocket to connect
+                    await AssertWaitForTrueAsync(() => Task.FromResult(changes.Connected));
+
+                    //give WaitForCompletion some time to send the request for the operation in Process before the server goes down
+                    await Task.Delay(500);
+
+                    // bring server down
+                    var result = await DisposeServerAndWaitForFinishOfDisposalAsync(leader);
+
+                    //bring server back up
+                    var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Core.ServerUrls), result.Url } };
+                    var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, DeletePrevious = false, DataDirectory = result.DataDirectory, CustomSettings = settings, NodeTag = result.NodeTag });
+                    Servers.Add(server);
+
+                    //run the operation again
+                    op = await store.Operations.SendAsync(patch, token: cts.Token);
+                    var resTask = op.WaitForCompletionAsync(cts.Token);
+
+                    var task = await Task.WhenAny(waitForCompletionErrorTask, resTask);
+                    
+                    Assert.True(task.IsCompletedSuccessfully, $"task {task} hasn't completed successfully. ex: {task.Exception}");
+                    Assert.Equal(resTask, task);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ChangesApiMonitoringMultipleShouldNotFailAllWhenOneTimesOut(Options options)
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
+            {
+                var (clusterNodes, leader) = await CreateRaftCluster(1, leaderIndex: 0, shouldRunInMemory: false);
+
+                if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+                    options = Sharding.GetOptionsForCluster(leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 1);
+                else
+                    options.ReplicationFactor = 1;
+
+                using (var store = GetDocumentStore(new Options(options)
+                {
+                    Server = leader,
+                }))
+                {
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "users/1");
+                        await session.SaveChangesAsync();
+                    }
+
+                    var patch = new PatchByQueryOperation(
+                        new IndexQuery
+                        {
+                            Query =
+                                $@"
+from Users as doc
+update {{
+    var copy = {{}};
+}}
+"
+                        },
+                        new QueryOperationOptions { AllowStale = false, StaleTimeout = TimeSpan.FromSeconds(30) }
+                    );
+
+                    //set up waiting for changes api in WaitForCompletionAsync to set up web socket
+                    DocumentDatabase database = options.DatabaseMode == RavenDatabaseMode.Single
+                        ? await Databases.GetDocumentDatabaseInstanceFor(leader.ServerStore.NodeTag, store.Database)
+                        : await (await Sharding.GetShardsDocumentDatabaseInstancesForDocId(store, "users/1", clusterNodes)).SingleAsync(cts.Token);
+                    var delayQueryByPatch = new AsyncManualResetEvent();
+                    database.ForTestingPurposesOnly().DelayQueryByPatch = delayQueryByPatch;
+
+                    var op = await store.Operations.SendAsync(patch, token: cts.Token);
+
+                    var list = new BlockingCollection<DocumentChange>();
+
+                    var changes = store.Changes(store.Database, op.NodeTag);
+                    await changes.EnsureConnectedNow();
+                    var documentsObservable = changes.ForAllDocuments();
+                    documentsObservable.Subscribe(list.Add);
+                    await documentsObservable.EnsureSubscribedNow();
+
+                    //wait for websocket to connect
+                    await AssertWaitForTrueAsync(() => Task.FromResult(changes.Connected));
+
+                    using var ctsToFail = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+                    //this will throw on timeout
+                    var waitForCompletionErrorTask = Assert.ThrowsAsync<TimeoutException>(async () =>
+                    {
+                        await op.WaitForCompletionAsync(ctsToFail.Token);
+                    });
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "users/1", cts.Token);
+                        await session.SaveChangesAsync(cts.Token);
+                    }
+
+                    await AssertWaitForTrueAsync(() => Task.FromResult(list.Count == 1));
+                    
+                    //make sure operation throws an error
+                    ctsToFail.Cancel();
+                    await waitForCompletionErrorTask;
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "users/2", cts.Token);
+                        await session.SaveChangesAsync(cts.Token);
+                    }
+
+                    // make sure document monitoring is still working
+                    await AssertWaitForTrueAsync(() => Task.FromResult(list.Count == 2));
+                }
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ChangesApiMonitoringMultipleShouldNotFailAllWhenOneFailsOnFetch(Options options)
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
+            {
+                var (clusterNodes, leader) = await CreateRaftCluster(1, leaderIndex: 0, shouldRunInMemory: false);
+
+                if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+                    options = Sharding.GetOptionsForCluster(leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 1);
+                else
+                    options.ReplicationFactor = 1;
+
+                using (var store = GetDocumentStore(new Options(options)
+                {
+                    Server = leader,
+                }))
+                {
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "users/1");
+                        await session.SaveChangesAsync();
+                    }
+
+                    var patch = new PatchByQueryOperation(
+                        new IndexQuery
+                        {
+                            Query =
+                                $@"
+from Users as doc
+update {{
+    var copy = {{}};
+}}
+"
+                        },
+                        new QueryOperationOptions { AllowStale = false, StaleTimeout = TimeSpan.FromSeconds(30) }
+                    );
+
+                    //set up waiting for changes api in WaitForCompletionAsync to set up web socket
+                    DocumentDatabase database = options.DatabaseMode == RavenDatabaseMode.Single
+                        ? await Databases.GetDocumentDatabaseInstanceFor(leader.ServerStore.NodeTag, store.Database)
+                        : await (await Sharding.GetShardsDocumentDatabaseInstancesForDocId(store, "users/1", clusterNodes)).SingleAsync(cts.Token);
+                    var delayQueryByPatch = new AsyncManualResetEvent();
+                    database.ForTestingPurposesOnly().DelayQueryByPatch = delayQueryByPatch;
+
+                    var re = store.GetRequestExecutor();
+                    var delayFetchOperationStatus = new Nito.AsyncEx.AsyncManualResetEvent();
+                    re.ForTestingPurposesOnly().WaitBeforeFetchOperationStatus = delayFetchOperationStatus;
+
+                    var op = await store.Operations.SendAsync(patch, token: cts.Token);
+
+                    var list = new BlockingCollection<DocumentChange>();
+
+                    var changes = store.Changes(store.Database, op.NodeTag);
+                    await changes.EnsureConnectedNow();
+                    var documentsObservable = changes.ForAllDocuments();
+                    documentsObservable.Subscribe(list.Add);
+                    await documentsObservable.EnsureSubscribedNow();
+
+                    //wait for websocket to connect
+                    await AssertWaitForTrueAsync(() => Task.FromResult(changes.Connected));
+
+                    //this will throw on timeout
+                    var waitForCompletionErrorTask = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    {
+                        await op.WaitForCompletionAsync();
+                    });
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "users/1", cts.Token);
+                        await session.SaveChangesAsync(cts.Token);
+                    }
+
+                    await AssertWaitForTrueAsync(() => Task.FromResult(list.Count == 1));
+
+                    // bring server down
+                    var result = await DisposeServerAndWaitForFinishOfDisposalAsync(leader);
+
+                    //bring server back up
+                    var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Core.ServerUrls), result.Url } };
+                    var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, DeletePrevious = false, DataDirectory = result.DataDirectory, CustomSettings = settings, NodeTag = result.NodeTag });
+                    Servers.Add(server);
+
+                    //should fail on fetch operation status in Process because after server restart the request to watch the operation id is no longer in memory
+                    delayFetchOperationStatus.Set();
+                    await waitForCompletionErrorTask;
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "users/2", cts.Token);
+                        await session.SaveChangesAsync(cts.Token);
+                    }
+
+                    // make sure document monitoring is still working
+                    await AssertWaitForTrueAsync(() => Task.FromResult(list.Count == 2));
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ChangesApiShouldNotIndependentlyFailOverWhenNodeTagSpecified_OnlyRequestExecutorWillFailOver(Options options)
+        {
+            // request executor will failover after server is down and changes api will not attempt to failover the same connection, but instead will open a new connection for the new specific node
+            // that is in order to avoid having a connection entry in _databaseChanges that contains a certain node as key but the connection inside has failed over to another node
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+            {
+                var (clusterNodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, shouldRunInMemory: false);
+
+                if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+                    options = Sharding.GetOptionsForCluster(leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 3);
+                else
+                    options.ReplicationFactor = 3;
+
+                using (var store = GetDocumentStore(new Options(options)
+                {
+                    Server = leader,
+                }))
+                {
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User(), "users/1");
+                        await session.SaveChangesAsync();
+                    }
+
+                    var patch = new PatchByQueryOperation(
+                        new IndexQuery
+                        {
+                            Query =
+                                $@"
+from Users as doc
+update {{
+    var copy = {{}};
+}}
+"
+                        },
+                        new QueryOperationOptions { AllowStale = false, StaleTimeout = TimeSpan.FromSeconds(30) }
+                    );
+
+                    var expectedNode = (await store.GetRequestExecutor().GetPreferredNode()).Node.ClusterTag;
+
+                    //set up waiting for changes api in WaitForCompletionAsync to set up web socket
+                    DocumentDatabase database = options.DatabaseMode == RavenDatabaseMode.Single
+                        ? await Databases.GetDocumentDatabaseInstanceFor(leader.ServerStore.NodeTag, store.Database)
+                        : await (await Sharding.GetShardsDocumentDatabaseInstancesForDocId(store, "users/1", clusterNodes)).SingleAsync(cts.Token);
+                    var delayQueryByPatch = new AsyncManualResetEvent();
+                    database.ForTestingPurposesOnly().DelayQueryByPatch = delayQueryByPatch;
+
+                    var op = await store.Operations.SendAsync(patch, token: cts.Token);
+                    Assert.Equal(expectedNode, op.NodeTag);
+
+                    // set up mre for detecting websocket error
+                    var waitWebSocketError = new AsyncManualResetEvent(cts.Token);
+                    var changes = store.Changes(store.Database, op.NodeTag);
+                    await changes.EnsureConnectedNow();
+                    changes.ConnectionStatusChanged += (sender, args) => { waitWebSocketError.Set(); };
+
+                    //wait for websocket to connect
+                    await AssertWaitForTrueAsync(() => Task.FromResult(changes.Connected));
+
+                    //bring down server
+                    var serverWithOperation = clusterNodes.Single(x => x.ServerStore.NodeTag == expectedNode);
+                    var result = await DisposeServerAndWaitForFinishOfDisposalAsync(serverWithOperation);
+
+                    await waitWebSocketError.WaitAsync(cts.Token);
+
+                    // Run a request to make request executor fail over to a different node
+                    await store.Maintenance.SendAsync(new GetIndexNamesOperation(0, 5));
+
+                    // Bring server back up
+                    var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Core.ServerUrls), result.Url } };
+                    var server = GetNewServer(new ServerCreationOptions { RunInMemory = false, DeletePrevious = false, DataDirectory = result.DataDirectory, CustomSettings = settings, NodeTag = result.NodeTag });
+                    Servers.Add(server);
+                    
+                    delayQueryByPatch.Set();
+
+                    var re = store.GetRequestExecutor(store.Database);
+                    //wait for executor to have a different preferred node
+                    await AssertWaitForTrueAsync(async () => (await re.GetPreferredNode()).Node.ClusterTag != expectedNode);
+
+                    //run the operation again - should work
+                    op = await store.Operations.SendAsync(patch, token: cts.Token);
+
+                    // Will attempt the operation again on a different node this time
+                    Assert.NotEqual(expectedNode, op.NodeTag);
+
+                    await op.WaitForCompletionAsync(cts.Token);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ChangesApiShouldCleanupFaultyConnectionByItself_TrackingSpecificNode(Options options)
+        {
+            // Notice the only possible faulty connection while writing this test is a DatabaseDoesNotExistException in DoWork
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+            {
+                var (_, leader) = await CreateRaftCluster(3, leaderIndex: 0, shouldRunInMemory: false);
+
+                if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+                    options = Sharding.GetOptionsForCluster(leader, shards: 3, shardReplicationFactor: 1, orchestratorReplicationFactor: 3);
+                else
+                    options.ReplicationFactor = 3;
+
+                using (var store = GetDocumentStore(new Options(options)
+                {
+                    Server = leader,
+                }))
+                {
+                    for (int i = 0; i < 2; i++)
+                    {
+                        (string DataDirectory, string Url, string NodeTag) result = default;
+
+                        //set up node-specific tracking
+                        IDatabaseChanges changes = store.Changes(store.Database, leader.ServerStore.NodeTag);
+
+                        var list = new BlockingCollection<DocumentChange>();
+
+                        await changes.EnsureConnectedNow().WithCancellation(cts.Token);
+                        var observableWithTask = changes.ForDocument("users/1");
+                        observableWithTask.Subscribe(list.Add);
+                        await observableWithTask.EnsureSubscribedNow().WithCancellation(cts.Token);
+
+                        using (var session = store.OpenAsyncSession())
+                        {
+                            await session.StoreAsync(new User(), "users/1");
+                            await session.SaveChangesAsync();
+                        }
+
+                        // check socket is connected
+                        await AssertWaitForTrueAsync(() => Task.FromResult(list.Count == 1));
+
+                        var waitWebSocketError = new AsyncManualResetEvent(cts.Token);
+                        changes.ConnectionStatusChanged += (sender, args) =>
+                        {
+                            waitWebSocketError.Set();
+                            throw new Exception("Test exception");
+                        };
+
+                        // first run, fail the websocket entirely
+                        if (i == 0)
+                        {
+                            //bring down server
+                            result = await DisposeServerAndWaitForFinishOfDisposalAsync(leader);
+
+                            //wait for the exception following socket being closed
+                            await waitWebSocketError.WaitAsync(cts.Token);
+
+                            var ex = await Assert.ThrowsAsync<WebSocketException>(async () =>
+                                await changes.EnsureConnectedNow().WithCancellation(cts.Token));
+
+                            // Bring server back up
+                            var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Core.ServerUrls), result.Url } };
+                            var server = GetNewServer(new ServerCreationOptions
+                            {
+                                RunInMemory = false,
+                                DeletePrevious = false,
+                                DataDirectory = result.DataDirectory,
+                                CustomSettings = settings,
+                                NodeTag = result.NodeTag
+                            });
+                            Servers.Add(server);
+
+                            // connection should have been disposed and removed from the dictionary
+                            // let's access the same entry in the dictionary to make sure the old one got removed and that we aren't using a faulted connection
+                            // In the next loop ->
+                        }
+                    }
+                }
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB-5014.cs
+++ b/test/SlowTests/Issues/RavenDB-5014.cs
@@ -39,7 +39,7 @@ namespace SlowTests.Issues
 
                     var operationId = JsonDeserializationClient.OperationIdResult(json);
 
-                    new Operation(commands.RequestExecutor, () => store.Changes(), store.Conventions, operationId.OperationId).WaitForCompletion(TimeSpan.FromSeconds(15));
+                    new Operation(commands.RequestExecutor, () => store.Changes(store.Database, Server.ServerStore.NodeTag), store.Conventions, operationId.OperationId, Server.ServerStore.NodeTag).WaitForCompletion(TimeSpan.FromSeconds(15));
 
                     var collectionStats = store.Maintenance.Send(new GetCollectionStatisticsOperation());
 

--- a/test/SlowTests/Issues/RavenDB_19693.cs
+++ b/test/SlowTests/Issues/RavenDB_19693.cs
@@ -30,7 +30,7 @@ public class RavenDB_19693 : RavenTestBase
             var token = new OperationCancelToken(database.DatabaseShutdown, CancellationToken.None);
             _ = database.Operations.AddLocalOperation(operationId, OperationType.DumpRawIndexData, "Test Operation", detailedDescription: null, onProgress => DoWorkAsync(onProgress, TimeSpan.FromSeconds(2), token.Token), token);
 
-            var operation = new Operation(store.GetRequestExecutor(), () => store.Changes(), store.Conventions, operationId);
+            var operation = new Operation(store.GetRequestExecutor(), () => store.Changes(store.Database, Server.ServerStore.NodeTag), store.Conventions, operationId, Server.ServerStore.NodeTag);
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(10)))
                 await Assert.ThrowsAsync<TimeoutException>(() => operation.WaitForCompletionAsync(cts.Token));
@@ -50,7 +50,7 @@ public class RavenDB_19693 : RavenTestBase
             var token = new OperationCancelToken(database.DatabaseShutdown, CancellationToken.None);
             _ = database.Operations.AddLocalOperation(operationId, OperationType.DumpRawIndexData, "Test Operation", detailedDescription: null, onProgress => DoWorkAsync(onProgress, TimeSpan.FromSeconds(5), token.Token), token);
 
-            var operation = new Operation(store.GetRequestExecutor(), () => store.Changes(), store.Conventions, operationId);
+            var operation = new Operation(store.GetRequestExecutor(), () => store.Changes(store.Database, Server.ServerStore.NodeTag), store.Conventions, operationId, Server.ServerStore.NodeTag);
 
             await operation.KillAsync();
 

--- a/test/SlowTests/Issues/RavenDB_9519.cs
+++ b/test/SlowTests/Issues/RavenDB_9519.cs
@@ -57,7 +57,7 @@ namespace SlowTests.Issues
 
                         await commands.ExecuteAsync(csvImportCommand);
 
-                        var operation = new Operation(commands.RequestExecutor, () => store.Changes(), store.Conventions, operationId);
+                        var operation = new Operation(commands.RequestExecutor, () => store.Changes(store.Database, Server.ServerStore.NodeTag), store.Conventions, operationId, Server.ServerStore.NodeTag);
 
                         await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     }
@@ -116,7 +116,7 @@ namespace SlowTests.Issues
 
                         await commands.ExecuteAsync(csvImportCommand);
 
-                        var operation = new Operation(commands.RequestExecutor, () => store.Changes(), store.Conventions, operationId);
+                        var operation = new Operation(commands.RequestExecutor, () => store.Changes(store.Database, Server.ServerStore.NodeTag), store.Conventions, operationId, Server.ServerStore.NodeTag);
 
                         await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     }
@@ -165,7 +165,7 @@ namespace SlowTests.Issues
                     var exception = await Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(async () =>
                     {
                         await commands.ExecuteAsync(csvImportCommand);
-                        var operation = new Operation(commands.RequestExecutor, () => store.Changes(), store.Conventions, operationId);
+                        var operation = new Operation(commands.RequestExecutor, () => store.Changes(store.Database, Server.ServerStore.NodeTag), store.Conventions, operationId, Server.ServerStore.NodeTag);
                         await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                     });
 

--- a/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
+++ b/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
@@ -765,7 +765,7 @@ namespace SlowTests.Server
 
                 var task = Task.Run(() => { store.Maintenance.Send(new ReplayTransactionsRecordingOperation(replayStream, command.Result)); });
 
-                var operation = new Operation(store.Commands().RequestExecutor, () => store.Changes(), store.Conventions, command.Result);
+                var operation = new Operation(store.Commands().RequestExecutor, () => store.Changes(store.Database, Server.ServerStore.NodeTag), store.Conventions, command.Result, Server.ServerStore.NodeTag);
                 var operationProgresses = new List<IOperationProgress>();
                 operation.OnProgressChanged += (_, progress) => operationProgresses.Add(progress);
 

--- a/test/SlowTests/Smuggler/RavenDB-16709.cs
+++ b/test/SlowTests/Smuggler/RavenDB-16709.cs
@@ -30,7 +30,7 @@ public class RavenDB_16709 : RavenTestBase
             await commands.RequestExecutor.ExecuteAsync(getOperationIdCommand, commands.Context);
             var operationId = getOperationIdCommand.Result;
             await commands.ExecuteAsync(new CsvImportCommand(stream, null, operationId));
-            var operation = new Operation(commands.RequestExecutor, () => store.Changes(), store.Conventions, operationId);
+            var operation = new Operation(commands.RequestExecutor, () => store.Changes(store.Database, Server.ServerStore.NodeTag), store.Conventions, operationId, Server.ServerStore.NodeTag);
             await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
 
             //Assert

--- a/test/Tests.Infrastructure/RavenTestBase.Databases.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Databases.cs
@@ -35,6 +35,12 @@ public partial class RavenTestBase
             return _parent.Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
         }
 
+        public Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(string node, string database)
+        {
+            var server = _parent.Servers.Single(s => s.ServerStore.NodeTag == node);
+            return server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+        }
+
         public Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(RavenServer server, IDocumentStore store, string database = null)
         {
             return server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -107,7 +107,7 @@ public partial class RavenTestBase
                 ReplicationFactor = shardReplicationFactor, // this ensures not to use the same path for the replicas
                 Server = leader
             };
-
+            options.AddToDescription($"{nameof(RavenDataAttribute.DatabaseMode)} = {nameof(RavenDatabaseMode.Sharded)}");
             return options;
         }
 
@@ -268,6 +268,12 @@ public partial class RavenTestBase
                     await orchestrator.RachisLogIndexNotifications.WaitForIndexNotification(index, TimeSpan.FromSeconds(10));
                 }
             }
+        }
+
+        public async ValueTask<IAsyncEnumerable<ShardedDocumentDatabase>> GetShardsDocumentDatabaseInstancesForDocId(IDocumentStore store, string docId, List<RavenServer> servers = null)
+        {
+            var shardDatabaseName = await GetShardDatabaseNameForDocAsync(store, docId);
+            return GetShardsDocumentDatabaseInstancesFor(shardDatabaseName, servers);
         }
 
         public IAsyncEnumerable<ShardedDocumentDatabase> GetShardsDocumentDatabaseInstancesFor(IDocumentStore store, List<RavenServer> servers = null)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21993

### Additional description

v6.0 PR for https://github.com/ravendb/ravendb/pull/18417#

Additional changes:

Disposing the orchestrator (`ShardedDatabaseContext`) will dispose existing operations, which in turn will dispose all shards' changes apis.
