### PR TITLE
RavenDB-17122 use async method instead of AsyncHelpers.RunSync in async context

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -95,6 +95,7 @@ namespace Raven.Client.Documents.Session
         /// </remarks>
         public IAsyncAdvancedSessionOperations Advanced => this;
 
+        [Obsolete("InMemoryDocumentSessionOperations.GenerateId is not supported anymore. Will be removed in next major version of the product.")]
         protected override string GenerateId(object entity)
         {
             throw new NotSupportedException("Async session cannot generate IDs synchronously");

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -170,6 +170,7 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         /// <param name="entity">The entity.</param>
         /// <returns></returns>
+        [Obsolete("InMemoryDocumentSessionOperations.GenerateId is not supported anymore. Will be removed in next major version of the product.")]
         protected override string GenerateId(object entity)
         {
             return Conventions.GenerateDocumentId(DatabaseName, entity);

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -243,7 +243,7 @@ namespace Raven.Client.Documents.Session
             NoTracking = options.NoTracking;
             UseOptimisticConcurrency = _requestExecutor.Conventions.UseOptimisticConcurrency;
             MaxNumberOfRequestsPerSession = _requestExecutor.Conventions.MaxNumberOfRequestsPerSession;
-            GenerateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(_requestExecutor.Conventions, GenerateId);
+            GenerateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(_requestExecutor.Conventions, entity => _requestExecutor.Conventions.GenerateDocumentIdAsync(DatabaseName, entity));
             JsonConverter = _requestExecutor.Conventions.Serialization.CreateConverter(this);
             _sessionInfo = new SessionInfo(this, options, _documentStore, asyncCommandRunning: false);
             TransactionMode = options.TransactionMode;
@@ -784,6 +784,7 @@ more responsive application.
             return new AsyncTaskHolder(this);
         }
 
+        [Obsolete("InMemoryDocumentSessionOperations.GenerateId is not supported anymore. Will be removed in next major version of the product.")]
         protected abstract string GenerateId(object entity);
 
         protected virtual void RememberEntityForDocumentIdGeneration(object entity)
@@ -793,21 +794,7 @@ more responsive application.
 
         protected internal async Task<string> GenerateDocumentIdForStorageAsync(object entity)
         {
-            if (Conventions.AddIdFieldToDynamicObjects && entity is IDynamicMetaObjectProvider)
-            {
-                if (GenerateEntityIdOnTheClient.TryGetIdFromDynamic(entity, out string id))
-                    return id;
-
-                id = await GenerateIdAsync(entity).ConfigureAwait(false);
-                // If we generated a new id, store it back into the Id field so the client has access to it
-                if (id != null)
-                    GenerateEntityIdOnTheClient.TrySetIdOnDynamic(entity, id);
-                return id;
-            }
-
-            var result = await GetOrGenerateDocumentIdAsync(entity).ConfigureAwait(false);
-            GenerateEntityIdOnTheClient.TrySetIdentity(entity, result);
-            return result;
+            return await GenerateEntityIdOnTheClient.GenerateDocumentIdForStorageAsync(entity).ConfigureAwait(false);
         }
 
         protected abstract Task<string> GenerateIdAsync(object entity);
@@ -855,6 +842,7 @@ more responsive application.
             throw new NonUniqueObjectException("Attempted to associate a different object with id '" + id + "'.");
         }
 
+        [Obsolete("InMemoryDocumentSessionOperations.GetOrGenerateDocumentIdAsync is not supported anymore. Will be removed in next major version of the product.")]
         protected async Task<string> GetOrGenerateDocumentIdAsync(object entity)
         {
             GenerateEntityIdOnTheClient.TryGetIdFromInstance(entity, out var id);

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
@@ -15,7 +15,7 @@ namespace Raven.Client.Documents.Subscriptions
         public SubscriptionBatch(RequestExecutor requestExecutor, IDocumentStore store, string dbName, Logger logger) : base(requestExecutor, dbName, logger)
         {
             _store = store;
-            _generateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(_requestExecutor.Conventions, entity => throw new InvalidOperationException("Shouldn't be generating new ids here"));
+            _generateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(_requestExecutor.Conventions, generateIdAsync: entity => throw new InvalidOperationException("Shouldn't be generating new ids here"));
         }
 
 

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/NewtonsoftJsonBlittableEntitySerializer.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/NewtonsoftJsonBlittableEntitySerializer.cs
@@ -20,7 +20,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
 
         public NewtonsoftJsonBlittableEntitySerializer(ISerializationConventions conventions)
         {
-            _generateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(conventions.Conventions, null);
+            _generateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(conventions.Conventions, generateIdAsync: null);
             _deserializer = new LightWeightThreadLocal<IJsonSerializer>(() => conventions.CreateDeserializer());
             _reader = new LightWeightThreadLocal<BlittableJsonReader>(() => new BlittableJsonReader());
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17122

### Additional description

This PR substitutes https://github.com/ravendb/ravendb/pull/13855

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
