### PR TITLE
RavenDB-22210 Pin leaf and any issuer in the chain

### DIFF
--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -94,6 +94,8 @@ namespace Raven.Server.Utils
             if (knownCertChain.ChainElements.Count == 1 && userChain.ChainElements.Count == 1)
                 return true;
             
+            // compare issuers pinning hashes starting from top of the chain (CA) since it's least likely to change
+            // chain may have additional elements due to cross-signing, that's why we compare every issuer with each other
             for (var i = knownCertChain.ChainElements.Count - 1; i > 0; i--)
             {
                 var knownPinningHash = knownCertChain.ChainElements[i].Certificate.GetPublicKeyPinningHash();

--- a/test/SlowTests/Issues/RavenDB-22210.cs
+++ b/test/SlowTests/Issues/RavenDB-22210.cs
@@ -1,0 +1,142 @@
+﻿using System.Security.Cryptography.X509Certificates;
+using Raven.Server.Config.Categories;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Utils;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22210
+{
+    [RavenFact(RavenTestCategory.Certificates)]
+    public void RenewedWithDifferentIntermediate_CanAccess()
+    {
+        var certificates = GenerateAndRenewWithDifferentIntermediate();
+        PopulateCaStore(certificates.ca, certificates.intermediate, certificates.intermediate2);
+
+        Assert.True(CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration()));
+
+        CleanupCaStore(certificates.ca, certificates.intermediate, certificates.intermediate2);
+    }
+
+    [RavenFact(RavenTestCategory.Certificates)]
+    public void RenewedWithTheSameIntermediate_CanAccess()
+    {
+        var certificates = GenerateAndRenewWithTheSameIntermediate();
+        PopulateCaStore(certificates.ca, certificates.intermediate);
+
+        Assert.True(CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration()));
+
+        CleanupCaStore(certificates.ca, certificates.intermediate);
+    }
+
+    [RavenFact(RavenTestCategory.Certificates)]
+    public void SelfSigned_Renewed_CanAccess()
+    {
+        var certificates = GenerateAndRenewSelfSigned();
+
+        Assert.True(CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration()));
+    }
+
+    [RavenFact(RavenTestCategory.Certificates)]
+    public void RenewedWithDifferentChain_CannotAccess()
+    {
+        var certificates = GenerateAndRenewWithDifferentChain();
+        PopulateCaStore(certificates.ca, certificates.intermediate, certificates.intermediate2);
+
+        Assert.False(CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration()));
+
+        CleanupCaStore(certificates.ca, certificates.intermediate, certificates.intermediate2);
+    }
+
+    private static (X509Certificate2 ca, X509Certificate2 intermediate, X509Certificate2 intermediate2, X509Certificate2 client, X509Certificate2 clientRenewed)
+        GenerateAndRenewWithDifferentIntermediate()
+    {
+        var caKp = CertificateGenerator.GenerateRSAKeyPair();
+        var ca = CertificateGenerator.GenerateRootCACertificate(CaName, 5, caKp);
+
+        var intermediateKp = CertificateGenerator.GenerateRSAKeyPair();
+        var intermediate = CertificateGenerator.GenerateIntermediateCACertificate(ca, caKp, IntermediateName, 2, intermediateKp);
+
+        var intermediate2Kp = CertificateGenerator.GenerateRSAKeyPair();
+        var intermediate2 = CertificateGenerator.GenerateIntermediateCACertificate(ca, caKp, $"{IntermediateName}-2", 2, intermediate2Kp);
+
+        var clientKp = CertificateGenerator.GenerateRSAKeyPair();
+        var client = CertificateGenerator.GenerateSignedClientCertificate(intermediate, intermediateKp, ClientName, 1, clientKp);
+
+        var client2 = CertificateGenerator.GenerateSignedClientCertificate(intermediate2, intermediate2Kp, ClientRenewedName, 1, clientKp);
+
+        return (ca, intermediate, intermediate2, client, client2);
+    }
+
+    private static (X509Certificate2 ca, X509Certificate2 intermediate, X509Certificate2 intermediate2, X509Certificate2 client, X509Certificate2 clientRenewed)
+        GenerateAndRenewWithDifferentChain()
+    {
+        var caKp = CertificateGenerator.GenerateRSAKeyPair();
+        var ca = CertificateGenerator.GenerateRootCACertificate(CaName, 5, caKp);
+
+        var ca2Kp = CertificateGenerator.GenerateRSAKeyPair();
+        var ca2 = CertificateGenerator.GenerateRootCACertificate($"{CaName}-2", 5, caKp);
+
+        var intermediateKp = CertificateGenerator.GenerateRSAKeyPair();
+        var intermediate = CertificateGenerator.GenerateIntermediateCACertificate(ca, caKp, IntermediateName, 2, intermediateKp);
+
+        var intermediate2Kp = CertificateGenerator.GenerateRSAKeyPair();
+        var intermediate2 = CertificateGenerator.GenerateIntermediateCACertificate(ca2, ca2Kp, $"{IntermediateName}-2", 2, intermediate2Kp);
+
+        var clientKp = CertificateGenerator.GenerateRSAKeyPair();
+        var client = CertificateGenerator.GenerateSignedClientCertificate(intermediate, intermediateKp, ClientName, 1, clientKp);
+
+        var client2 = CertificateGenerator.GenerateSignedClientCertificate(intermediate2, intermediate2Kp, ClientRenewedName, 1, clientKp);
+
+        return (ca, intermediate, intermediate2, client, client2);
+    }
+
+    private static (X509Certificate2 ca, X509Certificate2 intermediate, X509Certificate2 client, X509Certificate2 clientRenewed) GenerateAndRenewWithTheSameIntermediate()
+    {
+        var caKp = CertificateGenerator.GenerateRSAKeyPair();
+        var ca = CertificateGenerator.GenerateRootCACertificate(CaName, 5, caKp);
+
+        var intermediateKp = CertificateGenerator.GenerateRSAKeyPair();
+        var intermediate = CertificateGenerator.GenerateIntermediateCACertificate(ca, caKp, IntermediateName, 2, intermediateKp);
+
+        var clientKp = CertificateGenerator.GenerateRSAKeyPair();
+        var client = CertificateGenerator.GenerateSignedClientCertificate(intermediate, intermediateKp, ClientName, 1, clientKp);
+        var client2 = CertificateGenerator.GenerateSignedClientCertificate(intermediate, intermediateKp, ClientRenewedName, 1, clientKp);
+
+        return (ca, intermediate, client, client2);
+    }
+
+    private static (X509Certificate2 client, X509Certificate2 clientRenewed) GenerateAndRenewSelfSigned()
+    {
+        var clientKp = CertificateGenerator.GenerateRSAKeyPair();
+        var client = CertificateGenerator.GenerateSelfSignedClientCertificate(ClientName, 1, clientKp);
+        var client2 = CertificateGenerator.GenerateSelfSignedClientCertificate(ClientRenewedName, 1, clientKp);
+
+        return (client, client2);
+    }
+
+    private static void PopulateCaStore(params X509Certificate2[] certificates)
+    {
+        using (var store = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser))
+        {
+            store.Open(OpenFlags.ReadWrite);
+            store.AddRange(new X509Certificate2Collection(certificates));
+        }
+    }
+
+    private static void CleanupCaStore(params X509Certificate2[] certificates)
+    {
+        using (var store = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser))
+        {
+            store.Open(OpenFlags.ReadWrite);
+            store.RemoveRange(new X509Certificate2Collection(certificates));
+        }
+    }
+
+    private const string CaName = "raven-test-ca";
+    private const string IntermediateName = "raven-test-intermediate";
+    private const string ClientName = "raven-test-client";
+    private const string ClientRenewedName = "raven-test-client-renewed";
+}

--- a/test/SlowTests/Issues/RavenDB-22210.cs
+++ b/test/SlowTests/Issues/RavenDB-22210.cs
@@ -1,14 +1,20 @@
 ﻿using System.Security.Cryptography.X509Certificates;
+using FastTests;
 using Raven.Server.Config.Categories;
 using Raven.Server.Utils;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Utils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SlowTests.Issues;
 
-public class RavenDB_22210
+public class RavenDB_22210 : RavenTestBase
 {
+    public RavenDB_22210(ITestOutputHelper output) : base(output)
+    {
+    }
+
     [RavenFact(RavenTestCategory.Certificates)]
     public void RenewedWithDifferentIntermediate_CanAccess()
     {

--- a/test/SlowTests/Issues/RavenDB-22210.cs
+++ b/test/SlowTests/Issues/RavenDB-22210.cs
@@ -15,9 +15,15 @@ public class RavenDB_22210
         var certificates = GenerateAndRenewWithDifferentIntermediate();
         PopulateCaStore(certificates.ca, certificates.intermediate, certificates.intermediate2);
 
-        Assert.True(CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration()));
-
-        CleanupCaStore(certificates.ca, certificates.intermediate, certificates.intermediate2);
+        try
+        {
+            var result = CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration());
+            Assert.True(result);
+        }
+        finally
+        {
+            CleanupCaStore(certificates.ca, certificates.intermediate, certificates.intermediate2);
+        }
     }
 
     [RavenFact(RavenTestCategory.Certificates)]
@@ -26,9 +32,15 @@ public class RavenDB_22210
         var certificates = GenerateAndRenewWithTheSameIntermediate();
         PopulateCaStore(certificates.ca, certificates.intermediate);
 
-        Assert.True(CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration()));
-
-        CleanupCaStore(certificates.ca, certificates.intermediate);
+        try
+        {
+            var result = CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration());
+            Assert.True(result);
+        }
+        finally
+        {
+            CleanupCaStore(certificates.ca, certificates.intermediate);
+        }
     }
 
     [RavenFact(RavenTestCategory.Certificates)]
@@ -36,7 +48,8 @@ public class RavenDB_22210
     {
         var certificates = GenerateAndRenewSelfSigned();
 
-        Assert.True(CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration()));
+        var result = CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration());
+        Assert.True(result);
     }
 
     [RavenFact(RavenTestCategory.Certificates)]
@@ -44,10 +57,15 @@ public class RavenDB_22210
     {
         var certificates = GenerateAndRenewWithDifferentChain();
         PopulateCaStore(certificates.ca, certificates.intermediate, certificates.intermediate2);
-
-        Assert.False(CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration()));
-
-        CleanupCaStore(certificates.ca, certificates.intermediate, certificates.intermediate2);
+        try
+        {
+            var result = CertificateUtils.CertHasKnownIssuer(certificates.clientRenewed, certificates.client, new SecurityConfiguration());
+            Assert.False(result);
+        }
+        finally
+        {
+            CleanupCaStore(certificates.ca, certificates.intermediate, certificates.intermediate2);
+        }
     }
 
     private static (X509Certificate2 ca, X509Certificate2 intermediate, X509Certificate2 intermediate2, X509Certificate2 client, X509Certificate2 clientRenewed)

--- a/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
+++ b/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+
+namespace Tests.Infrastructure.Utils;
+
+public class CertificateGenerator
+{
+    public static X509Certificate2 GenerateRootCACertificate(string subjectName, int yearsValid, AsymmetricCipherKeyPair keyPair)
+    {
+        return GenerateCertificate(subjectName, yearsValid, keyPair, isCa: true);
+    }
+
+    public static AsymmetricCipherKeyPair GenerateRSAKeyPair()
+    {
+        var rsaGenerator = new RsaKeyPairGenerator();
+        rsaGenerator.Init(new KeyGenerationParameters(new SecureRandom(), 2048));
+        return rsaGenerator.GenerateKeyPair();
+    }
+
+    public static X509Certificate2 GenerateIntermediateCACertificate(X509Certificate2 rootCertificate, AsymmetricCipherKeyPair rootPrivateKey, string subjectName,
+        int yearsValid, AsymmetricCipherKeyPair intermediateKeyPair)
+    {
+        return GenerateCertificate(subjectName, yearsValid, intermediateKeyPair, signerKeyPair: rootPrivateKey, signerCertificate: rootCertificate, isCa: true);
+    }
+
+    public static X509Certificate2 GenerateSignedClientCertificate(X509Certificate2 signerCertificate, AsymmetricCipherKeyPair signerKeyPair, string subjectName,
+        int yearsValid, AsymmetricCipherKeyPair clientKeyPair)
+    {
+        var keyUsage = new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment);
+        var extendedKeyUsage = new ExtendedKeyUsage(new[] { KeyPurposeID.IdKPServerAuth, KeyPurposeID.IdKPClientAuth });
+        var subjectAlternativeName = new GeneralNames(new GeneralName(GeneralName.DnsName, "localhost"));
+
+        return GenerateCertificate(subjectName, yearsValid, clientKeyPair, keyUsage, extendedKeyUsage, subjectAlternativeName, signerCertificate, signerKeyPair);
+    }
+
+    public static X509Certificate2 GenerateSelfSignedClientCertificate(string subjectName, int yearsValid, AsymmetricCipherKeyPair keyPair)
+    {
+        var keyUsage = new KeyUsage(KeyUsage.DigitalSignature | KeyUsage.KeyEncipherment);
+        var extendedKeyUsage = new ExtendedKeyUsage(KeyPurposeID.IdKPServerAuth, KeyPurposeID.IdKPClientAuth);
+        var subjectAlternativeName = new GeneralNames(new GeneralName(GeneralName.DnsName, "localhost"));
+
+        return GenerateCertificate(subjectName, yearsValid, keyPair, keyUsage, extendedKeyUsage, subjectAlternativeName, isCa: true);
+    }
+
+    private static X509Certificate2 GenerateCertificate(string subjectName, int yearsValid, AsymmetricCipherKeyPair keyPair, KeyUsage keyUsage = null,
+        ExtendedKeyUsage extendedKeyUsage = null, GeneralNames subjectAlternativeName = null, X509Certificate2 signerCertificate = null,
+        AsymmetricCipherKeyPair signerKeyPair = null, bool isCa = false)
+    {
+        var certGenerator = new X509V3CertificateGenerator();
+        certGenerator.SetSerialNumber(BigInteger.ProbablePrime(120, new Random()));
+        certGenerator.SetSubjectDN(new X509Name($"CN={subjectName}"));
+        certGenerator.SetIssuerDN(signerCertificate != null ? new X509Name(signerCertificate.Subject) : new X509Name($"CN={subjectName}"));
+        certGenerator.SetNotBefore(DateTime.UtcNow);
+        certGenerator.SetNotAfter(DateTime.UtcNow.AddYears(yearsValid));
+        certGenerator.SetPublicKey(keyPair.Public);
+
+        if (isCa)
+        {
+            certGenerator.AddExtension(
+                X509Extensions.BasicConstraints.Id,
+                true,
+                new BasicConstraints(true));
+        }
+
+        if (keyUsage != null)
+        {
+            certGenerator.AddExtension(
+                X509Extensions.KeyUsage.Id,
+                true,
+                keyUsage);
+        }
+
+        if (extendedKeyUsage != null)
+        {
+            certGenerator.AddExtension(
+                X509Extensions.ExtendedKeyUsage.Id,
+                true,
+                extendedKeyUsage);
+        }
+
+        if (subjectAlternativeName != null)
+        {
+            certGenerator.AddExtension(
+                X509Extensions.SubjectAlternativeName.Id,
+                false,
+                subjectAlternativeName);
+        }
+
+        var signatureFactory = new Asn1SignatureFactory("SHA256WITHRSA", signerKeyPair != null ? signerKeyPair.Private : keyPair.Private);
+        var certificate = certGenerator.Generate(signatureFactory);
+
+        return new X509Certificate2(certificate.GetEncoded());
+    }
+}

--- a/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
+++ b/test/Tests.Infrastructure/Utils/CertificateGenerator.cs
@@ -10,7 +10,7 @@ using Org.BouncyCastle.X509;
 
 namespace Tests.Infrastructure.Utils;
 
-public class CertificateGenerator
+public static class CertificateGenerator
 {
     public static X509Certificate2 GenerateRootCACertificate(string subjectName, int yearsValid, AsymmetricCipherKeyPair keyPair)
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22210

### Additional description

Let's Encrypt introduces new, shorter intermediate certificates. This means that server certificate can be renewed by different intermediate certificate than previously thus the certificate chain will change.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
