### PR TITLE
RavenDB-21833 bulk insert fix

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -23,6 +23,7 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
     private JsonOperationContext.MemoryBuffer _memoryBuffer;
     private JsonOperationContext.MemoryBuffer _backgroundMemoryBuffer;
     private bool _isInitialWrite = true;
+    internal DateTime LastFlushToStream { get; private set; }
 
     private Stream _requestBodyStream;
 
@@ -39,6 +40,7 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
 
         var returnMemoryBuffer = ctx.GetMemoryBuffer(out _memoryBuffer);
         var returnBackgroundMemoryBuffer = ctx.GetMemoryBuffer(out _backgroundMemoryBuffer);
+        UpdateFlushTime();
 
         _disposeOnce = new DisposeOnceAsync<SingleAttempt>(async () =>
         {
@@ -106,6 +108,11 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
         return false;
     }
 
+    private void UpdateFlushTime()
+    {
+        LastFlushToStream = DateTime.UtcNow;
+    }
+
     protected virtual void OnCurrentWriteStreamSet(MemoryStream currentWriteStream)
     {
 
@@ -135,7 +142,10 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
             await dst.WriteAsync(buffer.Memory.Memory.Slice(0, bytesRead), _token).ConfigureAwait(false);
 
             if (forceDstFlush)
+            {
+                UpdateFlushTime();
                 await dst.FlushAsync(_token).ConfigureAwait(false);
+            }
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21833

### Additional description
Change _lastWriteToStream to be set only when we flush.
Fix the condition at FlushIfNeeded

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
