### PR TITLE
RavenDB-22271 - Audit log on revisions settings changes (V5.4)

### DIFF
--- a/src/Raven.Client/Documents/Operations/Revisions/RevisionsCollectionConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/RevisionsCollectionConfiguration.cs
@@ -56,5 +56,10 @@ namespace Raven.Client.Documents.Operations.Revisions
                 [nameof(MaximumRevisionsToDeleteUponDocumentUpdate)] = MaximumRevisionsToDeleteUponDocumentUpdate
             };
         }
+
+        public DynamicJsonValue ToAuditJson()
+        {
+            return ToJson();
+        }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Revisions/RevisionsConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/RevisionsConfiguration.cs
@@ -104,5 +104,10 @@ namespace Raven.Client.Documents.Operations.Revisions
                 [nameof(Collections)] = collections
             };
         }
+
+        public virtual DynamicJsonValue ToAuditJson()
+        {
+            return ToJson();
+        }
     }
 }

--- a/src/Raven.Server/Documents/DatabaseRequestHandler.cs
+++ b/src/Raven.Server/Documents/DatabaseRequestHandler.cs
@@ -180,6 +180,12 @@ namespace Raven.Server.Documents
         {
             switch (name)
             {
+                case RevisionsHandler.ReadRevisionsConfigTag:
+                    return JsonDeserializationServer.RevisionsConfiguration(configuration).ToAuditJson();
+
+                case RevisionsHandler.ConflictedRevisionsConfigTag:
+                    return JsonDeserializationServer.RevisionsCollectionConfiguration(configuration).ToAuditJson();
+
                 case OngoingTasksHandler.BackupDatabaseOnceTag:
                     return JsonDeserializationServer.BackupConfiguration(configuration).ToAuditJson();
 

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -88,21 +88,25 @@ namespace Raven.Server.Documents.Handlers
             }
         }
 
+        public const string ConflictedRevisionsConfigTag = "conflicted-revisions-config";
+
         [RavenAction("/databases/*/admin/revisions/conflicts/config", "POST", AuthorizationStatus.DatabaseAdmin)]
         public Task ConfigConflictedRevisions()
         {
             return DatabaseConfigurations(
                 ServerStore.ModifyRevisionsForConflicts,
-                "conflicted-revisions-config",
+                ConflictedRevisionsConfigTag,
                 GetRaftRequestIdFromQuery());
         }
+
+        public const string ReadRevisionsConfigTag = "read-revisions-config";
 
         [RavenAction("/databases/*/admin/revisions/config", "POST", AuthorizationStatus.DatabaseAdmin)]
         public Task ConfigRevisions()
         {
             return DatabaseConfigurations(
                 ServerStore.ModifyDatabaseRevisions,
-                "read-revisions-config",
+                ReadRevisionsConfigTag,
                 GetRaftRequestIdFromQuery(),
                 beforeSetupConfiguration: (string name, ref BlittableJsonReaderObject configuration, JsonOperationContext context) =>
                 {

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -104,6 +104,8 @@ namespace Raven.Server.Json
 
         public static readonly Func<BlittableJsonReaderObject, RevisionsConfiguration> RevisionsConfiguration = GenerateJsonDeserializationRoutine<RevisionsConfiguration>();
 
+        public static readonly Func<BlittableJsonReaderObject, RevisionsCollectionConfiguration> RevisionsCollectionConfiguration = GenerateJsonDeserializationRoutine<RevisionsCollectionConfiguration>();
+
         public static readonly Func<BlittableJsonReaderObject, ExpirationConfiguration> ExpirationConfiguration = GenerateJsonDeserializationRoutine<ExpirationConfiguration>();
 
         public static readonly Func<BlittableJsonReaderObject, IndexDefinition> IndexDefinition = GenerateJsonDeserializationRoutine<IndexDefinition>();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22271/Audit-log-on-revisions-settings-changes

### Additional description

Audit log on revisions settings changes

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
