### PR TITLE
RavenDB-22247 ExpiredDocumentsCleaner is lacking the usage of ForgetAbout

### DIFF
--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -268,6 +268,7 @@ namespace Raven.Server.Documents.Expiration
                                         _database.DocumentsStorage.Delete(context, ids.LowerId, ids.Id, expectedChangeVector: null);
                                     }
                                 }
+                                context.Transaction.ForgetAbout(doc);
                             }
                         }
                         catch (DocumentConflictException)
@@ -327,6 +328,7 @@ namespace Raven.Server.Documents.Expiration
                                     }
                                 }
                             }
+                            context.Transaction.ForgetAbout(doc);
                         }
 
                         refreshCount++;

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -164,6 +164,7 @@ namespace Raven.Server.Documents.Expiration
 
                                         expiredDocs.Add((clonedId, document.Id));
                                         totalCount++;
+                                        options.Context.Transaction.ForgetAbout(document);
                                     }
                                 }
                                 catch (DocumentConflictException)

--- a/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
+++ b/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
@@ -361,16 +361,15 @@ namespace SlowTests.Server.Documents.Expiration
         [RavenData(5, false, DatabaseMode = RavenDatabaseMode.All)]
         public async Task ExpirationWithMaxItemsToProcessConfiguredShouldWork(Options options, int batchSize, bool compressed)
         {
-            using (var store = GetDocumentStore(new Options
+            options.ModifyDatabaseRecord = record =>
             {
-                ModifyDatabaseRecord = record =>
+                if (compressed)
                 {
-                    if (compressed)
-                    {
-                        record.DocumentsCompression = new DocumentsCompressionConfiguration { CompressAllCollections = true, };
-                    }
+                    record.DocumentsCompression = new DocumentsCompressionConfiguration { CompressAllCollections = true, };
                 }
-            }))
+            };
+            
+            using (var store = GetDocumentStore(options))
             {
                 // Insert documents with expiration before activating the expiration
                 var expires = SystemTime.UtcNow.AddMinutes(5);
@@ -419,16 +418,15 @@ namespace SlowTests.Server.Documents.Expiration
         [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
         public async Task RefreshWithMaxItemsToProcessConfiguredShouldWork(Options options, bool compressed)
         {
-            using (var store = GetDocumentStore(new Options
+            options.ModifyDatabaseRecord = record =>
             {
-                ModifyDatabaseRecord = record =>
+                if (compressed)
                 {
-                    if (compressed)
-                    {
-                        record.DocumentsCompression = new DocumentsCompressionConfiguration { CompressAllCollections = true, };
-                    }
+                    record.DocumentsCompression = new DocumentsCompressionConfiguration { CompressAllCollections = true, };
                 }
-            }))
+            };
+            
+            using (var store = GetDocumentStore(options))
             {
                 // Insert documents with refresh before activating the refresh
                 var refresh = SystemTime.UtcNow.AddMinutes(5);

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6420;
+            const int numberToTolerate = 6414;
             if (array.Length == numberToTolerate)
                 return;
 

--- a/test/StressTests/Core/Expiration/ExpirationStressTest.cs
+++ b/test/StressTests/Core/Expiration/ExpirationStressTest.cs
@@ -26,7 +26,7 @@ namespace StressTests.Core.Expiration
         {
             using (var expiration = new ExpirationTests(Output))
             {
-                await expiration.CanAddALotOfEntitiesWithSameExpiry_ThenReadItBeforeItExpires_ButWillNotBeAbleToReadItAfterExpiry(count);
+                await expiration.CanAddALotOfEntitiesWithSameExpiry_ThenReadItBeforeItExpires_ButWillNotBeAbleToReadItAfterExpiry(false, count);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22247/ExpiredDocumentsCleaner-is-lacking-the-usage-of-ForgetAbout

### Additional description

Added `ForgetAbout` call, only on docs that are already scheduled to expire/refresh. 
There will be a second PR for 6.0 changes. (https://github.com/ravendb/ravendb/pull/18500)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
