### PR TITLE
RavenDB-22562 Cannot choose the backup to restore

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupDataUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupDataUtils.ts
@@ -177,13 +177,17 @@ function getSourceDto(
     encryptionDataIsEncrypted: boolean,
     encryptionDataKey: string
 ): SelectedSourceDto & Pick<CreateDatabaseFromBackupDto, "BackupLocation" | "Settings"> {
+    const backupLocation = isSharded
+        ? null
+        : sourceStep.sourceData[sourceStep.sourceType].pointsWithTags[0].restorePoint.location;
+
     switch (sourceStep.sourceType) {
         case "local": {
             const data = sourceStep.sourceData.local;
 
             return {
                 ...getSelectedSourceDto(isSharded, data, encryptionDataIsEncrypted, encryptionDataKey),
-                BackupLocation: isSharded ? null : data.pointsWithTags[0].restorePoint.location,
+                BackupLocation: backupLocation,
             };
         }
         case "ravenCloud": {
@@ -197,7 +201,7 @@ function getSourceDto(
                     AwsRegionName: data.awsSettings.regionName,
                     BucketName: data.awsSettings.bucketName,
                     AwsSessionToken: data.awsSettings.sessionToken,
-                    RemoteFolderName: data.awsSettings.remoteFolderName,
+                    RemoteFolderName: backupLocation,
                     Disabled: false,
                     CustomServerUrl: null,
                     ForcePathStyle: false,
@@ -216,7 +220,7 @@ function getSourceDto(
                     AwsRegionName: data.awsRegion,
                     BucketName: data.bucketName,
                     AwsSessionToken: "",
-                    RemoteFolderName: data.remoteFolderName,
+                    RemoteFolderName: backupLocation,
                     Disabled: false,
                     GetBackupConfigurationScript: null,
                     CustomServerUrl: data.isUseCustomHost ? data.customHost : null,
@@ -234,7 +238,7 @@ function getSourceDto(
                     SasToken: "",
                     AccountName: data.accountName,
                     StorageContainer: data.container,
-                    RemoteFolderName: data.remoteFolderName,
+                    RemoteFolderName: backupLocation,
                     Disabled: false,
                     GetBackupConfigurationScript: null,
                 } satisfies AzureSettings,
@@ -249,7 +253,7 @@ function getSourceDto(
                 Settings: {
                     BucketName: data.bucketName,
                     GoogleCredentialsJson: data.credentialsJson,
-                    RemoteFolderName: data.remoteFolderName,
+                    RemoteFolderName: backupLocation,
                     Disabled: false,
                     GetBackupConfigurationScript: null,
                 } satisfies GoogleCloudSettings,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22562

### Additional description

Sets RemoteFolderName from restore point location. (like in v5.4)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
