### PR TITLE
RavenDB-22362 Unify audit log lines

### DIFF
--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -258,16 +258,11 @@ namespace Raven.Server.Documents
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
                 DynamicJsonValue conf = GetCustomConfigurationAuditJson(description, configuration);
-                var clientCert = GetCurrentCertificate();
-                var auditLog = LoggingSource.AuditLog.GetLogger(Database.Name, "Audit");
                 var line = $"Task: '{description}' with taskId: '{id}'";
-
-                if (clientCert != null)
-                    line += $" executed by '{clientCert.Subject}' '{clientCert.Thumbprint}'";
 
                 if (conf != null)
                 {
-                    var confString = string.Empty;
+                    string confString;
                     using (ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
                     {
                         confString = ctx.ReadObject(conf, "conf").ToString();
@@ -276,7 +271,7 @@ namespace Raven.Server.Documents
                     line += ($" Configuration: {confString}");
                 }
 
-                auditLog.Info(line);
+                LogAuditFor(Database.Name, line);
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminAnalyzersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminAnalyzersHandler.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        LogAuditFor(Database.Name, $"Analyzer {analyzerDefinition.Name} PUT with definition: {analyzerToAdd}");
+                        LogAuditFor(Database.Name, $"Analyzer '{analyzerDefinition.Name}' PUT with definition: {analyzerToAdd}");
                     }
 
                     analyzerDefinition.Validate();
@@ -55,7 +55,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor(Database.Name, $"Analyzer {name} DELETE");
+                LogAuditFor(Database.Name, $"Analyzer '{name}' DELETE");
             }
 
             var command = new DeleteAnalyzerCommand(name, Database.Name, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminAnalyzersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminAnalyzersHandler.cs
@@ -29,10 +29,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        var clientCert = GetCurrentCertificate();
-
-                        var auditLog = LoggingSource.AuditLog.GetLogger(Database.Name, "Audit");
-                        auditLog.Info($"Analyzer {analyzerDefinition.Name} PUT by {clientCert?.Subject} {clientCert?.Thumbprint} with definition: {analyzerToAdd}");
+                        LogAuditFor(Database.Name, $"Analyzer {analyzerDefinition.Name} PUT with definition: {analyzerToAdd}");
                     }
 
                     analyzerDefinition.Validate();
@@ -58,10 +55,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                var clientCert = GetCurrentCertificate();
-
-                var auditLog = LoggingSource.AuditLog.GetLogger(Database.Name, "Audit");
-                auditLog.Info($"Analyzer {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
+                LogAuditFor(Database.Name, $"Analyzer {name} DELETE");
             }
 
             var command = new DeleteAnalyzerCommand(name, Database.Name, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminSortersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminSortersHandler.cs
@@ -31,10 +31,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        var clientCert = GetCurrentCertificate();
-
-                        var auditLog = LoggingSource.AuditLog.GetLogger(Database.Name, "Audit");
-                        auditLog.Info($"Sorter {sorterDefinition.Name} PUT by {clientCert?.Subject} {clientCert?.Thumbprint} with definition: {sorterToAdd}");
+                        LogAuditFor(Database.Name, $"Sorter {sorterDefinition.Name} PUT with definition: {sorterToAdd}");
                     }
 
                     sorterDefinition.Validate();
@@ -60,10 +57,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                var clientCert = GetCurrentCertificate();
-
-                var auditLog = LoggingSource.AuditLog.GetLogger(Database.Name, "Audit");
-                auditLog.Info($"Sorter {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
+                LogAuditFor(Database.Name, $"Sorter {name} DELETE");
             }
 
             var command = new DeleteSorterCommand(name, Database.Name, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -626,10 +626,7 @@ namespace Raven.Server.Documents.Handlers
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                var clientCert = GetCurrentCertificate();
-
-                var auditLog = LoggingSource.AuditLog.GetLogger(Database.Name, "Audit");
-                auditLog.Info($"Index {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
+                LogAuditFor(Database.Name, $"Index {name} DELETE");
             }
 
             HttpContext.Response.StatusCode = await Database.IndexStore.TryDeleteIndexIfExists(name, GetRaftRequestIdFromQuery())

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -35,7 +35,6 @@ namespace Raven.Server.Documents.PeriodicBackup
     public class PeriodicBackupRunner : ITombstoneAware, IDisposable
     {
         private readonly Logger _logger;
-        private readonly Logger _auditLog;
 
         private readonly DocumentDatabase _database;
         private readonly ServerStore _serverStore;
@@ -62,7 +61,6 @@ namespace Raven.Server.Documents.PeriodicBackup
             _database = database;
             _serverStore = serverStore;
             _logger = LoggingSource.Instance.GetLogger<PeriodicBackupRunner>(_database.Name);
-            _auditLog = LoggingSource.AuditLog.GetLogger(_database.Name, "Audit");
             _cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_database.DatabaseShutdown);
             _tempBackupPath = BackupUtils.GetBackupTempPath(_database.Configuration, "PeriodicBackupTemp", out _);
 
@@ -224,7 +222,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             return CreateBackupTask(periodicBackup, isFullBackup, SystemTime.UtcNow);
         }
 
-        public async Task DelayAsync(long taskId, TimeSpan delay, X509Certificate2 clientCert)
+        public async Task DelayAsync(long taskId, DateTime delayUntil)
         {
             foreach (var periodicBackup in _periodicBackups)
             {
@@ -232,7 +230,6 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (runningTask == null || runningTask.Id != taskId)
                     continue;
 
-                var delayUntil = DateTime.UtcNow.AddTicks(delay.Ticks);
                 var nextBackup = GetNextBackupDetails(
                     periodicBackup.Value.Configuration, 
                     periodicBackup.Value.BackupStatus,
@@ -264,16 +261,6 @@ namespace Raven.Server.Documents.PeriodicBackup
                         
                         _logger.Operations(msg, e);
                     }
-                }
-
-                if (_auditLog.IsInfoEnabled)
-                {
-                    var msg = $"Backup task with task id '{taskId}' was delayed until '{delayUntil}' UTC";
-
-                    if (clientCert != null)
-                        msg += $" by {clientCert.Subject} ({clientCert.Thumbprint})";
-
-                    _auditLog.Info(msg);
                 }
 
                 periodicBackup.Value.BackupStatus.DelayUntil = delayUntil;

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2266,7 +2266,7 @@ namespace Raven.Server
 
             if (tcpAuditLog != null)
                 tcpAuditLog.Info(
-                    $"Got connection from {tcpClient.Client.RemoteEndPoint} with certificate '{cert?.Subject} ({cert?.Thumbprint})'. Accepted for {header.Operation} on {header.DatabaseName}.");
+                    $"Got connection from {tcpClient.Client.RemoteEndPoint} with certificate '{cert?.Subject} ({cert?.Thumbprint})'. Accepted for {header.Operation} on {header.DatabaseName ?? "Server"}.");
             return header;
         }
 

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -226,13 +226,12 @@ namespace Raven.Server.Web.Authentication
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    var clientCertificate = GetCurrentCertificate();
-                    var auditLog = LoggingSource.AuditLog.GetLogger("Certificates","Audit");
                     var permissions = certificate?.Permissions != null
                         ? Environment.NewLine + string.Join(Environment.NewLine, certificate.Permissions.Select(kvp => kvp.Key + ": " + kvp.Value.ToString()))
                         : string.Empty;
-                    auditLog.Info($"Add new certificate '{certificate?.Thumbprint}'. Security Clearance: {certificate?.SecurityClearance}. Permissions:{permissions}." +
-                                  $"{Environment.NewLine}IP: '{HttpContext.Connection.RemoteIpAddress}'. Certificate: {clientCertificate?.Subject} ({clientCertificate?.Thumbprint})");
+
+                    LogAuditFor("Certificates",
+                        $"Add new certificate '{certificate?.Thumbprint}'. Security Clearance: {certificate?.SecurityClearance}. Permissions:{permissions}.");
                 }
                 
                 try
@@ -411,9 +410,7 @@ namespace Raven.Server.Web.Authentication
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    var clientCertificate = GetCurrentCertificate();
-                    var auditLog = LoggingSource.AuditLog.GetLogger("Certificates","Audit");
-                    auditLog.Info($"Delete certificate '{thumbprint}'. IP: '{HttpContext.Connection.RemoteIpAddress}'. Certificate: {clientCertificate?.Subject} ({clientCertificate?.Thumbprint})");
+                    LogAuditFor("Certificates", $"Delete certificate '{thumbprint}'.");
                 }
                 
                 await DeleteInternal(keysToDelete, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -231,7 +231,7 @@ namespace Raven.Server.Web.Authentication
                         : string.Empty;
 
                     LogAuditFor("Certificates",
-                        $"Add new certificate '{certificate?.Thumbprint}'. Security Clearance: {certificate?.SecurityClearance}. Permissions:{permissions}.");
+                        $"Add new certificate {certificate?.Name} ['{certificate?.Thumbprint}']. Security Clearance: {certificate?.SecurityClearance}. Permissions:{permissions}.");
                 }
                 
                 try

--- a/src/Raven.Server/Web/Authentication/TwoFactorAuthenticationHandler.cs
+++ b/src/Raven.Server/Web/Authentication/TwoFactorAuthenticationHandler.cs
@@ -94,7 +94,7 @@ public class TwoFactorAuthenticationHandler : ServerRequestHandler
             
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor(nameof(TwoFactorAuthenticationHandler), $"successfully authenticated with two factor auth for {period}. Has limits: {hasLimits}");
+                LogAuditFor(nameof(TwoFactorAuthenticationHandler), $"successfully authenticated with two factor auth for {period} (until: {DateTime.UtcNow.Add(period)}). Has limits: {hasLimits}");
             }
 
             string expectedCookieValue = null;
@@ -139,7 +139,7 @@ public class TwoFactorAuthenticationHandler : ServerRequestHandler
     {
         if (LoggingSource.AuditLog.IsInfoEnabled)
         {
-            LogAuditFor(nameof(TwoFactorAuthenticationHandler), $"Two factor auth failure, because: {err}");
+            LogAuditFor(nameof(TwoFactorAuthenticationHandler), $"Two factor auth failure: {err}");
         }
 
         HttpContext.Response.StatusCode = (int)httpStatusCode;

--- a/src/Raven.Server/Web/RequestHandler.Audit.cs
+++ b/src/Raven.Server/Web/RequestHandler.Audit.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Sparrow.Logging;
+
+namespace Raven.Server.Web
+{
+    public abstract partial class RequestHandler
+    {
+        public bool IsLocalRequest()
+        {
+            if (HttpContext.Connection.RemoteIpAddress == null && HttpContext.Connection.LocalIpAddress == null)
+            {
+                return true;
+            }
+            if (HttpContext.Connection.RemoteIpAddress.Equals(HttpContext.Connection.LocalIpAddress))
+            {
+                return true;
+            }
+            if (IPAddress.IsLoopback(HttpContext.Connection.RemoteIpAddress))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public string RequestIp => IsLocalRequest() ? Environment.MachineName : HttpContext.Connection.RemoteIpAddress.ToString();
+
+        public void LogAuditFor(string logger, string message)
+        {
+            var auditLog = LoggingSource.AuditLog.GetLogger(logger, "Audit");
+            Debug.Assert(auditLog.IsInfoEnabled, $"auditlog info is disabled");
+
+            var clientCert = GetCurrentCertificate();
+            
+            var sb = new StringBuilder();
+            sb.Append(RequestIp);
+            sb.Append(", ");
+            if (clientCert != null) 
+                sb.Append($"CN={clientCert.Subject} [{clientCert.Thumbprint}], ");
+            else
+                sb.Append("no certificate, ");
+            
+            sb.Append(message);
+
+            auditLog.Info(sb.ToString());
+        }
+    }
+}

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
@@ -25,6 +26,7 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
 using Sparrow;
+using Sparrow.Logging;
 
 namespace Raven.Server.Web
 {
@@ -761,6 +763,45 @@ namespace Raven.Server.Web
         public void AddStringToHttpContext(string str, TrafficWatchChangeType type)
         {
             HttpContext.Items["TrafficWatch"] = (str, type);
+        }
+
+        public bool IsLocalRequest()
+        {
+            if (HttpContext.Connection.RemoteIpAddress == null && HttpContext.Connection.LocalIpAddress == null)
+            {
+                return true;
+            }
+            if (HttpContext.Connection.RemoteIpAddress.Equals(HttpContext.Connection.LocalIpAddress))
+            {
+                return true;
+            }
+            if (IPAddress.IsLoopback(HttpContext.Connection.RemoteIpAddress))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public string RequestIp => IsLocalRequest() ? Environment.MachineName : HttpContext.Connection.RemoteIpAddress.ToString();
+
+        public void LogAuditFor(string logger, string message)
+        {
+            var auditLog = LoggingSource.AuditLog.GetLogger(logger, "Audit");
+            Debug.Assert(auditLog.IsInfoEnabled, $"auditlog info is disabled");
+
+            var clientCert = GetCurrentCertificate();
+            
+            var sb = new StringBuilder();
+            sb.Append(RequestIp);
+            sb.Append(", ");
+            if (clientCert != null) 
+                sb.Append($"CN={clientCert.Subject} [{clientCert.Thumbprint}], ");
+            else
+                sb.Append("no certificate, ");
+            
+            sb.Append(message);
+
+            auditLog.Info(sb.ToString());
         }
     }
 }

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
@@ -26,11 +25,10 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
 using Sparrow;
-using Sparrow.Logging;
 
 namespace Raven.Server.Web
 {
-    public abstract class RequestHandler
+    public abstract partial class RequestHandler
     {
         public const string StartParameter = "start";
 
@@ -763,45 +761,6 @@ namespace Raven.Server.Web
         public void AddStringToHttpContext(string str, TrafficWatchChangeType type)
         {
             HttpContext.Items["TrafficWatch"] = (str, type);
-        }
-
-        public bool IsLocalRequest()
-        {
-            if (HttpContext.Connection.RemoteIpAddress == null && HttpContext.Connection.LocalIpAddress == null)
-            {
-                return true;
-            }
-            if (HttpContext.Connection.RemoteIpAddress.Equals(HttpContext.Connection.LocalIpAddress))
-            {
-                return true;
-            }
-            if (IPAddress.IsLoopback(HttpContext.Connection.RemoteIpAddress))
-            {
-                return true;
-            }
-            return false;
-        }
-
-        public string RequestIp => IsLocalRequest() ? Environment.MachineName : HttpContext.Connection.RemoteIpAddress.ToString();
-
-        public void LogAuditFor(string logger, string message)
-        {
-            var auditLog = LoggingSource.AuditLog.GetLogger(logger, "Audit");
-            Debug.Assert(auditLog.IsInfoEnabled, $"auditlog info is disabled");
-
-            var clientCert = GetCurrentCertificate();
-            
-            var sb = new StringBuilder();
-            sb.Append(RequestIp);
-            sb.Append(", ");
-            if (clientCert != null) 
-                sb.Append($"CN={clientCert.Subject} [{clientCert.Thumbprint}], ");
-            else
-                sb.Append("no certificate, ");
-            
-            sb.Append(message);
-
-            auditLog.Info(sb.ToString());
         }
     }
 }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -199,10 +199,7 @@ namespace Raven.Server.Web.System
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    var clientCert = GetCurrentCertificate();
-
-                    var auditLog = LoggingSource.AuditLog.GetLogger("DbMgmt", "Audit");
-                    auditLog.Info($"Database {databaseRecord.DatabaseName} PUT by {clientCert?.Subject} ({clientCert?.Thumbprint})");
+                    LogAuditFor("DbMgmt", $"Database '{databaseRecord.DatabaseName}' PUT");
                 }
 
                 if (ServerStore.LicenseManager.LicenseStatus.HasDocumentsCompression && databaseRecord.DocumentsCompression == null)
@@ -681,7 +678,14 @@ namespace Raven.Server.Web.System
             if (database == null)
                 DatabaseDoesNotExistException.Throw(databaseName);
 
-            await database.PeriodicBackupRunner.DelayAsync(id, delay.Value, GetCurrentCertificate());
+            var delayUntil = DateTime.UtcNow.AddTicks(delay.Value.Ticks);
+            await database.PeriodicBackupRunner.DelayAsync(id, delayUntil);
+
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+            {
+                LogAuditFor(databaseName, $"Backup task with task id '{id}' was delayed until '{delayUntil}' UTC");
+            }
+
 
             NoContentStatus();
         }
@@ -704,10 +708,7 @@ namespace Raven.Server.Web.System
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    clientCertificate = GetCurrentCertificate();
-
-                    var auditLog = LoggingSource.AuditLog.GetLogger("DbMgmt", "Audit");
-                    auditLog.Info($"Attempt to delete [{string.Join(", ", parameters.DatabaseNames)}] database(s) from ({string.Join(", ", parameters.FromNodes ?? Enumerable.Empty<string>())}) by {clientCertificate?.Subject} ({clientCertificate?.Thumbprint})");
+                    LogAuditFor("DbMgmt", $"Attempt to delete [{string.Join(", ", parameters.DatabaseNames)}] database(s) from ({string.Join(", ", parameters.FromNodes ?? Enumerable.Empty<string>())})");
                 }
 
                 using (context.OpenReadTransaction())
@@ -770,10 +771,7 @@ namespace Raven.Server.Web.System
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    var clientCert = GetCurrentCertificate();
-
-                    var auditLog = LoggingSource.AuditLog.GetLogger("DbMgmt", "Audit");
-                    auditLog.Info($"Delete [{string.Join(", ", databasesToDelete)}] database(s) from ({string.Join(", ", parameters.FromNodes ?? Enumerable.Empty<string>())}) by {clientCert?.Subject} ({clientCert?.Thumbprint})");
+                    LogAuditFor("DbMgmt", $"Delete [{string.Join(", ", databasesToDelete)}] database(s) from ({string.Join(", ", parameters.FromNodes ?? Enumerable.Empty<string>())})");
                 }
 
                 long index = -1;

--- a/src/Raven.Server/Web/System/Analyzers/AdminAnalyzersHandler.cs
+++ b/src/Raven.Server/Web/System/Analyzers/AdminAnalyzersHandler.cs
@@ -31,10 +31,7 @@ namespace Raven.Server.Web.System.Analyzers
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        var clientCert = GetCurrentCertificate();
-
-                        var auditLog = LoggingSource.AuditLog.GetLogger("Server", "Audit");
-                        auditLog.Info($"Analyzer {analyzerDefinition.Name} PUT by {clientCert?.Subject} {clientCert?.Thumbprint} with definition: {analyzerToAdd}");
+                        LogAuditFor("Server", $"Analyzer {analyzerDefinition.Name} PUT with definition: {analyzerToAdd}");
                     }
 
                     analyzerDefinition.Validate();
@@ -64,10 +61,7 @@ namespace Raven.Server.Web.System.Analyzers
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                var clientCert = GetCurrentCertificate();
-
-                var auditLog = LoggingSource.AuditLog.GetLogger("Server", "Audit");
-                auditLog.Info($"Analyzer {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
+                LogAuditFor("Server", $"Analyzer {name} DELETE");
             }
 
             var command = new DeleteServerWideAnalyzerCommand(name, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -116,12 +116,9 @@ namespace Raven.Server.Web.System
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    var clientCert = GetCurrentCertificate();
-
-                    var auditLog = LoggingSource.AuditLog.GetLogger("DbMgmt", "Audit");
-                    auditLog.Info($"Database \'{dbName}\' topology is being modified by {clientCert?.Subject} ({clientCert?.Thumbprint})," +
-                                  $"Old topology: {databaseRecord.Topology} " +
-                                  $"New topology: {databaseTopology}.");
+                    LogAuditFor("DbMgmt", $"Database '{dbName}' topology is being modified " +
+                                          $"Old topology: {databaseRecord.Topology} " +
+                                          $"New topology: {databaseTopology}.");
                 }
 
                 // Validate Topology

--- a/src/Raven.Server/Web/System/Sorters/AdminSortersHandler.cs
+++ b/src/Raven.Server/Web/System/Sorters/AdminSortersHandler.cs
@@ -31,10 +31,7 @@ namespace Raven.Server.Web.System.Sorters
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        var clientCert = GetCurrentCertificate();
-
-                        var auditLog = LoggingSource.AuditLog.GetLogger("Server", "Audit");
-                        auditLog.Info($"Sorter {sorterDefinition.Name} PUT by {clientCert?.Subject} {clientCert?.Thumbprint} with definition: {sorterToAdd}");
+                        LogAuditFor("Server", $"Sorter {sorterDefinition.Name} PUT with definition: {sorterToAdd}");
                     }
 
                     sorterDefinition.Validate();
@@ -64,10 +61,7 @@ namespace Raven.Server.Web.System.Sorters
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                var clientCert = GetCurrentCertificate();
-
-                var auditLog = LoggingSource.AuditLog.GetLogger("Server", "Audit");
-                auditLog.Info($"Sorter {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
+                LogAuditFor("Server", $"Sorter {name} DELETE");
             }
 
             var command = new DeleteServerWideSorterCommand(name, GetRaftRequestIdFromQuery());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22362

### Additional description

Use single method for auditing an endpoint

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
