### PR TITLE
RavenDB-20511: throw less SubscriptionDoesNotBelongToNodeException on unstable cluster

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Subscriptions/OrchestratedSubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/OrchestratedSubscriptionConnection.cs
@@ -126,7 +126,7 @@ namespace Raven.Server.Documents.Sharding.Subscriptions
             }
         }
 
-        public override Task SendNoopAckAsync() => Task.CompletedTask;
+        public override Task SendNoopAckAsync(bool force = false) => Task.CompletedTask;
 
         protected override bool FoundAboutMoreDocs()
         {

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
@@ -31,19 +31,53 @@ public abstract class AbstractSubscriptionStorage
     public abstract bool DropSingleSubscriptionConnection(long subscriptionId, string workerId, SubscriptionException ex);
 
     public abstract bool DisableSubscriptionTasks { get; }
+    private readonly TimeSpan _waitForClusterStabilizationTimeout;
 
     protected AbstractSubscriptionStorage(ServerStore serverStore, int maxNumberOfConcurrentConnections)
     {
         _serverStore = serverStore;
         _concurrentConnectionsSemiSemaphore = new SemaphoreSlim(maxNumberOfConcurrentConnections);
+        _waitForClusterStabilizationTimeout = TimeSpan.FromMilliseconds(Math.Max(30000, (int)(2 * serverStore.Engine.OperationTimeout.TotalMilliseconds)));
+    }
+
+    public bool ShouldWaitForClusterStabilization()
+    {
+        var lastState = _serverStore.Engine.LastState;
+        if (lastState == null)
+            return false;
+
+        switch (lastState.To)
+        {
+            // get last cluster state
+            case RachisState.Passive:
+                // if the last state was passive, we will throw on next cluster command
+                return false;
+            case RachisState.Candidate:
+            {
+                if (DateTime.UtcNow - lastState.When < _waitForClusterStabilizationTimeout)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+            default:
+                // we are fine to proceed with the subscription on this node
+                return false;
+        }
     }
 
     public string GetSubscriptionResponsibleNode(ClusterOperationContext context, SubscriptionState taskStatus)
     {
+        return GetSubscriptionResponsibleNode(context, _serverStore.Engine.CurrentState, taskStatus);
+    }
+
+    internal string GetSubscriptionResponsibleNode(ClusterOperationContext context, RachisState currentState, SubscriptionState taskStatus)
+    {
         var topology = GetTopology(context);
         var tag = GetNodeFromState(taskStatus);
         var lastFunc = UpdateValueForDatabaseCommand.GetLastResponsibleNode(_serverStore.LicenseManager.HasHighlyAvailableTasks(), topology, tag);
-        return topology.WhoseTaskIsIt(_serverStore.Engine.CurrentState, taskStatus, lastFunc);
+        return topology.WhoseTaskIsIt(currentState, taskStatus, lastFunc);
     }
 
     public static string GetSubscriptionResponsibleNodeForProgress(RawDatabaseRecord record, string shardName, SubscriptionState taskStatus, bool hasHighlyAvailableTasks)
@@ -284,7 +318,13 @@ public abstract class AbstractSubscriptionStorage<TState> : AbstractSubscription
                     continue;
                 }
 
-                var whoseTaskIsIt = GetSubscriptionResponsibleNode(context, subscriptionState);
+                if (_serverStore.Engine.CurrentState == RachisState.Passive)
+                {
+                    DropSubscriptionConnections(id,
+                        new SubscriptionDoesNotBelongToNodeException($"Subscription operation was stopped on '{_serverStore.NodeTag}', because current node state is '{RachisState.Passive}'."));
+                }
+
+                var whoseTaskIsIt = GetSubscriptionResponsibleNode(context, RachisState.Follower, subscriptionState);
                 if (whoseTaskIsIt != _serverStore.NodeTag)
                 {
                     var reason = string.IsNullOrEmpty(whoseTaskIsIt) ? "could not get responsible node for subscription task." : $"because it's now under node '{whoseTaskIsIt}' responsibility.";

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionBinder.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionBinder.cs
@@ -161,7 +161,7 @@ public sealed class SubscriptionBinder<TState, TConnection, TIncludeCommand> : I
 
         _connection.CancellationTokenSource.Token.ThrowIfCancellationRequested();
 
-        await _connection.SendNoopAckAsync();
+        await _connection.SendNoopAckAsync(force: true);
         await _connection.SendAcceptMessageAsync();
 
         await _subscriptionConnectionsState.UpdateClientConnectionTime();

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -1134,7 +1134,7 @@ namespace Raven.Server.Documents.Subscriptions
                         // but we must wait for it before we release _copiedBuffer
                         _lastReplyFromClientTask.Wait();
                     }
-                    else if (_lastReplyFromClientTask.IsFaulted)
+                    else if (_lastReplyFromClientTask is { IsFaulted: true })
                     {
                         // need to catch the exception here to prevent UnobservedTaskException 
                         _lastReplyFromClientTask.Wait();

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.Subscriptions
         private static readonly StringSegment DataSegment = new("Data");
         private static readonly StringSegment ExceptionSegment = new("Exception");
 
-        private readonly AbstractSubscriptionStorage _subscriptions;
+        protected readonly AbstractSubscriptionStorage _subscriptions;
         protected readonly ServerStore ServerStore;
         private readonly IDisposable _tcpConnectionDisposable;
         internal readonly (IDisposable ReleaseBuffer, JsonOperationContext.MemoryBuffer Buffer) _copiedBuffer;
@@ -403,9 +403,9 @@ namespace Raven.Server.Documents.Subscriptions
             do
             {
                 var hasMoreDocsTask = state.WaitForMoreDocs();
-
+                var timeoutTask = TimeoutManager.WaitFor(ISubscriptionConnection.HeartbeatTimeout);
                 var resultingTask = await Task
-                    .WhenAny(hasMoreDocsTask, _lastReplyFromClientTask, TimeoutManager.WaitFor(ISubscriptionConnection.HeartbeatTimeout)).ConfigureAwait(false);
+                    .WhenAny(hasMoreDocsTask, _lastReplyFromClientTask, timeoutTask).ConfigureAwait(false);
 
                 TcpConnection.DocumentDatabase?.ForTestingPurposes?.Subscription_ActionToCallDuringWaitForChangedDocuments?.Invoke();
 
@@ -416,14 +416,30 @@ namespace Raven.Server.Documents.Subscriptions
                     return false;
 
                 if (hasMoreDocsTask == resultingTask)
-                    return true;
+                {
+                    if (_subscriptions.ShouldWaitForClusterStabilization())
+                    {
+                        // we have unstable cluster
+                        await timeoutTask;
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                }
 
                 await SendHeartBeatAsync("Waiting for changed documents");
                 await SendNoopAckAsync();
 
                 if (FoundAboutMoreDocs())
-                    return true;
+                {
+                    if (_subscriptions.ShouldWaitForClusterStabilization())
+                    {
+                        continue;
+                    }
 
+                    return true;
+                }
             } while (CancellationTokenSource.IsCancellationRequested == false);
 
             return false;
@@ -959,19 +975,28 @@ namespace Raven.Server.Documents.Subscriptions
             SubscriptionConnectionClientMessage clientReply;
             while (true)
             {
-                var result = await Task.WhenAny(_lastReplyFromClientTask, TimeoutManager.WaitFor(ISubscriptionConnection.HeartbeatTimeout, CancellationTokenSource.Token));
+                var timeoutTask = TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(5000), CancellationTokenSource.Token);
+                var result = await Task.WhenAny(_lastReplyFromClientTask, timeoutTask);
                 CancellationTokenSource.Token.ThrowIfCancellationRequested();
                 if (result == _lastReplyFromClientTask)
                 {
-                    clientReply = await _lastReplyFromClientTask;
-                    if (clientReply.Type == SubscriptionConnectionClientMessage.MessageType.DisposedNotification)
+                    if (_subscriptions.ShouldWaitForClusterStabilization())
                     {
-                        CancellationTokenSource.Cancel();
+                        // we have unstable cluster
+                        await timeoutTask;
+                    }
+                    else
+                    {
+                        clientReply = await _lastReplyFromClientTask;
+                        if (clientReply.Type == SubscriptionConnectionClientMessage.MessageType.DisposedNotification)
+                        {
+                            await CancellationTokenSource.CancelAsync();
+                            break;
+                        }
+
+                        _lastReplyFromClientTask = GetReplyFromClientAsync();
                         break;
                     }
-
-                    _lastReplyFromClientTask = GetReplyFromClientAsync();
-                    break;
                 }
 
                 await SendHeartBeatAsync("Waiting for client ACK");
@@ -1012,7 +1037,7 @@ namespace Raven.Server.Documents.Subscriptions
         protected abstract StatusMessageDetails GetStatusMessageDetails();
 
         protected abstract Task OnClientAckAsync(string clientReplyChangeVector);
-        public abstract Task SendNoopAckAsync();
+        public abstract Task SendNoopAckAsync(bool force = false);
         protected abstract bool FoundAboutMoreDocs();
         protected abstract SubscriptionConnectionInUse MarkInUse();
 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -373,7 +373,7 @@ namespace Raven.Server.Documents.TcpHandlers
             await SendConfirmAsync(TcpConnection.DocumentDatabase.Time.GetUtcNow());
         }
 
-        public override Task SendNoopAckAsync() => State.SendNoopAck();
+        public override Task SendNoopAckAsync(bool force = false) => State.SendNoopAck(force);
 
         protected override bool FoundAboutMoreDocs()
         {

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -931,7 +931,11 @@ namespace Raven.Server.Rachis
             PrevStates.LimitedSizeEnqueue(transition, 5);
 
             context.Transaction.InnerTransaction.LowLevelTransaction.AfterCommitWhenNewTransactionsPrevented +=
-                _ => CurrentState = rachisState; //  we need this to happened while we still under the write lock
+                _ =>
+                {
+                    CurrentState = rachisState;
+                    LastState = transition;
+                }; //  we need this to happened while we still under the write lock
 
             context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>
             {
@@ -1016,6 +1020,7 @@ namespace Raven.Server.Rachis
             });
         }
 
+        public StateTransition LastState;
         public ConcurrentQueue<StateTransition> PrevStates { get; set; } = new ConcurrentQueue<StateTransition>();
 
         public bool TakeOffice()


### PR DESCRIPTION
cherry pick https://github.com/ravendb/ravendb/pull/18760

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20511

### Additional description

in case the engine state is candidate, don't drop subscription connection, try to wait until it become follower/leader

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
