### PR TITLE
RavenDB-22494 Fix err msg for invalid percentile in time series query

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/PercentileAggregation.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/PercentileAggregation.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
             if (percentile.Value <= 0 || percentile.Value > 100)
                 throw new ArgumentOutOfRangeException(
                     $"Invalid argument passed to '{nameof(AggregationType.Percentile)}' aggregation method: '{percentile}'. " +
-                    "Argument must be a number between 0 and 100");
+                    "Argument must be a number greater than 0 and less than or equal to 100");
 
             _percentileFactor = percentile.Value / 100;
             _rankedValues = new List<SortedDictionary<double, int>>();


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22494/Fix-error-msg-for-invalid-percentile-in-time-series-query

### Additional description
fix err msg:
`Argument must be a number between 0 and 100` => `Argument must be a number between 1 and 100`

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed (Fixes are via https://issues.hibernatingrhinos.com/issue/RDoc-2880/Node.js-Document-extensions-Time-series-Querying-Aggregations-projections-Replace-C-samples)

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
