### PR TITLE
RavenDB-21854 : add more debug info to flaky test

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -331,14 +331,14 @@ namespace FastTests
                     _ => throw new ArgumentOutOfRangeException(nameof(databaseMode), databaseMode, null)
                 };
 
-                var sb = new StringBuilder($"ETL did not finish in {timeout?.TotalSeconds ?? 30} seconds.");
+                var sb = new StringBuilder().AppendLine($"ETL did not finish in {timeout?.TotalSeconds ?? 30} seconds.");
 
                 foreach (var documentDatabase in databases)
                 {
                     var performanceStats = GetEtlPerformanceStatsForDatabase(documentDatabase);
                     if (performanceStats == null)
                         continue;
-                    sb.AppendLine($"database '{documentDatabase.Name}' stats : {performanceStats}");
+                    sb.AppendLine($"Database '{documentDatabase.Name}' ETL performance stats : {performanceStats}");
                 }
 
                 return sb.ToString();

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -311,7 +311,7 @@ public partial class RavenTestBase
             return null;
         }
 
-        public async ValueTask<DatabaseStatistics> GetDatabaseStatisticsAsync(DocumentStore store, string database = null, DatabaseRecord record = null, List<RavenServer> servers = null)
+        public async ValueTask<DatabaseStatistics> GetDatabaseStatisticsAsync(IDocumentStore store, string database = null, DatabaseRecord record = null, List<RavenServer> servers = null)
         {
             var shardingConfiguration = record != null ? record.Sharding : await GetShardingConfigurationAsync(store, database);
             DatabaseStatistics combined = new DatabaseStatistics();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21854/SlowTests.Server.Documents.ETL.Raven.BasicRavenEtlTests.WithDocumentPrefixsrcDbMode-Single-dstDbMode-Sharded

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [X] Tests stabilization

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant