### PR TITLE
RavenDB-22537 Fix `in` and `all in` queries with null parameter

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -12,15 +12,14 @@ namespace Corax
         public const string BeforeAllKeys = "BeforeAllKeys-a8e5f221-613e-4eae-9962-2689e7c44506";
         public const string AfterAllKeys = "AfterAllKeys-3622a0bb-1cf4-4200-b830-5e937d57ac99";
         
-        public static readonly string NullValue = Encodings.Utf8.GetString(new []{(byte)0});
+        public static readonly string NullValue = Encodings.Utf8.GetString(NullValueSpan);
         public static readonly ReadOnlyMemory<char> NullValueCharSpan = new(Constants.NullValue.ToCharArray());
-        
+        public static ReadOnlySpan<byte> NullValueSpan => new[] { (byte)0 };
         
         public const string EmptyString = "\u0003";
         public static readonly ReadOnlyMemory<char> EmptyStringCharSpan = new(Constants.EmptyString.ToCharArray());
         public static ReadOnlySpan<byte> PhraseQuerySuffix => "__PQ"u8; 
-        public const string  PhraseQuerySuffixAsStr = "__PQ"; 
-
+        public const string PhraseQuerySuffixAsStr = "__PQ"; 
         
         public const string IndexMetadata = "@index_metadata";
         public const string IndexTimeFields = "@index_time_fields";

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -237,7 +237,7 @@ public partial class IndexSearcher
         var termAsSpan = term.AsReadOnlySpan();
         if (tree.TryGetValue(termAsSpan, out long containerId) == false)
         {
-            if (termAsSpan is [0])
+            if (termAsSpan.SequenceEqual(Constants.NullValueSpan))
             {
                 if (TryGetPostingListForNull(tree.Name, out containerId))
                     return NumberOfDocumentsUnderSpecificTerm(containerId);

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -160,7 +160,7 @@ public partial class IndexSearcher
         return termRatioToWholeCollection;
     }
 
-    public TermMatch TermQuery(in FieldMetadata field, long containerId, double termRatioToWholeCollection)
+    internal TermMatch TermQuery(in FieldMetadata field, long containerId, double termRatioToWholeCollection)
     {
         TermMatch matches;
         if ((containerId & (long)TermIdMask.PostingList) != 0)

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -518,10 +518,13 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         return exists;
     }
 
-    internal bool TryGetPostingListForNull(in FieldMetadata field, out long postingListId)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetPostingListForNull(in FieldMetadata field, out long postingListId) => TryGetPostingListForNull(field.FieldName, out postingListId);
+    
+    private bool TryGetPostingListForNull(Slice name, out long postingListId)
     {
         InitNullPostingList();
-        var result = _nullPostingList?.ReadStructure<(long PostingListId,long TermContainerId)>(field.FieldName);
+        var result = _nullPostingList?.ReadStructure<(long PostingListId,long TermContainerId)>(name);
         if (result == null)
         {
             postingListId = -1;

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.In.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.In.cs
@@ -45,9 +45,14 @@ namespace Corax.Querying.Matches.TermProviders
                 return false;
             }
 
-
             if (typeof(TTermsType) == typeof((string Term, bool Exact)) && (object)_terms[_termIndex] is (string stringTerm, bool isExact))
                 term = _searcher.TermQuery(isExact ? _exactField : _field, stringTerm);
+            else if (typeof(TTermsType) == typeof((string Term, bool Exact)) && (object)_terms[_termIndex] is (null, _))
+            {
+                term = _searcher.TryGetPostingListForNull(_field, out var postingListId) 
+                    ? _searcher.TermQuery(_field, postingListId, 1D) 
+                    : TermMatch.CreateEmpty(_searcher, _searcher.Allocator);
+            }
             else if (typeof(TTermsType) == typeof(string))
                 term = _searcher.TermQuery(_field, (string)(object)_terms[_termIndex]);
             else if (typeof(TTermsType) == typeof(Slice))

--- a/src/Corax/Utils/TermQueryItem.cs
+++ b/src/Corax/Utils/TermQueryItem.cs
@@ -3,4 +3,4 @@ using Voron.Data.CompactTrees;
 
 namespace Corax.Utils;
 
-public readonly record struct TermQueryItem(CompactKey Item, long Density, Slice Term);
+public readonly record struct TermQueryItem(CompactKey Key, long Density, Slice Term, long ContainerId);

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -29,6 +29,7 @@ namespace Voron.Data.CompactTrees;
 public sealed partial class CompactTree : IPrepareForCommit
 {
     internal readonly Lookup<CompactKeyLookup> _inner;
+    public Slice Name => _inner.Name;
 
     public CompactTree(Lookup<CompactKeyLookup> inner)
     {

--- a/test/SlowTests/Issues/RavenDB-22537.cs
+++ b/test/SlowTests/Issues/RavenDB-22537.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22537 : RavenTestBase
+{
+    public RavenDB_22537(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TestInQuery(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto() { Name = null };
+                var dto2 = new Dto() { Name = null };
+                var dto3 = new Dto() { Name = "NotNullName" };
+                 
+                session.Store(dto1);
+                session.Store(dto2);
+                session.Store(dto3);
+                
+                session.SaveChanges();
+                
+                var names = new List<string>() { null };
+                
+                var res = session.Query<Dto>().Where(x => x.Name.In(names)).ToList();
+
+                Assert.Equal(2, res.Count);
+
+                names = new List<string>() { null, "NotNullName" };
+                
+                res = session.Query<Dto>().Where(x => x.Name.In(names)).ToList();
+
+                Assert.Equal(3, res.Count);
+                
+                names = new List<string>() { null, "Something1", "Something2", "Something3" };
+                
+                res = session.Query<Dto>().Where(x => x.Name.In(names)).ToList();
+
+                Assert.Equal(2, res.Count);
+                
+                names = new List<string>() { null, "NotNullName", "Something1", "Something2" };
+                
+                res = session.Query<Dto>().Where(x => x.Name.In(names)).ToList();
+
+                Assert.Equal(3, res.Count);
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TestAllInQuery(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto() { Name = null, Names = new List<string>() { null } };
+                var dto2 = new Dto() { Name = null, Names = new List<string>() { null } };
+                var dto3 = new Dto() { Name = "NotNullName", Names = new List<string>() { "NotNullName" } };
+                 
+                session.Store(dto1);
+                session.Store(dto2);
+                session.Store(dto3);
+                
+                session.SaveChanges();
+                
+                var names = new List<string>() { null };
+
+                var res = session.Query<Dto>().Where(x => x.Names.ContainsAll(names)).ToList();
+                
+                Assert.Equal(2, res.Count);
+                
+                names = new List<string>() { "NotNullName" };
+                
+                res = session.Query<Dto>().Where(x => x.Names.ContainsAll(names)).ToList();
+                
+                Assert.Equal(1, res.Count);
+                
+                var dto4 = new Dto() { Name = null, Names = new List<string>() { "NotNullName", null } };
+                
+                session.Store(dto4);
+                
+                session.SaveChanges();
+                
+                Indexes.WaitForIndexing(store);
+                
+                names = new List<string>() { null, "NotNullName" };
+                
+                res = session.Query<Dto>().Where(x => x.Names.ContainsAll(names)).ToList();
+                
+                Assert.Equal(1, res.Count);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+        public List<string> Names { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-22537.cs
+++ b/test/SlowTests/Issues/RavenDB-22537.cs
@@ -32,18 +32,21 @@ public class RavenDB_22537 : RavenTestBase
                 
                 session.SaveChanges();
                 
+                // One term
                 var names = new List<string>() { null };
                 
                 var res = session.Query<Dto>().Where(x => x.Name.In(names)).ToList();
 
                 Assert.Equal(2, res.Count);
 
+                // Two terms
                 names = new List<string>() { null, "NotNullName" };
                 
                 res = session.Query<Dto>().Where(x => x.Name.In(names)).ToList();
 
                 Assert.Equal(3, res.Count);
                 
+                // Four terms
                 names = new List<string>() { null, "Something1", "Something2", "Something3" };
                 
                 res = session.Query<Dto>().Where(x => x.Name.In(names)).ToList();
@@ -51,6 +54,13 @@ public class RavenDB_22537 : RavenTestBase
                 Assert.Equal(2, res.Count);
                 
                 names = new List<string>() { null, "NotNullName", "Something1", "Something2" };
+                
+                res = session.Query<Dto>().Where(x => x.Name.In(names)).ToList();
+
+                Assert.Equal(3, res.Count);
+                
+                // Five terms
+                names = new List<string>() { null, "NotNullName", "Something1", "Something2", "Something3" };
                 
                 res = session.Query<Dto>().Where(x => x.Name.In(names)).ToList();
 
@@ -77,6 +87,7 @@ public class RavenDB_22537 : RavenTestBase
                 
                 session.SaveChanges();
                 
+                // One term
                 var names = new List<string>() { null };
 
                 var res = session.Query<Dto>().Where(x => x.Names.ContainsAll(names)).ToList();
@@ -89,7 +100,10 @@ public class RavenDB_22537 : RavenTestBase
                 
                 Assert.Equal(1, res.Count);
                 
-                var dto4 = new Dto() { Name = null, Names = new List<string>() { "NotNullName", null } };
+                // Two terms
+                names = new List<string>() { null, "NotNullName" };
+                
+                var dto4 = new Dto() { Name = null, Names = names };
                 
                 session.Store(dto4);
                 
@@ -97,7 +111,20 @@ public class RavenDB_22537 : RavenTestBase
                 
                 Indexes.WaitForIndexing(store);
                 
-                names = new List<string>() { null, "NotNullName" };
+                res = session.Query<Dto>().Where(x => x.Names.ContainsAll(names)).ToList();
+                
+                Assert.Equal(1, res.Count);
+                
+                // Five terms
+                names = new List<string>() { null, "NotNullName", "Something1", "Something2", "Something3" };
+                
+                var dto5 = new Dto() { Name = null, Names = names };
+                
+                session.Store(dto5);
+                
+                session.SaveChanges();
+                
+                Indexes.WaitForIndexing(store);
                 
                 res = session.Query<Dto>().Where(x => x.Names.ContainsAll(names)).ToList();
                 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22537/Corax-In-query-doesnt-handle-null-values

### Additional description

We want to handle `null` term in `all in` and `in` Corax queries

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
