### PR TITLE
RavenDB-21690 Better indication if query results are from cache or we…

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/query/query.ts
@@ -1842,7 +1842,15 @@ class query extends shardViewModelBase {
         this.projectionBehavior(projectionBehavior);
         // Force dropdown menu to close. (for nested dropdowns, the menu stays open)
         $(".projection-behavior-dropdown").removeClass("open");
-}
+    }
+    
+    formatTime(input: number) {
+        if (!input) {
+            return "<1 ms";
+        }
+        
+        return input.toLocaleString() + " ms";
+    }
 }
 
 export = query;

--- a/src/Raven.Studio/wwwroot/App/views/database/query/query.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/query/query.html
@@ -133,8 +133,8 @@
                             </strong>
                             <span data-bind="visible: queriedIndex() && queriedIndex().indexOf('collection') === 0">&nbsp;collection</span>
                             &nbsp;was used to get <span data-bind="text: fromCache() ? 'cached' : 'the'"></span> results in
-                            <strong data-bind="text: queryStats().DurationInMs.toLocaleString() + ' ms'"></strong>
-                            <span data-bind="visible: originalRequestTime, if: originalRequestTime">(original request took: <strong data-bind="text: originalRequestTime().toLocaleString() + ' ms'"></strong>)</span>
+                            <strong data-bind="text: $root.formatTime(queryStats().DurationInMs)"></strong>
+                            <span data-bind="visible: originalRequestTime, if: originalRequestTime">(original request took: <strong data-bind="text: $root.formatTime(originalRequestTime())"></strong>)</span>
                             <span data-bind="visible: queriedFieldsOnly">
                                 . Showing <strong>stored index fields</strong> only.
                             </span>


### PR DESCRIPTION
… are getting them extremely fast

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21690

### Additional description

If query is extremally fast (1 ms) , show <1 ms instead of 0. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
