### PR TITLE
RavenDB-22324 - Fix RavenDB_20628 failing tests

### DIFF
--- a/test/SlowTests/Issues/RavenDB-20628.cs
+++ b/test/SlowTests/Issues/RavenDB-20628.cs
@@ -67,6 +67,8 @@ namespace SlowTests.Issues
 
             using (var session = store.OpenAsyncSession())
             {
+                session.Advanced.WaitForReplicationAfterSaveChanges(timeout: new TimeSpan(hours: 0, minutes: 0, seconds: 15), throwOnTimeout: true, replicas: 1);
+
                 await session.StoreAsync(user1);
                 await session.StoreAsync(company3);
                 await session.StoreAsync(post4);
@@ -115,6 +117,8 @@ namespace SlowTests.Issues
 
             using (var session = store.OpenAsyncSession())
             {
+                session.Advanced.WaitForReplicationAfterSaveChanges(timeout: new TimeSpan(hours: 0, minutes: 0, seconds: 15), throwOnTimeout: true, replicas: 1);
+
                 await session.StoreAsync(user1);
                 await session.StoreAsync(user3);
                 await session.SaveChangesAsync();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22324/SlowTests.Issues.RavenDB20628.ClusterTransactionWithMultipleCommandsShouldWorkAfterCommitAndFailoverUseResultsoptions

### Additional description

The first session changes happen on node A but are replicated to node B after the cluster tx changes happen on B.
hence B executes the delete of 'user3' on the cluster tx execute before it actually has the doc (so it skips on that doc), and only after that node B gets 'user3' by replication from node A.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
