### PR TITLE
RavenDB-22394 - On update subscription populate PinToMentorNode from existing state if needed

### DIFF
--- a/src/Raven.Client/Documents/Commands/UpdateSubscriptionCommand.cs
+++ b/src/Raven.Client/Documents/Commands/UpdateSubscriptionCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Json.Serialization;
@@ -25,7 +26,11 @@ namespace Raven.Client.Documents.Commands
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
-                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_options, ctx)).ConfigureAwait(false))
+                Content = new BlittableJsonContent(async stream =>
+                {
+                    await using var writer = new AsyncBlittableJsonTextWriter(ctx, stream);
+                    writer.WriteSubscriptionUpdateOptions(_options);
+                })
             };
             return request;
         }

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionCriteria.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionCriteria.cs
@@ -18,7 +18,7 @@ namespace Raven.Client.Documents.Subscriptions
         public string ChangeVector { get; set; }
         public string MentorNode { get; set; }
         public bool Disabled { get; set; }
-        public bool PinToMentorNode { get; set; }
+        public virtual bool PinToMentorNode { get; set; }
     }
 
     public class SubscriptionCreationOptions<T>
@@ -52,6 +52,20 @@ namespace Raven.Client.Documents.Subscriptions
     {
         public long? Id { get; set; }
         public bool CreateNew { get; set; }
+
+        private bool _pinToMentorNode;
+
+        public override bool PinToMentorNode
+        {
+            get => _pinToMentorNode;
+            set
+            {
+                _pinToMentorNode = value;
+                PinToMentorNodeWasSet = true;
+            }
+        }
+
+        internal bool PinToMentorNodeWasSet { get; set; }
     }
 
     public class Revision<T> where T : class

--- a/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Subscriptions;
 using Sparrow.Json;
 
 namespace Raven.Client.Extensions
@@ -72,6 +73,49 @@ namespace Raven.Client.Extensions
                 writer.WritePropertyName(nameof(query.ProjectionBehavior));
                 writer.WriteString(query.ProjectionBehavior.ToString());
             }
+
+            writer.WriteEndObject();
+        }
+
+        public static void WriteSubscriptionUpdateOptions(this AbstractBlittableJsonTextWriter writer, SubscriptionUpdateOptions options)
+        {
+            writer.WriteStartObject();
+
+            if (options.Id.HasValue)
+            {
+                writer.WritePropertyName(nameof(options.Id));
+                writer.WriteInteger(options.Id.Value);
+                writer.WriteComma();
+            }
+
+            if (options.PinToMentorNodeWasSet)
+            {
+                writer.WritePropertyName(nameof(options.PinToMentorNode));
+                writer.WriteBool(options.PinToMentorNode);
+                writer.WriteComma();
+            }
+
+            writer.WritePropertyName(nameof(options.CreateNew));
+            writer.WriteBool(options.CreateNew);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(options.Name));
+            writer.WriteString(options.Name);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(options.Query));
+            writer.WriteString(options.Query);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(options.ChangeVector));
+            writer.WriteString(options.ChangeVector);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(options.MentorNode));
+            writer.WriteString(options.MentorNode);
+            writer.WriteComma();
+            writer.WritePropertyName(nameof(options.Disabled));
+            writer.WriteBool(options.Disabled);
 
             writer.WriteEndObject();
         }

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -417,6 +417,8 @@ namespace Raven.Server.Documents.Handlers
                         [nameof(SubscriptionState.Disabled)] = x.Disabled,
                         [nameof(SubscriptionState.LastClientConnectionTime)] = x.LastClientConnectionTime,
                         [nameof(SubscriptionState.LastBatchAckTime)] = x.LastBatchAckTime,
+                        [nameof(SubscriptionState.MentorNode)] = x.MentorNode,
+                        [nameof(SubscriptionState.PinToMentorNode)] = x.PinToMentorNode,
                         [nameof(SubscriptionGeneralDataAndStats.Connections)] = GetSubscriptionConnectionsJson(x.Connections),
                         [nameof(SubscriptionGeneralDataAndStats.RecentConnections)] = x.RecentConnections == null ? Array.Empty<SubscriptionConnectionInfo>() : x.RecentConnections.Select(r => r.ToJson()),
                         [nameof(SubscriptionGeneralDataAndStats.RecentRejectedConnections)] = x.RecentRejectedConnections == null ? Array.Empty<SubscriptionConnectionInfo>() : x.RecentRejectedConnections.Select(r => r.ToJson()),
@@ -550,6 +552,7 @@ namespace Raven.Server.Documents.Handlers
             using (context.OpenReadTransaction())
             {
                 var json = await context.ReadForMemoryAsync(RequestBodyStream(), null);
+                bool pinToMentorNodeWasSet = json.TryGet(nameof(SubscriptionUpdateOptions.PinToMentorNode), out bool pinToMentorNode);
                 var options = JsonDeserializationServer.SubscriptionUpdateOptions(json);
 
                 var id = options.Id;
@@ -614,6 +617,9 @@ namespace Raven.Server.Documents.Handlers
 
                 if (options.MentorNode == null)
                     options.MentorNode = state.MentorNode;
+
+                if (pinToMentorNodeWasSet == false)
+                    options.PinToMentorNode = state.PinToMentorNode;
 
                 if (options.Query == null)
                     options.Query = state.Query;


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22394/On-update-subscription-populate-PinToMentorNode-from-existing-state-if-needed

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented? added 
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
