### PR TITLE
RavenDB-22382 - add a transaction size limit in the expiration and refresh commands

### DIFF
--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -136,7 +136,6 @@ namespace Raven.Server.Documents
                     do
                     {
                         var command = new ExecuteRateLimitedOperations<string>(ids, action, rateGate, token,
-                            maxTransactionSize: 16 * Voron.Global.Constants.Size.Megabyte,
                             batchSize: OperationBatchSize);
 
                         await Database.TxMerger.Enqueue(command);

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.WebSockets;
-using System.Runtime.ExceptionServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Configuration;
@@ -32,7 +29,6 @@ using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Documents.TimeSeries;
-using Raven.Server.Json;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.Routing;
@@ -47,7 +43,6 @@ using Raven.Server.Utils.IoMetrics;
 using Sparrow;
 using Sparrow.Backups;
 using Sparrow.Collections;
-using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Json.Sync;
 using Sparrow.Logging;
@@ -61,7 +56,6 @@ using Voron;
 using Voron.Data.Tables;
 using Voron.Exceptions;
 using Voron.Impl.Backup;
-using static Raven.Server.Documents.DatabasesLandlord;
 using Constants = Raven.Client.Constants;
 using DatabaseInfo = Raven.Client.ServerWide.Operations.DatabaseInfo;
 using DatabaseSmuggler = Raven.Server.Smuggler.Documents.DatabaseSmuggler;
@@ -106,6 +100,9 @@ namespace Raven.Server.Documents
 
         private DocumentsCompressionConfiguration _documentsCompression = new(compressRevisions: false, collections: Array.Empty<string>());
         private HashSet<string> _compressedCollections = new(StringComparer.OrdinalIgnoreCase);
+
+        internal Sparrow.Size _maxTransactionSize = new(16, SizeUnit.Megabytes);
+
 
         public void ResetIdleTime()
         {

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -244,10 +244,10 @@ namespace Raven.Server.Documents.Expiration
             {
             }
 
-            public DocumentExpirationInfo(Slice ticksAsSlice, Slice clonedId, string id)
+            public DocumentExpirationInfo(Slice ticks, Slice lowerId, string id)
             {
-                Ticks = ticksAsSlice;
-                LowerId = clonedId;
+                Ticks = ticks;
+                LowerId = lowerId;
                 Id = id;
             }
         }

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -219,7 +219,7 @@ namespace Raven.Server.Documents.Expiration
             {
                 return new DeleteExpiredDocumentsCommandDto
                 {
-                    Expired = _expired.Select(x => (x.Ticks, x.LowerId, x.Id)).ToArray(),
+                    Expired = _expired.Select(x => (Ticks: x.Ticks, LowerId: x.LowerId, Id: x.Id)).ToArray(),
                     ForExpiration = _forExpiration,
                     CurrentTime = _currentTime
                 };
@@ -234,7 +234,7 @@ namespace Raven.Server.Documents.Expiration
             var queue = new Queue<ExpirationStorage.DocumentExpirationInfo>();
             foreach (var item in Expired)
             {
-                queue.Enqueue(new ExpirationStorage.DocumentExpirationInfo(item.Item1, item.Item2, item.Item3));
+                queue.Enqueue(new ExpirationStorage.DocumentExpirationInfo(item.Item1.Clone(context.Allocator), item.Item2.Clone(context.Allocator), item.Item3));
             }
 
             var command = new ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand(queue, database, ForExpiration, CurrentTime);

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -189,14 +189,14 @@ namespace Raven.Server.Documents.Expiration
 
         internal class DeleteExpiredDocumentsCommand : TransactionOperationsMerger.MergedTransactionCommand
         {
-            private readonly Queue<ExpirationStorage.ExpiredDocumentInfo> _expired;
+            private readonly Queue<ExpirationStorage.DocumentExpirationInfo> _expired;
             private readonly DocumentDatabase _database;
             private readonly bool _forExpiration;
             private readonly DateTime _currentTime;
 
             public int DeletionCount;
 
-            public DeleteExpiredDocumentsCommand(Queue<ExpirationStorage.ExpiredDocumentInfo> expired, DocumentDatabase database, bool forExpiration, DateTime currentTime)
+            public DeleteExpiredDocumentsCommand(Queue<ExpirationStorage.DocumentExpirationInfo> expired, DocumentDatabase database, bool forExpiration, DateTime currentTime)
             {
                 _expired = expired;
                 _database = database;
@@ -230,11 +230,11 @@ namespace Raven.Server.Documents.Expiration
     {
         public ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
-            var command = new ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand(new Queue<ExpirationStorage.ExpiredDocumentInfo>(Expired), database, ForExpiration, CurrentTime);
+            var command = new ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand(new Queue<ExpirationStorage.DocumentExpirationInfo>(Expired), database, ForExpiration, CurrentTime);
             return command;
         }
 
-        public ExpirationStorage.ExpiredDocumentInfo[] Expired { get; set; }
+        public ExpirationStorage.DocumentExpirationInfo[] Expired { get; set; }
 
         public bool ForExpiration { get; set; }
 

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -234,14 +234,14 @@ namespace Raven.Server.Documents.Expiration
             var queue = new Queue<ExpirationStorage.DocumentExpirationInfo>();
             foreach (var item in Expired)
             {
-                queue.Enqueue(new ExpirationStorage.DocumentExpirationInfo(item.Item1.Clone(context.Allocator), item.Item2.Clone(context.Allocator), item.Item3));
+                queue.Enqueue(new ExpirationStorage.DocumentExpirationInfo(item.Ticks.Clone(context.Allocator), item.LowerId.Clone(context.Allocator), item.Id));
             }
 
             var command = new ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand(queue, database, ForExpiration, CurrentTime);
             return command;
         }
 
-        public (Slice, Slice, string)[] Expired { get; set; }
+        public (Slice Ticks, Slice LowerId, string Id)[] Expired { get; set; }
 
         public bool ForExpiration { get; set; }
 

--- a/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractQueryRunner.cs
@@ -199,7 +199,6 @@ namespace Raven.Server.Documents.Queries
 
                         return subCommand;
                     }, rateGate, token,
-                        maxTransactionSize: 16 * Constants.Size.Megabyte,
                         batchSize: batchSize);
 
                     await Database.TxMerger.Enqueue(command);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
@@ -238,7 +238,6 @@ namespace Raven.Server.Documents.TimeSeries
         internal class TimeSeriesRetentionCommand : TransactionOperationsMerger.MergedTransactionCommand
         {
             public const int BatchSize = 1024;
-            private static readonly Size MaxTransactionSize = new(16, SizeUnit.Megabytes);
 
             private readonly List<Slice> _keys;
             private readonly string _collection;
@@ -276,7 +275,7 @@ namespace Raven.Server.Documents.TimeSeries
                     if (logger.IsInfoEnabled)
                         logger.Info($"{request} was executed (successfully: {done})");
 
-                    if (context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSize > MaxTransactionSize)
+                    if (context.CanContinueTransaction == false)
                         break;
                 }
 

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -51,6 +51,15 @@ namespace Raven.Server.ServerWide.Context
             }
         }
 
+        public bool CanContinueTransaction
+        {
+            get
+            {
+                return Transaction.InnerTransaction.LowLevelTransaction.TransactionSize <= _documentDatabase._maxTransactionSize;
+            }
+        }
+
+
         protected internal override void Reset(bool forceResetLongLivedAllocator = false)
         {
             base.Reset(forceResetLongLivedAllocator);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22382/Expiration-command-has-no-size-limit

### Additional description

A single document can have multiple attachments/counters/time series. We need to take that into account when executing the expiration and refresh commands.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
