### PR TITLE
RavenDB-22467 Respect `Take` and `Skip` clauses in `MoreLikeThis` query in Corax

### DIFF
--- a/src/Raven.Client/Documents/Queries/MoreLikeThis/MoreLikeThisFactory.cs
+++ b/src/Raven.Client/Documents/Queries/MoreLikeThis/MoreLikeThisFactory.cs
@@ -45,7 +45,7 @@ namespace Raven.Client.Documents.Queries.MoreLikeThis
     public interface IMoreLikeThisOperations<T>
     {
         /// <summary>
-        /// Add custom parameters to your MoreLikeThis query./>
+        /// Add custom parameters to your MoreLikeThis query
         /// </summary>
         /// <param name="options">Configure custom options for your query. See more at: <see cref="MoreLikeThisOptions"/></param>
         /// <returns></returns>

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1288,18 +1288,17 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                     if (hit == baseDocId)
                         continue;
                     
+                    var id = _documentIdReader.GetTermFor(hit);
+                    if (ravenIds.Add(id) == false)
+                        continue;
+
                     if (skippedDocs < query.Start)
                     {
                         skippedDocs++;
                         continue;
                     }
-
+                    
                     var termsReader = IndexSearcher.GetEntryTermsReader(hit, ref page);
-                    var id = _documentIdReader.GetTermFor(hit);
-
-                    if (ravenIds.Add(id) == false)
-                        continue;
-
                     var retrieverInput = new RetrieverInput(IndexSearcher, _fieldMappings, termsReader, id, _index.IndexFieldsPersistence.HasTimeValues);
                     var result = retriever.Get(ref retrieverInput, token);
                     

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1273,6 +1273,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             long[] ids = QueryPool.Rent(pageSize);
             var read = 0;
             long returnedDocs = 0;
+            long skippedDocs = 0;
             Page page = default;
             while ((read = mltQuery.Fill(ids.AsSpan())) != 0)
             {
@@ -1286,6 +1287,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
                     if (hit == baseDocId)
                         continue;
+                    
+                    if (skippedDocs < query.Start)
+                    {
+                        skippedDocs++;
+                        continue;
+                    }
 
                     var termsReader = IndexSearcher.GetEntryTermsReader(hit, ref page);
                     var id = _documentIdReader.GetTermFor(hit);

--- a/test/SlowTests/Issues/RavenDB-22467.cs
+++ b/test/SlowTests/Issues/RavenDB-22467.cs
@@ -1,0 +1,150 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.MoreLikeThis;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22467 : RavenTestBase
+{
+    public RavenDB_22467(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TestIfTakeClauseLimitsNumberOfReturnedDocuments(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var u1 = new User() { Id = "user/1", Name = "CoolName", Note = "some note" };
+                var u2 = new User() { Id = "user/2", Name = "CoolName", Note = "some note" };
+                var u3 = new User() { Id = "user/3", Name = "CoolName", Note = "some note" };
+                var u4 = new User() { Id = "user/4", Name = "CoolName", Note = "some note" };
+                var u5 = new User() { Id = "user/5", Name = "CoolName", Note = "some note" };
+                
+                session.Store(u1);
+                session.Store(u2);
+                session.Store(u3);
+                session.Store(u4);
+                session.Store(u5);
+                
+                session.SaveChanges();
+
+                var index = new UserMoreLikeThisIndex();
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                var moreUsers = session.Query<User, UserMoreLikeThisIndex>()
+                    .MoreLikeThis(builder => builder
+                        .UsingDocument(x => x.Id == u1.Id)
+                        .WithOptions(new MoreLikeThisOptions
+                        {
+                            Fields = new[] { "Name", "Note" },
+                        }))
+                    .Take(3)
+                    .ToList();
+
+                Assert.Equal(3, moreUsers.Count);
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TestIfTakeClauseLimitsNumberOfReturnedDocumentsWithMultipleCoraxFills(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                for (var i = 0; i < 6000; i++)
+                {
+                    session.Store(new User(){ Id = $"user/{i + 1}", Name = "CoolName", Note = "SomeNote" });
+                }
+                
+                session.SaveChanges();
+
+                var index = new UserMoreLikeThisIndex();
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                var moreUsers = session.Query<User, UserMoreLikeThisIndex>()
+                    .MoreLikeThis(builder => builder
+                        .UsingDocument(x => x.Id == "user/1")
+                        .WithOptions(new MoreLikeThisOptions
+                        {
+                            Fields = new[] { "Name", "Note" },
+                        }))
+                    .Take(5000)
+                    .ToList();
+
+                Assert.Equal(5000, moreUsers.Count);
+                
+                moreUsers = session.Query<User, UserMoreLikeThisIndex>()
+                    .MoreLikeThis(builder => builder
+                        .UsingDocument(x => x.Id == "user/1")
+                        .WithOptions(new MoreLikeThisOptions
+                        {
+                            Fields = new[] { "Name" },
+                        }))
+                    .Take(3)
+                    .ToList();
+                
+                Assert.Equal(3, moreUsers.Count);
+                
+                moreUsers = session.Query<User, UserMoreLikeThisIndex>()
+                    .MoreLikeThis(builder => builder
+                        .UsingDocument(x => x.Id == "user/1"))
+                    .Take(254)
+                    .ToList();
+                
+                Assert.Equal(254, moreUsers.Count);
+                
+                moreUsers = session.Query<User, UserMoreLikeThisIndex>()
+                    .MoreLikeThis(builder => builder
+                        .UsingDocument(x => x.Id == "user/1"))
+                    .Take(99999)
+                    .ToList();
+                
+                Assert.Equal(5999, moreUsers.Count);
+            }
+        }
+    }
+    
+    private class UserMoreLikeThisIndex : AbstractIndexCreationTask<User>
+    {
+        public UserMoreLikeThisIndex()
+        {
+            Map = users => from user in users
+                select new
+                {
+                    user.Name,
+                    user.Note
+                };
+
+            Indexes.Add(x => x.Name, FieldIndexing.Search);
+            Indexes.Add(x => x.Note, FieldIndexing.Search);
+            
+            Stores.Add(x => x.Name, FieldStorage.Yes);
+            Stores.Add(x => x.Note, FieldStorage.Yes);
+        }
+    }
+    
+    private class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Note { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22467/Take-clause-is-not-respected-by-Corax-in-MoreLikeThis-query

### Additional description

We want to limit the number of documents returned by `MoreLikeThis` query in Corax when `Take` clause is used.
We also want to handle `Skip` clause there.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
