### PR TITLE
RavenDB-22362 Unify audit log lines v6.0

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Sorters/AbstractAdminSortersHandlerProcessorForDelete.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Sorters/AbstractAdminSortersHandlerProcessorForDelete.cs
@@ -24,10 +24,7 @@ internal abstract class AbstractAdminSortersHandlerProcessorForDelete<TRequestHa
 
         if (LoggingSource.AuditLog.IsInfoEnabled)
         {
-            var clientCert = RequestHandler.GetCurrentCertificate();
-
-            var auditLog = LoggingSource.AuditLog.GetLogger(databaseName, "Audit");
-            auditLog.Info($"Sorter {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
+           RequestHandler.LogAuditFor(databaseName, $"Sorter {name} DELETE");
         }
 
         var command = new DeleteSorterCommand(name, databaseName, RequestHandler.GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Sorters/AbstractAdminSortersHandlerProcessorForPut.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Sorters/AbstractAdminSortersHandlerProcessorForPut.cs
@@ -35,10 +35,7 @@ internal abstract class AbstractAdminSortersHandlerProcessorForPut<TRequestHandl
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    var clientCert = RequestHandler.GetCurrentCertificate();
-
-                    var auditLog = LoggingSource.AuditLog.GetLogger(databaseName, "Audit");
-                    auditLog.Info($"Sorter {sorterDefinition.Name} PUT by {clientCert?.Subject} {clientCert?.Thumbprint} with definition: {sorterToAdd}");
+                    RequestHandler.LogAuditFor(databaseName, $"Sorter {sorterDefinition.Name} PUT with definition: {sorterToAdd}");
                 }
 
                 sorterDefinition.Validate();

--- a/src/Raven.Server/Documents/Handlers/Processors/Analyzers/AbstractAdminAnalyzersHandlerProcessorForDelete.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Analyzers/AbstractAdminAnalyzersHandlerProcessorForDelete.cs
@@ -21,10 +21,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Analyzers
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                var clientCert = RequestHandler.GetCurrentCertificate();
-
-                var auditLog = LoggingSource.AuditLog.GetLogger(databaseName, "Audit");
-                auditLog.Info($"Analyzer {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
+                RequestHandler.LogAuditFor(databaseName, $"Analyzer '{name}' DELETE");
             }
 
             var command = new DeleteAnalyzerCommand(name, databaseName, RequestHandler.GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Documents/Handlers/Processors/Analyzers/AbstractAdminAnalyzersHandlerProcessorForPut.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Analyzers/AbstractAdminAnalyzersHandlerProcessorForPut.cs
@@ -36,10 +36,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Analyzers
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        var clientCert = RequestHandler.GetCurrentCertificate();
-
-                        var auditLog = LoggingSource.AuditLog.GetLogger(databaseName, "Audit");
-                        auditLog.Info($"Analyzer {analyzerDefinition.Name} PUT by {clientCert?.Subject} {clientCert?.Thumbprint} with definition: {analyzerToAdd}");
+                        RequestHandler.LogAuditFor(databaseName, $"Analyzer '{analyzerDefinition.Name}' PUT with definition: {analyzerToAdd}");
                     }
 
                     analyzerDefinition.Validate();

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForDelete.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForDelete.cs
@@ -4,6 +4,7 @@ using JetBrains.Annotations;
 using Raven.Server.Documents.Indexes;
 using Sparrow.Json;
 using Sparrow.Logging;
+using static Raven.Server.Utils.MetricCacher.Keys;
 
 namespace Raven.Server.Documents.Handlers.Processors.Indexes;
 
@@ -23,10 +24,7 @@ internal abstract class AbstractIndexHandlerProcessorForDelete<TRequestHandler, 
 
         if (LoggingSource.AuditLog.IsInfoEnabled)
         {
-            var clientCert = RequestHandler.GetCurrentCertificate();
-
-            var auditLog = LoggingSource.AuditLog.GetLogger(RequestHandler.DatabaseName, "Audit");
-            auditLog.Info($"Index {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
+           RequestHandler.LogAuditFor(RequestHandler.DatabaseName, $"Index {name} DELETE");
         }
 
         var processor = GetIndexDeleteProcessor();

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2270,7 +2270,7 @@ namespace Raven.Server
 
             if (tcpAuditLog != null)
                 tcpAuditLog.Info(
-                    $"Got connection from {tcpClient.Client.RemoteEndPoint} with certificate '{cert?.Subject} ({cert?.Thumbprint})'. Accepted for {header.Operation} on {header.DatabaseName}.");
+                    $"Got connection from {tcpClient.Client.RemoteEndPoint} with certificate '{cert?.Subject} ({cert?.Thumbprint})'. Accepted for {header.Operation} on {header.DatabaseName ?? "Server"}.");
             return header;
         }
 

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -223,13 +223,11 @@ namespace Raven.Server.Web.Authentication
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    var clientCertificate = GetCurrentCertificate();
-                    var auditLog = LoggingSource.AuditLog.GetLogger("Certificates", "Audit");
                     var permissions = certificate?.Permissions != null
                         ? Environment.NewLine + string.Join(Environment.NewLine, certificate.Permissions.Select(kvp => kvp.Key + ": " + kvp.Value.ToString()))
                         : string.Empty;
-                    auditLog.Info($"Add new certificate '{certificate?.Thumbprint}'. Security Clearance: {certificate?.SecurityClearance}. Permissions:{permissions}." +
-                                  $"{Environment.NewLine}IP: '{HttpContext.Connection.RemoteIpAddress}'. Certificate: {clientCertificate?.Subject} ({clientCertificate?.Thumbprint})");
+                    LogAuditFor("Certificates",
+                        $"Add new certificate {certificate?.Name} ['{certificate?.Thumbprint}']. Security Clearance: {certificate?.SecurityClearance}. Permissions:{permissions}.");
                 }
 
                 try
@@ -408,9 +406,7 @@ namespace Raven.Server.Web.Authentication
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    var clientCertificate = GetCurrentCertificate();
-                    var auditLog = LoggingSource.AuditLog.GetLogger("Certificates", "Audit");
-                    auditLog.Info($"Delete certificate '{thumbprint}'. IP: '{HttpContext.Connection.RemoteIpAddress}'. Certificate: {clientCertificate?.Subject} ({clientCertificate?.Thumbprint})");
+                    LogAuditFor("Certificates", $"Delete certificate '{thumbprint}'.");
                 }
 
                 await DeleteInternal(keysToDelete, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Web/Authentication/TwoFactorAuthenticationHandler.cs
+++ b/src/Raven.Server/Web/Authentication/TwoFactorAuthenticationHandler.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Raven.Server.Config.Settings;
-using Raven.Server.Monitoring.Snmp;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
@@ -16,13 +15,6 @@ namespace Raven.Server.Web.Authentication;
 
 public class TwoFactorAuthenticationHandler : ServerRequestHandler
 {
-    private readonly Logger _auditLogger;
-
-    public TwoFactorAuthenticationHandler()
-    {
-        _auditLogger = LoggingSource.AuditLog.GetLogger(nameof(TwoFactorAuthenticationHandler), "Audit");
-    }
-
     [RavenAction("/authentication/2fa/configuration", "GET", AuthorizationStatus.UnauthenticatedClients)]
     public async Task TotpConfiguration()
     {
@@ -100,9 +92,9 @@ public class TwoFactorAuthenticationHandler : ServerRequestHandler
         {
             var period = TimeSpan.FromMinutes(sessionDuration);
             
-            if (_auditLogger.IsInfoEnabled)
+            if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                _auditLogger.Info($"Connection from {HttpContext.Connection.RemoteIpAddress} with new certificate '{clientCert.Subject} ({clientCert.Thumbprint})' successfully authenticated with two factor auth for {period}. Has limits: {hasLimits}]");
+                LogAuditFor(nameof(TwoFactorAuthenticationHandler), $"successfully authenticated with two factor auth for {period} (until: {DateTime.UtcNow.Add(period)}). Has limits: {hasLimits}");
             }
 
             string expectedCookieValue = null;
@@ -145,12 +137,11 @@ public class TwoFactorAuthenticationHandler : ServerRequestHandler
 
     private async Task ReplyWith(TransactionOperationContext ctx, string err, HttpStatusCode httpStatusCode)
     {
-        if (_auditLogger.IsInfoEnabled)
+        if (LoggingSource.AuditLog.IsInfoEnabled)
         {
-            var clientCert = GetCurrentCertificate();
-            _auditLogger.Info(
-                $"Two factor auth failure from IP: {HttpContext.Connection.RemoteIpAddress}  with cert: '{clientCert?.Thumbprint ?? "None"}/{clientCert?.Subject ?? "None"}' because: {err}");
+            LogAuditFor(nameof(TwoFactorAuthenticationHandler), $"Two factor auth failure: {err}");
         }
+
         HttpContext.Response.StatusCode = (int)httpStatusCode;
         await using (var writer = new AsyncBlittableJsonTextWriter(ctx, ResponseBodyStream()))
         {

--- a/src/Raven.Server/Web/RequestHandler.Audit.cs
+++ b/src/Raven.Server/Web/RequestHandler.Audit.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Logging;
+
+namespace Raven.Server.Web
+{
+    public abstract partial class RequestHandler
+    {
+        public void LogTaskToAudit(string description, long id, BlittableJsonReaderObject configuration)
+        {
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+            {
+                DynamicJsonValue conf = GetCustomConfigurationAuditJson(description, configuration);
+                var line = $"Task: '{description}' with taskId: '{id}'";
+
+                if (conf != null)
+                {
+                    var confString = string.Empty;
+                    using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
+                    {
+                        confString = ctx.ReadObject(conf, "conf").ToString();
+                    }
+
+                    line += ($" Configuration: {confString}");
+                }
+
+                LogAuditFor(_context.DatabaseName ?? "Server", line);
+            }
+        }
+
+        public bool IsLocalRequest()
+        {
+            if (HttpContext.Connection.RemoteIpAddress == null && HttpContext.Connection.LocalIpAddress == null)
+            {
+                return true;
+            }
+            if (HttpContext.Connection.RemoteIpAddress.Equals(HttpContext.Connection.LocalIpAddress))
+            {
+                return true;
+            }
+            if (IPAddress.IsLoopback(HttpContext.Connection.RemoteIpAddress))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public string RequestIp => IsLocalRequest() ? Environment.MachineName : HttpContext.Connection.RemoteIpAddress.ToString();
+
+        public void LogAuditFor(string logger, string message)
+        {
+            var auditLog = LoggingSource.AuditLog.GetLogger(logger, "Audit");
+            Debug.Assert(auditLog.IsInfoEnabled, $"auditlog info is disabled");
+
+            var clientCert = GetCurrentCertificate();
+
+            var sb = new StringBuilder();
+            sb.Append(RequestIp);
+            sb.Append(", ");
+            if (clientCert != null) 
+                sb.Append($"CN={clientCert.Subject} [{clientCert.Thumbprint}], ");
+            else
+                sb.Append("no certificate, ");
+
+            sb.Append(message);
+
+            auditLog.Info(sb.ToString());
+        }
+    }
+}

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -890,32 +890,5 @@ namespace Raven.Server.Web
 
             return null;
         }
-
-        public void LogTaskToAudit(string description, long id, BlittableJsonReaderObject configuration)
-        {
-            if (LoggingSource.AuditLog.IsInfoEnabled)
-            {
-                DynamicJsonValue conf = GetCustomConfigurationAuditJson(description, configuration);
-                var clientCert = GetCurrentCertificate();
-                var auditLog = LoggingSource.AuditLog.GetLogger(_context.DatabaseName ?? "Server", "Audit");
-                var line = $"Task: '{description}' with taskId: '{id}'";
-
-                if (clientCert != null)
-                    line += $" executed by '{clientCert.Subject}' '{clientCert.Thumbprint}'";
-
-                if (conf != null)
-                {
-                    var confString = string.Empty;
-                    using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
-                    {
-                        confString = ctx.ReadObject(conf, "conf").ToString();
-                    }
-
-                    line += ($" Configuration: {confString}");
-                }
-
-                auditLog.Info(line);
-            }
-        }
     }
 }

--- a/src/Raven.Server/Web/System/Analyzers/AdminAnalyzersHandler.cs
+++ b/src/Raven.Server/Web/System/Analyzers/AdminAnalyzersHandler.cs
@@ -31,10 +31,7 @@ namespace Raven.Server.Web.System.Analyzers
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        var clientCert = GetCurrentCertificate();
-
-                        var auditLog = LoggingSource.AuditLog.GetLogger("Server", "Audit");
-                        auditLog.Info($"Analyzer {analyzerDefinition.Name} PUT by {clientCert?.Subject} {clientCert?.Thumbprint} with definition: {analyzerToAdd}");
+                        LogAuditFor("Server", $"Analyzer {analyzerDefinition.Name} PUT with definition: {analyzerToAdd}");
                     }
 
                     analyzerDefinition.Validate();
@@ -64,10 +61,7 @@ namespace Raven.Server.Web.System.Analyzers
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                var clientCert = GetCurrentCertificate();
-
-                var auditLog = LoggingSource.AuditLog.GetLogger("Server", "Audit");
-                auditLog.Info($"Analyzer {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
+                LogAuditFor("Server", $"Analyzer {name} DELETE");
             }
 
             var command = new DeleteServerWideAnalyzerCommand(name, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -63,12 +63,9 @@ namespace Raven.Server.Web.System
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    var clientCert = GetCurrentCertificate();
-
-                    var auditLog = LoggingSource.AuditLog.GetLogger("DbMgmt", "Audit");
-                    auditLog.Info($"Database \'{dbName}\' topology is being modified by {clientCert?.Subject} ({clientCert?.Thumbprint})," +
-                                  $"Old topology: {databaseRecord.Topology} " +
-                                  $"New topology: {databaseTopology}.");
+                    LogAuditFor("DbMgmt", $"Database '{dbName}' topology is being modified " +
+                                          $"Old topology: {databaseRecord.Topology} " +
+                                          $"New topology: {databaseTopology}.");
                 }
 
                 // Validate Topology

--- a/src/Raven.Server/Web/System/Sorters/AdminSortersHandler.cs
+++ b/src/Raven.Server/Web/System/Sorters/AdminSortersHandler.cs
@@ -31,10 +31,7 @@ namespace Raven.Server.Web.System.Sorters
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        var clientCert = GetCurrentCertificate();
-
-                        var auditLog = LoggingSource.AuditLog.GetLogger("Server", "Audit");
-                        auditLog.Info($"Sorter {sorterDefinition.Name} PUT by {clientCert?.Subject} {clientCert?.Thumbprint} with definition: {sorterToAdd}");
+                        LogAuditFor("Server", $"Sorter {sorterDefinition.Name} PUT with definition: {sorterToAdd}");
                     }
 
                     sorterDefinition.Validate();
@@ -64,10 +61,7 @@ namespace Raven.Server.Web.System.Sorters
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                var clientCert = GetCurrentCertificate();
-
-                var auditLog = LoggingSource.AuditLog.GetLogger("Server", "Audit");
-                auditLog.Info($"Sorter {name} DELETE by {clientCert?.Subject} {clientCert?.Thumbprint}");
+                LogAuditFor("Server", $"Sorter {name} DELETE");
             }
 
             var command = new DeleteServerWideSorterCommand(name, GetRaftRequestIdFromQuery());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22362

### Additional description

Use single method for auditing an endpoint

based on v5.4 version https://github.com/ravendb/ravendb/pull/18526

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
