### PR TITLE
RavenDB-20981 Add support for building package for Ubuntu 24.04, update script building packages

### DIFF
--- a/scripts/linux/pkg/deb/assets/build.sh
+++ b/scripts/linux/pkg/deb/assets/build.sh
@@ -5,7 +5,7 @@ DEST_DIR=/build
 release=$(lsb_release -sr | cut -d. -f1)
 
 if [[ $release -ge 22 ]]; then
-    mv -v $ASSETS_DIR/ravendb/debian/control_$release $ASSETS_DIR/ravendb/debian/control
+    mv -v $ASSETS_DIR/ravendb/debian/control_22 $ASSETS_DIR/ravendb/debian/control
 else
     apt install dh-systemd
     mv -v $ASSETS_DIR/ravendb/debian/control_legacy $ASSETS_DIR/ravendb/debian/control
@@ -43,7 +43,7 @@ export DOTNET_RUNTIME_VERSION="$DOTNET_VERSION_MINOR"
 
 # Show dependencies for amd64 since that's the only platform Microsoft ships package for,
 # however the dependencies are the same at the moment.
-DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-deps-$DOTNET_RUNTIME_VERSION:amd64"
+DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-$DOTNET_RUNTIME_VERSION:amd64"
 DOTNET_RUNTIME_DEPS=$(apt show $DOTNET_RUNTIME_DEPS_PKG 2>/dev/null | sed -n -e 's/Depends: //p')
 if [ -z "$DOTNET_RUNTIME_DEPS" ]; then
     echo "Could not extract dependencies from $DOTNET_RUNTIME_DEPS_PKG package."

--- a/scripts/linux/pkg/deb/assets/build.sh
+++ b/scripts/linux/pkg/deb/assets/build.sh
@@ -41,14 +41,25 @@ DOTNET_VERSION_MINOR=$(egrep -o -e '^[0-9]+.[0-9]+' <<< $DOTNET_FULL_VERSION)
 export DOTNET_DEPS_VERSION="$DOTNET_FULL_VERSION"
 export DOTNET_RUNTIME_VERSION="$DOTNET_VERSION_MINOR"
 
-# Show dependencies for amd64 since that's the only platform Microsoft ships package for,
-# however the dependencies are the same at the moment.
-DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-$DOTNET_RUNTIME_VERSION:amd64"
-DOTNET_RUNTIME_DEPS=$(apt show $DOTNET_RUNTIME_DEPS_PKG 2>/dev/null | sed -n -e 's/Depends: //p')
-if [ -z "$DOTNET_RUNTIME_DEPS" ]; then
-    echo "Could not extract dependencies from $DOTNET_RUNTIME_DEPS_PKG package."
-    exit 1
+if [[ $release -eq 24 && $RAVEN_PLATFORM == "raspberry-pi" ]]; then
+    DOTNET_RUNTIME_DEPS="libicu74, libc6 (>= 2.38), libgcc-s1 (>= 3.0), liblttng-ust1t64 (>= 2.13.0), libssl3t64 (>= 3.0.0), libstdc++6 (>= 13.1), zlib1g (>= 1:1.1.4)"
+else
+    if [[ $release -ge 24 ]]; then
+        DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-$DOTNET_RUNTIME_VERSION"
+    else
+        # Show dependencies for amd64 since that's the only platform Microsoft ships package for,
+        # however the dependencies are the same at the moment.
+        DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-$DOTNET_RUNTIME_VERSION:amd64"
+    fi
+    
+    # get depenencies and remove dotnet-host* dependencies
+    DOTNET_RUNTIME_DEPS=$(apt show $DOTNET_RUNTIME_DEPS_PKG 2>/dev/null | sed -n -e 's/Depends: //p' | sed -E 's/(^|, )dotnet-host[^,]*(, |$)/\1/; s/, $//')
+    if [ -z "$DOTNET_RUNTIME_DEPS" ]; then
+        echo "Could not extract dependencies from $DOTNET_RUNTIME_DEPS_PKG package."
+        exit 1
+    fi
 fi
+
 
 export DEB_DEPS="${DOTNET_RUNTIME_DEPS}, libc6-dev (>= 2.27)"
 

--- a/scripts/linux/pkg/deb/build-deb_ubuntu-noble_amd64.ps1
+++ b/scripts/linux/pkg/deb/build-deb_ubuntu-noble_amd64.ps1
@@ -1,0 +1,7 @@
+$env:OUTPUT_DIR = "$PSScriptRoot/dist"
+
+.\set-ubuntu-noble.ps1
+.\set-raven-platform-amd64.ps1
+.\set-raven-version-env.ps1
+
+.\build-deb.ps1

--- a/scripts/linux/pkg/deb/set-ubuntu-noble.ps1
+++ b/scripts/linux/pkg/deb/set-ubuntu-noble.ps1
@@ -1,0 +1,3 @@
+$env:DISTRO_NAME = "ubuntu"
+$env:DISTRO_VERSION = "24.04"
+$env:DISTRO_VERSION_NAME ="noble"

--- a/scripts/linux/pkg/deb/set-ubuntu-noble.sh
+++ b/scripts/linux/pkg/deb/set-ubuntu-noble.sh
@@ -1,0 +1,3 @@
+export DISTRO_NAME="ubuntu"
+export DISTRO_VERSION="24.04"
+export DISTRO_VERSION_NAME="noble"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20981

### Additional description

Scripts setting env vars for building deb package for ubuntu 24.04.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
