### PR TITLE
RavenDB-20325 : handle export and import of timeseries deleted ranges in v6.0

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupProgress.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupProgress.cs
@@ -69,6 +69,7 @@ namespace Raven.Client.Documents.Operations.Backups
             Counters = bp.Counters;
             TimeSeries = bp.TimeSeries;
             CompareExchangeTombstones = bp.CompareExchangeTombstones;
+            TimeSeriesDeletedRanges = bp.TimeSeriesDeletedRanges;
         }
 
         public override DynamicJsonValue ToJson()

--- a/src/Raven.Client/Documents/Smuggler/DatabaseItemType.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseItemType.cs
@@ -19,14 +19,13 @@ namespace Raven.Client.Documents.Smuggler
         LegacyAttachmentDeletions = 1 << 10,
         DatabaseRecord = 1 << 11,
         Unknown = 1 << 12,
-
         Attachments = 1 << 14,
         CounterGroups = 1 << 15,
         Subscriptions = 1 << 16,
         CompareExchangeTombstones = 1 << 17,
         TimeSeries = 1 << 18,
-
-        ReplicationHubCertificates = 1 << 19
+        ReplicationHubCertificates = 1 << 19,
+        TimeSeriesDeletedRanges = 1 << 20
     }
 
     [Flags]

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -16,7 +16,8 @@ namespace Raven.Client.Documents.Smuggler
                                                               DatabaseItemType.Attachments |
                                                               DatabaseItemType.CounterGroups |
                                                               DatabaseItemType.Subscriptions |
-                                                              DatabaseItemType.TimeSeries;
+                                                              DatabaseItemType.TimeSeries | 
+                                                              DatabaseItemType.TimeSeriesDeletedRanges;
 
         public const DatabaseRecordItemType DefaultOperateOnDatabaseRecordTypes = DatabaseRecordItemType.Client |
                                                                                   DatabaseRecordItemType.ConflictSolverConfig |

--- a/src/Raven.Client/Documents/Smuggler/ShardedSmugglerProgress.cs
+++ b/src/Raven.Client/Documents/Smuggler/ShardedSmugglerProgress.cs
@@ -31,6 +31,7 @@ public sealed class ShardedSmugglerProgress : SmugglerResult.SmugglerProgress, I
         Counters = sp.Counters;
         TimeSeries = sp.TimeSeries;
         CompareExchangeTombstones = sp.CompareExchangeTombstones;
+        TimeSeriesDeletedRanges = sp.TimeSeriesDeletedRanges;
     }
 
     public override DynamicJsonValue ToJson()

--- a/src/Raven.Client/Documents/Smuggler/SmugglerProgressBase.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerProgressBase.cs
@@ -34,6 +34,8 @@ public abstract class SmugglerProgressBase : IOperationProgress
 
     public Counts CompareExchangeTombstones { get; set; }
 
+    public CountsWithSkippedCountAndLastEtag TimeSeriesDeletedRanges { get; set; }
+
     public virtual DynamicJsonValue ToJson()
     {
         return new DynamicJsonValue(GetType())
@@ -51,6 +53,7 @@ public abstract class SmugglerProgressBase : IOperationProgress
             [nameof(CompareExchangeTombstones)] = CompareExchangeTombstones.ToJson(),
             [nameof(TimeSeries)] = TimeSeries.ToJson(),
             [nameof(ReplicationHubCertificates)] = ReplicationHubCertificates.ToJson(),
+            [nameof(TimeSeriesDeletedRanges)] = TimeSeriesDeletedRanges.ToJson()
         };
     }
 

--- a/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerResult.cs
@@ -43,6 +43,7 @@ namespace Raven.Client.Documents.Smuggler
             Subscriptions = new Counts();
             ReplicationHubCertificates = new Counts();
             TimeSeries = new CountsWithSkippedCountAndLastEtag();
+            TimeSeriesDeletedRanges = new CountsWithSkippedCountAndLastEtag();
             _progress = new SmugglerProgress(this);
         }
 
@@ -85,6 +86,11 @@ namespace Raven.Client.Documents.Smuggler
             smugglerResult.TimeSeries.SizeInBytes += TimeSeries.SizeInBytes;
 
             smugglerResult.TimeSeries.LastEtag = Math.Max(smugglerResult.TimeSeries.LastEtag, TimeSeries.LastEtag);
+
+            smugglerResult.TimeSeriesDeletedRanges.ReadCount += TimeSeriesDeletedRanges.ReadCount;
+            smugglerResult.TimeSeriesDeletedRanges.ErroredCount += TimeSeriesDeletedRanges.ErroredCount;
+            smugglerResult.TimeSeriesDeletedRanges.SizeInBytes += TimeSeriesDeletedRanges.SizeInBytes;
+            smugglerResult.TimeSeriesDeletedRanges.LastEtag = Math.Max(smugglerResult.TimeSeriesDeletedRanges.LastEtag, TimeSeriesDeletedRanges.LastEtag);
 
             smugglerResult.Identities.ReadCount += Identities.ReadCount;
             smugglerResult.Identities.ErroredCount += Identities.ErroredCount;
@@ -230,6 +236,7 @@ namespace Raven.Client.Documents.Smuggler
                 Subscriptions = _result?.Subscriptions;
                 TimeSeries = _result?.TimeSeries;
                 ReplicationHubCertificates = _result?.ReplicationHubCertificates;
+                TimeSeriesDeletedRanges = _result?.TimeSeriesDeletedRanges;
             }
 
             internal string Message { get; set; }
@@ -260,6 +267,9 @@ namespace Raven.Client.Documents.Smuggler
 
             if (TimeSeries.LastEtag > lastEtag)
                 lastEtag = TimeSeries.LastEtag;
+
+            if (TimeSeriesDeletedRanges.LastEtag > lastEtag)
+                lastEtag = TimeSeriesDeletedRanges.LastEtag;
 
             return lastEtag;
         }

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessor.cs
@@ -33,6 +33,13 @@ namespace Raven.Server.Documents.Handlers.Processors.Smuggler
             if (RequestRouter.TryGetClientVersion(HttpContext, out var version) == false)
                 return;
 
+            if (version.Major == 5 && (version.Minor < 4 || version.Minor == 4 && version.Build < 200) &&
+                options.OperateOnTypes.HasFlag(DatabaseItemType.TimeSeries))
+            {
+                // version is older than 5.4.200
+                options.OperateOnTypes |= DatabaseItemType.TimeSeriesDeletedRanges;
+            }
+
             if (version.Major != RavenVersionAttribute.Instance.MajorVersion)
                 return;
 

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -275,6 +275,8 @@ namespace Raven.Server.Documents.Handlers
 
             private readonly Dictionary<string, List<TimeSeriesItem>> _dictionary;
 
+            private readonly Dictionary<string, List<TimeSeriesDeletedRangeItemForSmuggler>> _deletedRanges;
+
             private readonly DocumentsOperationContext _context;
 
             public DocumentsOperationContext Context => _context;
@@ -292,7 +294,8 @@ namespace Raven.Server.Documents.Handlers
             public SmugglerTimeSeriesBatchCommand(DocumentDatabase database)
             {
                 _database = database;
-                _dictionary = new Dictionary<string, List<TimeSeriesItem>>();
+                _dictionary = new Dictionary<string, List<TimeSeriesItem>>(StringComparer.OrdinalIgnoreCase);
+                _deletedRanges = new Dictionary<string, List<TimeSeriesDeletedRangeItemForSmuggler>>(StringComparer.OrdinalIgnoreCase);
                 _toDispose = new();
                 _toReturn = new();
                 _releaseContext = _database.DocumentsStorage.ContextPool.AllocateOperationContext(out _context);
@@ -303,6 +306,27 @@ namespace Raven.Server.Documents.Handlers
                 var tss = _database.DocumentsStorage.TimeSeriesStorage;
 
                 var changes = 0L;
+
+                foreach (var (docId, items) in _deletedRanges)
+                {
+                    foreach (var item in items)
+                    {
+                        using (item)
+                        {
+                            var deletionRangeRequest = new TimeSeriesStorage.DeletionRangeRequest
+                            {
+                                DocumentId = docId,
+                                Collection = item.Collection,
+                                Name = item.Name,
+                                From = item.From,
+                                To = item.To
+                            };
+                            tss.DeleteTimestampRange(context, deletionRangeRequest, remoteChangeVector: null, updateMetadata: false);
+                        }
+                    }
+
+                    changes += items.Count;
+                }
 
                 foreach (var (docId, items) in _dictionary)
                 {
@@ -345,6 +369,21 @@ namespace Raven.Server.Documents.Handlers
                 itemsList.Add(item);
                 return newItem;
             }
+
+            public bool AddToDeletedRanges(TimeSeriesDeletedRangeItemForSmuggler item)
+            {
+                bool newItem = false;
+
+                if (_deletedRanges.TryGetValue(item.DocId, out var deletedRangesList) == false)
+                {
+                    _deletedRanges[item.DocId] = deletedRangesList = [];
+                    newItem = true;
+                }
+
+                deletedRangesList.Add(item);
+                return newItem;
+            }
+
 
             public void AddToDisposal(IDisposable disposable)
             {

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/ShardedRestoreResult.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/ShardedRestoreResult.cs
@@ -84,6 +84,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore.Sharding
             Counters = rp.Counters;
             TimeSeries = rp.TimeSeries;
             CompareExchangeTombstones = rp.CompareExchangeTombstones;
+            TimeSeriesDeletedRanges = rp.TimeSeriesDeletedRanges;
         }
 
         public override DynamicJsonValue ToJson()

--- a/src/Raven.Server/Smuggler/Documents/CsvStreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/CsvStreamSource.cs
@@ -443,6 +443,11 @@ namespace Raven.Server.Smuggler.Documents
             throw new NotSupportedException();
         }
 
+        public IAsyncEnumerable<TimeSeriesDeletedRangeItemForSmuggler> GetTimeSeriesDeletedRangesAsync(ITimeSeriesActions action, List<string> collectionsToExport)
+        {
+            return AsyncEnumerable.Empty<TimeSeriesDeletedRangeItemForSmuggler>();
+        }
+
         public void Dispose()
         {
         }

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -47,6 +47,8 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         ITimeSeriesActions TimeSeries();
 
+        ITimeSeriesActions TimeSeriesDeletedRanges();
+
         ILegacyActions LegacyDocumentDeletions();
 
         ILegacyActions LegacyAttachmentDeletions();
@@ -126,7 +128,9 @@ namespace Raven.Server.Smuggler.Documents.Data
     public interface ITimeSeriesActions : IAsyncDisposable, INewItemActions
     {
         ValueTask WriteTimeSeriesAsync(TimeSeriesItem ts);
-        
+
+        ValueTask WriteTimeSeriesDeletedRangeAsync(TimeSeriesDeletedRangeItemForSmuggler deletedRange);
+
         void RegisterForDisposal(IDisposable data);
 
         void RegisterForReturnToTheContext(AllocatedMemoryData data);

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerSource.cs
@@ -58,6 +58,8 @@ namespace Raven.Server.Smuggler.Documents.Data
         SmugglerSourceType GetSourceType();
 
         Stream GetAttachmentStream(LazyStringValue hash, out string tag);
+
+        IAsyncEnumerable<TimeSeriesDeletedRangeItemForSmuggler> GetTimeSeriesDeletedRangesAsync(ITimeSeriesActions action, List<string> collectionsToExport);
     }
 
     public enum SmugglerSourceType

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSource.cs
@@ -58,6 +58,7 @@ namespace Raven.Server.Smuggler.Documents
             DatabaseItemType.CompareExchangeTombstones,
             DatabaseItemType.CounterGroups,
             DatabaseItemType.Subscriptions,
+            DatabaseItemType.TimeSeriesDeletedRanges,
             DatabaseItemType.TimeSeries,
             DatabaseItemType.ReplicationHubCertificates,
             DatabaseItemType.None
@@ -600,6 +601,88 @@ namespace Raven.Server.Smuggler.Documents
         public SmugglerSourceType GetSourceType()
         {
             return _type;
+        }
+
+        public IAsyncEnumerable<TimeSeriesDeletedRangeItemForSmuggler> GetTimeSeriesDeletedRangesAsync(ITimeSeriesActions action, List<string> collectionsToExport) =>
+            GetTimeSeriesDeletedRanges(collectionsToExport).ToAsyncEnumerable();
+
+        private IEnumerable<TimeSeriesDeletedRangeItemForSmuggler> GetTimeSeriesDeletedRanges(IEnumerable<string> collectionsToExport)
+        {
+            Debug.Assert(_context != null);
+
+            var initialState = new TimeSeriesDeletedRangeIterationState(_context, _database.Configuration.Databases.PulseReadTransactionLimit)
+            {
+                StartEtag = _startDocumentEtag,
+                StartEtagByCollection = collectionsToExport.ToDictionary(x => x, x => _startDocumentEtag)
+            };
+
+            var enumerator = new PulsedTransactionEnumerator<TimeSeriesDeletedRangeItemForSmuggler, TimeSeriesDeletedRangeIterationState>(_context,
+                state =>
+                {
+                    if (state.StartEtagByCollection.Count != 0)
+                        return GetTimeSeriesDeletedRangesFromCollections(_context, state);
+                    return GetAlTimeSeriesDeletedRanges(_context, state.StartEtag);
+                }, initialState);
+
+            while (enumerator.MoveNext())
+            {
+                yield return enumerator.Current;
+            }
+        }
+
+        private static IEnumerable<TimeSeriesDeletedRangeItemForSmuggler> GetAlTimeSeriesDeletedRanges(DocumentsOperationContext context, long startEtag)
+        {
+            var database = context.DocumentDatabase;
+            foreach (var deletedRange in database.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(context, startEtag))
+            {
+                using (deletedRange)
+                {
+                    TimeSeriesValuesSegment.ParseTimeSeriesKey(deletedRange.Key, context, out var docId, out var name);
+
+                    yield return new TimeSeriesDeletedRangeItemForSmuggler
+                    {
+                        DocId = docId,
+                        Name = name,
+                        From = deletedRange.From,
+                        To = deletedRange.To,
+                        Collection = deletedRange.Collection.Clone(context),
+                        ChangeVector = context.GetLazyString(deletedRange.ChangeVector),
+                        Etag = deletedRange.Etag
+                    };
+                }
+            }
+        }
+
+        private static IEnumerable<TimeSeriesDeletedRangeItemForSmuggler> GetTimeSeriesDeletedRangesFromCollections(DocumentsOperationContext context, TimeSeriesDeletedRangeIterationState state)
+        {
+            var database = context.DocumentDatabase;
+            var collections = state.StartEtagByCollection.Keys.ToList();
+
+            foreach (var collection in collections)
+            {
+                var etag = state.StartEtagByCollection[collection];
+
+                state.CurrentCollection = collection;
+
+                foreach (var deletedRange in database.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(context, collection, etag))
+                {
+                    using (deletedRange)
+                    {
+                        TimeSeriesValuesSegment.ParseTimeSeriesKey(deletedRange.Key, context, out var docId, out var name);
+
+                        yield return new TimeSeriesDeletedRangeItemForSmuggler
+                        {
+                            DocId = docId,
+                            Name = name,
+                            From = deletedRange.From,
+                            To = deletedRange.To,
+                            Collection = deletedRange.Collection.Clone(context),
+                            ChangeVector = context.GetLazyString(deletedRange.ChangeVector),
+                            Etag = deletedRange.Etag
+                        };
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/Iteration/TimeSeriesDeletedRangeIterationState.cs
+++ b/src/Raven.Server/Smuggler/Documents/Iteration/TimeSeriesDeletedRangeIterationState.cs
@@ -1,0 +1,26 @@
+﻿using Raven.Server.ServerWide.Context;
+using Sparrow;
+
+namespace Raven.Server.Smuggler.Documents.Iteration
+{
+    public sealed class TimeSeriesDeletedRangeIterationState : CollectionAwareIterationState<TimeSeriesDeletedRangeItemForSmuggler>
+    {
+        public TimeSeriesDeletedRangeIterationState(DocumentsOperationContext context, Size pulseLimit) : base(context, pulseLimit)
+        {
+        }
+
+        public override void OnMoveNext(TimeSeriesDeletedRangeItemForSmuggler current)
+        {
+            if (StartEtagByCollection.Count != 0)
+            {
+                StartEtagByCollection[CurrentCollection] = current.Etag + 1;
+            }
+            else
+            {
+                StartEtag = current.Etag + 1;
+            }
+
+            ReadCount++;
+        }
+    }
+}

--- a/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
@@ -137,6 +137,9 @@ namespace Raven.Server.Smuggler.Documents
         public ITimeSeriesActions TimeSeries() =>
             new ShardedTimeSeriesActions(_databaseContext, _allocator, _destinations.ToDictionary(x => x.Key, x => x.Value.TimeSeries()), _options);
 
+        public ITimeSeriesActions TimeSeriesDeletedRanges() =>
+            new ShardedTimeSeriesActions(_databaseContext, _allocator, _destinations.ToDictionary(x => x.Key, x => x.Value.TimeSeriesDeletedRanges()), _options);
+
         public ILegacyActions LegacyDocumentDeletions() =>
             new ShardedLegacyActions(_databaseContext, _allocator, _destinations.ToDictionary(x => x.Key, x => x.Value.LegacyDocumentDeletions()), _options);
 
@@ -353,6 +356,12 @@ namespace Raven.Server.Smuggler.Documents
             {
                 var shardNumber = DatabaseContext.GetShardNumberFor(_allocator, ts.DocId);
                 await _actions[shardNumber].WriteTimeSeriesAsync(ts);
+            }
+
+            public async ValueTask WriteTimeSeriesDeletedRangeAsync(TimeSeriesDeletedRangeItemForSmuggler deletedRange)
+            {
+                var shardNumber = DatabaseContext.GetShardNumberFor(_allocator, deletedRange.DocId);
+                await _actions[shardNumber].WriteTimeSeriesDeletedRangeAsync(deletedRange);
             }
 
             public void RegisterForDisposal(IDisposable data)

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -18,7 +18,6 @@ using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.Documents.Indexes.MapReduce.Auto;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.Replication;
-using Raven.Server.Routing;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Processors;
@@ -253,6 +252,10 @@ namespace Raven.Server.Smuggler.Documents
                     counts = await ProcessTimeSeriesAsync(result);
                     break;
 
+                case DatabaseItemType.TimeSeriesDeletedRanges:
+                    counts = await ProcessTimeSeriesDeletedRangesAsync(result);
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);
             }
@@ -345,6 +348,10 @@ namespace Raven.Server.Smuggler.Documents
 
                 case DatabaseItemType.ReplicationHubCertificates:
                     counts = result.ReplicationHubCertificates;
+                    break;
+
+                case DatabaseItemType.TimeSeriesDeletedRanges:
+                    counts = result.TimeSeriesDeletedRanges;
                     break;
 
                 default:
@@ -955,6 +962,37 @@ namespace Raven.Server.Smuggler.Documents
                     return true;
 
                 return patcher != null && patcher.ShouldSkip(ts.DocId);
+            }
+        }
+
+        protected virtual async Task<SmugglerProgressBase.Counts> ProcessTimeSeriesDeletedRangesAsync(SmugglerResult result)
+        {
+            result.TimeSeriesDeletedRanges.Start();
+
+            await using (var actions = _destination.TimeSeriesDeletedRanges())
+            {
+                await foreach (var deletedRange in _source.GetTimeSeriesDeletedRangesAsync(actions, _options.Collections))
+                {
+                    _token.ThrowIfCancellationRequested();
+                    result.TimeSeriesDeletedRanges.ReadCount++;
+
+                    if (result.TimeSeriesDeletedRanges.ReadCount % 1000 == 0)
+                        AddInfoToSmugglerResult(result, $"Time Series deleted ranges entries {result.TimeSeriesDeletedRanges}");
+
+                    if (ShouldSkip(deletedRange, _patcher) == false)
+                        await actions.WriteTimeSeriesDeletedRangeAsync(deletedRange);
+                    else
+                        result.TimeSeriesDeletedRanges.SkippedCount++;
+
+                    result.TimeSeriesDeletedRanges.LastEtag = deletedRange.Etag;
+                }
+            }
+
+            return result.TimeSeriesDeletedRanges;
+
+            static bool ShouldSkip(TimeSeriesDeletedRangeItemForSmuggler deletedRange, SmugglerPatcher patcher)
+            {
+                return patcher != null && patcher.ShouldSkip(deletedRange.DocId);
             }
         }
 

--- a/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerDocumentType.cs
@@ -88,4 +88,29 @@ namespace Raven.Server.Smuggler.Documents
             Collection?.Dispose();
         }
     }
+
+    public sealed class TimeSeriesDeletedRangeItemForSmuggler : IDisposable
+    {
+        public LazyStringValue DocId;
+
+        public LazyStringValue Name;
+
+        public LazyStringValue Collection;
+
+        public LazyStringValue ChangeVector;
+
+        public DateTime From;
+
+        public DateTime To;
+
+        public long Etag;
+
+        public void Dispose()
+        {
+            DocId?.Dispose();
+            Name?.Dispose();
+            Collection?.Dispose();
+            ChangeVector?.Dispose();
+        }
+    }
 }

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -214,6 +214,11 @@ namespace Raven.Server.Smuggler.Documents
             return new StreamTimeSeriesActions(_writer, _context, nameof(DatabaseItemType.TimeSeries));
         }
 
+        public ITimeSeriesActions TimeSeriesDeletedRanges()
+        {
+            return new StreamTimeSeriesActions(_writer, _context, nameof(DatabaseItemType.TimeSeriesDeletedRanges));
+        }
+
         public IIndexActions Indexes()
         {
             return new StreamIndexActions(_writer, _context);
@@ -1212,6 +1217,46 @@ namespace Raven.Server.Smuggler.Documents
                     {
                         Writer.WriteMemoryChunk(item.Segment.Ptr, item.Segment.NumberOfBytes);
                     }
+
+                    await Writer.MaybeFlushAsync();
+                }
+            }
+
+            public async ValueTask WriteTimeSeriesDeletedRangeAsync(TimeSeriesDeletedRangeItemForSmuggler deletedRangeItem)
+            {
+                using (deletedRangeItem)
+                {
+                    if (First == false)
+                        Writer.WriteComma();
+
+                    First = false;
+
+                    Writer.WriteStartObject();
+
+                    Writer.WritePropertyName(nameof(TimeSeriesDeletedRangeItemForSmuggler.DocId));
+                    Writer.WriteString(deletedRangeItem.DocId, skipEscaping: true);
+                    Writer.WriteComma();
+
+                    Writer.WritePropertyName(nameof(TimeSeriesDeletedRangeItemForSmuggler.Name));
+                    Writer.WriteString(deletedRangeItem.Name, skipEscaping: true);
+                    Writer.WriteComma();
+
+                    Writer.WritePropertyName(nameof(TimeSeriesDeletedRangeItemForSmuggler.Collection));
+                    Writer.WriteString(deletedRangeItem.Collection);
+                    Writer.WriteComma();
+
+                    Writer.WritePropertyName(nameof(TimeSeriesDeletedRangeItemForSmuggler.ChangeVector));
+                    Writer.WriteString(deletedRangeItem.ChangeVector);
+                    Writer.WriteComma();
+
+                    Writer.WritePropertyName(nameof(TimeSeriesDeletedRangeItemForSmuggler.From));
+                    Writer.WriteDateTime(deletedRangeItem.From, isUtc: true);
+                    Writer.WriteComma();
+
+                    Writer.WritePropertyName(nameof(TimeSeriesDeletedRangeItemForSmuggler.To));
+                    Writer.WriteDateTime(deletedRangeItem.To, isUtc: true);
+
+                    Writer.WriteEndObject();
 
                     await Writer.MaybeFlushAsync();
                 }

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -28,7 +28,6 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.Json;
-using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.Smuggler.Documents.Data;
@@ -1042,6 +1041,8 @@ namespace Raven.Server.Smuggler.Documents
                 case DatabaseItemType.LegacyDocumentDeletions:
                 case DatabaseItemType.LegacyAttachmentDeletions:
                 case DatabaseItemType.CounterGroups:
+                case DatabaseItemType.TimeSeriesDeletedRanges:
+                case DatabaseItemType.ReplicationHubCertificates:
                     return await SkipArrayAsync(onSkipped, null, token);
 
                 case DatabaseItemType.TimeSeries:
@@ -1049,9 +1050,6 @@ namespace Raven.Server.Smuggler.Documents
 
                 case DatabaseItemType.DatabaseRecord:
                     return await SkipObjectAsync(onSkipped);
-
-                case DatabaseItemType.ReplicationHubCertificates:
-                    return await SkipArrayAsync(onSkipped, null, token);
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);
@@ -1061,6 +1059,41 @@ namespace Raven.Server.Smuggler.Documents
         public SmugglerSourceType GetSourceType()
         {
             return SmugglerSourceType.Import;
+        }
+
+        public async IAsyncEnumerable<TimeSeriesDeletedRangeItemForSmuggler> GetTimeSeriesDeletedRangesAsync(ITimeSeriesActions action, List<string> collectionsToExport)
+        {
+            var collectionsHashSet = new HashSet<string>(collectionsToExport, StringComparer.OrdinalIgnoreCase);
+
+            await foreach (var reader in ReadArrayAsync(action))
+            {
+                if (reader.TryGet(nameof(TimeSeriesDeletedRangeItemForSmuggler.Collection), out LazyStringValue collection) == false ||
+                    reader.TryGet(nameof(TimeSeriesDeletedRangeItemForSmuggler.DocId), out LazyStringValue docId) == false ||
+                    reader.TryGet(nameof(TimeSeriesDeletedRangeItemForSmuggler.Name), out LazyStringValue name) == false ||
+                    reader.TryGet(nameof(TimeSeriesDeletedRangeItemForSmuggler.ChangeVector), out LazyStringValue cv) == false ||
+                    reader.TryGet(nameof(TimeSeriesDeletedRangeItemForSmuggler.From), out DateTime from) == false ||
+                    reader.TryGet(nameof(TimeSeriesDeletedRangeItemForSmuggler.To), out DateTime to) == false)
+                {
+                    _result.TimeSeriesDeletedRanges.ErroredCount++;
+                    _result.AddWarning("Could not read timeseries deleted range entry.");
+                    continue;
+                }
+
+                if (collectionsHashSet.Count > 0 && collectionsHashSet.Contains(collection) == false)
+                    continue;
+
+                action.RegisterForDisposal(reader);
+
+                yield return new TimeSeriesDeletedRangeItemForSmuggler
+                {
+                    DocId = docId,
+                    Name = name,
+                    Collection = collection,
+                    ChangeVector = cv,
+                    From = from,
+                    To = to
+                };
+            }
         }
 
         public IAsyncEnumerable<DocumentItem> GetDocumentsAsync(List<string> collectionsToOperate, INewDocumentActions actions)
@@ -2000,6 +2033,9 @@ namespace Raven.Server.Smuggler.Documents
 
             if (type.Equals("AttachmentsDeletions", StringComparison.OrdinalIgnoreCase))
                 return DatabaseItemType.LegacyAttachmentDeletions;
+
+            if (type.Equals(nameof(DatabaseItemType.TimeSeriesDeletedRanges), StringComparison.OrdinalIgnoreCase))
+                return DatabaseItemType.TimeSeriesDeletedRanges;
 
             return DatabaseItemType.Unknown;
         }

--- a/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/exportDatabaseModel.ts
@@ -13,6 +13,7 @@ class exportDatabaseModel {
     includeCounters = ko.observable(true);
     includeAttachments = ko.observable(true);
     includeTimeSeries = ko.observable(true);
+    includeTimeSeriesDeletedRanges = ko.observable(true);
     includeRevisionDocuments = ko.observable(true);
     includeSubscriptions = ko.observable(true);
     
@@ -73,7 +74,7 @@ class exportDatabaseModel {
                 this.includeDocuments(true);
             }
         });
-
+        
         this.includeRevisionDocuments.subscribe(revisions => {
             if (revisions) {
                 this.includeDocuments(true);
@@ -164,6 +165,9 @@ class exportDatabaseModel {
         if (this.includeTimeSeries()) {
             operateOnTypes.push("TimeSeries");
         }
+        if (this.includeTimeSeriesDeletedRanges()) {
+            operateOnTypes.push("TimeSeriesDeletedRanges");
+        }
         if (this.includeSubscriptions()) {
             operateOnTypes.push("Subscriptions");
         }
@@ -202,6 +206,7 @@ class exportDatabaseModel {
                 || this.includeCounters() 
                 || this.includeRevisionDocuments()
                 || this.includeTimeSeries()
+                || this.includeTimeSeriesDeletedRanges()
                 || this.includeDocuments()
                 || this.includeArtificialDocuments()
                 || this.includeArchivedDocuments();

--- a/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/importDatabaseModel.ts
@@ -14,6 +14,7 @@ class importDatabaseModel {
     includeLegacyAttachments = ko.observable(false);
     includeAttachments = ko.observable(true);
     includeTimeSeries = ko.observable(true);
+    includeTimeSeriesDeletedRanges = ko.observable(true);
     includeSubscriptions = ko.observable(true);
     includeDocumentsTombstones = ko.observable(true);
     includeCompareExchangeTombstones = ko.observable(true);
@@ -160,6 +161,9 @@ class importDatabaseModel {
         if (this.includeTimeSeries()) {
             operateOnTypes.push("TimeSeries");
         }
+        if (this.includeTimeSeriesDeletedRanges()) {
+            operateOnTypes.push("TimeSeriesDeletedRanges");
+        }
         if (this.includeSubscriptions()) {
             operateOnTypes.push("Subscriptions");
         }
@@ -196,6 +200,7 @@ class importDatabaseModel {
                 || this.includeLegacyAttachments() 
                 || this.includeCounters() 
                 || this.includeTimeSeries()
+                || this.includeTimeSeriesDeletedRanges()
                 || this.includeRevisionDocuments() 
                 || this.includeDocuments()
                 || this.includeAttachments()

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.ts
@@ -188,6 +188,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
             RevisionDocuments: mergeCountsWithSkippedCountAndLastEtagAndAttachments(results.map(x => x.Result.RevisionDocuments)),
             Subscriptions: mergeCounts(results.map(x => x.Result.Subscriptions)),
             TimeSeries: mergeCountsWithSkippedCountAndLastEtag(results.map(x => x.Result.TimeSeries)),
+            TimeSeriesDeletedRanges: mergeCountsWithSkippedCountAndLastEtag(results.map(x => x.Result.TimeSeriesDeletedRanges)),
             Tombstones: mergeCountsWithLastEtag(results.map(x => x.Result.Tombstones)),
             ...extraProps
         };
@@ -296,6 +297,7 @@ class smugglerDatabaseDetails extends abstractOperationDetails {
                 }
 
                 result.push(this.mapToExportListItem("Subscriptions", status.Subscriptions));
+                result.push(this.mapToExportListItem("Time Series Deleted Ranges", status.TimeSeriesDeletedRanges));
             }
 
             const currentlyProcessingItems = smugglerDatabaseDetails.findCurrentlyProcessingItems(result);

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/exportDatabase.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/exportDatabase.html
@@ -57,6 +57,10 @@
                                 <input id="toggleConflicts" type="checkbox" data-bind="checked: includeConflicts" />
                                 <label for="toggleConflicts">Include Conflicts</label>
                             </div>
+                            <div class="toggle">
+                                <input id="importTimeSeriesDeletedRanges" type="checkbox" data-bind="checked: includeTimeSeriesDeletedRanges" />
+                                <label for="importTimeSeriesDeletedRanges" class="margin-right margin-right-sm">Include Time Series Deleted Ranges</label>
+                            </div>
                         </div>
                     </div>
                     <div class="col-lg-5">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromFile.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromFile.html
@@ -87,6 +87,10 @@
                                 <input id="importDocumentsTombstones" type="checkbox" data-bind="checked: includeDocumentsTombstones" />
                                 <label for="importDocumentsTombstones" class="margin-right margin-right-sm">Include Documents Tombstones</label>
                             </div>
+                            <div class="toggle">
+                                <input id="importTimeSeriesDeletedRanges" type="checkbox" data-bind="checked: includeTimeSeriesDeletedRanges" />
+                                <label for="importTimeSeriesDeletedRanges" class="margin-right margin-right-sm">Include Time Series Deleted Ranges</label>
+                            </div>
                         </div>
                     </div>
                     <div class="col-lg-5">

--- a/test/SlowTests/Issues/RavenDB-21050.cs
+++ b/test/SlowTests/Issues/RavenDB-21050.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3999,7 +3999,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }
 
                 var config = Backup.CreateBackupConfiguration(backupPath);
-                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                var backupTaskId = await Backup.RunBackupForDatabaseModeAsync(Server, config, store, options.DatabaseMode);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -4019,20 +4019,29 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Null(ts);
                 }
 
-                await Backup.RunBackupAsync(Server, backupTaskId, store, isFullBackup: false);
-
-                Assert.True(WaitForValue(() =>
-                {
-                    var dir = Directory.GetDirectories(backupPath).First();
-                    var files = Directory.GetFiles(dir);
-                    return files.Length == 2;
-                }, expectedVal: true));
+                await Backup.RunBackupForDatabaseModeAsync(Server, config, store, options.DatabaseMode, isFullBackup: false, backupTaskId);
             }
 
             using (var store = GetDocumentStore(options))
             {
-                await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(),
-                    Directory.GetDirectories(backupPath).First());
+                if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+                {
+                    // import from each shard backup dir
+                    var dirs = Directory.GetDirectories(backupPath);
+                    Assert.Equal(3, dirs.Length);
+
+                    foreach (var dir in dirs)
+                    {
+                        await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), dir);
+                    }
+                }
+                else
+                {
+                    var dir = Directory.GetDirectories(backupPath).First();
+                    Assert.Equal(2, Directory.GetFiles(dir).Length);
+
+                    await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), dir);
+                }
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -4069,7 +4078,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }
 
                 var config = Backup.CreateBackupConfiguration(backupPath);
-                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                var backupTaskId = await Backup.RunBackupForDatabaseModeAsync(Server, config, store, options.DatabaseMode);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -4095,20 +4105,29 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(1, ts.Length);
                 }
 
-                await Backup.RunBackupAsync(Server, backupTaskId, store, isFullBackup: false);
-
-                Assert.True(WaitForValue(() =>
-                {
-                    var dir = Directory.GetDirectories(backupPath).First();
-                    var files = Directory.GetFiles(dir);
-                    return files.Length == 2;
-                }, expectedVal: true));
+                await Backup.RunBackupForDatabaseModeAsync(Server, config, store, options.DatabaseMode, isFullBackup: false, backupTaskId);
             }
 
             using (var store = GetDocumentStore(options))
             {
-                await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(),
-                    Directory.GetDirectories(backupPath).First());
+                if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+                {
+                    // import from each shard backup dir
+                    var dirs = Directory.GetDirectories(backupPath);
+                    Assert.Equal(3, dirs.Length);
+
+                    foreach (var dir in dirs)
+                    {
+                        await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), dir);
+                    }
+                }
+                else
+                {
+                    var dir = Directory.GetDirectories(backupPath).First();
+                    Assert.Equal(2, Directory.GetFiles(dir).Length);
+
+                    await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), dir);
+                }
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -4146,7 +4165,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }
 
                 var config = Backup.CreateBackupConfiguration(backupPath);
-                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                var backupTaskId = await Backup.RunBackupForDatabaseModeAsync(Server, config, store, options.DatabaseMode);
 
                 using (var session = store.OpenAsyncSession())
                 {
@@ -4187,20 +4206,29 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Null(ts);
                 }
 
-                await Backup.RunBackupAsync(Server, backupTaskId, store, isFullBackup: false);
-
-                Assert.True(WaitForValue(() =>
-                {
-                    var dir = Directory.GetDirectories(backupPath).First();
-                    var files = Directory.GetFiles(dir);
-                    return files.Length == 2;
-                }, expectedVal: true));
+                await Backup.RunBackupForDatabaseModeAsync(Server, config, store, options.DatabaseMode, isFullBackup: false, backupTaskId);
             }
 
             using (var store = GetDocumentStore(options))
             {
-                await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(),
-                    Directory.GetDirectories(backupPath).First());
+                if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+                {
+                    // import from each shard backup dir
+                    var dirs = Directory.GetDirectories(backupPath);
+                    Assert.Equal(3, dirs.Length);
+
+                    foreach (var dir in dirs)
+                    {
+                        await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), dir);
+                    }
+                }
+                else
+                {
+                    var dir = Directory.GetDirectories(backupPath).First();
+                    Assert.Equal(2, Directory.GetFiles(dir).Length);
+
+                    await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), dir);
+                }
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3975,6 +3975,244 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
+        [RavenTheory(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport | RavenTestCategory.TimeSeries)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task can_backup_and_restore_with_deleted_timeseries_ranges(Options options)
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            const string id = "users/1";
+
+            using (var store = GetDocumentStore(options))
+            {
+                var baseline = DateTime.UtcNow;
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "fitzchak" }, id);
+
+                    var tsf = session.TimeSeriesFor(id, "heartrate");
+                    for (int i = 0; i < 10; i++)
+                    {
+                        tsf.Append(baseline.AddHours(i), i);
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "aviv" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var ts = await session.TimeSeriesFor(id, "heartrate").GetAsync();
+                    Assert.Null(ts);
+                }
+
+                await Backup.RunBackupAsync(Server, backupTaskId, store, isFullBackup: false);
+
+                Assert.True(WaitForValue(() =>
+                {
+                    var dir = Directory.GetDirectories(backupPath).First();
+                    var files = Directory.GetFiles(dir);
+                    return files.Length == 2;
+                }, expectedVal: true));
+            }
+
+            using (var store = GetDocumentStore(options))
+            {
+                await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(),
+                    Directory.GetDirectories(backupPath).First());
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    Assert.Equal("aviv", user.Name);
+
+                    var ts = await session.TimeSeriesFor(id, "heartrate").GetAsync();
+                    Assert.Null(ts); // fails, we get 10 entries
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport | RavenTestCategory.TimeSeries)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task deleted_ranges_should_be_processed_before_timeseries(Options options)
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            const string id = "users/1";
+
+            using (var store = GetDocumentStore(options))
+            {
+                var baseline = DateTime.UtcNow;
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "fitzchak" }, id);
+
+                    var tsf = session.TimeSeriesFor(id, "heartrate");
+                    for (int i = 0; i < 10; i++)
+                    {
+                        tsf.Append(baseline.AddHours(i), i);
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    // delete the document to create a timeseries deleted range 
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    // recreate the document and time series, and append a new entry to the series
+                    // importing the deleted range should not delete this new entry
+
+                    await session.StoreAsync(new User { Name = "aviv" }, id);
+                    session.TimeSeriesFor(id, "heartrate").Append(baseline.AddYears(1), 100);
+
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var ts = await session.TimeSeriesFor(id, "heartrate").GetAsync();
+                    Assert.Equal(1, ts.Length);
+                }
+
+                await Backup.RunBackupAsync(Server, backupTaskId, store, isFullBackup: false);
+
+                Assert.True(WaitForValue(() =>
+                {
+                    var dir = Directory.GetDirectories(backupPath).First();
+                    var files = Directory.GetFiles(dir);
+                    return files.Length == 2;
+                }, expectedVal: true));
+            }
+
+            using (var store = GetDocumentStore(options))
+            {
+                await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(),
+                    Directory.GetDirectories(backupPath).First());
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    Assert.Equal("aviv", user.Name);
+
+                    var ts = await session.TimeSeriesFor(id, "heartrate").GetAsync();
+                    Assert.Equal(1, ts.Length);
+                    Assert.Equal(100, ts[0].Value);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport | RavenTestCategory.TimeSeries)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task deleted_ranges_should_be_processed_before_timeseries2(Options options)
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            const string id = "users/1";
+
+            using (var store = GetDocumentStore(options))
+            {
+                var baseline = DateTime.UtcNow;
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "fitzchak" }, id);
+
+                    var tsf = session.TimeSeriesFor(id, "heartrate");
+                    for (int i = 0; i < 10; i++)
+                    {
+                        tsf.Append(baseline.AddHours(i), i);
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    // delete the document to create a timeseries deleted range 
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    // recreate the document and time series, and append a new entry to the series
+
+                    await session.StoreAsync(new User { Name = "aviv" }, id);
+                    session.TimeSeriesFor(id, "heartrate").Append(baseline.AddYears(1), 100);
+
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    // delete the document once again to create another deleted range
+                    // after importing this deleted range we should end up without timeseries
+
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    // recreate the document so that we won't have a tombstone to backup
+                    await session.StoreAsync(new User { Name = "egor" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var ts = await session.TimeSeriesFor(id, "heartrate").GetAsync();
+                    Assert.Null(ts);
+                }
+
+                await Backup.RunBackupAsync(Server, backupTaskId, store, isFullBackup: false);
+
+                Assert.True(WaitForValue(() =>
+                {
+                    var dir = Directory.GetDirectories(backupPath).First();
+                    var files = Directory.GetFiles(dir);
+                    return files.Length == 2;
+                }, expectedVal: true));
+            }
+
+            using (var store = GetDocumentStore(options))
+            {
+                await store.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(),
+                    Directory.GetDirectories(backupPath).First());
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    Assert.Equal("egor", user.Name);
+
+                    var ts = await session.TimeSeriesFor(id, "heartrate").GetAsync();
+                    Assert.Null(ts);
+                }
+            }
+        }
+
         private static IDisposable ReadOnly(string path)
         {
             var files = Directory.GetFiles(path);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20325/Backup-Export-doesnt-take-into-account-time-series-deleted-ranges

### Additional description

5.4 fix was handled in https://github.com/ravendb/ravendb/pull/18488


### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [X] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [X] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [X] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [X] No documentation update is needed 

### Testing by Contributor

- [X] Tests have been added that prove the fix is effective or that the feature works
- [X] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [X] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [X] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
