### PR TITLE
RavenDB-22377 Clear previous projection cache when performing `CacheClean` on PulseTransaction to avoid holding invalid pointers.

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/QueriedDocumentCache.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueriedDocumentCache.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -42,14 +43,16 @@ public sealed class QueriedDocumentCache : LruDictionary<string, QueriedDocument
         {
             if (valueTuple.Value is null)
                 continue;
-            
-#if DEBUG
-            Debug.Assert(valueTuple.Value.CanDispose);
-#endif
 
+#if DEBUG
+            if (valueTuple.Value.CanDispose == false)
+            {
+                throw new InvalidOperationException($"Document '{valueTuple.Value.Id}' should be disposable but it still has hanging reference (RefCount: {valueTuple.Value.RefCount}). This indicates a bug.");
+            }
+#endif
             Release(valueTuple.Value);
         }
-        
+
         Cache.Clear();
         List.Clear();
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22377 
### Additional description

On PulseTransaction we're cleaning the cache. This also has to clear last projection "small cache" since it holds references to original documents in LRU cache.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
