### PR TITLE
RavenDB-22394: On update subscription populate PinToMentorNode from e…

### DIFF
--- a/src/Raven.Client/Documents/Commands/UpdateSubscriptionCommand.cs
+++ b/src/Raven.Client/Documents/Commands/UpdateSubscriptionCommand.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Json.Serialization;
@@ -28,7 +29,11 @@ namespace Raven.Client.Documents.Commands
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
-                Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_options, ctx)).ConfigureAwait(false), _conventions)
+                Content = new BlittableJsonContent(async stream =>
+                {
+                    await using var writer = new AsyncBlittableJsonTextWriter(ctx, stream);
+                    writer.WriteSubscriptionUpdateOptions(_options);
+                }, _conventions)
             };
             return request;
         }

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionCriteria.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionCriteria.cs
@@ -22,7 +22,7 @@ namespace Raven.Client.Documents.Subscriptions
         public string ChangeVector { get; set; }
         public string MentorNode { get; set; }
         public bool Disabled { get; set; }
-        public bool PinToMentorNode { get; set; }
+        public virtual bool PinToMentorNode { get; set; }
         public ArchivedDataProcessingBehavior? ArchivedDataProcessingBehavior { get; set; }
     }
 
@@ -54,10 +54,24 @@ namespace Raven.Client.Documents.Subscriptions
         }
     }
 
-    public sealed class SubscriptionUpdateOptions : SubscriptionCreationOptions
+    public class SubscriptionUpdateOptions : SubscriptionCreationOptions
     {
         public long? Id { get; set; }
         public bool CreateNew { get; set; }
+
+        private bool _pinToMentorNode;
+
+        public override bool PinToMentorNode
+        {
+            get => _pinToMentorNode;
+            set
+            {
+                _pinToMentorNode = value;
+                PinToMentorNodeWasSet = true;
+            }
+        }
+
+        internal bool PinToMentorNodeWasSet { get; set; }
     }
 
     public sealed class Revision<T> where T : class

--- a/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Subscriptions;
 using Sparrow.Json;
 
 namespace Raven.Client.Extensions
@@ -54,6 +55,49 @@ namespace Raven.Client.Extensions
                 writer.WritePropertyName(nameof(query.ProjectionBehavior));
                 writer.WriteString(query.ProjectionBehavior.ToString());
             }
+
+            writer.WriteEndObject();
+        }
+
+        public static void WriteSubscriptionUpdateOptions(this AbstractBlittableJsonTextWriter writer, SubscriptionUpdateOptions options)
+        {
+            writer.WriteStartObject();
+
+            if (options.Id.HasValue)
+            {
+                writer.WritePropertyName(nameof(options.Id));
+                writer.WriteInteger(options.Id.Value);
+                writer.WriteComma();
+            }
+
+            if (options.PinToMentorNodeWasSet)
+            {
+                writer.WritePropertyName(nameof(options.PinToMentorNode));
+                writer.WriteBool(options.PinToMentorNode);
+                writer.WriteComma();
+            }
+
+            writer.WritePropertyName(nameof(options.CreateNew));
+            writer.WriteBool(options.CreateNew);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(options.Name));
+            writer.WriteString(options.Name);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(options.Query));
+            writer.WriteString(options.Query);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(options.ChangeVector));
+            writer.WriteString(options.ChangeVector);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(options.MentorNode));
+            writer.WriteString(options.MentorNode);
+            writer.WriteComma();
+            writer.WritePropertyName(nameof(options.Disabled));
+            writer.WriteBool(options.Disabled);
 
             writer.WriteEndObject();
         }

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForGetSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForGetSubscription.cs
@@ -66,6 +66,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
                 [nameof(SubscriptionState.Disabled)] = state.Disabled,
                 [nameof(SubscriptionState.LastClientConnectionTime)] = state.LastClientConnectionTime,
                 [nameof(SubscriptionState.LastBatchAckTime)] = state.LastBatchAckTime,
+                [nameof(SubscriptionState.MentorNode)] = state.MentorNode,
+                [nameof(SubscriptionState.PinToMentorNode)] = state.PinToMentorNode,
                 [nameof(SubscriptionState.ArchivedDataProcessingBehavior)] = state.ArchivedDataProcessingBehavior
             };
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForPostSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForPostSubscription.cs
@@ -36,6 +36,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
             using (context.OpenReadTransaction())
             {
                 var json = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), null);
+                bool pinToMentorNodeWasSet = json.TryGet(nameof(SubscriptionUpdateOptions.PinToMentorNode), out bool pinToMentorNode);
                 var options = JsonDeserializationServer.SubscriptionUpdateOptions(json);
                 var id = options.Id;
 
@@ -99,6 +100,9 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
                 options.MentorNode ??= state.MentorNode;
                 options.Query ??= state.Query;
                 options.ArchivedDataProcessingBehavior = state.ArchivedDataProcessingBehavior;
+
+                if (pinToMentorNodeWasSet == false)
+                    options.PinToMentorNode = state.PinToMentorNode;
 
                 if (SubscriptionsHandler.SubscriptionHasChanges(options, state) == false)
                 {

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedSubscriptionsHandler.cs
@@ -47,6 +47,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 InitialChangeVector = changeVectorValidationResult.InitialChangeVector,
                 SubscriptionName = options.Name,
                 SubscriptionId = id,
+                PinToMentorNode = options.PinToMentorNode,
                 Disabled = disabled ?? false
             });
 

--- a/src/Raven.Server/ServerWide/Commands/Sharding/PutShardedSubscriptionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/PutShardedSubscriptionCommand.cs
@@ -88,6 +88,7 @@ public sealed class PutShardedSubscriptionCommand : PutSubscriptionCommand
             LastBatchAckTime = null,
             Disabled = Disabled,
             MentorNode = MentorNode,
+            PinToMentorNode = PinToMentorNode,
             LastClientConnectionTime = null,
             ShardingState = new SubscriptionShardingState
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22394/On-update-subscription-populate-PinToMentorNode-from-existing-state-if-needed

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented? added 
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
