### PR TITLE
RavenDB-22046 added missing renew on builder

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -1424,7 +1424,9 @@ namespace Raven.Server.Smuggler.Documents
                         builder = CreateBuilder(context, modifier);
                     }
 
-                    _context.CachedProperties.NewDocument();
+                    builder.Renew("import/object", Mode);
+
+                    context.CachedProperties.NewDocument();
 
                     await ReadObjectAsync(builder);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22046

### Additional description

Adding back missing renew that was removed in previous PR https://github.com/ravendb/ravendb/pull/18766
This fixes RavenDB_14201 tests

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
