### PR TITLE
[Testing] RavenDB-22199  Flush reuqest stream to send the headers in all customized HttpContent implementations

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -59,11 +59,16 @@ namespace Raven.Client.Documents.BulkInsert
                 }
             }
 
-            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
             {
+                // Immediately flush request stream to send headers
+                // https://github.com/dotnet/corefx/issues/39586#issuecomment-516210081
+                // https://github.com/dotnet/runtime/issues/96223#issuecomment-1865009861
+                await stream.FlushAsync().ConfigureAwait(false);
+
                 _outputStreamTcs.TrySetResult(stream);
 
-                return _done.Task;
+                await _done.Task.ConfigureAwait(false);
             }
 
             protected override bool TryComputeLength(out long length)

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -410,6 +410,11 @@ namespace Raven.Client.Documents.Smuggler
             {
                 _parent.ForTestingPurposes?.BeforeSerializeToStreamAsync?.Invoke();
 
+                // Immediately flush request stream to send headers
+                // https://github.com/dotnet/corefx/issues/39586#issuecomment-516210081
+                // https://github.com/dotnet/runtime/issues/96223#issuecomment-1865009861
+                await stream.FlushAsync().ConfigureAwait(false);
+
                 await base.SerializeToStreamAsync(stream, context).ConfigureAwait(false);
                 _tcs.TrySetResult(null);
             }

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -19,6 +19,10 @@ namespace Raven.Client.Json
 
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
+            // Immediately flush request stream to send headers
+            // https://github.com/dotnet/corefx/issues/39586#issuecomment-516210081
+            // https://github.com/dotnet/runtime/issues/96223#issuecomment-1865009861
+            await stream.FlushAsync().ConfigureAwait(false);
 
 #if NETSTANDARD2_0 || NETCOREAPP2_1
             using (var gzipStream = new GZipStream(stream, CompressionMode.Compress, leaveOpen: true))


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22199

### Additional description

For testing purposes only against 6.0 branch

Also maybe related to https://issues.hibernatingrhinos.com/issue/RavenDB-21833/SlowTests.Issues.RavenDB17745.BulkInsertWithDelay#focus=Comments-67-1051914.0-0
