### PR TITLE
RavenDB-13389 Expose DocumentsOperationContext, TransactionOperationContext and ClusterOperationContext in Admin JS Console

### DIFF
--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -21,6 +21,7 @@ using Raven.Server.Documents.Indexes.Static.JavaScript;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Results;
 using Raven.Server.Documents.Queries.Results.TimeSeries;
+using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -468,9 +469,10 @@ namespace Raven.Server.Documents.Patch
             }
             
             // for admin
-            if (o is RavenServer || o is DocumentDatabase)
+            if (o is RavenServer || o is DocumentDatabase || o is DocumentsOperationContext || o is TransactionOperationContext || o is ClusterOperationContext)
             {
                 AssertAdminScriptInstance();
+
                 return JsValue.FromObject(engine, o);
             }
             if (o is ObjectInstance j)

--- a/test/SlowTests/Issues/RavenDB-13389.cs
+++ b/test/SlowTests/Issues/RavenDB-13389.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Documents.Patch;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_13389 : RavenTestBase
+{
+    public RavenDB_13389(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task TestDatabaseContextScript()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            
+            var scriptResult = new AdminJsConsole(Server, database).ApplyScript(new AdminJsScript(
+                "databaseCtx.OpenReadTransaction();\n\nreturn database.DocumentsStorage.GetNumberOfDocuments(databaseCtx)"));
+
+            Assert.Equal("{\"Result\":0}", scriptResult);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task TestClusterContextScript()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            
+            var scriptResult = new AdminJsConsole(Server, database).ApplyScript(new AdminJsScript(
+                "clusterCtx.OpenReadTransaction();\n\nreturn server.ServerStore.Engine.ReadNodeTag(clusterCtx);"));
+
+            Assert.Equal("{\"Result\":\"A\"}", scriptResult);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task TestServerContextScript()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            
+            var scriptResult = new AdminJsConsole(Server, database).ApplyScript(new AdminJsScript(
+                $"serverCtx.OpenReadTransaction();\n\nreturn server.ServerStore.Cluster.GetNumberOfIdentities(serverCtx, \"{database.Name}\");"));
+
+            Assert.Equal("{\"Result\":0}", scriptResult);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-13389/Ensure-we-have-a-way-to-get-a-json-context-in-JS-admin

### Additional description

We want to have `TransactionOperationContext`, `ClusterOperationContext` and `DocumentsOperationContext` available to use in Admin JS Console

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
