### PR TITLE
RavenDB-22431 ensure that result order of cluster wide tx in sharded database

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractBatchHandlerProcessorForBulkDocs.cs
@@ -98,8 +98,7 @@ internal abstract class AbstractBatchHandlerProcessorForBulkDocs<TBatchCommand, 
                 if (command.IsClusterTransaction)
                 {
                     var processor = GetClusterTransactionRequestProcessor();
-                    (long index, DynamicJsonArray clusterResults) = await processor.ProcessAsync(context, command, token.Token)
-                                                                                   .ConfigureAwait(false);
+                    var result = await processor.ProcessAsync(context, command, token.Token).ConfigureAwait(false);
 
                     RequestHandler.HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
 
@@ -107,8 +106,8 @@ internal abstract class AbstractBatchHandlerProcessorForBulkDocs<TBatchCommand, 
                     {
                         context.Write(writer, new DynamicJsonValue
                         {
-                            [nameof(BatchCommandResult.Results)] = clusterResults,
-                            [nameof(BatchCommandResult.TransactionIndex)] = index
+                            [nameof(BatchCommandResult.Results)] = result.Results,
+                            [nameof(BatchCommandResult.TransactionIndex)] = result.Index
                         });
                     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22431

### Additional description

The save changes of the session expect the returned results to be in the _exact_ same order as they were sent.
This was not the case for cluster wide transaction, where the results were returned in a per shard order

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
This is affecting only cluster wide tx for sharded database, we do not change the layout on the disk, nor the protocol over the wire, we change just the order of elements in the returned result.

- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
