### PR TITLE
RavenDB-14963 - All revisions view

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1186,21 +1186,21 @@ namespace Raven.Server.Documents.Revisions
         }
 
 
-        public IEnumerable<Document> GetAllRevisionsOrderedByEtag(DocumentsOperationContext context, int skip, int take)
+        public IEnumerable<Document> GetRevisionsInReverseEtagOrder(DocumentsOperationContext context, int skip, int take)
         {
-            return GetAllRevisionsByEtagInternal(context, 
+            return GetRevisionsInReverseEtagOrderInternal(context, 
                 table: new Table(RevisionsSchema, context.Transaction.InnerTransaction), 
                 index: RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], skip, take);
         }
 
-        public IEnumerable<Document> GetAllRevisionsOrderedByEtagForCollection(DocumentsOperationContext context, string collection, int skip, int take)
+        public IEnumerable<Document> GetRevisionsInReverseEtagOrderForCollection(DocumentsOperationContext context, string collection, int skip, int take)
         {
             var collectionName = _documentsStorage.ExtractCollectionName(context, collection);
             var table = EnsureRevisionTableCreated(context.Transaction.InnerTransaction, collectionName);
-            return GetAllRevisionsByEtagInternal(context, table, index: RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], skip, take);
+            return GetRevisionsInReverseEtagOrderInternal(context, table, index: RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], skip, take);
         }
 
-        private IEnumerable<Document> GetAllRevisionsByEtagInternal(DocumentsOperationContext context, Table table, TableSchema.FixedSizeKeyIndexDef index, int skip, int take)
+        private IEnumerable<Document> GetRevisionsInReverseEtagOrderInternal(DocumentsOperationContext context, Table table, TableSchema.FixedSizeKeyIndexDef index, int skip, int take)
         {
             int i = 0;
             foreach (var tvh in table.SeekBackwardFromLast(index, skip))
@@ -2676,23 +2676,14 @@ namespace Raven.Server.Documents.Revisions
             if (tvr == null)
                 return null;
             
-            return GetChangeVector((int)RevisionsTable.ChangeVector, ref tvr.Reader);
+            return TableValueToChangeVector(context, (int)RevisionsTable.ChangeVector, ref tvr.Reader);
         }
 
-        public string GetLastRevisionChangeVector(DocumentsOperationContext context, string collection)
+        public string GetLastRevisionChangeVectorForCollection(DocumentsOperationContext context, string collection)
         {
             var table = GetOrCreateTable(context.Transaction.InnerTransaction, new CollectionName(collection));
-            if (table == null)
-                throw new InvalidOperationException($"Collection \"{collection}\" doesn't exist");
-            
             var tvr = table.ReadLast(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice]);
-            return GetChangeVector((int)RevisionsTable.ChangeVector, ref tvr.Reader);
-        }
-
-        public static unsafe string GetChangeVector(int index, ref TableValueReader tvr)
-        {
-            var ptr = tvr.Read(index, out int size);
-            return Encodings.Utf8.GetString(ptr, size);
+            return TableValueToChangeVector(context, (int)RevisionsTable.ChangeVector, ref tvr.Reader);
         }
 
         public long GetNumberOfRevisionDocuments(DocumentsOperationContext context)
@@ -2701,36 +2692,19 @@ namespace Raven.Server.Documents.Revisions
             return table.GetNumberOfEntriesFor(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice]);
         }
 
-        public long GetNumberOfRevisionDocuments(DocumentsOperationContext context, string collection)
+        public long GetNumberOfRevisionDocumentsForCollection(DocumentsOperationContext context, string collection)
         {
             var table = GetOrCreateTable(context.Transaction.InnerTransaction, new CollectionName(collection));
-            if (table == null)
-                throw new InvalidOperationException($"Collection \"{collection}\" doesn't exist");
             return table.GetNumberOfEntriesFor(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice]);
         }
 
         internal Table GetOrCreateTable(Transaction tx, CollectionName collection)
         {
             string tableName = collection.GetTableName(CollectionTableType.Revisions);
-
-            if (tx.IsWriteTransaction && _tableCreated.Contains(tableName) == false)
-            {
-                RevisionsSchema.Create(tx, tableName, 16);
-                tx.LowLevelTransaction.OnDispose += _ =>
-                {
-                    if (tx.LowLevelTransaction.Committed == false)
-                        return;
-
-                    // not sure if we can _rely_ on the tx write lock here, so let's be safe and create
-                    // a new instance, just in case
-                    _tableCreated = new HashSet<string>(_tableCreated, StringComparer.OrdinalIgnoreCase)
-                    {
-                        tableName
-                    };
-                };
-            }
-
-            return tx.OpenTable(RevisionsSchema, tableName);
+            var table = tx.OpenTable(RevisionsSchema, tableName);
+            if (table == null)
+                throw new InvalidOperationException($"Collection \"{collection}\" doesn't exist");
+            return table;
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
@@ -210,7 +210,23 @@ namespace Raven.Server.Documents.Sharding
 
                 public static DocumentLastModifiedComparer Instance = new ();
             }
-            
+
+            public sealed class RevisionLastModifiedComparer : Comparer<ShardStreamItem<BlittableJsonReaderObject>>
+            {
+                public override int Compare(ShardStreamItem<BlittableJsonReaderObject> x, ShardStreamItem<BlittableJsonReaderObject> y)
+                {
+                    if (x.Item.TryGet(nameof(Document.LastModified), out DateTime xLastModified) == false)
+                        throw new InvalidOperationException($"Revision does not contain 'LastModified' field.");
+
+                    if (x.Item.TryGet(nameof(Document.LastModified), out DateTime yLastModified) == false)
+                        throw new InvalidOperationException($"Revision does not contain 'LastModified' field.");
+
+                    return yLastModified.CompareTo(xLastModified);
+                }
+
+                public static RevisionLastModifiedComparer Instance = new();
+            }
+
             public IEnumerable<BlittableJsonReaderObject> PagedShardedItemDocumentsByLastModified<TInput>(
                 Dictionary<int, ShardExecutionResult<TInput>> results,
                 Func<TInput, IEnumerable<BlittableJsonReaderObject>> selector,

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
@@ -218,7 +218,7 @@ namespace Raven.Server.Documents.Sharding
                     if (x.Item.TryGet(nameof(Document.LastModified), out DateTime xLastModified) == false)
                         throw new InvalidOperationException($"Revision does not contain 'LastModified' field.");
 
-                    if (x.Item.TryGet(nameof(Document.LastModified), out DateTime yLastModified) == false)
+                    if (y.Item.TryGet(nameof(Document.LastModified), out DateTime yLastModified) == false)
                         throw new InvalidOperationException($"Revision does not contain 'LastModified' field.");
 
                     return yLastModified.CompareTo(xLastModified);

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Streaming.cs
@@ -215,13 +215,18 @@ namespace Raven.Server.Documents.Sharding
             {
                 public override int Compare(ShardStreamItem<BlittableJsonReaderObject> x, ShardStreamItem<BlittableJsonReaderObject> y)
                 {
-                    if (x.Item.TryGet(nameof(Document.LastModified), out DateTime xLastModified) == false)
-                        throw new InvalidOperationException($"Revision does not contain 'LastModified' field.");
-
-                    if (y.Item.TryGet(nameof(Document.LastModified), out DateTime yLastModified) == false)
-                        throw new InvalidOperationException($"Revision does not contain 'LastModified' field.");
+                    var xLastModified = GetLatModified(x);
+                    var yLastModified = GetLatModified(y);
 
                     return yLastModified.CompareTo(xLastModified);
+                }
+
+                private DateTime GetLatModified(ShardStreamItem<BlittableJsonReaderObject> x)
+                {
+                    if (x.Item.TryGet(nameof(Document.LastModified), out DateTime lastModified) == false)
+                        throw new InvalidOperationException($"Revision does not contain 'LastModified' field.");
+
+                    return lastModified;
                 }
 
                 public static RevisionLastModifiedComparer Instance = new();

--- a/src/Raven.Server/Documents/Sharding/Streaming/ShardResultConverter.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/ShardResultConverter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Raven.Client.Extensions;
 using Sparrow.Json;
 

--- a/src/Raven.Server/Documents/Sharding/Streaming/ShardResultConverter.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/ShardResultConverter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Raven.Client.Extensions;
 using Sparrow.Json;
 
@@ -15,6 +16,29 @@ namespace Raven.Server.Documents.Sharding.Streaming
                 LowerId = metadata.GetIdAsLazyString(),
                 LastModified = metadata.GetLastModified()
             };
+        }
+
+        public static Document BlittableToRevisionConverter(BlittableJsonReaderObject json)
+        {
+            var revision = new Document();
+
+            if(json.TryGet(nameof(Document.Id), out revision.Id) == false)
+                throw new InvalidOperationException("Revision does not contain 'Id' field.");
+
+            if (json.TryGet(nameof(Document.ChangeVector), out revision.ChangeVector) == false)
+                throw new InvalidOperationException($"Revision of \"{revision.Id}\" does not contain 'ChangeVector' fields.");
+
+            if (json.TryGet(nameof(Document.Etag), out revision.Etag) == false)
+                throw new InvalidOperationException($"Revision of \"{revision.Id}\" and change vector '{revision.ChangeVector}' does not contain 'Etag' fields.");
+
+
+            if (json.TryGet(nameof(Document.LastModified), out revision.LastModified) == false)
+                throw new InvalidOperationException($"Revision of \"{revision.Id}\" and change vector '{revision.ChangeVector}' does not contain 'LastModified' fields.");
+
+            if (json.TryGet(nameof(Document.Flags), out revision.Flags) == false)
+                throw new InvalidOperationException($"Revision of \"{revision.Id}\" and change vector '{revision.ChangeVector}' does not contain 'Flags' fields.");
+
+            return revision;
         }
 
         public static List<string> BlittableToStringListConverter(BlittableJsonReaderArray json)

--- a/src/Raven.Server/Documents/Sharding/Streaming/ShardResultConverter.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/ShardResultConverter.cs
@@ -18,29 +18,6 @@ namespace Raven.Server.Documents.Sharding.Streaming
             };
         }
 
-        public static Document BlittableToRevisionConverter(BlittableJsonReaderObject json)
-        {
-            var revision = new Document();
-
-            if(json.TryGet(nameof(Document.Id), out revision.Id) == false)
-                throw new InvalidOperationException("Revision does not contain 'Id' field.");
-
-            if (json.TryGet(nameof(Document.ChangeVector), out revision.ChangeVector) == false)
-                throw new InvalidOperationException($"Revision of \"{revision.Id}\" does not contain 'ChangeVector' fields.");
-
-            if (json.TryGet(nameof(Document.Etag), out revision.Etag) == false)
-                throw new InvalidOperationException($"Revision of \"{revision.Id}\" and change vector '{revision.ChangeVector}' does not contain 'Etag' fields.");
-
-
-            if (json.TryGet(nameof(Document.LastModified), out revision.LastModified) == false)
-                throw new InvalidOperationException($"Revision of \"{revision.Id}\" and change vector '{revision.ChangeVector}' does not contain 'LastModified' fields.");
-
-            if (json.TryGet(nameof(Document.Flags), out revision.Flags) == false)
-                throw new InvalidOperationException($"Revision of \"{revision.Id}\" and change vector '{revision.ChangeVector}' does not contain 'Flags' fields.");
-
-            return revision;
-        }
-
         public static List<string> BlittableToStringListConverter(BlittableJsonReaderArray json)
         {
             var list = new List<string>();

--- a/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers.Processors;
 using Sparrow.Json;
@@ -39,7 +40,7 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
             }
 
             if (etag != null)
-                HttpContext.Response.Headers["ETag"] = "\"" + etag + "\"";
+                HttpContext.Response.Headers[Constants.Headers.Etag] = "\"" + etag + "\"";
 
             await InitializeAsync(context, token.Token);
 
@@ -54,9 +55,8 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
                 writer.WriteComma();
 
                 writer.WritePropertyName(nameof(PreviewRevisionsResult.Results));
-                await WriteItems(context, writer);
+                await WriteItemsAsync(context, writer);
 
-                
                 writer.WriteEndObject();
             }
 
@@ -69,7 +69,7 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
 
     protected abstract bool NotModified(TOperationContext context, out string etag);
 
-    protected abstract Task WriteItems(TOperationContext context, AsyncBlittableJsonTextWriter writer);
+    protected abstract Task WriteItemsAsync(TOperationContext context, AsyncBlittableJsonTextWriter writer);
 
     protected virtual Task InitializeAsync(TOperationContext context, CancellationToken token)
     {

--- a/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -64,7 +64,7 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
                 writer.WritePropertyName(nameof(PreviewRevisionsResult.Results));
                 await WriteItems(context, writer);
 
-                WriteAdditionalField(context, writer);
+                
                 writer.WriteEndObject();
             }
 
@@ -78,10 +78,6 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
     protected abstract bool NotModified(TOperationContext context, out string etag);
 
     protected abstract Task WriteItems(TOperationContext context, AsyncBlittableJsonTextWriter writer);
-
-    protected virtual void WriteAdditionalField(TOperationContext context, AsyncBlittableJsonTextWriter writer)
-    {
-    }
 
     protected virtual Task InitializeAsync(TOperationContext context, CancellationToken token)
     {

--- a/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -31,7 +31,7 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
         using (OpenReadTransaction(context))
         using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
-            Collection = RequestHandler.GetStringQueryString("collection", required: false);
+            await InitializeAsync(context, token.Token);
 
             if (NotModified(context, out var etag))
             {
@@ -41,8 +41,6 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
 
             if (etag != null)
                 HttpContext.Response.Headers[Constants.Headers.Etag] = "\"" + etag + "\"";
-
-            await InitializeAsync(context, token.Token);
 
             var count = await GetTotalCountAsync();
 

--- a/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -34,11 +34,20 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
         using (OpenReadTransaction(context))
         using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
         {
-            await InitializeAsync(context);
+            _collection = RequestHandler.GetStringQueryString("collection", required: false);
+
+            if (NotModified(context, out var etag))
+            {
+                RequestHandler.HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
+                return;
+            }
+
+            if (etag != null)
+                HttpContext.Response.Headers["ETag"] = "\"" + etag + "\"";
+
+            await InitializeAsync(context, token.Token);
 
             var count = await GetTotalCountAsync();
-
-            var revisions = GetRevisionsAsync(context);
 
             await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
             {
@@ -49,43 +58,7 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
                 writer.WriteComma();
 
                 writer.WritePropertyName(nameof(PreviewRevisionsResult.Results));
-                writer.WriteStartArray();
-
-                var first = true;
-                await foreach (var revision in revisions)
-                {
-                    token.ThrowIfCancellationRequested();
-
-                    if (first)
-                        first = false;
-                    else
-                        writer.WriteComma();
-
-                    writer.WriteStartObject();
-
-                    writer.WritePropertyName(nameof(Document.Id));
-                    writer.WriteString(revision.Id);
-                    writer.WriteComma();
-
-                    writer.WritePropertyName(nameof(Document.Etag));
-                    writer.WriteInteger(revision.Etag);
-                    writer.WriteComma();
-
-                    writer.WritePropertyName(nameof(Document.LastModified));
-                    writer.WriteDateTime(revision.LastModified, true);
-                    writer.WriteComma();
-
-                    writer.WritePropertyName(nameof(Document.ChangeVector));
-                    writer.WriteString(revision.ChangeVector);
-                    writer.WriteComma();
-
-                    writer.WritePropertyName(nameof(Document.Flags));
-                    writer.WriteString(revision.Flags.ToString());
-
-                    writer.WriteEndObject();
-                }
-
-                writer.WriteEndArray();
+                await WriteItems(context, writer);
 
                 WriteAdditionalField(context, writer);
                 writer.WriteEndObject();
@@ -95,6 +68,8 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
     }
 
     protected abstract IDisposable OpenReadTransaction(TOperationContext context);
+
+    protected abstract Task WriteItems(TOperationContext context, AsyncBlittableJsonTextWriter writer);
 
     protected virtual void WriteAdditionalField(TOperationContext context, AsyncBlittableJsonTextWriter writer)
     {
@@ -108,21 +83,7 @@ internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevis
 
     protected abstract ValueTask<long> GetTotalCountAsync();
 
-    protected abstract IAsyncEnumerable<Document> GetRevisionsAsync(TOperationContext context);
-
-    protected virtual ValueTask InitializeAsync(TOperationContext context)
-    {
-        _collection = RequestHandler.GetStringQueryString("collection", required: false);
-
-        if (NotModified(context, out var etag))
-        {
-            RequestHandler.HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
-        }
-        else if (etag != null)
-            HttpContext.Response.Headers["ETag"] = "\"" + etag + "\"";
-
-        return ValueTask.CompletedTask;
-    }
+    protected abstract ValueTask InitializeAsync(TOperationContext context, CancellationToken token);
 
     protected abstract bool NotModified(TOperationContext context, out string etag);
 }

--- a/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amqp.Listener;
+using Elastic.Clients.Elasticsearch;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
+using Raven.Server.Json;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Web.Studio.Processors;
+
+internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevisions<TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
+    where TOperationContext : JsonOperationContext
+    where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+{
+    protected string _collection;
+
+    public AbstractStudioCollectionsHandlerProcessorForPreviewRevisions([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        using (ContextPool.AllocateOperationContext(out TOperationContext context))
+        using (OpenReadTransaction(context))
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
+        {
+            await InitializeAsync(context);
+
+            var count = await GetTotalCountAsync();
+
+            var revisions = GetRevisionsAsync(context);
+
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+
+                writer.WritePropertyName(nameof(PreviewRevisionsResult.TotalResults));
+                writer.WriteInteger(count);
+                writer.WriteComma();
+
+                writer.WritePropertyName(nameof(PreviewRevisionsResult.Results));
+                writer.WriteStartArray();
+
+                var first = true;
+                await foreach (var revision in revisions)
+                {
+                    token.ThrowIfCancellationRequested();
+
+                    if (first)
+                        first = false;
+                    else
+                        writer.WriteComma();
+
+                    writer.WriteStartObject();
+
+                    writer.WritePropertyName(nameof(Document.Id));
+                    writer.WriteString(revision.Id);
+                    writer.WriteComma();
+
+                    writer.WritePropertyName(nameof(Document.Etag));
+                    writer.WriteInteger(revision.Etag);
+                    writer.WriteComma();
+
+                    writer.WritePropertyName(nameof(Document.LastModified));
+                    writer.WriteDateTime(revision.LastModified, true);
+                    writer.WriteComma();
+
+                    writer.WritePropertyName(nameof(Document.ChangeVector));
+                    writer.WriteString(revision.ChangeVector);
+                    writer.WriteComma();
+
+                    writer.WritePropertyName(nameof(Document.Flags));
+                    writer.WriteString(revision.Flags.ToString());
+
+                    writer.WriteEndObject();
+                }
+
+                writer.WriteEndArray();
+
+                WriteAdditionalField(context, writer);
+                writer.WriteEndObject();
+            }
+
+        }
+    }
+
+    protected abstract IDisposable OpenReadTransaction(TOperationContext context);
+
+    protected virtual void WriteAdditionalField(TOperationContext context, AsyncBlittableJsonTextWriter writer)
+    {
+    }
+
+    protected sealed class PreviewRevisionsResult
+    {
+        public List<Document> Results;
+        public long TotalResults;
+    }
+
+    protected abstract ValueTask<long> GetTotalCountAsync();
+
+    protected abstract IAsyncEnumerable<Document> GetRevisionsAsync(TOperationContext context);
+
+    protected virtual ValueTask InitializeAsync(TOperationContext context)
+    {
+        _collection = RequestHandler.GetStringQueryString("collection", required: false);
+
+        if (NotModified(context, out var etag))
+        {
+            RequestHandler.HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
+        }
+        else if (etag != null)
+            HttpContext.Response.Headers["ETag"] = "\"" + etag + "\"";
+
+        return ValueTask.CompletedTask;
+    }
+
+    protected abstract bool NotModified(TOperationContext context, out string etag);
+}
+

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -100,6 +100,10 @@ internal sealed class ShardedStudioCollectionsHandlerProcessorForPreviewRevision
         }
 
         writer.WriteEndArray();
+
+        writer.WriteComma();
+        writer.WritePropertyName(ContinuationToken.PropertyName);
+        writer.WriteString(_continuationToken.ToBase64(context));
     }
 
     protected override async Task InitializeAsync(TransactionOperationContext context, CancellationToken token)
@@ -117,17 +121,7 @@ internal sealed class ShardedStudioCollectionsHandlerProcessorForPreviewRevision
         _combinedHttpEtag = result.CombinedEtag;
     }
 
-    protected override IDisposable OpenReadTransaction(TransactionOperationContext context)
-    {
-        return context.OpenReadTransaction();
-    }
-
-    protected override void WriteAdditionalField(TransactionOperationContext context, AsyncBlittableJsonTextWriter writer)
-    {
-        writer.WriteComma();
-        writer.WritePropertyName(ContinuationToken.PropertyName);
-        writer.WriteString(_continuationToken.ToBase64(context));
-    }
+    protected override IDisposable OpenReadTransaction(TransactionOperationContext context) => null;
 
     protected override async ValueTask<long> GetTotalCountAsync()
     {

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -35,9 +35,9 @@ internal sealed class ShardedStudioCollectionsHandlerProcessorForPreviewRevision
     {
     }
 
-    protected override async Task WriteItems(TransactionOperationContext context, AsyncBlittableJsonTextWriter writer)
+    protected override async Task WriteItemsAsync(TransactionOperationContext context, AsyncBlittableJsonTextWriter writer)
     {
-        var shardItems = RequestHandler.DatabaseContext.Streaming.PagedShardedStream<BlittableJsonReaderObject>(
+        var shardItems = RequestHandler.DatabaseContext.Streaming.PagedShardedStream(
             _combinedReadState,
             "Results",
             x => x,

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.Runtime.Internal.Endpoints.StandardLibrary;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+using Raven.Client;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Http;
+using Raven.Client.Util;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.Processors.Revisions;
+using Raven.Server.Documents.Sharding.Executors;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
+using Raven.Server.Documents.Sharding.Operations;
+using Raven.Server.Documents.Sharding.Streaming;
+using Raven.Server.Documents.Sharding.Streaming.Comparers;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Studio.Processors;
+using Sparrow.Json;
+
+namespace Raven.Server.Web.Studio.Sharding.Processors;
+
+internal sealed class ShardedStudioCollectionsHandlerProcessorForPreviewRevisions : AbstractStudioCollectionsHandlerProcessorForPreviewRevisions<ShardedDatabaseRequestHandler,
+    TransactionOperationContext>
+{
+    private ShardedPagingContinuation _continuationToken;
+    private string _combinedHttpEtag;
+    private CombinedReadContinuationState _combinedReadState;
+
+    public ShardedStudioCollectionsHandlerProcessorForPreviewRevisions([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    protected override IAsyncEnumerable<Document> GetRevisionsAsync(TransactionOperationContext context)
+    {
+        return RequestHandler.DatabaseContext.Streaming.PagedShardedStream(
+            _combinedReadState,
+            "Results",
+            ShardResultConverter.BlittableToRevisionConverter,
+            StreamDocumentByLastModifiedComparer.Instance,
+            _continuationToken).Select(s => s.Item); ;
+    }
+
+    protected override async ValueTask InitializeAsync(TransactionOperationContext context1)
+    {
+        await base.InitializeAsync(context1);
+        using (RequestHandler.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            _continuationToken = RequestHandler.ContinuationTokens.GetOrCreateContinuationToken(context);
+
+        var expectedEtag = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
+
+        var op = new ShardedRevisionsCollectionPreviewOperation(RequestHandler, _collection, expectedEtag, _continuationToken);
+        var result = await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(op);
+        if (result.StatusCode != (int)HttpStatusCode.NotModified)
+            _combinedReadState = await result.Result.InitializeAsync(RequestHandler.DatabaseContext, RequestHandler.AbortRequestToken);
+        _combinedHttpEtag = result.CombinedEtag;
+    }
+
+    protected override IDisposable OpenReadTransaction(TransactionOperationContext context)
+    {
+        return context.OpenReadTransaction();
+    }
+
+    protected override void WriteAdditionalField(TransactionOperationContext context, AsyncBlittableJsonTextWriter writer)
+    {
+        writer.WriteComma();
+        writer.WritePropertyName(ContinuationToken.PropertyName);
+        writer.WriteString(_continuationToken.ToBase64(context));
+    }
+
+    protected override async ValueTask<long> GetTotalCountAsync()
+    {
+        var result = await RequestHandler.DatabaseContext.Streaming.ReadCombinedLongAsync(_combinedReadState, nameof(PreviewRevisionsResult.TotalResults));
+        var total = 0L;
+        for (int i = 0; i < result.Span.Length; i++)
+        {
+            total += result.Span[i].Item;
+        }
+
+        return total;
+    }
+
+    public override void Dispose()
+    {
+        _combinedReadState?.Dispose();
+        _combinedReadState = null;
+
+        base.Dispose();
+    }
+
+    protected override bool NotModified(TransactionOperationContext context, out string httpEtag)
+    {
+        httpEtag = null;
+        var httpEtagFromRequest = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
+
+        if (httpEtagFromRequest != null && httpEtagFromRequest == _combinedHttpEtag)
+            return true;
+
+        httpEtag = _combinedHttpEtag;
+        return false;
+    }
+
+    private readonly struct ShardedRevisionsCollectionPreviewOperation : IShardedStreamableOperation
+    {
+        private readonly ShardedDatabaseRequestHandler _handler;
+        private readonly string _collection;
+        private readonly ShardedPagingContinuation _continuationToken;
+
+        public ShardedRevisionsCollectionPreviewOperation(ShardedDatabaseRequestHandler handler, string collection, string etag, ShardedPagingContinuation continuationToken)
+        {
+            _handler = handler;
+            _collection = collection;
+            _continuationToken = continuationToken;
+            ExpectedEtag = etag;
+        }
+
+        public HttpRequest HttpRequest => _handler.HttpContext.Request;
+
+        public RavenCommand<StreamResult> CreateCommandForShard(int shardNumber)
+        {
+            return new ShardedRevisionsPreviewCommand(_collection, _continuationToken.Pages[shardNumber].Start, _continuationToken.PageSize);
+        }
+
+        private sealed class ShardedRevisionsPreviewCommand : RavenCommand<StreamResult>
+        {
+            private readonly string _collection;
+            private readonly int _start;
+            private readonly int _pageSize;
+
+            public ShardedRevisionsPreviewCommand(string collection, int start, int pageSize)
+            {
+                _collection = collection;
+                _start = start;
+                _pageSize = pageSize;
+            }
+
+            public override bool IsReadRequest => false;
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/studio/revisions/preview?{Web.RequestHandler.StartParameter}={_start}&{Web.RequestHandler.PageSizeParameter}={_pageSize}";
+
+                if (string.IsNullOrEmpty(_collection) == false)
+                    url += $"&collection={Uri.EscapeDataString(_collection)}";
+
+                var message = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get,
+                };
+
+                return message;
+            }
+
+            public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
+            {
+                var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
+
+                Result = new StreamResult
+                {
+                    Response = response,
+                    Stream = new StreamWithTimeout(responseStream)
+                };
+
+                return ResponseDisposeHandling.Manually;
+            }
+        }
+
+        public string ExpectedEtag { get; }
+
+        public CombinedStreamResult CombineResults(Dictionary<int, ShardExecutionResult<StreamResult>> results)
+        {
+            return new CombinedStreamResult { Results = results };
+        }
+    }
+}

--- a/src/Raven.Server/Web/Studio/Sharding/ShardedStudioCollectionsHandler.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/ShardedStudioCollectionsHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Handlers.Processors.Revisions;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Studio;
 using Raven.Server.Routing;
 using Raven.Server.Web.Studio.Sharding.Processors;
@@ -19,6 +20,14 @@ namespace Raven.Server.Web.Studio.Sharding
         public async Task Delete()
         {
             using (var processor = new ShardedStudioCollectionHandlerProcessorForDeleteCollection(this))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/studio/revisions/preview", "GET")]
+
+        public async Task PreviewRevisions()
+        {
+            using (var processor = new ShardedStudioCollectionsHandlerProcessorForPreviewRevisions(this))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Web/Studio/Sharding/ShardedStudioCollectionsHandler.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/ShardedStudioCollectionsHandler.cs
@@ -24,7 +24,6 @@ namespace Raven.Server.Web.Studio.Sharding
         }
 
         [RavenShardedAction("/databases/*/studio/revisions/preview", "GET")]
-
         public async Task PreviewRevisions()
         {
             using (var processor = new ShardedStudioCollectionsHandlerProcessorForPreviewRevisions(this))

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.Processors.Revisions;
 using Raven.Server.Documents.Handlers.Processors.Studio;
 using Raven.Server.Routing;
 using Raven.Server.Web.Studio.Processors;
@@ -19,6 +20,13 @@ namespace Raven.Server.Web.Studio
         public async Task Delete()
         {
             using (var processor = new StudioCollectionHandlerProcessorForDeleteCollection(this))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenAction("/databases/*/studio/revisions/preview", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        public async Task PreviewRevisions()
+        {
+            using (var processor = new StudioCollectionsHandlerProcessorForPreviewRevisions(this))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -37,7 +37,7 @@ internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : Abs
         return context.OpenReadTransaction();
     }
 
-    protected override Task WriteItems(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer)
+    protected override Task WriteItemsAsync(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer)
     {
         var revisions = string.IsNullOrEmpty(Collection)
             ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrder(context, _start, _pageSize)

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Schemas;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Web.Studio.Processors;
 using Sparrow.Json;
@@ -22,28 +24,66 @@ internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : Abs
     {
     }
 
-    protected override IAsyncEnumerable<Document> GetRevisionsAsync(DocumentsOperationContext context)
+    protected override ValueTask InitializeAsync(DocumentsOperationContext context, CancellationToken token)
     {
-        if (string.IsNullOrEmpty(_collection))
-            return RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetAllRevisionsOrderedByEtag(context, _start, _pageSize).ToAsyncEnumerable();
-        else
-            return RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetAllRevisionsOrderedByEtagForCollection(context, _collection, _start, _pageSize).ToAsyncEnumerable();
-    }
-
-    protected override async ValueTask InitializeAsync(DocumentsOperationContext context)
-    {
-        await base.InitializeAsync(context);
         _start = RequestHandler.GetStart();
         _pageSize = RequestHandler.GetPageSize();
 
         _totalResults = string.IsNullOrEmpty(_collection)
             ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocuments(context)
-            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocuments(context, _collection);
+            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocumentsForCollection(context, _collection);
+
+        return ValueTask.CompletedTask;
     }
 
     protected override IDisposable OpenReadTransaction(DocumentsOperationContext context)
     {
         return context.OpenReadTransaction();
+    }
+
+    protected override Task WriteItems(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer)
+    {
+        var revisions = string.IsNullOrEmpty(_collection)
+            ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrder(context, _start, _pageSize)
+            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrderForCollection(context, _collection, _start, _pageSize);
+
+        writer.WriteStartArray();
+
+        var first = true;
+        foreach (var revision in revisions)
+        {
+            if (first)
+                first = false;
+            else
+                writer.WriteComma();
+
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(nameof(Document.Id));
+            writer.WriteString(revision.Id);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(Document.Etag));
+            writer.WriteInteger(revision.Etag);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(Document.LastModified));
+            writer.WriteDateTime(revision.LastModified, true);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(Document.ChangeVector));
+            writer.WriteString(revision.ChangeVector);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(Document.Flags));
+            writer.WriteString(revision.Flags.ToString());
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+
+        return Task.CompletedTask;
     }
 
     protected override ValueTask<long> GetTotalCountAsync()
@@ -58,7 +98,7 @@ internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : Abs
 
         changeVector = string.IsNullOrEmpty(_collection)
             ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVector(context)
-            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVector(context, _collection);
+            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVectorForCollection(context, _collection);
 
         if (changeVector != null)
             etag = $"{changeVector}/{_totalResults}";

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client;
 using Raven.Server.Documents;
-using Raven.Server.Documents.Schemas;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Web.Studio.Processors;
 using Sparrow.Json;
@@ -24,16 +20,16 @@ internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : Abs
     {
     }
 
-    protected override ValueTask InitializeAsync(DocumentsOperationContext context, CancellationToken token)
+    protected override async Task InitializeAsync(DocumentsOperationContext context, CancellationToken token)
     {
+        await base.InitializeAsync(context, token);
+
         _start = RequestHandler.GetStart();
         _pageSize = RequestHandler.GetPageSize();
 
-        _totalResults = string.IsNullOrEmpty(_collection)
+        _totalResults = string.IsNullOrEmpty(Collection)
             ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocuments(context)
-            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocumentsForCollection(context, _collection);
-
-        return ValueTask.CompletedTask;
+            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocumentsForCollection(context, Collection);
     }
 
     protected override IDisposable OpenReadTransaction(DocumentsOperationContext context)
@@ -43,9 +39,9 @@ internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : Abs
 
     protected override Task WriteItems(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer)
     {
-        var revisions = string.IsNullOrEmpty(_collection)
+        var revisions = string.IsNullOrEmpty(Collection)
             ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrder(context, _start, _pageSize)
-            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrderForCollection(context, _collection, _start, _pageSize);
+            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrderForCollection(context, Collection, _start, _pageSize);
 
         writer.WriteStartArray();
 
@@ -96,9 +92,9 @@ internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : Abs
         string changeVector;
         etag = null;
 
-        changeVector = string.IsNullOrEmpty(_collection)
+        changeVector = string.IsNullOrEmpty(Collection)
             ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVector(context)
-            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVectorForCollection(context, _collection);
+            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVectorForCollection(context, Collection);
 
         if (changeVector != null)
             etag = $"{changeVector}/{_totalResults}";

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Studio.Processors;
+using Sparrow.Json;
+
+namespace Raven.Server.Web.Studio;
+
+internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : AbstractStudioCollectionsHandlerProcessorForPreviewRevisions<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    private int _start;
+    private int _pageSize;
+    private long _totalResults;
+
+    public StudioCollectionsHandlerProcessorForPreviewRevisions([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    protected override IAsyncEnumerable<Document> GetRevisionsAsync(DocumentsOperationContext context)
+    {
+        if (string.IsNullOrEmpty(_collection))
+            return RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetAllRevisionsOrderedByEtag(context, _start, _pageSize).ToAsyncEnumerable();
+        else
+            return RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetAllRevisionsOrderedByEtagForCollection(context, _collection, _start, _pageSize).ToAsyncEnumerable();
+    }
+
+    protected override async ValueTask InitializeAsync(DocumentsOperationContext context)
+    {
+        await base.InitializeAsync(context);
+        _start = RequestHandler.GetStart();
+        _pageSize = RequestHandler.GetPageSize();
+
+        _totalResults = string.IsNullOrEmpty(_collection)
+            ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocuments(context)
+            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocuments(context, _collection);
+    }
+
+    protected override IDisposable OpenReadTransaction(DocumentsOperationContext context)
+    {
+        return context.OpenReadTransaction();
+    }
+
+    protected override ValueTask<long> GetTotalCountAsync()
+    {
+        return ValueTask.FromResult(_totalResults);
+    }
+
+    protected override bool NotModified(DocumentsOperationContext context, out string etag)
+    {
+        string changeVector;
+        etag = null;
+
+        changeVector = string.IsNullOrEmpty(_collection)
+            ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVector(context)
+            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVector(context, _collection);
+
+        if (changeVector != null)
+            etag = $"{changeVector}/{_totalResults}";
+
+        if (etag == null)
+            return false;
+
+        if (etag == RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch))
+            return true;
+
+        return false;
+    }
+}
+

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -39,46 +39,48 @@ internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : Abs
 
     protected override Task WriteItemsAsync(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer)
     {
-        var revisions = string.IsNullOrEmpty(Collection)
-            ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrder(context, _start, _pageSize)
-            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrderForCollection(context, Collection, _start, _pageSize);
-
         writer.WriteStartArray();
 
-        var first = true;
-        foreach (var revision in revisions)
+        if (_totalResults > 0)
         {
-            if (first)
-                first = false;
-            else
+            var revisions = string.IsNullOrEmpty(Collection)
+                ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrder(context, _start, _pageSize)
+                : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrderForCollection(context, Collection, _start, _pageSize);
+
+            var first = true;
+            foreach (var revision in revisions)
+            {
+                if (first)
+                    first = false;
+                else
+                    writer.WriteComma();
+
+                writer.WriteStartObject();
+
+                writer.WritePropertyName(nameof(Document.Id));
+                writer.WriteString(revision.Id);
                 writer.WriteComma();
 
-            writer.WriteStartObject();
+                writer.WritePropertyName(nameof(Document.Etag));
+                writer.WriteInteger(revision.Etag);
+                writer.WriteComma();
 
-            writer.WritePropertyName(nameof(Document.Id));
-            writer.WriteString(revision.Id);
-            writer.WriteComma();
+                writer.WritePropertyName(nameof(Document.LastModified));
+                writer.WriteDateTime(revision.LastModified, true);
+                writer.WriteComma();
 
-            writer.WritePropertyName(nameof(Document.Etag));
-            writer.WriteInteger(revision.Etag);
-            writer.WriteComma();
+                writer.WritePropertyName(nameof(Document.ChangeVector));
+                writer.WriteString(revision.ChangeVector);
+                writer.WriteComma();
 
-            writer.WritePropertyName(nameof(Document.LastModified));
-            writer.WriteDateTime(revision.LastModified, true);
-            writer.WriteComma();
+                writer.WritePropertyName(nameof(Document.Flags));
+                writer.WriteString(revision.Flags.ToString());
 
-            writer.WritePropertyName(nameof(Document.ChangeVector));
-            writer.WriteString(revision.ChangeVector);
-            writer.WriteComma();
-
-            writer.WritePropertyName(nameof(Document.Flags));
-            writer.WriteString(revision.Flags.ToString());
-
-            writer.WriteEndObject();
+                writer.WriteEndObject();
+            }
         }
 
         writer.WriteEndArray();
-
         return Task.CompletedTask;
     }
 

--- a/test/SlowTests/Issues/RavenDB-14963.cs
+++ b/test/SlowTests/Issues/RavenDB-14963.cs
@@ -54,7 +54,6 @@ public class RavenDB_14963 : RavenTestBase
                     throw new InvalidOperationException($"revision data ({result.ChangeVector}, {result.Id}) doesn't contains field 'Name'.");
 
                 return name;
-
             }
 
         };

--- a/test/SlowTests/Issues/RavenDB-14963.cs
+++ b/test/SlowTests/Issues/RavenDB-14963.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing.Printing;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.Runtime.Documents;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Commands;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.Documents.Schemas;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using Task = System.Threading.Tasks.Task;
+using Web = Raven.Server.Web;
+
+namespace SlowTests.Issues;
+public class RavenDB_14963 : RavenTestBase
+{
+    public RavenDB_14963(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Voron | RavenTestCategory.Sharding)]
+    public async Task TestAllRevisionsViewForSharding()
+    {
+        using var store = Sharding.GetDocumentStore();
+
+        var list = await Initialize(store);
+
+        Func<RevisionInfo, Task<string>> getName = async (result) =>
+        {
+            var shardNumber = await Sharding.GetShardNumberForAsync(store, result.Id);
+
+            var db = await Sharding.GetAnyShardDocumentDatabaseInstanceFor($"{store.Database}${shardNumber}");
+
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var revision = db.DocumentsStorage.RevisionsStorage.GetRevision(ctx, result.ChangeVector);
+                if (revision.Data.TryGet("Name", out string name) == false)
+                    throw new InvalidOperationException($"revision data ({result.ChangeVector}, {result.Id}) doesn't contains field 'Name'.");
+
+                return name;
+
+            }
+
+        };
+
+        await AssertResults(store, getName, list, 8, 0, 3);
+        await AssertResults(store, getName, list, 8, 1, 3);
+        await AssertResults(store, getName, list, 8, 2, 3);
+        await AssertResults(store, getName, list, 8, 0, 8);
+
+    }
+
+
+
+    [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.Voron)]
+    public async Task TestAllRevisionsView()
+    {
+        using var store = GetDocumentStore();
+
+        var list = await Initialize(store);
+
+        var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+        using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+        using (ctx.OpenReadTransaction())
+        {
+            var usersLastCv = db.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVectorForCollection(ctx, "Users");
+            var docsLastCv = db.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVectorForCollection(ctx, "Docs");
+            var lastCv = db.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVector(ctx);
+
+            Assert.Equal(lastCv, docsLastCv);
+
+            var lastEtag = Convert.ToInt64(lastCv.Split(":")[1].Split("-")[0]);
+            var lastUsersEtag = Convert.ToInt64(usersLastCv.Split(":")[1].Split("-")[0]);
+
+            Assert.True(lastEtag > lastUsersEtag, $"lastCv {lastCv}, lastEtag {lastEtag}, usersLastCv: {usersLastCv}, lastUsersEtag {lastUsersEtag}");
+
+            Func<RevisionInfo, Task<string>> getName = (result) =>
+            {
+                var revision = db.DocumentsStorage.RevisionsStorage.GetRevision(ctx, result.ChangeVector);
+                if (revision.Data.TryGet("Name", out string name) == false)
+                    throw new InvalidOperationException($"revision data ({result.ChangeVector}, {result.Id}) doesn't contains field 'Name'.");
+
+                return Task.FromResult(name);
+            };
+
+            await AssertResults(store, getName, list, 8, 0, 3);
+            await AssertResults(store, getName, list, 8, 1, 3);
+            await AssertResults(store, getName, list, 8, 2, 3);
+            await AssertResults(store, getName, list, 8, 0, 8);
+        }
+    }
+
+
+    private async Task<List<(string Id, string Name)>> Initialize(DocumentStore store)
+    {
+        var configuration = new RevisionsConfiguration
+        {
+            Default = new RevisionsCollectionConfiguration
+            {
+                Disabled = false
+            }
+        };
+        await RevisionsHelper.SetupRevisionsAsync(store, configuration: configuration);
+
+        var list = new List<(string Id, string Name)>();
+
+        for (int i = 0; i < 2; i++)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = i.ToString() }, "Users/1");
+                list.Add(("Users/1", i.ToString()));
+                await session.SaveChangesAsync();
+            }
+            await Task.Delay(100);
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = i.ToString() }, "Users/2");
+                list.Add(("Users/2", i.ToString()));
+                await session.SaveChangesAsync();
+            }
+            await Task.Delay(100);
+        }
+
+        for (int i = 0; i < 2; i++)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Doc { Name = i.ToString() }, "Docs/1");
+                list.Add(("Docs/1", i.ToString()));
+                await session.SaveChangesAsync();
+            }
+            await Task.Delay(100);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Doc { Name = i.ToString() }, "Docs/2");
+                list.Add(("Docs/2", i.ToString()));
+                await session.SaveChangesAsync();
+            }
+            await Task.Delay(100);
+
+        }
+
+        list.Reverse();
+
+        return list;
+    }
+
+    private async Task AssertResults(DocumentStore store, Func<RevisionInfo, Task<string>> getName, List<(string Id, string Name)> list,
+        int totalResults, int start, int pageSize, string collection = null)
+    {
+        var results = await store.Maintenance.SendAsync(new RevisionsCollectionPreviewOperation(collection, start, pageSize));
+        Assert.Equal(totalResults, results.TotalResults);
+        Assert.Equal(pageSize, results.Results.Count);
+
+        int i = start;
+        foreach (var result in results.Results)
+        {
+            var info = list[i++];
+
+            Assert.Equal(info.Id, result.Id);
+
+            var name = await getName(result);
+
+            Assert.Equal(info.Name, name);
+        }
+    }
+
+
+    private class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class Doc
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class RevisionsCollectionPreviewOperation : IMaintenanceOperation<RevisionsPreviewResults>
+    {
+        private readonly string _collection;
+        private readonly int _start;
+        private readonly int _pageSize;
+
+        public RevisionsCollectionPreviewOperation(int start, int pageSize)
+        {
+            _start = start;
+            _pageSize = pageSize;
+        }
+
+        public RevisionsCollectionPreviewOperation(string collection, int start, int pageSize)
+        {
+            _collection = collection;
+            _start = start;
+            _pageSize = pageSize;
+        }
+
+        public RavenCommand<RevisionsPreviewResults> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        {
+            return new RevisionsPreviewCommand(_collection, _start, _pageSize);
+        }
+
+        private sealed class RevisionsPreviewCommand : RavenCommand<RevisionsPreviewResults>
+        {
+            private readonly string _collection;
+            private readonly int _start;
+            private readonly int _pageSize;
+
+
+            public RevisionsPreviewCommand(string collection, int start, int pageSize)
+            {
+                _collection = collection;
+                _start = start;
+                _pageSize = pageSize;
+            }
+
+            public override bool IsReadRequest => true;
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/studio/revisions/preview?{Web.RequestHandler.StartParameter}={_start}&{Web.RequestHandler.PageSizeParameter}={_pageSize}";
+
+                if (string.IsNullOrEmpty(_collection) == false)
+                    url += $"&collection={Uri.EscapeDataString(_collection)}";
+
+                return new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get,
+                };
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    throw new InvalidOperationException();
+                if (fromCache)
+                {
+                    // we have to clone the response here because  otherwise the cached item might be freed while
+                    // we are still looking at this result, so we clone it to the side
+                    response = response.Clone(context);
+                }
+
+                Result = GetRevisionsPreviewResults(response);
+            }
+
+            private static readonly Func<BlittableJsonReaderObject, RevisionsPreviewResults> GetRevisionsPreviewResults = JsonDeserializationBase.GenerateJsonDeserializationRoutine<RevisionsPreviewResults>();
+
+        }
+
+    }
+
+    private class RevisionInfo
+    {
+        public string Id { get; set; }
+        public int Etag { get; set; }
+        public DateTime LastModified { get; set; }
+        public string ChangeVector { get; set; }
+        public DocumentFlags Flags { get; set; }
+        public int? ShardNumber { get; set; }
+    }
+
+    private class RevisionsPreviewResults
+    {
+        public int TotalResults { get; set; }
+        public List<RevisionInfo> Results { get; set; }
+        public string ContinuationToken { get; set; }
+
+    }
+}
+

--- a/test/SlowTests/Issues/RavenDB-14963.cs
+++ b/test/SlowTests/Issues/RavenDB-14963.cs
@@ -75,7 +75,7 @@ public class RavenDB_14963 : RavenTestBase
         await AssertResultsAsync(store, list, totalResults: 8, start: 2, pageSize: 3);
         await AssertResultsAsync(store, list, totalResults: 8, start: 0, pageSize: 8);
 
-        await Assert.ThrowsAsync<RavenException>(() => AssertResultsAsync(store, list, totalResults: 0, start: 0, pageSize: 8, "Companies"));
+        await AssertResultsAsync(store, list, totalResults: 0, start: 0, pageSize: 8, "Companies");
 
         await AssertResultsAsync(store, list, totalResults: 4, start: 0, pageSize: 2, "Users");
         await AssertResultsAsync(store, list, totalResults: 4, start: 1, pageSize: 2, "Users");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14963/All-revisions-view

### Additional description
related to this PR:
https://github.com/ravendb/ravendb/pull/18504#discussion_r1604417150
which is merged by mistake and reverted..

Json Format:


Single:
```
{
  "TotalResults": 8,
  "Results": [
    {
      "Id": "Users/1",
      "Etag": 16,
      "LastModified": "2024-05-12T11:53:41.8128727Z",
      "ChangeVector": "A:15-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Companies/1",
      "Etag": 14,
      "LastModified": "2024-05-12T11:53:35.7369914Z",
      "ChangeVector": "A:13-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Companies/1",
      "Etag": 12,
      "LastModified": "2024-05-12T11:53:33.9179408Z",
      "ChangeVector": "A:11-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Docs/1",
      "Etag": 10,
      "LastModified": "2024-05-12T11:53:23.5946301Z",
      "ChangeVector": "A:9-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Docs/1",
      "Etag": 8,
      "LastModified": "2024-05-12T11:53:21.7090247Z",
      "ChangeVector": "A:7-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Users/1",
      "Etag": 6,
      "LastModified": "2024-05-12T11:53:13.4545503Z",
      "ChangeVector": "A:5-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Users/1",
      "Etag": 4,
      "LastModified": "2024-05-09T08:34:28.8081143Z",
      "ChangeVector": "A:3-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Users/1",
      "Etag": 2,
      "LastModified": "2024-05-09T08:34:25.7935544Z",
      "ChangeVector": "A:1-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    }
  ]
}
```
Sharded:
```
{
  "TotalResults": 12,
  "Results": [
    {
      "Id": "Users/2",
      "Etag": 17,
      "LastModified": "2024-05-08T09:56:49.0218539Z",
      "ChangeVector": "A:16-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Users/2",
      "Etag": 15,
      "LastModified": "2024-05-08T09:56:47.0754333Z",
      "ChangeVector": "A:13-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Users/2",
      "Etag": 14,
      "LastModified": "2024-05-08T09:55:18.3546928Z",
      "ChangeVector": "A:4-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, FromOldDocumentRevision, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Users/3",
      "Etag": 12,
      "LastModified": "2024-05-08T09:56:43.9053422Z",
      "ChangeVector": "A:10-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Users/3",
      "Etag": 11,
      "LastModified": "2024-05-08T09:55:25.3694998Z",
      "ChangeVector": "A:5-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, FromOldDocumentRevision, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Docs/2",
      "Etag": 9,
      "LastModified": "2024-05-08T09:56:32.9012798Z",
      "ChangeVector": "A:7-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Docs/2",
      "Etag": 8,
      "LastModified": "2024-05-08T09:55:48.9191329Z",
      "ChangeVector": "A:6-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, FromOldDocumentRevision, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Users/1",
      "Etag": 12,
      "LastModified": "2024-05-08T09:56:53.6674637Z",
      "ChangeVector": "A:10-0wZr2SRLP0erExEpAl9raA",
      "Flags": "HasRevisions, Revision",
      "ShardNumber": 2
    }
  ],
  "ContinuationToken": "DgACAQMDAgIDAAICAQMDAgIDAgQCAQMDAgIDAxkBURAEUQcFURACAQYDCwBRBVBhZ2VzAAEwAAVTdGFydAALU2hhcmROdW1iZXIAATEAATIACFBhZ2VTaXplABAuJyQdEA0KJltR"
}
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
