### PR TITLE
RavenDB-22551 we need to use same comparer as in the source dictionary when construction FrozenDictionary

### DIFF
--- a/src/Raven.Server/Documents/ResourceCache.cs
+++ b/src/Raven.Server/Documents/ResourceCache.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;
 using Raven.Client.Util;
+using Raven.Server.Extensions;
 using Sparrow;
 using Sparrow.Collections;
 
@@ -31,9 +32,9 @@ namespace Raven.Server.Documents
 
         public ResourceCache()
         {
-            _readonlyCaseSensitive = _caseSensitive.ToFrozenDictionary();
-            _readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionary();
-            _readonlyResourceDetails = _resourceDetails.ToFrozenDictionary();
+            _readonlyCaseSensitive = _caseSensitive.ToFrozenDictionaryWithSameComparer();
+            _readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionaryWithSameComparer();
+            _readonlyResourceDetails = _resourceDetails.ToFrozenDictionaryWithSameComparer();
         }
 
         public sealed class ResourceDetails
@@ -53,13 +54,13 @@ namespace Raven.Server.Documents
         public void Clear()
         {
             _caseSensitive.Clear();
-            _readonlyCaseSensitive = _caseSensitive.ToFrozenDictionary();
+            _readonlyCaseSensitive = _caseSensitive.ToFrozenDictionaryWithSameComparer();
 
             _caseInsensitive.Clear();
-            _readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionary();
+            _readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionaryWithSameComparer();
 
             _resourceDetails.Clear();
-            _readonlyResourceDetails = _resourceDetails.ToFrozenDictionary();
+            _readonlyResourceDetails = _resourceDetails.ToFrozenDictionaryWithSameComparer();
         }
 
         public bool TryGetValue(StringSegment resourceName, out Task<TResource> resourceTask)
@@ -88,7 +89,7 @@ namespace Raven.Server.Documents
 
             lock (this)
             {
-                if (_caseInsensitive.TryGetValue(resourceName, out var resourceTaskUnderLock) == false)
+                if (_readonlyCaseInsensitive.TryGetValue(resourceName, out var resourceTaskUnderLock) == false)
                 {
                     // database was deleted
                     return false;
@@ -106,7 +107,7 @@ namespace Raven.Server.Documents
                 {
                     mappingsForResource.Add(resourceName);
                     _caseSensitive.TryAdd(resourceName, resourceTask);
-                    _readonlyCaseSensitive = _caseSensitive.ToFrozenDictionary();
+                    _readonlyCaseSensitive = _caseSensitive.ToFrozenDictionaryWithSameComparer();
                 }
             }
             return true;
@@ -128,9 +129,9 @@ namespace Raven.Server.Documents
                 // at the end of the execution in order to diminish the time that an unstable state can be observed.
                 // While this is not a big issue because the code already supports dealing with that, the smaller the
                 // time such inconsistencies can be observed, the better.
-                var readonlyCaseSensitive = _caseSensitive.ToFrozenDictionary();
-                var readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionary();
-                var readonlyResourceDetails = _resourceDetails.ToFrozenDictionary();
+                var readonlyCaseSensitive = _caseSensitive.ToFrozenDictionaryWithSameComparer();
+                var readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionaryWithSameComparer();
+                var readonlyResourceDetails = _resourceDetails.ToFrozenDictionaryWithSameComparer();
 
                 _readonlyCaseSensitive = readonlyCaseSensitive;
                 _readonlyCaseInsensitive = readonlyCaseInsensitive;
@@ -207,9 +208,9 @@ namespace Raven.Server.Documents
                 // at the end of the execution in order to diminish the time that an unstable state can be observed.
                 // While this is not a big issue because the code already supports dealing with that, the smaller the
                 // time such inconsistencies can be observed, the better.
-                var readonlyCaseSensitive = _caseSensitive.ToFrozenDictionary();
-                var readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionary();
-                var readonlyResourceDetails = _resourceDetails.ToFrozenDictionary();
+                var readonlyCaseSensitive = _caseSensitive.ToFrozenDictionaryWithSameComparer();
+                var readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionaryWithSameComparer();
+                var readonlyResourceDetails = _resourceDetails.ToFrozenDictionaryWithSameComparer();
 
                 _readonlyCaseSensitive = readonlyCaseSensitive;
                 _readonlyCaseInsensitive = readonlyCaseInsensitive;
@@ -261,7 +262,7 @@ namespace Raven.Server.Documents
                             continue;
 
                         // We need to refresh only the case-insensitive dictionary.
-                        _readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionary();
+                        _readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionaryWithSameComparer();
 
                         return new DisposableAction(() =>
                         {
@@ -298,9 +299,9 @@ namespace Raven.Server.Documents
                     // at the end of the execution in order to diminish the time that an unstable state can be observed.
                     // While this is not a big issue because the code already supports dealing with that, the smaller the
                     // time such inconsistencies can be observed, the better.
-                    var readonlyCaseSensitive = _caseSensitive.ToFrozenDictionary();
-                    var readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionary();
-                    var readonlyResourceDetails = _resourceDetails.ToFrozenDictionary();
+                    var readonlyCaseSensitive = _caseSensitive.ToFrozenDictionaryWithSameComparer();
+                    var readonlyCaseInsensitive = _caseInsensitive.ToFrozenDictionaryWithSameComparer();
+                    var readonlyResourceDetails = _resourceDetails.ToFrozenDictionaryWithSameComparer();
 
                     _readonlyCaseSensitive = readonlyCaseSensitive;
                     _readonlyCaseInsensitive = readonlyCaseInsensitive;
@@ -389,9 +390,9 @@ namespace Raven.Server.Documents
                     // at the end of the execution in order to diminish the time that an unstable state can be observed.
                     // While this is not a big issue because the code already supports dealing with that, the smaller the
                     // time such inconsistencies can be observed, the better.
-                    var readonlyCaseSensitive = _parent._caseSensitive.ToFrozenDictionary();
-                    var readonlyCaseInsensitive = _parent._caseInsensitive.ToFrozenDictionary();
-                    var readonlyResourceDetails = _parent._resourceDetails.ToFrozenDictionary();
+                    var readonlyCaseSensitive = _parent._caseSensitive.ToFrozenDictionaryWithSameComparer();
+                    var readonlyCaseInsensitive = _parent._caseInsensitive.ToFrozenDictionaryWithSameComparer();
+                    var readonlyResourceDetails = _parent._resourceDetails.ToFrozenDictionaryWithSameComparer();
 
                     _parent._readonlyCaseSensitive = readonlyCaseSensitive;
                     _parent._readonlyCaseInsensitive = readonlyCaseInsensitive;

--- a/src/Raven.Server/Extensions/FrozenDictionaryExtensions.cs
+++ b/src/Raven.Server/Extensions/FrozenDictionaryExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+namespace Raven.Server.Extensions
+{
+    internal static class FrozenDictionaryExtensions
+    {
+        public static FrozenDictionary<TKey, TValue> ToFrozenDictionaryWithSameComparer<TKey, TValue>(this Dictionary<TKey, TValue> source)
+            where TKey : notnull => source.ToFrozenDictionary(source.Comparer);
+
+        public static FrozenDictionary<TKey, TValue> ToFrozenDictionaryWithSameComparer<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> source)
+            where TKey : notnull => source.ToFrozenDictionary(source.Comparer);
+    }
+}

--- a/test/FastTests/Issues/RavenDB_22551.cs
+++ b/test/FastTests/Issues/RavenDB_22551.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_22551 : RavenTestBase
+    {
+        public RavenDB_22551(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task Different_Casing_Should_Not_Create_New_Database_Instance()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var db1 = await GetDatabase(store.Database);
+                var db2 = await GetDatabase(store.Database.ToLower());
+
+                Assert.Same(db1, db2);
+
+                Assert.True(Server.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(store.Database, out _));
+                Assert.True(Server.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(store.Database.ToLower(), out _));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22551

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
