### PR TITLE
RavenDB-22369 Corax - store only fields || Throw when spatial field is only stored.

### DIFF
--- a/bench/Voron.Benchmark/Corax/AndOrBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/AndOrBenchmark.cs
@@ -114,7 +114,7 @@ namespace Voron.Benchmark.Corax
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             IndexFieldsMapping fields = CreateFieldsMapping(bsc);
 
-            using (var writer = new IndexWriter(env, fields))
+            using (var writer = new IndexWriter(env, fields, SupportedFeatures.All))
             {
                 {
                     using var builder = writer.Index("Arava");

--- a/bench/Voron.Benchmark/Corax/InBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/InBenchmark.cs
@@ -115,7 +115,7 @@ namespace Voron.Benchmark.Corax
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             IndexFieldsMapping fields = CreateFieldsMapping(bsc);
 
-            using (var writer = new IndexWriter(env, fields))
+            using (var writer = new IndexWriter(env, fields, SupportedFeatures.All))
             {
                 {
                     using var builder = writer.Index("Arava");

--- a/bench/Voron.Benchmark/Corax/OrderByBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/OrderByBenchmark.cs
@@ -121,7 +121,7 @@ namespace Voron.Benchmark.Corax
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             IndexFieldsMapping fields = CreateFieldsMapping(bsc);
 
-            using (var writer = new IndexWriter(env, fields))
+            using (var writer = new IndexWriter(env, fields, SupportedFeatures.All))
             {
                 {
                     using var builder = writer.Index("items/1"u8);

--- a/bench/Voron.Benchmark/Corax/StartWithBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/StartWithBenchmark.cs
@@ -114,7 +114,7 @@ namespace Voron.Benchmark.Corax
         {
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             IndexFieldsMapping fields = CreateFieldsMapping(bsc);
-            using (var writer = new IndexWriter(env, fields))
+            using (var writer = new IndexWriter(env, fields, SupportedFeatures.All))
             {
                 {
                     using var entryWriter = writer.Index("Arava");

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 using System.Text;
 using Corax.Analyzers;
 using Corax.Mappings;
@@ -18,7 +17,6 @@ using Sparrow.Compression;
 using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Server;
-using Sparrow.Server.Binary;
 using Sparrow.Server.Utils;
 using Sparrow.Server.Utils.VxSort;
 using Sparrow.Threading;
@@ -44,7 +42,7 @@ namespace Corax.Indexing
         private readonly HashSet<Slice> _indexedEntries = new(SliceComparer.Instance);
         private List<(long EntryId, float Boost)> _boostedDocs;
         private readonly IndexFieldsMapping _fieldsMapping;
-        private readonly bool _phraseQuerySupport;
+        private readonly SupportedFeatures _supportedFeatures;
         private FixedSizeTree _documentBoost;
         private Tree _indexMetadata;
         private Tree _persistedDynamicFieldsAnalyzers;
@@ -84,12 +82,12 @@ namespace Corax.Indexing
         // to explicitly provide the index writer with opening semantics and also every new
         // writer becomes essentially a unit of work which makes reusing assets tracking more explicit.
 
-        private IndexWriter(IndexFieldsMapping fieldsMapping, bool phraseQuerySupport)
+        private IndexWriter(IndexFieldsMapping fieldsMapping, SupportedFeatures supportedFeatures)
         {
             _indexDebugDumper = new IndexOperationsDumper(fieldsMapping);
             _builder = new IndexEntryBuilder(this);
             _fieldsMapping = fieldsMapping;
-            _phraseQuerySupport = phraseQuerySupport;
+            _supportedFeatures = supportedFeatures ?? new(); // if not explicitly set - all features are available
             _encodingBufferHandler = Analyzer.BufferPool.Rent(fieldsMapping.MaximumOutputSize);
             _tokensBufferHandler = Analyzer.TokensPool.Rent(fieldsMapping.MaximumTokenSize);
             _utf8ConverterBufferHandler = Analyzer.BufferPool.Rent(fieldsMapping.MaximumOutputSize * 10);
@@ -98,7 +96,7 @@ namespace Corax.Indexing
             _knownFieldsTerms = new IndexedField[bufferSize];
             for (int i = 0; i < bufferSize; ++i)
             {
-                _knownFieldsTerms[i] = new IndexedField(fieldsMapping.GetByFieldId(i));
+                _knownFieldsTerms[i] = new IndexedField(fieldsMapping.GetByFieldId(i), _supportedFeatures);
             }
 
             _entriesAlreadyAdded = new HashSet<long>();
@@ -106,7 +104,7 @@ namespace Corax.Indexing
             _removalsForTerm = new List<long>();
         }
 
-        public IndexWriter([NotNull] StorageEnvironment environment, IndexFieldsMapping fieldsMapping, bool phraseQuerySupport = true) : this(fieldsMapping, phraseQuerySupport)
+        public IndexWriter([NotNull] StorageEnvironment environment, IndexFieldsMapping fieldsMapping, in SupportedFeatures supportedFeatures = default) : this(fieldsMapping, supportedFeatures)
         {
             TransactionPersistentContext transactionPersistentContext = new(true);
             _transaction = environment.WriteTransaction(transactionPersistentContext);
@@ -115,7 +113,7 @@ namespace Corax.Indexing
             Init();
         }
         
-        public IndexWriter([NotNull] Transaction tx, IndexFieldsMapping fieldsMapping, bool phraseQuerySupport = true) : this(fieldsMapping, phraseQuerySupport)
+        public IndexWriter([NotNull] Transaction tx, IndexFieldsMapping fieldsMapping, in SupportedFeatures supportedFeatures = default) : this(fieldsMapping, supportedFeatures)
         {
             _transaction = tx;
 
@@ -163,7 +161,7 @@ namespace Corax.Indexing
         private void InitializeFieldRootPageForTermsVector(IndexedField field)
         {
             Debug.Assert(field.FieldIndexingMode is FieldIndexingMode.Search, "field.FieldIndexingMode is FieldIndexingMode.Search");
-            Debug.Assert(_phraseQuerySupport, "_phraseQuerySupport");
+            Debug.Assert(_supportedFeatures.PhraseQuery, "_phraseQuerySupport");
             
             if (field.TermsVectorFieldRootPage == -1)
             {
@@ -302,7 +300,7 @@ namespace Corax.Indexing
             {
                 indexedField = new IndexedField(Constants.IndexWriter.DynamicField, binding.FieldName, binding.FieldNameLong,
                     binding.FieldNameDouble, binding.FieldTermTotalSumField, binding.Analyzer,
-                    binding.FieldIndexingMode, binding.HasSuggestions, binding.ShouldStore);
+                    binding.FieldIndexingMode, binding.HasSuggestions, binding.ShouldStore, _supportedFeatures);
 
                 if (persistedAnalyzer != null)
                 {
@@ -349,7 +347,7 @@ namespace Corax.Indexing
                 IndexFieldsMappingBuilder.GetFieldNameForLongs(context, clonedFieldName, out var fieldNameLong);
                 IndexFieldsMappingBuilder.GetFieldNameForDoubles(context, clonedFieldName, out var fieldNameDouble);
                 IndexFieldsMappingBuilder.GetFieldForTotalSum(context, clonedFieldName, out var nameSum);
-                var field = new IndexedField(Constants.IndexWriter.DynamicField, clonedFieldName, fieldNameLong, fieldNameDouble, nameSum, analyzer, mode, false, false);
+                var field = new IndexedField(Constants.IndexWriter.DynamicField, clonedFieldName, fieldNameLong, fieldNameDouble, nameSum, analyzer, mode, hasSuggestions: false, shouldStore: false, _supportedFeatures);
                 _dynamicFieldsTerms[clonedFieldName] = field;
                 return field;
             }
@@ -2061,7 +2059,7 @@ namespace Corax.Indexing
             }
         }
 
-        private bool FieldSupportsPhraseQuery(in IndexedField field) => _phraseQuerySupport && field.FieldIndexingMode is FieldIndexingMode.Search;
+        private bool FieldSupportsPhraseQuery(in IndexedField field) => _supportedFeatures.PhraseQuery && field.FieldIndexingMode is FieldIndexingMode.Search;
         
         public void Dispose()
         {

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -87,7 +87,7 @@ namespace Corax.Indexing
             _indexDebugDumper = new IndexOperationsDumper(fieldsMapping);
             _builder = new IndexEntryBuilder(this);
             _fieldsMapping = fieldsMapping;
-            _supportedFeatures = supportedFeatures ?? new(); // if not explicitly set - all features are available
+            _supportedFeatures = supportedFeatures; // if not explicitly set - all features are available
             _encodingBufferHandler = Analyzer.BufferPool.Rent(fieldsMapping.MaximumOutputSize);
             _tokensBufferHandler = Analyzer.TokensPool.Rent(fieldsMapping.MaximumTokenSize);
             _utf8ConverterBufferHandler = Analyzer.BufferPool.Rent(fieldsMapping.MaximumOutputSize * 10);
@@ -104,7 +104,7 @@ namespace Corax.Indexing
             _removalsForTerm = new List<long>();
         }
 
-        public IndexWriter([NotNull] StorageEnvironment environment, IndexFieldsMapping fieldsMapping, in SupportedFeatures supportedFeatures = default) : this(fieldsMapping, supportedFeatures)
+        public IndexWriter([NotNull] StorageEnvironment environment, IndexFieldsMapping fieldsMapping, SupportedFeatures supportedFeatures) : this(fieldsMapping, supportedFeatures)
         {
             TransactionPersistentContext transactionPersistentContext = new(true);
             _transaction = environment.WriteTransaction(transactionPersistentContext);
@@ -113,7 +113,7 @@ namespace Corax.Indexing
             Init();
         }
         
-        public IndexWriter([NotNull] Transaction tx, IndexFieldsMapping fieldsMapping, in SupportedFeatures supportedFeatures = default) : this(fieldsMapping, supportedFeatures)
+        public IndexWriter([NotNull] Transaction tx, IndexFieldsMapping fieldsMapping, SupportedFeatures supportedFeatures) : this(fieldsMapping, supportedFeatures)
         {
             _transaction = tx;
 

--- a/src/Corax/Indexing/IndexedField.cs
+++ b/src/Corax/Indexing/IndexedField.cs
@@ -34,8 +34,10 @@ internal sealed class IndexedField
     public readonly Slice NameTotalLengthOfTerms;
     public readonly int Id;
     public readonly FieldIndexingMode FieldIndexingMode;
+    public readonly bool ShouldIndex;
     public readonly bool HasSuggestions;
     public readonly bool ShouldStore;
+    public readonly SupportedFeatures SupportedFeatures;
     public bool HasMultipleTermsPerField;
     public long FieldRootPage;
     public long TermsVectorFieldRootPage;
@@ -45,13 +47,13 @@ internal sealed class IndexedField
         return Name.ToString() + " Id: " + Id;
     }
 
-    public IndexedField(IndexFieldBinding binding) : this(binding.FieldId, binding.FieldName, binding.FieldNameLong, binding.FieldNameDouble,
-        binding.FieldTermTotalSumField, binding.Analyzer, binding.FieldIndexingMode, binding.HasSuggestions, binding.ShouldStore, binding.FieldNameForStatistics)
+    public IndexedField(IndexFieldBinding binding, in SupportedFeatures supportedFeatures) : this(binding.FieldId, binding.FieldName, binding.FieldNameLong, binding.FieldNameDouble,
+        binding.FieldTermTotalSumField, binding.Analyzer, binding.FieldIndexingMode, binding.HasSuggestions, binding.ShouldStore, supportedFeatures, binding.FieldNameForStatistics)
     {
     }
 
     public IndexedField(int id, Slice name, Slice nameLong, Slice nameDouble, Slice nameTotalLengthOfTerms, Analyzer analyzer,
-        FieldIndexingMode fieldIndexingMode, bool hasSuggestions, bool shouldStore,  string nameForStatistics = null, long fieldRootPage = -1, long termsVectorFieldRootPage = -1)
+        FieldIndexingMode fieldIndexingMode, bool hasSuggestions, bool shouldStore, in SupportedFeatures supportedFeatures, string nameForStatistics = null, long fieldRootPage = -1, long termsVectorFieldRootPage = -1)
     {
         Name = name;
         NameLong = nameLong;
@@ -61,6 +63,7 @@ internal sealed class IndexedField
         Analyzer = analyzer;
         HasSuggestions = hasSuggestions;
         ShouldStore = shouldStore;
+        SupportedFeatures = supportedFeatures;
         FieldRootPage = fieldRootPage;
         TermsVectorFieldRootPage = termsVectorFieldRootPage;
         Storage = new FastList<EntriesModifications>();
@@ -68,6 +71,7 @@ internal sealed class IndexedField
         Longs = new Dictionary<long, int>();
         Doubles = new Dictionary<double, int>();
         FieldIndexingMode = fieldIndexingMode;
+        ShouldIndex = supportedFeatures.StoreOnly == false || fieldIndexingMode != FieldIndexingMode.No;
         NameForStatistics = nameForStatistics ?? $"Field_{Name}";
 
         if (fieldIndexingMode is FieldIndexingMode.Search)

--- a/src/Corax/SupportedFeatures.cs
+++ b/src/Corax/SupportedFeatures.cs
@@ -1,18 +1,9 @@
 ﻿namespace Corax;
 
-public class SupportedFeatures
+public class SupportedFeatures(bool isPhraseQuerySupported, bool isStoreOnlySupported)
 {
-    public readonly bool PhraseQuery = true;
-    public readonly bool StoreOnly = true;
-
-    public SupportedFeatures(bool isPhraseQuerySupported, bool isStoreOnlySupported)
-    {
-        PhraseQuery = isPhraseQuerySupported;
-        StoreOnly = isStoreOnlySupported;
-    }
+    public static readonly SupportedFeatures All = new (true, true);
     
-    public SupportedFeatures()
-    {
-        // all is supported
-    }
+    public readonly bool PhraseQuery = isPhraseQuerySupported;
+    public readonly bool StoreOnly = isStoreOnlySupported;
 }

--- a/src/Corax/SupportedFeatures.cs
+++ b/src/Corax/SupportedFeatures.cs
@@ -1,0 +1,18 @@
+﻿namespace Corax;
+
+public class SupportedFeatures
+{
+    public readonly bool PhraseQuery = true;
+    public readonly bool StoreOnly = true;
+
+    public SupportedFeatures(bool isPhraseQuerySupported, bool isStoreOnlySupported)
+    {
+        PhraseQuery = isPhraseQuerySupported;
+        StoreOnly = isStoreOnlySupported;
+    }
+    
+    public SupportedFeatures()
+    {
+        // all is supported
+    }
+}

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -175,11 +175,12 @@ namespace Raven.Server.Documents.Indexes
             public const long TimeTicksSupportInJavaScriptIndexes_60 = 60_001; // RavenDB-19625
 
             public const long PhraseQuerySupportInCoraxIndexes = 60_002;
+            public const long StoreOnlySupportInCoraxIndexes = 60_003;
 
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = PhraseQuerySupportInCoraxIndexes;
+            public const long CurrentVersion = StoreOnlySupportInCoraxIndexes;
 
             public static bool IsTimeTicksInJavaScriptIndexesSupported(long indexVersion)
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -21,6 +21,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 {
     public class CoraxIndexWriteOperation : IndexWriteOperationBase
     {
+        
         public const int MaximumPersistedCapacityOfCoraxWriter = 512;
         private readonly IndexWriter _indexWriter;
         private readonly CoraxDocumentConverterBase _converter;
@@ -42,7 +43,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             _allocator = writeTransaction.Allocator;
             try
             {
-                _indexWriter =  new IndexWriter(writeTransaction, knownFields, phraseQuerySupport: index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.PhraseQuerySupportInCoraxIndexes);
+                _indexWriter =  new IndexWriter(writeTransaction, knownFields, new SupportedFeatures(
+                    isPhraseQuerySupported: index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.PhraseQuerySupportInCoraxIndexes,
+                    isStoreOnlySupported: index.Definition.Version >= IndexDefinitionBaseServerSide.IndexVersion.StoreOnlySupportInCoraxIndexes));
             }
             catch (Exception e) when (e.IsOutOfMemory())
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -84,8 +84,7 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
             {
                 do
                 {
-                    ProcessObject(iterator.Current, propertyAsString, field, indexingScope, documentToProcess,
-                        out shouldSaveAsBlittable, out value, out actualValue, out innerShouldSkip);
+                    ProcessObject(iterator.Current, propertyAsString, field, out shouldSaveAsBlittable, out value, out actualValue, out innerShouldSkip);
                     if (shouldSaveAsBlittable)
 {                        ProcessAsJson(actualValue, field, documentToProcess, out innerShouldSkip);}
                     hasFields |= innerShouldSkip == false;
@@ -95,7 +94,7 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
             }
             else
             {
-                ProcessObject(propertyDescriptor.Value, propertyAsString, field, indexingScope, documentToProcess,
+                ProcessObject(propertyDescriptor.Value, propertyAsString, field,
                     out shouldSaveAsBlittable, out value, out actualValue, out innerShouldSkip);
                 if (shouldSaveAsBlittable)
                     ProcessAsJson(actualValue, field, documentToProcess, out innerShouldSkip);
@@ -156,8 +155,7 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
             return value.IsObject() && value.IsArray() == false;
         }
 
-        void ProcessObject(JsValue valueToInsert, in string propertyAsString, IndexField field, 
-            CurrentIndexingScope indexingScope, ObjectInstance documentToProcess, out bool shouldProcessAsBlittable, out object value, out JsValue actualValue, out bool shouldSkip)
+        void ProcessObject(JsValue valueToInsert, in string propertyAsString, IndexField field, out bool shouldProcessAsBlittable, out object value, out JsValue actualValue, out bool shouldSkip)
         {
             shouldSkip = false;
             value = null;

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndexDefinition.cs
@@ -64,7 +64,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 {
                     var name = $"compound({string.Join(",",field)})";
                     var indexField = IndexField.Create(name, new IndexFieldOptions(), allFields, idX++);
-                    indexField.Indexing = FieldIndexing.No; // handled separately
+                    indexField.Indexing = FieldIndexing.Default; // handled separately
                     result.Add(indexField);
                 }
             }

--- a/test/FastTests/Corax/BoostingQuery.cs
+++ b/test/FastTests/Corax/BoostingQuery.cs
@@ -319,7 +319,7 @@ namespace FastTests.Corax
             
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             using var knownFields = CreateKnownFields(bsc);
-            using (var indexWriter = new IndexWriter(Env, knownFields))
+            using (var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All))
             {
                 indexWriter.TryDeleteEntry("list/1");
                 indexWriter.Commit();
@@ -387,7 +387,7 @@ namespace FastTests.Corax
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             using var knownFields = CreateKnownFields(bsc);
 
-            using var indexWriter = new IndexWriter(Env, knownFields);
+            using var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All);
 
             foreach (var entry in longList)
             {

--- a/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
+++ b/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
@@ -36,7 +36,7 @@ public class FacetIndexingRepro : StorageTest
         var fieldsTree = wtx.CreateTree(Constants.IndexWriter.FieldsSlice);
         CompactTree idTree = fieldsTree.CompactTreeFor(id);
 
-        using var iw = new IndexWriter(wtx, fields);
+        using var iw = new IndexWriter(wtx, fields, SupportedFeatures.All);
         string entryKey = "users/00000001";
         long entryId;
         using (var builder = iw.Index("entryKey"))
@@ -125,7 +125,7 @@ public class FacetIndexingRepro : StorageTest
         var wtx = Env.WriteTransaction();
         try
         {
-            var iw = new IndexWriter(wtx, fields);
+            var iw = new IndexWriter(wtx, fields, SupportedFeatures.All);
             while (true)
             {
                 string id;
@@ -178,7 +178,7 @@ public class FacetIndexingRepro : StorageTest
                 txns++;
                 items = 0;
                 wtx = Env.WriteTransaction();
-                iw = new IndexWriter(wtx, fields);
+                iw = new IndexWriter(wtx, fields, SupportedFeatures.All);
             }
         }
         finally
@@ -228,7 +228,7 @@ public class FacetIndexingRepro : StorageTest
         IndexFieldsMapping indexFieldsMapping = builder.Build();
         using (var wtx = Env.WriteTransaction())
         {
-            var iw = new IndexWriter(wtx, indexFieldsMapping);
+            var iw = new IndexWriter(wtx, indexFieldsMapping, SupportedFeatures.All);
             while (true)
             {
                 string id;
@@ -248,7 +248,7 @@ public class FacetIndexingRepro : StorageTest
                 {
                     iw.Commit();
                     iw.Dispose();
-                    iw = new IndexWriter(wtx, indexFieldsMapping);
+                    iw = new IndexWriter(wtx, indexFieldsMapping, SupportedFeatures.All);
                     continue;
                 }
 

--- a/test/FastTests/Corax/Bugs/IndexEntryReaderBigDoc.cs
+++ b/test/FastTests/Corax/Bugs/IndexEntryReaderBigDoc.cs
@@ -32,7 +32,7 @@ public class IndexEntryReaderBigDoc : StorageTest
         
         
         long entryId;
-        using (var indexWriter = new IndexWriter(Env, knownFields))
+        using (var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All))
         {
             var options = new[] { "one", "two", "three" };
             using (var writer = indexWriter.Index("users/1"))

--- a/test/FastTests/Corax/Bugs/OptimizedUpdatesOnIndexes.cs
+++ b/test/FastTests/Corax/Bugs/OptimizedUpdatesOnIndexes.cs
@@ -22,7 +22,7 @@ public unsafe class OptimizedUpdatesOnIndexes : StorageTest
     {
         using var fields = CreateKnownFields(Allocator);
         long oldId; 
-        using (var indexWriter = new IndexWriter(Env, fields))
+        using (var indexWriter = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entry = indexWriter.Update("cars/1"u8))
             {
@@ -45,7 +45,7 @@ public unsafe class OptimizedUpdatesOnIndexes : StorageTest
         }
 
         long newId;
-        using (var indexWriter = new IndexWriter(Env, fields))
+        using (var indexWriter = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entry = indexWriter.Update("cars/1"u8))
             {

--- a/test/FastTests/Corax/Bugs/RavenDB-19283.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-19283.cs
@@ -36,7 +36,7 @@ public class RavenDB_19283 : StorageTest
         using var knownFields = builder.Build();
 
         long entryId;
-        using (var indexWriter = new IndexWriter(Env, knownFields))
+        using (var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All))
         {
             var options = new[] { "one", "two", "three" };
             using (var writer = indexWriter.Index("users/1"))

--- a/test/FastTests/Corax/Bugs/RavenDB-22285.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-22285.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Corax;
 using Corax.Analyzers;
 using Corax.Indexing;
 using Corax.Mappings;
@@ -29,7 +30,7 @@ public class RavenDB_22285 : StorageTest
         using var mapping = CreateKnownFields(allocator);
         var descendingSortedTerm = Enumerable.Range(0, 26).Select(i => new[] { (byte)('z' - i) }).ToList();
         var database = new List<Dto>();
-        using (var indexWriter = new IndexWriter(Env, mapping))
+        using (var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All))
         {
             for (var idX = 0; idX < 2096; ++idX)
             {

--- a/test/FastTests/Corax/CoraxCrud.cs
+++ b/test/FastTests/Corax/CoraxCrud.cs
@@ -27,7 +27,7 @@ public class CoraxCrud: StorageTest
     {
         var fields = CreateKnownFields(Allocator);
         Span<long> ids = stackalloc long[1024];
-        using (var indexWriter = new IndexWriter(Env, fields))
+        using (var indexWriter = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var builder = indexWriter.Index("users/1"u8))
             {
@@ -51,7 +51,7 @@ public class CoraxCrud: StorageTest
     {
         var fields = CreateKnownFields(Allocator);
         Span<long> ids = stackalloc long[1024];
-        using (var indexWriter = new IndexWriter(Env, fields))
+        using (var indexWriter = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var builder = indexWriter.Index("users/1"u8))
             {
@@ -80,7 +80,7 @@ public class CoraxCrud: StorageTest
     {
         var fields = CreateKnownFields(Allocator);
         Span<long> ids = stackalloc long[1024];
-        using (var indexWriter = new IndexWriter(Env, fields))
+        using (var indexWriter = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var builder = indexWriter.Index("users/1"u8))
             {
@@ -90,7 +90,7 @@ public class CoraxCrud: StorageTest
             indexWriter.Commit();
         }
         
-        using (var indexWriter = new IndexWriter(Env, fields))
+        using (var indexWriter = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var builder = indexWriter.Update("users/1"u8))
             {
@@ -125,7 +125,7 @@ public class CoraxCrud: StorageTest
     {
         var fields = CreateKnownFields(Allocator);
         Span<long> ids = stackalloc long[1024];
-        using (var indexWriter = new IndexWriter(Env, fields))
+        using (var indexWriter = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var builder = indexWriter.Index("users/1"u8))
             {
@@ -135,7 +135,7 @@ public class CoraxCrud: StorageTest
             indexWriter.Commit();
         }
         
-        using (var indexWriter = new IndexWriter(Env, fields))
+        using (var indexWriter = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var builder = indexWriter.Update("users/1"u8))
             {

--- a/test/FastTests/Corax/CoraxQueries.cs
+++ b/test/FastTests/Corax/CoraxQueries.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using Corax;
 using Corax.Mappings;
 using Corax.Querying.Matches;
 using Corax.Querying.Matches.Meta;
@@ -334,7 +335,7 @@ namespace FastTests.Corax
             _knownFields.TryGetByFieldId(TextualValueId, out binding);
             _textualItemFieldMetadata = binding.Metadata;
             
-            using var indexWriter = new IndexWriter(Env, _knownFields);
+            using var indexWriter = new IndexWriter(Env, _knownFields, SupportedFeatures.All);
 
             foreach (var entry in _entries)
             {

--- a/test/FastTests/Corax/DeleteTest.cs
+++ b/test/FastTests/Corax/DeleteTest.cs
@@ -42,7 +42,7 @@ namespace FastTests.Corax
                 Assert.Equal(_longList.Count, match.Fill(ids));
             }
 
-            using (var indexWriter = new IndexWriter(Env, _analyzers))
+            using (var indexWriter = new IndexWriter(Env, _analyzers, SupportedFeatures.All))
             {
                 indexWriter.TryDeleteEntry("list/0");
                 indexWriter.Commit();
@@ -81,7 +81,7 @@ namespace FastTests.Corax
                 Assert.Equal(_longList.Count, match.Fill(ids));
             }
 
-            using (var indexWriter = new IndexWriter(Env, _analyzers))
+            using (var indexWriter = new IndexWriter(Env, _analyzers, SupportedFeatures.All))
             {
                 indexWriter.TryDeleteEntry("list/0");
                 indexWriter.Commit();
@@ -116,7 +116,7 @@ namespace FastTests.Corax
                 Assert.Equal(batchSize, indexSearcher.NumberOfEntries);
             }
             
-            using (var indexWriter = new IndexWriter(Env, _analyzers))
+            using (var indexWriter = new IndexWriter(Env, _analyzers, SupportedFeatures.All))
             {
                 indexWriter.TryDeleteEntry("list/0");
                 indexWriter.Commit();
@@ -144,7 +144,7 @@ namespace FastTests.Corax
                 Assert.Equal(count, match.Fill(ids));
             }
 
-            using (var indexWriter = new IndexWriter(Env, _analyzers))
+            using (var indexWriter = new IndexWriter(Env, _analyzers, SupportedFeatures.All))
             {
                 indexWriter.TryDeleteEntry("list/9");
                 indexWriter.Commit();
@@ -180,7 +180,7 @@ namespace FastTests.Corax
                 var match = indexSearcher.TermQuery("Content", "0");
                 Assert.Equal(1, match.Fill(ids));
             }
-            using (var indexWriter = new IndexWriter(Env, _analyzers))
+            using (var indexWriter = new IndexWriter(Env, _analyzers, SupportedFeatures.All))
             {
                 indexWriter.TryDeleteEntry("list/0");
                 indexWriter.Commit();
@@ -229,7 +229,7 @@ namespace FastTests.Corax
 
         private void IndexEntries(IndexFieldsMapping knownFields)
         {
-            using var indexWriter = new IndexWriter(Env, knownFields);
+            using var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All);
 
             foreach (var entry in _longList)
             {

--- a/test/FastTests/Corax/DynamicFieldsTests.cs
+++ b/test/FastTests/Corax/DynamicFieldsTests.cs
@@ -37,7 +37,7 @@ public unsafe class DynamicFieldsTests : StorageTest
         builder.AddBinding(0, "Id");
         using var knownFields = builder.Build();
         long entryId;
-        using (var indexWriter = new IndexWriter(Env, knownFields))
+        using (var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All))
         {
             indexWriter.UpdateDynamicFieldsMapping(IndexFieldsMappingBuilder.CreateForWriter(true)
                 .AddBinding(Constants.IndexWriter.DynamicField, fieldName, shouldStore:true)
@@ -79,7 +79,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             .AddBinding(1, dSlice)
             .Build();
 
-        using (var indexer = new IndexWriter(Env, knownFields))
+        using (var indexer = new IndexWriter(Env, knownFields, SupportedFeatures.All))
         {
             using (var writer = indexer.Index("elements/1"))
             {
@@ -153,7 +153,7 @@ public unsafe class DynamicFieldsTests : StorageTest
         var fields = builder.Build();
 
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entry = writer.Update("users/1"u8))
             {
@@ -165,7 +165,7 @@ public unsafe class DynamicFieldsTests : StorageTest
         }
 
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             writer.TryDeleteEntry("users/1");
             writer.Commit();
@@ -192,7 +192,7 @@ public unsafe class DynamicFieldsTests : StorageTest
         var fields = builder.Build();
 
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entry = writer.Update("users/1"u8))
             {
@@ -206,7 +206,7 @@ public unsafe class DynamicFieldsTests : StorageTest
         }
 
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             writer.TryDeleteEntry("users/1");
             writer.Commit();
@@ -234,7 +234,7 @@ public unsafe class DynamicFieldsTests : StorageTest
         var fields = builder.Build();
 
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entry = writer.Update("users/1"u8))
             {
@@ -246,7 +246,7 @@ public unsafe class DynamicFieldsTests : StorageTest
         }
 
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             writer.TryDeleteEntry("users/1");
             writer.Commit();
@@ -273,7 +273,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             .AddBinding(1, dSlice);
         var fields = builder.Build();
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entry = writer.Index("users/1"))
             {
@@ -285,7 +285,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             writer.Commit();
         }
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entry = writer.Update("users/1"u8))
             {
@@ -297,7 +297,7 @@ public unsafe class DynamicFieldsTests : StorageTest
         }
 
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entry = writer.Update("users/1"u8))
             {
@@ -331,7 +331,7 @@ public unsafe class DynamicFieldsTests : StorageTest
     {
         using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
         using IndexFieldsMapping fields = PrepareSpatial(bsc);
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var builder = writer.Index(IdString))
             {
@@ -359,7 +359,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             }
         }
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             writer.TryDeleteEntry(IdString);
             writer.Commit();
@@ -395,7 +395,7 @@ public unsafe class DynamicFieldsTests : StorageTest
         using IndexFieldsMapping fields = PrepareSpatial(bsc);
         
         long entryId;
-        using (var indexWriter = new IndexWriter(Env, fields))
+        using (var indexWriter = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var writer = indexWriter.Index("items/1"))
             {
@@ -449,7 +449,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             .AddBinding(1, dSlice);
         var fields = builder.Build();
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entryBuilder = writer.Index("users/1"))
             {
@@ -460,7 +460,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             writer.Commit();
         }
         
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entryBuilder = writer.Update("users/1"u8))
             {
@@ -479,7 +479,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             Assert.Equal(1, read);
         }
         
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             writer.TryDeleteEntry("users/1");
             writer.Commit();
@@ -505,7 +505,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             .AddBinding(1, dSlice);
         var fields = builder.Build();
 
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entryBuilder = writer.Update("users/1"u8))
             {
@@ -517,7 +517,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             writer.Commit();
         }
         
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entryBuilder = writer.Update("users/1"u8))
             {
@@ -536,7 +536,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             Assert.Equal(1, read);
         }
      
-        using (var writer = new IndexWriter(Env, fields))
+        using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
         {
             using (var entry = writer.Update("users/1"u8))
             {

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -39,7 +39,7 @@ namespace FastTests.Corax
             var entry1 = new IndexSingleEntry() {Id = "e/1", Content = "2023-08-02T12:01:34.2111452"};
             using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             var knownFields = CreateKnownFields(bsc);
-            using (var indexWriter = new IndexWriter(Env, knownFields))
+            using (var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All))
             {
                 using (var builder = indexWriter.Index(entry1.Id))
                 {
@@ -53,7 +53,7 @@ namespace FastTests.Corax
                 indexWriter.Commit();
             }
 
-            using (var indexWriter = new IndexWriter(Env, knownFields))
+            using (var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All))
             {
                 Assert.True(indexWriter.TryDeleteEntry("e/1"));
                 indexWriter.Commit();
@@ -1973,7 +1973,7 @@ namespace FastTests.Corax
 
         private void IndexEntries(ByteStringContext bsc, IEnumerable<IndexEntry> list, IndexFieldsMapping mapping)
         {
-            using var indexWriter = new IndexWriter(Env, mapping);
+            using var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All);
 
             foreach (var entry in list)
             {
@@ -2002,7 +2002,7 @@ namespace FastTests.Corax
 
         private void IndexEntries(ByteStringContext bsc, IEnumerable<IndexSingleEntry> list, IndexFieldsMapping mapping)
         {
-            using var indexWriter = new IndexWriter(Env, mapping);
+            using var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All);
 
             foreach (var entry in list)
             {
@@ -2021,7 +2021,7 @@ namespace FastTests.Corax
             var knownFields = CreateKnownFields(bsc);
 
             {
-                using var indexWriter = new IndexWriter(Env, knownFields);
+                using var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All);
 
                 foreach (var entry in list)
                 {

--- a/test/FastTests/Corax/OrderBySorting.cs
+++ b/test/FastTests/Corax/OrderBySorting.cs
@@ -89,7 +89,7 @@ namespace FastTests.Corax
             using var knownFields = CreateKnownFields(bsc);
 
             {
-                using var indexWriter = new IndexWriter(Env, knownFields);
+                using var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All);
                 foreach (var entry in longList)
                 {
                     using var builder = indexWriter.Index(entry.Id);

--- a/test/FastTests/Corax/Ranking/RankingFunctionTests.cs
+++ b/test/FastTests/Corax/Ranking/RankingFunctionTests.cs
@@ -181,7 +181,7 @@ public class RankingFunctionTests : StorageTest
     
     private void IndexEntries(IEnumerable<EntryData> entries)
     {
-        using var indexWriter = new IndexWriter(Env, _mapping);
+        using var indexWriter = new IndexWriter(Env, _mapping, SupportedFeatures.All);
         
         foreach (var dto in entries)
         {

--- a/test/FastTests/Corax/RawCoraxFlag.cs
+++ b/test/FastTests/Corax/RawCoraxFlag.cs
@@ -49,7 +49,7 @@ public class RawCoraxFlag : StorageTest
         using var blittable2 = ctx.ReadObject(json2, "foo");
         {
             
-            using var writer = new IndexWriter(Env, _analyzers);
+            using var writer = new IndexWriter(Env, _analyzers, SupportedFeatures.All);
             writer.UpdateDynamicFieldsMapping(IndexFieldsMappingBuilder.CreateForWriter(true)
                 .AddDynamicBinding(dynamicSlice,FieldIndexingMode.No, true)
                 .Build());
@@ -83,7 +83,7 @@ public class RawCoraxFlag : StorageTest
         }
 
         //Delete part
-        using (var indexWriter = new IndexWriter(Env, _analyzers))
+        using (var indexWriter = new IndexWriter(Env, _analyzers, SupportedFeatures.All))
         {
             indexWriter.TryDeleteEntry("1");
             indexWriter.Commit();
@@ -107,7 +107,7 @@ public class RawCoraxFlag : StorageTest
         _analyzers = CreateKnownFields(_bsc, true, shouldStore: true);
 
         {
-            using var writer = new IndexWriter(Env, _analyzers);
+            using var writer = new IndexWriter(Env, _analyzers, SupportedFeatures.All);
 
             using (var builder = writer.Index("us/1"u8))
             {
@@ -143,7 +143,7 @@ public class RawCoraxFlag : StorageTest
         _analyzers = CreateKnownFields(_bsc, true, shouldStore: true);
 
         {
-            using var writer = new IndexWriter(Env, _analyzers);
+            using var writer = new IndexWriter(Env, _analyzers, SupportedFeatures.All);
 
             using (var builder = writer.Index("us/1"u8))
             {
@@ -195,7 +195,7 @@ public class RawCoraxFlag : StorageTest
         using var blittable2 = ctx.ReadObject(json2, "foo");
         {
             
-            using var writer = new IndexWriter(Env, _analyzers);
+            using var writer = new IndexWriter(Env, _analyzers, SupportedFeatures.All);
 
             foreach (var (id, item) in new[] {("1", blittable1), ("2", blittable2)})
             {
@@ -232,7 +232,7 @@ public class RawCoraxFlag : StorageTest
         }
         
         //Delete part
-        using (var indexWriter = new IndexWriter(Env, _analyzers))
+        using (var indexWriter = new IndexWriter(Env, _analyzers, SupportedFeatures.All))
         {
             indexWriter.TryDeleteEntry("1");
             indexWriter.Commit();

--- a/test/FastTests/Corax/SpatialTests.cs
+++ b/test/FastTests/Corax/SpatialTests.cs
@@ -52,7 +52,7 @@ public class SpatialTests : StorageTest
         using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
         var fieldsMapping = GetFieldsMapping(bsc);
         
-        using (var writer = new IndexWriter(Env, fieldsMapping))
+        using (var writer = new IndexWriter(Env, fieldsMapping, SupportedFeatures.All))
         {
             using (var entry = writer.Index(IdString))
             {
@@ -82,7 +82,7 @@ public class SpatialTests : StorageTest
             }
         }
 
-        using (var writer = new IndexWriter(Env, fieldsMapping))
+        using (var writer = new IndexWriter(Env, fieldsMapping, SupportedFeatures.All))
         {
             writer.TryDeleteEntry(IdString);
             writer.Commit();

--- a/test/FastTests/Corax/StreamingOptimization_QueryBuilder.cs
+++ b/test/FastTests/Corax/StreamingOptimization_QueryBuilder.cs
@@ -556,7 +556,7 @@ public class StreamingOptimization_QueryBuilder : RavenTestBase
             TransactionPersistentContext transactionPersistentContext = new(true);
             using (var transaction = Env.WriteTransaction(transactionPersistentContext))
             {
-                using (var indexWriter = new IndexWriter(transaction, mapping))
+                using (var indexWriter = new IndexWriter(transaction, mapping, SupportedFeatures.All))
                 {
                     const string someValue = "3.14";
                     

--- a/test/FastTests/Corax/Suggestions.cs
+++ b/test/FastTests/Corax/Suggestions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Corax;
 using Corax.Analyzers;
 using Corax.Querying;
 using Corax.Mappings;
@@ -101,7 +102,7 @@ namespace FastTests.Corax
             mapping.TryGetByFieldId(1, out var contentField);
 
             {
-                using var indexWriter = new IndexWriter(Env, mapping);
+                using var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All);
                 indexWriter.TryDeleteEntry(entry1.Id);
                 indexWriter.Commit();
             }
@@ -185,7 +186,7 @@ namespace FastTests.Corax
 
         private void IndexEntries(ByteStringContext bsc, IEnumerable<IndexEntryValues> list, IndexFieldsMapping mapping)
         {
-            using var indexWriter = new IndexWriter(Env, mapping);
+            using var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All);
 
             foreach (var entry in list)
             {

--- a/test/FastTests/Corax/UpdateSameEntryTwiceInOneBatch.cs
+++ b/test/FastTests/Corax/UpdateSameEntryTwiceInOneBatch.cs
@@ -32,7 +32,7 @@ namespace FastTests.Corax
         public void ManyUpdateToTheSameEntry()
         {
             var fields = CreateKnownFields(_bsc);
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 using (var builder = writer.Index("users/1"u8))
                 {
@@ -43,7 +43,7 @@ namespace FastTests.Corax
                 writer.Commit();
             }
 
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 using (var builder = writer.Update("users/1"u8))
                 {
@@ -54,7 +54,7 @@ namespace FastTests.Corax
             }
             
             Dictionary<long, string> fieldNamesByRootPage;
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 using (var builder = writer.Update("users/1"u8))
                 {
@@ -67,7 +67,7 @@ namespace FastTests.Corax
                 writer.Commit();
             }
             
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 using (var builder = writer.Update("users/1"u8))
                 {
@@ -99,7 +99,7 @@ namespace FastTests.Corax
         public void CanWork()
         {
             var fields = CreateKnownFields(_bsc);
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 using (var builder = writer.Index("users/1"u8))
                 {
@@ -110,7 +110,7 @@ namespace FastTests.Corax
                 writer.Commit();
             }
 
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 {
                     using (var builder = writer.Update("users/1"u8))
@@ -146,7 +146,7 @@ namespace FastTests.Corax
         public void CanRemoveDocumentUpdatedTwiceInSameBatch()
         {
             var fields = CreateKnownFields(_bsc);
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 using (var builder = writer.Index("users/1"u8))
                 {
@@ -157,7 +157,7 @@ namespace FastTests.Corax
                 writer.Commit();
             }
 
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 {
                     using (var builder = writer.Update("users/1"u8))
@@ -194,7 +194,7 @@ namespace FastTests.Corax
         public void CanRemoveDocumentUpdatedTwiceInSameBatchNotByMainKey()
         {
             var fields = CreateKnownFields(_bsc);
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 using (var builder = writer.Index("users/1"u8))
                 {
@@ -206,7 +206,7 @@ namespace FastTests.Corax
                 writer.Commit();
             }
 
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 {
                     using (var builder = writer.Update("users/1"u8))
@@ -254,7 +254,7 @@ namespace FastTests.Corax
         public void InsertNewDocumentIntoTermWhileUpdatingAnotherDocumentWithTheSameTerm()
         {
             var fields = CreateKnownFields(_bsc);
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 using (var builder = writer.Index("users/1"u8))
                 {
@@ -267,7 +267,7 @@ namespace FastTests.Corax
                 writer.Commit();
             }
 
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                
                 using (var builder = writer.Update("users/1"u8))
@@ -301,7 +301,7 @@ namespace FastTests.Corax
                 Assert.Contains("maciej", output);
             }
 
-            using (var writer = new IndexWriter(Env, fields))
+            using (var writer = new IndexWriter(Env, fields, SupportedFeatures.All))
             {
                 Assert.True(writer.TryDeleteEntry("users/1"u8));
                 Assert.True(writer.TryDeleteEntry("users/2"u8));

--- a/test/SlowTests/Corax/DeleteTest.cs
+++ b/test/SlowTests/Corax/DeleteTest.cs
@@ -58,7 +58,7 @@ public class DeleteTest : StorageTest
             previousIds.AddRange(ids.Slice(0, read).ToArray());
         }
 
-        using (var indexWriter = new IndexWriter(Env, _analyzers))
+        using (var indexWriter = new IndexWriter(Env, _analyzers, SupportedFeatures.All))
         {
             indexWriter.TryDeleteEntry("list/9");
             indexWriter.Commit();
@@ -155,7 +155,7 @@ public class DeleteTest : StorageTest
 
     private void IndexEntries(IndexFieldsMapping knownFields)
     {
-        using var indexWriter = new IndexWriter(Env, knownFields);
+        using var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All);
 
         foreach (var entry in _longList)
         {

--- a/test/SlowTests/Corax/IndexSearcher.cs
+++ b/test/SlowTests/Corax/IndexSearcher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Corax;
 using Corax.Analyzers;
 using Corax.Mappings;
 using FastTests.Voron;
@@ -114,7 +115,7 @@ public class IndexSearcherTest : StorageTest
 
     private void IndexEntries(ByteStringContext bsc, IEnumerable<IndexEntry> list, IndexFieldsMapping mapping)
     {
-        using var indexWriter = new IndexWriter(Env, mapping);
+        using var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All);
 
         foreach (var entry in list)
         {

--- a/test/SlowTests/Corax/RavenDB-21689.cs
+++ b/test/SlowTests/Corax/RavenDB-21689.cs
@@ -38,7 +38,7 @@ public class RavenDB_21689 : StorageTest
     {
         const int docsSize = 64 * 1000;
         
-        using (var indexWriter = new IndexWriter(Env, _fieldsMapping))
+        using (var indexWriter = new IndexWriter(Env, _fieldsMapping, SupportedFeatures.All))
         {
             for (var docIdx = 0; docIdx < docsSize; ++docIdx)
             {

--- a/test/SlowTests/Issues/RavenDB-22369.cs
+++ b/test/SlowTests/Issues/RavenDB-22369.cs
@@ -1,0 +1,129 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22369 : RavenTestBase
+{
+    public RavenDB_22369(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public void CannotCreateSpatialFieldWithoutIndexingJs() => CannotCreateSpatialFieldWithoutIndexingBase<JsSpatialInvalidIndex>();
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public void CannotCreateSpatialFieldWithoutIndexingCSharp() => CannotCreateSpatialFieldWithoutIndexingBase<CsharpSpatialInvalidIndex>();
+    
+    private void CannotCreateSpatialFieldWithoutIndexingBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenSession();
+        session.Store(new SpatialDto(10, 10));
+        session.SaveChanges();
+        var index = new TIndex();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store, allowErrors: true);
+        var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] {index.IndexName}));
+        Assert.NotEmpty(indexErrors);
+        Assert.Contains($"Your spatial field 'Location' has 'Indexing' set to 'No'. Spatial fields cannot be stored, so this field is useless because it cannot be searched or retrieved.",
+            indexErrors[0].Errors[0].ToString());
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public void CoraxCanOnlyStoreFieldCsharpIndex() => CoraxCanOnlyStoreFieldBase<CsharpMapIndex>();
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    public void CoraxCanOnlyStoreFieldJsIndex() => CoraxCanOnlyStoreFieldBase<JsMapIndex>();
+    
+    private void CoraxCanOnlyStoreFieldBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenSession();
+        session.Store(new Dto("Test", 12.5D));
+        session.SaveChanges();
+        var index = new TIndex();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+        var terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Dto.Name), fromValue: null));
+        Assert.Equal(0, terms.Length);
+
+        terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(Dto.Numerical), fromValue: null));
+        Assert.Equal(0, terms.Length);
+
+        var resultTextual = session.Advanced.DocumentQuery<Dto>(index.IndexName).SelectFields<string>(nameof(Dto.Name)).First();
+        Assert.Equal("Test", resultTextual);
+        
+        var resultNumerical = session.Advanced.DocumentQuery<Dto>(index.IndexName).SelectFields<double>(nameof(Dto.Numerical)).First();
+        Assert.Equal(12.5D,resultNumerical);
+    }
+
+    private record Dto(string Name, double Numerical, string Id = null);
+
+    private record SpatialDto(double Lat, double Lon, string Id = null);
+
+    private class JsMapIndex : AbstractJavaScriptIndexCreationTask
+    {
+        public JsMapIndex()
+        {
+            Maps = new HashSet<string>(){@"
+map(""Dtos"", (dto) => {
+    return {
+        Name: dto.Name,
+        Numerical: dto.Numerical,
+    };
+})"};
+            Fields = new Dictionary<string, IndexFieldOptions>()
+            {
+                { "Name", new IndexFieldOptions() { Indexing = FieldIndexing.No, Storage = FieldStorage.Yes } },
+                { "Numerical", new IndexFieldOptions() { Indexing = FieldIndexing.No, Storage = FieldStorage.Yes } }
+            };
+        }
+    }
+
+    private class JsSpatialInvalidIndex : AbstractJavaScriptIndexCreationTask
+    {
+        public JsSpatialInvalidIndex()
+        {
+            Maps = new HashSet<string>(){@"
+map(""SpatialDtos"", (dto) => {
+    return {
+        Location: createSpatialField(dto.Lat, dto.Lon)
+    };
+})"};
+            Fields = new Dictionary<string, IndexFieldOptions>() { { "Location", new IndexFieldOptions() { Indexing = FieldIndexing.No, Storage = FieldStorage.Yes} } };
+        }
+    }
+    
+    private class CsharpSpatialInvalidIndex : AbstractIndexCreationTask<SpatialDto>
+    {
+        public CsharpSpatialInvalidIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new { Location = CreateSpatialField(dto.Lat, dto.Lon) };
+
+            Index("Location", FieldIndexing.No);
+            Store("Location", FieldStorage.Yes);
+        }
+    }
+    
+    private class CsharpMapIndex : AbstractIndexCreationTask<Dto>
+    {
+        public CsharpMapIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new { Name = dto.Name, dto.Numerical };
+
+            Store(x => x.Name, FieldStorage.Yes);
+            Store(x => x.Numerical, FieldStorage.Yes);
+            Index(x => x.Name, FieldIndexing.No);
+            Index(x => x.Numerical, FieldIndexing.No);
+        }
+    }
+}

--- a/test/StressTests/Corax/IndexSearcherTest.cs
+++ b/test/StressTests/Corax/IndexSearcherTest.cs
@@ -45,7 +45,7 @@ public class IndexSearcherTest : StorageTest
 
     private void IndexEntries(ByteStringContext bsc, IEnumerable<IndexSingleEntry> list, IndexFieldsMapping mapping)
     {
-        using var indexWriter = new IndexWriter(Env, mapping);
+        using var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All);
 
         foreach (var entry in list)
         {

--- a/test/StressTests/Corax/OrderByMultiSorting.cs
+++ b/test/StressTests/Corax/OrderByMultiSorting.cs
@@ -155,7 +155,7 @@ namespace StressTests.Corax
             using var knownFields = CreateKnownFields(bsc);
 
             {
-                using var indexWriter = new IndexWriter(Env, knownFields);
+                using var indexWriter = new IndexWriter(Env, knownFields, SupportedFeatures.All);
 
                 foreach (var entry in longList)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22369 

### Additional description

- Fields with option `Indexing: No`  will be only persisted for projections
- Spatial fields which is only stored (not indexed) will ends up with exception because we have nothing to store and it's useless.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
 - Indexes built on previous version will discard this fix. New indexes will append the configuration during indexing.
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
