### PR TITLE
RavenDB-22174 Fixing await used inside a write transaction in the test

### DIFF
--- a/test/SlowTests/Issues/RavenDB_11255.cs
+++ b/test/SlowTests/Issues/RavenDB_11255.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public async Task Can_update_lock_mode_and_priority_of_index_even_if_indexing_is_running()
+        public void Can_update_lock_mode_and_priority_of_index_even_if_indexing_is_running()
         {
             using (var database = CreateDocumentDatabase())
             {
@@ -40,7 +40,9 @@ namespace SlowTests.Issues
                             index.SetPriority(IndexPriority.High);
                         }, TaskCreationOptions.LongRunning);
 
-                        await task.WaitAsync(TimeSpan.FromMinutes(1));
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+                        task.Wait(TimeSpan.FromMinutes(1));
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
                     }
 
                     index.Start(); // will persist the introduced changes


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22174

### Additional description

It relates to https://github.com/ravendb/ravendb/pull/18487

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
