### PR TITLE
RavenDB-22362 Unify audit log lines

### DIFF
--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -258,7 +258,7 @@ namespace Raven.Server.Documents
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
                 DynamicJsonValue conf = GetCustomConfigurationAuditJson(description, configuration);
-                var line = $"Task: '{description}' with taskId: '{id}'";
+                var line = $"'{description}' with taskId: '{id}'";
 
                 if (conf != null)
                 {
@@ -271,7 +271,7 @@ namespace Raven.Server.Documents
                     line += ($" Configuration: {confString}");
                 }
 
-                LogAuditFor(Database.Name, line);
+                LogAuditFor(Database.Name, "TASK", line);
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminAnalyzersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminAnalyzersHandler.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        LogAuditFor(Database.Name, $"Analyzer '{analyzerDefinition.Name}' PUT with definition: {analyzerToAdd}");
+                        LogAuditFor(Database.Name, "PUT",  $"Analyzer '{analyzerDefinition.Name}' with definition: {analyzerToAdd}");
                     }
 
                     analyzerDefinition.Validate();
@@ -55,7 +55,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor(Database.Name, $"Analyzer '{name}' DELETE");
+                LogAuditFor(Database.Name, "DELETE", $"Analyzer '{name}'");
             }
 
             var command = new DeleteAnalyzerCommand(name, Database.Name, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminIndexHandler.cs
@@ -81,7 +81,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                     
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        LogAuditFor(Database.Name, $"Index {indexDefinition.Name} PUT with definition: {indexToAdd}");
+                        LogAuditFor(Database.Name, "PUT", $"Index '{indexDefinition.Name}' with definition: {indexToAdd}");
                     }
 
                     if (indexDefinition.Maps == null || indexDefinition.Maps.Count == 0)

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminSortersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminSortersHandler.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        LogAuditFor(Database.Name, $"Sorter {sorterDefinition.Name} PUT with definition: {sorterToAdd}");
+                        LogAuditFor(Database.Name, "PUT", $"Sorter '{sorterDefinition.Name}' with definition: {sorterToAdd}");
                     }
 
                     sorterDefinition.Validate();
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents.Handlers.Admin
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor(Database.Name, $"Sorter {name} DELETE");
+                LogAuditFor(Database.Name, "DELETE", $"Sorter '{name}'");
             }
 
             var command = new DeleteSorterCommand(name, Database.Name, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -578,7 +578,7 @@ namespace Raven.Server.Documents.Handlers
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor(Database.Name, $"Index {name} RESET");
+                LogAuditFor(Database.Name, "RESET", $"Index '{name}'");
             }
 
             IndexDefinition indexDefinition;
@@ -631,7 +631,7 @@ namespace Raven.Server.Documents.Handlers
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor(Database.Name, $"Index {name} DELETE");
+                LogAuditFor(Database.Name, "DELETE", $"Index '{name}'");
             }
 
             HttpContext.Response.StatusCode = await Database.IndexStore.TryDeleteIndexIfExists(name, GetRaftRequestIdFromQuery())

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -373,9 +373,9 @@ namespace Raven.Server.Documents.Handlers
 
                     if (TrafficWatchManager.HasRegisteredClients)
                         TrafficWatchQuery(query);
-
+                    
                     if (LoggingSource.AuditLog.IsInfoEnabled)
-                        LogAuditFor(Database.Name, $"DELETE documents matching the query: {query}");
+                        LogAuditFor(Database.Name, "DELETE", $"Documents matching the query: {query}");
 
                     await ExecuteQueryOperation(query,
                         (runner, options, onProgress, token) => runner.ExecuteDeleteQuery(query, options, queryContext, onProgress, token),

--- a/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Streaming/StreamingHandler.cs
@@ -168,7 +168,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
                 var propertiesArray = properties.Count == 0 ? null : properties.ToArray();
 
                 if (LoggingSource.AuditLog.IsInfoEnabled && query.Metadata.CollectionName == Constants.Documents.Collections.AllDocumentsCollection)
-                    LogAuditFor(Database.Name, $"Streaming results for all documents query: {query} (format: {format}, debug: {debug}, ignore limit: {ignoreLimit})");
+                    LogAuditFor(Database.Name, "QUERY", $"Streaming all documents (query: {query}, format: {format}, debug: {debug}, ignore limit: {ignoreLimit})");
 
                 // set the exported file name prefix
                 var fileNamePrefix = query.Metadata.IsCollectionQuery ? query.Metadata.CollectionName + "_collection" : "query_result";
@@ -261,7 +261,7 @@ namespace Raven.Server.Documents.Handlers.Streaming
                 var propertiesArray = properties.Count == 0 ? null : properties.ToArray();
 
                 if (LoggingSource.AuditLog.IsInfoEnabled && query.Metadata.CollectionName == Constants.Documents.Collections.AllDocumentsCollection)
-                    LogAuditFor(Database.Name, $"Streaming results for all documents query: {query} (format: {format}, debug: {debug}, ignore limit: {ignoreLimit})");
+                    LogAuditFor(Database.Name, "QUERY", $"Streaming all documents (query: {query}, format: {format}, debug: {debug}, ignore limit: {ignoreLimit})");
 
                 // set the exported file name prefix
                 var fileNamePrefix = query.Metadata.IsCollectionQuery ? query.Metadata.CollectionName + "_collection" : "query_result";

--- a/src/Raven.Server/Integrations/PostgreSQL/Handlers/PostgreSqlIntegrationHandler.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Handlers/PostgreSqlIntegrationHandler.cs
@@ -142,7 +142,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Handlers
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        LogAuditFor(Database.Name, $"Postgres integration. User {newUser.Username} PUT");
+                        LogAuditFor(Database.Name, "PUT", $"User '{newUser.Username}' in Postgres integration");
                     }
                 }
             }
@@ -201,7 +201,7 @@ namespace Raven.Server.Integrations.PostgreSQL.Handlers
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        LogAuditFor(Database.Name, $"Postgres integration. User {userToDelete.Username} DELETE");
+                        LogAuditFor(Database.Name, "DELETE", $"User '{userToDelete.Username}' in Postgres integration");
                     }
                 }
             }

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -230,8 +230,8 @@ namespace Raven.Server.Web.Authentication
                         ? Environment.NewLine + string.Join(Environment.NewLine, certificate.Permissions.Select(kvp => kvp.Key + ": " + kvp.Value.ToString()))
                         : string.Empty;
 
-                    LogAuditFor("Certificates",
-                        $"Add new certificate {certificate?.Name} ['{certificate?.Thumbprint}']. Security Clearance: {certificate?.SecurityClearance}. Permissions:{permissions}.");
+                    LogAuditFor("Certificates", "ADD", 
+                        $"New certificate {certificate?.Name} ['{certificate?.Thumbprint}']. Security Clearance: {certificate?.SecurityClearance}. Permissions:{permissions}.");
                 }
                 
                 try
@@ -410,7 +410,7 @@ namespace Raven.Server.Web.Authentication
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    LogAuditFor("Certificates", $"Delete certificate '{thumbprint}'.");
+                    LogAuditFor("Certificates", "DELETE", $"Certificate '{thumbprint}'.");
                 }
                 
                 await DeleteInternal(keysToDelete, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Web/Authentication/TwoFactorAuthenticationHandler.cs
+++ b/src/Raven.Server/Web/Authentication/TwoFactorAuthenticationHandler.cs
@@ -94,7 +94,7 @@ public class TwoFactorAuthenticationHandler : ServerRequestHandler
             
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor(nameof(TwoFactorAuthenticationHandler), $"successfully authenticated with two factor auth for {period} (until: {DateTime.UtcNow.Add(period)}). Has limits: {hasLimits}");
+                LogAuditFor(nameof(TwoFactorAuthenticationHandler), "AUTH", $"2FA session open for {period} (until: {DateTime.UtcNow.Add(period)}). Has limits: {hasLimits}");
             }
 
             string expectedCookieValue = null;
@@ -139,7 +139,7 @@ public class TwoFactorAuthenticationHandler : ServerRequestHandler
     {
         if (LoggingSource.AuditLog.IsInfoEnabled)
         {
-            LogAuditFor(nameof(TwoFactorAuthenticationHandler), $"Two factor auth failure: {err}");
+            LogAuditFor(nameof(TwoFactorAuthenticationHandler), "AUTH", $"2FA failure: {err}");
         }
 
         HttpContext.Response.StatusCode = (int)httpStatusCode;

--- a/src/Raven.Server/Web/RequestHandler.Audit.cs
+++ b/src/Raven.Server/Web/RequestHandler.Audit.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Web
 
         public string RequestIp => IsLocalRequest() ? Environment.MachineName : HttpContext.Connection.RemoteIpAddress.ToString();
 
-        public void LogAuditFor(string logger, string message)
+        public void LogAuditFor(string logger, string action, string target)
         {
             var auditLog = LoggingSource.AuditLog.GetLogger(logger, "Audit");
             Debug.Assert(auditLog.IsInfoEnabled, $"auditlog info is disabled");
@@ -44,8 +44,8 @@ namespace Raven.Server.Web
                 sb.Append($"CN={clientCert.Subject} [{clientCert.Thumbprint}], ");
             else
                 sb.Append("no certificate, ");
-            
-            sb.Append(message);
+
+            sb.Append($"{action} {target}");
 
             auditLog.Info(sb.ToString());
         }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -199,7 +199,7 @@ namespace Raven.Server.Web.System
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    LogAuditFor("DbMgmt", $"Database '{databaseRecord.DatabaseName}' PUT");
+                    LogAuditFor("DbMgmt", "PUT", $"Database '{databaseRecord.DatabaseName}'");
                 }
 
                 if (ServerStore.LicenseManager.LicenseStatus.HasDocumentsCompression && databaseRecord.DocumentsCompression == null)
@@ -683,7 +683,7 @@ namespace Raven.Server.Web.System
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor(databaseName, $"Backup task with task id '{id}' was delayed until '{delayUntil}' UTC");
+                LogAuditFor(databaseName, "DELAY", $"Backup task with task id '{id}' until '{delayUntil}' UTC");
             }
 
 
@@ -708,7 +708,7 @@ namespace Raven.Server.Web.System
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    LogAuditFor("DbMgmt", $"Attempt to delete [{string.Join(", ", parameters.DatabaseNames)}] database(s) from ({string.Join(", ", parameters.FromNodes ?? Enumerable.Empty<string>())})");
+                    LogAuditFor("DbMgmt", "DELETE", $"Attempt to delete database(s) [{string.Join(", ", parameters.DatabaseNames)}] from ({string.Join(", ", parameters.FromNodes ?? Enumerable.Empty<string>())})");
                 }
 
                 using (context.OpenReadTransaction())
@@ -771,7 +771,7 @@ namespace Raven.Server.Web.System
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    LogAuditFor("DbMgmt", $"Delete [{string.Join(", ", databasesToDelete)}] database(s) from ({string.Join(", ", parameters.FromNodes ?? Enumerable.Empty<string>())})");
+                    LogAuditFor("DbMgmt", "DELETE", $"Database(s) [{string.Join(", ", databasesToDelete)}] from ({string.Join(", ", parameters.FromNodes ?? Enumerable.Empty<string>())})");
                 }
 
                 long index = -1;

--- a/src/Raven.Server/Web/System/Analyzers/AdminAnalyzersHandler.cs
+++ b/src/Raven.Server/Web/System/Analyzers/AdminAnalyzersHandler.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Web.System.Analyzers
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        LogAuditFor("Server", $"Analyzer {analyzerDefinition.Name} PUT with definition: {analyzerToAdd}");
+                        LogAuditFor("Server", "PUT", $"Analyzer '{analyzerDefinition.Name}' with definition: {analyzerToAdd}");
                     }
 
                     analyzerDefinition.Validate();
@@ -61,7 +61,7 @@ namespace Raven.Server.Web.System.Analyzers
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor("Server", $"Analyzer {name} DELETE");
+                LogAuditFor("Server", "DELETE", $"Analyzer '{name}'");
             }
 
             var command = new DeleteServerWideAnalyzerCommand(name, GetRaftRequestIdFromQuery());

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -116,7 +116,7 @@ namespace Raven.Server.Web.System
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
-                    LogAuditFor("DbMgmt", $"Database '{dbName}' topology is being modified " +
+                    LogAuditFor("DbMgmt", "CHANGE", $"Database '{dbName}' topology. " +
                                           $"Old topology: {databaseRecord.Topology} " +
                                           $"New topology: {databaseTopology}.");
                 }

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -644,7 +644,7 @@ namespace Raven.Server.Web.System
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor(Database.Name, $"Connection string {connectionStringName} DELETE");
+                LogAuditFor(Database.Name, "DELETE", $"Connection string '{connectionStringName}'");
             }
 
             var (index, _) = await ServerStore.RemoveConnectionString(Database.Name, connectionStringName, type, GetRaftRequestIdFromQuery());
@@ -798,7 +798,7 @@ namespace Raven.Server.Web.System
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
                         if (connectionString.TryGet(nameof(ConnectionString.Name), out string name))
-                            LogAuditFor(Database.Name, $"Connection string {name} PUT");
+                            LogAuditFor(Database.Name, "PUT", $"Connection string '{name}'");
                     }
 
                     return ServerStore.PutConnectionString(_, databaseName, connectionString, guid);

--- a/src/Raven.Server/Web/System/Sorters/AdminSortersHandler.cs
+++ b/src/Raven.Server/Web/System/Sorters/AdminSortersHandler.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Web.System.Sorters
 
                     if (LoggingSource.AuditLog.IsInfoEnabled)
                     {
-                        LogAuditFor("Server", $"Sorter {sorterDefinition.Name} PUT with definition: {sorterToAdd}");
+                        LogAuditFor("Server", "PUT", $"Sorter '{sorterDefinition.Name}' with definition: {sorterToAdd}");
                     }
 
                     sorterDefinition.Validate();
@@ -61,7 +61,7 @@ namespace Raven.Server.Web.System.Sorters
 
             if (LoggingSource.AuditLog.IsInfoEnabled)
             {
-                LogAuditFor("Server", $"Sorter {name} DELETE");
+                LogAuditFor("Server", "DELETE", $"Sorter '{name}'");
             }
 
             var command = new DeleteServerWideSorterCommand(name, GetRaftRequestIdFromQuery());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22362/Unify-audit-log-lines

### Additional description

Continuation of:

- https://github.com/ravendb/ravendb/pull/18526
- https://github.com/ravendb/ravendb/pull/18605 - applied PR comments

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
