### PR TITLE
RavenDB-20325 Backup/Export doesn't take into account time series del…

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
@@ -13,6 +13,7 @@ class exportDatabaseModel {
     includeCounters = ko.observable(true);
     includeAttachments = ko.observable(true);
     includeTimeSeries = ko.observable(true);
+    includeTimeSeriesDeletedRanges = ko.observable(true);
     includeRevisionDocuments = ko.observable(true);
     includeSubscriptions = ko.observable(true);
     
@@ -72,7 +73,7 @@ class exportDatabaseModel {
                 this.includeDocuments(true);
             }
         });
-
+        
         this.includeRevisionDocuments.subscribe(revisions => {
             if (revisions) {
                 this.includeDocuments(true);
@@ -163,6 +164,9 @@ class exportDatabaseModel {
         if (this.includeTimeSeries()) {
             operateOnTypes.push("TimeSeries");
         }
+        if (this.includeTimeSeriesDeletedRanges()) {
+            operateOnTypes.push("TimeSeriesDeletedRanges");
+        }
         if (this.includeSubscriptions()) {
             operateOnTypes.push("Subscriptions");
         }
@@ -200,6 +204,7 @@ class exportDatabaseModel {
                 || this.includeCounters() 
                 || this.includeRevisionDocuments()
                 || this.includeTimeSeries()
+                || this.includeTimeSeriesDeletedRanges()
                 || this.includeDocuments()
                 || this.includeArtificialDocuments();
         });

--- a/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
@@ -15,6 +15,7 @@ class importDatabaseModel {
     includeLegacyAttachments = ko.observable(false);
     includeAttachments = ko.observable(true);
     includeTimeSeries = ko.observable(true);
+    includeTimeSeriesDeletedRanges = ko.observable(true);
     includeSubscriptions = ko.observable(true);
     includeDocumentsTombstones = ko.observable(true);
     includeCompareExchangeTombstones = ko.observable(true);
@@ -163,6 +164,9 @@ class importDatabaseModel {
         if (this.includeTimeSeries()) {
             operateOnTypes.push("TimeSeries");
         }
+        if (this.includeTimeSeriesDeletedRanges()) {
+            operateOnTypes.push("TimeSeriesDeletedRanges");
+        }
         if (this.includeSubscriptions()) {
             operateOnTypes.push("Subscriptions");
         }
@@ -199,6 +203,7 @@ class importDatabaseModel {
                 || this.includeCounters() 
                 || this.includeLegacyCounters()
                 || this.includeTimeSeries()
+                || this.includeTimeSeriesDeletedRanges()
                 || this.includeRevisionDocuments() 
                 || this.includeDocuments()
                 || this.includeAttachments()

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
@@ -168,6 +168,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
                 }
                 
                 result.push(this.mapToExportListItem("Subscriptions", status.Subscriptions));
+                result.push(this.mapToExportListItem("Time Series Deleted Ranges", status.TimeSeriesDeletedRanges));
             }
 
             const currentlyProcessingItems = smugglerDatabaseDetails.findCurrentlyProcessingItems(result);

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/exportDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/exportDatabase.html
@@ -52,6 +52,10 @@
                                 <input id="toggleConflicts" type="checkbox" data-bind="checked: includeConflicts" />
                                 <label for="toggleConflicts">Include Conflicts</label>
                             </div>
+                            <div class="toggle">
+                                <input id="importTimeSeriesDeletedRanges" type="checkbox" data-bind="checked: includeTimeSeriesDeletedRanges" />
+                                <label for="importTimeSeriesDeletedRanges" class="margin-right margin-right-sm">Include Time Series Deleted Ranges</label>
+                            </div>
                         </div>
                     </div>
                     <div class="col-lg-5">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromFile.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromFile.html
@@ -88,6 +88,10 @@
                                 <input id="importDocumentsTombstones" type="checkbox" data-bind="checked: includeDocumentsTombstones" />
                                 <label for="importDocumentsTombstones" class="margin-right margin-right-sm">Include Documents Tombstones</label>
                             </div>
+                            <div class="toggle">
+                                <input id="importTimeSeriesDeletedRanges" type="checkbox" data-bind="checked: includeTimeSeriesDeletedRanges" />
+                                <label for="importTimeSeriesDeletedRanges" class="margin-right margin-right-sm">Include Time Series Deleted Ranges</label>
+                            </div>
                         </div>
                     </div>
                     <div class="col-lg-5">


### PR DESCRIPTION
…eted ranges - studio work

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20325 

### Additional description

Expose ability to import/export time series deleted ranges - studio work

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
