### PR TITLE
RavenDB-22414 License - MaxClusterSize equal 0 means Infinity

### DIFF
--- a/src/Raven.Studio/typescript/components/common/shell/licenseSlice.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/licenseSlice.ts
@@ -29,6 +29,13 @@ export const licenseSlice = createSlice({
     reducers: {
         statusLoaded: (store, { payload: status }: PayloadAction<LicenseStatus>) => {
             store.status = status;
+
+            // 0 in MaxClusterSize means Infinity, in other fields null means Infinity
+            // for consistency we convert 0 to null
+            if ("MaxClusterSize" in store.status.Attributes && store.status.Attributes.MaxClusterSize === 0) {
+                store.status.Attributes.MaxClusterSize = null;
+                store.status.MaxClusterSize = null;
+            }
         },
         supportLoaded: (store, { payload: status }: PayloadAction<Raven.Server.Commercial.LicenseSupportInfo>) => {
             store.support = status;

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseDetails.tsx
@@ -69,8 +69,17 @@ function LicenseTable(props: LicenseTableProps) {
     };
 
     const getEffectiveValue = (feature: FeatureAvailabilityItem, column: LicenseColumn) => {
-        const valueFromLicense = column === currentColumn ? (licenseStatus[feature.fieldInLicense] as any) : null;
-        return valueFromLicense ?? feature[column].value;
+        if (column !== currentColumn || !feature.fieldInLicense) {
+            return feature[column].value;
+        }
+
+        const licenseValue = licenseStatus[feature.fieldInLicense];
+
+        if (licenseValue === null) {
+            return Infinity;
+        }
+
+        return licenseValue;
     };
 
     const filteredSections = filterFeatureAvailabilitySection(
@@ -1065,10 +1074,12 @@ interface FeatureAvailabilitySection {
     items: FeatureAvailabilityItem[];
 }
 
+type DisplayableLicenseField = keyof Omit<LicenseStatus, "Attributes">;
+
 interface FeatureAvailabilityItem {
     name: string;
 
-    fieldInLicense: keyof LicenseStatus;
+    fieldInLicense: DisplayableLicenseField;
     community: ValueData;
     professional: ValueData;
     enterprise: ValueData;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22414/License-MaxClusterSize-equal-0-means-Infinity

### Additional description

- if MaxClusterSize equal 0 -> set it to null in redux store
- fixes overriding in About view when license value equal null

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
