### PR TITLE
RavenDB-22415 

### DIFF
--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -35,8 +35,6 @@ function GetUbuntuImageTags($repo, $version, $arch) {
     switch ($arch) {
         "x64" { 
             return @(
-                "$($repo):latest",
-                "$($repo):ubuntu-latest",
                 "$($repo):latest-lts",
                 "$($repo):ubuntu-latest-lts",
                 "$($repo):5.4-ubuntu-latest",
@@ -46,7 +44,6 @@ function GetUbuntuImageTags($repo, $version, $arch) {
         }
         "arm32v7" {
             return @(
-                "$($repo):ubuntu-arm32v7-latest",
                 "$($repo):ubuntu-arm32v7-latest-lts",
                 "$($repo):5.4-ubuntu-arm32v7-latest",
                 "$($repo):$($version)-ubuntu.22.04-arm32v7"
@@ -55,7 +52,6 @@ function GetUbuntuImageTags($repo, $version, $arch) {
         }
         "arm64v8" {
             return @(
-                "$($repo):ubuntu-arm64v8-latest",
                 "$($repo):ubuntu-arm64v8-latest-lts",
                 "$($repo):5.4-ubuntu-arm64v8-latest",
                 "$($repo):$($version)-ubuntu.22.04-arm64v8"
@@ -74,7 +70,6 @@ function GetWindowsImageTags($repo, $version, $WinVer) {
         "1809" {
             return @(
                 "$($repo):$($version)-windows-1809",
-                "$($repo):windows-1809-latest",
                 "$($repo):windows-1809-latest-lts",
                 "$($repo):5.4-windows-1809-latest"
             )
@@ -83,7 +78,6 @@ function GetWindowsImageTags($repo, $version, $WinVer) {
         "ltsc2022" {
              return @(
                 "$($repo):$($version)-windows-ltsc2022",
-                "$($repo):windows-ltsc2022-latest",
                 "$($repo):windows-ltsc2022-latest-lts",
                 "$($repo):5.4-windows-ltsc2022-latest"
             )

--- a/docker/ravendb-nanoserver/Dockerfile.1809
+++ b/docker/ravendb-nanoserver/Dockerfile.1809
@@ -2,7 +2,14 @@
 
 FROM mcr.microsoft.com/powershell:lts-nanoserver-1809
 
-ENV RAVEN_ARGS='' RAVEN_SETTINGS='' RAVEN_Setup_Mode='Initial' RAVEN_DataDir='RavenData' RAVEN_ServerUrl_Tcp='38888' RAVEN_AUTO_INSTALL_CA='true' RAVEN_IN_DOCKER='true'
+ENV RAVEN_ARGS='' `
+    RAVEN_SETTINGS='' `
+    RAVEN_Setup_Mode='Initial' `
+    RAVEN_DataDir='RavenData' `
+    RAVEN_ServerUrl_Tcp='38888' `
+    RAVEN_AUTO_INSTALL_CA='true' `
+    RAVEN_IN_DOCKER='true' `
+    RAVEN_Security_UnsecuredAccessAllowed='PrivateNetwork'
 
 EXPOSE 8080 38888 161
 

--- a/docker/ravendb-nanoserver/Dockerfile.ltsc2022
+++ b/docker/ravendb-nanoserver/Dockerfile.ltsc2022
@@ -2,7 +2,14 @@
 
 FROM mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022
 
-ENV RAVEN_ARGS='' RAVEN_SETTINGS='' RAVEN_Setup_Mode='Initial' RAVEN_DataDir='RavenData' RAVEN_ServerUrl_Tcp='38888' RAVEN_AUTO_INSTALL_CA='true' RAVEN_IN_DOCKER='true'
+ENV RAVEN_ARGS='' `
+    RAVEN_SETTINGS='' `
+    RAVEN_Setup_Mode='Initial' `
+    RAVEN_DataDir='RavenData' `
+    RAVEN_ServerUrl_Tcp='38888' `
+    RAVEN_AUTO_INSTALL_CA='true' `
+    RAVEN_IN_DOCKER='true' `
+    RAVEN_Security_UnsecuredAccessAllowed='PrivateNetwork'
 
 EXPOSE 8080 38888 161
 

--- a/docker/ravendb-ubuntu/Dockerfile.arm32v7
+++ b/docker/ravendb-ubuntu/Dockerfile.arm32v7
@@ -4,7 +4,14 @@ RUN apt-get update \
     && apt-get install -y \
     && apt-get install --no-install-recommends openssl bzip2 jq curl -y
 
-ENV RAVEN_ARGS='' RAVEN_SETTINGS='' RAVEN_Setup_Mode='Initial' RAVEN_DataDir='RavenData' RAVEN_ServerUrl_Tcp='38888' RAVEN_AUTO_INSTALL_CA='true' RAVEN_IN_DOCKER='true'
+ENV RAVEN_ARGS='' \
+    RAVEN_SETTINGS='' \
+    RAVEN_Setup_Mode='Initial' \
+    RAVEN_DataDir='RavenData' \
+    RAVEN_ServerUrl_Tcp='38888' \
+    RAVEN_AUTO_INSTALL_CA='true' \
+    RAVEN_IN_DOCKER='true' \
+    RAVEN_Security_UnsecuredAccessAllowed='PrivateNetwork'
 
 EXPOSE 8080 38888 161
 

--- a/docker/ravendb-ubuntu/Dockerfile.arm64v8
+++ b/docker/ravendb-ubuntu/Dockerfile.arm64v8
@@ -4,7 +4,14 @@ RUN apt-get update \
     && apt-get install -y \
     && apt-get install --no-install-recommends openssl bzip2 jq curl -y
 
-ENV RAVEN_ARGS='' RAVEN_SETTINGS='' RAVEN_Setup_Mode='Initial' RAVEN_DataDir='RavenData' RAVEN_ServerUrl_Tcp='38888' RAVEN_AUTO_INSTALL_CA='true' RAVEN_IN_DOCKER='true'
+ENV RAVEN_ARGS='' \
+    RAVEN_SETTINGS='' \
+    RAVEN_Setup_Mode='Initial' \
+    RAVEN_DataDir='RavenData' \
+    RAVEN_ServerUrl_Tcp='38888' \
+    RAVEN_AUTO_INSTALL_CA='true' \
+    RAVEN_IN_DOCKER='true' \
+    RAVEN_Security_UnsecuredAccessAllowed='PrivateNetwork'
 
 EXPOSE 8080 38888 161
 

--- a/docker/ravendb-ubuntu/Dockerfile.x64
+++ b/docker/ravendb-ubuntu/Dockerfile.x64
@@ -4,7 +4,14 @@ RUN apt-get update \
     && apt-get install -y \
     && apt-get install --no-install-recommends openssl bzip2 jq curl -y
 
-ENV RAVEN_ARGS='' RAVEN_SETTINGS='' RAVEN_Setup_Mode='Initial' RAVEN_DataDir='RavenData' RAVEN_ServerUrl_Tcp='38888' RAVEN_AUTO_INSTALL_CA='true' RAVEN_IN_DOCKER='true'
+ENV RAVEN_ARGS='' \
+    RAVEN_SETTINGS='' \
+    RAVEN_Setup_Mode='Initial' \
+    RAVEN_DataDir='RavenData' \
+    RAVEN_ServerUrl_Tcp='38888' \
+    RAVEN_AUTO_INSTALL_CA='true' \
+    RAVEN_IN_DOCKER='true' \
+    RAVEN_Security_UnsecuredAccessAllowed='PrivateNetwork'
 
 EXPOSE 8080 38888 161
 

--- a/src/Raven.Server/Properties/Settings/settings.docker.posix.json
+++ b/src/Raven.Server/Properties/Settings/settings.docker.posix.json
@@ -1,4 +1,2 @@
-﻿{
-    "Security.UnsecuredAccessAllowed": "PrivateNetwork"
-}
+﻿{}
 

--- a/src/Raven.Server/Properties/Settings/settings.docker.windows.json
+++ b/src/Raven.Server/Properties/Settings/settings.docker.windows.json
@@ -1,3 +1,1 @@
-﻿{
-    "Security.UnsecuredAccessAllowed": "PrivateNetwork"
-}
+﻿{}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22415

### Additional description

- move the default value for UnsecuredAccessAllowed from settings to env var
- v5.4 should not use `latest` tag

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. 

Instead of using a value in settings.json, which is hard and not intuitive to override we use a default value declared as ENV in the dockerfile, which is something that is less confusing and more discoverable.

- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. COntainers
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

We should check if we have proper docs explaining how to run unsecured in docker if someone is just running a POC.

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

I built it on my local and tested the Ubuntu image (with and without the Unsecured... option set):
```
$ docker run -it -p 8080:8080 -e RAVEN_ServerUrl=http://0.0.0.0:8080 -e RAVEN_Security_UnsecuredAccessAllowed=PublicNetwork -e RAVEN_Setup_Mode=None ravendb/ravendb:latest-lts
```

I was not successful in testing the Windows image. Something seems to be broken on my laptop. @poissoncorp @hiddenshadow21 Can you check on your environment please? 

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

The flag works as it's been before - it is just defined elsewhere.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
