### PR TITLE
RavenDB-19152 - SlowTests.Server.Documents.Revisions.RevisionsReplica…

### DIFF
--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -19,6 +19,7 @@ using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Sharding;
+using Raven.Server;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Revisions;
 using Raven.Server.NotificationCenter;
@@ -455,6 +456,8 @@ namespace SlowTests.Server.Documents.Revisions
 
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store1);
+
+                Assert.True(await WaitForChangeVectorInClusterForModeAsync(new List<RavenServer>{ cluster.Nodes[0], cluster.Nodes[1] }, database, mode: options.DatabaseMode, timeout: 30_000));
 
                 using (var session1 = store1.OpenAsyncSession())
                 using (var session2 = store2.OpenAsyncSession())

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -457,7 +457,7 @@ namespace SlowTests.Server.Documents.Revisions
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store1);
 
-                Assert.True(await WaitForChangeVectorInClusterForModeAsync(new List<RavenServer>{ cluster.Nodes[0], cluster.Nodes[1] }, database, mode: options.DatabaseMode, timeout: 30_000));
+                Assert.True(await WaitForChangeVectorInClusterForModeAsync(new List<RavenServer>{ cluster.Nodes[0], cluster.Nodes[1] }, database, mode: options.DatabaseMode, replicationFactor: 2, timeout: 30_000));
 
                 using (var session1 = store1.OpenAsyncSession())
                 using (var session2 = store2.OpenAsyncSession())


### PR DESCRIPTION
…tion.IdenticalRevisionCountCluster(options: DatabaseMode = Single , SearchEngineMode = Lucene)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19152/SlowTests.Server.Documents.Revisions.RevisionsReplication.IdenticalRevisionCountClusteroptions-DatabaseMode-Single

### Additional description

I tested this multiple times, and it failed around the 600th iteration. After implementing the suggested change, I ran it for over 10,000 iterations without any issues. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
