### PR TITLE
RavenDB-22366 XML docs warnings in IncludeBuilder

### DIFF
--- a/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
@@ -88,7 +88,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="name">The name of the time series to include.</param>
         /// <param name="type">Indicates how to retrieve the time series entries.
         /// When set to 'Last', retrieves entries from the end of the time series within the specified time range. <br/>
-        /// <remarks>Note that <typeparamref name="TimeSeriesRangeType"></typeparamref> cannot be 'None' when time is specified.</remarks></param>
+        /// <remarks>Note that <see cref="TimeSeriesRangeType"/> cannot be 'None' when time is specified.</remarks></param>
         /// <param name="time">The time range to consider when retrieving time series entries.</param>
         TBuilder IncludeTimeSeries(string name, TimeSeriesRangeType type, TimeValue time);
 
@@ -96,7 +96,7 @@ namespace Raven.Client.Documents.Session.Loaders
         /// <param name="name">The name of the time series to include.</param>
         /// <param name="type">Indicates how to retrieve the time series entries.
         /// When set to 'Last', retrieves the last X entries, where X is determined by the 'count' parameter. <br/>
-        /// <remarks>Note that <typeparamref name="TimeSeriesRangeType"></typeparamref> cannot be 'None' when count is specified.</remarks></param>
+        /// <remarks>Note that <see cref="TimeSeriesRangeType"/> cannot be 'None' when count is specified.</remarks></param>
         /// <param name="count">The maximum number of entries to take when retrieving time series entries.</param>
         TBuilder IncludeTimeSeries(string name, TimeSeriesRangeType type, int count);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22366/XML-docs-warnings-in-IncludeBuilder

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
