### PR TITLE
RavenDB-22423 Lucene - rollback indexing for document where exception happened during indexing/mapping.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -135,58 +135,68 @@ namespace Raven.Server.Documents.Indexes
 
         private int UpdateIndexEntriesLucene(IndexItem indexItem, IEnumerable mapResults, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
-            var numberOfOutputs = 0;
-            var first = true;
-
-            foreach (var mapResult in mapResults)
+            bool shouldRollbackCurrentDocument = true;
+            try
             {
-                if (first)
+                var numberOfOutputs = 0;
+                var first = true;
+
+                foreach (var mapResult in mapResults)
                 {
-                    if (indexItem.KnownToBeNew)
+                    if (first)
                     {
-                        // we skip deleting from lucene for the initial indexing run.
-                        // we already know that the ids that we get here are unique,
-                        // so we can directly add the id to the current filter without checking if it was already added.
-                        using (_stats.BloomStats.Start())
-                            _filters.DirectAdd(indexItem.LowerId);
-                    }
-                    else
-                    {
-                        // this isn't the initial indexing run.
-                        // if we already indexed that document in the past, we must delete it from the index before we index it again.
-                        bool mustDelete;
-                        using (_stats.BloomStats.Start())
+                        if (indexItem.KnownToBeNew)
                         {
-                            mustDelete = _filters.Add(indexItem.LowerId) == false;
+                            // we skip deleting from lucene for the initial indexing run.
+                            // we already know that the ids that we get here are unique,
+                            // so we can directly add the id to the current filter without checking if it was already added.
+                            using (_stats.BloomStats.Start())
+                                _filters.DirectAdd(indexItem.LowerId);
+                        }
+                        else
+                        {
+                            // this isn't the initial indexing run.
+                            // if we already indexed that document in the past, we must delete it from the index before we index it again.
+                            bool mustDelete;
+                            using (_stats.BloomStats.Start())
+                            {
+                                mustDelete = _filters.Add(indexItem.LowerId) == false;
+                            }
+
+                            if (mustDelete)
+                                writer.Value.Delete(indexItem.LowerId, stats);
                         }
 
-                        if (mustDelete)
-                            writer.Value.Delete(indexItem.LowerId, stats);
+                        first = false;
                     }
 
-                    first = false;
+                    writer.Value.IndexDocument(indexItem.LowerId, indexItem.LowerSourceDocumentId, mapResult, stats, indexContext);
+
+                    numberOfOutputs++;
                 }
 
-                writer.Value.IndexDocument(indexItem.LowerId, indexItem.LowerSourceDocumentId, mapResult, stats, indexContext);
-
-                numberOfOutputs++;
-            }
-
-            if (indexItem.KnownToBeNew == false && numberOfOutputs == 0)
-            {
-                // this isn't the first indexing run and we didn't have any outputs for this document.
-                // however, if the document was already indexed in the past and now it isn't, we must delete it from the index.
-                bool mustDelete;
-                using (_stats.BloomStats.Start())
+                if (indexItem.KnownToBeNew == false && numberOfOutputs == 0)
                 {
-                    mustDelete = _filters.Contains(indexItem.LowerId);
+                    // this isn't the first indexing run and we didn't have any outputs for this document.
+                    // however, if the document was already indexed in the past and now it isn't, we must delete it from the index.
+                    bool mustDelete;
+                    using (_stats.BloomStats.Start())
+                    {
+                        mustDelete = _filters.Contains(indexItem.LowerId);
+                    }
+
+                    if (mustDelete)
+                        writer.Value.Delete(indexItem.LowerId, stats);
                 }
 
-                if (mustDelete)
+                shouldRollbackCurrentDocument = false;
+                return numberOfOutputs;
+            }
+            finally
+            {
+                if (shouldRollbackCurrentDocument)
                     writer.Value.Delete(indexItem.LowerId, stats);
             }
-
-            return numberOfOutputs;
         }
 
         public override IQueryResultRetriever<QueriedDocument> GetQueryResultRetriever(IndexQueryServerSide query, QueryTimingsScope queryTimings, DocumentsOperationContext documentsContext, SearchEngineType searchEngineType, FieldsToFetch fieldsToFetch, IncludeDocumentsCommand includeDocumentsCommand, IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, IncludeRevisionsCommand includeRevisionsCommand)

--- a/test/SlowTests/Issues/RavenDB_22406.cs
+++ b/test/SlowTests/Issues/RavenDB_22406.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22406 : RavenTestBase
+{
+    public RavenDB_22406(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void CanIndexProperlyWithOneInvalidDocument(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Store(new FanoutDto(){Inners = new []{new Inner(false, 1), new Inner(false, 2)}});
+        session.Store(new FanoutDto(){Inners = new []{new Inner(false, 3), new Inner(false, 4), new Inner(true, 5)}});
+        session.Store(new FanoutDto(){Inners = new []{new Inner(false, 6), new Inner(false, 7)}});
+        new Index().Execute(store);
+        session.Advanced.WaitForIndexesAfterSaveChanges();
+        session.SaveChanges();
+        
+        var count = session.Query<FanoutDto, Index>().Count();
+        Assert.Equal(4, count); //doc1 and doc3 only
+        var terms = store
+            .Maintenance
+            .Send(new GetTermsOperation(new Index().IndexName, "id()", null, int.MaxValue));
+        
+        Assert.Equal(2, terms.Length);
+    }
+
+    private class FanoutDto
+    {
+        public Inner[] Inners { get; set; }
+    }
+
+    private record Inner(bool Throw, decimal Value);
+    
+    private class Index : AbstractIndexCreationTask<FanoutDto>
+    {
+        public Index()
+        {
+            Map = dtos => from dto in dtos
+                from inner in dto.Inners
+                select new
+                {
+                    Alphabet = inner.Value.ToString(),
+                    Value = inner.Throw ? inner.Value / 0 : inner.Value
+                };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22423

### Additional description

In case when we've error during mapping document in fanout manner we should not index partial results and we should be consistent about it:

- Index all fanout results for document or none.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
