### PR TITLE
RavenDB-22573 test and revert to RavenDB-21636

### DIFF
--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -256,7 +256,8 @@ internal static class BackupUtils
         Debug.Assert(parameters.Configuration.TaskId != 0);
 
         var isFullBackup = IsFullBackup(parameters.BackupStatus, parameters.Configuration, nextFullBackup, nextIncrementalBackup, parameters.ResponsibleNodeTag);
-        var nextBackupTimeUtc = GetNextBackupDateTime(nextFullBackup, nextIncrementalBackup, parameters.BackupStatus.DelayUntil);
+        var nextBackupTimeLocal = GetNextBackupDateTime(nextFullBackup, nextIncrementalBackup, parameters.BackupStatus.DelayUntil);
+        var nextBackupTimeUtc = nextBackupTimeLocal.ToUniversalTime();
         var timeSpan = nextBackupTimeUtc - nowUtc;
 
         TimeSpan nextBackupTimeSpan;
@@ -299,7 +300,7 @@ internal static class BackupUtils
         try
         {
             var backupParser = CrontabSchedule.Parse(parameters.BackupFrequency);
-            return backupParser.GetNextOccurrence(parameters.LastBackupUtc);
+            return backupParser.GetNextOccurrence(parameters.LastBackupUtc.ToLocalTime());
         }
         catch (Exception e)
         {
@@ -314,7 +315,7 @@ internal static class BackupUtils
         }
     }
 
-    private static DateTime GetNextBackupDateTime(DateTime? nextFullBackup, DateTime? nextIncrementalBackup, DateTime? delayUntil)
+    public static DateTime GetNextBackupDateTime(DateTime? nextFullBackup, DateTime? nextIncrementalBackup, DateTime? delayUntil)
     {
         Debug.Assert(nextFullBackup != null || nextIncrementalBackup != null);
         DateTime? nextBackup;
@@ -326,8 +327,8 @@ internal static class BackupUtils
         else
             nextBackup = nextFullBackup <= nextIncrementalBackup ? nextFullBackup.Value : nextIncrementalBackup.Value;
 
-        return delayUntil.HasValue && delayUntil.Value > nextBackup.Value
-            ? delayUntil.Value : nextBackup.Value;
+        return delayUntil.HasValue && delayUntil.Value.ToLocalTime() > nextBackup.Value
+            ? delayUntil.Value.ToLocalTime() : nextBackup.Value;
     }
 
     private static bool IsFullBackup(PeriodicBackupStatus backupStatus,

--- a/test/SlowTests/Issues/RavenDB-22573.cs
+++ b/test/SlowTests/Issues/RavenDB-22573.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Backups;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using static Raven.Server.Utils.BackupUtils;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22573 :RavenTestBase
+    {
+        public RavenDB_22573(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task GetNextBackupTime()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var store = GetDocumentStore())
+            {
+                var periodicBackupRunner = (await Databases.GetDocumentDatabaseInstanceFor(store)).PeriodicBackupRunner;
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 1 * * *", backupType: BackupType.Backup, disabled: false);
+                var id = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store);
+                var status = documentDatabase.PeriodicBackupRunner.GetBackupStatus(id);
+                config.TaskId = id;
+                var nextBackupDetails = periodicBackupRunner.GetNextBackupDetails(config, status, out string _);
+                var nextBackup = nextBackupDetails.DateTime.ToLocalTime();
+
+                Assert.Equal(1,nextBackup.Hour);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -2958,7 +2958,6 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                     var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: fullBackupFrequency);
                     var taskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
-
                     // Let's delay the backup task
                     var taskBackupInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.Backup)) as OngoingTaskBackup;
                     Assert.NotNull(taskBackupInfo);
@@ -2966,7 +2965,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.NotNull(taskBackupInfo.OnGoingBackup.StartTime);
 
                     var delayDuration = TimeSpan.FromMinutes(delayDurationInMinutes);
-                    var delayUntil = DateTime.UtcNow + delayDuration;
+                    var delayUntil = DateTime.Now + delayDuration;
                     await store.Maintenance.SendAsync(new DelayBackupOperation(taskBackupInfo.OnGoingBackup.RunningBackupTaskId, delayDuration));
 
                     // There should be no OnGoingBackup operation in the OngoingTaskBackup
@@ -2992,7 +2991,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(backupStatus.OriginalBackupTime,
                         delayUntil < nextFullBackup
                             ? taskBackupInfo.OnGoingBackup.StartTime    // until the next scheduled backup time.
-                            : nextFullBackup.Value);  // after the next scheduled backup.
+                            : nextFullBackup.Value.ToUniversalTime());  // after the next scheduled backup.
                 }, tcs: new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously));
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21636

### Additional description

Backup is running on UTC instead of the server's local time duo to the issue:
https://issues.hibernatingrhinos.com/issue/RavenDB-21636/SlowTests.Issues.RavenDB20084.ShouldUpdateBackupInfoIfDatabaseUnloaded

We are reverting the previous pull request:
https://github.com/ravendb/ravendb/pull/18304

A new fix for Issue-21636 will be addressed in a new PR

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
