### PR TITLE
RavenDB-22451 Server-wide custom sorters test button opens for all

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersServerWideList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersServerWideList.tsx
@@ -1,21 +1,9 @@
 import { EmptySet } from "components/common/EmptySet";
 import { LoadError } from "components/common/LoadError";
 import { LoadingView } from "components/common/LoadingView";
-import {
-    RichPanel,
-    RichPanelActions,
-    RichPanelHeader,
-    RichPanelInfo,
-    RichPanelName,
-} from "components/common/RichPanel";
-import useBoolean from "components/hooks/useBoolean";
-import DatabaseCustomSorterTest from "components/pages/database/settings/customSorters/DatabaseCustomSorterTest";
-import { Icon } from "components/common/Icon";
 import React from "react";
 import { UseAsyncReturn } from "react-async-hook";
-import { Button, Collapse } from "reactstrap";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
-import { useAppSelector } from "components/store";
+import DatabaseCustomSortersServerWideListItem from "components/pages/database/settings/customSorters/DatabaseCustomSortersServerWideListItem";
 
 interface DatabaseCustomSortersServerWideListProps {
     asyncGetSorters: UseAsyncReturn<Raven.Client.Documents.Queries.Sorting.SorterDefinition[], any[]>;
@@ -24,10 +12,6 @@ interface DatabaseCustomSortersServerWideListProps {
 export default function DatabaseCustomSortersServerWideList({
     asyncGetSorters,
 }: DatabaseCustomSortersServerWideListProps) {
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
-
-    const { value: isTestMode, toggle: toggleIsTestMode } = useBoolean(false);
-
     if (asyncGetSorters.status === "loading") {
         return <LoadingView />;
     }
@@ -43,24 +27,7 @@ export default function DatabaseCustomSortersServerWideList({
     return (
         <div>
             {asyncGetSorters.result.map((sorter) => (
-                <RichPanel key={sorter.Name} className="mt-3">
-                    <RichPanelHeader>
-                        <RichPanelInfo>
-                            <RichPanelName>{sorter.Name}</RichPanelName>
-
-                            {hasDatabaseAdminAccess && (
-                                <RichPanelActions>
-                                    <Button onClick={toggleIsTestMode}>
-                                        <Icon icon="rocket" addon={isTestMode ? "cancel" : null} margin="m-0" />
-                                    </Button>
-                                </RichPanelActions>
-                            )}
-                        </RichPanelInfo>
-                    </RichPanelHeader>
-                    <Collapse isOpen={isTestMode}>
-                        <DatabaseCustomSorterTest name={sorter.Name} />
-                    </Collapse>
-                </RichPanel>
+                <DatabaseCustomSortersServerWideListItem key={sorter.Name} sorter={sorter} />
             ))}
         </div>
     );

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersServerWideListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersServerWideListItem.tsx
@@ -1,0 +1,47 @@
+import { Icon } from "components/common/Icon";
+import {
+    RichPanel,
+    RichPanelHeader,
+    RichPanelInfo,
+    RichPanelName,
+    RichPanelActions,
+} from "components/common/RichPanel";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import useBoolean from "components/hooks/useBoolean";
+import DatabaseCustomSorterTest from "components/pages/database/settings/customSorters/DatabaseCustomSorterTest";
+import { useAppSelector } from "components/store";
+import React from "react";
+import { Button, Collapse } from "reactstrap";
+
+interface DatabaseCustomSortersServerWideListItemProps {
+    sorter: Raven.Client.Documents.Queries.Sorting.SorterDefinition;
+}
+
+export default function DatabaseCustomSortersServerWideListItem({
+    sorter,
+}: DatabaseCustomSortersServerWideListItemProps) {
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+
+    const { value: isTestMode, toggle: toggleIsTestMode } = useBoolean(false);
+
+    return (
+        <RichPanel className="mt-3">
+            <RichPanelHeader>
+                <RichPanelInfo>
+                    <RichPanelName>{sorter.Name}</RichPanelName>
+
+                    {hasDatabaseAdminAccess && (
+                        <RichPanelActions>
+                            <Button onClick={toggleIsTestMode}>
+                                <Icon icon="rocket" addon={isTestMode ? "cancel" : null} margin="m-0" />
+                            </Button>
+                        </RichPanelActions>
+                    )}
+                </RichPanelInfo>
+            </RichPanelHeader>
+            <Collapse isOpen={isTestMode}>
+                <DatabaseCustomSorterTest name={sorter.Name} />
+            </Collapse>
+        </RichPanel>
+    );
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22451/Server-wide-custom-sorters-test-button-opens-for-all

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
