### PR TITLE
RavenDB-22369 During the index entry building phase, also check if the field has the `Search` option.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -156,7 +156,7 @@ public partial class IndexWriter
             term.Addition(_parent._entriesAllocator, _entryId, _termPerEntryIndex, freq: 1);
 
             // Creates a mapping for PhraseQuery
-            if (field.SupportedFeatures.PhraseQuery)
+            if (field.FieldSupportsPhraseQuery)
             {
                 // We're aligning our EntryToTerms list to have exactly _termPerEntryIndex items.
                 // For most use cases, we will append only one element for each document, but we may be in a situation when the difference between sizes is bigger than 1.

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -1143,7 +1143,7 @@ namespace Corax.Indexing
                 _pagesToPrefetch = new ContextBoundNativeList<long>(_writer._entriesAllocator);
                 _buffers = _writer._textualFieldBuffers ??= new TextualFieldBuffers(_writer);
 
-                if (_writer.FieldSupportsPhraseQuery(indexedField))
+                if (indexedField.FieldSupportsPhraseQuery)
                 {
                     // For most cases, _indexField.Storage.Count is equal to _indexedField.Textual.Count().
                     // However, in cases where the field has mixed values (string/numerics), it differs. Therefore, we need to ensure that we have enough space to create the mapping.
@@ -1313,7 +1313,7 @@ namespace Corax.Indexing
                 RecordTermsForEntries(_entriesForTerm, entries, termContainerId);
     
                 //Update mapping virtual<=> storage location location. Final writing will be done after inserting ALL terms for specific field.
-                if (_writer.FieldSupportsPhraseQuery(_indexedField))
+                if (_indexedField.FieldSupportsPhraseQuery)
                 {
                     Debug.Assert(_virtualTermIdToTermContainerId[storageLocation] == Constants.IndexedField.Invalid, "virtualMapping[entries.StorageLocation] == Constants.IndexedField.Invalid, Term was already set! Persisted: {_virtualTermIdToTermContainerId[storageLocation]}, new: {termContainerId}");
                     _virtualTermIdToTermContainerId[storageLocation] = termContainerId;
@@ -1331,7 +1331,7 @@ namespace Corax.Indexing
             
             void ProcessTermsVector()
             {
-                if (_writer.FieldSupportsPhraseQuery(_indexedField) == false)
+                if (_indexedField.FieldSupportsPhraseQuery == false)
                     return;
 
                 const StoredFieldType storedFieldType = (StoredFieldType.List | StoredFieldType.Term);
@@ -2058,8 +2058,6 @@ namespace Corax.Indexing
                 _tokensBufferHandler = Analyzer.TokensPool.Rent(newTokenSize);
             }
         }
-
-        private bool FieldSupportsPhraseQuery(in IndexedField field) => _supportedFeatures.PhraseQuery && field.FieldIndexingMode is FieldIndexingMode.Search;
         
         public void Dispose()
         {

--- a/src/Corax/Indexing/IndexedField.cs
+++ b/src/Corax/Indexing/IndexedField.cs
@@ -41,6 +41,7 @@ internal sealed class IndexedField
     public bool HasMultipleTermsPerField;
     public long FieldRootPage;
     public long TermsVectorFieldRootPage;
+    public bool FieldSupportsPhraseQuery => SupportedFeatures.PhraseQuery && FieldIndexingMode is FieldIndexingMode.Search;
 
     public override string ToString()
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22369

### Additional description

Additional unnecessary work was done due to an incomplete condition during entry building.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
