### PR TITLE
RavenDB-22410 Corax search - analyzer produces multiple tokens from a single word

### DIFF
--- a/src/Corax/Querying/IndexSearcher.Search.cs
+++ b/src/Corax/Querying/IndexSearcher.Search.cs
@@ -214,6 +214,10 @@ public partial class IndexSearcher
                     termMatches ??= new();
                     terms.Clear(); // Clear the terms list.
                     EncodeAndApplyAnalyzerForMultipleTerms(field, word, ref terms);
+
+                    //When single term outputs multiple terms we've to jump into phraseQuery
+                    if (terms.Count > 1)
+                        goto PhraseQuery;
                     
                     foreach (var term in terms.GetEnumerator())
                     {
@@ -264,9 +268,10 @@ public partial class IndexSearcher
             //Phrase query
             terms.Clear();
             EncodeAndApplyAnalyzerForMultipleTerms(field, word, ref terms);
+            
             if (terms.Count == 0) 
                 continue; //sentence contained only stop-words
-
+            PhraseQuery:
             var hs = new HashSet<Slice>(SliceComparer.Instance);
             for (var i = 0; i < terms.Count; ++i)
             {

--- a/test/SlowTests/Issues/RavenDB_22410.cs
+++ b/test/SlowTests/Issues/RavenDB_22410.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22410 : RavenTestBase
+{
+    public RavenDB_22410(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void SearchMethodWhenWordIsTransformedIntoMultipleTokensWeTreatThemAsPhraseQuery(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Store(new Dto("Din ner"), "Dtos/1");
+        session.Store(new Dto("Ner din"), "Dtos/2");
+        session.SaveChanges();
+
+        var results = session.Query<Dto>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .Search(x => x.Search, "din%ner")
+            .ToList();
+        
+        Assert.Equal(1, results.Count);
+        Assert.Equal("Dtos/1", results[0].Id);
+    }
+
+    private record struct Dto(string Search, string Id = null);
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22410
### Additional description

When word is transformed into multiple tokens we treat them as a PhraseQuery

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
