### PR TITLE
RavenDB-19844 - Add the LuceneManagedAllocations to the cluster dashboard

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/MemoryUsageNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/MemoryUsageNotificationSender.cs
@@ -61,6 +61,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
                 AvailableMemory = memoryInfo.AvailableMemory.GetValue(SizeUnit.Bytes),
                 AvailableMemoryForProcessing = memoryInfo.AvailableMemoryForProcessing.GetValue(SizeUnit.Bytes),
                 TotalSwapUsage = memoryInfo.TotalSwapUsage.GetValue(SizeUnit.Bytes),
+                LuceneManagedTermCacheAllocations = NativeMemory.TotalLuceneManagedAllocationsForTermCache,
                 LuceneUnmanagedAllocations = NativeMemory.TotalLuceneUnmanagedAllocationsForSorting
             };
         }

--- a/src/Raven.Server/Dashboard/Cluster/Notifications/MemoryUsagePayload.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/MemoryUsagePayload.cs
@@ -26,6 +26,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
         public long AvailableMemory { get; set; }
         public long AvailableMemoryForProcessing { get; set; }
         public long TotalSwapUsage { get; set; }
+        public long LuceneManagedTermCacheAllocations { get; set; }
         public long LuceneUnmanagedAllocations { get; set; }
 
         public override ClusterDashboardNotificationType Type => ClusterDashboardNotificationType.MemoryUsage;
@@ -48,6 +49,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
             json[nameof(AvailableMemory)] = AvailableMemory;
             json[nameof(AvailableMemoryForProcessing)] = AvailableMemoryForProcessing;
             json[nameof(TotalSwapUsage)] = TotalSwapUsage;
+            json[nameof(LuceneManagedTermCacheAllocations)] = LuceneManagedTermCacheAllocations;
             json[nameof(LuceneUnmanagedAllocations)] = LuceneUnmanagedAllocations;
 
             return json;

--- a/src/Raven.Studio/typescript/models/resources/widgets/memoryUsage.ts
+++ b/src/Raven.Studio/typescript/models/resources/widgets/memoryUsage.ts
@@ -19,6 +19,7 @@ class memoryUsage extends historyAwareNodeStats<Raven.Server.Dashboard.Cluster.N
     systemCommitLimit = this.dataExtractor(x => x.SystemCommitLimit);
     totalSwapUsage = this.dataExtractor(x => x.TotalSwapUsage);
     totalSwap = this.dataExtractor(x => x.PhysicalMemory != null && x.SystemCommitLimit != null ? x.SystemCommitLimit - x.PhysicalMemory : undefined);
+    luceneManagedTermCacheAllocations = this.dataExtractor(x => x.LuceneManagedTermCacheAllocations);
     luceneUnmanagedAllocations = this.dataExtractor(x => x.LuceneUnmanagedAllocations);
 
     workingSetFormatted: KnockoutComputed<[string, string]>;

--- a/src/Raven.Studio/wwwroot/App/views/resources/widgets/memoryUsageWidget.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/widgets/memoryUsageWidget.html
@@ -37,6 +37,10 @@
                                 <div class="details-item-value" data-bind="text: sizeFormatter(unmanagedAllocations())"></div>
                             </div>
                             <div class="details-item">
+                                <div class="details-item-name">Lucene Term Cache Allocations</div>
+                                <div class="details-item-value" data-bind="text: sizeFormatter(luceneManagedTermCacheAllocations())"></div>
+                            </div>
+                            <div class="details-item">
                                 <div class="details-item-name">Lucene Unmanaged Allocations</div>
                                 <div class="details-item-value" data-bind="text: sizeFormatter(luceneUnmanagedAllocations())"></div>
                             </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19844/Add-the-LuceneUnmanagedAllocations-to-the-cluster-dashboard

### Additional description

Add the Lucene managed allocations for term cache.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
