### PR TITLE
RavenDB-22416 - Make StringCompilationAllowed configurable

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -268,6 +268,12 @@ namespace Raven.Server.Config.Categories
         [IndexUpdateType(IndexUpdateType.Reset)]
         [ConfigurationEntry("Indexing.MaxStepsForScript", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public int MaxStepsForScript { get; set; }
+        
+        [Description("Enables calling 'eval' with custom code and function constructors taking function code as string")]
+        [DefaultValue(false)]
+        [IndexUpdateType(IndexUpdateType.Reset)]
+        [ConfigurationEntry("Indexing.AllowStringCompilation", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public bool AllowStringCompilation { get; set; }
 
         [Description("Time (in minutes) between auto-index cleanup")]
         [DefaultValue(10)]

--- a/src/Raven.Server/Config/Categories/PatchingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/PatchingConfiguration.cs
@@ -10,9 +10,15 @@ namespace Raven.Server.Config.Categories
         /// The maximum number of steps iterations to give a script before timing out.
         /// Default: 10000
         /// </summary>
+        [Description("Max number of steps in the script execution of a JavaScript patch")]
         [DefaultValue(10_000)]
         [ConfigurationEntry("Patching.MaxStepsForScript", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public int MaxStepsForScript { get; set; }
+
+        [Description("Enables calling 'eval' with custom code and function constructors taking function code as string")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Patching.AllowStringCompilation", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public bool AllowStringCompilation { get; set; }
 
         [Description("Enables Strict Mode in JavaScript engine. Default: true")]
         [DefaultValue(true)]

--- a/src/Raven.Server/Config/Categories/PatchingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/PatchingConfiguration.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Config.Categories
 
         [Description("Enables calling 'eval' with custom code and function constructors taking function code as string")]
         [DefaultValue(false)]
-        [ConfigurationEntry("Patching.AllowStringCompilation", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        [ConfigurationEntry("Patching.AllowStringCompilation", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public bool AllowStringCompilation { get; set; }
 
         [Description("Enables Strict Mode in JavaScript engine. Default: true")]

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -230,7 +230,7 @@ function map(name, lambda) {
                     .AddObjectConverter(new JintDateTimeConverter())
                     .AddObjectConverter(new JintTimeSpanConverter())
                     .LocalTimeZone(TimeZoneInfo.Utc)
-                    .StringCompilationAllowed = false;
+                    .StringCompilationAllowed = indexConfiguration.AllowStringCompilation;
             });
 
             using (_engine.DisableMaxStatements())

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptMapOperation.cs
@@ -55,8 +55,14 @@ namespace Raven.Server.Documents.Indexes.Static
                         }
                         catch (StatementsCountOverflowException e)
                         {
-                            throw new Raven.Client.Exceptions.Documents.Patching.JavaScriptException(
-                                $"The maximum number of statements executed has been reached. You can configure it by modifying the configuration option: '{RavenConfiguration.GetKey(x => x.Indexing.MaxStepsForScript)}'.", e);
+                            throw new Client.Exceptions.Documents.Patching.JavaScriptException(
+                                $"The maximum number of statements executed has been reached. You can configure it by modifying the configuration option: '{RavenConfiguration.GetKey(x => x.Indexing.MaxStepsForScript)}'.",
+                                e);
+                        }
+                        catch (JavaScriptException jse) when (jse.Message.Contains("String compilation has been disabled in engine options"))
+                        {
+                            throw new Client.Exceptions.Documents.Patching.JavaScriptException(
+                                $"String compilation has been disabled in engine options. You can configure it by modifying the configuration option: '{RavenConfiguration.GetKey(x => x.Indexing.AllowStringCompilation)}'.", jse);;
                         }
                         catch (JavaScriptException jse)
                         {

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -3,6 +3,7 @@ import jsonUtil = require("common/jsonUtil");
 
 class configurationItem {
     static readonly PerDatabaseIndexingConfigurationOptions: Array<string> = [
+        "Indexing.AllowStringCompilation",
         "Indexing.Analyzers.Default",
         "Indexing.Analyzers.Exact.Default",
         "Indexing.Analyzers.Lucene.NGram.MaxGram",

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -45,6 +45,7 @@ namespace FastTests.Issues
                  * See for details: RavenDB-16590
                  * 
                  */
+                "Indexing.AllowStringCompilation",
                 "Indexing.Analyzers.Default",
                 "Indexing.Analyzers.Exact.Default",
                 "Indexing.Lucene.Analyzers.NGram.MaxGram",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22416/Make-StringCompilationAllowed-configurable

### Additional description

We've set `StringCompilationAllowed` to `false` by default.
Making this configurable.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
