### PR TITLE
RavenDB-22323 Wrap where clause in parentheses when it precedes search clause

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -54,8 +54,8 @@ namespace Raven.Client.Documents.Linq
         private readonly Action<QueryResult> _afterQueryExecuted;
         private readonly LinqQueryHighlightings _highlightings;
         private bool _chainedWhere;
-        private int _insideWhere;
-        private int _insideFilter;
+        private int _insideWhereOrSearchCounter;
+        private int _insideFilterCounter;
         private bool _insideNegate;
         private bool _insideExact;
         private SpecialQueryType _queryType = SpecialQueryType.None;
@@ -232,7 +232,7 @@ namespace Raven.Client.Documents.Linq
 
         private void VisitBinaryExpression(BinaryExpression expression)
         {
-            if (_insideWhere > 0)
+            if (_insideWhereOrSearchCounter > 0)
             {
                 VerifyLegalBinaryExpression(expression);
             }
@@ -311,7 +311,6 @@ namespace Raven.Client.Documents.Linq
         {
             if (TryHandleBetween(andAlso))
                 return;
-
 
             if (_subClauseDepth > 0)
                 DocumentQuery.OpenSubclause();
@@ -1680,7 +1679,6 @@ The recommended method is to use full text search (mark the field as Analyzed an
             object value;
             while (true)
             {
-
                 expressions.Add(search);
 
                 if (LinqPathProvider.GetValueFromExpressionWithoutConversion(search.Arguments[4], out value) == false)
@@ -1700,7 +1698,12 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 target = search.Arguments[0];
             }
 
+            // This has to be set in order to have correct parentheses
+            // when using both search and where clause, e.g.
+            // where (Category = $p0 or Category = $p1) and search(Name, $p2)
+            _insideWhereOrSearchCounter++;
             VisitExpression(target);
+            _insideWhereOrSearchCounter--;
 
             if (expressions.Count > 1)
             {
@@ -1892,7 +1895,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     break;
                 case "Filter":
                 {
-                    _insideFilter++;
+                    _insideFilterCounter++;
                     VisitExpression(expression.Arguments[0]);
                     using (FilterModeScope(true))
                     {
@@ -1902,15 +1905,15 @@ The recommended method is to use full text search (mark the field as Analyzed an
                             DocumentQuery.OpenSubclause();
                         }
 
-                        if (_chainedWhere == false && _insideFilter > 1)
+                        if (_chainedWhere == false && _insideFilterCounter > 1)
                             DocumentQuery.OpenSubclause();
 
                         VisitExpression(((UnaryExpression)expression.Arguments[1]).Operand);
-                        if (_chainedWhere == false && _insideFilter > 1)
+                        if (_chainedWhere == false && _insideFilterCounter > 1)
                             DocumentQuery.CloseSubclause();
                         if (_chainedWhere)
                             DocumentQuery.CloseSubclause();
-                        _insideFilter--;
+                        _insideFilterCounter--;
                         if (expression.Arguments.Count is 3 && LinqPathProvider.GetValueFromExpressionWithoutConversion(expression.Arguments[2], out var limit))
                         {
                             AddFilterLimit((int)limit);
@@ -1923,14 +1926,14 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     {
                         using (FilterModeScope(@on: false))
                         {
-                            _insideWhere++;
+                            _insideWhereOrSearchCounter++;
                             VisitExpression(expression.Arguments[0]);
                             if (_chainedWhere)
                             {
                                 DocumentQuery.AndAlso();
                                 DocumentQuery.OpenSubclause();
                             }
-                            if (_chainedWhere == false && _insideWhere > 1)
+                            if (_chainedWhere == false && _insideWhereOrSearchCounter > 1)
                                 DocumentQuery.OpenSubclause();
 
                             if (expression.Arguments.Count == 3)
@@ -1939,12 +1942,12 @@ The recommended method is to use full text search (mark the field as Analyzed an
                             VisitExpression(((UnaryExpression)expression.Arguments[1]).Operand);
                             _insideExact = false;
 
-                            if (_chainedWhere == false && _insideWhere > 1)
+                            if (_chainedWhere == false && _insideWhereOrSearchCounter > 1)
                                 DocumentQuery.CloseSubclause();
                             if (_chainedWhere)
                                 DocumentQuery.CloseSubclause();
                             _chainedWhere = true;
-                            _insideWhere--;
+                            _insideWhereOrSearchCounter--;
                         }
                         break;
                     }
@@ -2908,7 +2911,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
         private void VisitLet(NewExpression expression)
         {
-            if (_insideWhere > 0)
+            if (_insideWhereOrSearchCounter > 0)
                 throw new NotSupportedException("Queries with a LET clause before a WHERE clause are not supported. " +
                                                 "WHERE clauses should appear before any LET clauses.");
 

--- a/test/FastTests/Issues/RavenDB_12235.cs
+++ b/test/FastTests/Issues/RavenDB_12235.cs
@@ -24,7 +24,7 @@ namespace FastTests.Issues
                     q = q.Where(x => x.Name == "123");
                     q = q.Search(x => x.Age, "123");
 
-                    Assert.Equal("from 'Users' where Name = $p0 and search(Age, $p1)", q.ToString());
+                    Assert.Equal("from 'Users' where (Name = $p0) and search(Age, $p1)", q.ToString());
                     Assert.Equal("from 'Users'", docQuery.ToString());
                 }
 
@@ -35,7 +35,7 @@ namespace FastTests.Issues
                     q = q.Where(x => x.Name == "123");
                     q = q.Search(x => x.Age, "123");
 
-                    Assert.Equal("from 'Users' where Name = $p0 and search(Age, $p1)", q.ToString());
+                    Assert.Equal("from 'Users' where (Name = $p0) and search(Age, $p1)", q.ToString());
                     Assert.Equal("from 'Users'", docQuery.ToString());
                 }
             }

--- a/test/SlowTests/Client/Queries/FullTextSearch.cs
+++ b/test/SlowTests/Client/Queries/FullTextSearch.cs
@@ -175,7 +175,7 @@ namespace SlowTests.Client.Queries
 
                     var query = RavenTestHelper.GetIndexQuery(ravenQueryable);
 
-                    Assert.Equal("from index 'test' where Name = $p0 and search(Tags, $p1)", query.Query);
+                    Assert.Equal("from index 'test' where (Name = $p0) and search(Tags, $p1)", query.Query);
                     Assert.Equal("i love cats", query.QueryParameters["p1"]);
                     Assert.Equal("User", query.QueryParameters["p0"]);
                 }

--- a/test/SlowTests/Issues/RavenDB-22323.cs
+++ b/test/SlowTests/Issues/RavenDB-22323.cs
@@ -1,0 +1,128 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22323 : RavenTestBase
+{
+    public RavenDB_22323(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void TestParenthesesWhenUsingSearchAndWhereClause()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A" || d.Category == "B")
+                    .Search(d => d.Name, "Peter*")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where (Category = $p0 or Category = $p1) and search(Name, $p2)", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Search(d => d.Name, "Peter*")
+                    .Where(d => d.Category == "A" || d.Category == "B")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where search(Name, $p0) and (Category = $p1 or Category = $p2)", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A" || d.Category == "B")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where Category = $p0 or Category = $p1", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where Category = $p0", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A")
+                    .Where(d => d.Name == "aaa")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where (Category = $p0) and (Name = $p1)", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A")
+                    .Search(d => d.Name, "Peter*")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where (Category = $p0) and search(Name, $p1)", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Search(d => d.Name, "Peter*")
+                    .Search(d => d.Category, "A", options: SearchOptions.Or)
+                    .Where(d => d.Category == "A" || d.Category == "B")
+                    .Search(d => d.Surname, "DDD", options: SearchOptions.And)
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where search(Name, $p0) or search(Category, $p1) and (Category = $p2 or Category = $p3) and search(Surname, $p4)", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Category == "A" || d.Category == "B")
+                    .Search(d => d.Name, "Peter*")
+                    .Search(d => d.Category, "A", options: SearchOptions.Or)
+                    .Search(d => d.Surname, "DDD", options: SearchOptions.And)
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where (Category = $p0 or Category = $p1) and search(Name, $p2) or search(Category, $p3) and search(Surname, $p4)", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Search(d => d.Name, "Peter*")
+                    .Where(d => d.Category == "A")
+                    .Search(d => d.Category, "A")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where search(Name, $p0) and (Category = $p1) and search(Category, $p2)", query);
+
+                query = session.Query<DummyIndex.Result, DummyIndex>()
+                    .Where(d => d.Name == "Peter")
+                    .Search(d => d.Name, "Peter*")
+                    .Where(d => d.Category == "A")
+                    .ToString();
+
+                Assert.Equal("from index 'DummyIndex' where (Name = $p0) and search(Name, $p1) and (Category = $p2)", query);
+            }
+        }
+    }
+
+    private class Dto
+    { 
+        public string Category { get; set; }
+        public string Name { get; set; }
+        public string Surname { get; set; }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public class Result
+        {
+            public string Category { get; set; }
+            public string Name { get; set; }
+            public string Surname { get; set; }
+        }
+        
+        public DummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new Result()
+                {
+                    Category = dto.Category, 
+                    Name = dto.Name, 
+                    Surname = dto.Surname
+                };
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_12346.cs
+++ b/test/SlowTests/Issues/RavenDB_12346.cs
@@ -29,7 +29,7 @@ namespace SlowTests.Issues
                     docQuery = q.ToDocumentQuery();
 
                     Assert.Equal(q.ToString(), docQuery.ToString());
-                    Assert.Equal("from 'Users' where Name = $p0 and search(Age, $p1)", docQuery.ToString());
+                    Assert.Equal("from 'Users' where (Name = $p0) and search(Age, $p1)", docQuery.ToString());
 
                     var e = Assert.Throws<InvalidOperationException>(() => q.ToAsyncDocumentQuery());
                     Assert.Equal("Cannot convert sync query to async document query.", e.Message);
@@ -41,7 +41,7 @@ namespace SlowTests.Issues
                     docQuery = q.ToDocumentQuery();
 
                     Assert.Equal(q.ToString(), docQuery.ToString());
-                    Assert.Equal("from 'Users' where Name = $p0 and search(Age, $p1) or Age > $p2", docQuery.ToString());
+                    Assert.Equal("from 'Users' where (Name = $p0) and search(Age, $p1) or Age > $p2", docQuery.ToString());
                 }
 
                 using (var asyncSession = store.OpenAsyncSession())
@@ -54,7 +54,7 @@ namespace SlowTests.Issues
                     docQuery = q.ToAsyncDocumentQuery();
 
                     Assert.Equal(q.ToString(), docQuery.ToString());
-                    Assert.Equal("from 'Users' where Name = $p0 and search(Age, $p1)", docQuery.ToString());
+                    Assert.Equal("from 'Users' where (Name = $p0) and search(Age, $p1)", docQuery.ToString());
 
                     var e = Assert.Throws<InvalidOperationException>(() => q.ToDocumentQuery());
                     Assert.Equal("Cannot convert async query to sync document query.", e.Message);
@@ -66,7 +66,7 @@ namespace SlowTests.Issues
                     docQuery = q.ToAsyncDocumentQuery();
 
                     Assert.Equal(q.ToString(), docQuery.ToString());
-                    Assert.Equal("from 'Users' where Name = $p0 and search(Age, $p1) or Age > $p2", docQuery.ToString());
+                    Assert.Equal("from 'Users' where (Name = $p0) and search(Age, $p1) or Age > $p2", docQuery.ToString());
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22323/Parentheses-missing-when-combining-Where-and-Search-clause

### Additional description

We want to treat usage of both search and where clause similarly to the usage of where clause twice and wrap the where clause in parentheses.

Because we use `_insideWhere` to handle parentheses for multiple `where` clauses, we can also use it to add parentheses for `where` clause preceding `search` clause. Unlike `_chainedWhere`, it doesn't force `and` conjunction between the current and next clause. Instead, the conjunction is added according to [these rules](https://issues.hibernatingrhinos.com/issue/RavenDB-22364/Inconsistency-between-LINQ-and-DocumentQuery-when-using-Where-clause-after-Search#focus=Comments-67-1051765.0-0).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
