### PR TITLE
RavenDB-22463 extract class name from collection name if Raven-Clr-Type is unavailable

### DIFF
--- a/src/Raven.Server/Documents/JsonClassGenerator.cs
+++ b/src/Raven.Server/Documents/JsonClassGenerator.cs
@@ -257,19 +257,19 @@ namespace Raven.Server.Documents
             for (var i = 0; i < classes.Count; i++)
             {
                 var @class = classes[i];
-                codeBuilder.Append("\tpublic class " + @class.Name + Environment.NewLine);
-                codeBuilder.Append("\t{" + Environment.NewLine);
+                codeBuilder.Append("    public class " + @class.Name + Environment.NewLine);
+                codeBuilder.Append("    {" + Environment.NewLine);
 
                 foreach (var field in @class.Properties)
                 {
-                    codeBuilder.Append("\t\tpublic ");
+                    codeBuilder.Append("        public ");
                     codeBuilder.Append(field.Value.IsArray ? $"List<{field.Value.Name}>" : field.Value.Name);
                     codeBuilder.Append(" ");
                     codeBuilder.Append(field.Key + " { get; set; } ");
                     codeBuilder.Append(Environment.NewLine);
                 }
 
-                codeBuilder.Append("\t}");
+                codeBuilder.Append("    }");
 
                 if (i < classes.Count - 1)
                     codeBuilder.Append(Environment.NewLine + Environment.NewLine);

--- a/test/SlowTests/Issues/RavenDB_22463.cs
+++ b/test/SlowTests/Issues/RavenDB_22463.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Server.Documents.Commands;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22463 : RavenTestBase
+{
+    public RavenDB_22463(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task Can_Extract_Class_Name_From_Collection()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var commands = store.Commands())
+            {
+                await commands.PutAsync("cats/1", null, new Cat
+                {
+                    Name = "Mr Kittenz",
+                    Birthday = DateTime.Now,
+                    BirthdayOffset = DateTimeOffset.UtcNow
+                }, new Dictionary<string, object> { { Constants.Documents.Metadata.Collection, "Cats" } });
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var command = new GenerateClassFromDocumentCommand("cats/1", "csharp");
+
+                await session.Advanced.RequestExecutor.ExecuteAsync(command, session.Advanced.Context);
+
+                var @class = command.Result;
+
+                RavenTestHelper.AssertEqualRespectingNewLines(ExpectedResult, @class);
+            }
+        }
+    }
+
+    private class Cat
+    {
+        public string Name { get; set; }
+
+        public DateTime Birthday { get; set; }
+
+        public DateTimeOffset BirthdayOffset { get; set; }
+    }
+
+    private const string ExpectedResult = """
+                                          using System;
+                                          using System.Collections.Generic;
+                                          using System.Linq;
+                                          using System.Text;
+                                          using System.Threading.Tasks;
+
+                                          namespace My.RavenDB
+                                          {
+                                          	public class Cat
+                                          	{
+                                          		public DateTime Birthday { get; set; } 
+                                          		public DateTimeOffset BirthdayOffset { get; set; } 
+                                          		public string Name { get; set; } 
+                                          	}
+                                          }
+                                          """;
+}

--- a/test/SlowTests/Issues/RavenDB_22463.cs
+++ b/test/SlowTests/Issues/RavenDB_22463.cs
@@ -58,15 +58,15 @@ public class RavenDB_22463 : RavenTestBase
                                           using System.Linq;
                                           using System.Text;
                                           using System.Threading.Tasks;
-
+                                          
                                           namespace My.RavenDB
                                           {
-                                          	public class Cat
-                                          	{
-                                          		public DateTime Birthday { get; set; } 
-                                          		public DateTimeOffset BirthdayOffset { get; set; } 
-                                          		public string Name { get; set; } 
-                                          	}
+                                              public class Cat
+                                              {
+                                                  public DateTime Birthday { get; set; } 
+                                                  public DateTimeOffset BirthdayOffset { get; set; } 
+                                                  public string Name { get; set; } 
+                                              }
                                           }
                                           """;
 }

--- a/test/SlowTests/Sharding/Issues/RavenDB_18199.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_18199.cs
@@ -98,22 +98,24 @@ namespace SlowTests.Sharding.Issues
 
                     string commandResult = command.Result;
 
-                    RavenTestHelper.AssertEqualRespectingNewLines(@"using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+                    RavenTestHelper.AssertEqualRespectingNewLines("""
+                                                                  using System;
+                                                                  using System.Collections.Generic;
+                                                                  using System.Linq;
+                                                                  using System.Text;
+                                                                  using System.Threading.Tasks;
 
-namespace SlowTests.Core.Utils.Entities
-{
-	public class User
-	{
-		public object AddressId { get; set; } 
-		public int Count { get; set; } 
-		public object LastName { get; set; } 
-		public object Name { get; set; } 
-	}
-}", commandResult);
+                                                                  namespace SlowTests.Core.Utils.Entities
+                                                                  {
+                                                                      public class User
+                                                                      {
+                                                                          public object AddressId { get; set; } 
+                                                                          public int Count { get; set; } 
+                                                                          public object LastName { get; set; } 
+                                                                          public object Name { get; set; } 
+                                                                      }
+                                                                  }
+                                                                  """, commandResult);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22463

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
