### PR TITLE
RavenDB-22372 save one RUN call in the Dockerfile

### DIFF
--- a/docker/ravendb-ubuntu/Dockerfile.arm32v7
+++ b/docker/ravendb-ubuntu/Dockerfile.arm32v7
@@ -28,8 +28,7 @@ RUN apt install /opt/ravendb.deb -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY server-utils.sh cert-utils.sh run-raven.sh healthcheck.sh link-legacy-datadir.sh /usr/lib/ravendb/scripts/
-COPY settings.json /etc/ravendb
-RUN chown root:${RAVEN_USER_ID} /etc/ravendb/settings.json && chmod 660 /etc/ravendb/settings.json
+COPY --chown=root:${RAVEN_USER_ID} --chmod=660 settings.json /etc/ravendb
 
 USER ravendb:ravendb
 

--- a/docker/ravendb-ubuntu/Dockerfile.arm64v8
+++ b/docker/ravendb-ubuntu/Dockerfile.arm64v8
@@ -28,8 +28,7 @@ RUN apt install /opt/ravendb.deb -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY server-utils.sh cert-utils.sh run-raven.sh healthcheck.sh link-legacy-datadir.sh /usr/lib/ravendb/scripts/
-COPY settings.json /etc/ravendb
-RUN chown root:${RAVEN_USER_ID} /etc/ravendb/settings.json && chmod 660 /etc/ravendb/settings.json
+COPY --chown=root:${RAVEN_USER_ID} --chmod=660 settings.json /etc/ravendb
 
 USER ravendb:ravendb
 

--- a/docker/ravendb-ubuntu/Dockerfile.x64
+++ b/docker/ravendb-ubuntu/Dockerfile.x64
@@ -28,8 +28,7 @@ RUN apt install /opt/ravendb.deb -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY server-utils.sh cert-utils.sh run-raven.sh healthcheck.sh link-legacy-datadir.sh /usr/lib/ravendb/scripts/
-COPY settings.json /etc/ravendb
-RUN chown root:${RAVEN_USER_ID} /etc/ravendb/settings.json && chmod 660 /etc/ravendb/settings.json
+COPY --chown=root:${RAVEN_USER_ID} --chmod=660 settings.json /etc/ravendb
 
 USER ravendb:ravendb
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22372

### Additional description

It allows for a smaller image.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Docker
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

```
> docker run -it ravendb/ravendb ls -l /etc/ravendb/
total 8
drwxrwx--- 2 root ravendb 4096 May 16 11:18 security
-rw-rw---- 1 root ravendb   68 Mar 18 11:30 settings.json
```

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
