### PR TITLE
RavenDB-22438 Connection string dialog is closed when we get any changes api update

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
@@ -24,7 +24,7 @@ export default function ConnectionStrings(props: ConnectionStringsUrlParameters)
     const { name: nameFromUrl, type: typeFromUrl } = props;
 
     const { hasNone: hasNoneInLicense } = useConnectionStringsLicense();
-    const db = useAppSelector(databaseSelectors.activeDatabase);
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
 
     const dispatch = useAppDispatch();
@@ -36,12 +36,12 @@ export default function ConnectionStrings(props: ConnectionStringsUrlParameters)
                 type: typeFromUrl,
             })
         );
-        dispatch(connectionStringsActions.fetchData(db));
+        dispatch(connectionStringsActions.fetchData(databaseName));
 
         return () => {
             dispatch(connectionStringsActions.reset());
         };
-    }, [db, dispatch, nameFromUrl, typeFromUrl]);
+    }, [databaseName, dispatch, nameFromUrl, typeFromUrl]);
 
     const loadStatus = useAppSelector(connectionStringSelectors.loadStatus);
     const connections = useAppSelector(connectionStringSelectors.connections);
@@ -52,7 +52,7 @@ export default function ConnectionStrings(props: ConnectionStringsUrlParameters)
         return (
             <LoadError
                 error="Unable to load connection strings"
-                refresh={() => dispatch(connectionStringsActions.fetchData(db))}
+                refresh={() => dispatch(connectionStringsActions.fetchData(databaseName))}
             />
         );
     }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
@@ -13,8 +13,8 @@ import {
     mapSqlConnectionsFromDto,
 } from "./connectionStringsMapsFromDto";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
-import { DatabaseSharedInfo } from "components/models/databases";
 import DatabaseUtils from "components/utils/DatabaseUtils";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 
 interface ConnectionStringsState {
     loadStatus: loadStatus;
@@ -136,15 +136,17 @@ interface FetchDataResult {
 
 const fetchData = createAsyncThunk<
     FetchDataResult,
-    DatabaseSharedInfo,
+    string,
     {
         state: RootState;
     }
->(connectionStringsSlice.name + "/fetchConnectionStrings", async (db, { getState }) => {
+>(connectionStringsSlice.name + "/fetchConnectionStrings", async (databaseName, { getState }) => {
     const state = getState();
 
+    const db = databaseSelectors.databaseByName(databaseName)(state);
+
     const ongoingTasksDto = await services.tasksService.getOngoingTasks(
-        db.name,
+        databaseName,
         DatabaseUtils.getFirstLocation(db, state.cluster.localNodeTag)
     );
     const connectionStringsDto = await services.tasksService.getConnectionStrings(db.name);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22438

### Additional description

There was an active database object in the dependency array of useEffect. This resulted in data reloading whenever the object changed (for example, the number of documents changed).

Now there is the database name in the dependency array.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
