### PR TITLE
RavenDB-22046 builder and modifier lifecycle needs to be bound to the command (and context) lifecycle

### DIFF
--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -15,6 +15,8 @@ namespace Raven.Server.Documents
 {
     public sealed class BlittableMetadataModifier : IDisposable, IBlittableDocumentModifier
     {
+        private bool _disposed;
+
         private bool _readingMetadataObject;
         private int _depth;
         private State _state = State.None;
@@ -129,6 +131,8 @@ namespace Raven.Server.Documents
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void StartObject()
         {
+            AssertNotDisposed();
+
             if (_readingMetadataObject == false)
                 return;
 
@@ -138,6 +142,8 @@ namespace Raven.Server.Documents
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void EndObject()
         {
+            AssertNotDisposed();
+
             if (_readingMetadataObject == false)
                 return;
 
@@ -151,6 +157,8 @@ namespace Raven.Server.Documents
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool AboutToReadPropertyName(IJsonParser reader, JsonParserState state)
         {
+            AssertNotDisposed();
+
             if (reader is UnmanagedJsonParser)
                 return AboutToReadPropertyNameInternal((UnmanagedJsonParser)reader, state);
             if (reader is ObjectJsonParser)
@@ -892,10 +900,14 @@ namespace Raven.Server.Documents
                 _ctx.ReturnMemory(_allocations[i]);
             }
             _allocations.Clear();
+
+            _disposed = true;
         }
 
         public void Reset(JsonOperationContext ctx)
         {
+            AssertNotDisposed();
+
             if (_ctx == null) // should never happen
             {
                 _ctx = ctx;
@@ -916,6 +928,13 @@ namespace Raven.Server.Documents
             _ctx = ctx;
             _metadataCollections = _ctx.GetLazyStringForFieldWithCaching(CollectionName.MetadataCollectionSegment);
             _metadataExpires = _ctx.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Expires);
+        }
+
+        [Conditional("DEBUG")]
+        private void AssertNotDisposed()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(BlittableMetadataModifier));
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -284,6 +284,9 @@ namespace Raven.Server.Documents.Handlers
 
             public long ErrorCount;
 
+            private BlittableJsonDocumentBuilder _builder;
+            private BlittableMetadataModifier _metadataModifier;
+
             public SmugglerCounterBatchCommand(DocumentDatabase database, SmugglerResult result)
             {
                 _database = database;
@@ -352,6 +355,21 @@ namespace Raven.Server.Documents.Handlers
             public void RegisterForDisposal(IDisposable data)
             {
                 _toDispose.Add(data);
+            }
+
+            public BlittableJsonDocumentBuilder GetOrCreateBuilder(UnmanagedJsonParser parser, JsonParserState state, string debugTag, BlittableMetadataModifier modifier = null)
+            {
+                return _builder ??= new BlittableJsonDocumentBuilder(_context, BlittableJsonDocumentBuilder.UsageMode.ToDisk, debugTag, parser, state, modifier: modifier);
+            }
+
+            public BlittableMetadataModifier GetOrCreateMetadataModifier(string firstEtagOfLegacyRevision = null, long legacyRevisionsCount = 0, bool legacyImport = false,
+                bool readLegacyEtag = false, DatabaseItemType operateOnTypes = DatabaseItemType.None)
+            {
+                _metadataModifier ??= new BlittableMetadataModifier(_context, legacyImport, readLegacyEtag, operateOnTypes);
+                _metadataModifier.FirstEtagOfLegacyRevision = firstEtagOfLegacyRevision;
+                _metadataModifier.LegacyRevisionsCount = legacyRevisionsCount;
+
+                return _metadataModifier;
             }
 
             protected override long ExecuteCmd(DocumentsOperationContext context)
@@ -580,6 +598,9 @@ namespace Raven.Server.Documents.Handlers
                 _resetContext = null;
 
                 _result.Counters.ErroredCount += ErrorCount;
+
+                _builder?.Dispose();
+                _metadataModifier?.Dispose();
             }
 
             public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -594,13 +594,13 @@ namespace Raven.Server.Documents.Handlers
 
                 _legacyDictionary?.Clear();
 
+                _builder?.Dispose();
+                _metadataModifier?.Dispose();
+
                 _resetContext?.Dispose();
                 _resetContext = null;
 
                 _result.Counters.ErroredCount += ErrorCount;
-
-                _builder?.Dispose();
-                _metadataModifier?.Dispose();
             }
 
             public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -1338,12 +1338,12 @@ namespace Raven.Server.Documents.Handlers
                 foreach (var returnable in _toReturn)
                     _context.ReturnMemory(returnable);
                 _toReturn.Clear();
-                
-                _releaseContext?.Dispose();
-                _releaseContext = null;
 
                 _builder?.Dispose();
                 _metadataModifier?.Dispose();
+
+                _releaseContext?.Dispose();
+                _releaseContext = null;
             }
         }
 

--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -15,6 +15,7 @@ using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Smuggler.Documents.Data
 {
@@ -71,6 +72,10 @@ namespace Raven.Server.Smuggler.Documents.Data
     public interface INewItemActions
     {
         DocumentsOperationContext GetContextForNewDocument();
+
+        BlittableJsonDocumentBuilder GetBuilderForNewDocument(UnmanagedJsonParser parser, JsonParserState state, BlittableMetadataModifier modifier = null);
+
+        BlittableMetadataModifier GetMetadataModifierForNewDocument(string firstEtagOfLegacyRevision = null, long legacyRevisionsCount = 0, bool legacyImport = false, bool readLegacyEtag = false, DatabaseItemType operateOnTypes = DatabaseItemType.None);
     }
     
     public interface INewDocumentActions : INewItemActions

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -1846,17 +1846,18 @@ namespace Raven.Server.Smuggler.Documents
                     }
                 }
                 Documents.Clear();
-                _resetContext?.Dispose();
-                _resetContext = null;
-
-                AttachmentStreamsTempFile?.Dispose();
-                AttachmentStreamsTempFile = null;
 
                 _metadataModifier?.Dispose();
                 _metadataModifier = null;
 
                 _builder?.Dispose();
                 _builder = null;
+
+                _resetContext?.Dispose();
+                _resetContext = null;
+
+                AttachmentStreamsTempFile?.Dispose();
+                AttachmentStreamsTempFile = null;
             }
 
             /// <summary>

--- a/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Sparrow.Collections;
 using Sparrow.Platform;
@@ -7,6 +8,8 @@ namespace Sparrow.Json
 {
     public abstract class AbstractBlittableJsonDocumentBuilder : IDisposable
     {
+        private bool _disposed;
+
         private readonly GlobalPoolItem _cacheItem;
         protected readonly ListCache<PropertyTag> _propertiesCache;
         protected readonly ListCache<int> _positionsCache;
@@ -42,6 +45,8 @@ namespace Sparrow.Json
             // PERF: We are clearing the array without removing the references because the type is an struct.
             _continuationState.WeakClear();
             ContinuationPool.Free(_continuationState);
+
+            _disposed = true;
         }
 
         protected void ClearState()
@@ -53,6 +58,13 @@ namespace Sparrow.Json
                 _tokensCache.Return(ref state.Types);
                 _positionsCache.Return(ref state.Positions);
             }
+        }
+
+        [Conditional("DEBUG")]
+        protected void AssertNotDisposed()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(GetType().Name);
         }
 
         protected struct BuildingState

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -52,6 +52,8 @@ namespace Sparrow.Json
 
         public void Reset()
         {
+            AssertNotDisposed();
+
             _debugTag = null;
             _mode = UsageMode.None;
 
@@ -63,6 +65,8 @@ namespace Sparrow.Json
 
         public void Renew(string debugTag, UsageMode mode)
         {
+            AssertNotDisposed();
+
             _writeToken = default;
             _debugTag = debugTag;
             _mode = mode;
@@ -77,21 +81,29 @@ namespace Sparrow.Json
 
         public void ReadArrayDocument()
         {
+            AssertNotDisposed();
+
             _continuationState.Push(new BuildingState(ContinuationState.ReadArrayDocument));
         }
 
         public void ReadObjectDocument()
         {
+            AssertNotDisposed();
+
             _continuationState.Push(new BuildingState(ContinuationState.ReadObjectDocument));
         }
 
         public void ReadNestedObject()
         {
+            AssertNotDisposed();
+
             _continuationState.Push(new BuildingState(ContinuationState.ReadObject));
         }
 
         public void ReadProperty()
         {
+            AssertNotDisposed();
+
             var state = new BuildingState(ContinuationState.ReadPropertyName)
             {
                 State = ContinuationState.ReadPropertyName,
@@ -102,7 +114,15 @@ namespace Sparrow.Json
             _continuationState.Push(state);
         }
 
-        public int SizeInBytes => _writer.SizeInBytes;
+        public int SizeInBytes
+        {
+            get
+            {
+                AssertNotDisposed();
+
+                return _writer.SizeInBytes;
+            }
+        }
 
         public override void Dispose()
         {
@@ -298,6 +318,8 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Read()
         {
+            AssertNotDisposed();
+
             if (_continuationState.Count == 0)
                 return false; //nothing to do
 
@@ -462,6 +484,8 @@ namespace Sparrow.Json
 
         public void FinalizeDocument()
         {
+            AssertNotDisposed();
+
             var documentToken = _writeToken.WrittenToken;
             var rootOffset = _writeToken.ValuePos;
 
@@ -470,11 +494,15 @@ namespace Sparrow.Json
 
         public BlittableJsonReaderObject CreateReader()
         {
+            AssertNotDisposed();
+
             return _writer.CreateReader();
         }
 
         public BlittableJsonReaderArray CreateArrayReader(bool noCache)
         {
+            AssertNotDisposed();
+
             var reader = CreateReader();
             reader.NoCache = noCache;
             if (reader.TryGet("_", out BlittableJsonReaderArray array))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22046

### Additional description

The smuggler during processing is batching the documents, timeseries, etc. None of those commands is waiting to finish before next command is getting prepared, due to that approach when prevCommand is getting executed and currentCommand is getting filled from the source, we might encounter an issue with disposal of builder and modifier before 'prevCommand' finishes the execution (the data in the command was build/modified using those two entities). 

To fix that we are binding the lifecycle of the builder and modifier to the lifecycle of the command.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
