### PR TITLE
RavenDB-22413 - Majority of replicas doesn't take itself into account

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BatchHandler.cs
@@ -400,7 +400,7 @@ namespace Raven.Server.Documents.Handlers
 
             if (numberOfReplicasStr == "majority")
             {
-                numberOfReplicasToWaitFor = database.ReplicationLoader.GetSizeOfMajority();
+                numberOfReplicasToWaitFor = database.ReplicationLoader.GetMinNumberOfReplicas();
             }
             else
             {

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -2025,9 +2025,9 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        public int GetSizeOfMajority()
+        public int GetMinNumberOfReplicas()
         {
-            return (_numberOfSiblings + 1) / 2 + 1;
+            return (_numberOfSiblings + 1) / 2; // not "(_numberOfSiblings + 1) / 2 + 1" because 1 node already have got the data and only need to replicate
         }
 
         public async Task<int> WaitForReplicationAsync(int numberOfReplicasToWaitFor, TimeSpan waitForReplicasTimeout, string lastChangeVector)

--- a/test/SlowTests/Issues/RavenDB-22413.cs
+++ b/test/SlowTests/Issues/RavenDB-22413.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22413 : ReplicationTestBase
+    {
+        public RavenDB_22413(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task ReplicationMajority()
+        {
+            var (_, leader) = await CreateRaftCluster(3);
+
+            using (var store = GetDocumentStore(new Options
+                   {
+                       Server = leader,
+                       ReplicationFactor = 3
+                   }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "Karmel"
+                    }, "users/1");
+                    session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(30), majority: true);
+                    session.SaveChanges();
+                }
+
+                // fail the node to to where the data is sent
+                await DisposeServerAndWaitForFinishOfDisposalAsync(Servers.First());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User
+                    {
+                        Name = "Karmel2"
+                    }, "users/2");
+                    session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(30), majority: true);
+                    session.SaveChanges();
+                }
+
+                // WaitForUserToContinueTheTest(store, false);
+
+                using (var session = store.OpenSession())
+                {
+                    var u = session.Load<User>("users/2");
+                    Assert.NotNull(u);
+                }
+            }
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22413/Majority-of-replicas-doesnt-take-itself-into-account

### Additional description

The problem was that the minimum number of replicas was calculated the same as the majority, 
Without referring to the fact that one node has already received the data and just needs to duplicate it to `[majority-1]` nodes.
```
majority = (dbNodes + 1) / 2 + 1
=>
majority - 1 = (dbNodes + 1) / 2
```

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
