### PR TITLE
RavenDB-21545 For a RavenDB Cloud license do not show Download Now in…

### DIFF
--- a/src/Raven.Server/Web/System/BuildVersionHandler.cs
+++ b/src/Raven.Server/Web/System/BuildVersionHandler.cs
@@ -59,6 +59,12 @@ namespace Raven.Server.Web.System
         [RavenAction("/build/version/updates", "POST", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetVersionUpdatesInfo()
         {
+            if (Server.Configuration.Updates.BackgroundChecksDisabled)
+            {
+                NoContentStatus();
+                return;
+            }
+            
             var shouldRefresh = GetBoolValueQueryString("refresh", required: false) ?? false;
             if (shouldRefresh && IsLatestVersionCheckThrottled() == false)
             {

--- a/src/Raven.Studio/typescript/viewmodels/shell/about.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell/about.ts
@@ -13,6 +13,8 @@ import popoverUtils = require("common/popoverUtils");
 import app = require("durandal/app");
 import feedback from "viewmodels/shell/feedback";
 
+type newVersionStatus = "available" | "latest" | "checksDisabled";
+
 class about extends viewModelBase {
 
     view = require("views/shell/about.html");
@@ -37,30 +39,33 @@ class about extends viewModelBase {
     developerLicense = license.developerLicense;
 
     static latestVersion = ko.observable<Raven.Server.ServerWide.BackgroundTasks.LatestVersionCheck.VersionInfo>();
-    currentServerVersion = ko.pureComputed(() => this.serverVersion() ? this.serverVersion().FullVersion : "");   
-    
-    isNewVersionAvailable = ko.pureComputed(() => {
+    currentServerVersion = ko.pureComputed(() => this.serverVersion() ? this.serverVersion().FullVersion : "");
+
+    newVersionStatus = ko.pureComputed((): newVersionStatus => {
         const latestVersionInfo = about.latestVersion();
         if (!latestVersionInfo) {
-            return false;
+            return "checksDisabled";
         }
 
         const serverVersion = this.serverVersion();
         if (!serverVersion) {
-            return false;
+            return "checksDisabled";
         }
 
         const isDevBuildNumber = (num: number) => num >= 40 && num < 60;
 
-        return !isDevBuildNumber(latestVersionInfo.BuildNumber) &&
-            latestVersionInfo.BuildNumber > serverVersion.BuildVersion;
+        return (!isDevBuildNumber(latestVersionInfo.BuildNumber) &&
+            latestVersionInfo.BuildNumber > serverVersion.BuildVersion) ? "available" : "latest";
     });
 
     newVersionAvailableHtml = ko.pureComputed(() => {
-        if (this.isNewVersionAvailable()) {
-            return `New version available<br/> <span class="nobr">${ about.latestVersion().Version }</span>`;
-        } else {
-            return `You are using the latest version`;
+        switch (this.newVersionStatus()) {
+            case "available":
+                return `New version available<br/> <span class="nobr">${ about.latestVersion().Version }</span>`;
+            case "latest":
+                return `You are using the latest version`;
+            default:
+                return null;
         }
     });
     
@@ -255,6 +260,8 @@ class about extends viewModelBase {
             .done(versionInfo => {
                 if (versionInfo && versionInfo.Version) {
                     about.latestVersion(versionInfo);
+                } else {
+                    about.latestVersion(null);
                 }
             })
             .always(() => this.spinners.latestVersionUpdates(false));
@@ -267,6 +274,8 @@ class about extends viewModelBase {
             .done(versionInfo => {
                 if (versionInfo && versionInfo.Version) {
                     about.latestVersion(versionInfo);
+                } else {
+                    about.latestVersion(null);
                 }
             })
             .always(() => this.spinners.latestVersionUpdates(false));

--- a/src/Raven.Studio/wwwroot/App/views/shell/about.html
+++ b/src/Raven.Studio/wwwroot/App/views/shell/about.html
@@ -53,15 +53,15 @@
                             </div>
                         </a>
                     </div>
-                    <div>
+                    <div data-bind="if: newVersionStatus() !== 'checksDisabled'">
                         <div class="flex-horizontal flex-stretch-items">
                             <button data-bind="click: openLatestVersionDownload" class="btn btn-primary big-button flex-grow">
                                 <i class="icon-server"></i>
                                 <div class="content">
                                     <small data-bind="html: newVersionAvailableHtml"></small>
-                                    <strong data-bind="visible: !isNewVersionAvailable(), text: currentServerVersion"></strong>
-                                    <small data-bind="visible: isNewVersionAvailable">Newer version exists</small>
-                                    <strong data-bind="visible: isNewVersionAvailable">Download Now</strong>
+                                    <strong data-bind="visible: newVersionStatus() === 'latest', text: currentServerVersion"></strong>
+                                    <small data-bind="visible: newVersionStatus() === 'available'">Newer version exists</small>
+                                    <strong data-bind="visible: newVersionStatus() === 'available'">Download Now</strong>
                                 </div>
                             </button>
                             <button data-bind="disable: spinners.latestVersionUpdates, click: refreshLatestVersionInfo, css: { 'btn-spinner': spinners.latestVersionUpdates }"
@@ -69,7 +69,7 @@
                                 <i class="icon-refresh"></i>
                             </button>
                         </div>
-                        <div class="text-center margin-top" data-bind="if: isNewVersionAvailable">
+                        <div class="text-center margin-top" data-bind="if: newVersionStatus() === 'available'">
                             <a href="#" data-bind="attr: { href: latestVersionWhatsNewUrl }" target="_blank">See What's New</a>
                         </div>
                     </div>


### PR DESCRIPTION
… the Studio on the new version notification

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21545 

### Additional description

Handle `Updates.BackgroundChecks.Disable` in studio

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
