### PR TITLE
RavenDB-17604 added support for disable.tasks.marker

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -135,6 +135,16 @@ namespace Raven.Server.Documents
                     _addToInitLog("Creating db.lock file");
                     _fileLocker = new FileLocker(Configuration.Core.DataDirectory.Combine("db.lock").FullPath);
                     _fileLocker.TryAcquireWriteLock(_logger);
+
+                    var disableFileMarkerPath = Configuration.Core.DataDirectory.Combine("disable.tasks.marker").FullPath;
+                    DisableOngoingTasks = File.Exists(disableFileMarkerPath);
+                    if (DisableOngoingTasks)
+                    {
+                        var msg = $"MAINTENANCE WARNING: Found disable.tasks.marker file. All tasks will not start. Please remove the file and restart the '{Name}' database.";
+                        _addToInitLog(msg);
+                        if (_logger.IsOperationsEnabled)
+                            _logger.Operations(msg);
+                    }
                 }
 
                 using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
@@ -196,6 +206,7 @@ namespace Raven.Server.Documents
             }
         }
 
+        public readonly bool DisableOngoingTasks;
 
         public ServerStore ServerStore => _serverStore;
 

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -317,6 +317,9 @@ namespace Raven.Server.Documents.PeriodicBackup
                 if (periodicBackup.Disposed)
                     throw new InvalidOperationException("Backup task was already disposed");
 
+                if (_database.DisableOngoingTasks)
+                    throw new InvalidOperationException("Backup task is disabled via marker file");
+
                 var runningTask = periodicBackup.RunningTask;
                 if (runningTask != null)
                 {

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -958,7 +958,7 @@ namespace Raven.Server.Documents.Replication
 
                 var pullReplication = newRecord.HubPullReplications.Find(x => x.Name == instance.PullReplicationDefinitionName);
 
-                if (pullReplication != null && pullReplication.Disabled == false)
+                if (pullReplication != null && pullReplication.Disabled == false && Database.DisableOngoingTasks == false)
                 {
                     // update the destination
                     var current = (ExternalReplication)instance.Destination;
@@ -1104,7 +1104,7 @@ namespace Raven.Server.Documents.Replication
 
             var newDestinations = GetMyNewDestinations(newRecord, changes.AddedDestinations);
 
-            if (newDestinations.Count > 0)
+            if (newDestinations.Count > 0 && Database.DisableOngoingTasks == false)
             {
                 Task.Run(() =>
                 {

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -272,7 +272,7 @@ namespace Raven.Server.Documents.Subscriptions
                         RegisterConnectionDurationInTicks = registerConnectionDurationInTicks
                     };
                 }
-                if (subscription.Disabled)
+                if (subscription.Disabled || _db.DisableOngoingTasks)
                     throw new SubscriptionClosedException($"The subscription with id '{id}' and name '{name}' is disabled and cannot be used until enabled");
 
                 return subscription;
@@ -698,7 +698,7 @@ namespace Raven.Server.Documents.Subscriptions
                         continue;
 
                     var subscriptionState = JsonDeserializationClient.SubscriptionState(subscriptionBlittable);
-                    if (subscriptionState.Disabled)
+                    if (subscriptionState.Disabled || _db.DisableOngoingTasks)
                     {
                         DropSubscriptionConnections(subscriptionStateKvp.Key, new SubscriptionClosedException($"The subscription {subscriptionName} is disabled and cannot be used until enabled"));
                         continue;

--- a/test/SlowTests/Issues/RavenDB_17604.cs
+++ b/test/SlowTests/Issues/RavenDB_17604.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17604 : RavenTestBase
+{
+    public RavenDB_17604(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public async Task Can_Disable_Etls_With_Marker()
+    {
+        var path = NewDataPath();
+        IOExtensions.DeleteDirectory(path);
+
+        using (var store = GetDocumentStore(new Options { RunInMemory = false, Path = path }))
+        {
+            var connectionStringName = Guid.NewGuid().ToString();
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Name = connectionStringName,
+                TopologyDiscoveryUrls = store.Urls,
+                Database = connectionStringName
+            }));
+
+            await store.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(new RavenEtlConfiguration
+            {
+                ConnectionStringName = connectionStringName,
+                Transforms = [new Transformation { Name = "MyScript", Collections = ["Orders"], Script = "loadToOrders(this);" }]
+            }));
+
+            var database = await GetDatabase(store.Database);
+            Assert.Equal(1, database.EtlLoader.Processes.Length);
+            Assert.True(database.EtlLoader.Processes[0].IsRunning);
+
+            Server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+
+            database = await GetDatabase(store.Database);
+            Assert.Equal(1, database.EtlLoader.Processes.Length);
+            Assert.True(database.EtlLoader.Processes[0].IsRunning);
+
+            Server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+            File.Create(Path.Combine(path, "disable.tasks.marker"));
+
+            database = await GetDatabase(store.Database);
+            Assert.Equal(1, database.EtlLoader.Processes.Length);
+            Assert.False(database.EtlLoader.Processes[0].IsRunning);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public async Task Can_Disable_Backup_With_Marker()
+    {
+        var path = NewDataPath();
+        IOExtensions.DeleteDirectory(path);
+
+        using (var store = GetDocumentStore(new Options { RunInMemory = false, Path = path }))
+        {
+            var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(new PeriodicBackupConfiguration
+            {
+                LocalSettings = new LocalSettings { FolderPath = NewDataPath() },
+                FullBackupFrequency = "* * * * *"
+            }));
+
+            await Backup.RunBackupAsync(Server, result.TaskId, store);
+
+            Server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+
+            var database = await GetDatabase(store.Database);
+            await WaitForValueAsync(() => database.PeriodicBackupRunner.PeriodicBackups.Count, 1);
+            await Backup.RunBackupAsync(Server, result.TaskId, store);
+
+            Server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+            File.Create(Path.Combine(path, "disable.tasks.marker"));
+            database = await GetDatabase(store.Database);
+            await WaitForValueAsync(() => database.PeriodicBackupRunner.PeriodicBackups.Count, 1);
+
+            var e = await Assert.ThrowsAsync<InvalidOperationException>(() => Backup.RunBackupAsync(Server, result.TaskId, store));
+            Assert.Contains("Backup task is disabled via marker file", e.Message);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17604

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
