### PR TITLE
RavenDB-22566 - Cannot cancel a restore of a snapshot

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -248,7 +248,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                     Key = key
                 }, _cancellationToken);
 
-                return new RavenStorageClient.Blob(response.ResponseStream, ConvertMetadata(response.Metadata), response);
+                return new RavenStorageClient.Blob(response.ResponseStream, ConvertMetadata(response.Metadata), response.ContentLength, response);
             }
             catch (AmazonS3Exception e)
             {

--- a/src/Raven.Server/Documents/PeriodicBackup/Azure/LegacyRavenAzureClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Azure/LegacyRavenAzureClient.cs
@@ -439,7 +439,14 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
             var data = await response.Content.ReadAsStreamAsync();
             var headers = response.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault());
 
-            return new Blob(data, headers);
+            if (response.Content.Headers.TryGetValues("Content-Length", out var values) == false)
+                throw new InvalidOperationException("Content-Length header is not present");
+
+            var contentLength = values.FirstOrDefault();
+            if (long.TryParse(contentLength, out var size) == false)
+                throw new InvalidOperationException($"Content-Length header is present but could not be parsed, got: {contentLength}");
+
+            return new Blob(data, headers, size);
         }
 
         public void DeleteContainer()

--- a/src/Raven.Server/Documents/PeriodicBackup/Azure/LegacyRavenAzureClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Azure/LegacyRavenAzureClient.cs
@@ -174,7 +174,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
                     {"x-ms-date", now.ToString("R")},
                     {"x-ms-version", AzureStorageVersion},
                     {"x-ms-blob-type", "BlockBlob"},
-                    {"Content-Length", stream.Length.ToString(CultureInfo.InvariantCulture)}
+                    {Constants.Headers.ContentLength, stream.Length.ToString(CultureInfo.InvariantCulture)}
                 }
             };
 
@@ -247,7 +247,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
                     {
                         {"x-ms-date", now.ToString("R")},
                         {"x-ms-version", AzureStorageVersion},
-                        {"Content-Length", subStream.Length.ToString(CultureInfo.InvariantCulture)}
+                        {Constants.Headers.ContentLength, subStream.Length.ToString(CultureInfo.InvariantCulture)}
                     }
                 };
 
@@ -305,7 +305,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
                 {
                     {"x-ms-date", now.ToString("R")},
                     {"x-ms-version", AzureStorageVersion},
-                    {"Content-Length", Encoding.UTF8.GetBytes(xmlString).Length.ToString(CultureInfo.InvariantCulture)}
+                    {Constants.Headers.ContentLength, Encoding.UTF8.GetBytes(xmlString).Length.ToString(CultureInfo.InvariantCulture)}
                 }
             };
 
@@ -439,7 +439,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
             var data = await response.Content.ReadAsStreamAsync();
             var headers = response.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault());
 
-            if (response.Content.Headers.TryGetValues("Content-Length", out var values) == false)
+            if (response.Content.Headers.TryGetValues(Constants.Headers.ContentLength, out var values) == false)
                 throw new InvalidOperationException("Content-Length header is not present");
 
             var contentLength = values.FirstOrDefault();
@@ -662,7 +662,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
 
             if (httpContentHeaders != null)
             {
-                if (httpContentHeaders.TryGetValues("Content-Length", out IEnumerable<string> lengthValues))
+                if (httpContentHeaders.TryGetValues(Constants.Headers.ContentLength, out IEnumerable<string> lengthValues))
                     contentLength = lengthValues.First();
 
                 if (httpContentHeaders.TryGetValues(Constants.Headers.ContentType, out IEnumerable<string> typeValues))
@@ -670,7 +670,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
             }
             else
             {
-                if (httpHeaders.TryGetValues("Content-Length", out IEnumerable<string> lengthValues))
+                if (httpHeaders.TryGetValues(Constants.Headers.ContentLength, out IEnumerable<string> lengthValues))
                     contentLength = lengthValues.First();
 
                 if (httpHeaders.TryGetValues(Constants.Headers.ContentType, out IEnumerable<string> typeValues))

--- a/src/Raven.Server/Documents/PeriodicBackup/Azure/RavenAzureClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Azure/RavenAzureClient.cs
@@ -171,7 +171,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
             var properties = await blob.GetPropertiesAsync(cancellationToken: _cancellationToken);
             var response = await blob.DownloadAsync(cancellationToken: _cancellationToken);
 
-            return new RavenStorageClient.Blob(response.Value.Content, properties.Value.Metadata, response.Value);
+            return new RavenStorageClient.Blob(response.Value.Content, properties.Value.Metadata, response.Value.ContentLength, response.Value);
         }
 
         public void DeleteBlobs(List<string> blobsToDelete)

--- a/src/Raven.Server/Documents/PeriodicBackup/GoogleCloud/RavenGoogleCloudClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/GoogleCloud/RavenGoogleCloudClient.cs
@@ -149,6 +149,15 @@ namespace Raven.Server.Documents.PeriodicBackup.GoogleCloud
             );
         }
 
+        public async Task<Size> GetObjectSizeAsync(string fileName)
+        {
+            var obj = await GetObjectAsync(fileName);
+            if (obj.Size == null)
+                throw new InvalidOperationException("Size isn't available");
+
+            return new Size((long)obj.Size.Value, SizeUnit.Bytes);
+        }
+
         public Task DeleteObjectAsync(string fileName)
         {
             return _client.DeleteObjectAsync(

--- a/src/Raven.Server/Documents/PeriodicBackup/RavenStorageClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/RavenStorageClient.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using Raven.Server.Utils;
+using Sparrow;
 
 namespace Raven.Server.Documents.PeriodicBackup
 {
@@ -70,16 +71,19 @@ namespace Raven.Server.Documents.PeriodicBackup
         {
             private IDisposable _toDispose;
 
-            public Blob(Stream data, IDictionary<string, string> metadata, IDisposable toDispose = null)
+            public Blob(Stream data, IDictionary<string, string> metadata, long sizeInBytes, IDisposable toDispose = null)
             {
                 Data = data ?? throw new ArgumentNullException(nameof(data));
                 Metadata = metadata;
+                Size = new Size(sizeInBytes, SizeUnit.Bytes);
                 _toDispose = toDispose;
             }
 
             public Stream Data { get; }
 
             public IDictionary<string, string> Metadata { get; }
+
+            public Size Size { get; }
 
             public void Dispose()
             {

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetBlobAsync(filePath);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _configuration, _cancellationToken);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _configuration, onProgress: null, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetBlobAsync(filePath);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _configuration, _cancellationToken);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Config;
@@ -14,12 +15,14 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
     public sealed class AzureRestorePoints : RestorePointsBase
     {
         private readonly RavenConfiguration _configuration;
+        private readonly CancellationToken _cancellationToken;
         private readonly IRavenAzureClient _client;
         
-        public AzureRestorePoints(RavenConfiguration configuration, TransactionOperationContext context, AzureSettings azureSettings) : base(context)
+        public AzureRestorePoints(RavenConfiguration configuration, TransactionOperationContext context, AzureSettings azureSettings, CancellationToken cancellationToken) : base(context)
         {
             _configuration = configuration;
-            _client = RavenAzureClient.Create(azureSettings, configuration.Backup);
+            _cancellationToken = cancellationToken;
+            _client = RavenAzureClient.Create(azureSettings, configuration.Backup, cancellationToken: cancellationToken);
         }
 
         public override Task<RestorePoints> FetchRestorePoints(string path, int? shardNumber = null)
@@ -57,7 +60,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetBlobAsync(filePath);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _configuration);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/GoogleCloudRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/GoogleCloudRestorePoints.cs
@@ -61,7 +61,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             Stream downloadObject = _client.DownloadObject(filePath);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(downloadObject, _configuration, _cancellationToken);
+            var size = await _client.GetObjectSizeAsync(filePath);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(downloadObject, size, _configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/GoogleCloudRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/GoogleCloudRestorePoints.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             Stream downloadObject = _client.DownloadObject(filePath);
             var size = await _client.GetObjectSizeAsync(filePath);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(downloadObject, size, _configuration, _cancellationToken);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(downloadObject, size, _configuration, onProgress: null, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/IRestoreSource.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/IRestoreSource.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Operations;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
@@ -10,7 +11,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
     {
         Task<Stream> GetStream(string path);
 
-        Task<ZipArchive> GetZipArchiveForSnapshot(string path);
+        Task<ZipArchive> GetZipArchiveForSnapshot(string path, Action<string> onProgress);
 
         Task<List<string>> GetFilesForRestore();
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Azure;
 using Raven.Server.ServerWide;
@@ -34,10 +35,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return blob.Data;
         }
 
-        public async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
+        public async Task<ZipArchive> GetZipArchiveForSnapshot(string path, Action<string> onProgress)
         {
             var blob = await _client.GetBlobAsync(path);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _serverStore.Configuration, _cancellationToken);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _serverStore.Configuration, onProgress, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.Backups;
@@ -15,12 +16,14 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
     public sealed class RestoreFromAzure : IRestoreSource
     {
         private readonly ServerStore _serverStore;
+        private readonly CancellationToken _cancellationToken;
         private readonly IRavenAzureClient _client;
         private readonly string _remoteFolderName;
 
-        public RestoreFromAzure([NotNull] ServerStore serverStore, RestoreFromAzureConfiguration restoreFromConfiguration)
+        public RestoreFromAzure([NotNull] ServerStore serverStore, RestoreFromAzureConfiguration restoreFromConfiguration, CancellationToken cancellationToken)
         {
             _serverStore = serverStore ?? throw new ArgumentNullException(nameof(serverStore));
+            _cancellationToken = cancellationToken;
             _client = RavenAzureClient.Create(restoreFromConfiguration.Settings, serverStore.Configuration.Backup);
             _remoteFolderName = restoreFromConfiguration.Settings.RemoteFolderName;
         }
@@ -34,7 +37,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         public async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
         {
             var blob = await _client.GetBlobAsync(path);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _serverStore.Configuration);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _serverStore.Configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         public async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
         {
             var blob = await _client.GetBlobAsync(path);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _serverStore.Configuration, _cancellationToken);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _serverStore.Configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
@@ -35,7 +35,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         public async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
         {
             Stream stream = _client.DownloadObject(path);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(stream, _serverStore.Configuration, _cancellationToken);
+            var size = await _client.GetObjectSizeAsync(path);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(stream, size, _serverStore.Configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
@@ -5,6 +5,7 @@ using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.GoogleCloud;
 using Raven.Server.ServerWide;
@@ -32,11 +33,11 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return Task.FromResult(_client.DownloadObject(path));
         }
 
-        public async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
+        public async Task<ZipArchive> GetZipArchiveForSnapshot(string path, Action<string> onProgress)
         {
             Stream stream = _client.DownloadObject(path);
             var size = await _client.GetObjectSizeAsync(path);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(stream, size, _serverStore.Configuration, _cancellationToken);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(stream, size, _serverStore.Configuration, onProgress, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
@@ -32,7 +33,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return Task.FromResult<Stream>(stream);
         }
 
-        public Task<ZipArchive> GetZipArchiveForSnapshot(string path)
+        public Task<ZipArchive> GetZipArchiveForSnapshot(string path, Action<string> onProgress)
         {
             return Task.FromResult(ZipFile.Open(path, ZipArchiveMode.Read, System.Text.Encoding.UTF8));
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.Backups;
@@ -15,13 +16,15 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
     public sealed class RestoreFromS3 : IRestoreSource
     {
         private readonly ServerStore _serverStore;
+        private readonly CancellationToken _cancellationToken;
         private readonly RavenAwsS3Client _client;
         private readonly string _remoteFolderName;
 
-        public RestoreFromS3([NotNull] ServerStore serverStore, RestoreFromS3Configuration restoreFromConfiguration)
+        public RestoreFromS3([NotNull] ServerStore serverStore, RestoreFromS3Configuration restoreFromConfiguration, CancellationToken cancellationToken)
         {
             _serverStore = serverStore ?? throw new ArgumentNullException(nameof(serverStore));
-            _client = new RavenAwsS3Client(restoreFromConfiguration.Settings, serverStore.Configuration.Backup);
+            _cancellationToken = cancellationToken;
+            _client = new RavenAwsS3Client(restoreFromConfiguration.Settings, serverStore.Configuration.Backup, cancellationToken: cancellationToken);
             _remoteFolderName = restoreFromConfiguration.Settings.RemoteFolderName;
         }
 
@@ -34,7 +37,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         public async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
         {
             var blob = await _client.GetObjectAsync(path);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _serverStore.Configuration);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _serverStore.Configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Aws;
 using Raven.Server.ServerWide;
@@ -34,10 +35,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return blob.Data;
         }
 
-        public async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
+        public async Task<ZipArchive> GetZipArchiveForSnapshot(string path, Action<string> onProgress)
         {
             var blob = await _client.GetObjectAsync(path);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _serverStore.Configuration, _cancellationToken);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _serverStore.Configuration, onProgress, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         public async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
         {
             var blob = await _client.GetObjectAsync(path);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _serverStore.Configuration, _cancellationToken);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _serverStore.Configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -176,7 +176,11 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             RestoreSettings restoreSettings = null;
 
             var fullBackupPath = RestoreSource.GetBackupPath(backupPath);
-            _zipArchive = await RestoreSource.GetZipArchiveForSnapshot(fullBackupPath);
+            _zipArchive = await RestoreSource.GetZipArchiveForSnapshot(fullBackupPath, onProgress: message =>
+            {
+                restoreResult.AddInfo(message);
+                onProgress.Invoke(restoreResult.Progress);
+            });
 
             var restorePath = new VoronPathSetting(RestoreConfiguration.DataDirectory);
             if (Directory.Exists(restorePath.FullPath) == false)

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreUtils.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreUtils.cs
@@ -188,8 +188,9 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 return;
 
             // + we need to download the snapshot
+            // + we need to unzip the snapshot
             // + leave 1GB of free space
-            var freeSpaceNeeded = size + new Size(1, SizeUnit.Gigabytes);
+            var freeSpaceNeeded = 2 * size + new Size(1, SizeUnit.Gigabytes);
 
             if (freeSpaceNeeded > spaceInfo.TotalFreeSpace)
                 throw new DiskFullException($"There is not enough space on '{basePath}', we need at least {freeSpaceNeeded} in order to successfully copy the snapshot backup file locally. Currently available space is {spaceInfo.TotalFreeSpace}.");

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreUtils.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreUtils.cs
@@ -119,7 +119,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
                 onProgress?.Invoke($"Copying ZipArchive locally, size: {size}");
 
-                stream.CopyTo(file, readCount =>
+                await stream.CopyToAsync(file, readCount =>
                 {
                     totalRead += readCount;
                     if (swForProgress.ElapsedMilliseconds > 5000)
@@ -129,7 +129,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     }
                 }, cancellationToken);
 
-                onProgress?.Invoke($"Copied ZipArchive locally, took: {sw.ElapsedMilliseconds:#,#;;0}ms");
+                onProgress?.Invoke($"Copied ZipArchive locally, took: {sw.Elapsed}");
 
                 file.Seek(0, SeekOrigin.Begin);
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetObjectAsync(filePath);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _configuration, _cancellationToken);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _configuration, onProgress: null, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Config;
@@ -14,12 +15,14 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
     public sealed class S3RestorePoints : RestorePointsBase
     {
         private readonly RavenConfiguration _configuration;
+        private readonly CancellationToken _cancellationToken;
         private readonly RavenAwsS3Client _client;
 
-        public S3RestorePoints(RavenConfiguration configuration, TransactionOperationContext context, S3Settings s3Settings) : base(context)
+        public S3RestorePoints(RavenConfiguration configuration, TransactionOperationContext context, S3Settings s3Settings, CancellationToken cancellationToken) : base(context)
         {
             _configuration = configuration;
-            _client = new RavenAwsS3Client(s3Settings, configuration.Backup);
+            _cancellationToken = cancellationToken;
+            _client = new RavenAwsS3Client(s3Settings, configuration.Backup, cancellationToken: cancellationToken);
         }
 
         public override async Task<RestorePoints> FetchRestorePoints(string path, int? shardNumber = null)
@@ -69,7 +72,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetObjectAsync(filePath);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _configuration);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetObjectAsync(filePath);
-            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, _configuration, _cancellationToken);
+            var file = await RestoreUtils.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -473,8 +473,9 @@ namespace Raven.Server.Web.System
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
+                var cancelToken = CreateBackgroundOperationToken();
                 var configuration = await context.ReadForMemoryAsync(RequestBodyStream(), "database-restore");
-                var restoreConfiguration = RestoreUtils.GetRestoreConfigurationAndSource(ServerStore, configuration, out var restoreSource);
+                var restoreConfiguration = RestoreUtils.GetRestoreConfigurationAndSource(ServerStore, configuration, out var restoreSource, cancelToken);
 
                 if (restoreConfiguration.ShardRestoreSettings != null)
                 {
@@ -496,8 +497,6 @@ namespace Raven.Server.Web.System
                 }
 
                 await ServerStore.EnsureNotPassiveAsync();
-
-                var cancelToken = CreateBackgroundOperationToken();
 
                 var operationId = ServerStore.Operations.GetNextOperationId();
 

--- a/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGetRestorePoints.cs
+++ b/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGetRestorePoints.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Conventions;
@@ -61,7 +62,7 @@ internal sealed class DatabasesHandlerProcessorForGetRestorePoints : AbstractSer
             var connectionType = GetPeriodicBackupConnectionType();
             var settings = await GetSettingsAsync(context);
 
-            using var source = GetRestorePointsSource(context, connectionType, settings, out string path);
+            using var source = GetRestorePointsSource(context, connectionType, settings, out string path, RequestHandler.AbortRequestToken);
 
             var shardNumber = JsonDeserializationServer.LocalSettings(settings).ShardNumber;
             var restorePoints = await source.FetchRestorePoints(path, shardNumber);
@@ -82,7 +83,7 @@ internal sealed class DatabasesHandlerProcessorForGetRestorePoints : AbstractSer
         return RequestHandler.ServerStore.ClusterRequestExecutor.ExecuteAsync(command, context, token: token.Token);
     }
 
-    private RestorePointsBase GetRestorePointsSource(TransactionOperationContext context, PeriodicBackupConnectionType connectionType, BlittableJsonReaderObject settings, out string path)
+    private RestorePointsBase GetRestorePointsSource(TransactionOperationContext context, PeriodicBackupConnectionType connectionType, BlittableJsonReaderObject settings, out string path, CancellationToken token)
     {
         path = null;
 
@@ -105,15 +106,15 @@ internal sealed class DatabasesHandlerProcessorForGetRestorePoints : AbstractSer
             case PeriodicBackupConnectionType.S3:
                 var s3Settings = JsonDeserializationServer.S3Settings(settings);
                 path = s3Settings.RemoteFolderName;
-                return new S3RestorePoints(ServerStore.Configuration, context, s3Settings);
+                return new S3RestorePoints(ServerStore.Configuration, context, s3Settings, token);
             case PeriodicBackupConnectionType.Azure:
                 var azureSettings = JsonDeserializationServer.AzureSettings(settings);
                 path = azureSettings.RemoteFolderName;
-                return new AzureRestorePoints(ServerStore.Configuration, context, azureSettings);
+                return new AzureRestorePoints(ServerStore.Configuration, context, azureSettings, token);
             case PeriodicBackupConnectionType.GoogleCloud:
                 var googleCloudSettings = JsonDeserializationServer.GoogleCloudSettings(settings);
                 path = googleCloudSettings.RemoteFolderName;
-                return new GoogleCloudRestorePoints(ServerStore.Configuration, context, googleCloudSettings);
+                return new GoogleCloudRestorePoints(ServerStore.Configuration, context, googleCloudSettings, token);
             default:
                 throw new ArgumentOutOfRangeException(nameof(connectionType));
         }

--- a/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGetRestorePoints.cs
+++ b/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGetRestorePoints.cs
@@ -62,7 +62,8 @@ internal sealed class DatabasesHandlerProcessorForGetRestorePoints : AbstractSer
             var connectionType = GetPeriodicBackupConnectionType();
             var settings = await GetSettingsAsync(context);
 
-            using var source = GetRestorePointsSource(context, connectionType, settings, out string path, RequestHandler.AbortRequestToken);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(RequestHandler.Server.ServerStore.ServerShutdown, RequestHandler.AbortRequestToken);
+            using var source = GetRestorePointsSource(context, connectionType, settings, out string path, cts.Token);
 
             var shardNumber = JsonDeserializationServer.LocalSettings(settings).ShardNumber;
             var restorePoints = await source.FetchRestorePoints(path, shardNumber);

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -334,7 +334,7 @@ namespace Voron.Impl.Backup
 
                 onProgress?.Invoke($"Restored file: '{entry.Name}' to: '{dst}', " +
                                    $"size: {new Size(totalRead, SizeUnit.Bytes)}, " +
-                                   $"took: {sw.ElapsedMilliseconds:#,#;;0}ms");
+                                   $"took: {sw.Elapsed}");
             }
         }
 

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Sparrow.Utils;
 
 namespace Voron.Impl.Backup
@@ -31,5 +32,17 @@ namespace Voron.Impl.Backup
             }
         }
 
+        public static async Task CopyToAsync(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
+        {
+            var readBuffer = new byte[DefaultBufferSize];
+
+            int count;
+            while ((count = await source.ReadAsync(readBuffer, 0, readBuffer.Length, cancellationToken)) != 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                onProgress?.Invoke(count);
+                await destination.WriteAsync(readBuffer, 0, count, cancellationToken);
+            }
+        }
     }
 }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Aws.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Aws.cs
@@ -46,6 +46,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var @object = await client.GetObjectAsync(key);
                 Assert.NotNull(@object);
+                Assert.True(@object.Size.GetValue(SizeUnit.Bytes) > 0);
 
                 using (var reader = new StreamReader(@object.Data))
                     Assert.Equal("231", await reader.ReadToEndAsync());

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Azure.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Azure.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.PeriodicBackup.Azure;
+using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -107,6 +108,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     });
                 var blob = await holder.Client.GetBlobAsync(blobKey);
                 Assert.NotNull(blob);
+                Assert.True(blob.Size.GetValue(SizeUnit.Bytes) > 0);
 
                 using (var reader = new StreamReader(blob.Data))
                     Assert.Equal("123", reader.ReadToEnd());

--- a/test/SlowTests/Server/Documents/PeriodicBackup/GoogleCloud.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/GoogleCloud.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Server.Documents.PeriodicBackup.GoogleCloud;
+using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -131,6 +132,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     var obj = await client.GetObjectAsync(fileName);
                     Assert.Equal("value1", obj.Metadata["key1"]);
                     Assert.Equal("value2", obj.Metadata["key2"]);
+
+                    var size = await client.GetObjectSizeAsync(fileName);
+                    Assert.True(size.GetValue(SizeUnit.Bytes) > 0);
                 }
 
                 finally


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22566/Cannot-cancel-a-restore-of-a-snapshot

### Additional description

- Allow to cancel the restore when downloading the snapshot.
- Get the file size of the snapshot from the API.
- Add the progress of downloading the restore file.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
