### PR TITLE
RavenDB-22476 Fix missing space for Status in Index Progress Tooltip

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
@@ -104,7 +104,7 @@ export function IndexProgressTooltip(props: IndexProgressTooltipProps) {
                         </LocationSpecificDetailsItem>
                     ) : (
                         <LocationSpecificDetailsItem className="status">
-                            <Icon icon="check" margin="m-0" /> Up to date
+                            <Icon icon="check" margin="me-sm-1" /> Up to date
                         </LocationSpecificDetailsItem>
                     )}
                 </LocationSpecificDetailsItemsContainer>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22476

### Additional description

Fixed spacing between icon and status in Index Progress tooltip

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
