### PR TITLE
RavenDB-22484

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.11/WellKnownAdminIssuers.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.11/WellKnownAdminIssuers.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
         private readonly OctetString _wellKnownAdminCertificates;
 
         public WellKnownAdminIssuers(ServerStore store)
-            : base(SnmpOids.Server.WellKnownAdminCertificates)
+            : base(SnmpOids.Server.WellKnownAdminIssuers)
         {
             var wellKnownIssuersThumbprints = store.Server.WellKnownIssuersThumbprints;
             if (wellKnownIssuersThumbprints == null || wellKnownIssuersThumbprints.Length == 0)

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.18/MonitorLockContentionCount.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.18/MonitorLockContentionCount.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using Lextm.SharpSnmpLib;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Server
+{
+    public class MonitorLockContentionCount : ScalarObjectBase<Integer32>
+    {
+        public MonitorLockContentionCount()
+            : base(SnmpOids.Server.MonitorLockContentionCount)
+        {
+        }
+
+        protected override Integer32 GetData()
+        {
+            return new Integer32((int)Monitor.LockContentionCount);
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -283,6 +283,9 @@ namespace Raven.Server.Monitoring.Snmp
 
             public const string ServerLimitsPrefix = "1.17.{0}";
 
+            [Description("Monitor lock contention count")]
+            public const string MonitorLockContentionCount = "1.18.1";
+
             public static DynamicJsonArray ToJson()
             {
                 var array = new DynamicJsonArray();

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -508,6 +508,8 @@ namespace Raven.Server.Monitoring.Snmp
             AddGc(GCKind.Ephemeral);
             AddGc(GCKind.FullBlocking);
 
+            store.Add(new MonitorLockContentionCount());
+
             return store;
 
             void AddGc(GCKind gcKind)


### PR DESCRIPTION
- exposed Monitor.LockContentionCount via SNMP
- fixed WellKnownAdminIssuers in SNMP

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22484

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
