### PR TITLE
RavenDB-22428 Test fix : extensive memory testing is done only on X64 platforms.

### DIFF
--- a/test/SlowTests/Corax/GrowableBufferTests.cs
+++ b/test/SlowTests/Corax/GrowableBufferTests.cs
@@ -14,10 +14,17 @@ public class GrowableBufferTests : NoDisposalNoOutputNeeded
     {
     }
 
-    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenArchitecture.All)]
     [InlineData(4 * Sparrow.Global.Constants.Size.Megabyte)]
+    [InlineData(8 * Sparrow.Global.Constants.Size.Megabyte)]
+    public void CanExtendAndNotLooseAnything(int size) => CanExtendAndNotLooseAnythingBase(size);
+    
+    [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     [InlineData(16 * Sparrow.Global.Constants.Size.Megabyte)]
-    public void CanExtendAndNotLooseAnything(int size)
+    [InlineData(32 * Sparrow.Global.Constants.Size.Megabyte)]
+    public void CanExtendAndNotLooseAnythingExtended(int size) => CanExtendAndNotLooseAnythingBase(size);
+    
+    private void CanExtendAndNotLooseAnythingBase(int size)
     {
         using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
         using var growableBuffer = new GrowableBuffer<Progressive>();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22428

### Additional description


### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
