### PR TITLE
RavenDB-22294 Fix include cmpXchg & atomic-guard

### DIFF
--- a/src/Raven.Client/Util/ClusterWideTransactionHelper.cs
+++ b/src/Raven.Client/Util/ClusterWideTransactionHelper.cs
@@ -6,7 +6,7 @@ internal static class ClusterWideTransactionHelper
 {
     public static bool IsAtomicGuardKey(string id, out string docId)
     {
-        if (IsAtomicGuardKey(id))
+        if (IsAtomicGuardKey(id) == false)
         {
             docId = null;
             return false;

--- a/src/Raven.Client/Util/ClusterWideTransactionHelper.cs
+++ b/src/Raven.Client/Util/ClusterWideTransactionHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace Raven.Client.Util;
 
@@ -19,6 +20,10 @@ internal static class ClusterWideTransactionHelper
     public static bool IsAtomicGuardKey(string key) => key.StartsWith(Constants.CompareExchange.RvnAtomicPrefix, StringComparison.OrdinalIgnoreCase);
 
     public static string GetAtomicGuardKey(string docId) => Constants.CompareExchange.RvnAtomicPrefix + docId;
-    
-    public static string ExtractDocumentIdFromAtomicGuard(string key) => key.Substring(Constants.CompareExchange.RvnAtomicPrefix.Length);
+
+    public static string ExtractDocumentIdFromAtomicGuard(string key)
+    {
+        Debug.Assert(key.StartsWith(Constants.CompareExchange.RvnAtomicPrefix));
+        return key[Constants.CompareExchange.RvnAtomicPrefix.Length..];
+    }
 }

--- a/src/Raven.Client/Util/ClusterWideTransactionHelper.cs
+++ b/src/Raven.Client/Util/ClusterWideTransactionHelper.cs
@@ -24,6 +24,6 @@ internal static class ClusterWideTransactionHelper
     public static string ExtractDocumentIdFromAtomicGuard(string key)
     {
         Debug.Assert(key.StartsWith(Constants.CompareExchange.RvnAtomicPrefix));
-        return key[Constants.CompareExchange.RvnAtomicPrefix.Length..];
+        return key.Substring(Constants.CompareExchange.RvnAtomicPrefix.Length);
     }
 }

--- a/src/Raven.Client/Util/ClusterWideTransactionHelper.cs
+++ b/src/Raven.Client/Util/ClusterWideTransactionHelper.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Raven.Client.Util;
+
+internal static class ClusterWideTransactionHelper
+{
+    public static bool IsAtomicGuardKey(string id, out string docId)
+    {
+        if (IsAtomicGuardKey(id))
+        {
+            docId = null;
+            return false;
+        }
+
+        docId = ExtractDocumentIdFromAtomicGuard(id);
+        return true;
+    }
+    
+    public static bool IsAtomicGuardKey(string key) => key.StartsWith(Constants.CompareExchange.RvnAtomicPrefix, StringComparison.OrdinalIgnoreCase);
+
+    public static string GetAtomicGuardKey(string docId) => Constants.CompareExchange.RvnAtomicPrefix + docId;
+    
+    public static string ExtractDocumentIdFromAtomicGuard(string key) => key.Substring(Constants.CompareExchange.RvnAtomicPrefix.Length);
+}

--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -101,7 +101,13 @@ namespace Raven.Server.Config.Categories
         [TimeUnit(TimeUnit.Minutes)]
         [ConfigurationEntry("Cluster.CompareExchangeTombstonesCleanupIntervalInMin", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting CompareExchangeTombstonesCleanupInterval { get; set; }
-
+        
+        [Description("The maximum interval (in minutes) between checks for compare exchange tombstones performed by the cluster-wide transaction mechanism")]
+        [DefaultValue(5)]
+        [TimeUnit(TimeUnit.Minutes)]
+        [ConfigurationEntry("Cluster.MaxClusterTransactionCompareExchangeTombstoneCheckIntervalInMin", ConfigurationEntryScope.ServerWideOnly)]
+        public TimeSetting MaxClusterTransactionCompareExchangeTombstoneCheckInterval { get; set; }
+                           
         [Description("Maximum number of log entires to keep in the history log table.")]
         [DefaultValue(2048)]
         [ConfigurationEntry("Cluster.LogHistoryMaxEntries", ConfigurationEntryScope.ServerWideOnly)]

--- a/src/Raven.Server/Documents/DatabaseRaftIndexNotifications.cs
+++ b/src/Raven.Server/Documents/DatabaseRaftIndexNotifications.cs
@@ -20,7 +20,7 @@ public class DatabaseRaftIndexNotifications : AbstractRaftIndexNotifications<Raf
         if (await _clusterStateMachineLogIndexNotifications.WaitForTaskCompletion(index, waitingTask) == false)
             return false;
 
-        foreach (var error in _errors)
+        foreach (var error in Errors)
         {
             if (error.Index == index)
                 error.Exception.Throw(); // rethrow

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -167,7 +167,7 @@ namespace Raven.Server.Documents
                             await database.StateChangedAsync(index);
                             if (type == ClusterStateMachine.SnapshotInstalled)
                             {
-                                database.NotifyOnPendingClusterTransaction(index, changeType);
+                                database.NotifyOnPendingClusterTransaction();
                             }
                             break;
 
@@ -176,13 +176,12 @@ namespace Raven.Server.Documents
                             break;
 
                         case ClusterDatabaseChangeType.PendingClusterTransactions:
-                        case ClusterDatabaseChangeType.ClusterTransactionCompleted:
                             if (ForTestingPurposes?.BeforeHandleClusterTransactionOnDatabaseChanged != null)
                                 await ForTestingPurposes.BeforeHandleClusterTransactionOnDatabaseChanged.Invoke(_serverStore);
 
                             database.DatabaseGroupId = topology.DatabaseTopologyIdBase64;
                             database.ClusterTransactionId = topology.ClusterTransactionIdBase64;
-                            database.NotifyOnPendingClusterTransaction(index, changeType);
+                            database.NotifyOnPendingClusterTransaction();
                             break;
 
                         default:
@@ -1016,7 +1015,6 @@ namespace Raven.Server.Documents
             RecordRestored,
             ValueChanged,
             PendingClusterTransactions,
-            ClusterTransactionCompleted
         }
 
         public bool UnloadDirectly(StringSegment databaseName, DateTime? wakeup = null, [CallerMemberName] string caller = null)

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -551,7 +551,10 @@ namespace Raven.Server.Documents
             
             if (batch.Count == 0)
             {
-                var index = _serverStore.Cluster.GetLastCompareExchangeIndexForDatabase(context, Name);
+                var cmpXchgIndex = _serverStore.Cluster.GetLastCompareExchangeIndexForDatabase(context, Name);
+                var tombstoneCmpxchgIndex = _serverStore.Cluster.GetLastCompareExchangeTombstoneIndexForDatabase(context, Name);
+                var index = Math.Max(cmpXchgIndex, tombstoneCmpxchgIndex);
+                
                 ClusterWideTransactionIndexWaiter.SetAndNotifyListenersIfHigher(index);
                 return batch;
             }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -191,7 +191,7 @@ namespace Raven.Server.Documents
                 DatabaseInfoCache = serverStore.DatabaseInfoCache;
                 
                 RachisLogIndexNotifications = new DatabaseRaftIndexNotifications(_serverStore.Engine.StateMachine._rachisLogIndexNotifications, DatabaseShutdown);
-                ClusterWideTransactionIndexWaiter = new IndexWaiter(DatabaseShutdown);
+                ClusterWideTransactionIndexWaiter = new RaftIndexWaiter(DatabaseShutdown);
                 CatastrophicFailureNotification = new CatastrophicFailureNotification((environmentId, environmentPath, e, stacktrace) =>
                 {
                     serverStore.DatabasesLandlord.CatastrophicFailureHandler.Execute(name, e, environmentId, environmentPath, stacktrace);
@@ -470,7 +470,7 @@ namespace Raven.Server.Documents
         private long _lastCompletedClusterTransaction;
         public long LastCompletedClusterTransaction => _lastCompletedClusterTransaction;
 
-        public readonly IndexWaiter ClusterWideTransactionIndexWaiter;
+        public readonly RaftIndexWaiter ClusterWideTransactionIndexWaiter;
         public bool IsEncrypted => MasterKey != null;
 
         private PoolOfThreads.LongRunningWork _clusterTransactionsThread;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -503,7 +503,7 @@ namespace Raven.Server.Documents
                 }
 
                 //To make sure we mark compare exchange tombstone for cleaning  
-                _hasClusterTransaction.Wait(TimeSpan.FromMinutes(5), DatabaseShutdown);
+                _hasClusterTransaction.Wait(Configuration.Cluster.MaxClusterTransactionCompareExchangeTombstoneCheckInterval.AsTimeSpan, DatabaseShutdown);
                 if (DatabaseShutdown.IsCancellationRequested)
                     return;
 

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -13,11 +13,11 @@ using Voron.Data.Tables;
 using System.Linq;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
+using Raven.Client.Util;
 using Sparrow.Server;
 using static Raven.Server.Documents.DocumentsStorage;
 using Constants = Raven.Client.Constants;
 using Raven.Server.ServerWide;
-using Raven.Server.ServerWide.Commands;
 
 namespace Raven.Server.Documents
 {
@@ -79,13 +79,13 @@ namespace Raven.Server.Documents
                 using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext clusterContext))
                 using (clusterContext.OpenReadTransaction())
                 {
-                    var guardId = CompareExchangeKey.GetStorageKey(_parent._documentDatabase.Name, ClusterTransactionCommand.GetAtomicGuardKey(id));
+                    var guardId = CompareExchangeKey.GetStorageKey(_parent._documentDatabase.Name, ClusterWideTransactionHelper.GetAtomicGuardKey(id));
                     var (indexFromCluster, val) = _serverStore.Cluster.GetCompareExchangeValue(clusterContext, guardId);
                     if (indexFromChangeVector != indexFromCluster)
                     {
                         throw new ConcurrencyException(
                             $"Cannot PUT document '{id}' because its change vector's cluster transaction index is set to {indexFromChangeVector} " +
-                            $"but the compare exchange guard ('{ClusterTransactionCommand.GetAtomicGuardKey(id)}') is {(val == null ? "missing" : $"set to {indexFromCluster}")}")
+                            $"but the compare exchange guard ('{ClusterWideTransactionHelper.GetAtomicGuardKey(id)}') is {(val == null ? "missing" : $"set to {indexFromCluster}")}")
                         {
                             Id = id
                         };

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -11,7 +11,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Changes;
@@ -24,8 +23,8 @@ using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.Loaders;
-using Raven.Client.Exceptions;
 using Raven.Client.Http;
+using Raven.Client.Util;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Queries.Revisions;
@@ -33,7 +32,6 @@ using Raven.Server.Documents.Replication;
 using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.Routing;
-using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
 using Raven.Server.Utils;
@@ -229,7 +227,7 @@ namespace Raven.Server.Documents.Handlers
             GetCompareExchangeValueQueryString(Database, clusterWideTx, out var includeCompareExchangeValues);
 
             // we have to read this _before_ we open the transaction
-            long lastModifiedIndex = Database.LastCompletedClusterTransactionIndex;
+            long lastModifiedIndex = Database.ClusterWideTransactionIndexWaiter.LastIndex;
 
             using (context.OpenReadTransaction())
             using (includeCompareExchangeValues)
@@ -247,7 +245,7 @@ namespace Raven.Server.Documents.Handlers
                         if (clusterWideTx)
                         {
                             Debug.Assert(includeCompareExchangeValues != null, nameof(includeCompareExchangeValues) + " != null");
-                            includeCompareExchangeValues.AddDocument(ClusterTransactionCommand.GetAtomicGuardKey(id));
+                            includeCompareExchangeValues.AddDocument(ClusterWideTransactionHelper.GetAtomicGuardKey(id));
                             continue;
                         }
                         if (ids.Count == 1)
@@ -265,7 +263,7 @@ namespace Raven.Server.Documents.Handlers
                             changeVector.Contains(Database.ClusterTransactionId) == false)
                         {
                             Debug.Assert(includeCompareExchangeValues != null, nameof(includeCompareExchangeValues) + " != null");
-                            if (includeCompareExchangeValues.TryGetAtomicGuard(ClusterTransactionCommand.GetAtomicGuardKey(id), lastModifiedIndex, out var guardIndex, out _))
+                            if (includeCompareExchangeValues.TryGetCompareExchange(ClusterWideTransactionHelper.GetAtomicGuardKey(id), lastModifiedIndex, out var guardIndex, out _))
                             {
                                 var (isValid, cv) = ChangeVectorUtils.TryUpdateChangeVector(ChangeVectorParser.TrxnTag, Database.ClusterTransactionId, guardIndex, changeVector);
                                 Debug.Assert(isValid, "ChangeVector didn't have ClusterTransactionId tag but now does?!");
@@ -527,7 +525,8 @@ namespace Raven.Server.Documents.Handlers
                     {
                         foreach (var (k,v) in compareExchangeValues)
                         {
-                            v.ChangeVector = ChangeVectorUtils.NewChangeVector(ChangeVectorParser.TrxnTag,v.Index,Database.ClusterTransactionId);
+                            if (v.Index >= 0)
+                                v.ChangeVector = ChangeVectorUtils.NewChangeVector(ChangeVectorParser.TrxnTag,v.Index,Database.ClusterTransactionId);
                         }
                     }
                     await writer.WriteCompareExchangeValuesAsync(compareExchangeValues, Database.DatabaseShutdown);

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -229,7 +229,7 @@ namespace Raven.Server.Documents.Handlers
             GetCompareExchangeValueQueryString(Database, clusterWideTx, out var includeCompareExchangeValues);
 
             // we have to read this _before_ we open the transaction
-            long lastModifiedIndex = Database.RachisLogIndexNotifications.LastModifiedIndex;
+            long lastModifiedIndex = Database.LastCompletedClusterTransactionIndex;
 
             using (context.OpenReadTransaction())
             using (includeCompareExchangeValues)

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -523,10 +523,10 @@ namespace Raven.Server.Documents.Handlers
                     writer.WritePropertyName(nameof(GetDocumentsResult.CompareExchangeValueIncludes));
                     if (clusterWideTx)
                     {
-                        foreach (var (k,v) in compareExchangeValues)
+                        foreach (var (k, v) in compareExchangeValues)
                         {
                             if (v.Index >= 0)
-                                v.ChangeVector = ChangeVectorUtils.NewChangeVector(ChangeVectorParser.TrxnTag,v.Index,Database.ClusterTransactionId);
+                                v.ChangeVector = ChangeVectorUtils.NewChangeVector(ChangeVectorParser.TrxnTag, v.Index, Database.ClusterTransactionId);
                         }
                     }
                     await writer.WriteCompareExchangeValuesAsync(compareExchangeValues, Database.DatabaseShutdown);

--- a/src/Raven.Server/Documents/IndexWaiter.cs
+++ b/src/Raven.Server/Documents/IndexWaiter.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Sparrow.Server;
+using Sparrow.Utils;
+
+namespace Raven.Server.Documents;
+
+public class IndexWaiter : IDisposable
+{
+    private long _lastCompletedIndex;
+    private readonly AsyncManualResetEvent _notifiedListeners;
+
+    public long LastIndex => Interlocked.Read(ref _lastCompletedIndex);
+
+    public IndexWaiter(CancellationToken token)
+    {
+        _notifiedListeners = new AsyncManualResetEvent(token);
+    }
+    
+    public void SetAndNotifyListenersIfHigher(long newIndex)
+    {
+        if (ThreadingHelper.InterlockedExchangeMax(ref _lastCompletedIndex, newIndex))
+        {
+            _notifiedListeners.SetAndResetAtomically();
+        }
+    }
+
+    public void NotifyListenersAboutError(Exception e)
+    {
+        _notifiedListeners.SetException(e);
+    }
+    
+    public async Task WaitAsync(long index, CancellationToken token)
+    {
+        while (true)
+        {
+            Task waitAsync = _notifiedListeners.WaitAsync(token);
+            long lastIndex = LastIndex;
+            if (index <= lastIndex)
+                break;
+
+            try
+            {
+                await waitAsync;
+            }
+            catch (TaskCanceledException)
+            {
+                ThrowCanceledException(index, lastIndex);
+            }
+        }
+    }
+    
+    public async Task WaitAsync(long index, TimeSpan timeout)
+    {
+        while (true)
+        {
+            Task waitAsync = _notifiedListeners.WaitAsync(timeout);
+            long lastIndex = LastIndex;
+            if (index <= lastIndex)
+                break;
+
+            try
+            {
+                await waitAsync;
+            }
+            catch (TaskCanceledException)
+            {
+                ThrowTimeoutException(index, lastIndex);
+            }
+        }
+    }
+
+    private static void ThrowCanceledException(long index, long lastModifiedIndex)
+    {
+        throw new OperationCanceledException($"Cancelled while waiting to get an index notification for {index}. lastModifiedIndex {lastModifiedIndex}");
+    }
+    private static void ThrowTimeoutException(long index, long lastModifiedIndex)
+    {
+        throw new TimeoutException($"Timeout while waiting to get an index notification for {index}. lastModifiedIndex {lastModifiedIndex}");
+    }
+
+    public void Dispose()
+    {
+        _notifiedListeners?.Dispose();
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3365,7 +3365,7 @@ namespace Raven.Server.Documents.Indexes
                                 using (fillScope?.Start())
                                 {
                                     includeDocumentsCommand.Fill(resultToFill.Includes);
-                                    includeCompareExchangeValuesCommand?.Materialize(null);
+                                    includeCompareExchangeValuesCommand?.Materialize(maxAllowedAtomicGuardIndex: null);
                                 }
 
                                 if (includeCountersCommand != null)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3304,7 +3304,6 @@ namespace Raven.Server.Documents.Indexes
                                         token.Token);
                                 }
 
-                                long lastRaftId = DocumentDatabase.RachisLogIndexNotifications.LastModifiedIndex;
                                 try
                                 {
                                     var enumerator = documents.GetEnumerator();
@@ -3366,7 +3365,7 @@ namespace Raven.Server.Documents.Indexes
                                 using (fillScope?.Start())
                                 {
                                     includeDocumentsCommand.Fill(resultToFill.Includes);
-                                    includeCompareExchangeValuesCommand?.Materialize(lastRaftId);
+                                    includeCompareExchangeValuesCommand?.Materialize(null);
                                 }
 
                                 if (includeCountersCommand != null)

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -151,7 +151,6 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 var scannedResults = new Reference<int>();
                 IEnumerator<Document> enumerator;
 
-                var lastRaftId = Database.RachisLogIndexNotifications.LastModifiedIndex;
                 if (pulseReadingTransaction == false)
                 {
                     var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope, context.Documents,
@@ -245,7 +244,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 {
                     includeDocumentsCommand.Fill(resultToFill.Includes);
 
-                    includeCompareExchangeValuesCommand.Materialize(lastRaftId);
+                    includeCompareExchangeValuesCommand.Materialize(null);
                 }
 
                 if (includeCompareExchangeValuesCommand != null)

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -244,7 +244,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 {
                     includeDocumentsCommand.Fill(resultToFill.Includes);
 
-                    includeCompareExchangeValuesCommand.Materialize(null);
+                    includeCompareExchangeValuesCommand.Materialize(maxAllowedAtomicGuardIndex: null);
                 }
 
                 if (includeCompareExchangeValuesCommand != null)

--- a/src/Raven.Server/Documents/RaftIndexWaiter.cs
+++ b/src/Raven.Server/Documents/RaftIndexWaiter.cs
@@ -6,14 +6,14 @@ using Sparrow.Utils;
 
 namespace Raven.Server.Documents;
 
-public class IndexWaiter : IDisposable
+public class RaftIndexWaiter : IDisposable
 {
     private long _lastCompletedIndex;
     private readonly AsyncManualResetEvent _notifiedListeners;
 
     public long LastIndex => Interlocked.Read(ref _lastCompletedIndex);
 
-    public IndexWaiter(CancellationToken token)
+    public RaftIndexWaiter(CancellationToken token)
     {
         _notifiedListeners = new AsyncManualResetEvent(token);
     }

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -399,9 +399,9 @@ namespace Raven.Server.Routing
                     {
                         if (context.Request.Headers.TryGetValue(Constants.Headers.LastKnownClusterTransactionIndex, out var value)
                             && long.TryParse(value, out var index)
-                            && index > reqCtx.Database.RachisLogIndexNotifications.LastModifiedIndex)
+                            && index > reqCtx.Database.ClusterWideTransactionIndexWaiter.LastIndex)
                         {
-                            await reqCtx.Database.RachisLogIndexNotifications.WaitForIndexNotification(index, context.RequestAborted);
+                            await reqCtx.Database.ClusterWideTransactionIndexWaiter.WaitAsync(index, context.RequestAborted);
                         }
 
                         await handler(reqCtx);

--- a/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
+++ b/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
@@ -15,13 +15,13 @@ where TNotification : RaftIndexNotification
     protected readonly ConcurrentQueue<ErrorHolder> Errors = new ConcurrentQueue<ErrorHolder>();
     private readonly ConcurrentQueue<TNotification> _recentNotifications = new ConcurrentQueue<TNotification>();
     private int _numberOfErrors;
-    private readonly IndexWaiter _raftIndexWaiter;
+    private readonly RaftIndexWaiter _raftIndexWaiter;
 
     public long LastModifiedIndex => _raftIndexWaiter.LastIndex;
 
     protected AbstractRaftIndexNotifications(CancellationToken token)
     {
-        _raftIndexWaiter = new IndexWaiter(token);
+        _raftIndexWaiter = new RaftIndexWaiter(token);
     }
 
     public virtual void Dispose()

--- a/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
+++ b/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
@@ -4,7 +4,7 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Sparrow.Server;
+using Raven.Server.Documents;
 using Sparrow.Utils;
 
 namespace Raven.Server.ServerWide;
@@ -12,41 +12,32 @@ namespace Raven.Server.ServerWide;
 public abstract class AbstractRaftIndexNotifications<TNotification> : IDisposable
 where TNotification : RaftIndexNotification
 {
-    public long LastModifiedIndex;
-    protected readonly ConcurrentQueue<ErrorHolder> _errors = new ConcurrentQueue<ErrorHolder>();
+    protected readonly ConcurrentQueue<ErrorHolder> Errors = new ConcurrentQueue<ErrorHolder>();
     private readonly ConcurrentQueue<TNotification> _recentNotifications = new ConcurrentQueue<TNotification>();
-    private readonly AsyncManualResetEvent _notifiedListeners;
     private int _numberOfErrors;
+    private readonly IndexWaiter _raftIndexWaiter;
+
+    public long LastModifiedIndex => _raftIndexWaiter.LastIndex;
 
     protected AbstractRaftIndexNotifications(CancellationToken token)
     {
-        _notifiedListeners = new AsyncManualResetEvent(token);
+        _raftIndexWaiter = new IndexWaiter(token);
     }
 
     public virtual void Dispose()
     {
-        _notifiedListeners.Dispose();
+        _raftIndexWaiter.Dispose();
     }
 
     public async Task WaitForIndexNotification(long index, CancellationToken token)
     {
-        while (true)
+        try
         {
-            // first get the task, then wait on it
-            var waitAsync = _notifiedListeners.WaitAsync(token);
-
-            if (index <= Interlocked.Read(ref LastModifiedIndex))
-                break;
-
-            if (token.IsCancellationRequested)
-                ThrowCanceledException(index, LastModifiedIndex, isExecution: false);
-
-            if (await waitAsync == false)
-            {
-                var copy = Interlocked.Read(ref LastModifiedIndex);
-                if (index <= copy)
-                    break;
-            }
+            await _raftIndexWaiter.WaitAsync(index, token);
+        }
+        catch (TaskCanceledException)
+        {
+            ThrowCanceledException(index, _raftIndexWaiter.LastIndex);
         }
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -55,34 +46,25 @@ where TNotification : RaftIndexNotification
             if (await WaitForTaskCompletion(index, new Lazy<Task>(tcs.Task)))
                 return;
 
-            ThrowCanceledException(index, LastModifiedIndex, isExecution: true);
+            ThrowCanceledException(index, _raftIndexWaiter.LastIndex, isExecution: true);
         }
     }
 
     public async Task WaitForIndexNotification(long index, TimeSpan timeout)
     {
-        while (true)
+        try
         {
-            // first get the task, then wait on it
-            var waitAsync = _notifiedListeners.WaitAsync(timeout);
-
-            if (index <= Interlocked.Read(ref LastModifiedIndex))
-                break;
-
-            if (await waitAsync == false)
-            {
-                var copy = Interlocked.Read(ref LastModifiedIndex);
-                if (index <= copy)
-                    break;
-
-                ThrowTimeoutException(timeout, index, copy);
-            }
+            await _raftIndexWaiter.WaitAsync(index, timeout);
+        }
+        catch (TaskCanceledException)
+        {
+            ThrowTimeoutException(timeout, index, _raftIndexWaiter.LastIndex);
         }
 
         if (await WaitForTaskCompletion(index, new Lazy<Task>(TimeoutManager.WaitFor(timeout))))
             return;
 
-        ThrowTimeoutException(timeout, index, LastModifiedIndex, isExecution: true);
+        ThrowTimeoutException(timeout, index, _raftIndexWaiter.LastIndex, isExecution: true);
     }
 
     public abstract Task<bool> WaitForTaskCompletion(long index, Lazy<Task> waitingTask);
@@ -91,7 +73,7 @@ where TNotification : RaftIndexNotification
     {
         if (e != null)
         {
-            _errors.Enqueue(new ErrorHolder
+            Errors.Enqueue(new ErrorHolder
             {
                 Index = index,
                 Exception = ExceptionDispatchInfo.Capture(e)
@@ -99,13 +81,12 @@ where TNotification : RaftIndexNotification
 
             if (Interlocked.Increment(ref _numberOfErrors) > 25)
             {
-                _errors.TryDequeue(out _);
+                Errors.TryDequeue(out _);
                 Interlocked.Decrement(ref _numberOfErrors);
             }
         }
 
-        ThreadingHelper.InterlockedExchangeMax(ref LastModifiedIndex, index);
-        _notifiedListeners.SetAndResetAtomically();
+        _raftIndexWaiter.SetAndNotifyListenersIfHigher(index);
     }
 
     public void RecordNotification(TNotification notification)

--- a/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
+++ b/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
@@ -54,7 +54,7 @@ where TNotification : RaftIndexNotification
     {
         try
         {
-            await Task.WhenAny(_raftIndexWaiter.WaitAsync(index, timeout));
+            await _raftIndexWaiter.WaitAsync(index, timeout);
         }
         catch (TimeoutException)
         {

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -308,7 +308,7 @@ namespace Raven.Server.ServerWide
             });
         }
 
-        public long LastNotifiedIndex => Interlocked.Read(ref _rachisLogIndexNotifications.LastModifiedIndex);
+        public long LastNotifiedIndex => _rachisLogIndexNotifications.LastModifiedIndex;
 
         public readonly RachisLogIndexNotifications _rachisLogIndexNotifications = new RachisLogIndexNotifications(CancellationToken.None);
 
@@ -965,18 +965,13 @@ namespace Raven.Server.ServerWide
                 var errors = clusterTransaction.ExecuteCompareExchangeCommands(rawRecord.GetClusterTransactionId(), context, index, compareExchangeItems);
                 if (errors == null)
                 {
-                    DatabasesLandlord.ClusterDatabaseChangeType notify;
                     var clusterTransactionResult = new ClusterTransactionResult();
                     if (clusterTransaction.HasDocumentsInTransaction)
                     {
                         clusterTransactionResult.GeneratedResult = clusterTransaction.SaveCommandsBatch(context, rawRecord, index);
-                        notify = DatabasesLandlord.ClusterDatabaseChangeType.PendingClusterTransactions;
-                    }
-                    else
-                    {
-                        notify = DatabasesLandlord.ClusterDatabaseChangeType.ClusterTransactionCompleted;
                     }
 
+                    var notify = DatabasesLandlord.ClusterDatabaseChangeType.PendingClusterTransactions;
                     NotifyDatabaseAboutChanged(context, clusterTransaction.DatabaseName, index, nameof(ClusterTransactionCommand), notify, null);
 
                     return clusterTransactionResult;
@@ -2370,8 +2365,11 @@ namespace Raven.Server.ServerWide
                 // we do this under the write tx lock before we update the last applied index
                 _rachisLogIndexNotifications.AddTask(index);
 
-                context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>
+                var tx = context.Transaction.InnerTransaction.LowLevelTransaction;
+                tx.OnDispose += _ =>
                 {
+                    if (tx.Committed == false)
+                        return;
                     ExecuteAsyncTask(index, () => Changes.OnDatabaseChanges(databaseName, index, type, change, changeState));
                 };
             };

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -317,7 +317,7 @@ namespace Raven.Server.ServerWide.Commands
             {
                 var cmdType = dbCmd[nameof(ClusterTransactionDataCommand.Type)].ToString();
                 var docId = dbCmd[nameof(ClusterTransactionDataCommand.Id)].ToString();
-                var atomicGuardKey = GetAtomicGuardKey(docId);
+                var atomicGuardKey = ClusterWideTransactionHelper.GetAtomicGuardKey(docId);
                 var changeVector = dbCmd[nameof(ClusterTransactionDataCommand.ChangeVector)]?.ToString();
                 long changeVectorIndex = 0;
 
@@ -382,24 +382,7 @@ namespace Raven.Server.ServerWide.Commands
 
             return null;
         }
-
-        public static bool IsAtomicGuardKey(string id, out string docId)
-        {
-            if (id.StartsWith(Constants.CompareExchange.RvnAtomicPrefix) == false)
-            {
-                docId = null;
-                return false;
-            }
-
-            docId = id.Substring(Constants.CompareExchange.RvnAtomicPrefix.Length);
-            return true;
-        }
-
-        public static string GetAtomicGuardKey(string docId)
-        {
-            return Constants.CompareExchange.RvnAtomicPrefix + docId;
-        }
-
+        
         public DynamicJsonArray SaveCommandsBatch(ClusterOperationContext context, RawDatabaseRecord rawRecord, long index)
         {
             var result = new DynamicJsonArray();
@@ -546,11 +529,11 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
-        public static unsafe ByteStringContext.InternalScope GetPrefix<TTransaction>(TransactionOperationContext<TTransaction> context, string database, out Slice prefixSlice, long? index = null)
+        public static unsafe ByteStringContext.InternalScope GetPrefix<TTransaction>(TransactionOperationContext<TTransaction> context, string database, out Slice prefixSlice, long? prevCount = null)
             where TTransaction : RavenTransaction
         {
             var maxSize = database.GetUtf8MaxSize() + sizeof(byte);
-            if (index.HasValue)
+            if (prevCount.HasValue)
                 maxSize += sizeof(long);
 
             var lowerBufferSize = database.Length * sizeof(char);
@@ -571,9 +554,9 @@ namespace Raven.Server.ServerWide.Commands
                     var dbLen = Encoding.UTF8.GetBytes(lowerBufferStart, database.Length, prefixBuffer.Ptr, prefixBuffer.Length);
                     prefixBuffer.Ptr[dbLen] = Separator;
                     var actualSize = dbLen + 1;
-                    if (index.HasValue)
+                    if (prevCount.HasValue)
                     {
-                        *(long*)(prefixBuffer.Ptr + actualSize) = Bits.SwapBytes(index.Value);
+                        *(long*)(prefixBuffer.Ptr + actualSize) = Bits.SwapBytes(prevCount.Value);
                         actualSize += sizeof(long);
                     }
                     prefixBuffer.Truncate(actualSize);

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -300,6 +300,7 @@ namespace Raven.Server.ServerWide.Maintenance
         {
             report.LastTransactionId = dbInstance.LastTransactionId;
             report.LastCompletedClusterTransaction = dbInstance.LastCompletedClusterTransaction;
+            report.LastClusterWideTransactionRaftIndex = dbInstance.ClusterWideTransactionIndexWaiter.LastIndex;
         }
 
         private static void FillIndexInfo(Index index, QueryOperationContext context, DateTime now, DatabaseStatusReport report)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -62,6 +62,7 @@ namespace Raven.Server.ServerWide.Maintenance
         public Dictionary<string, long> LastSentEtag = new Dictionary<string, long>();
 
         public long LastCompareExchangeIndex { get; set; }
+        public long LastClusterWideTransactionRaftIndex { get; set; }
 
         public class ObservedIndexStatus
         {
@@ -104,7 +105,8 @@ namespace Raven.Server.ServerWide.Maintenance
                 [nameof(LastSentEtag)] = DynamicJsonValue.Convert(LastSentEtag),
                 [nameof(Error)] = Error,
                 [nameof(UpTime)] = UpTime,
-                [nameof(LastCompareExchangeIndex)] = LastCompareExchangeIndex
+                [nameof(LastCompareExchangeIndex)] = LastCompareExchangeIndex,
+                [nameof(LastClusterWideTransactionRaftIndex)] = LastClusterWideTransactionRaftIndex
             };
             var indexStats = new DynamicJsonValue();
             foreach (var stat in LastIndexStats)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -643,14 +643,14 @@ namespace Raven.Server.ServerWide.Maintenance
                         return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
 
                     var tryGetValue = nodeReport.Report.TryGetValue(state.Name, out var report);
-                    Debug.Assert(tryGetValue, $"Could not find state for node '{nodeTag}' for database '{state.Name}'.");
+                    Debug.Assert(tryGetValue, $"Could not find report for node '{nodeTag}' for database '{state.Name}'.");
                     if (tryGetValue == false)
                     {
                         return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
                     }
 
                     var clusterWideTransactionIndex = report.LastClusterWideTransactionRaftIndex;
-                    if (clusterWideTransactionIndex < maxEtag)
+                    if (clusterWideTransactionIndex > maxEtag)
                         maxEtag = clusterWideTransactionIndex;
                     
                     foreach (var kvp in report.LastIndexStats)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -636,7 +636,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
 
                 var hasReport = nodeReport.Report.TryGetValue(state.Name, out var report);
-                Debug.Assert(hasReport, $"Could not find report for node '{nodeTag}' for database '{state.Name}'.");
+                Debug.Assert(hasReport || nodeReport.Error != null, $"Could not find report for node '{nodeTag}' for database '{state.Name}'.");
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                 if (hasReport == false)
                     return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;

--- a/src/Raven.Server/ServerWide/RachisLogIndexNotifications.cs
+++ b/src/Raven.Server/ServerWide/RachisLogIndexNotifications.cs
@@ -37,7 +37,7 @@ public class RachisLogIndexNotifications : AbstractRaftIndexNotifications<Recent
         {
             // the task has already completed
             // let's check if we had errors in it
-            foreach (var error in _errors)
+            foreach (var error in Errors)
             {
                 if (error.Index == index)
                     error.Exception.Throw(); // rethrow

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -738,7 +738,7 @@ namespace Raven.Server.Smuggler.Documents
                         if (_backupKind is null or BackupKind.None)
                         {
                             // waiting for the commands to be applied
-                            await _database.RachisLogIndexNotifications.WaitForIndexNotification(_lastClusterTransactionIndex.Value, _token);
+                            await _database.ClusterWideTransactionIndexWaiter.WaitAsync(_lastClusterTransactionIndex.Value, _token);
                         }
                         else
                         {

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -656,7 +656,7 @@ namespace Raven.Server.Smuggler.Documents
                     _clusterTransactionCommandsSize.Set(0, SizeUnit.Bytes);
                 }
 
-                if (ClusterTransactionCommand.IsAtomicGuardKey(key, out var docId))
+                if (ClusterWideTransactionHelper.IsAtomicGuardKey(key, out var docId))
                 {
                     value?.Dispose();
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -784,7 +784,7 @@ namespace Raven.Server.Smuggler.Documents
 
                     if (compareExchangeActions != null && item.Document.ChangeVector != null && item.Document.ChangeVector.Contains(ChangeVectorParser.TrxnTag))
                     {
-                        var key = ClusterTransactionCommand.GetAtomicGuardKey(item.Document.Id);
+                        var key = ClusterWideTransactionHelper.GetAtomicGuardKey(item.Document.Id);
                         await compareExchangeActions.WriteKeyValueAsync(key, null, item.Document);
                         continue;
                     }

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -1499,8 +1499,8 @@ namespace SlowTests.Cluster
         }
         
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
-        [InlineData(true)]
-        [InlineData(false)]
+        [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
         public async Task ClusterTransaction_WhenLoadReturnEmptyAndCompareExchangeExit_ShouldStillThrowConcurrency(bool clusterTrxBefore)
         {
             const string id = "testObjs/1";
@@ -1553,7 +1553,8 @@ namespace SlowTests.Cluster
             }
         }
         
-        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task LoadAndIncludeClusterTrxCmpxchg_WhenCmpxchgIsFromLastClusterTransactionWithNoDatabaseCommand_ShouldGetCmpxchg()
         {
             const string cmpxchgId = "cmpxchg/0";
@@ -1583,7 +1584,8 @@ namespace SlowTests.Cluster
             }
         }
         
-        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryAndIncludeClusterTrxCmpxchg_WhenDocumentsCommandsDidntFinished_ShouldNotReturnNull()
         {
             const string id1 = "testObjs/0";
@@ -1647,7 +1649,8 @@ select incl(c)"
             }
         }
         
-        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryIndexAndIncludeClusterTrxCmpxchg_WhenModifiedButDocumentsCommandsDidntFinished_ShouldNotBeNull()
         {
             const string id1 = "testObjs/0";
@@ -1714,7 +1717,8 @@ select incl(c)"
             }
         }
 
-        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryAndIncludeClusterTrxCmpxchg_WhenModifiedButDocumentsCommandsDidntFinished_ShouldNotBeNull()
         {
             const string id1 = "testObjs/0";
@@ -1778,7 +1782,8 @@ select incl(c)"
             }
         }
         
-        [RavenFact(RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task QueryIncludeCmpxchg_WhenEmpty_ShouldNotCreateAdditionalRequest()
         {
             const string notExistCmpxchgId = "not-exist";
@@ -1814,7 +1819,8 @@ select incl(c)"
             }
         }
         
-        [RavenFact(RavenTestCategory.CompareExchange | RavenTestCategory.ClusterTransactions)]
+        [RavenTheory(RavenTestCategory.CompareExchange | RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void LoadIncludeCmpxchg_WhenGet_ShouldNotTriggerAdditionalRequest()
         {
             const string docId = "testObjs/0";
@@ -1844,7 +1850,8 @@ select incl(c)"
             }
         }
         
-        [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task LoadClusterWideSession_WhenDeletedWithoutClusterWideSessionAndClusterWideTransactionInProcess_ShouldNotReturnAtomicGuard()
         {
             using var store = GetDocumentStore();
@@ -1911,8 +1918,8 @@ select incl(c)"
         }
 
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
-        [InlineData(true)]
-        [InlineData(false)]
+        [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
         public async Task DatabaseRequest_WhenHasLastClusterTransaction_ShouldWaitForIndex(bool withClusterTrxBefore)
         {
             var cmpXchgKey = "cmpXchgKey";
@@ -1964,8 +1971,8 @@ select incl(c)"
         }
 
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
-        [InlineData(true)]
-        [InlineData(false)]
+        [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
         public async Task DatabaseRequest_WhenLastClusterTrxWasDeleteCmpxchg_ShouldNotHang(bool withClusterTrxBefore)
         {
             var cmpXchgKey = "cmpXchgKey";
@@ -2049,7 +2056,8 @@ select incl(c)"
             }
         }
         
-        [RavenFact(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task DatabaseRequest_WhenWaitForIndexAndClusterTransactionHasError_ShouldThrow()
         {
             const string id = "testObjs/0";

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -1501,10 +1501,10 @@ namespace SlowTests.Cluster
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
         [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
-        public async Task ClusterTransaction_WhenLoadReturnEmptyAndCompareExchangeExit_ShouldStillThrowConcurrency(bool clusterTrxBefore)
+        public async Task ClusterTransaction_WhenLoadReturnEmptyAndCompareExchangeExit_ShouldStillThrowConcurrency(Options options, bool clusterTrxBefore)
         {
             const string id = "testObjs/1";
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
 
             if (clusterTrxBefore)
             {
@@ -1555,12 +1555,12 @@ namespace SlowTests.Cluster
         
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public async Task LoadAndIncludeClusterTrxCmpxchg_WhenCmpxchgIsFromLastClusterTransactionWithNoDatabaseCommand_ShouldGetCmpxchg()
+        public async Task LoadAndIncludeClusterTrxCmpxchg_WhenCmpxchgIsFromLastClusterTransactionWithNoDatabaseCommand_ShouldGetCmpxchg(Options options)
         {
             const string cmpxchgId = "cmpxchg/0";
             const string id = "testObjs/1";
 
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
 
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true}))
             {
@@ -1586,11 +1586,11 @@ namespace SlowTests.Cluster
         
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public async Task QueryAndIncludeClusterTrxCmpxchg_WhenDocumentsCommandsDidntFinished_ShouldNotReturnNull()
+        public async Task QueryAndIncludeClusterTrxCmpxchg_WhenDocumentsCommandsDidntFinished_ShouldNotReturnNull(Options options)
         {
             const string id1 = "testObjs/0";
             const string id2 = "testObjs/1";
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
             await store.ExecuteIndexAsync(new TestIndex("TestIndex"));
 
 
@@ -1651,11 +1651,11 @@ select incl(c)"
         
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public async Task QueryIndexAndIncludeClusterTrxCmpxchg_WhenModifiedButDocumentsCommandsDidntFinished_ShouldNotBeNull()
+        public async Task QueryIndexAndIncludeClusterTrxCmpxchg_WhenModifiedButDocumentsCommandsDidntFinished_ShouldNotBeNull(Options options)
         {
             const string id1 = "testObjs/0";
             const string id2 = "testObjs/1";
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
             await store.ExecuteIndexAsync(new TestIndex("TestIndex"));
 
 
@@ -1719,11 +1719,11 @@ select incl(c)"
 
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public async Task QueryAndIncludeClusterTrxCmpxchg_WhenModifiedButDocumentsCommandsDidntFinished_ShouldNotBeNull()
+        public async Task QueryAndIncludeClusterTrxCmpxchg_WhenModifiedButDocumentsCommandsDidntFinished_ShouldNotBeNull(Options options)
         {
             const string id1 = "testObjs/0";
             const string id2 = "testObjs/1";
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
 
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true}))
             {
@@ -1784,10 +1784,10 @@ select incl(c)"
         
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public async Task QueryIncludeCmpxchg_WhenEmpty_ShouldNotCreateAdditionalRequest()
+        public async Task QueryIncludeCmpxchg_WhenEmpty_ShouldNotCreateAdditionalRequest(Options options)
         {
             const string notExistCmpxchgId = "not-exist";
-            using var store = GetDocumentStore(); 
+            using var store = GetDocumentStore(options); 
             await store.ExecuteIndexAsync(new TestIndex("TestIndex"));
 
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
@@ -1821,12 +1821,12 @@ select incl(c)"
         
         [RavenTheory(RavenTestCategory.CompareExchange | RavenTestCategory.ClusterTransactions)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void LoadIncludeCmpxchg_WhenGet_ShouldNotTriggerAdditionalRequest()
+        public void LoadIncludeCmpxchg_WhenGet_ShouldNotTriggerAdditionalRequest(Options options)
         {
             const string docId = "testObjs/0";
             const string cmpxchgId = "cmpxchg/0";
 
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {                
                 using (var session = store.OpenSession())
                 {
@@ -1852,9 +1852,9 @@ select incl(c)"
         
         [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public async Task LoadClusterWideSession_WhenDeletedWithoutClusterWideSessionAndClusterWideTransactionInProcess_ShouldNotReturnAtomicGuard()
+        public async Task LoadClusterWideSession_WhenDeletedWithoutClusterWideSessionAndClusterWideTransactionInProcess_ShouldNotReturnAtomicGuard(Options options)
         {
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
             using var store2 = new DocumentStore{Urls = store.Urls, Database = store.Database}.Initialize();
 
             const string id = "foo/bar";
@@ -1920,12 +1920,13 @@ select incl(c)"
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
         [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
-        public async Task DatabaseRequest_WhenHasLastClusterTransaction_ShouldWaitForIndex(bool withClusterTrxBefore)
+        public async Task DatabaseRequest_WhenHasLastClusterTransaction_ShouldWaitForIndex(Options options, bool withClusterTrxBefore)
         {
             var cmpXchgKey = "cmpXchgKey";
 
             var server = GetNewServer();
-            using var store = GetDocumentStore(new Options{Server = server});
+            options.Server = server;
+            using var store = GetDocumentStore(options);
             using var store2 = new DocumentStore{Urls = store.Urls, Database = store.Database}.Initialize();
 
             if (withClusterTrxBefore)
@@ -1973,7 +1974,7 @@ select incl(c)"
         [RavenTheory(RavenTestCategory.ClusterTransactions)]
         [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
         [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
-        public async Task DatabaseRequest_WhenLastClusterTrxWasDeleteCmpxchg_ShouldNotHang(bool withClusterTrxBefore)
+        public async Task DatabaseRequest_WhenLastClusterTrxWasDeleteCmpxchg_ShouldNotHang(Options options, bool withClusterTrxBefore)
         {
             var cmpXchgKey = "cmpXchgKey";
 
@@ -2058,11 +2059,11 @@ select incl(c)"
         
         [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public async Task DatabaseRequest_WhenWaitForIndexAndClusterTransactionHasError_ShouldThrow()
+        public async Task DatabaseRequest_WhenWaitForIndexAndClusterTransactionHasError_ShouldThrow(Options options)
         {
             const string id = "testObjs/0";
             
-            using var store = GetDocumentStore();
+            using var store = GetDocumentStore(options);
             var database = await GetDatabase(store.Database);
 
             store.SetLastTransactionIndex(store.Database, long.MaxValue);

--- a/test/SlowTests/Issues/RavenDB-16614.cs
+++ b/test/SlowTests/Issues/RavenDB-16614.cs
@@ -4,19 +4,16 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using FastTests;
 using FastTests.Server.Replication;
-using Raven.Client;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Documents.Replication;
-using Raven.Server.ServerWide.Commands;
-using Raven.Server.Utils;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -58,7 +55,7 @@ namespace SlowTests.Issues
             using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 // this forces us to create an orphan!
-                await store.Operations.SendAsync(new PutCompareExchangeValueOperation<AtomicGuard>(ClusterTransactionCommand.GetAtomicGuardKey("users/phoebe"),new AtomicGuard{Id = "users/phoebe"}, 0));
+                await store.Operations.SendAsync(new PutCompareExchangeValueOperation<AtomicGuard>(ClusterWideTransactionHelper.GetAtomicGuardKey("users/phoebe"),new AtomicGuard{Id = "users/phoebe"}, 0));
                 await session.StoreAsync(new User { Name = "arava" }, "users/arava");
                 await session.SaveChangesAsync();
             }
@@ -80,10 +77,10 @@ namespace SlowTests.Issues
                 TransactionMode = TransactionMode.ClusterWide
             }))
             {
-                var val = await store2.Operations.SendAsync(new GetCompareExchangeValueOperation<AtomicGuard>(ClusterTransactionCommand.GetAtomicGuardKey("users/phoebe")));
+                var val = await store2.Operations.SendAsync(new GetCompareExchangeValueOperation<AtomicGuard>(ClusterWideTransactionHelper.GetAtomicGuardKey("users/phoebe")));
                 Assert.Null(val);
 
-                val = await store2.Operations.SendAsync(new GetCompareExchangeValueOperation<AtomicGuard>(ClusterTransactionCommand.GetAtomicGuardKey("users/arava")));
+                val = await store2.Operations.SendAsync(new GetCompareExchangeValueOperation<AtomicGuard>(ClusterWideTransactionHelper.GetAtomicGuardKey("users/arava")));
 
                 var arava = await session.LoadAsync<User>("users/arava");
                 var cv = session.Advanced.GetChangeVectorFor(arava);
@@ -150,7 +147,7 @@ namespace SlowTests.Issues
                 var metadata = session.Advanced.GetMetadataFor(arava);
                 var cv = session.Advanced.GetChangeVectorFor(arava);
                 var cti = cv.ToChangeVectorList().Single(x => x.NodeTag == ChangeVectorParser.TrxnInt);
-                var guard = await store.Operations.SendAsync(new GetCompareExchangeValueOperation<AtomicGuard>(ClusterTransactionCommand.GetAtomicGuardKey("users/arava")));
+                var guard = await store.Operations.SendAsync(new GetCompareExchangeValueOperation<AtomicGuard>(ClusterWideTransactionHelper.GetAtomicGuardKey("users/arava")));
                 Assert.Equal(cti.Etag, guard.Index);
             }
         }

--- a/test/SlowTests/Issues/RavenDB-17872.cs
+++ b/test/SlowTests/Issues/RavenDB-17872.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Session;
-using Raven.Server.ServerWide.Commands;
+using Raven.Client.Util;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -262,9 +262,9 @@ namespace SlowTests.Issues
                 }
 
                 var compareExchangeValue =
-                    await store.Operations.SendAsync(new GetCompareExchangeValueOperation<AtomicGuard>(ClusterTransactionCommand.GetAtomicGuardKey("users/1")));
+                    await store.Operations.SendAsync(new GetCompareExchangeValueOperation<AtomicGuard>(ClusterWideTransactionHelper.GetAtomicGuardKey("users/1")));
                 compareExchangeValue.Metadata.Add(Constants.Documents.Metadata.Expires, DateTime.UtcNow.AddHours(1));
-                await store.Operations.SendAsync(new PutCompareExchangeValueOperation<AtomicGuard>(ClusterTransactionCommand.GetAtomicGuardKey("users/1"), compareExchangeValue.Value, compareExchangeValue.Index));
+                await store.Operations.SendAsync(new PutCompareExchangeValueOperation<AtomicGuard>(ClusterWideTransactionHelper.GetAtomicGuardKey("users/1"), compareExchangeValue.Value, compareExchangeValue.Index));
 
                 using (var session = store.OpenAsyncSession(new SessionOptions() { TransactionMode = TransactionMode.ClusterWide }))
                 {

--- a/test/SlowTests/Issues/RavenDB_14006.cs
+++ b/test/SlowTests/Issues/RavenDB_14006.cs
@@ -489,7 +489,7 @@ select incl(c)"
                         lastClusterTxIndex = value.Index;
                     }
 
-                    await database.RachisLogIndexNotifications.WaitForIndexNotification(lastClusterTxIndex, TimeSpan.FromSeconds(5));
+                    await database.ClusterWideTransactionIndexWaiter.WaitAsync(lastClusterTxIndex, TimeSpan.FromSeconds(5));
 
                     companies = companies = session.Advanced
                         .RawQuery<Company>(

--- a/test/SlowTests/Issues/RavenDB_20150.cs
+++ b/test/SlowTests/Issues/RavenDB_20150.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
 using Raven.Server.Config;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
@@ -92,6 +93,13 @@ public class RavenDB_20150 : ClusterTestBase
                 }, true);
 
                 Assert.True(done);
+
+                //Running cluster transaction to immediately mark the tombstone as handled by the cluster transaction mechanism and allow cleaning it
+                using (var session = store.OpenAsyncSession(new SessionOptions{TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true}))
+                {
+                    await session.StoreAsync(new TestOjb());
+                    await session.SaveChangesAsync();
+                }
             }
 
             //unsuspend and wait for the tombstone cleaner
@@ -120,5 +128,10 @@ public class RavenDB_20150 : ClusterTestBase
                 Assert.Equal(0, numOfCompareExchanges);
             }
         }
+    }
+    
+    private class TestOjb
+    {
+        public string Id { get; set; }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_20206.cs
+++ b/test/SlowTests/Issues/RavenDB_20206.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Server;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.ServerWide.Maintenance;
+using SlowTests.Utils;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -62,7 +63,7 @@ public class RavenDB_20206 : RavenTestBase
             using (context.OpenReadTransaction())
             {
                 // clean tombstones
-                var cleanupState = await CleanupCompareExchangeTombstonesAsync(server, store1.Database, context);
+                var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store1.Database, context);
                 Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
             }
 
@@ -84,7 +85,7 @@ public class RavenDB_20206 : RavenTestBase
             using (context.OpenReadTransaction())
             {
                 // clean tombstones
-                var cleanupState = await CleanupCompareExchangeTombstonesAsync(server, store2.Database, context);
+                var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store2.Database, context);
                 Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
             }
 
@@ -117,22 +118,5 @@ public class RavenDB_20206 : RavenTestBase
 
             return true;
         }, true));
-    }
-
-    private static async Task<ClusterObserver.CompareExchangeTombstonesCleanupState> CleanupCompareExchangeTombstonesAsync(RavenServer server, string database, TransactionOperationContext context)
-    {
-        var cmd = server.ServerStore.Observer.GetCompareExchangeTombstonesToCleanup(database, state: null, context, out var cleanupState);
-        if (cleanupState != ClusterObserver.CompareExchangeTombstonesCleanupState.HasMoreTombstones)
-            return cleanupState;
-
-        Assert.NotNull(cmd);
-
-        var result = await server.ServerStore.SendToLeaderAsync(cmd);
-        await server.ServerStore.Cluster.WaitForIndexNotification(result.Index);
-
-        var hasMore = (bool)result.Result;
-        return hasMore
-            ? ClusterObserver.CompareExchangeTombstonesCleanupState.HasMoreTombstones
-            : ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones;
     }
 }

--- a/test/SlowTests/Utils/CompareExchangeTombstonCleanerTestHelper.cs
+++ b/test/SlowTests/Utils/CompareExchangeTombstonCleanerTestHelper.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Server;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.ServerWide.Maintenance;
+using Xunit;
+
+namespace SlowTests.Utils;
+
+internal static class CompareExchangeTombstoneCleanerTestHelper
+{
+    public static async Task<ClusterObserver.CompareExchangeTombstonesCleanupState> Clean(RavenServer server, string database, TransactionOperationContext context)
+    {
+        CleanCompareExchangeTombstonesCommand cmd;
+        var serverStore = server.ServerStore;
+        using (var rawRecord = serverStore.Cluster.ReadRawDatabaseRecord(context, database))
+        {
+            var report = new Dictionary<string, DatabaseStatusReport>
+            {
+                { database, new DatabaseStatusReport { Name = database, LastClusterWideTransactionRaftIndex = long.MaxValue } }
+            };
+            var current = rawRecord.Topology.AllNodes.ToDictionary(x => x,
+                _ => new ClusterNodeStatusReport(new ServerReport(), report, ClusterNodeStatusReport.ReportStatus.Ok, null, DateTime.UtcNow, null));
+            var state = new ClusterObserver.DatabaseObservationState
+            {
+                RawDatabase = rawRecord,
+                ClusterTopology = serverStore.GetClusterTopology(context),
+                DatabaseTopology = rawRecord.Topology,
+                Current = current,
+                Name = database
+            };
+
+            cmd = serverStore.Observer.GetCompareExchangeTombstonesToCleanup(database, state: state, context, out var cleanupState);
+            if (cleanupState != ClusterObserver.CompareExchangeTombstonesCleanupState.HasMoreTombstones)
+                return cleanupState;
+
+            Assert.NotNull(cmd);
+        }
+
+        var result = await serverStore.SendToLeaderAsync(cmd);
+        await serverStore.Cluster.WaitForIndexNotification(result.Index);
+
+        var hasMore = (bool)result.Result;
+        return hasMore
+            ? ClusterObserver.CompareExchangeTombstonesCleanupState.HasMoreTombstones
+            : ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones;
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22294
https://issues.hibernatingrhinos.com/issue/RavenDB-22258

### V6.0 PR
https://github.com/ravendb/ravendb/pull/18931

### Additional description

#### Atomic Guard
To allow to recreate an atomic-guard-protected document after deleting it by a non-cluster-wide transaction
we include its atomic guard when loading the document and with it, we set the right change vector in the batch request (`SaveChanges`).
The atomic guard must be associated with the result of the load - no document.
If a cluster transaction that recreates the is in process and its compare-exchange part is already finished but the document part is not we can't use this compare-exchange.
To avoid that we need to check the cluster part and the database part of the cluster transaction are aligned (for the loaded document).
Using `Database.RachisLogIndexNotifications.LastModifiedIndex` is problematic since it is modified in other places rather than after a cluster transaction is done.
To solve that we rely here on what was `Database.LastCompletedClusterTransactionIndex` and it was changed to a "waiter" object to allow waiting on it the the `RequestRouter".
If the `atomic guard` is newer than the max version allowed for the document we considered it as we didn't find the `atomic guard`.

#### Compare Exchange (cmpXchg)
Besides the atomic guard case, we also need to consider including compare-exchange.
While in the `atomic guard`, we can tread too new atomic guard like there is no atomic guard (we just need it to throw concurrency exception) 
for `compare exchange` we can't.
It will be very surprising to modify an `atomic guard` and then get a null after including it in a load.
The decision is to return the "too" new `compare exchange`.

#### The problem
Consider the following  (let's assume the `atomic guard` is disabled to simplify):
* A document with cmpXchg is created - **doc:v1 cmpXchg:v1**.
* Another cluster transaction is triggered but only the cmpXchg is completed - **doc:v1 cmpXchg:v2** 
* The client loads the document and includes the cmpXchg  - **doc:v1 cmpXchg:v2**.
* The client modifies the document and to ensure no concurrency the `compare exchange` is also modified.
* The client triggers `SaveChanges`

With the current implementation, doc version 3 will override doc version 2 with no concurrency exception.

#### To document
To deal with that the client must keep information in both the document and its `compare exchange` to validate they are aligned with each other.

#### Additional:
In this PR we also addressed the issue when we included a cmpXchg so getting it should not trigger additional requests.
This was handled for both existing and non-existent cmpXchg

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
