### PR TITLE
RavenDB-22543 Fix restoring a encrypted snapshot

### DIFF
--- a/src/Raven.Studio/typescript/components/common/FormEncryption.tsx
+++ b/src/Raven.Studio/typescript/components/common/FormEncryption.tsx
@@ -21,6 +21,7 @@ export interface FormEncryptionProps<TFieldValues extends FieldValues, TName ext
     fileName: string;
     setEncryptionKey: (value: string) => void;
     triggerEncryptionKey: () => Promise<boolean>;
+    isReadOnly?: boolean;
 }
 
 export default function FormEncryption<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>({
@@ -32,6 +33,7 @@ export default function FormEncryption<TFieldValues extends FieldValues, TName e
     fileName,
     setEncryptionKey,
     triggerEncryptionKey,
+    isReadOnly,
 }: FormEncryptionProps<TFieldValues, TName>) {
     const { databasesService } = useServices();
 
@@ -99,14 +101,21 @@ export default function FormEncryption<TFieldValues extends FieldValues, TName e
                     <div className="small-label mb-1">Key (Base64 Encoding)</div>
                     <div className="d-flex">
                         <InputGroup>
-                            <FormInput type="text" control={control} name={encryptionKeyFieldName} />
-                            <Button
-                                type="button"
-                                title="Regenerate key"
-                                onClick={() => asyncGenerateSecret.execute(true)}
-                            >
-                                <Icon icon="reset" margin="m-0" />
-                            </Button>
+                            <FormInput
+                                type="text"
+                                control={control}
+                                name={encryptionKeyFieldName}
+                                readOnly={isReadOnly}
+                            />
+                            {!isReadOnly && (
+                                <Button
+                                    type="button"
+                                    title="Regenerate key"
+                                    onClick={() => asyncGenerateSecret.execute(true)}
+                                >
+                                    <Icon icon="reset" margin="m-0" />
+                                </Button>
+                            )}
                         </InputGroup>
                         <ActionButton isEncryptionKeyValid={isEncryptionKeyValid}>
                             <Button

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupValidation.ts
@@ -64,9 +64,7 @@ type PointsWithTags = yup.InferType<ReturnType<typeof getPointsWithTagsSchema>>;
 function getEncryptionKeySchema(sourceType: RestoreSource) {
     return yup.string().when(["$sourceType", "pointsWithTags"], {
         is: (currentSourceType: RestoreSource, pointsWithTags: PointsWithTags) =>
-            currentSourceType === sourceType &&
-            pointsWithTags[0]?.restorePoint?.isEncrypted &&
-            !pointsWithTags[0]?.restorePoint?.isSnapshotRestore,
+            currentSourceType === sourceType && pointsWithTags[0]?.restorePoint?.isEncrypted,
         then: (schema) => schema.base64().required(),
     });
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22543/Restore-encrypted-snapshot-fails

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
