### PR TITLE
RavenDB-22572 Azure Storage Queue ETL: small fix in the syntax example

### DIFF
--- a/src/Raven.Server/Config/Categories/EtlConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EtlConfiguration.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Config.Categories
         public TimeSetting AzureQueueStorageTimeToLive{ get; set; }
         
         [Description("How long a message is hidden after being retrieved but not deleted")]
-        [DefaultValue(0)] // azure default
+        [DefaultValue(0)] // Azure default
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("ETL.Queue.AzureQueueStorage.VisibilityTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting AzureQueueStorageVisibilityTimeout{ get; set; }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/EditAzureQueueStorageEtlInfoHub.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/EditAzureQueueStorageEtlInfoHub.tsx
@@ -31,8 +31,8 @@ export function EditAzureQueueStorageEtlInfoHub() {
                 description="Get additional info on this feature"
             >
                 <p>
-                    A <strong>Azure Queue Storage ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
-                    that transfers data from this RavenDB database to a Azure Queue Storage.
+                    An <strong>Azure Queue Storage ETL</strong> ongoing-task is an ETL (Extract, Transform & Load) process
+                    that transfers data from this RavenDB database to Azure Queue Storage.
                 </p>
                 <ul>
                     <li>
@@ -62,7 +62,7 @@ export function EditAzureQueueStorageEtlInfoHub() {
                     <ul>
                         <li>A connection string to the Azure Queue Storage server.</li>
                         <li>The transformation scripts definitions.</li>
-                        <li>Per queue, select whether processed documents will be deleted from your RavenDB database.
+                        <li>Per queue, select whether processed documents will be deleted from your source RavenDB database.
                         </li>
                         <li>A responsible node to handle this task can be set.</li>
                     </ul>

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/transformationScriptSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/transformationScriptSyntax.ts
@@ -208,9 +208,8 @@ loadToOrders(orderData, "routingKey", {  // load to the 'Orders' Exchange with o
     static readonly azureQueueStorageEtlSampleText =
         `${transformationScriptSyntax.queueEtlBaseSampleText}
 
-loadToOrders(orderData, {  // load to the 'Orders' Topic with optional params
+loadToOrders(orderData, {  // load to the 'Orders' Queue with optional params
     Id: id(this),
-    PartitionKey: id(this),
     Type: 'com.github.users',
     Source: '/registrations/direct-signup'
 });`;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22572/Azure-Storage-Queue-ETL-small-fix-in-the-syntax-example

### Additional description
Apply these fixes in the syntax example:
1. Topic => Queue
2. Remove PartionKey

Plus some small grammar fixes

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. See https://issues.hibernatingrhinos.com/issue/RDoc-2882/Document-ETL-to-Azure-Queue-Storage
- [ ] No documentation update is needed

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
