### PR TITLE
RavenDB-21706 marked /databases/*/admin/pull-replication/generate-certificate endpoint as heavy in tests

### DIFF
--- a/test/SlowTests/Authentication/AuthenticationBasicTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationBasicTests.cs
@@ -795,6 +795,11 @@ namespace SlowTests.Authentication
                     ("GET", "/admin/debug/info-package"),               // heavy
                 };
 
+                var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
+                {
+                    ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
+                };
+
                 using (var httpClientHandler = new HttpClientHandler())
                 {
                     httpClientHandler.ClientCertificates.Add(userCert);
@@ -823,7 +828,7 @@ namespace SlowTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseName1, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
                         if (route.EndpointType == EndpointType.Write)
@@ -841,7 +846,7 @@ namespace SlowTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseName2, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
                     {
                         var canAccess = false;
 
@@ -910,6 +915,11 @@ namespace SlowTests.Authentication
                     ("GET", "/admin/debug/info-package"),               // heavy
                 };
 
+                var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
+                {
+                    ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
+                };
+
                 using (var httpClientHandler = new HttpClientHandler())
                 {
                     httpClientHandler.ClientCertificates.Add(userCert);
@@ -938,7 +948,7 @@ namespace SlowTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseName1, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
                     {
                         var canAccess = route.AuthorizationStatus == AuthorizationStatus.ValidUser;
 
@@ -950,7 +960,7 @@ namespace SlowTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseName2, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
                     {
                         var canAccess = false;
 
@@ -1019,6 +1029,11 @@ namespace SlowTests.Authentication
                     ("GET", "/admin/debug/info-package"),               // heavy
                 };
 
+                var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
+                {
+                    ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
+                };
+
                 using (var httpClientHandler = new HttpClientHandler())
                 {
                     httpClientHandler.ClientCertificates.Add(userCert);
@@ -1047,7 +1062,7 @@ namespace SlowTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseName1, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 
@@ -1059,7 +1074,7 @@ namespace SlowTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseName2, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
                     {
                         var canAccess = false;
 
@@ -1125,6 +1140,11 @@ namespace SlowTests.Authentication
                     ("GET", "/admin/debug/info-package"),               // heavy
                 };
 
+                var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
+                {
+                    ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
+                };
+
                 using (var httpClientHandler = new HttpClientHandler())
                 {
                     httpClientHandler.ClientCertificates.Add(userCert);
@@ -1148,7 +1168,7 @@ namespace SlowTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseName1, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 
@@ -1160,7 +1180,7 @@ namespace SlowTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseName2, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 
@@ -1212,7 +1232,7 @@ namespace SlowTests.Authentication
                     ("POST", "/setup/hosts"),                           // only available in setup mode
                     ("POST", "/setup/unsecured"),                       // only available in setup mode
                     ("POST", "/setup/unsecured/package"),               // only available in setup mode
-                    ("POST", "/setup/continue/unsecured"),               // only available in setup mode
+                    ("POST", "/setup/continue/unsecured"),              // only available in setup mode
                     ("POST", "/setup/secured"),                         // only available in setup mode
                     ("GET", "/setup/letsencrypt/agreement"),            // only available in setup mode
                     ("POST", "/setup/letsencrypt"),                     // only available in setup mode
@@ -1224,6 +1244,11 @@ namespace SlowTests.Authentication
                     ("GET", "/admin/debug/cluster-info-package"),       // heavy
                     ("GET", "/admin/debug/remote-cluster-info-package"),// heavy
                     ("GET", "/admin/debug/info-package"),               // heavy
+                };
+
+                var databaseEndpointsToIgnore = new HashSet<(string Method, string Path)>
+                {
+                    ("POST", "/databases/*/admin/pull-replication/generate-certificate"), // heavy
                 };
 
                 using (var httpClientHandler = new HttpClientHandler())
@@ -1246,7 +1271,7 @@ namespace SlowTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseName1, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName1, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 
@@ -1258,7 +1283,7 @@ namespace SlowTests.Authentication
                         }
                     });
 
-                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseName2, httpClient, (route, statusCode) =>
+                    AssertDatabaseRoutes(RouteScanner.AllRoutes.Values, databaseEndpointsToIgnore, databaseName2, httpClient, (route, statusCode) =>
                     {
                         var canAccess = true;
 
@@ -1305,7 +1330,7 @@ namespace SlowTests.Authentication
             }
         }
 
-        private static void AssertDatabaseRoutes(IEnumerable<RouteInformation> routes, string databaseName, HttpClient httpClient, Action<RouteInformation, HttpStatusCode> assert)
+        private static void AssertDatabaseRoutes(IEnumerable<RouteInformation> routes, HashSet<(string Method, string Path)> endpointsToIgnore, string databaseName, HttpClient httpClient, Action<RouteInformation, HttpStatusCode> assert)
         {
             foreach (var route in routes)
             {
@@ -1314,6 +1339,9 @@ namespace SlowTests.Authentication
 
                 if (route.Method == "OPTIONS")
                     continue; // artificially added routes for CORS
+
+                if (endpointsToIgnore.Contains((route.Method, route.Path)))
+                    continue;
 
                 var requestUri = new Uri(route.Path.Replace("/databases/*/", $"/databases/{databaseName}/", StringComparison.OrdinalIgnoreCase), UriKind.Relative);
                 HttpResponseMessage response;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21706

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
