### PR TITLE
RavenDB-17388 Add an eye-icon to view hidden text

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/azureSettings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/azureSettings.ts
@@ -12,6 +12,7 @@ class azureSettings extends backupSettings {
     remoteFolderName = ko.observable<string>();
     accountName = ko.observable<string>();
     accountKey = ko.observable<string>();
+    isKeyHidden = ko.observable<boolean>(true);
     sasToken = ko.observable<string>();
 
     targetOperation: string;
@@ -118,6 +119,10 @@ class azureSettings extends backupSettings {
             SasToken: null,
             GetBackupConfigurationScript: null
         }, targetOperation);
+    }
+
+    toggleIsKeyHidden() {
+        this.isKeyHidden(!this.isKeyHidden());
     }
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/ftpSettings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/ftpSettings.ts
@@ -11,6 +11,7 @@ class ftpSettings extends backupSettings {
     url = ko.observable<string>();
     userName = ko.observable<string>();
     password = ko.observable<string>();
+    isPasswordHidden = ko.observable<boolean>(true);
     certificateAsBase64 = ko.observable<string>();
 
     isLoadingFile = ko.observable<boolean>();
@@ -135,6 +136,10 @@ class ftpSettings extends backupSettings {
             CertificateAsBase64: null,
             GetBackupConfigurationScript: null
         }, targetOperation);
+    }
+
+    toggleIsPasswordHidden() {
+        this.isPasswordHidden(!this.isPasswordHidden());
     }
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/glacierSettings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/glacierSettings.ts
@@ -9,6 +9,7 @@ class glacierSettings extends amazonSettings {
     view = require("views/database/tasks/destinations/glacierSettings.html");
     
     vaultName = ko.observable<string>();
+    isSecretHidden = ko.observable<boolean>(true);
 
     targetOperation: string;
     
@@ -86,6 +87,10 @@ class glacierSettings extends amazonSettings {
             VaultName: null,
             GetBackupConfigurationScript: null
         }, allowedRegions, targetOperation);
+    }
+    
+    toggleIsSecretHidden() {
+        this.isSecretHidden(!this.isSecretHidden());
     }
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/s3Settings.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/destinations/s3Settings.ts
@@ -14,6 +14,7 @@ class s3Settings extends amazonSettings {
     forcePathStyle = ko.observable<boolean>();
     accessKeyPropertyName: KnockoutComputed<string>;
     secretKeyPropertyName: KnockoutComputed<string>;
+    isSecretHidden = ko.observable<boolean>(true);
 
     targetOperation: string;
 
@@ -167,6 +168,10 @@ class s3Settings extends amazonSettings {
             ForcePathStyle: false,
             CustomServerUrl: null,
         }, allowedRegions, targetOperation);
+    }
+    
+    toggleIsSecretHidden() {
+        this.isSecretHidden(!this.isSecretHidden());
     }
 }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/azureSettings.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/azureSettings.html
@@ -21,6 +21,14 @@
 <div class="row margin-bottom" data-bind="validationElement: accountKey">
     <label class="control-label col-xs-12 col-sm-6 col-lg-4">Account key <i class="required"></i></label>
     <div class="col-xs-12 col-sm-6 col-lg-8" >
-        <input data-bind="textInput: accountKey" type="password" class="form-control" />
+        <div class="input-group flex-grow">
+            <input data-bind="textInput: accountKey, attr: { type: isKeyHidden() ? 'password' : 'text' }" class="form-control" />
+            <button type="button" class="btn btn-default" data-bind="click: toggleIsKeyHidden, visible: isKeyHidden()" title="View hidden characters">
+                <i class="icon-preview"></i>
+            </button>
+            <button type="button" class="btn btn-info" data-bind="click: toggleIsKeyHidden, visible: !isKeyHidden()" title="Hide characters">
+                <i class="icon-preview-off"></i>
+            </button>
+        </div>
     </div>
 </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/ftpSettings.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/ftpSettings.html
@@ -15,7 +15,15 @@
 <div class="row margin-bottom" data-bind="validationElement: password">
     <label class="control-label col-xs-12 col-sm-6 col-lg-4">Password <i class="required"></i></label>
     <div class="col-xs-12 col-sm-6 col-lg-8">
-        <input data-bind="textInput: password" type="password" class="form-control" />
+        <div class="input-group flex-grow">
+            <input data-bind="textInput: password, attr: { type: isPasswordHidden() ? 'password' : 'text' }" class="form-control" />
+            <button type="button" class="btn btn-default" data-bind="click: toggleIsPasswordHidden, visible: isPasswordHidden()" title="View hidden characters">
+                <i class="icon-preview"></i>
+            </button>
+            <button type="button" class="btn btn-info" data-bind="click: toggleIsPasswordHidden, visible: !isPasswordHidden()" title="Hide characters">
+                <i class="icon-preview-off"></i>
+            </button>
+        </div>
     </div>
 </div>
 <div class="row margin-bottom" data-bind="visible: isFtps, validationElement: certificateAsBase64">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/glacierSettings.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/glacierSettings.html
@@ -39,6 +39,14 @@
 <div class="row margin-bottom" data-bind="validationElement: awsSecretKey">
     <label class="control-label col-xs-12 col-sm-6 col-lg-4">Secret key <i class="required"></i></label>
     <div class="col-xs-12 col-sm-6 col-lg-8">
-        <input data-bind="textInput: awsSecretKey" type="password" class="form-control" />
+        <div class="input-group flex-grow">
+            <input data-bind="textInput: awsSecretKey, attr: { type: isSecretHidden() ? 'password' : 'text' }" class="form-control" />
+            <button type="button" class="btn btn-default" data-bind="click: toggleIsSecretHidden, visible: isSecretHidden()" title="View hidden characters">
+                <i class="icon-preview"></i>
+            </button>
+            <button type="button" class="btn btn-info" data-bind="click: toggleIsSecretHidden, visible: !isSecretHidden()" title="Hide characters">
+                <i class="icon-preview-off"></i>
+            </button>
+        </div>
     </div>
 </div>

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/s3Settings.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/destinations/s3Settings.html
@@ -67,6 +67,14 @@
 <div class="row margin-bottom" data-bind="validationElement: awsSecretKey">
     <label class="control-label col-xs-12 col-sm-6 col-lg-4"><span data-bind="text: secretKeyPropertyName"></span> <i class="required"></i></label>
     <div class="col-xs-12 col-sm-6 col-lg-8">
-        <input data-bind="textInput: awsSecretKey" type="password" class="form-control" />
+        <div class="input-group flex-grow">
+            <input data-bind="textInput: awsSecretKey, attr: { type: isSecretHidden() ? 'password' : 'text' }" class="form-control" />
+            <button type="button" class="btn btn-default" data-bind="click: toggleIsSecretHidden, visible: isSecretHidden()" title="View hidden characters">
+                <i class="icon-preview"></i>
+            </button>
+            <button type="button" class="btn btn-info" data-bind="click: toggleIsSecretHidden, visible: !isSecretHidden()" title="Hide characters">
+                <i class="icon-preview-off"></i>
+            </button>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17388/Add-an-eye-icon-to-view-hidden-text

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
