### PR TITLE
RavenDB-22365 Confusing message for SQL ETL after upgrade from 5.4.11…

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringSql.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/connectionStringSql.html
@@ -24,7 +24,12 @@
         <span class="help-block" data-bind="validationMessage: factoryName"></span>
         <div class="has-warning" data-bind="visible: factoryName() === 'MySql.Data.MySqlClient'">
             <div class="help-block">
-                <i class="icon-warning"></i> <span> This connector is deprecated</span>
+                <i class="icon-warning"></i>
+                <span>
+                    This connector is deprecated. 
+                    MySqlConnector will be used instead. 
+                    Please update Factory to: MySqlConnector.MySqlConnectorFactory.
+                </span>
             </div>
         </div>
     </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/importDatabaseFromSql.html
@@ -26,7 +26,12 @@
                                     <span class="help-block" data-bind="validationMessage: databaseType"></span>
                                     <div class="has-warning" data-bind="visible: databaseType() === 'MySQL_MySql_Data'">
                                         <div class="help-block">
-                                            <i class="icon-warning"></i> <span> This connector is deprecated</span>
+                                            <i class="icon-warning"></i> 
+                                            <span>
+                                                This connector is deprecated. 
+                                                MySqlConnector will be used instead. 
+                                                Please update Factory to: MySqlConnector.MySqlConnectorFactory.
+                                            </span>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
…5 to 118

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22365 

### Additional description

More detailed information about deprecated connector. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
