### PR TITLE
RavenDB-22351 Sharing the instance of table stats in case of switching between compressed and uncompressed schema in the same transaction

### DIFF
--- a/src/Raven.Server/Storage/Schema/Updates/Documents/40014/From40013.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/40014/From40013.cs
@@ -21,6 +21,9 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                 {
                     if (it.Seek(Slices.BeforeAllKeys) == false)
                         return true;
+
+                    var stats = new TableSchemaStatsReference();
+
                     do
                     {
                         var rootObjectType = tx.GetRootObjectType(it.CurrentKey);
@@ -33,7 +36,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                             var writtenSchemaData = tableTree.DirectRead(TableSchema.SchemasSlice);
                             var writtenSchemaDataSize = tableTree.GetDataSize(TableSchema.SchemasSlice);
                             var schema = TableSchema.ReadFrom(tx.Allocator, writtenSchemaData, writtenSchemaDataSize);
-                            new Table(schema, it.CurrentKey, tx, tableTree,schema.TableType).AssertValidFixedSizeTrees();
+                            new Table(schema, it.CurrentKey, tx, tableTree, stats, schema.TableType).AssertValidFixedSizeTrees();
                         }
                     } while (it.MoveNext());
                 }

--- a/src/Voron/Data/Tables/TableSchemaStatsReference.cs
+++ b/src/Voron/Data/Tables/TableSchemaStatsReference.cs
@@ -1,0 +1,8 @@
+﻿namespace Voron.Data.Tables;
+
+public class TableSchemaStatsReference
+{
+    public long NumberOfEntries { get; set; }
+
+    public long OverflowPageCount { get; set; }
+}

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -15,6 +15,7 @@ using Voron.Data.Containers;
 using Voron.Data.RawData;
 using Voron.Data.PostingLists;
 using Constants = Voron.Global.Constants;
+using System.IO;
 
 namespace Voron.Impl
 {
@@ -39,6 +40,7 @@ namespace Voron.Impl
         private Dictionary<Slice, PostingList> _postingLists;
         
         private Dictionary<TableKey, Table> _tables;
+        private Dictionary<Slice, TableSchemaStatsReference> _tableSchemaStats;
 
         private Dictionary<Slice, Tree> _trees;
 
@@ -227,7 +229,22 @@ namespace Voron.Impl
             if (tableTree == null)
                 return null;
 
-            value = new Table(schema, clonedName, this, tableTree, schema.TableType);
+            _tableSchemaStats ??= new Dictionary<Slice, TableSchemaStatsReference>(SliceComparer.Instance);
+
+            if (_tableSchemaStats.TryGetValue(clonedName, out var tableStatsRef) == false)
+            {
+                var stats = (TableSchemaStats*)tableTree.DirectRead(TableSchema.StatsSlice);
+                if (stats == null)
+                    throw new InvalidDataException($"Cannot find stats value for table {name}");
+
+                _tableSchemaStats[clonedName] = tableStatsRef = new TableSchemaStatsReference()
+                {
+                    NumberOfEntries = stats->NumberOfEntries,
+                    OverflowPageCount = stats->OverflowPageCount
+                };
+            }
+
+            value = new Table(schema, clonedName, this, tableTree, tableStatsRef, schema.TableType);
             _tables[key] = value;
             return value;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22351/Error-during-import

### Additional description

Please see the comment - https://issues.hibernatingrhinos.com/issue/RavenDB-22351/Error-during-import#focus=Comments-67-1052799.0-0

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
