### PR TITLE
RavenDB-19741 take into account server-wide configuration when determining identity parts separator on the database side

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReferencesPattern.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReferencesPattern.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.RegularExpressions;
+using Raven.Client;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static;
 
@@ -126,7 +127,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
 
             public void ValidateId(string id)
             {
-                var identityPartsSeparator = _database?.IdentityPartsSeparator ?? '/';
+                var identityPartsSeparator = _database?.IdentityPartsSeparator ?? Constants.Identities.DefaultSeparator;
 
                 if (id.EndsWith(identityPartsSeparator))
                     ThrowInvalidId(id, $"reference ID must not end with '{identityPartsSeparator}' character");

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.Configuration.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.Configuration.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Raven.Client;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.ServerWide;
+
+public sealed partial class ClusterStateMachine
+{
+    private void PutClientConfiguration(ClusterOperationContext context, string type, BlittableJsonReaderObject cmd, long index, ServerStore serverStore)
+    {
+        Exception exception = null;
+        PutClientConfigurationCommand command = null;
+        try
+        {
+            command = (PutClientConfigurationCommand)JsonDeserializationCluster.Commands[type](cmd);
+            if (command.Name.StartsWith(Constants.Documents.Prefix))
+                throw new RachisApplyException("Cannot set " + command.Name + " using PutValueCommand, only via dedicated database calls");
+
+            command.UpdateValue(context, index);
+
+            using (var rec = context.ReadObject(command.ValueToJson(), "inner-val"))
+                PutValueDirectly(context, command.Name, rec, index);
+
+            context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented += _ => _parent.ServerStore.LoadDefaultIdentityPartsSeparator(command.Value);
+        }
+        catch (Exception e)
+        {
+            exception = e;
+            throw;
+        }
+        finally
+        {
+            LogCommand(type, index, exception, command);
+            NotifyValueChanged(context, type, index);
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -642,7 +642,7 @@ namespace Raven.Server.ServerWide
 
                     case nameof(PutClientConfigurationCommand):
                         AssertLicenseLimits(type, serverStore, databaseRecord: null, items: null, context);
-                        PutValue<ClientConfiguration>(context, type, cmd, index);
+                        PutClientConfiguration(context, type, cmd, index, serverStore);
                         break;
 
                     case nameof(PutServerWideStudioConfigurationCommand):

--- a/test/SlowTests/Issues/RavenDB_19741.cs
+++ b/test/SlowTests/Issues/RavenDB_19741.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_19741 : RavenTestBase
+{
+    public RavenDB_19741(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task Will_Respect_Server_Wide_Client_Configuration_For_IdentityPartsSeparator()
+    {
+        UseNewLocalServer();
+
+        using (var store = GetDocumentStore())
+        {
+            await store.Maintenance.Server.SendAsync(new PutServerWideClientConfigurationOperation(new ClientConfiguration
+            {
+                Disabled = true,
+                IdentityPartsSeparator = '^'
+            }));
+
+            var database = await GetDatabase(store.Database);
+
+            Assert.Equal(Constants.Identities.DefaultSeparator, database.IdentityPartsSeparator);
+
+            await store.Maintenance.Server.SendAsync(new PutServerWideClientConfigurationOperation(new ClientConfiguration
+            {
+                Disabled = false,
+                IdentityPartsSeparator = '^'
+            }));
+
+            Assert.Equal('^', database.IdentityPartsSeparator);
+
+            Server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+
+            database = await GetDatabase(store.Database);
+
+            Assert.Equal('^', database.IdentityPartsSeparator);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19741

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
