### PR TITLE
RavenDB-19963 Optimize chained negated search query in LINQ

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19963.cs
+++ b/test/SlowTests/Issues/RavenDB-19963.cs
@@ -1,0 +1,69 @@
+using FastTests;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19963 : RavenTestBase
+{
+    public RavenDB_19963(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void TestSearch()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var rql = session.Query<Dto>()
+                    .Search(i => i.Name, "*ion")
+                    .Search(i => i.Name, "point", options: SearchOptions.And | SearchOptions.Not)
+                    .ToString();
+                
+                Assert.Equal("from 'Dtos' where search(Name, $p0) and not search(Name, $p1)", rql);
+
+                rql = session.Query<Dto>()
+                    .Search(i => i.Name, "*ion")
+                    .Search(i => i.Name, "whatever")
+                    .Search(i => i.Name, "point", options: SearchOptions.And | SearchOptions.Not)
+                    .ToString();
+                
+                Assert.Equal("from 'Dtos' where (search(Name, $p0) or search(Name, $p1)) and not search(Name, $p2)", rql);
+                
+                rql = session.Query<Dto>()
+                    .Search(i => i.Name, "*ion")
+                    .Search(i => i.Name, "whatever", options: SearchOptions.And)
+                    .Search(i => i.Name, "point", options: SearchOptions.And | SearchOptions.Not)
+                    .ToString();
+                
+                Assert.Equal("from 'Dtos' where search(Name, $p0) and search(Name, $p1) and not search(Name, $p2)", rql);
+                
+                rql = session.Query<Dto>()
+                    .Search(i => i.Name, "*ion")
+                    .Search(i => i.Name, "point", options: SearchOptions.And)
+                    .Search(i => i.Name, "point", options: SearchOptions.Or | SearchOptions.Not)
+                    .ToString();
+                
+                Assert.Equal("from 'Dtos' where search(Name, $p0) and search(Name, $p1) or (exists(Name) and not search(Name, $p2))", rql);
+                
+                rql = session.Query<Dto>()
+                    .Search(i => i.Name, "*ion")
+                    .Search(i => i.Description, "point", options: SearchOptions.And | SearchOptions.Not)
+                    .ToString();
+
+                Assert.Equal("from 'Dtos' where search(Name, $p0) and (exists(Description) and not search(Description, $p1))", rql);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+        
+        public string Description { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19963/Optimize-chained-negated-search-query-in-LINQ

### Additional description

We don't have to check if field exists in the document for search with negated `and` operator preceded by search on the same field.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
