### PR TITLE
RavenDB-22473 - allow to backup all shards of the same database concurrently

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
@@ -55,7 +55,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                 AssertBackup(backupConfiguration);
 
                 var sw = Stopwatch.StartNew();
-                ServerStore.ConcurrentBackupsCounter.StartBackup(backupName, Logger);
+                ServerStore.ConcurrentBackupsCounter.StartBackup(RequestHandler.DatabaseName, backupName, Logger);
                 try
                 {
                     var cancelToken = RequestHandler.CreateBackgroundOperationToken();
@@ -70,7 +70,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                 }
                 catch (Exception e)
                 {
-                    ServerStore.ConcurrentBackupsCounter.FinishBackup(backupName, backupStatus: null, sw.Elapsed, Logger);
+                    ServerStore.ConcurrentBackupsCounter.FinishBackup(RequestHandler.DatabaseName, backupName, backupStatus: null, sw.Elapsed, Logger);
 
                     var message = $"Failed to run backup: '{backupName}'";
 

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForBackupDatabaseOnce.cs
@@ -78,7 +78,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                         }
                         finally
                         {
-                            ServerStore.ConcurrentBackupsCounter.FinishBackup(backupName, backupStatus: null, sw.Elapsed, Logger);
+                            ServerStore.ConcurrentBackupsCounter.FinishBackup(RequestHandler.DatabaseName, backupName, backupStatus: null, sw.Elapsed, Logger);
                         }
                     }, null, ThreadNames.ForBackup(threadName, backupName, RequestHandler.DatabaseName));
                     return tcs.Task;

--- a/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
@@ -314,17 +314,22 @@ public partial class RavenTestBase
             }
         }
 
+        public Task<WaitHandle[]> WaitForBackupToComplete(IDocumentStore store, RavenServer server)
+        {
+            return WaitForBackupsToComplete(new[] { store }, [server]);
+        }
+
         public Task<WaitHandle[]> WaitForBackupToComplete(IDocumentStore store)
         {
             return WaitForBackupsToComplete(new[] { store });
         }
 
-        public async Task<WaitHandle[]> WaitForBackupsToComplete(IEnumerable<IDocumentStore> stores)
+        public async Task<WaitHandle[]> WaitForBackupsToComplete(IEnumerable<IDocumentStore> stores, List<RavenServer> servers = null)
         {
             var waitHandles = new List<WaitHandle>();
             foreach (var store in stores)
             {
-                await foreach (var db in _parent.Sharding.GetShardsDocumentDatabaseInstancesFor(store))
+                await foreach (var db in _parent.Sharding.GetShardsDocumentDatabaseInstancesFor(store, servers))
                 {
                     BackupTestBase.FillBackupCompletionHandles(waitHandles, db);
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22473/Unable-to-execute-a-backup-on-sharded-DB

### Additional description

Allow to backup all shards of the same database concurrently.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
