### PR TITLE
RavenDB-22264 / RavenDB-22267 / RavenDB-22272 / RavenDB-22272 More audit logs

### DIFF
--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -576,6 +576,11 @@ namespace Raven.Server.Documents.Handlers
         {
             var name = GetQueryStringValueAndAssertIfSingleAndNotEmpty("name");
 
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+            {
+                LogAuditFor(Database.Name, $"Index {name} RESET");
+            }
+
             IndexDefinition indexDefinition;
             lock (Database)
             {

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -375,7 +375,7 @@ namespace Raven.Server.Documents.Handlers
                         TrafficWatchQuery(query);
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
-                        LogAuditFor(Database.Name, $"Deleting documents matching the query: {query}");
+                        LogAuditFor(Database.Name, $"DELETE documents matching the query: {query}");
 
                     await ExecuteQueryOperation(query,
                         (runner, options, onProgress, token) => runner.ExecuteDeleteQuery(query, options, queryContext, onProgress, token),

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -26,6 +26,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 using PatchRequest = Raven.Server.Documents.Patch.PatchRequest;
 
 namespace Raven.Server.Documents.Handlers
@@ -372,6 +373,9 @@ namespace Raven.Server.Documents.Handlers
 
                     if (TrafficWatchManager.HasRegisteredClients)
                         TrafficWatchQuery(query);
+
+                    if (LoggingSource.AuditLog.IsInfoEnabled)
+                        LogAuditFor(Database.Name, $"Deleting documents matching the query: {query}");
 
                     await ExecuteQueryOperation(query,
                         (runner, options, onProgress, token) => runner.ExecuteDeleteQuery(query, options, queryContext, onProgress, token),

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Raven.Client;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.Exceptions.Documents.Indexes;
@@ -18,6 +19,7 @@ using Raven.Server.TrafficWatch;
 using Raven.Server.Utils;
 using Raven.Server.Utils.Enumerators;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Handlers.Streaming
 {
@@ -164,6 +166,10 @@ namespace Raven.Server.Documents.Handlers.Streaming
                 var ignoreLimit = GetBoolValueQueryString("ignoreLimit", required: false) ?? false;
                 var properties = GetStringValuesQueryString("field", false);
                 var propertiesArray = properties.Count == 0 ? null : properties.ToArray();
+
+                if (LoggingSource.AuditLog.IsInfoEnabled && query.Metadata.CollectionName == Constants.Documents.Collections.AllDocumentsCollection)
+                    LogAuditFor(Database.Name, $"Streaming results for all documents query: {query} (format: {format}, debug: {debug}, ignore limit: {ignoreLimit})");
+
                 // set the exported file name prefix
                 var fileNamePrefix = query.Metadata.IsCollectionQuery ? query.Metadata.CollectionName + "_collection" : "query_result";
                 fileNamePrefix = $"{Database.Name}_{fileNamePrefix}";
@@ -247,11 +253,15 @@ namespace Raven.Server.Documents.Handlers.Streaming
                     AddStringToHttpContext(sb.ToString(), TrafficWatchChangeType.Streams);
                 }
 
+
                 var format = GetStringQueryString("format", false);
                 var debug = GetStringQueryString("debug", false);
                 var ignoreLimit = GetBoolValueQueryString("ignoreLimit", required: false) ?? false;
                 var properties = GetStringValuesQueryString("field", false);
                 var propertiesArray = properties.Count == 0 ? null : properties.ToArray();
+
+                if (LoggingSource.AuditLog.IsInfoEnabled && query.Metadata.CollectionName == Constants.Documents.Collections.AllDocumentsCollection)
+                    LogAuditFor(Database.Name, $"Streaming results for all documents query: {query} (format: {format}, debug: {debug}, ignore limit: {ignoreLimit})");
 
                 // set the exported file name prefix
                 var fileNamePrefix = query.Metadata.IsCollectionQuery ? query.Metadata.CollectionName + "_collection" : "query_result";

--- a/src/Raven.Server/Integrations/PostgreSQL/Handlers/PostgreSqlIntegrationHandler.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Handlers/PostgreSqlIntegrationHandler.cs
@@ -18,6 +18,7 @@ using Raven.Server.Utils;
 using Raven.Server.Utils.Features;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 
 namespace Raven.Server.Integrations.PostgreSQL.Handlers
 {
@@ -138,6 +139,11 @@ namespace Raven.Server.Integrations.PostgreSQL.Handlers
 
                     using (Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext transactionOperationContext))
                         await DatabaseConfigurations(ServerStore.ModifyPostgreSqlConfiguration, transactionOperationContext, RaftIdGenerator.DontCareId, config);
+
+                    if (LoggingSource.AuditLog.IsInfoEnabled)
+                    {
+                        LogAuditFor(Database.Name, $"Postgres integration. User {newUser.Username} PUT");
+                    }
                 }
             }
 
@@ -192,6 +198,11 @@ namespace Raven.Server.Integrations.PostgreSQL.Handlers
 
                     using (Database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext transactionOperationContext))
                         await DatabaseConfigurations(ServerStore.ModifyPostgreSqlConfiguration, transactionOperationContext, RaftIdGenerator.DontCareId, config);
+
+                    if (LoggingSource.AuditLog.IsInfoEnabled)
+                    {
+                        LogAuditFor(Database.Name, $"Postgres integration. User {userToDelete.Username} DELETE");
+                    }
                 }
             }
 

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -44,6 +44,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
 
@@ -641,6 +642,11 @@ namespace Raven.Server.Web.System
 
             await ServerStore.EnsureNotPassiveAsync();
 
+            if (LoggingSource.AuditLog.IsInfoEnabled)
+            {
+                LogAuditFor(Database.Name, $"Connection string {connectionStringName} DELETE");
+            }
+
             var (index, _) = await ServerStore.RemoveConnectionString(Database.Name, connectionStringName, type, GetRaftRequestIdFromQuery());
             await ServerStore.Cluster.WaitForIndexNotification(index);
             HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
@@ -787,7 +793,16 @@ namespace Raven.Server.Web.System
         [RavenAction("/databases/*/admin/connection-strings", "PUT", AuthorizationStatus.DatabaseAdmin)]
         public async Task PutConnectionString()
         {
-            await DatabaseConfigurations((_, databaseName, connectionString, guid) => ServerStore.PutConnectionString(_, databaseName, connectionString, guid),
+            await DatabaseConfigurations((_, databaseName, connectionString, guid) =>
+                {
+                    if (LoggingSource.AuditLog.IsInfoEnabled)
+                    {
+                        if (connectionString.TryGet(nameof(ConnectionString.Name), out string name))
+                            LogAuditFor(Database.Name, $"Connection string {name} PUT");
+                    }
+
+                    return ServerStore.PutConnectionString(_, databaseName, connectionString, guid);
+                },
                 PutConnectionStringDebugTag, GetRaftRequestIdFromQuery(),
                 beforeSetupConfiguration: (string databaseName, ref BlittableJsonReaderObject readerObject, JsonOperationContext context) =>
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22264/Audit-log-on-specific-query-operations
https://issues.hibernatingrhinos.com/issue/RavenDB-22267/Audit-log-on-indexes-additional-sources-custom-sorters-and-analyzers
https://issues.hibernatingrhinos.com/issue/RavenDB-22272/Audit-log-on-connection-strings-operations
https://issues.hibernatingrhinos.com/issue/RavenDB-22273/Audit-log-on-changes-in-Integrations

### Additional description

Added extra logging for auditing purposes

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
