### PR TITLE
RavenDB-17196 use same @metadata instance

### DIFF
--- a/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
+++ b/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
@@ -45,6 +45,8 @@ namespace Raven.Server.Documents.Patch
 
         public ProjectionOptions Projection;
 
+        public BlittableObjectInstance Metadata;
+
         public SpatialResult? Distance => _doc?.Distance;
         public float? IndexScore => _doc?.IndexScore;
 

--- a/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
+++ b/src/Raven.Server/Documents/Patch/JavaScriptUtils.cs
@@ -145,6 +145,9 @@ namespace Raven.Server.Documents.Patch
                 !(args[0].AsObject() is BlittableObjectInstance boi)) 
                 throw new InvalidOperationException("metadataFor(doc) must be called with a single entity argument");
 
+            if (boi.Metadata != null)
+                return boi.Metadata;
+
             var modifiedMetadata = new DynamicJsonValue();
 
             // we need to set the metadata on the blittable itself, because we are might get the actual blittable here instead of Document
@@ -173,8 +176,9 @@ namespace Raven.Server.Documents.Patch
                     Context.ReadObject(modifiedMetadata, boi.DocumentId) : 
                     Context.ReadObject(metadata, boi.DocumentId);
                 
-                JsValue metadataJs = TranslateToJs(_scriptEngine, Context, metadata);
+                var metadataJs = (BlittableObjectInstance)TranslateToJs(_scriptEngine, Context, metadata);
                 boi.Set(Constants.Documents.Metadata.Key, metadataJs);
+                boi.Metadata = metadataJs;
 
                 return metadataJs;
             }

--- a/test/SlowTests/Issues/RavenDB_17196.cs
+++ b/test/SlowTests/Issues/RavenDB_17196.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17196 : RavenTestBase
+{
+    public RavenDB_17196(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Patching)]
+    public async Task can_patch_metadata()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new TestDocument { Name = "TestDocument", Id = "test/1" });
+                await session.SaveChangesAsync();
+            }
+
+            // New Sesson so document is not in cache
+            using (var session = store.OpenAsyncSession())
+            {
+                var metadataPatch = new PatchRequest
+                {
+                    Script = @"
+                                    this.my_first_value = args.myval_1;
+                                    this.my_second_value = args.myval_2; 
+                                    this['@metadata']['my_first_value_metadata'] = args.myval_1;
+                                    this['@metadata']['my_second_value_metadata'] = args.myval_2;
+                                   ",
+                    Values = {
+                            { "myval_1", "this does not work" },
+                            { "myval_2", "but this does!" }
+                        }
+                };
+                session.Advanced.Defer(new PatchCommandData("test/1", null, metadataPatch, null));
+                await session.SaveChangesAsync();
+            }
+
+            // New Sesson so document is not in cache
+            using (var session = store.OpenAsyncSession())
+            {
+                var document = await session.LoadAsync<TestDocument2>("test/1");
+                var metadata = session.Advanced.GetMetadataFor(document);
+                Assert.Equal(document.my_first_value, "this does not work");
+                Assert.Equal(document.my_second_value, "but this does!");
+                Assert.True(metadata.ContainsKey("my_first_value_metadata"), "'my_second_value' exists");   // this is true
+                Assert.True(metadata.ContainsKey("my_second_value_metadata"), "'my_first_value' exists");    // this failes
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Patching)]
+    public async Task can_patch_metadata_2()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var test = new TestDocument();
+            const string id = "test/1";
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(test, id);
+                await session.SaveChangesAsync();
+            }
+
+            Dictionary<string, object> values = new()
+            {
+                {
+                    "processed", "yes"
+                },
+                {
+                    "verify", true
+                }
+            };
+
+            var patchRequest = new PatchRequest
+            {
+                Script = "this['@metadata']['processed'] = args.processed; this['@metadata']['verify'] = args.verify;",
+                Values = values
+            };
+
+            store.Operations.Send(new PatchOperation(id, null, patchRequest, patchIfMissing: null));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<TestDocument>(test.Id);
+                var m = session.Advanced.GetMetadataFor(loaded);
+
+                m.TryGetValue("processed", out object processed);
+                m.TryGetValue("verify", out object verify);
+
+                Assert.Equal(values["processed"], processed);
+                Assert.Equal(values["verify"], verify);
+            }
+        }
+    }
+
+    private class TestDocument
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class TestDocument2
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string my_first_value { get; set; }
+        public string my_second_value { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17196

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
