### PR TITLE
RavenDB-22278 Make sure ResponseStream, MemoryStream and StreamReader are disposed - v5.4

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1921,31 +1921,38 @@ namespace Raven.Client.Http
         {
             if (response != null)
             {
-                var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                var ms = new MemoryStream(); // todo: have a pool of those
-                await stream.CopyToAsync(ms).ConfigureAwait(false);
-                try
+                using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                using (var ms = new MemoryStream()) // todo: have a pool of those
                 {
-                    ms.Position = 0;
-                    using (var responseJson = await context.ReadForMemoryAsync(ms, "RequestExecutor/HandleServerDown/ReadResponseContent").ConfigureAwait(false))
+                    await stream.CopyToAsync(ms).ConfigureAwait(false);
+                    try
                     {
-                        return ExceptionDispatcher.Get(responseJson, response.StatusCode, e);
+                        ms.Position = 0;
+                        using (var responseJson = await context.ReadForMemoryAsync(ms, "RequestExecutor/HandleServerDown/ReadResponseContent").ConfigureAwait(false))
+                        {
+                            return ExceptionDispatcher.Get(responseJson, response.StatusCode, e);
+                        }
+                    }
+                    catch
+                    {
+                        using (var streamReader = new StreamReader(ms))
+                        {
+                            // we failed to parse the error
+                            ms.Position = 0;
+                            return ExceptionDispatcher.Get(
+                                new ExceptionDispatcher.ExceptionSchema
+                                {
+                                    Url = request.RequestUri.ToString(),
+                                    Message = "Got unrecognized response from the server",
+                                    Error = await streamReader.ReadToEndAsync().ConfigureAwait(false),
+                                    Type = "Unparseable Server Response"
+                                }, response.StatusCode, e);
+                        }
                     }
                 }
-                catch
-                {
-                    // we failed to parse the error
-                    ms.Position = 0;
-                    return ExceptionDispatcher.Get(new ExceptionDispatcher.ExceptionSchema
-                    {
-                        Url = request.RequestUri.ToString(),
-                        Message = "Got unrecognized response from the server",
-                        Error = await new StreamReader(ms).ReadToEndAsync().ConfigureAwait(false),
-                        Type = "Unparseable Server Response"
-                    }, response.StatusCode, e);
-                }
             }
-            //this would be connections that didn't have response, such as "couldn't connect to remote server"
+
+            // this would be connections that didn't have response, such as "couldn't connect to remote server"
             return ExceptionDispatcher.Get(new ExceptionDispatcher.ExceptionSchema
             {
                 Url = request.RequestUri.ToString(),


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22278/Possible-leak-due-to-not-disposing-ReadAsStreamWithZstdSupportAsync

### Additional description

We want to wrap these objects in `using` statement to assure they're disposed

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
