### PR TITLE
RavenDB-19578 Provide copy button in error dialogs

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/recentErrorDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/recentErrorDetails.ts
@@ -3,6 +3,7 @@ import abstractNotification = require("common/notifications/models/abstractNotif
 import notificationCenter = require("common/notifications/notificationCenter");
 import recentError = require("common/notifications/models/recentError");
 import dialogViewModelBase = require("viewmodels/dialogViewModelBase");
+import copyToClipboard from "common/copyToClipboard";
 
 class recentErrorDetails extends dialogViewModelBase {
 
@@ -13,7 +14,7 @@ class recentErrorDetails extends dialogViewModelBase {
 
     constructor(recentError: recentError, notificationCenter: notificationCenter) {
         super();
-        this.bindToCurrentInstance("close", "dismiss");
+        this.bindToCurrentInstance("close", "dismiss", "copyErrorDetails");
 
         this.recentError = recentError;
         this.dismissFunction = () => notificationCenter.dismiss(recentError);
@@ -22,6 +23,11 @@ class recentErrorDetails extends dialogViewModelBase {
     dismiss() {
         this.dismissFunction();
         this.close();
+    }
+
+    copyErrorDetails(): void {
+        const errorDetails = this.recentError.details();
+        copyToClipboard.copy(errorDetails, "Error has been copied to clipboard");
     }
 
     static supportsDetailsFor(notification: abstractNotification) {

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/recentErrorDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/recentErrorDetails.html
@@ -11,7 +11,13 @@
         </div>
         <div class="modal-body" data-bind="with: recentError">
             <div data-bind="html: longerMessage"></div>
-            <pre class="margin-top error-messages" data-bind="visible: details"><code data-bind="text: details"></code></pre>
+            <div class="d-flex margin-top" data-bind="visible: details">
+                <div class="flex-grow"></div>
+                <button class="btn btn-default btn-sm" data-bind="click: $parent.copyErrorDetails"><i class="icon-copy-to-clipboard"></i><span>Copy error message</span></button>
+            </div>
+            <pre class="d-flex error-messages position-relative" data-bind="visible: details">
+                <code data-bind="text: details"></code>
+            </pre>
         </div>
         <div class="modal-footer">
             <div class="flex-horizontal">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19578

### Additional description

Added `Copy` button to error dialogs

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
