### PR TITLE
RavenDB-19194 Add navigation buttons to revisions compare view

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -108,16 +108,26 @@
                         <span class="text-warning" data-bind="visible: $root.leftRevisionIsNewer()">Older revision:</span>
                         <span class="text-success" data-bind="visible: !$root.leftRevisionIsNewer()">Newer revision:</span>
                     </span>
-                    <span class="margin-left margin-left-sm" data-bind="text: $root.comparingWith() ? $root.comparingWith().__metadata.lastModified() : ''"></span>
-                    <div class="dropdown pull-right" data-bind="if: comparingWith">
-                        <button type="button" class="btn btn-sm dropdown-toggle" data-toggle="dropdown">
-                            Compare with: <span class="caret margin-left margin-left-sm"></span>
-                        </button>
-                        <ul class="dropdown-menu" data-bind="foreach: revisionsToCompare">
-                            <li data-bind="css: { active: $data === $root.comparingWith() }">
-                                <a href="#" data-bind="text: $data.__metadata.lastModified(), click: _.partial($root.compareRevisions, $data)"></a>
-                            </li>
-                        </ul>
+                    <div data-bind="if: comparingWith" class="margin-left margin-left-sm inline-block">
+                        <div class="btn-group">
+                            <button class="btn btn-sm btn-default" title="Previous revision" 
+                                    data-bind="click: _.partial(revisionNavigate, 'backward', 'right'), enable: canNavigateObservable('backward', 'right')">
+                                <i class="icon-arrow-filled-left"></i>
+                            </button>
+                            <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" title="Choose revision">
+                                <span data-bind="text: $root.comparingWith().__metadata.lastModified()"></span> <span class="caret margin-left margin-left-sm"></span>
+                            </button>
+                            <ul class="dropdown-menu" data-bind="foreach: revisionsToCompare">
+                                <li data-bind="css: { active: $data === $root.comparingWith() }">
+                                    <a href="#" data-bind="text: $data.__metadata.lastModified(), click: _.partial($root.compareRevisions, $data)"></a>
+                                </li>
+                            </ul>
+                            <button class="btn btn-sm btn-default" title="Next revision" 
+                                    data-bind="click: _.partial(revisionNavigate, 'forward', 'right'), enable: canNavigateObservable('forward', 'right')">
+                                <i class="icon-arrow-filled-right"></i>
+                            </button>
+                        </div>
+                       
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19194 

### Additional description

Add ability to navigate between revisions between revisions

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
