### PR TITLE
RavenDB-22455 - Allow to import a disabled revisions configuration

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -279,7 +279,8 @@ public sealed partial class ClusterStateMachine
             return;
 
         if (licenseStatus.CanSetupDefaultRevisionsConfiguration == false &&
-            databaseRecord.Revisions.Default != null)
+            databaseRecord.Revisions.Default != null &&
+            databaseRecord.Revisions.Default.Disabled == false)
         {
             throw new LicenseLimitException(LimitType.RevisionsConfiguration, "Your license doesn't allow the creation of a default configuration for revisions.");
         }
@@ -289,6 +290,9 @@ public sealed partial class ClusterStateMachine
 
         foreach (KeyValuePair<string, RevisionsCollectionConfiguration> revisionPerCollectionConfiguration in databaseRecord.Revisions.Collections)
         {
+            if (revisionPerCollectionConfiguration.Value.Disabled)
+                continue;
+
             if (revisionPerCollectionConfiguration.Value.MinimumRevisionsToKeep != null &&
                 maxRevisionsToKeep != null &&
                 revisionPerCollectionConfiguration.Value.MinimumRevisionsToKeep > maxRevisionsToKeep)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -299,7 +299,7 @@ public sealed partial class ClusterStateMachine
             {
                 throw new LicenseLimitException(LimitType.RevisionsConfiguration,
                     $"The defined minimum revisions to keep '{revisionPerCollectionConfiguration.Value.MinimumRevisionsToKeep}' " +
-                    $"for collection {revisionPerCollectionConfiguration.Key} exceeds the licensed one '{maxRevisionsToKeep}'");
+                    $"for collection '{revisionPerCollectionConfiguration.Key}' exceeds the licensed one '{maxRevisionsToKeep}'");
             }
 
             if (revisionPerCollectionConfiguration.Value.MinimumRevisionAgeToKeep != null &&
@@ -308,7 +308,7 @@ public sealed partial class ClusterStateMachine
             {
                 throw new LicenseLimitException(LimitType.RevisionsConfiguration,
                     $"The defined minimum revisions age to keep '{revisionPerCollectionConfiguration.Value.MinimumRevisionAgeToKeep}' " +
-                    $"for collection {revisionPerCollectionConfiguration.Key} exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
+                    $"for collection '{revisionPerCollectionConfiguration.Key}' exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
             }
         }
     }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -299,7 +299,7 @@ public sealed partial class ClusterStateMachine
             {
                 throw new LicenseLimitException(LimitType.RevisionsConfiguration,
                     $"The defined minimum revisions to keep '{revisionPerCollectionConfiguration.Value.MinimumRevisionsToKeep}' " +
-                    $" exceeds the licensed one '{maxRevisionsToKeep}'");
+                    $"for collection {revisionPerCollectionConfiguration.Key} exceeds the licensed one '{maxRevisionsToKeep}'");
             }
 
             if (revisionPerCollectionConfiguration.Value.MinimumRevisionAgeToKeep != null &&
@@ -308,7 +308,7 @@ public sealed partial class ClusterStateMachine
             {
                 throw new LicenseLimitException(LimitType.RevisionsConfiguration,
                     $"The defined minimum revisions age to keep '{revisionPerCollectionConfiguration.Value.MinimumRevisionAgeToKeep}' " +
-                    $" exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
+                    $"for collection {revisionPerCollectionConfiguration.Key} exceeds the licensed one '{maxRevisionAgeToKeepInDays}'");
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22455/Cannot-import-disabled-revisions-configuration

### Additional description

Allow to import a disabled revisions configuration.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
