### PR TITLE
RavenDB-22376 - Revisions.GetAsync fails in sharding

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisions.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsHandlerProcessorForGetRevisions.cs
@@ -30,18 +30,18 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
             var cmd = new ShardedGetRevisionsByChangeVectorsOperation(HttpContext, changeVectors.ToArray(), metadataOnly, context, etag);
             var result = await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(cmd, token);
 
+            if (result.StatusCode == (int)HttpStatusCode.NotModified)
+            {
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
+                return;
+            }
+
             if (result.Result == null && changeVectors.Count == 1)
             {
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
                 return;
             }
 
-            if (result.StatusCode == (int)HttpStatusCode.NotModified)
-            {
-                HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
-                return;
-            }
-            
             if (string.IsNullOrEmpty(result.CombinedEtag) == false)
                 HttpContext.Response.Headers[Constants.Headers.Etag] = "\"" + result.CombinedEtag + "\"";
 

--- a/test/SlowTests/SlowTests/Issues/RavenDB-22376.cs
+++ b/test/SlowTests/SlowTests/Issues/RavenDB-22376.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents.Operations.Revisions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.SlowTests.Issues
+{
+    internal class RavenDB_22376 : RavenTestBase
+    {
+        public RavenDB_22376(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sharding | RavenTestCategory.Revisions | RavenTestCategory.ClientApi)]
+        public async Task ShardingGetRevisionByCV()
+        {
+            using var store = Sharding.GetDocumentStore();
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false
+                }
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store, configuration: configuration);
+
+
+            for (int i = 0; i < 2; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Doc { Name = i.ToString() }, "Docs/1");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            string cv = null;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                (await session.Advanced.Revisions.GetMetadataForAsync("Docs/1")).First().TryGetValue(Constants.Documents.Metadata.ChangeVector, out cv);
+                Assert.NotNull(cv);
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.Advanced.Revisions.GetAsync<Doc>(cv);
+                Assert.NotNull(doc);
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.Advanced.Revisions.GetAsync<Doc>(cv);
+                Assert.NotNull(doc); // Fail here
+            }
+
+        }
+
+        private class Doc
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22376/Revisions.GetAsync-fails-in-sharding

### Additional description

Revisions.GetAsync was returning `HttpStatusCode.NotFound` instead `HttpStatusCode.NotModified` in the second call, hence the client was returning null..

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
