### PR TITLE
RavenDB-20285 Add links to ongoing tasks widget

### DIFF
--- a/src/Raven.Studio/typescript/common/appUrl.ts
+++ b/src/Raven.Studio/typescript/common/appUrl.ts
@@ -563,7 +563,7 @@ class appUrl {
         return "#databases/tasks/backups?" + databasePart;
     }
     
-    static forOngoingTasks(db: database | databaseInfo): string {
+    static forOngoingTasks(db: database | databaseInfo | string): string {
         const databasePart = appUrl.getEncodedDbPart(db);
         return "#databases/tasks/ongoingTasks?" + databasePart;
     }

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/ongoingTasksWidget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/ongoingTasksWidget.ts
@@ -3,11 +3,13 @@ import websocketBasedWidget = require("viewmodels/resources/widgets/websocketBas
 import virtualGridController = require("widgets/virtualGrid/virtualGridController");
 import virtualColumn = require("widgets/virtualGrid/columns/virtualColumn");
 import iconsPlusTextColumn = require("widgets/virtualGrid/columns/iconsPlusTextColumn");
-import textColumn = require("widgets/virtualGrid/columns/textColumn");
 import genUtils = require("common/generalUtils");
 import clusterDashboardWebSocketClient = require("common/clusterDashboardWebSocketClient");
 import multiNodeTagsColumn = require("widgets/virtualGrid/columns/multiNodeTagsColumn");
 import taskItem = require("models/resources/widgets/taskItem");
+import hyperlinkColumn = require("widgets/virtualGrid/columns/hyperlinkColumn");
+import appUrl = require("common/appUrl");
+import clusterTopologyManager = require("common/shell/clusterTopologyManager");
 
 class ongoingTasksWidget extends websocketBasedWidget<Raven.Server.Dashboard.Cluster.Notifications.OngoingTasksPayload> {
 
@@ -183,35 +185,66 @@ class ongoingTasksWidget extends websocketBasedWidget<Raven.Server.Dashboard.Clu
     private getTaskCountClass(item: taskItem): string {
         if (!item.isTitleItem()) {
             return ""
-    }
+        }
         
         if (item.taskCount()) {
             return "text-bold";
-    }
+        }
 
         return "text-muted small";
+    }
+
+    private getOngoingTasksUrlForNode(databaseName: string, nodeTag: string): string {
+        const node = clusterTopologyManager.default.getClusterNodeByTag(nodeTag);
+
+        if (!node) {
+            return "#"
         }
+
+        return node.serverUrl() + "/studio/index.html" + appUrl.forOngoingTasks(databaseName);
+    }
 
     private prepareColumns(): virtualColumn[] {
         const grid = this.gridController();
         return [
-            new iconsPlusTextColumn<taskItem>(grid, x => x.isTitleItem() ? this.getTaskTypeHtml(x) : "", "Task", "30%", {
-                headerTitle: "Tasks type"
-            }),
-
-            new iconsPlusTextColumn<taskItem>(grid, x => this.getTaskCountHtml(x), "Count", "15%", {
-                headerTitle: "Tasks count"
-            }),
-
-            new textColumn<taskItem>(grid, x => x.isTitleItem() ? "" : x.databaseName(), "Database", "30%", {
-                title: x => x.databaseName()
-            }),
-
-            new multiNodeTagsColumn(grid, taskItem.createNodeTagsProvider(), "20%", {
-                headerTitle: "Nodes running the tasks"
-            })
+            new iconsPlusTextColumn<taskItem>(
+                grid, x => x.isTitleItem() ? this.getTaskTypeHtml(x) : "",
+                "Task",
+                "30%",
+                {
+                    headerTitle: "Tasks type"
+                }
+            ),
+            new iconsPlusTextColumn<taskItem>(
+                grid,
+                x => this.getTaskCountHtml(x),
+                "Count",
+                "15%",
+                {
+                    headerTitle: "Tasks count"
+                }
+            ),
+            new hyperlinkColumn<taskItem>(
+                grid, x => x.isTitleItem() ? "" : x.databaseName(),
+                x => appUrl.forOngoingTasks(x.databaseName()),
+                "Database",
+                "30%",
+                {
+                    title: x => `Ongoing tasks for database ${x.databaseName()}`
+                }
+            ),
+            new multiNodeTagsColumn<taskItem>(
+                grid,
+                taskItem.createNodeTagsProvider(),
+                "20%",
+                {
+                    headerTitle: "Nodes running the tasks",
+                    nodeHrefAccessor: (item, nodeTag) => this.getOngoingTasksUrlForNode(item.databaseName(), nodeTag),
+                    nodeLinkTitleAccessor: (item, nodeTag) => `Ongoing tasks for database ${item.databaseName()} on node ${nodeTag}`
+                }
+            )
         ];
-        }
+    }
 
     reducePerDatabase(itemsArray: rawTaskItem[]): taskItem[] {
         const output: taskItem[] = [];

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columns/multiNodeTagsColumn.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columns/multiNodeTagsColumn.ts
@@ -5,11 +5,16 @@ import virtualColumn = require("widgets/virtualGrid/columns/virtualColumn");
 import generalUtils = require("common/generalUtils");
 
 class multiNodeTagsColumn<T extends object> implements virtualColumn {
+    private readonly nodeHrefAccessor: (item: T, nodeTag: string) => string;
+    private readonly nodeLinkTitleAccessor: (item: T, nodeTag: string) => string;
 
     constructor(gridController: virtualGridController<T>,
-                public valueAccessor: ((item: T) => string[]),
-                public width: string,
-                public opts: textColumnOpts<T> = {}) {
+        public valueAccessor: ((item: T) => string[]),
+        public width: string,
+        public opts: multiNodeTagsColumnOpts<T> = {}
+    ) {
+        this.nodeHrefAccessor = opts.nodeHrefAccessor;
+        this.nodeLinkTitleAccessor = opts.nodeLinkTitleAccessor;
     }
 
     canHandle(actionId: string): boolean {
@@ -34,20 +39,31 @@ class multiNodeTagsColumn<T extends object> implements virtualColumn {
     renderCell(item: T): string {
         const extraCssClasses = this.opts.extraClass ? this.opts.extraClass(item) : '';
         
-        return `<div class="cell text-cell ${extraCssClasses}" style="width: ${this.width}">${this.getValueHtml(this.getValue(item))}</div>`;
+        return `<div class="cell text-cell ${extraCssClasses}" style="width: ${this.width}; display: flex">${this.getValueHtml(item)}</div>`;
     }
     
     private getValue(item: T): string[] {
         return this.valueAccessor.bind(item)(item);
     }
 
-    private getValueHtml(nodeTags: string[]): string {
+    private getValueHtml(item: T): string {
         let result = "";
-        
+        const nodeTags = this.getValue(item);
+
         if (nodeTags) {
             for (const tag of nodeTags) {
                 const extraClass = `node-${tag}`;
-                result += `<span class="node-label ${extraClass}">${tag}</span>`;
+
+                let nodeHtml = `<span class="node-label ${extraClass}">${tag}</span>`;
+                
+                if (this.nodeHrefAccessor) {
+                    const href = this.nodeHrefAccessor(item, tag);
+                    const title = this.nodeLinkTitleAccessor ? this.nodeLinkTitleAccessor(item, tag) : tag;
+
+                    nodeHtml = `<a href="${href}" title="${title}">${nodeHtml}</a>`;
+                }
+
+                result += nodeHtml;
             }
         }
 

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -697,6 +697,11 @@ interface hypertextColumnOpts<T> extends textColumnOpts<T> {
     openInNewTab?: (item: T) => boolean;
 }
 
+interface multiNodeTagsColumnOpts<T> extends textColumnOpts<T> {
+    nodeHrefAccessor?: (item: T, nodeTag: string) => string;
+    nodeLinkTitleAccessor?: (item: T, nodeTag: string) => string;
+}
+
 type timeSeriesColumnEventType = "plot" | "preview";
 
 interface timeSeriesColumnOpts<T> extends textColumnOpts<T> {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20285/Ongoing-tasks-widget-does-not-link-anywhere

### Additional description

Adds link to ongoing task for database and node.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
