### PR TITLE
RavenDB-21833 change stream read timeout

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17745.cs
+++ b/test/SlowTests/Issues/RavenDB-17745.cs
@@ -22,8 +22,8 @@ namespace SlowTests.Issues
         {
         }
 
-        private readonly int _readTimeout = 500;
-        private readonly TimeSpan _delay = TimeSpan.FromSeconds(1);
+        private readonly int _readTimeout = 5000;
+        private readonly TimeSpan _delay = TimeSpan.FromSeconds(10);
 
         [RavenTheory(RavenTestCategory.BulkInsert)]
         [InlineData(null)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21833

### Additional description

The bulk insert fails due delay at the timer callback . 
In the test the stream timeout was 500ms. Now I changed it to 5 sec. (Normal timeout is 2 min)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
