### PR TITLE
RavenDB-21683 adding index created timestamp to the result etag calculation in order to avoid a situation where result etag is the same after changing index configuration option that could affect the returned results

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3034,7 +3034,7 @@ namespace Raven.Server.Documents.Indexes
         {
             // multiple maps can reference the same collections, we wants to return distinct names only
             return GetReferencedCollections()?
-                .SelectMany(p =>  p.Value?.Select(z => z.Name))
+                .SelectMany(p => p.Value?.Select(z => z.Name))
                 .ToHashSet();
         }
 
@@ -4084,7 +4084,8 @@ namespace Raven.Server.Documents.Indexes
             var length = sizeof(long) * 4 * Collections.Count + // last document etag, last tombstone etag and last mapped etags per collection
                          sizeof(int) + // definition hash
                          1 + // isStale
-                         1; // index state
+                         1 + // index state
+                         sizeof(long); // created timestamp (binary)
 
             if (q == null)
                 return length;
@@ -4126,6 +4127,8 @@ namespace Raven.Server.Documents.Indexes
             *indexEtagBytes = isStale ? (byte)0 : (byte)1;
             indexEtagBytes += sizeof(byte);
             *indexEtagBytes = (byte)indexState;
+            indexEtagBytes += sizeof(byte);
+            *(long*)indexEtagBytes = _indexStorage.CreatedTimestampAsBinary;
         }
 
         public long GetIndexEtag(QueryOperationContext context, QueryMetadata q)
@@ -4179,7 +4182,7 @@ namespace Raven.Server.Documents.Indexes
         {
             var dict = new Dictionary<TombstoneDeletionBlockageSource, HashSet<string>>();
 
-            if (Status is not (IndexRunningStatus.Disabled or IndexRunningStatus.Paused)) 
+            if (Status is not (IndexRunningStatus.Disabled or IndexRunningStatus.Paused))
                 return dict;
 
             var source = new TombstoneDeletionBlockageSource(ITombstoneAware.TombstoneDeletionBlockerType.Index, Name);

--- a/test/SlowTests/Issues/RavenDB_21683.cs
+++ b/test/SlowTests/Issues/RavenDB_21683.cs
@@ -1,0 +1,95 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21683 : RavenTestBase
+{
+    public RavenDB_21683(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    public async Task Index_Configuration_That_Resets_Index_Should_Change_ResultEtag()
+    {
+        using (var store = GetDocumentStore(new Options { RunInMemory = false }))
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Company { Name = "HR" });
+                await session.SaveChangesAsync();
+            }
+
+            var index = new Companies_ByName();
+            var indexDefinition = index.CreateIndexDefinition();
+
+            await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session
+                    .Query<Company, Companies_ByName>()
+                    .Statistics(out var initialStats)
+                    .ToListAsync();
+
+                // will cause index refresh only
+                indexDefinition.Configuration[RavenConfiguration.GetKey(x => x.Indexing.MaxTimeForDocumentTransactionToRemainOpen)] = "10";
+
+                await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+                Indexes.WaitForIndexing(store);
+
+                await session
+                    .Query<Company, Companies_ByName>()
+                    .Statistics(out var stats)
+                    .ToListAsync();
+
+                Assert.Equal(initialStats.ResultEtag, stats.ResultEtag);
+
+                // will cause index reset
+                indexDefinition.Configuration[RavenConfiguration.GetKey(x => x.Indexing.IndexEmptyEntries)] = "true";
+
+                await store.Maintenance.SendAsync(new PutIndexesOperation(indexDefinition));
+                Indexes.WaitForIndexing(store);
+
+                await session
+                    .Query<Company, Companies_ByName>()
+                    .Statistics(out var lastStats)
+                    .ToListAsync();
+
+                Assert.NotEqual(initialStats.ResultEtag, lastStats.ResultEtag);
+
+                // checking if etag is stable after database restart
+                Server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+
+                await session
+                    .Query<Company, Companies_ByName>()
+                    .Statistics(out stats)
+                    .ToListAsync();
+
+                Assert.Equal(lastStats.ResultEtag, stats.ResultEtag);
+            }
+        }
+    }
+
+    private class Companies_ByName : AbstractIndexCreationTask<Company>
+    {
+        public Companies_ByName()
+        {
+            Map = companies => from company in companies
+                               select new
+                               {
+                                   Name = company.Name
+                               };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21683

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
