### PR TITLE
RavenDB-17300 - fix failing test

### DIFF
--- a/test/SlowTests/Client/Subscriptions/RavenDB-9068.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-9068.cs
@@ -35,9 +35,9 @@ namespace SlowTests.Client.Subscriptions
                 cts.Cancel();
 
                 var task = Assert.ThrowsAnyAsync<Exception>(() => subscriptionTask);
-                Assert.True(await task.WaitWithoutExceptionAsync(_reasonableWaitTime));
+                Assert.True(await task.WaitWithoutExceptionAsync(_reasonableWaitTime), "1. await task.WaitWithoutExceptionAsync(_reasonableWaitTime)");
                 var e = await task;
-                Assert.True(e is OperationCanceledException || e is TaskCanceledException);
+                Assert.True(e is TaskCanceledException or OperationCanceledException or AggregateException { InnerException: TaskCanceledException }, $"1. e is TaskCanceledException or OperationCanceledException or AggregateException {{ InnerException: TaskCanceledException }}, {e}");
 
                 subscription = store.Subscriptions.GetSubscriptionWorker<User>(subscriptionId);
                 cts = new CancellationTokenSource();
@@ -45,9 +45,9 @@ namespace SlowTests.Client.Subscriptions
                 cts.Cancel();
 
                 task = Assert.ThrowsAnyAsync<Exception>(() => subscriptionTask);
-                Assert.True(await task.WaitWithoutExceptionAsync(_reasonableWaitTime));
+                Assert.True(await task.WaitWithoutExceptionAsync(_reasonableWaitTime), "2. await task.WaitWithoutExceptionAsync(_reasonableWaitTime)");
                 e = await task;
-                Assert.True(e is OperationCanceledException || e is TaskCanceledException);
+                Assert.True(e is TaskCanceledException or OperationCanceledException or AggregateException { InnerException: TaskCanceledException }, $"2. e is TaskCanceledException or OperationCanceledException or AggregateException {{ InnerException: TaskCanceledException }}, {e}");
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17300

### Additional description

if we are too fast, we might get a `AggregateException` here:
https://github.com/ravendb/ravendb/blob/5d8a32e39ec7067d6fc17ded4bfefb1c2b3919cb/src/Raven.Client/Util/TcpUtils.cs#L364
need to catch it in test

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
