### PR TITLE
RavenDB-22066 - StressTests.Issues.RavenDB_14292.ServerWideBackupShouldBackupIdleDatabase(rounds: 1)

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -249,6 +249,7 @@ namespace Raven.Server.Documents
             {
                 case nameof(PutServerWideBackupConfigurationCommand):
                 case nameof(UpdatePeriodicBackupStatusCommand):
+                case nameof(UpdateResponsibleNodeForTasksCommand):
                     return true;
 
                 default:
@@ -1133,7 +1134,8 @@ namespace Raven.Server.Documents
                                 DatabaseName = databaseName,
                                 LastEtag = nextIdleDatabaseActivity.LastEtag,
                                 Logger = _logger,
-                                ServerStore = _serverStore
+                                ServerStore = _serverStore,
+                                IsIdle = true
                             });
 
                             RescheduleNextIdleDatabaseActivity(databaseName, nextIdleDatabaseActivity);

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -306,7 +306,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                 NotificationCenter = _database.NotificationCenter,
                 OnParsingError = OnParsingError,
                 OnMissingNextBackupInfo = OnMissingNextBackupInfo,
-                ServerStore = _serverStore
+                ServerStore = _serverStore,
+                IsIdle = false
             });
         }
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using FastTests.Utils;
-using NCrontab.Advanced;
 using Newtonsoft.Json;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Commands;
@@ -31,7 +30,6 @@ using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
-using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Config;
@@ -66,180 +64,6 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public PeriodicBackupTestsSlow(ITestOutputHelper output) : base(output)
         {
             _output = output;
-        }
-
-        [Theory]
-        [InlineData(1)]
-        [InlineData(5)]
-        public async Task ServerWideBackupShouldBackupIdleDatabase(int rounds)
-        {
-            const string fullBackupFrequency = "*/2 * * * *";
-            var backupParser = CrontabSchedule.Parse(fullBackupFrequency);
-            const int maxIdleTimeInSec = 10;
-
-            using var server = GetNewServer(new ServerCreationOptions
-            {
-                CustomSettings = new Dictionary<string, string>
-                {
-                    [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = $"{maxIdleTimeInSec}",
-                    [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "3",
-                    [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
-                }
-            });
-            using var dispose = new DisposableAction(() => server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false);
-            server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
-
-            var dbName = GetDatabaseName();
-            var controlgroupDbName = GetDatabaseName() + "controlgroup";
-            var baseBackupPath = NewDataPath(suffix: "BackupFolder");
-
-            using var store = new DocumentStore { Database = dbName, Urls = new[] { server.WebUrl } }.Initialize();
-            store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(dbName)));
-            store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(controlgroupDbName)));
-            await using var keepControlGroupAlive = new RepeatableAsyncAction(async token =>
-            {
-                await store.Maintenance.ForDatabase(controlgroupDbName).SendAsync(new GetStatisticsOperation(), token);
-                await Task.Delay(TimeSpan.FromSeconds(maxIdleTimeInSec), token);
-            }).Run();
-
-            using (var session = store.OpenAsyncSession())
-            {
-                await session.StoreAsync(new User { Name = "EGOR" }, "su");
-                await session.SaveChangesAsync();
-            }
-            using (var session = store.OpenAsyncSession(controlgroupDbName))
-            {
-                await session.StoreAsync(new User { Name = "egor" }, "susu");
-                await session.SaveChangesAsync();
-            }
-
-            var first = true;
-            DateTime backupStartTime = default;
-            GetPeriodicBackupStatusOperation periodicBackupStatusOperation = null;
-            PeriodicBackupStatus status = null;
-            PeriodicBackupStatus controlGroupStatus = null;
-
-            for (int i = 0; i < rounds; i++)
-            {
-                // let db get idle
-                await WaitForValueAsync(() => Task.FromResult(server.ServerStore.IdleDatabases.Count > 0), true, 180 * 1000, 3000);
-
-                Assert.True(1 == server.ServerStore.IdleDatabases.Count, $"IdleDatabasesCount({server.ServerStore.IdleDatabases.Count}), Round({i})");
-                Assert.True(server.ServerStore.IdleDatabases.ContainsKey(store.Database), $"Round({i})");
-                
-                DateTime lastBackup;
-                if (first)
-                {
-                    var putConfiguration = new ServerWideBackupConfiguration
-                    {
-                        FullBackupFrequency = fullBackupFrequency,
-                        LocalSettings = new LocalSettings { FolderPath = baseBackupPath },
-                    };
-                    var result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
-                    backupStartTime = DateTime.UtcNow;
-
-                    var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
-                    Assert.NotNull(serverWideConfiguration);
-                    periodicBackupStatusOperation = new GetPeriodicBackupStatusOperation(serverWideConfiguration.TaskId);
-
-                    // the configuration is applied to existing databases
-                    var periodicBackupConfigurations = (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).PeriodicBackups;
-                    Assert.Equal(1, periodicBackupConfigurations.Count);
-                    var backupConfigurations = (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(controlgroupDbName))).PeriodicBackups;
-                    Assert.Equal(1, backupConfigurations.Count);
-
-                    first = false;
-                    lastBackup = backupStartTime;
-                }
-                else
-                {
-                    Assert.True(status.LastFullBackup.HasValue);
-                    lastBackup = status.LastFullBackup.Value;
-                }
-                var nextBackup = backupParser.GetNextOccurrence(lastBackup);
-                var timeToWait = nextBackup - DateTime.UtcNow;
-                if (timeToWait > TimeSpan.Zero)
-                {
-                    await Task.Delay(timeToWait);
-                }
-                
-                status = await AssertWaitForNextBackup(store.Database, status);
-                controlGroupStatus = await AssertWaitForNextBackup(controlgroupDbName, controlGroupStatus);
-                async Task<PeriodicBackupStatus> AssertWaitForNextBackup(string db, PeriodicBackupStatus prevStatus)
-                {
-                    PeriodicBackupStatus nextStatus = null;
-                    Assert.True(await WaitForValueAsync(async () =>
-                    {
-                        nextStatus = (await store.Maintenance.ForDatabase(db).SendAsync(periodicBackupStatusOperation)).Status;
-                        
-                        if (nextStatus == null)
-                            return false;
-                        Assert.True(nextStatus.Error?.Exception == null, nextStatus.Error?.Exception);
-                        Assert.True(nextStatus.LocalBackup?.Exception == null, nextStatus.LocalBackup?.Exception);
-
-                        return prevStatus == null || nextStatus.LastOperationId.HasValue && nextStatus.LastOperationId > prevStatus.LastOperationId;
-                    }, true), $"Round {i}");
-                    return nextStatus;
-                }
-
-                var backupsDir = Directory.GetDirectories(baseBackupPath);
-                Assert.Equal(2, backupsDir.Length);
-
-                AssertBackupDirCount(controlgroupDbName, controlGroupStatus);
-                AssertBackupDirCount(store.Database, status);
-                void AssertBackupDirCount(string db, PeriodicBackupStatus periodicBackupStatus)
-                {
-                    var backupPath = Path.Combine(baseBackupPath, db);
-                    var backupDirs = Directory.GetDirectories(backupPath);
-                    Assert.True(i + 1 == backupDirs.Length,
-                        $"firstBackupStartTime: {backupStartTime}, checkTime: {DateTime.UtcNow}, i: {i}, " +
-                        $"controlGroupBackupNum: {backupDirs.Length}, path: {backupPath}, {PrintBackups(periodicBackupStatus, backupDirs)}");
-                }
-            }
-        }
-
-        private string PrintBackups(PeriodicBackupStatus pb, string[] dirs)
-        {
-            var sb = new StringBuilder();
-            sb.AppendLine($"LocalBackup:{Environment.NewLine}Directory:{pb.LocalBackup.BackupDirectory}, Exception: {pb.LocalBackup.Exception}");
-            sb.AppendLine($"Status:{Environment.NewLine}LastFullBackup: {pb.LastFullBackup}, FolderName: {pb.FolderName}, Exception:{pb.Error?.Exception}");
-            sb.AppendLine($"Dirs:{Environment.NewLine}{string.Join(", ", dirs)}");
-            return sb.ToString();
-        }
-
-        private class RepeatableAsyncAction : IAsyncDisposable
-        {
-            private readonly Func<CancellationToken, Task> _action;
-            private readonly CancellationTokenSource _source = new CancellationTokenSource();
-            private Task _task;
-
-            public RepeatableAsyncAction(Func<CancellationToken, Task> action) => _action = action;
-
-            public RepeatableAsyncAction Run()
-            {
-                _task = Task.Run(async () =>
-                {
-                    try
-                    {
-                        while (_source.Token.IsCancellationRequested == false)
-                        {
-                            await _action(_source.Token);
-                        }
-                    }
-                    catch
-                    {
-                        /* ignored */
-                    }
-                });
-
-                return this;
-            }
-
-            public async ValueTask DisposeAsync()
-            {
-                _source.Cancel();
-                await _task;
-            }
         }
 
         [Fact, Trait("Category", "Smuggler")]

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -11,8 +11,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using FastTests.Utils;
+using NCrontab.Advanced;
 using Newtonsoft.Json;
-using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
@@ -31,6 +31,7 @@ using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Config;
@@ -54,6 +55,7 @@ using Xunit;
 using Xunit.Abstractions;
 using static Raven.Server.Utils.BackupUtils;
 using BackupUtils = Raven.Client.Documents.Smuggler.BackupUtils;
+using Constants = Raven.Client.Constants;
 
 namespace SlowTests.Server.Documents.PeriodicBackup
 {
@@ -64,6 +66,180 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public PeriodicBackupTestsSlow(ITestOutputHelper output) : base(output)
         {
             _output = output;
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(5)]
+        public async Task ServerWideBackupShouldBackupIdleDatabase(int rounds)
+        {
+            const string fullBackupFrequency = "*/2 * * * *";
+            var backupParser = CrontabSchedule.Parse(fullBackupFrequency);
+            const int maxIdleTimeInSec = 10;
+
+            using var server = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = $"{maxIdleTimeInSec}",
+                    [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "3",
+                    [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
+                }
+            });
+            using var dispose = new DisposableAction(() => server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = false);
+            server.ServerStore.DatabasesLandlord.SkipShouldContinueDisposeCheck = true;
+
+            var dbName = GetDatabaseName();
+            var controlgroupDbName = GetDatabaseName() + "controlgroup";
+            var baseBackupPath = NewDataPath(suffix: "BackupFolder");
+
+            using var store = new DocumentStore { Database = dbName, Urls = new[] { server.WebUrl } }.Initialize();
+            store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(dbName)));
+            store.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(controlgroupDbName)));
+            await using var keepControlGroupAlive = new RepeatableAsyncAction(async token =>
+            {
+                await store.Maintenance.ForDatabase(controlgroupDbName).SendAsync(new GetStatisticsOperation(), token);
+                await Task.Delay(TimeSpan.FromSeconds(maxIdleTimeInSec), token);
+            }).Run();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "EGOR" }, "su");
+                await session.SaveChangesAsync();
+            }
+            using (var session = store.OpenAsyncSession(controlgroupDbName))
+            {
+                await session.StoreAsync(new User { Name = "egor" }, "susu");
+                await session.SaveChangesAsync();
+            }
+
+            var first = true;
+            DateTime backupStartTime = default;
+            GetPeriodicBackupStatusOperation periodicBackupStatusOperation = null;
+            PeriodicBackupStatus status = null;
+            PeriodicBackupStatus controlGroupStatus = null;
+
+            for (int i = 0; i < rounds; i++)
+            {
+                // let db get idle
+                await WaitForValueAsync(() => Task.FromResult(server.ServerStore.IdleDatabases.Count > 0), true, 180 * 1000, 3000);
+
+                Assert.True(1 == server.ServerStore.IdleDatabases.Count, $"IdleDatabasesCount({server.ServerStore.IdleDatabases.Count}), Round({i})");
+                Assert.True(server.ServerStore.IdleDatabases.ContainsKey(store.Database), $"Round({i})");
+                
+                DateTime lastBackup;
+                if (first)
+                {
+                    var putConfiguration = new ServerWideBackupConfiguration
+                    {
+                        FullBackupFrequency = fullBackupFrequency,
+                        LocalSettings = new LocalSettings { FolderPath = baseBackupPath },
+                    };
+                    var result = await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
+                    backupStartTime = DateTime.UtcNow;
+
+                    var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
+                    Assert.NotNull(serverWideConfiguration);
+                    periodicBackupStatusOperation = new GetPeriodicBackupStatusOperation(serverWideConfiguration.TaskId);
+
+                    // the configuration is applied to existing databases
+                    var periodicBackupConfigurations = (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database))).PeriodicBackups;
+                    Assert.Equal(1, periodicBackupConfigurations.Count);
+                    var backupConfigurations = (await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(controlgroupDbName))).PeriodicBackups;
+                    Assert.Equal(1, backupConfigurations.Count);
+
+                    first = false;
+                    lastBackup = backupStartTime;
+                }
+                else
+                {
+                    Assert.True(status.LastFullBackup.HasValue);
+                    lastBackup = status.LastFullBackup.Value;
+                }
+                var nextBackup = backupParser.GetNextOccurrence(lastBackup);
+                var timeToWait = nextBackup - DateTime.UtcNow;
+                if (timeToWait > TimeSpan.Zero)
+                {
+                    await Task.Delay(timeToWait);
+                }
+                
+                status = await AssertWaitForNextBackup(store.Database, status);
+                controlGroupStatus = await AssertWaitForNextBackup(controlgroupDbName, controlGroupStatus);
+                async Task<PeriodicBackupStatus> AssertWaitForNextBackup(string db, PeriodicBackupStatus prevStatus)
+                {
+                    PeriodicBackupStatus nextStatus = null;
+                    Assert.True(await WaitForValueAsync(async () =>
+                    {
+                        nextStatus = (await store.Maintenance.ForDatabase(db).SendAsync(periodicBackupStatusOperation)).Status;
+                        
+                        if (nextStatus == null)
+                            return false;
+                        Assert.True(nextStatus.Error?.Exception == null, nextStatus.Error?.Exception);
+                        Assert.True(nextStatus.LocalBackup?.Exception == null, nextStatus.LocalBackup?.Exception);
+
+                        return prevStatus == null || nextStatus.LastOperationId.HasValue && nextStatus.LastOperationId > prevStatus.LastOperationId;
+                    }, true), $"Round {i}");
+                    return nextStatus;
+                }
+
+                var backupsDir = Directory.GetDirectories(baseBackupPath);
+                Assert.Equal(2, backupsDir.Length);
+
+                AssertBackupDirCount(controlgroupDbName, controlGroupStatus);
+                AssertBackupDirCount(store.Database, status);
+                void AssertBackupDirCount(string db, PeriodicBackupStatus periodicBackupStatus)
+                {
+                    var backupPath = Path.Combine(baseBackupPath, db);
+                    var backupDirs = Directory.GetDirectories(backupPath);
+                    Assert.True(i + 1 == backupDirs.Length,
+                        $"firstBackupStartTime: {backupStartTime}, checkTime: {DateTime.UtcNow}, i: {i}, " +
+                        $"controlGroupBackupNum: {backupDirs.Length}, path: {backupPath}, {PrintBackups(periodicBackupStatus, backupDirs)}");
+                }
+            }
+        }
+
+        private string PrintBackups(PeriodicBackupStatus pb, string[] dirs)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"LocalBackup:{Environment.NewLine}Directory:{pb.LocalBackup.BackupDirectory}, Exception: {pb.LocalBackup.Exception}");
+            sb.AppendLine($"Status:{Environment.NewLine}LastFullBackup: {pb.LastFullBackup}, FolderName: {pb.FolderName}, Exception:{pb.Error?.Exception}");
+            sb.AppendLine($"Dirs:{Environment.NewLine}{string.Join(", ", dirs)}");
+            return sb.ToString();
+        }
+
+        private class RepeatableAsyncAction : IAsyncDisposable
+        {
+            private readonly Func<CancellationToken, Task> _action;
+            private readonly CancellationTokenSource _source = new CancellationTokenSource();
+            private Task _task;
+
+            public RepeatableAsyncAction(Func<CancellationToken, Task> action) => _action = action;
+
+            public RepeatableAsyncAction Run()
+            {
+                _task = Task.Run(async () =>
+                {
+                    try
+                    {
+                        while (_source.Token.IsCancellationRequested == false)
+                        {
+                            await _action(_source.Token);
+                        }
+                    }
+                    catch
+                    {
+                        /* ignored */
+                    }
+                });
+
+                return this;
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                _source.Cancel();
+                await _task;
+            }
         }
 
         [Fact, Trait("Category", "Smuggler")]

--- a/test/StressTests/Issues/RavenDB_14292.cs
+++ b/test/StressTests/Issues/RavenDB_14292.cs
@@ -97,6 +97,8 @@ namespace StressTests.Issues
 
                     var serverWideConfiguration = await store.Maintenance.Server.SendAsync(new GetServerWideBackupConfigurationOperation(result.Name));
                     Assert.NotNull(serverWideConfiguration);
+                    Backup.WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, serverWideConfiguration.TaskId);
+
                     periodicBackupStatusOperation = new GetPeriodicBackupStatusOperation(serverWideConfiguration.TaskId);
 
                     // the configuration is applied to existing databases


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22066

### Additional description

Test checks that database wakes up from idle state when its next backup time arrived.
Problem: the db wakes up before it should and creates an extra backup directory

In the test there is a command `UpdateResponsibleNodeForTasksCommand` that is fired after we put a new backup config and it wakes up the database immediately (in `HandleClusterDatabaseChanges`). Next backup timer is calculated in `GetNextBackupDetails` according to the `lastFullBackupUtc = dbWakeupTime` which causes duetime to be overdue and triggers backup immediately, resulting in another directory.

Fixes:
After adding this command to the `PreventWakeUpIdleDatabase` no backup is scheduled at all.
So added this command to trigger a reschedule to the wakeup timer in `OnChange`. We determine the next backup time according to the behavior in the `GetNextBackupDetails`.
However the current behavior in `GetNextBackupDetails` returns a wakeup with a duetime of now when there is no backup status (backup never happened). This case is there to provide for the check in `UnloadDirectly`->`ShouldContinueDispose` if we can unload or not (if the due time is small enough, we do not bother to unload the db).
So this resulted in the db waking up as well.
Changed so now passing another parameter `IsIdle`, so that in the case our db is idle and there is no backup status, we do not wake up immediately.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
