### PR TITLE
RavenDB-22188 Cannot view a MultiGet request in the Traffic Watch - l…

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
@@ -86,8 +86,8 @@ class runQueryFeature implements columnPreviewFeature {
             if (line) {
                 const jsonObj = JSON.parse(line);
 
-                const queriesEndpoint = jsonObj.Url.endsWith("/queries");
-                const query = jsonObj.Query.slice("?query=".length);
+                const queriesEndpoint = jsonObj.Url?.endsWith("/queries");
+                const query = jsonObj.Query?.slice("?query=".length);
 
                 if (queriesEndpoint && query) {
                     queryList.push(query);


### PR DESCRIPTION
…ess strict parsing

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22188 

### Additional description

Less strict parsing of executed Queries

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
