### PR TITLE
RavenDB-21859 both Load and LazyLoad should return null when id is null

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Lazy.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Lazy.cs
@@ -212,6 +212,9 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         public Lazy<Task<T>> LoadAsync<T>(string id, Action<T> onEval, CancellationToken token = new CancellationToken())
         {
+            if (string.IsNullOrWhiteSpace(id))
+                return new Lazy<Task<T>>(() => Task.FromResult<T>(default));
+
             if (IsLoaded(id))
                 return new Lazy<Task<T>>(() => LoadAsync<T>(id, token));
 

--- a/src/Raven.Client/Documents/Session/DocumentSession.Lazy.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.Lazy.cs
@@ -63,6 +63,9 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         Lazy<T> ILazySessionOperations.Load<T>(string id, Action<T> onEval)
         {
+            if (string.IsNullOrWhiteSpace(id))
+                return new Lazy<T>(() => default);
+
             if (IsLoaded(id))
                 return new Lazy<T>(() => Load<T>(id));
             var lazyLoadOperation = new LazyLoadOperation<T>(this, new LoadOperation(this).ById(id)).ById(id);

--- a/test/SlowTests/Issues/RavenDB_21859.cs
+++ b/test/SlowTests/Issues/RavenDB_21859.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21859 : RavenTestBase
+{
+    public RavenDB_21859(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task Load_And_Lazy_Load_Should_Return_Null_When_Id_Is_Null()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                Assert.Null(session.Load<object>((string)null));
+
+                Assert.Null(session.Advanced.Lazily.Load<object>((string)null).Value);
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                Assert.Null(await session.LoadAsync<object>((string)null));
+
+                Assert.Null(await session.Advanced.Lazily.LoadAsync<object>((string)null).Value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21859

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
