### PR TITLE
RavenDB-22481 Error when switching databases on revisions config view

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/useIndexCleanup.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/useIndexCleanup.tsx
@@ -177,6 +177,7 @@ export default function useIndexCleanup() {
         await fetchIndexMergeSuggestions(resultMap);
     };
 
+    // Changing the database causes re-mount
     const asyncFetchStats = useAsync(fetchStats, []);
 
     const surpassingSelectionState = genUtils.getSelectionState(

--- a/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/ConflictResolution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/ConflictResolution.tsx
@@ -42,7 +42,9 @@ export default function ConflictResolution() {
         return () => {
             dispatch(conflictResolutionActions.reset());
         };
-    }, [databaseName, dispatch]);
+        // Changing the database causes re-mount
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const asyncSave = useAsyncCallback(async () => {
         reportEvent("conflict-resolution", "save");

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
@@ -41,7 +41,9 @@ export default function ConnectionStrings(props: ConnectionStringsUrlParameters)
         return () => {
             dispatch(connectionStringsActions.reset());
         };
-    }, [databaseName, dispatch, nameFromUrl, typeFromUrl]);
+        // Changing the database causes re-mount
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const loadStatus = useAppSelector(connectionStringSelectors.loadStatus);
     const connections = useAppSelector(connectionStringSelectors.connections);

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzers.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzers.tsx
@@ -27,7 +27,8 @@ export default function DatabaseCustomAnalyzers() {
 
     const { analyzers, setAnalyzers, addNewAnalyzer, removeAnalyzer, mapFromDto } = useCustomAnalyzers();
 
-    const asyncGetDatabaseAnalyzers = useAsync(() => databasesService.getCustomAnalyzers(db.name), [db.name], {
+    // Changing the database causes re-mount
+    const asyncGetDatabaseAnalyzers = useAsync(() => databasesService.getCustomAnalyzers(db.name), [], {
         onSuccess(result) {
             setAnalyzers(mapFromDto(result));
         },

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorterTest.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorterTest.tsx
@@ -41,6 +41,7 @@ export default function DatabaseCustomSorterTest(props: DatabaseCustomSorterTest
 
     const { databasesService } = useServices();
 
+    // Changing the database causes re-mount
     const asyncGetIndexNames = useAsync(async () => {
         const dto = await databasesService.getEssentialStats(db.name);
         return dto?.Indexes?.map((x) => x.Name);

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorters.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorters.tsx
@@ -28,7 +28,8 @@ export default function DatabaseCustomSorters() {
 
     const { sorters, setSorters, addNewSorter, removeSorter, mapFromDto } = useCustomSorters();
 
-    const asyncGetDatabaseSorters = useAsync(() => databasesService.getCustomSorters(db.name), [db.name], {
+    // Changing the database causes re-mount
+    const asyncGetDatabaseSorters = useAsync(() => databasesService.getCustomSorters(db.name), [], {
         onSuccess(result) {
             setSorters(mapFromDto(result));
         },

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -99,7 +99,9 @@ export default function DocumentRevisions() {
         return () => {
             dispatch(documentRevisionsActions.reset());
         };
-    }, [databaseName, dispatch]);
+        // Changing the database causes re-mount
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const { databasesService } = useServices();
     const { reportEvent } = useEventsCollector();

--- a/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.tsx
@@ -21,6 +21,8 @@ export default function TombstonesState({ location }: { location?: databaseLocat
     const { databasesService } = useServices();
 
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+
+    // Changing the database causes re-mount
     const asyncGetTombstonesState = useAsync(() => databasesService.getTombstonesState(databaseName, location), []);
     const asyncForceTombstonesCleanup = useAsyncCallback(() =>
         databasesService.forceTombstonesCleanup(databaseName, location)

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/createSampleData/CreateSampleData.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/createSampleData/CreateSampleData.tsx
@@ -25,6 +25,7 @@ function CreateSampleData() {
 
     const docsLink = useRavenLink({ hash: "SUTS29" });
 
+    // Changing the database causes re-mount
     const asyncFetchCollectionsStats = useAsync(() => tasksService.fetchCollectionsStats(databaseName), []);
     const asyncGetSampleDataClasses = useAsync(() => tasksService.getSampleDataClasses(databaseName), []);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22481/Error-when-switching-databases-on-revisions-config-view

### Additional description

Changing the active database causes re-mount of all react components, so putting the database name in the dependency array causes the function to be called 2 times.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
