### PR TITLE
RavenDB-21679 Require to assign AuthorizationStatus

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -29,7 +28,6 @@ using Raven.Server.Dashboard;
 using Raven.Server.Documents.ETL;
 using Raven.Server.Documents.Expiration;
 using Raven.Server.Documents.Handlers.Batches.Commands;
-using Raven.Server.Documents.Handlers.Processors.Batches;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.Patch;
@@ -43,11 +41,9 @@ using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Documents.TransactionMerger;
-using Raven.Server.Json;
 using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
-using Raven.Server.Rachis;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
@@ -1418,9 +1414,8 @@ namespace Raven.Server.Documents
                         using (DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                         {
                             var smugglerDestination = new StreamDestination(outputStream, context, smugglerSource, compressionAlgorithm.ToExportCompressionAlgorithm(), compressionLevel);
-                            var databaseSmugglerOptionsServerSide = new DatabaseSmugglerOptionsServerSide
+                            var databaseSmugglerOptionsServerSide = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)
                             {
-                                AuthorizationStatus = AuthorizationStatus.DatabaseAdmin,
                                 OperateOnTypes = DatabaseItemType.CompareExchange | DatabaseItemType.Identities
                             };
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImport.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.IO.Compression;
 using System.Net;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -9,7 +8,6 @@ using Microsoft.Net.Http.Headers;
 using Raven.Client;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
-using Raven.Client.Http;
 using Raven.Client.Properties;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Json;
@@ -108,6 +106,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Smuggler
                                     IgnoreDatabaseItemTypesIfCurrentVersionIsOlderThenClientVersion(context, ref blittableJson);
 
                                     options = JsonDeserializationServer.DatabaseSmugglerOptions(blittableJson);
+                                    options.SetAuthorizationStatus(RequestHandler.GetAuthorizationStatusForSmuggler(RequestHandler.DatabaseName));
+
                                     continue;
                                 }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.IO.Compression;
 using System.Net.Http;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -34,7 +33,8 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportGet<TRequestHan
         }
 
         operationId ??= GetOperationId();
-        var options = DatabaseSmugglerOptionsServerSide.Create(HttpContext);
+
+        var options = DatabaseSmugglerOptionsServerSide.Create(HttpContext, RequestHandler.GetAuthorizationStatusForSmuggler(RequestHandler.DatabaseName));
         await using (var file = await GetImportStream())
         await using (var stream = await BackupUtils.GetDecompressionStreamAsync(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte)))
         using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -576,9 +576,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                         Configuration.BackupType == BackupType.Snapshot && _isFullBackup == false)
                     {
                         // smuggler backup
-                        var options = new DatabaseSmugglerOptionsServerSide
+                        var options = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)
                         {
-                            AuthorizationStatus = AuthorizationStatus.DatabaseAdmin,
                             IncludeArtificial = true, // we want to include artificial in backup
                             IncludeArchived = true // wa want also to include archived documents in backup
                         };

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -303,9 +303,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 return;
 
             // restore the smuggler backup
-            var options = new DatabaseSmugglerOptionsServerSide
+            var options = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)
             {
-                AuthorizationStatus = AuthorizationStatus.DatabaseAdmin,
                 SkipRevisionCreation = true,
                 IncludeArchived = true
             };
@@ -466,7 +465,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             await using (var fileStream = await RestoreSource.GetStream(filePath))
             await using (var inputStream = GetInputStream(fileStream, database.MasterKey))
             await using (var gzipStream = await RavenServerBackupUtils.GetDecompressionStreamAsync(inputStream))
-            using (var source = new StreamSource(gzipStream, context, database.Name))
+            using (var source = new StreamSource(gzipStream, context, database.Name, options))
             {
                 var smuggler = database.Smuggler.CreateForRestore(RestoreSettings.DatabaseRecord, source, destination, context, options, restoreResult, onProgress);
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -274,9 +274,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             var destination = database.Smuggler.CreateDestination();
 
-            var smugglerOptions = new DatabaseSmugglerOptionsServerSide
+            var smugglerOptions = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)
             {
-                AuthorizationStatus = AuthorizationStatus.DatabaseAdmin,
                 OperateOnTypes = DatabaseItemType.CompareExchange | DatabaseItemType.Identities | DatabaseItemType.Subscriptions,
                 SkipRevisionCreation = true
             };
@@ -296,7 +295,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 await using (var inputStream = GetSnapshotInputStream(input, database.Name))
                 await using (var uncompressed = await RavenServerBackupUtils.GetDecompressionStreamAsync(inputStream))
                 {
-                    var source = new StreamSource(uncompressed, context, database.Name);
+                    var source = new StreamSource(uncompressed, context, database.Name, smugglerOptions);
 
                     var smuggler = database.Smuggler.CreateForRestore(databaseRecord: null, source, destination, context, smugglerOptions, result: null, onProgress,
                         OperationCancelToken.Token);

--- a/src/Raven.Server/Documents/Smuggler/AbstractDatabaseSmugglerFactory.cs
+++ b/src/Raven.Server/Documents/Smuggler/AbstractDatabaseSmugglerFactory.cs
@@ -34,7 +34,7 @@ public abstract class AbstractDatabaseSmugglerFactory
         ISmugglerSource source,
         ISmugglerDestination destination,
         JsonOperationContext context,
-        DatabaseSmugglerOptionsServerSide options = null,
+        DatabaseSmugglerOptionsServerSide options,
         SmugglerResult result = null,
         Action<IOperationProgress> onProgress = null,
         CancellationToken token = default);

--- a/src/Raven.Server/Documents/Smuggler/DatabaseSmugglerFactory.cs
+++ b/src/Raven.Server/Documents/Smuggler/DatabaseSmugglerFactory.cs
@@ -55,7 +55,7 @@ public sealed class DatabaseSmugglerFactory : AbstractDatabaseSmugglerFactory
         ISmugglerSource source, 
         ISmugglerDestination destination,
         JsonOperationContext context,
-        DatabaseSmugglerOptionsServerSide options = null,
+        DatabaseSmugglerOptionsServerSide options,
         SmugglerResult result = null,
         Action<IOperationProgress> onProgress = null,
         CancellationToken token = default)

--- a/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/DatabaseSmugglerOptionsServerSide.cs
@@ -8,11 +8,32 @@ namespace Raven.Server.Smuggler.Documents.Data
 {
     public sealed class DatabaseSmugglerOptionsServerSide : DatabaseSmugglerOptions, IDatabaseSmugglerImportOptions, IDatabaseSmugglerExportOptions
     {
+        private DatabaseSmugglerOptionsServerSide()
+        {
+            //Only for GenerateJsonDeserializationRoutine
+        }
+
+        public DatabaseSmugglerOptionsServerSide(AuthorizationStatus authorizationStatus)
+        {
+            _authorizationStatus = authorizationStatus;
+        }
+
         public bool ReadLegacyEtag { get; set; }
 
         public string FileName { get; set; }
 
-        public AuthorizationStatus AuthorizationStatus { get; set; } = AuthorizationStatus.ValidUser;
+        private AuthorizationStatus? _authorizationStatus;
+
+        public AuthorizationStatus AuthorizationStatus
+        {
+            get
+            {
+                if (_authorizationStatus == null)
+                    throw new InvalidOperationException("AuthorizationStatus must be set");
+
+                return _authorizationStatus.Value;
+            }
+        }
 
         public bool SkipRevisionCreation { get; set; }
         
@@ -20,9 +41,14 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         public CompressionLevel? CompressionLevel { get; set; }
 
-        public static DatabaseSmugglerOptionsServerSide Create(HttpContext httpContext)
+        public void SetAuthorizationStatus(AuthorizationStatus authorizationStatus)
         {
-            var result = new DatabaseSmugglerOptionsServerSide();
+            _authorizationStatus = authorizationStatus;
+        }
+
+        public static DatabaseSmugglerOptionsServerSide Create(HttpContext httpContext, AuthorizationStatus authorizationStatus)
+        {
+            var result = new DatabaseSmugglerOptionsServerSide(authorizationStatus);
 
             foreach (var item in httpContext.Request.Query)
             {

--- a/src/Raven.Server/Smuggler/Documents/OrchestratorStreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/OrchestratorStreamSource.cs
@@ -15,7 +15,7 @@ public sealed class OrchestratorStreamSource : StreamSource
 {
     private readonly int _numberOfShards;
 
-    public OrchestratorStreamSource(Stream stream, JsonOperationContext context, string databaseName, int numberOfShards, DatabaseSmugglerOptionsServerSide options = null) : base(stream, context, databaseName, options)
+    public OrchestratorStreamSource(Stream stream, JsonOperationContext context, string databaseName, int numberOfShards, DatabaseSmugglerOptionsServerSide options) : base(stream, context, databaseName, options)
     {
         Mode = BlittableJsonDocumentBuilder.UsageMode.None;
         _numberOfShards = numberOfShards;

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -49,14 +49,14 @@ namespace Raven.Server.Smuggler.Documents
             ISmugglerDestination destination,
             SystemTime time,
             JsonOperationContext context,
-            DatabaseSmugglerOptionsServerSide options = null,
+            DatabaseSmugglerOptionsServerSide options,
             SmugglerResult result = null,
             Action<IOperationProgress> onProgress = null,
             CancellationToken token = default)
         {
             _databaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseName));
             _source = source;
-            _options = options ?? new DatabaseSmugglerOptionsServerSide();
+            _options = options;
             _result = result;
             _token = token;
             _context = context;

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using Raven.Client.Documents.DataArchival;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Analysis;
@@ -27,9 +26,9 @@ using Raven.Client.ServerWide.Operations.Integrations;
 using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers;
-using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Json;
+using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.Smuggler.Documents.Data;
@@ -69,12 +68,12 @@ namespace Raven.Server.Smuggler.Documents
         private readonly DatabaseSmugglerOptionsServerSide _options;
         protected readonly ByteStringContext _allocator;
         
-        public StreamSource(Stream stream, JsonOperationContext context, string databaseName, DatabaseSmugglerOptionsServerSide options = null)
+        public StreamSource(Stream stream, JsonOperationContext context, string databaseName, DatabaseSmugglerOptionsServerSide options)
         {
             _peepingTomStream = new PeepingTomStream(stream, context);
             _context = context;
             _log = LoggingSource.Instance.GetLogger<StreamSource>(databaseName);
-            _options = options ?? new DatabaseSmugglerOptionsServerSide();
+            _options = options;
             _allocator = new ByteStringContext(SharedMultipleUseFlag.None);
         }
 

--- a/src/Raven.Server/Smuggler/Migration/AbstractLegacyMigrator.cs
+++ b/src/Raven.Server/Smuggler/Migration/AbstractLegacyMigrator.cs
@@ -13,6 +13,7 @@ using Raven.Client.Exceptions.Security;
 using Raven.Server.Documents;
 using Raven.Server.Extensions;
 using Raven.Server.Json;
+using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
@@ -26,7 +27,7 @@ namespace Raven.Server.Smuggler.Migration
 {
     public abstract class AbstractLegacyMigrator : AbstractMigrator
     {
-        protected AbstractLegacyMigrator(MigratorOptions options, MigratorParameters parameters) : base(options, parameters)
+        protected AbstractLegacyMigrator(MigratorOptions options, MigratorParameters parameters, AuthorizationStatus authorizationStatus) : base(options, parameters, authorizationStatus)
         {
         }
 

--- a/src/Raven.Server/Smuggler/Migration/AbstractMigrator.cs
+++ b/src/Raven.Server/Smuggler/Migration/AbstractMigrator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Documents.Handlers;
 using Sparrow.Json;
+using Raven.Server.Routing;
 
 namespace Raven.Server.Smuggler.Migration
 {
@@ -8,11 +9,13 @@ namespace Raven.Server.Smuggler.Migration
     {
         protected readonly MigratorOptions Options;
         protected readonly MigratorParameters Parameters;
+        protected readonly AuthorizationStatus AuthorizationStatus;
 
-        protected AbstractMigrator(MigratorOptions options, MigratorParameters parameters)
+        protected AbstractMigrator(MigratorOptions options, MigratorParameters parameters, AuthorizationStatus authorizationStatus)
         {
             Options = options;
             Parameters = parameters;
+            AuthorizationStatus = authorizationStatus;
         }
 
         public abstract Task Execute();

--- a/src/Raven.Server/Web/RequestHandler.SmugglerHelper.cs
+++ b/src/Raven.Server/Web/RequestHandler.SmugglerHelper.cs
@@ -1,6 +1,9 @@
 ﻿using System.Text;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Raven.Client.Documents.Changes;
 using Raven.Server.Documents.Queries;
+using Raven.Server.Routing;
+using static Raven.Server.RavenServer;
 
 namespace Raven.Server.Web
 {
@@ -27,6 +30,12 @@ namespace Raven.Server.Web
                 sb.AppendLine().Append(indexQuery.QueryParameters);
 
             AddStringToHttpContext(sb.ToString(), type);
+        }
+
+        public AuthorizationStatus GetAuthorizationStatusForSmuggler(string databaseName)
+        {
+            var authenticateConnection = HttpContext.Features.Get<IHttpAuthenticationFeature>() as AuthenticateConnection;
+            return authenticateConnection?.GetAuthorizationStatus(databaseName) ?? AuthorizationStatus.DatabaseAdmin;
         }
     }
 }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1256,6 +1256,7 @@ namespace Raven.Server.Web.System
             {
                 throw new DatabaseDoesNotExistException($"Can't import into database {databaseName} because it doesn't exist.");
             }
+            var options = new DatabaseSmugglerOptionsServerSide(GetAuthorizationStatusForSmuggler(databaseName));
             var (commandline, tmpFile) = configuration.GenerateExporterCommandLine();
             var processStartInfo = new ProcessStartInfo(dataExporter, commandline);
 
@@ -1353,7 +1354,6 @@ namespace Raven.Server.Web.System
 
                                 result.AddInfo("Starting the import phase of the migration");
                                 onProgress(overallProgress);
-                                var options = new DatabaseSmugglerOptionsServerSide(GetAuthorizationStatusForSmuggler(databaseName));
                                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                                 await using (var reader = File.OpenRead(configuration.OutputFilePath))
                                 await using (var stream = await BackupUtils.GetDecompressionStreamAsync(reader))

--- a/test/SlowTests/Issues/RDoc-1995.cs
+++ b/test/SlowTests/Issues/RDoc-1995.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
+using Raven.Server.Routing;
 using Raven.Server.Smuggler.Migration;
 using SlowTests.Core.Utils.Entities;
 using Xunit;
@@ -186,6 +187,7 @@ namespace SlowTests.Issues
 
             await migrate.UpdateBuildInfoIfNeeded();
             var database = await Databases.GetDocumentDatabaseInstanceFor(store2);
+
             var operationId =
                 migrate.StartMigratingSingleDatabase(
                     new DatabaseMigrationSettings
@@ -193,7 +195,7 @@ namespace SlowTests.Issues
                         DatabaseName = store1.Database,
                         OperateOnTypes = operateOnTypes,
                     },
-                    database);
+                    database, AuthorizationStatus.DatabaseAdmin);
 
             WaitForValue(() =>
             {

--- a/test/SlowTests/Issues/RavenDB-13937.cs
+++ b/test/SlowTests/Issues/RavenDB-13937.cs
@@ -6,6 +6,7 @@ using FastTests;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Util;
+using Raven.Server.Routing;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
@@ -29,7 +30,7 @@ namespace SlowTests.Issues
             {
                 using (var database = CreateDocumentDatabase())
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                using (var source = new StreamSource(stream, context, database.Name))
+                using (var source = new StreamSource(stream, context, database.Name, new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)))
                 {
                     var editRevisions = new EditRevisionsConfigurationCommand(new RevisionsConfiguration
                     {
@@ -47,7 +48,7 @@ namespace SlowTests.Issues
 
                     var destination = database.Smuggler.CreateDestination();
 
-                    var smuggler = await (database.Smuggler.Create(source, destination, context, new DatabaseSmugglerOptionsServerSide
+                    var smuggler = await (database.Smuggler.Create(source, destination, context, new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)
                     {
                         OperateOnTypes = DatabaseItemType.Documents | DatabaseItemType.RevisionDocuments | DatabaseItemType.Attachments |
                                          DatabaseItemType.Indexes,

--- a/test/SlowTests/Issues/RavenDB_5998.cs
+++ b/test/SlowTests/Issues/RavenDB_5998.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Extensions;
 using Raven.Server.Documents;
+using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
@@ -32,11 +33,11 @@ namespace SlowTests.Issues
 
                 using (DocumentDatabase database = CreateDocumentDatabase())
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                using (var source = new StreamSource(stream, context, database.Name))
+                using (var source = new StreamSource(stream, context, database.Name, new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)))
                 {
                     var destination = database.Smuggler.CreateDestination();
 
-                    var smuggler = database.Smuggler.Create(source, destination, context, new DatabaseSmugglerOptionsServerSide
+                    var smuggler = database.Smuggler.Create(source, destination, context, new DatabaseSmugglerOptionsServerSide(AuthorizationStatus.DatabaseAdmin)
                     {
                         TransformScript = "this['Test'] = 'NewValue';"
                     });

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -27,6 +27,7 @@ using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
+using Raven.Server.Routing;
 using Raven.Server.Smuggler.Migration;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Issues;
@@ -180,7 +181,6 @@ namespace SlowTests.Smuggler
 
                     operation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
-
                     var periodicBackupRunner = (await Databases.GetDocumentDatabaseInstanceFor(store2)).PeriodicBackupRunner;
                     var backups = periodicBackupRunner.PeriodicBackups;
 
@@ -419,7 +419,7 @@ namespace SlowTests.Smuggler
                                                        DatabaseRecordItemType.SqlEtls |
                                                        DatabaseRecordItemType.RavenConnectionStrings |
                                                        DatabaseRecordItemType.Analyzers
-                    }, database);
+                    }, database, AuthorizationStatus.DatabaseAdmin);
 
                     WaitForValue(() =>
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21679

### Additional description

We encountered a situation where the AuthorizationStatus was not assigned in the DatabaseSmugglerOptionsServerSide class. 
Now, we ensure that it's assigned when creating a new instance.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
