### PR TITLE
RavenDB-22426 Replace System.Data.SqlClient with Microsoft.Data.SqlClient

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlProviderParser.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlProviderParser.cs
@@ -8,6 +8,7 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
         {
             switch (factoryName)
             {
+                case "System.Data.SqlClient":
                 case "Microsoft.Data.SqlClient":
                     return SqlProvider.SqlClient;
                 case "Npgsql":

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlProviderParser.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlProviderParser.cs
@@ -8,7 +8,7 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
         {
             switch (factoryName)
             {
-                case "System.Data.SqlClient":
+                case "Microsoft.Data.SqlClient":
                     return SqlProvider.SqlClient;
                 case "Npgsql":
                     return SqlProvider.Npgsql;

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/DbProviderFactories.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/DbProviderFactories.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Npgsql;
 using Oracle.ManagedDataAccess.Client;
 using Raven.Client.Documents.Operations.ETL.SQL;

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -51,11 +51,14 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
             _connection = _providerFactory.CreateConnection();
             var connectionString = etl.Configuration.Connection.ConnectionString;
 
-            // We want to ensure compatibility between deprecated System.Data.SqlClient (where Encrypt parameter defaults to false)
-            // and Microsoft.Data.SqlClient which defaults it to SqlConnectionEncryptOption.Mandatory. If no option is provided,
-            // we set it to SqlConnectionEncryptOption.Optional (equivalent of false).
-            if (SqlConnectionStringParser.GetConnectionStringValue(connectionString, new string[] { "Encrypt" }) == null)
+            if (_etl.Configuration.Connection.FactoryName == "System.Data.SqlClient" &&
+                SqlConnectionStringParser.GetConnectionStringValue(connectionString, new string[] { "Encrypt" }) == null)
+            {
+                // We want to ensure compatibility between deprecated System.Data.SqlClient (where Encrypt parameter defaults to false)
+                // and Microsoft.Data.SqlClient which defaults it to SqlConnectionEncryptOption.Mandatory. If no option is provided,
+                // we set it to SqlConnectionEncryptOption.Optional (equivalent of false).
                 connectionString = SqlConnectionStringUtil.GetConnectionStringWithOptionalEncrypt(connectionString);
+            }
             
             _connection.ConnectionString = connectionString;
 

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -50,6 +50,13 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
             _commandBuilder = _providerFactory.InitializeCommandBuilder();
             _connection = _providerFactory.CreateConnection();
             var connectionString = etl.Configuration.Connection.ConnectionString;
+
+            // We want to ensure compatibility between deprecated System.Data.SqlClient (where Encrypt parameter defaults to false)
+            // and Microsoft.Data.SqlClient which defaults it to SqlConnectionEncryptOption.Mandatory. If no option is provided,
+            // we set it to SqlConnectionEncryptOption.Optional (equivalent of false).
+            if (SqlConnectionStringParser.GetConnectionStringValue(connectionString, new string[] { "Encrypt" }) == null)
+                connectionString = SqlConnectionStringUtil.GetConnectionStringWithOptionalEncrypt(connectionString);
+            
             _connection.ConnectionString = connectionString;
 
             OpenConnection(database, etl.Configuration.Name, etl.Configuration.ConnectionStringName);

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriterBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriterBase.cs
@@ -8,6 +8,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
 
         private static readonly string[] SqlServerFactoryNames =
         {
+            "System.Data.SqlClient",
             "Microsoft.Data.SqlClient",
             "System.Data.SqlServerCe.4.0",
             "MySql.Data.MySqlClient",

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriterBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriterBase.cs
@@ -8,7 +8,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
 
         private static readonly string[] SqlServerFactoryNames =
         {
-            "System.Data.SqlClient",
+            "Microsoft.Data.SqlClient",
             "System.Data.SqlServerCe.4.0",
             "MySql.Data.MySqlClient",
             "System.Data.SqlServerCe.3.5"

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriterSimulator.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriterSimulator.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading;

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/SqlConnectionStringUtil.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/SqlConnectionStringUtil.cs
@@ -4,6 +4,8 @@ public static class SqlConnectionStringUtil
 {
     public static string GetConnectionStringWithOptionalEncrypt(string connectionString)
     {
+        connectionString = connectionString.Trim();
+        
         if (connectionString.EndsWith(';') == false)
             connectionString += ";";
 

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/SqlConnectionStringUtil.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/SqlConnectionStringUtil.cs
@@ -1,0 +1,14 @@
+namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters;
+
+public static class SqlConnectionStringUtil
+{
+    public static string GetConnectionStringWithOptionalEncrypt(string connectionString)
+    {
+        if (connectionString.EndsWith(';') == false)
+            connectionString += ";";
+
+        connectionString += "Encrypt=Optional";
+
+        return connectionString;
+    }
+}

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -176,6 +176,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
@@ -198,7 +199,6 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />

--- a/src/Raven.Server/SqlMigration/MsSQL/MsSqlDatabaseMigrator.Migration.cs
+++ b/src/Raven.Server/SqlMigration/MsSQL/MsSqlDatabaseMigrator.Migration.cs
@@ -1,4 +1,6 @@
-﻿using Raven.Server.SqlMigration.Schema;
+﻿using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters;
+using Raven.Server.SqlMigration.Schema;
 
 namespace Raven.Server.SqlMigration.MsSQL
 {
@@ -6,7 +8,7 @@ namespace Raven.Server.SqlMigration.MsSQL
     {
         protected override string FactoryName => "Microsoft.Data.SqlClient";
         
-        public MsSqlDatabaseMigrator(string connectionString) : base(connectionString)
+        public MsSqlDatabaseMigrator(string connectionString) : base(OverrideConnectionStringIfNeeded(connectionString))
         {
         }
 
@@ -77,6 +79,14 @@ namespace Raven.Server.SqlMigration.MsSQL
         protected override string GetSelectAllQueryForTable(string tableSchema, string tableName)
         {
             return "select * from " + QuoteTable(tableSchema, tableName);
+        }
+
+        private static string OverrideConnectionStringIfNeeded(string connectionString)
+        {
+            if (SqlConnectionStringParser.GetConnectionStringValue(connectionString, new string[] { "Encrypt" }) == null)
+                connectionString = SqlConnectionStringUtil.GetConnectionStringWithOptionalEncrypt(connectionString);
+
+            return connectionString;
         }
     }
 }

--- a/src/Raven.Server/SqlMigration/MsSQL/MsSqlDatabaseMigrator.Migration.cs
+++ b/src/Raven.Server/SqlMigration/MsSQL/MsSqlDatabaseMigrator.Migration.cs
@@ -4,7 +4,7 @@ namespace Raven.Server.SqlMigration.MsSQL
 {
     internal partial class MsSqlDatabaseMigrator : GenericDatabaseMigrator
     {
-        protected override string FactoryName => "System.Data.SqlClient";
+        protected override string FactoryName => "Microsoft.Data.SqlClient";
         
         public MsSqlDatabaseMigrator(string connectionString) : base(connectionString)
         {

--- a/src/Raven.Studio/mockups/src/partials/modals/newDatabase.html
+++ b/src/Raven.Studio/mockups/src/partials/modals/newDatabase.html
@@ -352,7 +352,7 @@
                                                         <span class="caret"></span>
                                                     </button>
                                                     <ul class="dropdown-menu">
-                                                        <li><a href="#" value="Microsoft.Data.SqlClient">Microsoft.Data.SqlClient</a></li>
+                                                        <li><a href="#" value="System.Data.SqlClient">System.Data.SqlClient</a></li>
                                                         <li><a href="#" value="System.Data.SqlServerCe.4.0">System.Data.SqlServerCe.4.0</a></li>
                                                         <li><a href="#" value="System.Data.OleDb">System.Data.OleDb</a></li>
                                                         <li><a href="#" value="System.Data.OracleClient">System.Data.OracleClient</a></li>

--- a/src/Raven.Studio/mockups/src/partials/modals/newDatabase.html
+++ b/src/Raven.Studio/mockups/src/partials/modals/newDatabase.html
@@ -352,7 +352,7 @@
                                                         <span class="caret"></span>
                                                     </button>
                                                     <ul class="dropdown-menu">
-                                                        <li><a href="#" value="System.Data.SqlClient">System.Data.SqlClient</a></li>
+                                                        <li><a href="#" value="Microsoft.Data.SqlClient">Microsoft.Data.SqlClient</a></li>
                                                         <li><a href="#" value="System.Data.SqlServerCe.4.0">System.Data.SqlServerCe.4.0</a></li>
                                                         <li><a href="#" value="System.Data.OleDb">System.Data.OleDb</a></li>
                                                         <li><a href="#" value="System.Data.OracleClient">System.Data.OracleClient</a></li>

--- a/src/Raven.Studio/typescript/models/database/settings/connectionStringSqlEtlModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/connectionStringSqlEtlModel.ts
@@ -9,11 +9,12 @@ import sqlConnectionStringSyntax = require("common/helpers/database/sqlConnectio
 class connectionStringSqlEtlModel extends connectionStringModel {
 
     static sqlProviders: Array<valueAndLabelItem<string, string> & { tooltip: string }> = [
-        { value: "System.Data.SqlClient", label: "Microsoft SQL Server", tooltip: sqlConnectionStringSyntax.mssqlSyntax },
+        { value: "Microsoft.Data.SqlClient", label: "Microsoft SQL Server", tooltip: sqlConnectionStringSyntax.mssqlSyntax },
         { value: "MySqlConnector.MySqlConnectorFactory", label: "MySQL Server", tooltip: sqlConnectionStringSyntax.mysqlSyntax },
         { value: "Npgsql", label: "PostgreSQL", tooltip: sqlConnectionStringSyntax.npgsqlSyntax },
         { value: "Oracle.ManagedDataAccess.Client", label: "Oracle Database", tooltip: sqlConnectionStringSyntax.oracleSyntax },
         { value: "MySql.Data.MySqlClient", label: "DEPRECATED: MySQL Server", tooltip: sqlConnectionStringSyntax.mysqlSyntax },
+        { value: "System.Data.SqlClient", label: "DEPRECATED: Microsoft SQL Server", tooltip: sqlConnectionStringSyntax.mssqlSyntax },
     ];
     
     connectionString = ko.observable<string>();

--- a/src/Raven.Studio/typescript/models/database/settings/connectionStringSqlEtlModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/connectionStringSqlEtlModel.ts
@@ -9,7 +9,7 @@ import sqlConnectionStringSyntax = require("common/helpers/database/sqlConnectio
 class connectionStringSqlEtlModel extends connectionStringModel {
 
     static sqlProviders: Array<valueAndLabelItem<string, string> & { tooltip: string }> = [
-        { value: "Microsoft.Data.SqlClient", label: "Microsoft SQL Server", tooltip: sqlConnectionStringSyntax.mssqlSyntax },
+        { value: "System.Data.SqlClient", label: "Microsoft SQL Server", tooltip: sqlConnectionStringSyntax.mssqlSyntax },
         { value: "MySqlConnector.MySqlConnectorFactory", label: "MySQL Server", tooltip: sqlConnectionStringSyntax.mysqlSyntax },
         { value: "Npgsql", label: "PostgreSQL", tooltip: sqlConnectionStringSyntax.npgsqlSyntax },
         { value: "Oracle.ManagedDataAccess.Client", label: "Oracle Database", tooltip: sqlConnectionStringSyntax.oracleSyntax },

--- a/src/Raven.Studio/typescript/models/database/settings/connectionStringSqlEtlModel.ts
+++ b/src/Raven.Studio/typescript/models/database/settings/connectionStringSqlEtlModel.ts
@@ -9,7 +9,7 @@ import sqlConnectionStringSyntax = require("common/helpers/database/sqlConnectio
 class connectionStringSqlEtlModel extends connectionStringModel {
 
     static sqlProviders: Array<valueAndLabelItem<string, string> & { tooltip: string }> = [
-        { value: "System.Data.SqlClient", label: "Microsoft SQL Server", tooltip: sqlConnectionStringSyntax.mssqlSyntax },
+        { value: "Microsoft.Data.SqlClient", label: "Microsoft SQL Server", tooltip: sqlConnectionStringSyntax.mssqlSyntax },
         { value: "MySqlConnector.MySqlConnectorFactory", label: "MySQL Server", tooltip: sqlConnectionStringSyntax.mysqlSyntax },
         { value: "Npgsql", label: "PostgreSQL", tooltip: sqlConnectionStringSyntax.npgsqlSyntax },
         { value: "Oracle.ManagedDataAccess.Client", label: "Oracle Database", tooltip: sqlConnectionStringSyntax.oracleSyntax },

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
@@ -127,15 +127,13 @@ class ongoingTaskSqlEtlEditModel extends ongoingTaskEditModel {
             Disabled: this.taskState() === "Disabled",
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
             PinToMentorNode: this.pinMentorNode(),
-            FactoryName: "System.Data.SqlClient",
             ForceQueryRecompile: this.forceRecompileQuery(),
             ParameterizeDeletes: this.parameterizedDeletes(),
             CommandTimeout: this.commandTimeout() || null,
             QuoteTables: this.tableQuotation(),
             Transforms: this.transformationScripts().map(x => x.toDto()),
             SqlTables: this.sqlTables().map(x => x.toDto())
-        
-        } as Raven.Client.Documents.Operations.ETL.SQL.SqlEtlConfiguration;
+        };
     }
     
     static empty(): ongoingTaskSqlEtlEditModel {

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
@@ -127,7 +127,7 @@ class ongoingTaskSqlEtlEditModel extends ongoingTaskEditModel {
             Disabled: this.taskState() === "Disabled",
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
             PinToMentorNode: this.pinMentorNode(),
-            FactoryName: "System.Data.SqlClient",
+            FactoryName: "Microsoft.Data.SqlClient",
             ForceQueryRecompile: this.forceRecompileQuery(),
             ParameterizeDeletes: this.parameterizedDeletes(),
             CommandTimeout: this.commandTimeout() || null,

--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskSqlEtlEditModel.ts
@@ -127,7 +127,7 @@ class ongoingTaskSqlEtlEditModel extends ongoingTaskEditModel {
             Disabled: this.taskState() === "Disabled",
             MentorNode: this.manualChooseMentor() ? this.mentorNode() : undefined,
             PinToMentorNode: this.pinMentorNode(),
-            FactoryName: "Microsoft.Data.SqlClient",
+            FactoryName: "System.Data.SqlClient",
             ForceQueryRecompile: this.forceRecompileQuery(),
             ParameterizeDeletes: this.parameterizedDeletes(),
             CommandTimeout: this.commandTimeout() || null,

--- a/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
@@ -161,7 +161,7 @@ class sqlMigration {
     labelForProvider(type: Raven.Server.SqlMigration.MigrationProvider) {
         switch (type) {
             case "MsSQL":
-                return "Microsoft SQL Server (Microsoft.Data.SqlClient)";
+                return "Microsoft SQL Server (System.Data.SqlClient)";
             case "MySQL_MySql_Data":
                 return "DEPRECATED: MySQL Server (MySql.Data.MySqlClient)";
             case "MySQL_MySqlConnector":
@@ -305,7 +305,7 @@ class sqlMigration {
             case "MySQL_MySqlConnector":
                 return "MySqlConnector.MySqlConnectorFactory";
             case "MsSQL":
-                return "Microsoft.Data.SqlClient";
+                return "System.Data.SqlClient";
             case "NpgSQL":
                 return "Npgsql";
             case "Oracle":

--- a/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/sql/sqlMigration.ts
@@ -161,7 +161,7 @@ class sqlMigration {
     labelForProvider(type: Raven.Server.SqlMigration.MigrationProvider) {
         switch (type) {
             case "MsSQL":
-                return "Microsoft SQL Server (System.Data.SqlClient)";
+                return "Microsoft SQL Server (Microsoft.Data.SqlClient)";
             case "MySQL_MySql_Data":
                 return "DEPRECATED: MySQL Server (MySql.Data.MySqlClient)";
             case "MySQL_MySqlConnector":
@@ -305,7 +305,7 @@ class sqlMigration {
             case "MySQL_MySqlConnector":
                 return "MySqlConnector.MySqlConnectorFactory";
             case "MsSQL":
-                return "System.Data.SqlClient";
+                return "Microsoft.Data.SqlClient";
             case "NpgSQL":
                 return "Npgsql";
             case "Oracle":

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringSql.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringSql.html
@@ -32,6 +32,16 @@
                 </span>
             </div>
         </div>
+        <div class="has-warning" data-bind="visible: factoryName() === 'System.Data.SqlClient'">
+            <div class="help-block">
+                <i class="icon-warning"></i>
+                <span>
+                    This connector is deprecated. 
+                    Microsoft SqlClient will be used instead. 
+                    Please update Factory to: Microsoft.Data.SqlClient.
+                </span>
+            </div>
+        </div>
     </div>
 </div>
 <div class="form-group" data-bind="validationElement: connectionString">

--- a/test/FastTests/Client/OnGoingTask.cs
+++ b/test/FastTests/Client/OnGoingTask.cs
@@ -213,7 +213,7 @@ loadToOrders(orderData);
                 {
                     Name = "abc",
                     ConnectionString = @"Data Source=localhost\sqlexpress;Integrated Security=SSPI;Connection Timeout=3" + $";Initial Catalog=SqlReplication-{store.Database};",
-                    FactoryName = "System.Data.SqlClient"
+                    FactoryName = "Microsoft.Data.SqlClient"
                 };
 
                 var result = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));

--- a/test/RachisTests/DatabaseCluster/OngoingTasks.cs
+++ b/test/RachisTests/DatabaseCluster/OngoingTasks.cs
@@ -108,7 +108,7 @@ loadToOrders(orderData);
                 {
                     Name = "abc",
                     ConnectionString = @"Data Source=localhost\sqlexpress;Integrated Security=SSPI;Connection Timeout=3" + $";Initial Catalog=SqlReplication-{store.Database};",
-                    FactoryName = "System.Data.SqlClient"
+                    FactoryName = "Microsoft.Data.SqlClient"
                 };
                 var result2 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
                 Assert.NotNull(result2.RaftCommandIndex);
@@ -265,7 +265,7 @@ loadToOrders(orderData);
                 {
                     Name = "abc",
                     ConnectionString = @"Data Source=localhost\sqlexpress;Integrated Security=SSPI;Connection Timeout=3" + $";Initial Catalog=SqlReplication-{store.Database};",
-                    FactoryName = "System.Data.SqlClient"
+                    FactoryName = "Microsoft.Data.SqlClient"
                 };
                 var result2 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
                 Assert.NotNull(result2.RaftCommandIndex);

--- a/test/SlowTests/Issues/RavenDB-19967.cs
+++ b/test/SlowTests/Issues/RavenDB-19967.cs
@@ -331,7 +331,7 @@ namespace SlowTests.Issues
                         blockerType = ITombstoneAware.TombstoneDeletionBlockerType.RavenEtl;
                         break;
                     case EtlType.Sql:
-                        var sqlConnectionString = new SqlConnectionString { Name = store.Identifier, FactoryName = "System.Data.SqlClient", ConnectionString = "Server=127.0.0.1;Port=2345;Database=myDataBase;User Id=foo;Password=bar;" };
+                        var sqlConnectionString = new SqlConnectionString { Name = store.Identifier, FactoryName = "Microsoft.Data.SqlClient", ConnectionString = "Server=127.0.0.1;Port=2345;Database=myDataBase;User Id=foo;Password=bar;" };
                         var sqlConfiguration = new SqlEtlConfiguration { Name = _customTaskName, ConnectionStringName = sqlConnectionString.Name, Transforms = { transforms }, SqlTables = { new SqlEtlTable { TableName = "Orders", DocumentIdColumn = "Id" } } };
                         taskId = await AddEtlAndDisableIt(store, sqlConnectionString, sqlConfiguration, OngoingTaskType.SqlEtl);
                         blockerType = ITombstoneAware.TombstoneDeletionBlockerType.SqlEtl;

--- a/test/SlowTests/Issues/RavenDB-22426.cs
+++ b/test/SlowTests/Issues/RavenDB-22426.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.SqlClient;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Server.SqlMigration;
+using SlowTests.Server.Documents.ETL;
+using SlowTests.Server.Documents.Migration;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22426 : EtlTestBase
+{
+    private const string EtlScript = @"
+        var updatedDto = {
+            Id: id(this),
+            Name: 'NewName'
+        };
+
+        loadToDtos(updatedDto);
+    ";
+    
+    public RavenDB_22426(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public void TestOldFactoryNameWithNoEncryptParameter()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (SqlAwareTestBase.WithSqlDatabase(MigrationProvider.MsSQL, out var connectionString, out string schemaName, dataSet: null, includeData: false))
+            {
+                CreateRdbmsSchema(connectionString);
+
+                using (var session = store.OpenSession())
+                {
+                    var dto = new Dto() { Name = "CoolName" };
+                    
+                    session.Store(dto);
+                    
+                    session.SaveChanges();
+                }
+
+                var etlDone = WaitForEtl(store, (n, s) => GetDtosCount(connectionString) == 1);
+                
+                var connectionStringWithoutEncryptOption = connectionString.Replace("Encrypt=Optional;", string.Empty);
+                
+                SetupSqlEtl(store, connectionStringWithoutEncryptOption, EtlScript);
+
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                Assert.Equal(1, GetDtosCount(connectionString));
+            }
+        }
+    }
+    
+    protected void CreateRdbmsSchema(string connectionString, string command = @"
+CREATE TABLE [dbo].[Dtos]
+(
+    [Id] [nvarchar](50) NOT NULL,
+    [Name] [nvarchar](50) NULL
+)
+")
+    {
+        using (var con = new SqlConnection())
+        {
+            con.ConnectionString = connectionString;
+            con.Open();
+
+            using (var dbCommand = con.CreateCommand())
+            {
+                dbCommand.CommandText = command;
+                dbCommand.ExecuteNonQuery();
+            }
+            con.Close();
+        }
+    }
+    
+    protected static int GetDtosCount(string connectionString)
+    {
+        using (var con = new SqlConnection())
+        {
+            con.ConnectionString = connectionString;
+            con.Open();
+
+            using (var dbCommand = con.CreateCommand())
+            {
+                dbCommand.CommandText = " SELECT COUNT(*) FROM Dtos";
+                return (int)dbCommand.ExecuteScalar();
+            }
+        }
+    }
+    
+    protected void SetupSqlEtl(DocumentStore store, string connectionString, string script, bool insertOnly = false, List<string> collections = null)
+    {
+        var connectionStringName = $"{store.Database}@{store.Urls.First()} to SQL DB";
+
+        AddEtl(store, new SqlEtlConfiguration()
+        {
+            Name = connectionStringName,
+            ConnectionStringName = connectionStringName,
+            SqlTables =
+            {
+                new SqlEtlTable {TableName = "Dtos", DocumentIdColumn = "Id", InsertOnlyMode = insertOnly}
+            },
+            Transforms =
+            {
+                new Transformation()
+                {
+                    Name = "UpdateName",
+                    Collections = collections ?? new List<string> { "Dtos" },
+                    Script = script
+                }
+            }
+        }, new SqlConnectionString
+        {
+            Name = connectionStringName,
+            ConnectionString = connectionString,
+            FactoryName = "System.Data.SqlClient"
+        });
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_16303.cs
+++ b/test/SlowTests/Issues/RavenDB_16303.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Threading;
 using Npgsql;
@@ -191,7 +191,7 @@ loadToTestGuidEtls(item);"
                 case MigrationProvider.Oracle:
                     return @"Oracle.ManagedDataAccess.Client";
                 case MigrationProvider.MsSQL:
-                    return @"System.Data.SqlClient";
+                    return @"Microsoft.Data.SqlClient";
 #pragma warning disable CS0618 // Type or member is obsolete
                 case MigrationProvider.MySQL_MySql_Data:
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_9626.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_9626.cs
@@ -36,7 +36,7 @@ namespace SlowTests.Server.Documents.ETL.SQL
                 }
             };
 
-            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress", FactoryName = "System.Data.SqlClient"});
+            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress", FactoryName = "Microsoft.Data.SqlClient"});
 
             List<string> errors;
             config.Validate(out errors);
@@ -72,7 +72,7 @@ namespace SlowTests.Server.Documents.ETL.SQL
                 }
             };
 
-            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress", FactoryName = "System.Data.SqlClient"});
+            config.Initialize(new SqlConnectionString { ConnectionString = @"Data Source=localhost\sqlexpress", FactoryName = "Microsoft.Data.SqlClient"});
 
             List<string> errors;
             config.Validate(out errors);

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -6,7 +6,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Net.WebSockets;
@@ -299,7 +299,7 @@ loadToOrDerS(orderData); // note 'OrDerS' here vs 'Orders' defined in the config
                     {
                         Name = connectionStringName,
                         ConnectionString = connectionString,
-                        FactoryName = "System.Data.SqlClient"
+                        FactoryName = "Microsoft.Data.SqlClient"
                     });
 
                     etlDone.Wait(TimeSpan.FromMinutes(5));
@@ -697,7 +697,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
                     {
                         Name = "simulate",
                         ConnectionString = connectionString,
-                        FactoryName = "System.Data.SqlClient",
+                        FactoryName = "Microsoft.Data.SqlClient",
                     }));
                     Assert.NotNull(result1.RaftCommandIndex);
 
@@ -779,7 +779,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
                     {
                         Name = "simulate",
                         ConnectionString = connectionString,
-                        FactoryName = "System.Data.SqlClient",
+                        FactoryName = "Microsoft.Data.SqlClient",
                     }));
                     Assert.NotNull(result1.RaftCommandIndex);
 
@@ -1028,7 +1028,7 @@ for (var i = 0; i < attachments.length; i++)
 "
                             }
                         }
-                    }, new SqlConnectionString { Name = "test", FactoryName = "System.Data.SqlClient", ConnectionString = connectionString });
+                    }, new SqlConnectionString { Name = "test", FactoryName = "Microsoft.Data.SqlClient", ConnectionString = connectionString });
 
                     etlDone.Wait(TimeSpan.FromMinutes(5));
 
@@ -1202,7 +1202,7 @@ loadToUsers(
 "
                                 }
                             }
-                    }, new SqlConnectionString { Name = "test", FactoryName = "System.Data.SqlClient", ConnectionString = connectionString });
+                    }, new SqlConnectionString { Name = "test", FactoryName = "Microsoft.Data.SqlClient", ConnectionString = connectionString });
 
                     etlDone.Wait(TimeSpan.FromMinutes(5));
 
@@ -1351,7 +1351,7 @@ loadToOrders(orderData);
             {
                 Name = connectionStringName,
                 ConnectionString = connectionString,
-                FactoryName = "System.Data.SqlClient"
+                FactoryName = "Microsoft.Data.SqlClient"
             });
         }
 

--- a/test/SlowTests/Server/Documents/Migration/SqlAwareTestBase.cs
+++ b/test/SlowTests/Server/Documents/Migration/SqlAwareTestBase.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -141,7 +141,7 @@ namespace SlowTests.Smuggler
                     {
                         Name = "connection",
                         ConnectionString = @"Data Source=localhost\sqlexpress;Integrated Security=SSPI;Connection Timeout=3" + $";Initial Catalog=SqlReplication-{store1.Database};",
-                        FactoryName = "System.Data.SqlClient"
+                        FactoryName = "Microsoft.Data.SqlClient"
                     };
 
                     var result2 = store1.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -345,7 +345,7 @@ namespace SlowTests.Smuggler
                     {
                         Name = "connection",
                         ConnectionString = @"Data Source=localhost\sqlexpress;Integrated Security=SSPI;Connection Timeout=3" + $";Initial Catalog=SqlReplication-{store1.Database};",
-                        FactoryName = "System.Data.SqlClient"
+                        FactoryName = "Microsoft.Data.SqlClient"
                     };
 
                     var result2 = store1.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -802,25 +802,25 @@ namespace SlowTests.Smuggler
                     {
                         Name = "scon1",
                         ConnectionString = "http://127.0.0.1:8081",
-                        FactoryName = "System.Data.SqlClient"
+                        FactoryName = "Microsoft.Data.SqlClient"
                     };
                     var scon2 = new SqlConnectionString()
                     {
                         Name = "scon2",
                         ConnectionString = "http://127.0.0.1:8082",
-                        FactoryName = "System.Data.SqlClient"
+                        FactoryName = "Microsoft.Data.SqlClient"
                     };
                     var scon3 = new SqlConnectionString()
                     {
                         Name = "scon3",
                         ConnectionString = "http://127.0.0.1:8083",
-                        FactoryName = "System.Data.SqlClient"
+                        FactoryName = "Microsoft.Data.SqlClient"
                     };
                     var scon4 = new SqlConnectionString()
                     {
                         Name = "scon4",
                         ConnectionString = "http://127.0.0.1:8084",
-                        FactoryName = "System.Data.SqlClient"
+                        FactoryName = "Microsoft.Data.SqlClient"
                     };
                     var putResult1 = await store1.Maintenance.SendAsync(new PutConnectionStringOperation<SqlConnectionString>(scon1));
                     var putResult2 = await store1.Maintenance.SendAsync(new PutConnectionStringOperation<SqlConnectionString>(scon2));
@@ -1102,7 +1102,7 @@ namespace SlowTests.Smuggler
                 {
                     Name = "connection",
                     ConnectionString = @"Data Source=localhost\sqlexpress;Integrated Security=SSPI;Connection Timeout=3" + $";Initial Catalog=SqlReplication-{store.Database};",
-                    FactoryName = "System.Data.SqlClient"
+                    FactoryName = "Microsoft.Data.SqlClient"
                 };
 
                 var result2 = store.Maintenance.Send(new PutConnectionStringOperation<SqlConnectionString>(sqlConnectionString));
@@ -1317,7 +1317,7 @@ namespace SlowTests.Smuggler
                 {
                     Name = "sql-cs",
                     ConnectionString = "http://127.0.0.1:8081",
-                    FactoryName = "System.Data.SqlClient"
+                    FactoryName = "Microsoft.Data.SqlClient"
                 }));
 
                 await store.Maintenance.SendAsync(new PutConnectionStringOperation<OlapConnectionString>(new OlapConnectionString

--- a/test/Tests.Infrastructure/ConnectionString/MssqlConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/MssqlConnectionString.cs
@@ -15,7 +15,7 @@ namespace Tests.Infrastructure.ConnectionString
 
         protected override string VerifiedConnectionStringFactory(string cs)
         {
-            const string localConnectionString = @"Data Source=localhost\sqlexpress;Integrated Security=SSPI;Connection Timeout=3";
+            const string localConnectionString = @"Data Source=localhost\sqlexpress;Integrated Security=SSPI;Connection Timeout=3;Encrypt=Optional";
             if (TryConnect(localConnectionString, out var errorMessage))
                 return localConnectionString;
 

--- a/test/Tests.Infrastructure/ConnectionString/MssqlConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/MssqlConnectionString.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Tests.Infrastructure.ConnectionString
 {

--- a/test/Tests.Infrastructure/ConnectionString/MssqlConnectionString.cs
+++ b/test/Tests.Infrastructure/ConnectionString/MssqlConnectionString.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Data.SqlClient;
+using Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters;
 
 namespace Tests.Infrastructure.ConnectionString
 {
@@ -20,6 +21,9 @@ namespace Tests.Infrastructure.ConnectionString
                 return localConnectionString;
 
             var remoteConnectionString = Environment.GetEnvironmentVariable(EnvironmentVariable);
+
+            remoteConnectionString = SqlConnectionStringUtil.GetConnectionStringWithOptionalEncrypt(remoteConnectionString);
+            
             if (TryConnect(remoteConnectionString, out errorMessage))
                 return remoteConnectionString;
 

--- a/test/Tests.Infrastructure/RequiresMsSqlRetryFactAttribute.cs
+++ b/test/Tests.Infrastructure/RequiresMsSqlRetryFactAttribute.cs
@@ -18,7 +18,7 @@ public class RequiresMsSqlRetryFactAttribute : RetryFactAttribute
         if (RavenTestHelper.IsRunningOnCI)
             return;
 
-        if (MySqlConnectionString.Instance.CanConnect == false)
-            Skip = "Test requires MySQL database";
+        if (MsSqlConnectionString.Instance.CanConnect == false)
+            Skip = "Test requires MsSQL database";
     }
 }

--- a/test/Tests.Infrastructure/RequiresMsSqlRetryTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/RequiresMsSqlRetryTheoryAttribute.cs
@@ -18,7 +18,7 @@ public class RequiresMsSqlRetryTheoryAttribute : RetryTheoryAttribute
         if (RavenTestHelper.IsRunningOnCI)
             return;
 
-        if (MySqlConnectionString.Instance.CanConnect == false)
-            Skip = "Test requires MySQL database";
+        if (MsSqlConnectionString.Instance.CanConnect == false)
+            Skip = "Test requires MsSQL database";
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22426/Replace-System.Data.SqlClient-NuGet-package-with-Microsoft.Data.SqlClient

### Additional description

Replaced `System.Data.SqlClient` package with `Microsoft.Data.SqlClient`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
