### PR TITLE
RavenDB-22150 align delta with rest of the API in CounterOperation

### DIFF
--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
@@ -18,7 +18,7 @@ namespace Raven.Client.Documents.Operations.Counters
     {
         public List<CounterOperation> Operations;
         public string DocumentId;
-        
+
         public static DocumentCountersOperation Parse(BlittableJsonReaderObject input)
         {
             if (input.TryGet(nameof(DocumentId), out string docId) == false || docId == null)
@@ -86,7 +86,7 @@ namespace Raven.Client.Documents.Operations.Counters
     {
         public CounterOperationType Type;
         public string CounterName;
-        public long Delta;
+        public long Delta = 1;
 
         internal string ChangeVector;
         internal string DocumentId;

--- a/test/SlowTests/Issues/RavenDB_22150.cs
+++ b/test/SlowTests/Issues/RavenDB_22150.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using FastTests;
+using Raven.Client.Documents.Operations.Counters;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22150 : RavenTestBase
+{
+    public RavenDB_22150(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Counters | RavenTestCategory.ClientApi)]
+    public void IncrementByDefaultValue()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User { Name = "Danielle" }, "users/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var documentCounters = session.CountersFor("users/1");
+                documentCounters.Increment("Likes", 10);
+                documentCounters.Increment("Dislikes", 20);
+                documentCounters.Increment("Downloads", 30);
+                session.SaveChanges();
+            }
+
+            var operationResult = store.Operations.Send(new CounterBatchOperation(new CounterBatch
+            {
+                Documents = new List<DocumentCountersOperation>
+                    {
+                        new DocumentCountersOperation
+                        {
+                            DocumentId = "users/1",
+                            Operations = new List<CounterOperation>
+                            {
+                                new CounterOperation
+                                {
+                                    // Increment by 5
+                                    Type = CounterOperationType.Increment,
+                                    CounterName = "likes",
+                                    Delta = 5
+                                },
+                                new CounterOperation
+                                {
+                                    // Should increment by 1 (default value)
+                                    Type = CounterOperationType.Increment,
+                                    CounterName = "dislikes"
+                                }
+                            }
+                        }
+                    }
+            }));
+
+            // This fails, value doesn't increment, stays 20 
+            Assert.Equal(21, operationResult.Counters[1].TotalValue);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22150

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
