### PR TITLE
RavenDB-22382 - missing if statement that wasn't ported from 5.4

### DIFF
--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -205,6 +205,9 @@ public abstract unsafe class AbstractBackgroundWorkStorage
 
             dequeueCount++;
             docsTree.MultiDelete(info.Ticks, info.LowerId);
+
+            if (context.CanContinueTransaction == false)
+                break;
         }
 
         var tx = context.Transaction.InnerTransaction.LowLevelTransaction;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22382/Expiration-command-has-no-size-limit

### Additional description

Missing if statement that wasn't ported from 5.4.
https://github.com/ravendb/ravendb/pull/18542/files#diff-be34884e1bd779584e34af0721515c99e9c5358fd4a3663c19f8f72c1de29b9dR291

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
