### PR TITLE
RavenDB-20325 : minor fix 

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -1035,6 +1035,7 @@ namespace Raven.Server.Smuggler.Documents
                 case DatabaseItemType.Counters:
 #pragma warning restore 618
                 case DatabaseItemType.CounterGroups:
+                case DatabaseItemType.TimeSeriesDeletedRanges:
                     return await SkipArrayAsync(onSkipped, null, token);
 
                 case DatabaseItemType.TimeSeries:

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -4251,6 +4251,80 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
+        [RavenTheory(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport | RavenTestCategory.TimeSeries)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task can_skip_deleted_timeseries_ranges_on_import(Options options)
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            const string id = "users/1";
+
+            using (var store = GetDocumentStore())
+            {
+                var baseline = DateTime.UtcNow;
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "fitzchak" }, id);
+
+                    var tsf = session.TimeSeriesFor(id, "heartrate");
+                    for (int i = 0; i < 10; i++)
+                    {
+                        tsf.Append(baseline.AddHours(i), i);
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "aviv" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var ts = await session.TimeSeriesFor(id, "heartrate").GetAsync();
+                    Assert.Null(ts);
+                }
+
+                await Backup.RunBackupAsync(Server, backupTaskId, store, isFullBackup: false);
+
+                Assert.True(WaitForValue(() =>
+                {
+                    var dir = Directory.GetDirectories(backupPath).First();
+                    var files = Directory.GetFiles(dir);
+                    return files.Length == 2;
+                }, expectedVal: true));
+            }
+
+            using (var store = GetDocumentStore(options))
+            {
+                // skip deleted ranges on import
+                var importOptions = new DatabaseSmugglerImportOptions();
+                importOptions.OperateOnTypes &= ~DatabaseItemType.TimeSeriesDeletedRanges;
+
+                await store.Smuggler.ImportIncrementalAsync(importOptions,
+                    Directory.GetDirectories(backupPath).First());
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    Assert.Equal("aviv", user.Name);
+
+                    var ts = await session.TimeSeriesFor(id, "heartrate").GetAsync();
+                    Assert.Equal(10, ts.Length);
+                }
+            }
+        }
+
         private static string GetBackupPath(IDocumentStore store, long backTaskId, bool incremental = true)
         {
             var status = store.Maintenance.Send(new GetPeriodicBackupStatusOperation(backTaskId)).Status;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20325/Backup-Export-doesnt-take-into-account-time-series-deleted-ranges

### Additional description

handle `TimeSeriesDeletedRanges` in `StreamSource.SkipTypeAsync` (5.4)
already handled in 6.0 PR 

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant