### PR TITLE
RavenDB-22247 ExpiredDocumentsCleaner is lacking the usage of ForgetAbout (6.0)

### DIFF
--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -120,6 +120,7 @@ public abstract unsafe class AbstractBackgroundWorkStorage
 
                                     docsToProcess.Add((clonedId, document.Id));
                                     totalCount++;
+                                    options.Context.Transaction.ForgetAbout(document);
                                 }
                             }
                             catch (DocumentConflictException)

--- a/src/Raven.Server/Documents/DataArchival/DataArchivalStorage.cs
+++ b/src/Raven.Server/Documents/DataArchival/DataArchivalStorage.cs
@@ -43,6 +43,7 @@ public sealed class DataArchivalStorage : AbstractBackgroundWorkStorage
             {
                 Database.DocumentsStorage.Put(context, id, null, updated, flags: doc.Flags.Strip(DocumentFlags.FromClusterTransaction));
             }
+            context.Transaction.ForgetAbout(doc); 
         }
     }
 

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -33,6 +33,7 @@ namespace Raven.Server.Documents.Expiration
                         return;
 
                     Database.DocumentsStorage.Delete(context, lowerId, id, expectedChangeVector: null);
+                    context.Transaction.ForgetAbout(doc); 
                 }
             }
             catch (DocumentConflictException)

--- a/src/Raven.Server/Documents/Refresh/RefreshStorage.cs
+++ b/src/Raven.Server/Documents/Refresh/RefreshStorage.cs
@@ -54,6 +54,7 @@ namespace Raven.Server.Documents.Refresh
                         // the issue when the conflict is resolved
                     }
                 }
+                context.Transaction.ForgetAbout(doc); 
             }
         }
 

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-            const int numberToTolerate = 4590;
+            const int numberToTolerate = 4580;
 
             if (array.Length == numberToTolerate)
                 return;

--- a/test/StressTests/Core/Expiration/ExpirationStressTest.cs
+++ b/test/StressTests/Core/Expiration/ExpirationStressTest.cs
@@ -25,7 +25,7 @@ namespace StressTests.Core.Expiration
         {
             using (var expiration = new ExpirationTests(Output))
             {
-                await expiration.CanAddALotOfEntitiesWithSameExpiry_ThenReadItBeforeItExpires_ButWillNotBeAbleToReadItAfterExpiry(count);
+                await expiration.CanAddALotOfEntitiesWithSameExpiry_ThenReadItBeforeItExpires_ButWillNotBeAbleToReadItAfterExpiry(false, count);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22247/ExpiredDocumentsCleaner-is-lacking-the-usage-of-ForgetAbout

### Additional description

Added ForgetAbout call, only on docs that are already scheduled to expire/refresh.
PR for 5.4 - https://github.com/ravendb/ravendb/pull/18499

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
