### PR TITLE
RavenDB-22382 - add a transaction size limit in the expiration and refresh commands 

### DIFF
--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -143,10 +143,10 @@ public abstract unsafe class AbstractBackgroundWorkStorage
         {
         }
 
-        public DocumentExpirationInfo(Slice ticksAsSlice, Slice clonedId, string id)
+        public DocumentExpirationInfo(Slice ticks, Slice lowerId, string id)
         {
-            Ticks = ticksAsSlice;
-            LowerId = clonedId;
+            Ticks = ticks;
+            LowerId = lowerId;
             Id = id;
         }
     }

--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -137,8 +137,7 @@ namespace Raven.Server.Documents
 
                     do
                     {
-                        var command = new ExecuteRateLimitedOperations<string>(ids, action, rateGate, token,
-                            maxTransactionSize: 16 * Voron.Global.Constants.Size.Megabyte,
+                        var command = new ExecuteRateLimitedOperations<string>(ids, action, rateGate, token, 
                             batchSize: OperationBatchSize);
 
                         await Database.TxMerger.Enqueue(command).ConfigureAwait(false);

--- a/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
@@ -34,7 +34,7 @@ internal class ArchiveDocumentsCommand : MergedTransactionCommand<DocumentsOpera
     {
         return new ArchiveDocumentsCommandDto 
         {
-            ToArchive = _toArchive.Select(x => (x.Ticks, x.LowerId, x.Id)).ToArray(),
+            ToArchive = _toArchive.Select(x => (Ticks: x.Ticks, LowerId: x.LowerId, Id: x.Id)).ToArray(),
             CurrentTime = _currentTime
         };
     }

--- a/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
@@ -1,21 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Voron;
+using static Raven.Server.Documents.AbstractBackgroundWorkStorage;
 
 namespace Raven.Server.Documents.DataArchival;
 
 internal class ArchiveDocumentsCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
 {
-    private readonly Dictionary<Slice, List<(Slice LowerId, string Id)>> _toArchive;
+    private readonly Queue<DocumentExpirationInfo> _toArchive;
     private readonly DocumentDatabase _database;
     private readonly DateTime _currentTime;
 
     public int ArchivedDocsCount;
 
-    public ArchiveDocumentsCommand([NotNull] Dictionary<Slice, List<(Slice LowerId, string Id)>> toArchive, [NotNull] DocumentDatabase database, DateTime currentTime)
+    public ArchiveDocumentsCommand([NotNull] Queue<DocumentExpirationInfo> toArchive, [NotNull] DocumentDatabase database, DateTime currentTime)
     {
         _toArchive = toArchive ?? throw new ArgumentNullException(nameof(toArchive));
         _database = database ?? throw new ArgumentNullException(nameof(database));
@@ -30,17 +32,9 @@ internal class ArchiveDocumentsCommand : MergedTransactionCommand<DocumentsOpera
 
     public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, ArchiveDocumentsCommand> ToDto(DocumentsOperationContext context)
     {
-        var keyValuePairs = new KeyValuePair<Slice, List<(Slice LowerId, string Id)>>[_toArchive.Count];
-        var i = 0;
-        foreach (var item in _toArchive)
-        {
-            keyValuePairs[i] = item;
-            i++;
-        }
-
         return new ArchiveDocumentsCommandDto 
         {
-            ToArchive = keyValuePairs,
+            ToArchive = _toArchive.Select(x => (x.Ticks, x.LowerId, x.Id)).ToArray(),
             CurrentTime = _currentTime
         };
     }
@@ -51,16 +45,16 @@ internal class ArchiveDocumentsCommandDto: IReplayableCommandDto<DocumentsOperat
 {
     public ArchiveDocumentsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
     {
-        var toArchive = new Dictionary<Slice, List<(Slice LowerId, string Id)>>(SliceComparer.Instance);
+        var toArchive = new Queue<DocumentExpirationInfo>();
         foreach (var item in ToArchive)
         {
-            toArchive[item.Key] = item.Value;
+            toArchive.Enqueue(new DocumentExpirationInfo(item.Item1, item.Item2, item.Item3));
         }
         var command = new ArchiveDocumentsCommand(toArchive, database, CurrentTime);
         return command;
     }
 
-    public KeyValuePair<Slice, List<(Slice LowerId, string Id)>>[] ToArchive { get; set; }
+    public (Slice, Slice, string)[] ToArchive { get; set; }
 
     public DateTime CurrentTime { get; set; }
 }

--- a/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
@@ -48,13 +48,13 @@ internal class ArchiveDocumentsCommandDto: IReplayableCommandDto<DocumentsOperat
         var toArchive = new Queue<DocumentExpirationInfo>();
         foreach (var item in ToArchive)
         {
-            toArchive.Enqueue(new DocumentExpirationInfo(item.Item1, item.Item2, item.Item3));
+            toArchive.Enqueue(new DocumentExpirationInfo(item.Ticks.Clone(context.Allocator), item.LowerId.Clone(context.Allocator), item.Id));
         }
         var command = new ArchiveDocumentsCommand(toArchive, database, CurrentTime);
         return command;
     }
 
-    public (Slice, Slice, string)[] ToArchive { get; set; }
+    public (Slice Ticks, Slice LowerId, string Id)[] ToArchive { get; set; }
 
     public DateTime CurrentTime { get; set; }
 }

--- a/src/Raven.Server/Documents/DataArchival/DataArchivalStorage.cs
+++ b/src/Raven.Server/Documents/DataArchival/DataArchivalStorage.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Raven.Client;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
-using Sparrow.Logging;
 using Voron;
 using Sparrow.Json.Parsing;
 using Voron.Impl;
@@ -15,7 +14,7 @@ public sealed class DataArchivalStorage : AbstractBackgroundWorkStorage
     private const string DocumentsByArchiveAtDateTime = "DocumentsByArchiveAtDateTime";
 
     public DataArchivalStorage(DocumentDatabase database, Transaction tx)
-        : base(tx, database, LoggingSource.Instance.GetLogger<DataArchivalStorage>(database.Name), DocumentsByArchiveAtDateTime, Constants.Documents.Metadata.ArchiveAt)
+        : base(tx, database, DocumentsByArchiveAtDateTime, Constants.Documents.Metadata.ArchiveAt)
     {
     }
 
@@ -47,7 +46,7 @@ public sealed class DataArchivalStorage : AbstractBackgroundWorkStorage
         }
     }
 
-    protected override void HandleDocumentConflict(BackgroundWorkParameters options, Slice clonedId, ref int totalCount, ref List<(Slice LowerId, string Id)> docsToProcess)
+    protected override void HandleDocumentConflict(BackgroundWorkParameters options, Slice ticksAsSlice, Slice clonedId, Queue<DocumentExpirationInfo> expiredDocs, ref int totalCount)
     {
         // data archival ignores conflicts
     }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -7,8 +6,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.WebSockets;
-using System.Runtime.ExceptionServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Changes;
@@ -29,7 +26,6 @@ using Raven.Server.Dashboard;
 using Raven.Server.Documents.ETL;
 using Raven.Server.Documents.Expiration;
 using Raven.Server.Documents.Handlers.Batches.Commands;
-using Raven.Server.Documents.Handlers.Processors.Batches;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Operations;
 using Raven.Server.Documents.Patch;
@@ -43,11 +39,9 @@ using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Documents.TransactionMerger;
-using Raven.Server.Json;
 using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
-using Raven.Server.Rachis;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
@@ -72,14 +66,12 @@ using Voron;
 using Voron.Data.Tables;
 using Voron.Exceptions;
 using Voron.Impl.Backup;
-using static Raven.Server.Documents.DatabasesLandlord;
 using Constants = Raven.Client.Constants;
 using MountPointUsage = Raven.Client.ServerWide.Operations.MountPointUsage;
 using Size = Raven.Client.Util.Size;
 using System.Diagnostics.CodeAnalysis;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
-using static Raven.Server.Smuggler.Documents.CounterItem;
 
 namespace Raven.Server.Documents
 {
@@ -121,6 +113,8 @@ namespace Raven.Server.Documents
         public DocumentsCompressionConfiguration DocumentsCompression => _documentsCompression;
         private DocumentsCompressionConfiguration _documentsCompression = new(compressRevisions: false, collections: Array.Empty<string>());
         private HashSet<string> _compressedCollections = new(StringComparer.OrdinalIgnoreCase);
+
+        internal Sparrow.Size _maxTransactionSize = new(16, SizeUnit.Megabytes);
 
         public void ResetIdleTime()
         {

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -225,7 +225,7 @@ namespace Raven.Server.Documents.Expiration
             {
                 return new DeleteExpiredDocumentsCommandDto
                 {
-                    Expired = _expired.Select(x => (x.Ticks, x.LowerId, x.Id)).ToArray(),
+                    Expired = _expired.Select(x => (Ticks: x.Ticks, LowerId: x.LowerId, Id: x.Id)).ToArray(),
                     ForExpiration = _forExpiration,
                     CurrentTime = _currentTime
                 };
@@ -240,7 +240,7 @@ namespace Raven.Server.Documents.Expiration
             var expired = new Queue<AbstractBackgroundWorkStorage.DocumentExpirationInfo>();
             foreach (var item in Expired)
             {
-                expired.Enqueue(new AbstractBackgroundWorkStorage.DocumentExpirationInfo(item.Item1, item.Item2, item.Item3));
+                expired.Enqueue(new AbstractBackgroundWorkStorage.DocumentExpirationInfo(item.Item1.Clone(context.Allocator), item.Item2.Clone(context.Allocator), item.Item3));
             }
             var command = new ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand(expired, database, ForExpiration, CurrentTime);
             return command;

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -168,11 +168,16 @@ namespace Raven.Server.Documents.Expiration
                             if (expired == null || expired.Count == 0)
                                 return;
 
-                            var command = new DeleteExpiredDocumentsCommand(expired, _database, forExpiration, currentTime);
-                            await _database.TxMerger.Enqueue(command);
+                            while (expired.Count > 0)
+                            {
+                                _database.DatabaseShutdown.ThrowIfCancellationRequested();
 
-                            if (Logger.IsInfoEnabled)
-                                Logger.Info($"Successfully {(forExpiration ? "deleted" : "refreshed")} {command.DeletionCount:#,#;;0} documents in {duration.ElapsedMilliseconds:#,#;;0} ms.");
+                                var command = new DeleteExpiredDocumentsCommand(expired, _database, forExpiration, currentTime);
+                                await _database.TxMerger.Enqueue(command);
+
+                                if (Logger.IsInfoEnabled)
+                                    Logger.Info($"Successfully {(forExpiration ? "deleted" : "refreshed")} {command.DeletionCount:#,#;;0} documents in {duration.ElapsedMilliseconds:#,#;;0} ms.");
+                            }
                         }
                     }
                 }
@@ -191,14 +196,14 @@ namespace Raven.Server.Documents.Expiration
 
         internal sealed class DeleteExpiredDocumentsCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
-            private readonly Dictionary<Slice, List<(Slice LowerId, string Id)>> _expired;
+            private readonly Queue<AbstractBackgroundWorkStorage.DocumentExpirationInfo> _expired;
             private readonly DocumentDatabase _database;
             private readonly bool _forExpiration;
             private readonly DateTime _currentTime;
 
             public int DeletionCount;
 
-            public DeleteExpiredDocumentsCommand(Dictionary<Slice, List<(Slice LowerId, string Id)>> expired, DocumentDatabase database, bool forExpiration, DateTime currentTime)
+            public DeleteExpiredDocumentsCommand(Queue<AbstractBackgroundWorkStorage.DocumentExpirationInfo> expired, DocumentDatabase database, bool forExpiration, DateTime currentTime)
             {
                 _expired = expired;
                 _database = database;
@@ -218,18 +223,9 @@ namespace Raven.Server.Documents.Expiration
 
             public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
-
-                var keyValuePairs = new KeyValuePair<Slice, List<(Slice LowerId, string Id)>>[_expired.Count];
-                var i = 0;
-                foreach (var item in _expired)
-                {
-                    keyValuePairs[i] = item;
-                    i++;
-                }
-
                 return new DeleteExpiredDocumentsCommandDto
                 {
-                    Expired = keyValuePairs,
+                    Expired = _expired.Select(x => (x.Ticks, x.LowerId, x.Id)).ToArray(),
                     ForExpiration = _forExpiration,
                     CurrentTime = _currentTime
                 };
@@ -241,16 +237,16 @@ namespace Raven.Server.Documents.Expiration
     {
         public ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
-            var expired = new Dictionary<Slice, List<(Slice LowerId, string Id)>>(SliceComparer.Instance);
+            var expired = new Queue<AbstractBackgroundWorkStorage.DocumentExpirationInfo>();
             foreach (var item in Expired)
             {
-                expired[item.Key] = item.Value;
+                expired.Enqueue(new AbstractBackgroundWorkStorage.DocumentExpirationInfo(item.Item1, item.Item2, item.Item3));
             }
             var command = new ExpiredDocumentsCleaner.DeleteExpiredDocumentsCommand(expired, database, ForExpiration, CurrentTime);
             return command;
         }
 
-        public KeyValuePair<Slice, List<(Slice LowerId, string Id)>>[] Expired { get; set; }
+        public (Slice, Slice, string)[] Expired { get; set; }
 
         public bool ForExpiration { get; set; }
 

--- a/src/Raven.Server/Documents/Queries/AbstractDatabaseQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/AbstractDatabaseQueryRunner.cs
@@ -200,7 +200,6 @@ public abstract class AbstractDatabaseQueryRunner : AbstractQueryRunner
 
                         return subCommand;
                     }, rateGate, token,
-                    maxTransactionSize: 16 * Constants.Size.Megabyte,
                     batchSize: batchSize);
 
                 await Database.TxMerger.Enqueue(command).ConfigureAwait(false);

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -336,8 +336,6 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
 
     private const long MaxDocumentsToDeleteInBucket = 1024;
 
-    private readonly Size _maxTransactionSize = new Size(16 * Constants.Size.Megabyte, SizeUnit.Bytes);
-
     public ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult DeleteBucket(DocumentsOperationContext context, int bucket, ChangeVector upTo)
     {
         long deleted = 0;
@@ -368,7 +366,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
             RevisionsStorage.ForceDeleteAllRevisionsFor(context, document.Id);
             deleted++;
 
-            if (context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSize > _maxTransactionSize)
+            if (context.CanContinueTransaction == false)
                 return ShardedDocumentDatabase.DeleteBucketCommand.DeleteBucketResult.ReachedTransactionLimit;
         }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
@@ -238,7 +238,6 @@ namespace Raven.Server.Documents.TimeSeries
         internal sealed class TimeSeriesRetentionCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             public const int BatchSize = 1024;
-            private static readonly Size MaxTransactionSize = new(16, SizeUnit.Megabytes);
 
             private readonly List<Slice> _keys;
             private readonly string _collection;
@@ -276,7 +275,7 @@ namespace Raven.Server.Documents.TimeSeries
                     if (logger.IsInfoEnabled)
                         logger.Info($"{request} was executed (successfully: {done})");
 
-                    if (context.Transaction.InnerTransaction.LowLevelTransaction.TransactionSize > MaxTransactionSize)
+                    if (context.CanContinueTransaction == false)
                         break;
                 }
 

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -54,6 +54,14 @@ namespace Raven.Server.ServerWide.Context
             }
         }
 
+        public bool CanContinueTransaction
+        {
+            get
+            {
+                return Transaction.InnerTransaction.LowLevelTransaction.TransactionSize <= _documentDatabase._maxTransactionSize;
+            }
+        }
+
         protected internal override void Reset(bool forceResetLongLivedAllocator = false)
         {
             base.Reset(forceResetLongLivedAllocator);

--- a/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
+++ b/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
@@ -31,6 +31,7 @@ using Tests.Infrastructure;
 using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
+using Size = Sparrow.Size;
 
 namespace SlowTests.Server.Documents.Expiration
 {
@@ -586,6 +587,45 @@ namespace SlowTests.Server.Documents.Expiration
                     }
                 }
                 Assert.Equal(1, count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ExpirationRefresh)]
+        public async Task Can_Expire_Large_Transactions()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var expires = SystemTime.UtcNow.AddMinutes(5);
+                for (int i = 0; i < 10; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var company = new Company { Name = "Company Name", Id = $"companies/{i}" };
+                        await session.StoreAsync(company);
+                        var metadata = session.Advanced.GetMetadataFor(company);
+                        metadata[Constants.Documents.Metadata.Expires] = expires.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                var config = new ExpirationConfiguration
+                {
+                    Disabled = false,
+                    DeleteFrequencyInSec = (long)TimeSpan.FromMinutes(10).TotalSeconds,
+                };
+
+                await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
+
+                var database = await GetDatabase(store.Database);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                database._maxTransactionSize = new Size(1, SizeUnit.Kilobytes);
+                await database.ExpiredDocumentsCleaner.CleanupExpiredDocs();
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var count = await session.Query<Company>().CountAsync();
+                    Assert.Equal(0, count);
+                }
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22382/Expiration-command-has-no-size-limit

### Additional description

This is port from 5.4 - https://github.com/ravendb/ravendb/pull/18542
A single document can have multiple attachments/counters/time series. We need to take that into account when executing the expiration and refresh commands.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
