### PR TITLE
RavenDB-20511: throw less SubscriptionDoesNotBelongToNodeException on unstable cluster

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -797,6 +797,12 @@ namespace Raven.Server.Documents.Subscriptions
                 }
             }
 
+            if (_subscriptionStorage.ShouldWaitForClusterStabilization())
+            {
+                // in case of unstable cluster, we will try to heartbeat the client for 30 seconds and then send actual no-op command
+                return;
+            }
+
             var (etag, _) = await _documentsStorage.DocumentDatabase.ServerStore.SendToLeaderAsync(command);
             await _documentsStorage.DocumentDatabase.RachisLogIndexNotifications.WaitForIndexNotification(etag, _documentsStorage.DocumentDatabase.ServerStore.Engine.OperationTimeout);
         }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionStorage.cs
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents.Subscriptions
             _db = db;
             _serverStore = serverStore;
             _logger = LoggingSource.Instance.GetLogger<SubscriptionStorage>(db.Name);
-
+            WaitForClusterStabilizationTimeout = TimeSpan.FromMilliseconds(Math.Max(30000, (int)(2 * serverStore.Engine.OperationTimeout.TotalMilliseconds)));
             _concurrentConnectionsSemiSemaphore = new SemaphoreSlim(db.Configuration.Subscriptions.MaxNumberOfConcurrentConnections);
             LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
         }
@@ -675,6 +675,35 @@ namespace Raven.Server.Documents.Subscriptions
             return subscriptionData;
         }
 
+        public TimeSpan WaitForClusterStabilizationTimeout;
+
+        public bool ShouldWaitForClusterStabilization()
+        {
+            var lastState = _serverStore.Engine.LastState;
+            if (lastState == null)
+                return false;
+
+            switch (lastState.To)
+            {
+                // get last cluster state
+                case RachisState.Passive:
+                    // if the last state was passive, we will throw on next cluster command
+                    return false;
+                case RachisState.Candidate:
+                    {
+                        if (DateTime.UtcNow - lastState.When < WaitForClusterStabilizationTimeout)
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    }
+                default:
+                    // we are fine to proceed with the subscription on this node
+                    return false;
+            }
+        }
+
         public void HandleDatabaseRecordChange(DatabaseTopology topology)
         {
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
@@ -720,11 +749,18 @@ namespace Raven.Server.Documents.Subscriptions
                         continue;
                     }
 
-                    var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, topology, subscriptionState, subscriptionState, _db.NotificationCenter);
+                    if (_serverStore.Engine.CurrentState == RachisState.Passive)
+                    {
+                        DropSubscriptionConnections(subscriptionStateKvp.Key,
+                            new SubscriptionDoesNotBelongToNodeException($"Subscription operation was stopped on '{_serverStore.NodeTag}', because current node state is '{RachisState.Passive}'."));
+                    }
+
+                    // we pass here RachisState.Follower so the task won't be disconnected if the node is in candidate state
+                    var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, topology, RachisState.Follower, subscriptionState, subscriptionState, _db.NotificationCenter);
                     if (whoseTaskIsIt != _serverStore.NodeTag)
                     {
                         DropSubscriptionConnections(subscriptionStateKvp.Key,
-                            new SubscriptionDoesNotBelongToNodeException("Subscription operation was stopped, because it's now under a different server's responsibility"));
+                            new SubscriptionDoesNotBelongToNodeException($"Subscription operation was stopped on '{_serverStore.NodeTag}', because it's now under node '{whoseTaskIsIt}' responsibility"));
                     }
                 }
             }

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -238,7 +238,7 @@ namespace Raven.Server.Documents.TcpHandlers
             await TcpConnection.DocumentDatabase.SubscriptionStorage.UpdateClientConnectionTime(SubscriptionState.SubscriptionId,
                 SubscriptionState.SubscriptionName, SubscriptionState.MentorNode);
 
-            await SubscriptionConnectionsState.SendNoopAck();
+            await SubscriptionConnectionsState.SendNoopAck(force: true);
             await WriteJsonAsync(new DynamicJsonValue
             {
                 [nameof(SubscriptionConnectionServerMessage.Type)] = nameof(SubscriptionConnectionServerMessage.MessageType.ConnectionStatus),
@@ -818,20 +818,28 @@ namespace Raven.Server.Documents.TcpHandlers
             SubscriptionConnectionClientMessage clientReply;
             while (true)
             {
-                var result = await Task.WhenAny(replyFromClientTask,
-                    TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(5000), CancellationTokenSource.Token)).ConfigureAwait(false);
+                var timeoutTask = TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(5000), CancellationTokenSource.Token);
+                var result = await Task.WhenAny(replyFromClientTask, timeoutTask).ConfigureAwait(false);
                 CancellationTokenSource.Token.ThrowIfCancellationRequested();
                 if (result == replyFromClientTask)
                 {
-                    clientReply = await replyFromClientTask;
-                    if (clientReply.Type == SubscriptionConnectionClientMessage.MessageType.DisposedNotification)
+                    if (TcpConnection.DocumentDatabase.SubscriptionStorage.ShouldWaitForClusterStabilization())
                     {
-                        CancellationTokenSource.Cancel();
+                        // we have unstable cluster
+                        await timeoutTask;
+                    }
+                    else
+                    {
+                        clientReply = await replyFromClientTask;
+                        if (clientReply.Type == SubscriptionConnectionClientMessage.MessageType.DisposedNotification)
+                        {
+                            await CancellationTokenSource.CancelAsync();
+                            break;
+                        }
+
+                        replyFromClientTask = _lastReplyFromClientTask = GetReplyFromClientAsync();
                         break;
                     }
-
-                    replyFromClientTask = _lastReplyFromClientTask = GetReplyFromClientAsync();
-                    break;
                 }
 
                 await SendHeartBeatAsync("Waiting for client ACK");
@@ -1245,6 +1253,11 @@ namespace Raven.Server.Documents.TcpHandlers
                     {
                         // it's supposed this task will fail here since we disposed all resources used by connection
                         // but we must wait for it before we release _copiedBuffer
+                        _lastReplyFromClientTask.Wait();
+                    }
+                    else if (_lastReplyFromClientTask is { IsFaulted: true })
+                    {
+                        // need to catch the exception here to prevent UnobservedTaskException 
                         _lastReplyFromClientTask.Wait();
                     }
                 }

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -1149,9 +1149,9 @@ namespace Raven.Server.Documents.TcpHandlers
             do
             {
                 var hasMoreDocsTask = _subscriptionConnectionsState.WaitForMoreDocs();
-
+                var timeoutTask = TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(WaitForChangedDocumentsTimeoutInMs));
                 var resultingTask = await Task
-                    .WhenAny(hasMoreDocsTask, pendingReply, TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(WaitForChangedDocumentsTimeoutInMs))).ConfigureAwait(false);
+                    .WhenAny(hasMoreDocsTask, pendingReply, timeoutTask).ConfigureAwait(false);
 
                 TcpConnection.DocumentDatabase.ForTestingPurposes?.Subscription_ActionToCallDuringWaitForChangedDocuments?.Invoke();
 
@@ -1163,8 +1163,16 @@ namespace Raven.Server.Documents.TcpHandlers
 
                 if (hasMoreDocsTask == resultingTask)
                 {
-                    _subscriptionConnectionsState.NotifyNoMoreDocs();
-                    return true;
+                    if (TcpConnection.DocumentDatabase.SubscriptionStorage.ShouldWaitForClusterStabilization())
+                    {
+                        // we have unstable cluster
+                        await timeoutTask;
+                    }
+                    else
+                    {
+                        _subscriptionConnectionsState.NotifyNoMoreDocs();
+                        return true;
+                    }
                 }
 
                 await SendHeartBeatAsync("Waiting for changed documents");

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -896,7 +896,12 @@ namespace Raven.Server.Rachis
             PrevStates.LimitedSizeEnqueue(transition, 5);
 
             context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented +=
-                _ => CurrentState = rachisState; //  we need this to happened while we still under the write lock
+                _ =>
+                {
+                    CurrentState = rachisState;
+                    LastState = transition;
+
+                }; //  we need this to happened while we still under the write lock
 
             context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>
             {
@@ -981,6 +986,7 @@ namespace Raven.Server.Rachis
             });
         }
 
+        public StateTransition LastState;
         public ConcurrentQueue<StateTransition> PrevStates { get; set; } = new ConcurrentQueue<StateTransition>();
 
         public bool TakeOffice()

--- a/src/Raven.Server/Utils/OngoingTasksUtils.cs
+++ b/src/Raven.Server/Utils/OngoingTasksUtils.cs
@@ -16,10 +16,16 @@ internal static class OngoingTasksUtils
         IDatabaseTaskStatus taskStatus,
         NotificationCenter.NotificationCenter notificationCenter)
     {
+        return WhoseTaskIsIt(serverStore, databaseTopology, serverStore.Engine.CurrentState, configuration, taskStatus, notificationCenter);
+    }
+
+    internal static string WhoseTaskIsIt(ServerStore serverStore, DatabaseTopology databaseTopology, RachisState currentState, IDatabaseTask configuration, IDatabaseTaskStatus taskStatus,
+        NotificationCenter.NotificationCenter notificationCenter)
+    {
         Debug.Assert(taskStatus is not PeriodicBackupStatus);
 
         var whoseTaskIsIt = databaseTopology.WhoseTaskIsIt(
-            serverStore.Engine.CurrentState, configuration,
+            currentState, configuration,
             getLastResponsibleNode:
             () =>
             {


### PR DESCRIPTION
…

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20511

### Additional description

in case the engine state is candidate, don't drop subscription connection, try to wait until it become follower/leader

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
