### PR TITLE
RavenDB-22492: Implementation of a UtcNow accessor to centralize access and control calls.

### DIFF
--- a/src/Sparrow.Server/TimestampAccessor.cs
+++ b/src/Sparrow.Server/TimestampAccessor.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading;
+
+namespace Sparrow.Server
+{
+    // The idea behind the timestamp accessor is to be able to query the UTC datetime value
+    // while at the same time avoid multiple calls to the kernel operations when they are not
+    // needed for accuracy. 
+    public static class TimestampAccessor
+    {
+        private static long _timestamp;
+        private static readonly Timer _timer;
+
+        // Static constructor to initialize the timestamp and timer
+        static TimestampAccessor()
+        {
+            _timestamp = DateTime.UtcNow.Ticks;
+            _timer = new Timer(UpdateTimestamp, null, 0, 500); // Update every 500 milliseconds (0.5 second)
+        }
+
+        // Method called by the timer to update the timestamp
+        private static void UpdateTimestamp(object state)
+        {
+            // This will force an update.
+            GetTimestamp();
+        }
+
+        public static long GetTimestamp()
+        {
+            long newTimestamp = DateTime.UtcNow.Ticks;
+            long oldTimestamp = _timestamp;
+            
+            // We will bail if the new timestamp is smaller than or equal to the current one, no need to use
+            // an older timestamp because of losing the CPU against someone else.
+            if (newTimestamp <= oldTimestamp)
+                return oldTimestamp;
+
+            // Attempt to update the timestamp atomically, if it fails we just take the current one.
+            Interlocked.CompareExchange(ref _timestamp, newTimestamp, oldTimestamp);
+
+            return newTimestamp;
+        }
+
+        public static DateTime GetTime()
+        {
+            return new DateTime(GetTimestamp());
+        }
+
+        public static DateTime GetApproximateTime()
+        {
+            return new DateTime(GetApproximateTimestamp());
+        }
+
+        public static long GetApproximateTimestamp()
+        {
+            // We increase to ensure that we always get a new one even if approximate since by the time that
+            // interlocked ended we have already elapsed a tick anyway.
+            return Interlocked.Increment(ref _timestamp);
+        }
+    }
+}

--- a/src/Voron/Impl/EncryptionBuffersPool.cs
+++ b/src/Voron/Impl/EncryptionBuffersPool.cs
@@ -10,6 +10,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
+using Sparrow.Server;
 using Sparrow.Server.Debugging;
 using Sparrow.Server.Platform;
 using Sparrow.Threading;
@@ -59,7 +60,7 @@ namespace Voron.Impl
             _lastGlobalStackRebuilds = new DateTime[numberOfSlots];
             _numberOfAllocationsDisposedInGlobalStacks = new long[numberOfSlots];
 
-            var now = DateTime.UtcNow;
+            var now = TimestampAccessor.GetTime();
 
             for (int i = 0; i < _items.Length; i++)
             {
@@ -169,7 +170,7 @@ namespace Voron.Impl
             {
                 Ptr = ptr,
                 Size = size,
-                InPoolSince = DateTime.UtcNow
+                InPoolSince = TimestampAccessor.GetTime()
             };
 
             var addToPerCorePool = ForTestingPurposes == null || ForTestingPurposes.CanAddToPerCorePool;
@@ -319,7 +320,7 @@ namespace Voron.Impl
 
             try
             {
-                var currentTime = DateTime.UtcNow;
+                var currentTime = TimestampAccessor.GetTime();
                 var idleTime = TimeSpan.FromMinutes(10);
 
                 for (int i = 0; i < _items.Length; i++)

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -104,7 +104,7 @@ namespace Voron.Impl.Journal
 
         private JournalFile NextFile(int numberOf4Kbs = 1)
         {
-            var now = DateTime.UtcNow;
+            var now = TimestampAccessor.GetTime();
             if ((now - _lastFile).TotalSeconds < 90)
             {
                 _currentJournalFileSize = Math.Min(_env.Options.MaxLogFileSize, _currentJournalFileSize * 2);
@@ -657,7 +657,7 @@ namespace Voron.Impl.Journal
             {
                 Interlocked.Exchange(ref _lastFlushed, state);
 
-                _lastFlushTime = DateTime.UtcNow;
+                _lastFlushTime = TimestampAccessor.GetTime();
             }
 
             public void AddJournalToDelete(JournalFile journal)
@@ -1237,7 +1237,7 @@ namespace Voron.Impl.Journal
                         toDelete.Release();
                     }
 
-                    _parent._lastSyncTime = DateTime.UtcNow;
+                    _parent._lastSyncTime = TimestampAccessor.GetTime();
 
                     return true;
                 }
@@ -1793,7 +1793,7 @@ namespace Voron.Impl.Journal
 
                 _compressionPager.Dispose();
                 _compressionPager = CreateCompressionPager(_env.Options.InitialFileSize ?? _env.Options.InitialLogFileSize);
-                _lastCompressionBufferReduceCheck = DateTime.UtcNow;
+                _lastCompressionBufferReduceCheck = TimestampAccessor.GetTime();
                 throw;
             }
 
@@ -1895,7 +1895,7 @@ namespace Voron.Impl.Journal
 
                     _compressionPager.Dispose();
                     _compressionPager = CreateCompressionPager(_env.Options.InitialFileSize ?? _env.Options.InitialLogFileSize);
-                    _lastCompressionBufferReduceCheck = DateTime.UtcNow;
+                    _lastCompressionBufferReduceCheck = TimestampAccessor.GetTime();
                     throw;
                 }
 
@@ -2113,7 +2113,7 @@ namespace Voron.Impl.Journal
             return _env.Options.CreateTemporaryBufferPager($"compression.{_compressionPagerCounter++:D10}{StorageEnvironmentOptions.DirectoryStorageEnvironmentOptions.BuffersFileExtension}", initialSize);
         }
 
-        private DateTime _lastCompressionBufferReduceCheck = DateTime.UtcNow;
+        private DateTime _lastCompressionBufferReduceCheck = TimestampAccessor.GetTime();
         private readonly CompressionAccelerationStats _lastCompressionAccelerationInfo;
         private readonly bool _is32Bit;
 
@@ -2141,7 +2141,7 @@ namespace Voron.Impl.Journal
                     " consider raising the limit (MaxScratchBufferSize option control it), since it can cause performance issues");
             }
 
-            _lastCompressionBufferReduceCheck = DateTime.UtcNow;
+            _lastCompressionBufferReduceCheck = TimestampAccessor.GetTime();
 
             _compressionPager.Dispose();
            
@@ -2181,14 +2181,14 @@ namespace Voron.Impl.Journal
             if (forceReduce)
                 return true;
 
-            if ((DateTime.UtcNow - _lastCompressionBufferReduceCheck).TotalMinutes < 5)
+            if ((TimestampAccessor.GetTime() - _lastCompressionBufferReduceCheck).TotalMinutes < 5)
                 return false;
 
             // prevent resize if we recently used at least half of the compression buffer
             var preventResize = _maxNumberOfPagesRequiredForCompressionBuffer > _compressionPager.NumberOfAllocatedPages / 2;
 
             _maxNumberOfPagesRequiredForCompressionBuffer = 0;
-            _lastCompressionBufferReduceCheck = DateTime.UtcNow;
+            _lastCompressionBufferReduceCheck = TimestampAccessor.GetTime();
             return !preventResize;
         }
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -244,8 +244,9 @@ namespace Voron.Impl
 
             FlushInProgressLockTaken = previous.FlushInProgressLockTaken;
             CurrentTransactionHolder = previous.CurrentTransactionHolder;
-            TxStartTime = DateTime.UtcNow;
+            TxStartTime = TimestampAccessor.GetApproximateTime();
             DataPager = env.Options.DataPager;
+            
             _txHeader = TxHeaderInitializerTemplate;
             _env = env;
             _journal = env.Journal;
@@ -339,7 +340,7 @@ namespace Voron.Impl
 
         public LowLevelTransaction(StorageEnvironment env, long id, TransactionPersistentContext transactionPersistentContext, TransactionFlags flags, IFreeSpaceHandling freeSpaceHandling, ByteStringContext context = null)
         {
-            TxStartTime = DateTime.UtcNow;
+            TxStartTime = TimestampAccessor.GetApproximateTime();
 
             if (flags == TransactionFlags.ReadWrite)
                 env.Options.AssertNoCatastrophicFailure();
@@ -492,7 +493,7 @@ namespace Voron.Impl
 
             _txHeader.TransactionId = _id;
             _txHeader.NextPageNumber = _state.NextPageNumber;
-            _txHeader.TimeStampTicksUtc = DateTime.UtcNow.Ticks;
+            _txHeader.TimeStampTicksUtc = TimestampAccessor.GetApproximateTimestamp();
         }
 
         internal HashSet<PageFromScratchBuffer> GetTransactionPages()
@@ -1109,7 +1110,7 @@ namespace Voron.Impl
 
             if (WriteToJournalIsRequired())
             {
-                Environment.LastWorkTime = DateTime.UtcNow;
+                Environment.LastWorkTime = TimestampAccessor.GetTime();
                 CommitStage2_WriteToJournal();
             }
             
@@ -1230,7 +1231,7 @@ namespace Voron.Impl
             }
 
             if (AsyncCommit.Result)
-                Environment.LastWorkTime = DateTime.UtcNow;
+                Environment.LastWorkTime = TimestampAccessor.GetTime();
 
             BeforeCommitFinalization?.Invoke(this);
             CommitStage3_DisposeTransactionResources();

--- a/src/Voron/Impl/Paging/AbstractPager.cs
+++ b/src/Voron/Impl/Paging/AbstractPager.cs
@@ -11,6 +11,7 @@ using Sparrow.Binary;
 using Sparrow.Logging;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
+using Sparrow.Server;
 using Sparrow.Server.Platform;
 using Sparrow.Threading;
 using Sparrow.Utils;
@@ -462,7 +463,7 @@ namespace Voron.Impl.Paging
 
         private long GetNewLength(long current, long minRequested)
         {
-            DateTime now = DateTime.UtcNow;
+            DateTime now = TimestampAccessor.GetTime();
             if (_lastIncrease == DateTime.MinValue)
             {
                 _lastIncrease = now;

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -16,6 +16,7 @@ using Voron.Impl.Paging;
 using Sparrow.Server.Utils;
 using System.Diagnostics.CodeAnalysis;
 using Sparrow.Server.LowMemory;
+using Sparrow.Server;
 
 namespace Voron.Impl.Scratch
 {
@@ -111,7 +112,7 @@ namespace Voron.Impl.Scratch
             _allocatedPagesCount = 0;
 
             DebugInfo.NumberOfResets++;
-            DebugInfo.LastResetTime = DateTime.UtcNow;
+            DebugInfo.LastResetTime = TimestampAccessor.GetApproximateTime();
         }
 
         public PagerState PagerState => _scratchPager.PagerState;
@@ -243,7 +244,7 @@ namespace Voron.Impl.Scratch
                 return; // never called
             }
 
-            DebugInfo.LastFreeTime = DateTime.UtcNow;
+            DebugInfo.LastFreeTime = TimestampAccessor.GetApproximateTime();
             DebugInfo.LastAsOfTxIdWhenFree = asOfTxId;
 
             _allocatedPagesCount -= value.NumberOfPages;

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -269,8 +269,8 @@ namespace Voron.Impl.Scratch
             {
                 var recycledScratch = _recycleArea.First.Value;
 
-                if (IsLowMemory() == false && 
-                    DateTime.UtcNow - recycledScratch.RecycledAt <= RecycledScratchFileTimeout)
+                if (IsLowMemory() == false &&
+                    TimestampAccessor.GetTime() - recycledScratch.RecycledAt <= RecycledScratchFileTimeout)
                     break;
 
                 _recycleArea.RemoveFirst();
@@ -341,7 +341,7 @@ namespace Voron.Impl.Scratch
             if (IsLowMemory())
                 return;
 
-            scratch.RecycledAt = DateTime.UtcNow;
+            scratch.RecycledAt = TimestampAccessor.GetTime();
             _recycleArea.AddLast(scratch);
         }
 
@@ -704,7 +704,7 @@ namespace Voron.Impl.Scratch
                 CurrentFileNumber = currentFile.Number,
                 CurrentFileSizeInMB = currentFile.Size / 1024L / 1024L,
                 PerScratchFileSizeLimitInMB = _options.MaxScratchBufferSize / 1024L / 1024L,
-                CurrentUtcTime = DateTime.UtcNow
+                CurrentUtcTime = TimestampAccessor.GetTime()
             };
 
             foreach (var scratchBufferItem in _scratchBuffers.Values.OrderBy(x => x.Number))
@@ -757,12 +757,12 @@ namespace Voron.Impl.Scratch
             if (_lowMemoryFlag.IsRaised())
                 return true;
 
-            return DateTime.UtcNow.Ticks - _lastLowMemoryEventTicks <= _lowMemoryIntervalTicks;
+            return TimestampAccessor.GetTimestamp() - _lastLowMemoryEventTicks <= _lowMemoryIntervalTicks;
         }
 
         public void LowMemory(LowMemorySeverity lowMemorySeverity)
         {
-            _lastLowMemoryEventTicks = DateTime.UtcNow.Ticks;
+            _lastLowMemoryEventTicks = TimestampAccessor.GetTimestamp();
             _lowMemoryFlag.Raise();
         }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22492

### Additional description

When faced with debug information or other non time critical usages, we could avoid having to read the CPU ticks counter or the OS kernel call required to read them. In those cases we are well enough knowing that we are going to get a monotonically increasing ticks counter and values that are updated at worst every 1 second.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
