### PR TITLE
RavenDB-22554: Enhance SIMD Support Configuration via Environment Variables

### DIFF
--- a/bench/Micro.Benchmark/Benchmarks/Hardware/Compare.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Hardware/Compare.cs
@@ -159,13 +159,13 @@ namespace Micro.Benchmark.Benchmarks.Hardware
         [Benchmark]
         public int Avx2Ref()
         {
-            return Memory.CompareAvx2(ref Unsafe.AsRef<byte>(source.Ptr), ref Unsafe.AsRef<byte>(destination.Ptr), Length);
+            return Memory.CompareAvx256(ref Unsafe.AsRef<byte>(source.Ptr), ref Unsafe.AsRef<byte>(destination.Ptr), Length);
         }
 
         [Benchmark]
         public int Avx2()
         {
-            return Memory.CompareAvx2(source.Ptr, destination.Ptr, Length);
+            return Memory.CompareAvx256(source.Ptr, destination.Ptr, Length);
         }
 
         [Benchmark]
@@ -197,7 +197,7 @@ namespace Micro.Benchmark.Benchmarks.Hardware
         public int Avx2_WithCacheMisses()
         {
             int index = randomLocation[(_randomIdx++) % Operations];
-            return Memory.CompareAvx2(source.Ptr + index, destination.Ptr + index, Length);
+            return Memory.CompareAvx256(source.Ptr + index, destination.Ptr + index, Length);
         }
 
         [Benchmark]

--- a/src/Corax/Querying/Matches/Meta/MergeHelper.cs
+++ b/src/Corax/Querying/Matches/Meta/MergeHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+using Sparrow;
 
 namespace Corax.Querying.Matches.Meta
 {
@@ -24,7 +25,7 @@ namespace Corax.Querying.Matches.Meta
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int And(long* dst, int dstLength, long* left, int leftLength, long* right, int rightLength)
         {
-            if (Vector256.IsHardwareAccelerated)
+            if (AdvInstructionSet.IsAcceleratedVector256)
                 return AndVectorized(dst, dstLength, left, leftLength, right, rightLength);
 
             return AndScalar(dst, dstLength, left, leftLength, right, rightLength);
@@ -212,7 +213,7 @@ namespace Corax.Querying.Matches.Meta
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Or(long* dst, int dstLength, long* left, int leftLength, long* right, int rightLength)
         {
-            if (Sse2.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedSse)
                 return OrNonTemporal(dst, dstLength, left, leftLength, right, rightLength);
             return OrScalar(dst, dstLength, left, leftLength, right, rightLength);
         }

--- a/src/Sparrow.Server/Utils/VxSort/VectorizedSort.cs
+++ b/src/Sparrow.Server/Utils/VxSort/VectorizedSort.cs
@@ -26,7 +26,7 @@ namespace Sparrow.Server.Utils.VxSort
             if (array == null)
                 throw new ArgumentNullException(nameof(array));
 
-            if (Avx2.IsSupported == false || Popcnt.X64.IsSupported == false)
+            if (AdvInstructionSet.X86.IsSupportedAvx256 == false)
             {
                 MemoryExtensions.Sort(array.AsSpan());
                 return;
@@ -45,7 +45,7 @@ namespace Sparrow.Server.Utils.VxSort
             if (array == null)
                 throw new ArgumentNullException(nameof(array));
 
-            if (Avx2.IsSupported == false || Popcnt.X64.IsSupported == false)
+            if (AdvInstructionSet.X86.IsSupportedAvx256 == false)
             {
                 MemoryExtensions.Sort(array);
                 return;
@@ -65,7 +65,7 @@ namespace Sparrow.Server.Utils.VxSort
             if (start == null)
                 throw new ArgumentNullException(nameof(start));
 
-            if (Avx2.IsSupported == false || Popcnt.X64.IsSupported == false)
+            if (AdvInstructionSet.X86.IsSupportedAvx256 == false)
             {
                 MemoryExtensions.Sort(new Span<T>(start, count));
                 return;

--- a/src/Sparrow/AdvInstructionSet.cs
+++ b/src/Sparrow/AdvInstructionSet.cs
@@ -1,0 +1,152 @@
+﻿using System;
+
+#if NET7_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+#endif
+
+namespace Sparrow
+{
+    internal static class AdvInstructionSet
+    {
+        // PERF: Because all those values are static readonly booleans that are defined during the process of loading the type,
+        // the JIT will detect them as such and will use the values instead. 
+        // https://alexandrnikitin.github.io/blog/jit-optimization-static-readonly-to-const/
+
+        public static readonly bool IsAcceleratedVector128;
+        public static readonly bool IsAcceleratedVector256;
+        public static readonly bool IsAcceleratedVector512;
+
+        static AdvInstructionSet()
+        {
+#if NET7_0_OR_GREATER
+            IsAcceleratedVector128 = Vector128.IsHardwareAccelerated;
+            IsAcceleratedVector256 = Vector256.IsHardwareAccelerated;
+#else
+            IsAcceleratedVector128 = false;
+            IsAcceleratedVector256 = false;
+#endif
+
+#if NET8_0_OR_GREATER
+            IsAcceleratedVector512 = Vector512.IsHardwareAccelerated;
+#else
+            IsAcceleratedVector512 = false;
+#endif
+
+            if (Environment.GetEnvironmentVariable("RAVENDB_AdvInstructions_Disable_Simd")?.ToLowerInvariant() == "true")
+            {
+                // We are disabling the whole SIMD support (at all levels) and activating fallback mechanisms.
+                // Some algorithms will not have fallback mechanism and therefore use the vector versions anyways.
+                // But this allows us to distinguish the case where when we know that not having the support
+                // implies we are better off using a different algorithm altogether.
+                IsAcceleratedVector128 = false;
+                IsAcceleratedVector256 = false;
+                IsAcceleratedVector512 = false;
+            }
+
+            switch (Environment.GetEnvironmentVariable("RAVENDB_AdvInstructions_Disable_VectorsBiggerThan")?.ToLowerInvariant())
+            {
+                case "256":
+                    IsAcceleratedVector512 = false;
+                    goto case "128";
+                case "128":
+                    IsAcceleratedVector256 = false;
+                    break;
+                case "0":
+                case "all":
+                    IsAcceleratedVector128 = false;
+                    break;
+            }
+        }
+
+        public static class X86
+        {
+            public static readonly bool IsSupportedSse;
+            public static readonly bool IsSupportedAvx256;
+            public static readonly bool IsSupportedAvx512;
+
+            static X86()
+            {
+
+#if NET7_0_OR_GREATER
+                IsSupportedSse = Sse42.IsSupported & Popcnt.X64.IsSupported; // We will only enable SSE if it support up to SSE 4.2
+                IsSupportedAvx256 = IsSupportedSse & Avx2.IsSupported; // We will only enable AVX if it support up to AVX2
+#else
+                IsSupportedSse = false;
+                IsSupportedAvx256 = false;
+#endif
+
+#if NET8_0_OR_GREATER
+                // We require the full set of instructions set to be enabled in order to support AVX-512
+                IsSupportedAvx512 = IsSupportedAvx256 & Avx512CD.IsSupported & Avx512BW.IsSupported & Avx512DQ.IsSupported & Avx512Vbmi.IsSupported & Avx512F.IsSupported;
+#else
+                IsSupportedAvx512 = false;
+#endif
+
+                if (Environment.GetEnvironmentVariable("RAVENDB_AdvInstructions_Disable_Simd")?.ToLowerInvariant() == "true")
+                {
+                    // We are disabling the whole SIMD support (at all levels) and activating fallback mechanisms.
+                    // Some algorithms will not have fallback mechanism and therefore use the vector versions without acceleration.
+                    // When special operations are needed we can switch on and off accordingly.
+                    IsSupportedSse = false;
+                    IsSupportedAvx256 = false;
+                    IsSupportedAvx512 = false;
+                }
+
+                // We assume for simplicity in the testing matrix and to simplify our life that whenever AVX512 also is AVX2, etc.
+                // This allow us an easier upgrade path for our algorithms without having to rely on a highly complex architecture selector.
+                switch (Environment.GetEnvironmentVariable("RAVENDB_AdvInstructions_Disable_Intel_InstSet")?.ToLowerInvariant())
+                {
+                    case "sse":
+                        IsSupportedSse = false;
+                        goto case "avx256";
+                    case "avx256":
+                        IsSupportedAvx256 = false;
+                        goto case "avx512";
+                    case "avx512":
+                        IsSupportedAvx512 = false;
+                        break;
+                }
+            }
+        }
+
+        public static class Arm
+        {
+            public static readonly bool IsSupported;
+            public static readonly bool IsSupportedArm64;
+
+            static Arm()
+            {
+#if NET7_0_OR_GREATER
+                IsSupported = AdvSimd.IsSupported;
+                IsSupportedArm64 = IsSupported & AdvSimd.Arm64.IsSupported;
+#else
+                IsSupported = false;
+                IsSupportedArm64 = false;
+#endif
+
+                if (Environment.GetEnvironmentVariable("RAVENDB_AdvInstructions_Disable_Simd")?.ToLowerInvariant() == "true")
+                {
+                    // We are disabling the whole SIMD support (at all levels) and activating fallback mechanisms.
+                    // Some algorithms will not have fallback mechanism and therefore use the vector versions without acceleration.
+                    // When special operations are needed we can switch on and off accordingly.
+                    IsSupported = false;
+                    IsSupportedArm64 = false;
+                }
+
+                // We assume for simplicity in the testing matrix and to simplify our life that whenever NEON is used, etc.
+                // This allow us an easier upgrade path for our algorithms without having to rely on a highly complex architecture selector.
+                switch (Environment.GetEnvironmentVariable("RAVENDB_AdvInstructions_Disable_Arm_InstSet")?.ToLowerInvariant())
+                {
+                    case "base":
+                        IsSupported = false;
+                        goto case "arm64";
+                    case "arm64":
+                        IsSupportedArm64 = false;
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/Sparrow/Binary/BitVector.cs
+++ b/src/Sparrow/Binary/BitVector.cs
@@ -171,9 +171,9 @@ namespace Sparrow.Binary
         {
             ref var storage = ref MemoryMarshal.GetReference(_storage);
 #if NET7_0_OR_GREATER
-            if (Avx2.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
                 return IndexOfFirstSetBitAvx2(ref storage, _storage.Length);
-            if (Sse2.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedSse)
                 return IndexOfFirstSetBitSse2(ref storage, _storage.Length);
 #endif
             return IndexOfFirstSetBitScalar(ref storage, _storage.Length);

--- a/src/Sparrow/Memory.cs
+++ b/src/Sparrow/Memory.cs
@@ -38,8 +38,10 @@ namespace Sparrow
         };
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int CompareAvx2(void* p1, void* p2, int size)
+        internal static int CompareAvx256(void* p1, void* p2, int size)
         {
+            Debug.Assert(AdvInstructionSet.X86.IsSupportedAvx256);
+            
             // PERF: Given all the preparation that must happen before even accessing the pointers, even if we increase
             // the size of the method by 10+ bytes, by the time we access the data it is already there in L1 cache.
             Sse.Prefetch0(p1);
@@ -178,8 +180,10 @@ namespace Sparrow
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int CompareAvx2(ref byte p1, ref byte p2, int size)
+        internal static int CompareAvx256(ref byte p1, ref byte p2, int size)
         {
+            Debug.Assert(AdvInstructionSet.X86.IsSupportedAvx256);
+            
             ref byte bpx = ref p1;
             ref byte bpy = ref p2;
             ref byte bpxEnd = ref Unsafe.AddByteOffset(ref p1, size);
@@ -313,8 +317,10 @@ namespace Sparrow
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsEqualConstantAvx2(ref byte constantRef, byte* ptr, int size)
+        internal static bool IsEqualConstantAvx256(ref byte constantRef, byte* ptr, int size)
         {
+            Debug.Assert(AdvInstructionSet.X86.IsSupportedAvx256);
+
             if (size >= Vector256<byte>.Count)
             {
                 Vector256<byte> result = Vector256.Equals(
@@ -733,9 +739,9 @@ namespace Sparrow
                 return 0;
 
 #if NET7_0_OR_GREATER
-            if (Avx2.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
             {
-                return CompareAvx2(p1, p2, size);
+                return CompareAvx256(p1, p2, size);
             }
 
             return new ReadOnlySpan<byte>(p1, size).SequenceCompareTo(new ReadOnlySpan<byte>(p2, size));
@@ -752,9 +758,9 @@ namespace Sparrow
                 return 0;
 
 #if NET7_0_OR_GREATER
-            if (Avx2.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
             {
-                return CompareAvx2(p1, p2, size);
+                return CompareAvx256(p1, p2, size);
             }
 
             return new ReadOnlySpan<byte>(p1, size).SequenceCompareTo(new ReadOnlySpan<byte>(p2, size));
@@ -767,9 +773,9 @@ namespace Sparrow
         public static int CompareInline(ref byte p1, ref byte p2, int size)
         {
 #if NET7_0_OR_GREATER
-            if (Avx2.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
             {
-                return CompareAvx2(ref p1, ref p2, size);
+                return CompareAvx256(ref p1, ref p2, size);
             }
 
             return MemoryMarshal.CreateReadOnlySpan(ref p1, size)
@@ -785,9 +791,9 @@ namespace Sparrow
 #if NET7_0_OR_GREATER
             ref byte p1Start = ref MemoryMarshal.GetReference(p1);
             ref byte p2Start = ref MemoryMarshal.GetReference(p2);
-            if (Avx2.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
             {
-                return CompareAvx2(ref p1Start, ref p2Start, size);
+                return CompareAvx256(ref p1Start, ref p2Start, size);
             }
 #endif
             return p1.SequenceCompareTo(p2);
@@ -906,8 +912,8 @@ namespace Sparrow
 
             ref var constantRef = ref MemoryMarshal.GetReference(constant);
 
-            if (Avx2.IsSupported)
-                return IsEqualConstantAvx2(ref constantRef, ptr, constant.Length);
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
+                return IsEqualConstantAvx256(ref constantRef, ptr, constant.Length);
 
             return IsEqualConstantVector128(ref constantRef, ptr, constant.Length);
 #endif
@@ -930,8 +936,8 @@ namespace Sparrow
 
             ref var constantRef = ref *constant;
 
-            if (Avx2.IsSupported)
-                return IsEqualConstantAvx2(ref constantRef, ptr, size);
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
+                return IsEqualConstantAvx256(ref constantRef, ptr, size);
 
             return IsEqualConstantVector128(ref constantRef, ptr, size);
 #else
@@ -958,8 +964,8 @@ namespace Sparrow
 
             ref var constantRef = ref MemoryMarshal.GetReference(constant);
 
-            if (Avx2.IsSupported)
-                return IsEqualConstantAvx2(ref constantRef, ptr, constant.Length);
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
+                return IsEqualConstantAvx256(ref constantRef, ptr, constant.Length);
 
             return IsEqualConstantVector128(ref constantRef, ptr, constant.Length);
 #else

--- a/test/FastTests/Corax/Primitives.cs
+++ b/test/FastTests/Corax/Primitives.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.Intrinsics.X86;
 using Corax.Querying.Matches.Meta;
+using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -15,7 +16,7 @@ namespace FastTests.Corax
         }
 
 
-        [RavenMultiplatformFact(RavenTestCategory.Corax, RavenIntrinsics.Avx2)]
+        [RavenMultiplatformFact(RavenTestCategory.Corax, RavenIntrinsics.Vector256)]
         public void SmallForVectorized()
         {
             long* aS = stackalloc long[256];
@@ -95,7 +96,7 @@ namespace FastTests.Corax
             Assert.Equal(10, dV[0]);
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenIntrinsics.Avx2)]
+        [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenIntrinsics.Vector256)]
         [InlineData(125, 89, 90, 22)]
         [InlineData(125, 1, 24, 1)]
         [InlineData(125, 24, 1, 1)]
@@ -155,14 +156,10 @@ namespace FastTests.Corax
             }
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenIntrinsics.Avx2, Skip="Only used to find runs that could be problematic.")]
+        [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenIntrinsics.Vector256, Skip="Only used to find runs that could be problematic.")]
         [InlineData(1337)]
         public void OutputCompatibilityForVectorizedExhaustive(int seed)
         {
-            // This method can only be run on platforms where the AVX2 instruction set is supported.
-            if (!Avx2.IsSupported)
-                return;
-
             Span<long> aS = stackalloc long[256];
             Span<long> bS = stackalloc long[256];
             Span<long> dS = stackalloc long[256];

--- a/test/FastTests/Corax/Ranking/QuantizationTest.cs
+++ b/test/FastTests/Corax/Ranking/QuantizationTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
@@ -24,7 +25,7 @@ public class QuantizationTest : RavenTestBase
         for (short value = 1; value < short.MaxValue; ++value)
         {
             var quantized = EntryIdEncodings.FrequencyQuantization(value);
-            var quantizedByClassic = EntryIdEncodings.FrequencyQuantizationWithoutAcceleration(value);
+            var quantizedByClassic = EntryIdEncodings.FrequencyQuantizationReference(value);
             Assert.Equal(quantizedByClassic, quantized);
             Assert.True(quantized <= byte.MaxValue); //In range
 
@@ -56,7 +57,7 @@ public class QuantizationTest : RavenTestBase
         Assert.Equal(idsWithShifted, idsWithShiftedCopy);
     }
 
-    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Intrinsics, RavenIntrinsics.AdvSimd)]
+    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Intrinsics, RavenIntrinsics.ArmBase)]
     [InlineData(7)]
     [InlineData(8)]
     [InlineData(16)]
@@ -107,7 +108,7 @@ public class QuantizationTest : RavenTestBase
         }
     }
     
-    [RavenMultiplatformFact(RavenTestCategory.Corax | RavenTestCategory.Intrinsics, RavenIntrinsics.Avx2)]
+    [RavenMultiplatformFact(RavenTestCategory.Corax | RavenTestCategory.Intrinsics, RavenIntrinsics.Avx256)]
     public unsafe void CanSafelyReadVectorFromManagedMemory()
     {
         var toDelete = new List<int[]>();

--- a/test/FastTests/Sparrow/AdvMemoryTests.cs
+++ b/test/FastTests/Sparrow/AdvMemoryTests.cs
@@ -30,9 +30,9 @@ namespace FastTests.Sparrow
                         Assert.False(Memory.IsEqualConstant(s2Span, s1Ptr, size));
                         Assert.False(Memory.IsEqualConstantVector128(ref s2Span[0], s1Ptr, size));
 
-                        if (Avx2.IsSupported)
+                        if (AdvInstructionSet.X86.IsSupportedAvx256)
                         {
-                            Assert.False(Memory.IsEqualConstantAvx2(ref s2Span[0], s1Ptr, size));
+                            Assert.False(Memory.IsEqualConstantAvx256(ref s2Span[0], s1Ptr, size));
                         }
 
                         // We reset the state to zero
@@ -43,9 +43,9 @@ namespace FastTests.Sparrow
                         Assert.True(Memory.IsEqualConstant(s2Span, s1Ptr, size));
                         Assert.True(Memory.IsEqualConstantVector128(ref s2Span[0], s1Ptr, size));
 
-                        if (Avx2.IsSupported)
+                        if (AdvInstructionSet.X86.IsSupportedAvx256)
                         {
-                            Assert.True(Memory.IsEqualConstantAvx2(ref s2Span[0], s1Ptr, size));
+                            Assert.True(Memory.IsEqualConstantAvx256(ref s2Span[0], s1Ptr, size));
                         }
                     };
                 }

--- a/test/FastTests/Sparrow/Memory.cs
+++ b/test/FastTests/Sparrow/Memory.cs
@@ -159,13 +159,13 @@ namespace FastTests.Sparrow
             Assert.True(Memory.CompareSmallInlineNet7(ref Unsafe.AsRef<byte>(s1Ptr), ref Unsafe.AsRef<byte>(s2Ptr), length) > 0);
             Assert.True(Memory.CompareSmallInlineNet7(ref Unsafe.AsRef<byte>(s2Ptr), ref Unsafe.AsRef<byte>(s1Ptr), length) < 0);
 
-            if (Avx2.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
             {
-                Assert.True(Memory.CompareAvx2(s1Ptr, s2Ptr, length) > 0);
-                Assert.True(Memory.CompareAvx2(s2Ptr, s1Ptr, length) < 0);
+                Assert.True(Memory.CompareAvx256(s1Ptr, s2Ptr, length) > 0);
+                Assert.True(Memory.CompareAvx256(s2Ptr, s1Ptr, length) < 0);
 
-                Assert.True(Memory.CompareAvx2(ref Unsafe.AsRef<byte>(s1Ptr), ref Unsafe.AsRef<byte>(s2Ptr), length) > 0);
-                Assert.True(Memory.CompareAvx2(ref Unsafe.AsRef<byte>(s2Ptr), ref Unsafe.AsRef<byte>(s1Ptr), length) < 0);
+                Assert.True(Memory.CompareAvx256(ref Unsafe.AsRef<byte>(s1Ptr), ref Unsafe.AsRef<byte>(s2Ptr), length) > 0);
+                Assert.True(Memory.CompareAvx256(ref Unsafe.AsRef<byte>(s2Ptr), ref Unsafe.AsRef<byte>(s1Ptr), length) < 0);
             }
         }
 
@@ -175,10 +175,10 @@ namespace FastTests.Sparrow
             Assert.True(Memory.CompareInlineNet6OorLesser(s1Ptr, s2Ptr, length) == 0);
             Assert.True(Memory.CompareSmallInlineNet7(ref Unsafe.AsRef<byte>(s1Ptr), ref Unsafe.AsRef<byte>(s2Ptr), length) == 0);
 
-            if (Avx2.IsSupported)
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
             {
-                Assert.True(Memory.CompareAvx2(s1Ptr, s2Ptr, length) == 0);
-                Assert.True(Memory.CompareAvx2(ref Unsafe.AsRef<byte>(s1Ptr), ref Unsafe.AsRef<byte>(s2Ptr), length) == 0);
+                Assert.True(Memory.CompareAvx256(s1Ptr, s2Ptr, length) == 0);
+                Assert.True(Memory.CompareAvx256(ref Unsafe.AsRef<byte>(s1Ptr), ref Unsafe.AsRef<byte>(s2Ptr), length) == 0);
             }
         }
 
@@ -197,13 +197,15 @@ namespace FastTests.Sparrow
                 Assert.Equal(reference, Math.Sign(Memory.CompareInline(firstPtr, secondPtr, length)));
                 Assert.Equal(reference, Math.Sign(Memory.CompareInlineNet6OorLesser(firstPtr, secondPtr, length)));
 
-                if (Avx2.IsSupported)
+                if (AdvInstructionSet.X86.IsSupportedAvx256)
                 {
-                    Assert.Equal(reference, Math.Sign(Memory.CompareAvx2(firstPtr, secondPtr, length)));
+                    Assert.Equal(reference, Math.Sign(Memory.CompareAvx256(firstPtr, secondPtr, length)));
                 }
             }
 
-            Assert.Equal(reference, Math.Sign(Memory.CompareAvx2(ref first[0], ref second[0], length)));
+            if (AdvInstructionSet.X86.IsSupportedAvx256)
+                Assert.Equal(reference, Math.Sign(Memory.CompareAvx256(ref first[0], ref second[0], length)));
+
             Assert.Equal(reference, Math.Sign(Memory.CompareSmallInlineNet7(ref first[0], ref second[0], length)));
         }
 
@@ -245,13 +247,13 @@ namespace FastTests.Sparrow
                             Assert.Equal(s1s2Reference, Math.Sign(Memory.CompareSmallInlineNet7(ref s1[0], ref s2[0], s1.Length)));
                             Assert.Equal(s2s1Reference, Math.Sign(Memory.CompareSmallInlineNet7(ref s2[0], ref s1[0], s1.Length)));
 
-                            if (Avx2.IsSupported)
+                            if (AdvInstructionSet.X86.IsSupportedAvx256)
                             {
-                                Assert.Equal(s1s2Reference, Math.Sign(Memory.CompareAvx2(s1Ptr, s2Ptr, s1.Length)));
-                                Assert.Equal(s2s1Reference, Math.Sign(Memory.CompareAvx2(s2Ptr, s1Ptr, s1.Length)));
+                                Assert.Equal(s1s2Reference, Math.Sign(Memory.CompareAvx256(s1Ptr, s2Ptr, s1.Length)));
+                                Assert.Equal(s2s1Reference, Math.Sign(Memory.CompareAvx256(s2Ptr, s1Ptr, s1.Length)));
 
-                                Assert.Equal(s1s2Reference, Math.Sign(Memory.CompareAvx2(ref s1[0], ref s2[0], s1.Length)));
-                                Assert.Equal(s2s1Reference, Math.Sign(Memory.CompareAvx2(ref s2[0], ref s1[0], s1.Length)));
+                                Assert.Equal(s1s2Reference, Math.Sign(Memory.CompareAvx256(ref s1[0], ref s2[0], s1.Length)));
+                                Assert.Equal(s2s1Reference, Math.Sign(Memory.CompareAvx256(ref s2[0], ref s1[0], s1.Length)));
                             }
                         }
                         catch
@@ -297,13 +299,13 @@ namespace FastTests.Sparrow
                             Assert.True(Memory.CompareSmallInlineNet7(ref s1[0], ref s2[0], s1.Length) > 0);
                             Assert.True(Memory.CompareSmallInlineNet7(ref s2[0], ref s1[0], s1.Length) < 0);
 
-                            if (Avx2.IsSupported)
+                            if (AdvInstructionSet.X86.IsSupportedAvx256)
                             {
-                                Assert.True(Memory.CompareAvx2(s1Ptr, s2Ptr, s1.Length) > 0);
-                                Assert.True(Memory.CompareAvx2(s2Ptr, s1Ptr, s1.Length) < 0);
+                                Assert.True(Memory.CompareAvx256(s1Ptr, s2Ptr, s1.Length) > 0);
+                                Assert.True(Memory.CompareAvx256(s2Ptr, s1Ptr, s1.Length) < 0);
 
-                                Assert.True(Memory.CompareAvx2(ref s1[0], ref s2[0], s1.Length) > 0);
-                                Assert.True(Memory.CompareAvx2(ref s2[0], ref s1[0], s1.Length) < 0);
+                                Assert.True(Memory.CompareAvx256(ref s1[0], ref s2[0], s1.Length) > 0);
+                                Assert.True(Memory.CompareAvx256(ref s2[0], ref s1[0], s1.Length) < 0);
                             }
 
                             // We reset the state to zero
@@ -314,10 +316,10 @@ namespace FastTests.Sparrow
                             Assert.True(Memory.CompareInlineNet6OorLesser(s1Ptr, s2Ptr, s1.Length) == 0, "Memory.CompareInlineNet6OorLesser(s1Ptr, s2Ptr, s1.Length) == 0");
                             Assert.True(Memory.CompareSmallInlineNet7(ref s1[0], ref s2[0], s1.Length) == 0, "Memory.CompareSmallInlineNet7(ref s1[0], ref s2[0], s1.Length) == 0");
 
-                            if (Avx2.IsSupported)
+                            if (AdvInstructionSet.X86.IsSupportedAvx256)
                             {
-                                Assert.True(Memory.CompareAvx2(s1Ptr, s2Ptr, s1.Length) == 0, "Memory.CompareAvx2(s1Ptr, s2Ptr, s1.Length) == 0");
-                                Assert.True(Memory.CompareAvx2(ref s1[0], ref s2[0], s1.Length) == 0, "Memory.CompareAvx2(ref s1[0], ref s2[0], s1.Length) == 0");
+                                Assert.True(Memory.CompareAvx256(s1Ptr, s2Ptr, s1.Length) == 0, "Memory.CompareAvx2(s1Ptr, s2Ptr, s1.Length) == 0");
+                                Assert.True(Memory.CompareAvx256(ref s1[0], ref s2[0], s1.Length) == 0, "Memory.CompareAvx2(ref s1[0], ref s2[0], s1.Length) == 0");
                             }
                         }
                         catch

--- a/test/SlowTests/SparrowTests/VxSort/BitonicSort.cs
+++ b/test/SlowTests/SparrowTests/VxSort/BitonicSort.cs
@@ -80,7 +80,7 @@ namespace SlowTests.SparrowTests.VxSort
                 () => GenerateData(size, seed))
             select new object[] { generator.Labeled($"{size:000}/R{i}") };
 
-        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Sse42)]
+        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Avx256)]
         [MemberData(nameof(PreSorted))]
         [MemberData(nameof(HalfMinValue))]
         [MemberData(nameof(HalfMaxValue))]
@@ -103,7 +103,7 @@ namespace SlowTests.SparrowTests.VxSort
             Assert.Equal(randomData, sortedData);
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Sse42)]
+        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Avx256)]
         [MemberData(nameof(PreSorted))]
         [MemberData(nameof(HalfMinValue))]
         [MemberData(nameof(HalfMaxValue))]
@@ -133,7 +133,7 @@ namespace SlowTests.SparrowTests.VxSort
             Assert.Equal(randomData, sortedData);
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Sse42)]
+        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Avx256)]
         [MemberData(nameof(PreSorted))]
         [MemberData(nameof(HalfMinValue))]
         [MemberData(nameof(HalfMaxValue))]
@@ -163,7 +163,7 @@ namespace SlowTests.SparrowTests.VxSort
             Assert.Equal(randomData, sortedData);
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Sse42)]
+        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Avx256)]
         [MemberData(nameof(PreSorted))]
         [MemberData(nameof(HalfMinValue))]
         [MemberData(nameof(HalfMaxValue))]
@@ -193,7 +193,7 @@ namespace SlowTests.SparrowTests.VxSort
             Assert.Equal(randomData, sortedData);
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Sse42)]
+        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Avx256)]
         [MemberData(nameof(PreSorted))]
         [MemberData(nameof(HalfMinValue))]
         [MemberData(nameof(HalfMaxValue))]
@@ -223,7 +223,7 @@ namespace SlowTests.SparrowTests.VxSort
             Assert.Equal(randomData, sortedData);
         }
 
-        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Sse42)]
+        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Avx256)]
         [MemberData(nameof(PreSorted))]
         [MemberData(nameof(HalfMinValue))]
         [MemberData(nameof(HalfMaxValue))]

--- a/test/SlowTests/SparrowTests/VxSort/ParityTests.cs
+++ b/test/SlowTests/SparrowTests/VxSort/ParityTests.cs
@@ -114,7 +114,7 @@ namespace SlowTests.SparrowTests.VxSort
 
 
 
-        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Sse42)]
+        [RavenMultiplatformTheory(RavenTestCategory.Intrinsics, RavenIntrinsics.Sse)]
         [MemberData(nameof(PreSorted))]
         [MemberData(nameof(ReverseSorted))]
         [MemberData(nameof(HalfMinValue))]

--- a/test/Tests.Infrastructure/RavenMultiplatformFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenMultiplatformFactAttribute.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
+using Sparrow;
 
 namespace Tests.Infrastructure;
 
@@ -32,14 +34,15 @@ public enum RavenArchitecture
 public enum RavenIntrinsics
 {
     None = 0,
-    AdvSimd = 1 << 1,
-    Avx = 1 << 2,
-    Avx2 = 1 << 3,
-    Sse = 1 << 4,
-    Sse2 = 1 << 5,
-    Sse3 = 1 << 6,
-    Sse41 = 1 << 7,
-    Sse42 = 1 << 8,
+    ArmBase = 1 << 1,
+    Arm64 = 1 << 2,
+    Sse = 1 << 3,
+    Avx256 = 1 << 4,
+    Avx512 = 1 << 5,
+
+    Vector128 = 1 << 7,
+    Vector256 = 1 << 8,
+    Vector512 = 1 << 9
 }
 
 public class RavenMultiplatformFactAttribute : RavenFactAttribute
@@ -156,28 +159,28 @@ public class RavenMultiplatformFactAttribute : RavenFactAttribute
         if (intrinsics is RavenIntrinsics.None)
             return true;
 
-        if (intrinsics.HasFlag(RavenIntrinsics.Avx) && Avx.IsSupported == false)
+        if (intrinsics.HasFlag(RavenIntrinsics.Vector128) && AdvInstructionSet.IsAcceleratedVector128 == false)
             return false;
 
-        if (intrinsics.HasFlag(RavenIntrinsics.Avx2) && Avx2.IsSupported == false)
+        if (intrinsics.HasFlag(RavenIntrinsics.Vector256) && AdvInstructionSet.IsAcceleratedVector256 == false)
             return false;
 
-        if (intrinsics.HasFlag(RavenIntrinsics.AdvSimd) && AdvSimd.IsSupported == false)
+        if (intrinsics.HasFlag(RavenIntrinsics.Vector512) && AdvInstructionSet.IsAcceleratedVector512 == false)
             return false;
 
-        if (intrinsics.HasFlag(RavenIntrinsics.Sse) && Sse.IsSupported == false)
+        if (intrinsics.HasFlag(RavenIntrinsics.ArmBase) && AdvInstructionSet.Arm.IsSupported == false)
             return false;
 
-        if (intrinsics.HasFlag(RavenIntrinsics.Sse2) && Sse2.IsSupported == false)
+        if (intrinsics.HasFlag(RavenIntrinsics.Arm64) && AdvInstructionSet.Arm.IsSupportedArm64 == false)
             return false;
 
-        if (intrinsics.HasFlag(RavenIntrinsics.Sse3) && Sse3.IsSupported == false)
+        if (intrinsics.HasFlag(RavenIntrinsics.Sse) && AdvInstructionSet.X86.IsSupportedSse == false)
             return false;
 
-        if (intrinsics.HasFlag(RavenIntrinsics.Sse41) && Sse41.IsSupported == false)
+        if (intrinsics.HasFlag(RavenIntrinsics.Avx256) && AdvInstructionSet.X86.IsSupportedAvx256 == false)
             return false;
 
-        if (intrinsics.HasFlag(RavenIntrinsics.Sse42) && Sse42.IsSupported == false)
+        if (intrinsics.HasFlag(RavenIntrinsics.Avx512) && AdvInstructionSet.X86.IsSupportedAvx512 == false)
             return false;
 
         return true;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22554

### Additional description

This PR introduces a mechanism to configure and selectively disable SIMD instruction sets in RavenDB via environment variables. The goal is to simplify the testing matrix and development complexity by allowing more granular control over SIMD support.

Environment Variables for SIMD Control:

- RAVENDB_AdvInstructions_Disable_Simd: Disables all SIMD support.
- RAVENDB_AdvInstructions_Disable_VectorsBiggerThan: Disables SIMD vectors larger than the specified size (64, 128, 256).
- RAVENDB_AdvInstructions_Disable_Intel_InstSet: Disables specific Intel instruction sets (sse, avx256, avx512).
- RAVENDB_AdvInstructions_Disable_Arm_InstSet: Disables specific ARM instruction sets (base, arm64).

The idea is to simplify the test matrix by having a tiered support level. For example, on Intel we have:

- low tier: SSE42
- mid tier: AVX2
- high tier: AVX512

This allows us to simplify writing the code and provide a consistent experience. There are also cases where vector acceleration is required, in those cases we can also disable vector acceleration to force fallbacks.

The expectation is that this would be the test matrix based on chipset architecture. We will need some QA field work (at least for the ones we care about) because it can be possible that AVX512 is not fully supported (5 different extensions) but still Vector512 acceleration could be available.

```
AWS

M7g class -> Graviton3  (up to Vector512, ARM64, SVE*)
M7i class -> Sapphire Rapids 8488C (up to Vector512, AVX512)
M7a class -> AMD EPYC 9R14 (up to Vector512, AVX512)
Mac class -> Intel's 8th generation 3.2 GHz (4.6 GHz turbo) Core i7 processors (up to Vector256, AVX256)
M6g class -> Custom built AWS Graviton2 Processor with 64-bit Arm Neoverse cores (up to Vector256, ARM64)
M6i class -> Ice Lake 8375C (up to Vector512, AVX512)
M6a class -> AMD EPYC 7R13 (up to Vector256, AVX256)
M5 class -> Skylake 8175M or Cascade Lake 8259CL (up to Vector512, AVX512)
M5n class -> Cascade Lake 8259CL (up to Vector512, AVX512)
M5a class -> AMD EPYC 7571 (up to Vector256, AVX256)
M4 class -> Broadwell E5-2686 v4 or Haswell E5-2676 v3 (up to Vector256, AVX256)
T4g class -> AWS Graviton2 (up to Vector256, Arm64)
T3 class -> Skylake 8175M or Cascade Lake 8259CL (up to Vector512, AVX256)
T3a class -> AMD EPYC 7571 (up to Vector256, AVX2)
T2 class -> Haswell E5-2676 v3 or Broadwell E5-2686 v4 (up to Vector256, AVX256)

Azure

Dv3 class -> Intel® XEON ® E5-2673 v4 (Broadwell) (up to Vector256, AVX256)
Dv4 class -> Intel® Xeon® Platinum 8272CL (up to Vector512, AVX256)
Dasv5 class -> AMD EPYC™ 7763v (Milan) 
B class -> undisclosed feature-set (most likely not guaranteed)

* SVE instruction set would not be available before .Net 9.0
```


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
