### PR TITLE
RavenDB-22582 Bugfix - Windows Docker container does not run

### DIFF
--- a/docker/ravendb-nanoserver/run-raven.ps1
+++ b/docker/ravendb-nanoserver/run-raven.ps1
@@ -24,7 +24,7 @@ function Get-RavenServerScheme {
 
 if ([string]::IsNullOrEmpty($env:RAVEN_ServerUrl)) {
     $RAVEN_SERVER_SCHEME = Get-RavenServerScheme
-    $env:RAVEN_ServerUrl = "$RAVEN_SERVER_SCHEME://$hostname:8080"
+    $env:RAVEN_ServerUrl = "$($RAVEN_SERVER_SCHEME)://$($hostname):8080"
 }
 
 if ([string]::IsNullOrEmpty($env:RAVEN_ARGS) -eq $False) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22582/Windows-Docker-container-does-not-run

### Additional description

Simple bugfix, relates to https://issues.hibernatingrhinos.com/issue/RavenDB-17474/Set-https-scheme-in-Docker-automatically-if-cert-options-are-passed-through-one-of-the-available-channels

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms. Docker Nanoserver
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
