### PR TITLE
RavenDB-22400 -  SlowTests.Server.Documents.PeriodicBackup.PeriodicBackupTestsSlow.can_snapshot_and_restore_with_subscription

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3901,6 +3901,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 await mre.WaitAsync(_reasonableWaitTime);
 
                 var subscriptionsConfig = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
+
+                await WaitForValueAsync(async () =>
+                {
+                    subscriptionsConfig = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
+                    return subscriptionsConfig[0].ChangeVectorForNextBatchStartingPoint;
+                }, lastCv);
+
                 Assert.Equal(1, subscriptionsConfig.Count);
                 Assert.Equal(lastCv, subscriptionsConfig[0].ChangeVectorForNextBatchStartingPoint);
                 var snapshotCv = lastCv;
@@ -3923,6 +3930,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     }.Initialize();
 
                     subscriptionsConfig = await destination.Subscriptions.GetSubscriptionsAsync(0, 10);
+
+                    await WaitForValueAsync(async () =>
+                    {
+                        subscriptionsConfig = await store.Subscriptions.GetSubscriptionsAsync(0, 10);
+                        return subscriptionsConfig[0].ChangeVectorForNextBatchStartingPoint;
+                    }, lastCv);
+
                     Assert.Equal(1, subscriptionsConfig.Count);
                     Assert.Equal(snapshotCv.Split("-")[0], subscriptionsConfig[0].ChangeVectorForNextBatchStartingPoint.Split("-")[0]);
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22400

### Additional description

There is a race between setting lastCv in the test and having the ChangeVectorForNextBatchStartingPoint updated to it in the server.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
