### PR TITLE
RavenDB-22454 - Missing ForgetAbout in HandleReferences

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -398,24 +398,32 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                 if (indexed.Add(item.Id) == false)
                 {
-                    item.Dispose();
+                    DisposeItem();
                     continue;
                 }
 
                 if (item.Etag > lastIndexedEtag)
                 {
-                    item.Dispose();
+                    DisposeItem();
                     continue;
                 }
 
                 if (ItemsAndReferencesAreUsingSameEtagPool && item.Etag > referencedItem.Etag)
                 {
                     //if the map worker already mapped this "doc" version it must be with this version of "referencedItem" and if the map worker didn't mapped the "doc" so it will process it later
-                    item.Dispose();
+                    DisposeItem();
                     continue;
                 }
 
                 yield return item;
+
+                void DisposeItem()
+                {
+                    if (item.Item is Document doc)
+                        queryContext.Documents.Transaction.ForgetAbout(doc);
+
+                    item.Dispose();
+                }
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-15754.cs
+++ b/test/SlowTests/Issues/RavenDB-15754.cs
@@ -61,7 +61,7 @@ namespace SlowTests.Issues
                 }
 
                 var index = new DocumentsIndex();
-                await new DocumentsIndex().ExecuteAsync(store);
+                await index.ExecuteAsync(store);
 
                 Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
                 await AssertCount(store, _companyName1, _employeesCount);
@@ -90,6 +90,86 @@ namespace SlowTests.Issues
                 await AssertCount(store, _companyName2, _employeesCount);
                 Assert.True(await Task.WhenAny(tcs.Task, Task.Delay(10_000)) == tcs.Task);
                 Assert.True(batchCount > 1);
+
+                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+                Assert.Equal(_employeesCount, indexStats.MapAttempts);
+                Assert.Equal(_employeesCount, indexStats.MapReferenceAttempts);
+            }
+        }
+
+        [Fact]
+        public async Task CanIndexReferencedAndParentDocumentChange()
+        {
+            using (var store = GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = x => x.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = _managedAllocationsBatchLimit
+            }))
+            {
+                var company = new Company
+                {
+                    Name = _companyName1
+                };
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(company);
+                    await session.SaveChangesAsync();
+
+                    using (var bulk = store.BulkInsert())
+                    {
+                        for (var i = 0; i < _employeesCount; i++)
+                        {
+                            await bulk.StoreAsync(new Employee
+                            {
+                                CompanyId = company.Id
+                            }, i.ToString());
+                        }
+                    }
+                }
+
+                var index = new DocumentsIndex();
+                await index.ExecuteAsync(store);
+
+                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
+                await AssertCount(store, _companyName1, _employeesCount);
+
+                var batchCount = 0;
+                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                store.Changes().ForIndex(index.IndexName).Subscribe(x =>
+                {
+                    if (x.Type == IndexChangeTypes.BatchCompleted)
+                    {
+                        if (Interlocked.Increment(ref batchCount) > 1)
+                            tcs.TrySetResult(null);
+                    }
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    company.Name = _companyName2;
+                    await session.StoreAsync(company, company.Id);
+
+                    for (var i = 0; i < _employeesCount; i++)
+                    {
+                        await session.StoreAsync(new Employee
+                        {
+                            CompanyId = company.Id
+                        }, i.ToString());
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
+                await AssertCount(store, _companyName1, 0);
+                await AssertCount(store, _companyName2, _employeesCount);
+                Assert.True(await Task.WhenAny(tcs.Task, Task.Delay(10_000)) == tcs.Task);
+                Assert.True(batchCount > 1);
+
+                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+                Assert.Equal(2 * _employeesCount, indexStats.MapAttempts);
+                Assert.Equal(0, indexStats.MapReferenceAttempts);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22454/Missing-ForgetAbout-in-HandleReferences

### Additional description

Use `ForgetAbout` in `HandleReferences` when we skip indexing the document.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
