### PR TITLE
RavenDB-9167 script for creating & publishing docker multiarch manifest

### DIFF
--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -35,7 +35,6 @@ function GetUbuntuImageTags($repo, $version, $arch) {
     switch ($arch) {
         "x64" { 
             return @(
-                "$($repo):latest-lts",
                 "$($repo):ubuntu-latest-lts",
                 "$($repo):5.4-ubuntu-latest",
                 "$($repo):$($version)-ubuntu.22.04-x64"
@@ -88,4 +87,29 @@ function GetWindowsImageTags($repo, $version, $WinVer) {
         }        
     }
 
+}
+
+function GetManifestTags {
+    param (
+        $repo
+    )
+
+    return @(
+        "${repo}:latest-lts",
+        "${repo}:5.4-latest"
+    )
+}
+
+function GetImageTagsForManifest {
+    param (
+        [string]$repo
+    )
+
+    return @(
+        "${repo}:5.4-ubuntu-latest",
+        "${repo}:5.4-ubuntu-arm32v7-latest",
+        "${repo}:5.4-ubuntu-arm64v8-latest",
+        "${repo}:5.4-windows-1809-latest",
+        "${repo}:5.4-windows-ltsc2022-latest"
+    )
 }

--- a/docker/publish-multiarch.ps1
+++ b/docker/publish-multiarch.ps1
@@ -1,0 +1,57 @@
+param(
+    $Repo = "ravendb/ravendb",
+    [switch]$DryRun = $False)
+
+$ErrorActionPreference = "Stop"
+
+. ".\common.ps1"
+
+if ($env:DRY_RUN) {
+    $DryRun = $True
+}
+
+function CreateDockerManifests {
+    param (
+        [string]$repo,
+        [string[]]$manifestTags,
+        [string[]]$tags
+    )
+
+    Write-Host "Creating docker manifests combining: $tags"
+
+    foreach ($manifestTag in $manifestTags) {
+        Write-Host "Creating docker manifest $manifestTag."
+        
+        $command = "docker manifest create $manifestTag"
+        foreach ($tag in $tags) {
+            $command += " --amend $tag"
+        }
+
+        Invoke-Expression $command
+    }
+}
+
+function PushDockerManifests {
+    param (
+        [string[]]$manifests
+    )
+
+    Write-Host "Pushing manifests to docker."
+
+    foreach ($manifest in $manifests) {
+        if ($DryRun) {
+            Write-Host "DRY RUN: docker manifest push $manifest"
+        }
+        else {
+            Write-Host "Pushing manifest $manifest"
+            docker manifest push $manifest
+        }
+    }
+    
+}
+
+$tags = GetImageTagsForManifest $Repo
+$manifestTags = GetManifestTags $Repo
+
+CreateDockerManifests $Repo $manifestTags $tags
+PushDockerManifests $manifestTags


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-9167

### Additional description

Use multiarch feature of docker images.
Manifest tags created and image tags used for manifest creation has to be changed when merging to v6.0 and v6.1

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
