### PR TITLE
RavenDB-21428 Ongoing tasks view: Subscription connection errors can'…

### DIFF
--- a/src/Raven.Studio/typescript/common/generalUtils.ts
+++ b/src/Raven.Studio/typescript/common/generalUtils.ts
@@ -351,16 +351,16 @@ class genUtils {
             message = message.toString();
         }
         
-        const lineBreakIdx = Math.min(message.indexOf("\r"), message.indexOf("\r"));
-        if (lineBreakIdx !== -1 && lineBreakIdx < 256) {
-            return message.substr(0, lineBreakIdx);
+        const lineBreakIdx = Math.min(message.indexOf("\n"), message.indexOf("\r"));
+        if (lineBreakIdx !== -1 && lineBreakIdx < limit) {
+            return message.substring(0, lineBreakIdx);
         }
 
         if (message.length < limit) {
             return message;
         }
 
-        return message.substr(0, limit) + "...";
+        return message.substring(0, limit) + "...";
     }
 
     static sortedAlphaNumericIndex<T>(items: T[], newItem: T, extractor: (item: T) => string): number {

--- a/src/Raven.Studio/wwwroot/Content/css/pages/metrics.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/metrics.less
@@ -5,6 +5,10 @@
     
     .tooltip-inner {
         white-space: nowrap;
+        
+        .tooltip-li .value {
+            word-wrap: break-word;
+        }
     }
 
     .extent {
@@ -35,9 +39,6 @@ rect.pane {
 
 .ongoing-tasks-stats {
     
-    .tooltip {
-        pointer-events: none;
-    }
     .tooltip-inner {
         max-width: 400px;
     }


### PR DESCRIPTION
…t be copied and are truncated on the view

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21428 

### Additional description

Better exception view on ongoing stats view. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
