### PR TITLE
RavenDB-22458: Race Condition in _released Variable of PagerState

### DIFF
--- a/test/SlowTests/Voron/Issues/RavenDB_16507.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16507.cs
@@ -77,7 +77,7 @@ namespace SlowTests.Voron.Issues
 
             foreach (var state in pagerStates)
             {
-                Assert.True(state._released);
+                Assert.True(state.IsReleased);
             }
         }
     }

--- a/test/SlowTests/Voron/Issues/RavenDB_17997.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_17997.cs
@@ -59,7 +59,7 @@ public unsafe class RavenDB_17997 : StorageTest
 
             dataPager.AllocateMorePages(16 * 1024 * 1024);
 
-            if (ptr == stateUsedDuringAcquirePagePointer.MapBase && stateUsedDuringAcquirePagePointer._released)
+            if (ptr == stateUsedDuringAcquirePagePointer.MapBase && stateUsedDuringAcquirePagePointer.IsReleased)
             {
                 throw new InvalidOperationException("Cannot read from already unmapped allocation of memory mapped file");
             }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22458

### Additional description

The `_released` variable in the `PagerState` class is designed to track whether the pager state has been disposed of. However, its current usage introduces a potential race condition in concurrent environments. This race condition arises when multiple threads attempt to modify the `_released` state concurrently, leading to possible inconsistencies and undefined behavior.

 In the existing code, `_released` is checked and modified without atomic operations or proper synchronization, leading to a race conditions when we would remove the lock for read transactions.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
