### PR TITLE
RavenDB-21833 ONLY FOR TESTING -More info to find the problem at bulkInsertWithDelay

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -190,6 +190,7 @@ namespace Raven.Client.Documents.BulkInsert
                     {
                         await _streamLock.WaitAsync().ConfigureAwait(false);
                         await _writer.DisposeAsync().ConfigureAwait(false);
+                        Console.WriteLine($"{SystemTime.UtcNow}:{SystemTime.UtcNow.Millisecond}- {_database} - AfterDispose");
                     }
                     catch (Exception e)
                     {
@@ -258,14 +259,13 @@ namespace Raven.Client.Documents.BulkInsert
 
                 if (_first == false)
                 {
-
                     WriteComma();
                 }
 
                 _first = false;
                 _inProgressCommand = CommandType.None;
                 _writer.Write("{\"Type\":\"HeartBeat\"}");
-
+                Console.WriteLine($"{SystemTime.UtcNow}:{SystemTime.UtcNow.Millisecond}- {_database} - HeartBeat");
                 
                 await FlushIfNeeded(force: true).ConfigureAwait(false);
                 await _writer._requestBodyStream.FlushAsync(_token).ConfigureAwait(false);
@@ -277,6 +277,7 @@ namespace Raven.Client.Documents.BulkInsert
             finally
             {
                 _streamLock.Release();
+                Console.WriteLine($"{SystemTime.UtcNow}:{SystemTime.UtcNow.Millisecond} - {_database} - _streamLock.Release");
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -166,8 +166,13 @@ namespace Raven.Server.Documents.Handlers.Batches
 
             while (true)
             {
+                if (token.IsCancellationRequested)
+                    throw new OperationCanceledException("The token was canceled at ReadSingleCommand - true");
                 while (parser.Read() == false)
                     await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+
+                if (token.IsCancellationRequested)
+                    throw new OperationCanceledException("The token was canceled at ReadSingleCommand");
 
                 if (state.CurrentTokenType == JsonParserToken.EndObject)
                 {
@@ -184,6 +189,10 @@ namespace Raven.Server.Documents.Handlers.Batches
                     case CommandPropertyName.Type:
                         while (parser.Read() == false)
                             await RefillParserBuffer(stream, buffer, parser, token).ConfigureAwait(false);
+
+                        if (token.IsCancellationRequested)
+                            throw new OperationCanceledException("The token was canceled at CommandPropertyName.Type");
+
                         if (state.CurrentTokenType != JsonParserToken.String)
                         {
                             ThrowUnexpectedToken(JsonParserToken.String, state);

--- a/src/Raven.Server/Documents/Handlers/BulkInsert/AbstractBulkInsertBatchCommandsReader.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsert/AbstractBulkInsertBatchCommandsReader.cs
@@ -36,7 +36,8 @@ public abstract class AbstractBulkInsertBatchCommandsReader<TCommandData> : IDis
     {
         while (_parser.Read() == false)
             await BatchRequestParser.RefillParserBuffer(_stream, _buffer, _parser, _token);
-
+        if (_token.IsCancellationRequested)
+            throw new OperationCanceledException("The token was canceled at InitAsync");
         if (_state.CurrentTokenType != JsonParserToken.StartArray)
         {
             BatchRequestParser.ThrowUnexpectedToken(JsonParserToken.StartArray, _state);
@@ -62,6 +63,8 @@ public abstract class AbstractBulkInsertBatchCommandsReader<TCommandData> : IDis
         do
         {
             await BatchRequestParser.RefillParserBuffer(_stream, _buffer, _parser, _token);
+            if (_token.IsCancellationRequested)
+                throw new OperationCanceledException("The token was canceled at MoveNextUnlikely");
         } while (_parser.Read() == false);
 
         if (_state.CurrentTokenType == JsonParserToken.EndArray)

--- a/test/SlowTests/Issues/RavenDB-17745.cs
+++ b/test/SlowTests/Issues/RavenDB-17745.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.BulkInsert;
+using Raven.Client.Util;
 using SlowTests.Core.Utils.Entities;
 using Sparrow.Server;
 using Tests.Infrastructure;
@@ -41,6 +42,210 @@ namespace SlowTests.Issues
                     await Task.Delay(_delay);
                     await bulk.StoreAsync(new User { Name = "Ido" }, "users/3");
                     await Task.Delay(_delay);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("Daniel", user.Name);
+
+                    user = session.Load<User>("users/2");
+                    Assert.NotNull(user);
+                    Assert.Equal("Yael", user.Name);
+
+                    user = session.Load<User>("users/3");
+                    Assert.NotNull(user);
+                    Assert.Equal("Ido", user.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BulkInsert)]
+        public async Task BulkInsertWithDelay2()
+        {
+            DoNotReuseServer();
+            var delay = TimeSpan.FromMilliseconds(1200);
+            using (var store = GetDocumentStore())
+            {
+                var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                db.ForTestingPurposesOnly().BulkInsertStreamReadTimeout = _readTimeout;
+                var bulkInsertOptions = new BulkInsertOptions();
+                bulkInsertOptions.ForTestingPurposesOnly().OverrideHeartbeatCheckInterval = _readTimeout;
+
+                await using (var bulk = store.BulkInsert(bulkInsertOptions))
+                {
+                    await Task.Delay(delay);
+                    await bulk.StoreAsync(new User { Name = "Daniel" }, "users/1");
+                    await bulk.StoreAsync(new User { Name = "Yael" }, "users/2");
+
+                    await Task.Delay(delay);
+                    await bulk.StoreAsync(new User { Name = "Ido" }, "users/3");
+                    await Task.Delay(delay);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("Daniel", user.Name);
+
+                    user = session.Load<User>("users/2");
+                    Assert.NotNull(user);
+                    Assert.Equal("Yael", user.Name);
+
+                    user = session.Load<User>("users/3");
+                    Assert.NotNull(user);
+                    Assert.Equal("Ido", user.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BulkInsert)]
+        public async Task BulkInsertWithDelay200()
+        {
+            DoNotReuseServer();
+            var delay = TimeSpan.FromMilliseconds(400);
+            using (var store = GetDocumentStore())
+            {
+                var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                db.ForTestingPurposesOnly().BulkInsertStreamReadTimeout = 200;
+                var bulkInsertOptions = new BulkInsertOptions();
+                bulkInsertOptions.ForTestingPurposesOnly().OverrideHeartbeatCheckInterval = 200;
+
+                await using (var bulk = store.BulkInsert(bulkInsertOptions))
+                {
+                    await Task.Delay(delay);
+                    await bulk.StoreAsync(new User { Name = "Daniel" }, "users/1");
+                    await bulk.StoreAsync(new User { Name = "Yael" }, "users/2");
+
+                    await Task.Delay(delay);
+                    await bulk.StoreAsync(new User { Name = "Ido" }, "users/3");
+                    Console.WriteLine($"{SystemTime.UtcNow}:{SystemTime.UtcNow.Millisecond}- {db.Name} - After users/3");
+                    await Task.Delay(delay);
+                    Console.WriteLine($"{SystemTime.UtcNow}:{SystemTime.UtcNow.Millisecond}- {db.Name} - before dispose");
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("Daniel", user.Name);
+
+                    user = session.Load<User>("users/2");
+                    Assert.NotNull(user);
+                    Assert.Equal("Yael", user.Name);
+
+                    user = session.Load<User>("users/3");
+                    Assert.NotNull(user);
+                    Assert.Equal("Ido", user.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BulkInsert)]
+        public async Task BulkInsertWithDelay_2()
+        {
+            DoNotReuseServer();
+
+            using (var store = GetDocumentStore())
+            {
+                var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                db.ForTestingPurposesOnly().BulkInsertStreamReadTimeout = _readTimeout;
+                var bulkInsertOptions = new BulkInsertOptions();
+                bulkInsertOptions.ForTestingPurposesOnly().OverrideHeartbeatCheckInterval = _readTimeout;
+
+                await using (var bulk = store.BulkInsert(bulkInsertOptions))
+                {
+                    await Task.Delay(_delay);
+                    await bulk.StoreAsync(new User { Name = "Daniel" }, "users/1");
+                    await bulk.StoreAsync(new User { Name = "Yael" }, "users/2");
+
+                    await Task.Delay(_delay);
+                    await bulk.StoreAsync(new User { Name = "Ido" }, "users/3");
+                    await Task.Delay(_delay);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("Daniel", user.Name);
+
+                    user = session.Load<User>("users/2");
+                    Assert.NotNull(user);
+                    Assert.Equal("Yael", user.Name);
+
+                    user = session.Load<User>("users/3");
+                    Assert.NotNull(user);
+                    Assert.Equal("Ido", user.Name);
+                }
+            }
+        }
+        
+        [RavenFact(RavenTestCategory.BulkInsert)]
+        public async Task BulkInsertWithDelay200_2()
+        {
+            DoNotReuseServer();
+            var delay = TimeSpan.FromMilliseconds(400);
+            using (var store = GetDocumentStore())
+            {
+                var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                db.ForTestingPurposesOnly().BulkInsertStreamReadTimeout = 200;
+                var bulkInsertOptions = new BulkInsertOptions();
+                bulkInsertOptions.ForTestingPurposesOnly().OverrideHeartbeatCheckInterval = 200;
+
+                await using (var bulk = store.BulkInsert(bulkInsertOptions))
+                {
+                    await Task.Delay(delay);
+                    await bulk.StoreAsync(new User { Name = "Daniel" }, "users/1");
+                    await bulk.StoreAsync(new User { Name = "Yael" }, "users/2");
+
+                    await Task.Delay(delay);
+                    await bulk.StoreAsync(new User { Name = "Ido" }, "users/3");
+                    Console.WriteLine($"{SystemTime.UtcNow}:{SystemTime.UtcNow.Millisecond}- {db.Name} - After users/3");
+                    await Task.Delay(delay);
+                    Console.WriteLine($"{SystemTime.UtcNow}:{SystemTime.UtcNow.Millisecond}- {db.Name} - before dispose");
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.NotNull(user);
+                    Assert.Equal("Daniel", user.Name);
+
+                    user = session.Load<User>("users/2");
+                    Assert.NotNull(user);
+                    Assert.Equal("Yael", user.Name);
+
+                    user = session.Load<User>("users/3");
+                    Assert.NotNull(user);
+                    Assert.Equal("Ido", user.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BulkInsert)]
+        public async Task BulkInsertWithDelay1000()
+        {
+            DoNotReuseServer();
+            var delay = TimeSpan.FromMilliseconds(2000);
+            using (var store = GetDocumentStore())
+            {
+                var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                db.ForTestingPurposesOnly().BulkInsertStreamReadTimeout = 1000;
+                var bulkInsertOptions = new BulkInsertOptions();
+                bulkInsertOptions.ForTestingPurposesOnly().OverrideHeartbeatCheckInterval = 1000;
+
+                await using (var bulk = store.BulkInsert(bulkInsertOptions))
+                {
+                    await Task.Delay(delay);
+                    await bulk.StoreAsync(new User { Name = "Daniel" }, "users/1");
+                    await bulk.StoreAsync(new User { Name = "Yael" }, "users/2");
+
+                    await Task.Delay(delay);
+                    await bulk.StoreAsync(new User { Name = "Ido" }, "users/3");
+                    await Task.Delay(delay);
                 }
 
                 using (var session = store.OpenSession())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-...

### Additional description

ONLY FOR TESTING

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
