### PR TITLE
RavenDB-22462: AbstractPager includes properties and state that belongs to Tree

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/Fields/BlittableObjectReaderPool.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/Fields/BlittableObjectReaderPool.cs
@@ -4,15 +4,13 @@ using Sparrow.Platform;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents.Fields
 {
-    public sealed class BlittableObjectReaderPool : ILowMemoryHandler
+    public sealed class BlittableObjectReaderPool
     {
         public static BlittableObjectReaderPool Instance;
 
         private static readonly int PoolSize;
 
         private static readonly Size LowMemoryCapacityThreshold;
-
-        private bool _isLowMemory;
 
         private readonly ObjectPool<BlittableObjectReader> _pool;
 
@@ -35,8 +33,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents.Fields
         private BlittableObjectReaderPool()
         {
             _pool = new ObjectPool<BlittableObjectReader>(() => new BlittableObjectReader(), PoolSize);
-
-            LowMemoryNotification.Instance?.RegisterLowMemoryHandler(this);
         }
 
         public BlittableObjectReader Allocate()
@@ -46,23 +42,13 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents.Fields
 
         public void Free(BlittableObjectReader reader)
         {
-            if (_isLowMemory)
+            if (LowMemoryNotification.Instance.InLowMemory)
             {
                 if (reader.Capacity > LowMemoryCapacityThreshold.GetValue(SizeUnit.Bytes))
                     reader.ResetCapacity();
             }
 
             _pool.Free(reader);
-        }
-
-        public void LowMemory(LowMemorySeverity lowMemorySeverity)
-        {
-            _isLowMemory = true;
-        }
-
-        public void LowMemoryOver()
-        {
-            _isLowMemory = false;
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexFacetedReadOperation.cs
@@ -419,12 +419,11 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
         }
 
-        private sealed class IntArraysPool : ILowMemoryHandler
+        private sealed class IntArraysPool
         {
-            public static readonly IntArraysPool Instance = new IntArraysPool();
+            public static readonly IntArraysPool Instance = new();
 
-            private readonly ConcurrentDictionary<int, ObjectPool<int[]>> _arraysPoolBySize = new ConcurrentDictionary<int, ObjectPool<int[]>>();
-            //private readonly TimeSensitiveStore<ObjectPool<int[]>> _timeSensitiveStore = new TimeSensitiveStore<ObjectPool<int[]>>(TimeSpan.FromDays(1));
+            private readonly ConcurrentDictionary<int, ObjectPool<int[]>> _arraysPoolBySize = new();
 
             private IntArraysPool()
             {
@@ -436,8 +435,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 var matchingQueue = _arraysPoolBySize.GetOrAdd(roundedSize, x => new ObjectPool<int[]>(() => new int[roundedSize]));
 
                 var allocatedArray = matchingQueue.Allocate();
-
-                //_timeSensitiveStore.Seen(matchingQueue);
 
                 return allocatedArray;
             }
@@ -463,28 +460,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 }
 
                 return (size / roundSize + 1) * roundSize;
-            }
-
-            private static void RunIdleOperations()
-            {
-                //_timeSensitiveStore.ForAllExpired(x =>
-                //{
-                //    var matchingQueue = _arraysPoolBySize.FirstOrDefault(y => y.Value == x).Key;
-                //    if (matchingQueue != 0)
-                //    {
-                //        ObjectPool<int[]> removedQueue;
-                //        _arraysPoolBySize.TryRemove(matchingQueue, out removedQueue);
-                //    }
-                //});
-            }
-
-            public void LowMemory(LowMemorySeverity lowMemorySeverity)
-            {
-                RunIdleOperations();
-            }
-
-            public void LowMemoryOver()
-            {
             }
         }
 

--- a/src/Sparrow/LowMemory/LowMemoryNotification.cs
+++ b/src/Sparrow/LowMemory/LowMemoryNotification.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Sparrow.Collections;
 using Sparrow.Logging;
 using Sparrow.Platform;
+using Sparrow.Threading;
 using Sparrow.Utils;
 
 namespace Sparrow.LowMemory
@@ -17,6 +18,8 @@ namespace Sparrow.LowMemory
 
         private readonly ConcurrentSet<WeakReference<ILowMemoryHandler>> _lowMemoryHandlers = new ConcurrentSet<WeakReference<ILowMemoryHandler>>();
 
+        public MultipleUseFlag InLowMemory = new MultipleUseFlag(false);
+        
         internal enum LowMemReason
         {
             None = 0,
@@ -84,9 +87,15 @@ namespace Sparrow.LowMemory
                         try
                         {
                             if (isLowMemory)
+                            {
+                                InLowMemory.Raise();
                                 handler.LowMemory(lowMemorySeverity);
+                            }
                             else if (_wasLowMemory)
+                            {
+                                InLowMemory.Lower();
                                 handler.LowMemoryOver();
+                            }
                         }
                         catch (Exception e)
                         {

--- a/src/Voron/Data/BTrees/TreePageSplitter.cs
+++ b/src/Voron/Data/BTrees/TreePageSplitter.cs
@@ -434,7 +434,7 @@ namespace Voron.Data.BTrees
         {
             Slice keyToInsert = _newKey;
 
-            int pageSize = TreeSizeOf.NodeEntry(AbstractPager.PageMaxSpace, keyToInsert, _len) + Constants.Tree.NodeOffsetSize;
+            int pageSize = TreeSizeOf.NodeEntry(Tree.PageMaxSpace, keyToInsert, _len) + Constants.Tree.NodeOffsetSize;
 
             if (toRight == false)
             {

--- a/src/Voron/Data/BTrees/TreeRebalancer.cs
+++ b/src/Voron/Data/BTrees/TreeRebalancer.cs
@@ -75,7 +75,7 @@ namespace Voron.Data.BTrees
                 }
 
                 var minKeys = page.IsBranch ? 2 : 1;
-                if ((page.UseMoreSizeThan(_tx.DataPager.PageMinSpace)) && page.NumberOfEntries >= minKeys)
+                if ((page.UseMoreSizeThan(Tree.PageMinSpace)) && page.NumberOfEntries >= minKeys)
                     return null; // above space/keys thresholds
 
                 Debug.Assert(parentPage.NumberOfEntries >= 2); // if we have less than 2 entries in the parent, the tree is invalid
@@ -97,7 +97,7 @@ namespace Voron.Data.BTrees
                 Debug.Assert(page.IsCompressed == false);
 
                 minKeys = sibling.IsBranch ? 2 : 1; // branch must have at least 2 keys
-                if (sibling.UseMoreSizeThan(_tx.DataPager.PageMinSpace) &&
+                if (sibling.UseMoreSizeThan(Tree.PageMinSpace) &&
                     sibling.NumberOfEntries > minKeys)
                 {
                     // neighbor is over the min size and has enough key, can move just one key to  the current page

--- a/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
+++ b/src/Voron/Platform/Win32/WindowsMemoryMapPager.cs
@@ -54,8 +54,6 @@ namespace Voron.Platform.Win32
             bool usePageProtection = false)
             : base(options, !fileAttributes.HasFlag(Win32NativeFileAttributes.Temporary), usePageProtection)
         {
-            SYSTEM_INFO systemInfo;
-            GetSystemInfo(out systemInfo);
             FileName = file;
             _logger = LoggingSource.Instance.GetLogger<StorageEnvironment>($"Pager-{file}");
 

--- a/test/SlowTests/Voron/Storage/StorageReportGenerationTests.cs
+++ b/test/SlowTests/Voron/Storage/StorageReportGenerationTests.cs
@@ -465,7 +465,7 @@ namespace SlowTests.Voron.Storage
 
         private OverflowsAddResult AddOverflows(Transaction tx, Tree tree, int treeNumber, Random r)
         {
-            var minOverflowSize = tx.LowLevelTransaction.DataPager.NodeMaxSize - Constants.Tree.NodeHeaderSize + 1;
+            var minOverflowSize = Tree.NodeMaxSize - Constants.Tree.NodeHeaderSize + 1;
             var entriesAdded = new List<string>();
             var overflowsAdded = 0;
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22462

### Additional description

While working to redesign the paging system (RavenDB-22286) we found instances of state that do not belong to `AbstractPager` and related classes.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
