### PR TITLE
RavenDB-22430 Update query statistics after all results are retrieved from IndexReadOperation

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3474,17 +3474,9 @@ namespace Raven.Server.Documents.Indexes
                                         while (enumerator.MoveNext())
                                         {
                                             var document = enumerator.Current;
-
-                                            resultToFill.TotalResults = totalResults.Value;
-
-                                            if (query.Offset != null || query.Limit != null)
-                                            {
-                                                resultToFill.CappedMaxResults = Math.Min(
-                                                    query.Limit ?? long.MaxValue,
-                                                    totalResults.Value - (query.Offset ?? 0)
-                                                );
-                                            }
-
+                                            //Streaming:
+                                            UpdateQueryStatistics();
+                                            
                                             await resultToFill.AddResultAsync(document.Result, token.Token);
 
                                             if (document.Highlightings != null)
@@ -3504,6 +3496,21 @@ namespace Raven.Server.Documents.Indexes
                                             includeTimeSeriesCommand?.Fill(document.Result);
 
                                             includeRevisionsCommand?.Fill(document.Result);
+                                        }
+                                        
+                                        // Corax: we have to update the statistics again (after all) due to take parameter in OrderBy clauses.
+                                        UpdateQueryStatistics();
+                                        void UpdateQueryStatistics()
+                                        {
+                                            resultToFill.TotalResults = totalResults.Value;
+
+                                            if (query.Offset != null || query.Limit != null)
+                                            {
+                                                resultToFill.CappedMaxResults = Math.Max(0, Math.Min(
+                                                    query.Limit ?? long.MaxValue,
+                                                    totalResults.Value - (query.Offset ?? 0)
+                                                ));
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22430

### Additional description

In Corax for Paging, we use take parameters that limit the output of the query primitive to avoid loading unnecessary documents during the query, and update totalResults after all documents are returned, so we need to update query statistics after all documents are retrieved.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
