### PR TITLE
RavenDB-17474 Set https scheme in Docker automatically if cert options are passed through one of the available channels (5.4)

### DIFF
--- a/docker/ravendb-nanoserver/run-raven.ps1
+++ b/docker/ravendb-nanoserver/run-raven.ps1
@@ -2,12 +2,29 @@ $ErrorActionPreference = 'Stop'
 
 $COMMAND=".\Raven.Server.exe"
 $hostname = & "hostname.exe"
-if ([string]::IsNullOrEmpty($env:RAVEN_ServerUrl) -eq $True) {
-    $env:RAVEN_ServerUrl = "http://$($hostname):8080"
-}
 
 if ([string]::IsNullOrEmpty($env:RAVEN_SETTINGS) -eq $False) {
     Set-Content -Path "settings.json" -Value "$env:RAVEN_SETTINGS"
+}
+
+function Get-RavenServerScheme {
+    if (Get-Content "settings.json" -Raw | Select-String -Pattern "Server.Certificate.Path|Server.Certificate.Load.Exec") {
+        return "https"
+    }
+    elseif (![string]::IsNullOrEmpty($env:RAVEN_Server_Certificate_Path) -or
+            ![string]::IsNullOrEmpty($env:RAVEN_Server_Certificate_Load_Exec) -or
+            $env:RAVEN_ARGS -like "*--Server.Certificate.Path*" -or
+            $env:RAVEN_ARGS -like "*--Server.Certificate.Load.Exec*") {
+        return "https"
+    }
+    else {
+        return "http"
+    }
+}
+
+if ([string]::IsNullOrEmpty($env:RAVEN_ServerUrl)) {
+    $RAVEN_SERVER_SCHEME = Get-RavenServerScheme
+    $env:RAVEN_ServerUrl = "$RAVEN_SERVER_SCHEME://$hostname:8080"
 }
 
 if ([string]::IsNullOrEmpty($env:RAVEN_ARGS) -eq $False) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17474/Set-https-scheme-in-Docker-automatically-if-cert-options-are-passed-through-one-of-the-available-channels

### Additional description
Motivation for this PR - https://github.com/ravendb/ravendb/pull/12906#issuecomment-951599465
6.0 PR - https://github.com/ravendb/ravendb/pull/18712

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Docker.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
