### PR TITLE
RavenDB-21833 change stream read timeout

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -332,7 +332,7 @@ namespace Raven.Client.Documents.BulkInsert
                 _inProgressCommand = CommandType.None;
                 _currentWriter.Write("{\"Type\":\"HeartBeat\"}");
 
-                await FlushIfNeeded().ConfigureAwait(false);
+                await FlushIfNeeded(force: true).ConfigureAwait(false);
             }
             catch (Exception)
             {
@@ -542,7 +542,7 @@ namespace Raven.Client.Documents.BulkInsert
             }
         }
 
-        private async Task FlushIfNeeded()
+        private async Task FlushIfNeeded(bool force = false)
         {
             await _currentWriter.FlushAsync().ConfigureAwait(false);
 
@@ -556,8 +556,8 @@ namespace Raven.Client.Documents.BulkInsert
                 _backgroundWriter = tmp;
                 _currentWriter.BaseStream.SetLength(0);
                 ((MemoryStream)tmp.BaseStream).TryGetBuffer(out var buffer);
-
-                _asyncWrite = WriteToRequestBodyStreamAsync(buffer, IsHeartbeatIntervalExceeded());
+                force = force || IsHeartbeatIntervalExceeded();
+                _asyncWrite = WriteToRequestBodyStreamAsync(buffer, force: force);
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB-17745.cs
+++ b/test/SlowTests/Issues/RavenDB-17745.cs
@@ -17,8 +17,8 @@ namespace SlowTests.Issues
         {
         }
 
-        private readonly int _readTimeout = 500;
-        private readonly TimeSpan _delay = TimeSpan.FromSeconds(1);
+        private readonly int _readTimeout = 5000;
+        private readonly TimeSpan _delay = TimeSpan.FromSeconds(10);
 
         [RavenFact(RavenTestCategory.BulkInsert)]
         public async Task BulkInsertWithDelay()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21833

### Additional description

Change stream timeout at bulk insert test. v6.0: https://github.com/ravendb/ravendb/pull/18773
remove unnecessary flush and fix heartbeat interval check v6.0: https://github.com/ravendb/ravendb/pull/18681
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
