### PR TITLE
RavenDB-22516 Fix ordering by multiple fields in Corax

### DIFF
--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Helpers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Helpers.cs
@@ -106,13 +106,11 @@ public unsafe partial struct SortingMultiMatch<TInner>
             where TComparer2 : struct, IComparer<UnmanagedSpan>, IComparer<int>, IEntryComparer
             where TComparer3 : struct, IComparer<UnmanagedSpan>, IComparer<int>, IEntryComparer
         {
-            
             if (match._orderMetadata[0].Ascending)
                 indexes.Sort(new IndirectComparer<TComparer1, TComparer2, TComparer3>(ref match, batchTerms, comparer1,
-                comparer2, comparer3, false));
+                comparer2, comparer3));
             else
-                indexes.Sort(new IndirectComparer<Descending<TComparer1>, TComparer2, TComparer3>(ref match, batchTerms, new(comparer1), comparer2, comparer3, true));
-
+                indexes.Sort(new IndirectComparer<Descending<TComparer1>, TComparer2, TComparer3>(ref match, batchTerms, new(comparer1), comparer2, comparer3));
             
             // Support for including scores in the projection in case the score comparer is not first. 
             // We only have one chance to copy in the right order before pagination happens

--- a/test/SlowTests/Issues/RavenDB-22516.cs
+++ b/test/SlowTests/Issues/RavenDB-22516.cs
@@ -1,0 +1,117 @@
+using System.Linq;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22516 : RavenTestBase
+{
+    public RavenDB_22516(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TestMultipleOrdering(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var bar1 = new Bar() { Foo = new Foo(){ BarBool = true, BarShort = 14, BarLong = 21 } };
+                var bar2 = new Bar() { Foo = new Foo(){ BarBool = true, BarShort = 12, BarLong = 21 } };
+                
+                session.Store(bar1);
+                session.Store(bar2);
+                
+                session.SaveChanges();
+                
+                var result = session.Query<Bar>()
+                    .OrderByDescending(dto => dto.Foo.BarBool)
+                    .ThenByDescending(dto => dto.Foo.BarShort)
+                    .ToList();
+
+                Assert.Equal(bar1.Id, result[0].Id);
+                Assert.Equal(bar2.Id, result[1].Id);
+                
+                var bar3 = new Bar() { Foo = new Foo(){ BarBool = true, BarShort = 14, BarLong = 37 } };
+                
+                session.Store(bar3);
+                
+                session.SaveChanges();
+                
+                result = session.Query<Bar>()
+                    .OrderByDescending(dto => dto.Foo.BarBool)
+                    .ThenByDescending(dto => dto.Foo.BarShort)
+                    .ThenByDescending(dto => dto.Foo.BarLong)
+                    .ToList();
+                
+                Assert.Equal(bar3.Id, result[0].Id);
+                Assert.Equal(bar1.Id, result[1].Id);
+                Assert.Equal(bar2.Id, result[2].Id);
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TestEntryComparerByLong(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto { FirstLong = 21, SecondLong = 37 };
+                var dto2 = new Dto { FirstLong = 21, SecondLong = 10 };
+                var dto3 = new Dto { FirstLong = 21, SecondLong = 21 };
+                
+                session.Store(dto1);
+                session.Store(dto2);
+                session.Store(dto3);
+                
+                session.SaveChanges();
+                
+                var result = session.Query<Dto>()
+                    .OrderByDescending(dto => dto.FirstLong)
+                    .ThenByDescending(dto => dto.SecondLong)
+                    .ToList();
+                
+                Assert.Equal(dto1.Id, result[0].Id);
+                Assert.Equal(dto3.Id, result[1].Id);
+                Assert.Equal(dto2.Id, result[2].Id);
+                
+                result = session.Query<Dto>()
+                    .OrderByDescending(dto => dto.FirstLong)
+                    .ThenBy(dto => dto.SecondLong)
+                    .ToList();
+                
+                Assert.Equal(dto2.Id, result[0].Id);
+                Assert.Equal(dto3.Id, result[1].Id);
+                Assert.Equal(dto1.Id, result[2].Id);
+            }
+        }
+    }
+
+    private class Bar
+    {
+        public string Id { get; set; }
+        public Foo Foo { get; set; } = null!;
+    }
+    
+    private class Foo
+    {
+        public string Id { get; set; }
+        public short BarShort { get; set; }
+        public bool BarBool { get; set; }
+        public long BarLong { get; set; }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public long FirstLong { get; set; }
+        public long SecondLong { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22516/Ordering-by-second-property-doesnt-work-properly-in-Corax

### Additional description

Descending ordering should be handled by particular comparers rather than `IndirectComparer`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
