### PR TITLE
RavenDB-21833 - Remove unnecessary flush which might run concurrently with writing to the stream

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -258,17 +258,14 @@ namespace Raven.Client.Documents.BulkInsert
 
                 if (_first == false)
                 {
-
                     WriteComma();
                 }
 
                 _first = false;
                 _inProgressCommand = CommandType.None;
                 _writer.Write("{\"Type\":\"HeartBeat\"}");
-
                 
                 await FlushIfNeeded(force: true).ConfigureAwait(false);
-                await _writer._requestBodyStream.FlushAsync(_token).ConfigureAwait(false);
             }
             catch (Exception)
             {

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -24,7 +24,7 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
     private JsonOperationContext.MemoryBuffer _backgroundMemoryBuffer;
     private bool _isInitialWrite = true;
 
-    internal Stream _requestBodyStream;
+    private Stream _requestBodyStream;
 
     internal readonly BulkInsertOperation.BulkInsertStreamExposerContent StreamExposer;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21833/SlowTests.Issues.RavenDB17745.BulkInsertWithDelay

### Additional description

When we have to send a heartbeat, we call `FlushIfNeeded`, this creates an async task, `WriteToStreamAsync` (that we don't wait on):
https://github.com/ravendb/ravendb/blob/a5b39345c2c9b54cfbaded72a6a1b6b8f1f35eeb/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs#L101

This task is writing to the stream:
https://github.com/ravendb/ravendb/blob/a5b39345c2c9b54cfbaded72a6a1b6b8f1f35eeb/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs#L135

After that we are trying to Flush again (while we are still might be writing to the stream):
https://github.com/ravendb/ravendb/blob/a5b39345c2c9b54cfbaded72a6a1b6b8f1f35eeb/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs#L271

When sending the heartbeat, we force flushing so we shouldn't try to flush again.
https://github.com/ravendb/ravendb/blob/a5b39345c2c9b54cfbaded72a6a1b6b8f1f35eeb/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs#L138

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
