### PR TITLE
RavenDB-7070 wait for 15 seconds and not 15,000,000 ms

### DIFF
--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -134,11 +134,11 @@ namespace Tests.Infrastructure
             Assert.NotNull(await WaitForDocumentToReplicateAsync<object>(dst, id, 15 * 1000));
         }
 
-        protected async Task<T> WaitForDocumentToReplicateAsync<T>(IDocumentStore store, string id, int timeout)
+        protected async Task<T> WaitForDocumentToReplicateAsync<T>(IDocumentStore store, string id, TimeSpan timeout)
             where T : class
         {
             var sw = Stopwatch.StartNew();
-            while (sw.ElapsedMilliseconds <= timeout)
+            while (sw.Elapsed <= timeout)
             {
                 using (var session = store.OpenAsyncSession(store.Database))
                 {
@@ -151,6 +151,12 @@ namespace Tests.Infrastructure
             }
 
             return null;
+        }
+
+        protected Task<T> WaitForDocumentToReplicateAsync<T>(IDocumentStore store, string id, int timeoutInMs)
+            where T : class
+        {
+            return WaitForDocumentToReplicateAsync<T>(store, id, TimeSpan.FromMilliseconds(timeoutInMs));
         }
 
         protected T WaitForDocumentToReplicate<T>(IDocumentStore store, string id, int timeout)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-7070

### Additional description

In the test we waited for 15,000,000 ms instead of 15,000 (15 seconds)

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
