### PR TITLE
RavenDB-22454 - Missing ForgetAbout in HandleReferences

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -437,18 +437,26 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                 if (item.Etag > lastIndexedEtag)
                 {
-                    item.Dispose();
+                    DisposeItem();
                     continue;
                 }
 
                 if (ItemsAndReferencesAreUsingSameEtagPool && item.Etag > referencedItem.Etag)
                 {
                     // if the map worker already mapped this "doc" version it must be with this version of "referencedItem" and if the map worker didn't mapped the "doc" so it will process it later
-                    item.Dispose();
+                    DisposeItem();
                     continue;
                 }
 
                 yield return item;
+
+                void DisposeItem()
+                {
+                    if (item.Item is Document doc)
+                        queryContext.Documents.Transaction.ForgetAbout(doc);
+
+                    item.Dispose();
+                }
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-15754.cs
+++ b/test/SlowTests/Issues/RavenDB-15754.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Indexes.Counters;
 using Raven.Client.Documents.Indexes.TimeSeries;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes;
 using Sparrow.Platform;
@@ -98,12 +99,15 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
-        public async Task CanIndexReferencedAndParentDocumentChange()
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task CanIndexReferencedCompressedDocumentsAndParentDocumentChange()
         {
             using (var store = GetDocumentStore(new Options
             {
-                ModifyDatabaseRecord = x => x.Settings[RavenConfiguration.GetKey(x => x.Indexing.ManagedAllocationsBatchLimit)] = _managedAllocationsBatchLimit
+                ModifyDatabaseRecord = x =>
+                {
+                    x.DocumentsCompression = new DocumentsCompressionConfiguration(compressRevisions: false, compressAllCollections: true);
+                }
             }))
             {
                 var company = new Company
@@ -134,18 +138,6 @@ namespace SlowTests.Issues
                 Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(3));
                 await AssertCount(store, _companyName1, _employeesCount);
 
-                var batchCount = 0;
-                var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-                store.Changes().ForIndex(index.IndexName).Subscribe(x =>
-                {
-                    if (x.Type == IndexChangeTypes.BatchCompleted)
-                    {
-                        if (Interlocked.Increment(ref batchCount) > 1)
-                            tcs.TrySetResult(null);
-                    }
-                });
-
                 using (var session = store.OpenAsyncSession())
                 {
                     company.Name = _companyName2;
@@ -165,8 +157,6 @@ namespace SlowTests.Issues
                 Indexes.WaitForIndexing(store, timeout: TimeSpan.FromMinutes(5));
                 await AssertCount(store, _companyName1, 0);
                 await AssertCount(store, _companyName2, _employeesCount);
-                Assert.True(await Task.WhenAny(tcs.Task, Task.Delay(10_000)) == tcs.Task);
-                Assert.True(batchCount > 1);
 
                 var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
                 Assert.Equal(2 * _employeesCount, indexStats.MapAttempts);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22454/Missing-ForgetAbout-in-HandleReferences

### Additional description

Port from 5.4: https://github.com/ravendb/ravendb/pull/18629

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
