### PR TITLE
RavenDB-22471 Displayed `created` info in indexing view is toggling between two different values while indexing

### DIFF
--- a/src/Raven.Studio/typescript/components/models/indexes.ts
+++ b/src/Raven.Studio/typescript/components/models/indexes.ts
@@ -22,7 +22,6 @@ export interface IndexSharedInfo {
     patternForReferencesToReduceOutputCollection: string;
     collectionNameForReferenceDocuments: string;
     nodesInfo: IndexNodeInfo[];
-    createdTimestamp: Date;
     referencedCollections: string[];
 }
 
@@ -32,6 +31,7 @@ export interface IndexNodeInfo {
     details: IndexNodeInfoDetails;
     loadError?: any;
     progress: IndexProgressInfo;
+    createdTimestamp: Date;
 }
 
 export interface IndexProgressInfo {
@@ -62,7 +62,8 @@ export interface IndexNodeInfoDetails {
 
 export type IndexGroupBy = "Collection" | "None";
 export type IndexSortBy =
-    | Extract<keyof IndexSharedInfo, "name" | "createdTimestamp">
+    | Extract<keyof IndexSharedInfo, "name">
+    | Extract<keyof IndexNodeInfo, "createdTimestamp">
     | Extract<keyof IndexNodeInfoDetails, "lastIndexingTime" | "lastQueryingTime">;
 
 export interface IndexFilterCriteria {

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -108,8 +108,9 @@ export function IndexDistribution(props: IndexDistributionProps) {
 
     const sharded = IndexUtils.isSharded(index);
 
-    const formattedCreatedTimestamp = index.createdTimestamp
-        ? genUtils.formatDurationByDate(moment(index.createdTimestamp)) + " ago"
+    const earliestCreatedTimestamp = IndexUtils.getEarliestCreatedTimestamp(index);
+    const formattedEarliestCreatedTimestamp = earliestCreatedTimestamp
+        ? genUtils.formatDurationByDate(moment(earliestCreatedTimestamp)) + " ago"
         : null;
 
     const items = (
@@ -168,9 +169,9 @@ export function IndexDistribution(props: IndexDistributionProps) {
                 </DistributionSummary>
                 {items}
             </LocationDistribution>
-            {formattedCreatedTimestamp && (
+            {formattedEarliestCreatedTimestamp && (
                 <div className="small">
-                    <span className="text-muted">Created:</span> <strong>{formattedCreatedTimestamp}</strong>
+                    <span className="text-muted">Created:</span> <strong>{formattedEarliestCreatedTimestamp}</strong>
                 </div>
             )}
         </div>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -111,7 +111,6 @@ function mapToIndexSharedInfo(stats: IndexStats): IndexSharedInfo {
         patternForReferencesToReduceOutputCollection: stats.ReduceOutputReferencePattern,
         collectionNameForReferenceDocuments: stats.PatternReferencesCollectionName,
         searchEngine: stats.SearchEngineType,
-        createdTimestamp: genUtils.isServerMinDate(stats.CreatedTimestamp) ? null : new Date(stats.CreatedTimestamp),
         referencedCollections: stats.ReferencedCollections,
     };
 }
@@ -131,6 +130,7 @@ function mapToIndexNodeInfo(stats: IndexStats, location: databaseLocationSpecifi
             lastQueryingTime: stats.LastQueryingTime ? new Date(stats.LastQueryingTime) : null,
         },
         progress: null,
+        createdTimestamp: genUtils.isServerMinDate(stats.CreatedTimestamp) ? null : new Date(stats.CreatedTimestamp),
     };
 }
 
@@ -140,6 +140,7 @@ function initNodesInfo(locations: databaseLocationSpecifier[]): IndexNodeInfo[] 
         status: "idle",
         details: null,
         progress: null,
+        createdTimestamp: null,
     }));
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -793,8 +793,9 @@ function getSortedRegularIndexes(
 ): IndexSharedInfo[] {
     switch (sortBy) {
         case "name":
-        case "createdTimestamp":
             return _.orderBy(indexes, [sortBy], [sortDirection]);
+        case "createdTimestamp":
+            return _.orderBy(indexes, (index) => IndexUtils.getEarliestCreatedTimestamp(index), [sortDirection]);
         case "lastIndexingTime":
         case "lastQueryingTime":
             return _.orderBy(

--- a/src/Raven.Studio/typescript/components/utils/IndexUtils.ts
+++ b/src/Raven.Studio/typescript/components/utils/IndexUtils.ts
@@ -221,4 +221,8 @@ export default class IndexUtils {
 
         return Array.from(perShardMax.values()).reduce((a, b) => a + b, 0);
     }
+
+    static getEarliestCreatedTimestamp(index: IndexSharedInfo): Date {
+        return _.min(index.nodesInfo.map((nodeInfo) => nodeInfo.createdTimestamp)) ?? null;
+    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22471/Displayed-created-info-in-indexing-view-is-toggling-between-two-different-values-while-indexing

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
