### PR TITLE
RavenDB-22405 - Include the indexes that are stale after getting a timeout inWaitForIndexesAfterSaveChanges

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -501,7 +501,7 @@ namespace Raven.Server.Documents.Handlers
 
         private static void ThrowTimeoutException(List<WaitForIndexItem> indexesToWait, int i, Stopwatch sp, QueryOperationContext context, long cutoffEtag)
         {
-            var staleIndexesCount = 0;
+            var staleIndexes = new List<string>();
             var erroredIndexes = new List<string>();
             var pausedIndexes = new List<string>();
 
@@ -519,11 +519,13 @@ namespace Raven.Server.Documents.Handlers
                 }
 
                 if (index.IsStale(context, cutoffEtag))
-                    staleIndexesCount++;
+                {
+                    staleIndexes.Add(index.Name);
+                }
             }
 
             var errorMessage = $"After waiting for {sp.Elapsed}, could not verify that all indexes has caught up with the changes as of etag: {cutoffEtag:#,#;;0}. " +
-                               $"Total relevant indexes: {indexesToWait.Count}, total stale indexes: {staleIndexesCount}";
+                               $"Total relevant indexes: {indexesToWait.Count}, total stale indexes: {staleIndexes.Count} ({string.Join(", ", staleIndexes)})";
 
             if (erroredIndexes.Count > 0)
             {

--- a/test/SlowTests/Issues/RavenDB-17157.cs
+++ b/test/SlowTests/Issues/RavenDB-17157.cs
@@ -1,17 +1,12 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using FastTests;
-using Parquet.Thrift;
-using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
-using Raven.Client.Json;
 using SlowTests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -47,7 +42,7 @@ namespace SlowTests.Issues
                     session.Store(new User { Name = "Bar" });
                     var exception = Assert.Throws<RavenTimeoutException>(() => session.SaveChanges());
 
-                    Assert.Contains("total stale indexes: 1", exception.Message);
+                    Assert.Contains($"total stale indexes: 1 ({indexName})", exception.Message);
                 }
             }
         }

--- a/test/SlowTests/Issues/RavenDB-18688.cs
+++ b/test/SlowTests/Issues/RavenDB-18688.cs
@@ -90,7 +90,7 @@ namespace SlowTests.Issues
                     session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5));
                     var error = await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
                     Assert.StartsWith("Raven.Client.Exceptions.RavenTimeoutException", error.Message);
-                    Assert.Contains($"Total relevant indexes: 1, total stale indexes: 1, total errored indexes: 1 ({index.IndexName})", error.Message);
+                    Assert.Contains($"Total relevant indexes: 1, total stale indexes: 1 ({index.IndexName}), total errored indexes: 1 ({index.IndexName})", error.Message);
                     Assert.DoesNotContain("total paused indexes", error.Message);
                 }
 
@@ -104,7 +104,7 @@ namespace SlowTests.Issues
                     session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5), indexes: new[] { index.IndexName });
                     var error = await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
                     Assert.StartsWith("Raven.Client.Exceptions.RavenTimeoutException", error.Message);
-                    Assert.Contains($"Total relevant indexes: 1, total stale indexes: 1, total errored indexes: 1 ({index.IndexName})", error.Message);
+                    Assert.Contains($"Total relevant indexes: 1, total stale indexes: 1 ({index.IndexName}), total errored indexes: 1 ({index.IndexName})", error.Message);
                     Assert.DoesNotContain("total paused indexes", error.Message);
                 }
 
@@ -120,7 +120,7 @@ namespace SlowTests.Issues
                     session.Advanced.WaitForIndexesAfterSaveChanges(timeout: TimeSpan.FromSeconds(5));
                     var error = await Assert.ThrowsAsync<RavenTimeoutException>(async () => await session.SaveChangesAsync());
                     Assert.StartsWith("Raven.Client.Exceptions.RavenTimeoutException", error.Message);
-                    Assert.Contains($"Total relevant indexes: 2, total stale indexes: 1, total errored indexes: 1 ({index.IndexName})", error.Message);
+                    Assert.Contains($"Total relevant indexes: 2, total stale indexes: 1 ({index.IndexName}), total errored indexes: 1 ({index.IndexName})", error.Message);
                     Assert.DoesNotContain("total paused indexes", error.Message);
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22405/Missing-index-names-after-timeout-in-WaitForIndexesAfterSaveChanges

### Additional description

Include the indexes that are stale after getting a timeout inWaitForIndexesAfterSaveChanges

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
