### PR TITLE
RavenDB-22585 : fix failing smuggler inter-version test

### DIFF
--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -92,11 +92,12 @@ namespace Raven.Server.Smuggler.Migration
                         smugglerResult.TimeSeries = new SmugglerProgressBase.CountsWithSkippedCountAndLastEtag();
                     }
 
-                    if ((_buildVersion >= 4000 && _buildVersion <= 54133) || (_buildVersion >= 6000 && _buildVersion <= 60035))
+                    if ((_buildVersion >= 4000 && _buildVersion <= 54133) || 
+                        (_buildVersion >= 6000 && _buildVersion <= 60035) ||
+                        (_buildVersion >= 40 && _buildVersion < 54))
                     {
                         // prevent NRE, time series deleted ranges were added in 5.4.201 and 6.0.105 
                         smugglerResult.TimeSeriesDeletedRanges = new SmugglerProgressBase.CountsWithSkippedCountAndLastEtag();
-
                     }
 
                     var importInfo = new ImportInfo

--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -80,20 +80,20 @@ namespace Raven.Server.Smuggler.Migration
                     if (smugglerResult == null)
                         return;
 
-                    if ((_buildVersion >= 40000 && _buildVersion < 41000) || _buildVersion == 40)
+                    if ((_buildVersion >= 40_000 && _buildVersion < 41_000) || _buildVersion == 40)
                     {
                         // prevent NRE, counter were added in 4.1
                         smugglerResult.Counters = new SmugglerProgressBase.CountsWithSkippedCountAndLastEtag();
                     }
 
-                    if ((_buildVersion >= 40000 && _buildVersion < 50000) || (_buildVersion >= 40 && _buildVersion < 50))
+                    if ((_buildVersion >= 40_000 && _buildVersion < 50_000) || (_buildVersion >= 40 && _buildVersion < 50))
                     {
                         // prevent NRE, time series were added in 5.0
                         smugglerResult.TimeSeries = new SmugglerProgressBase.CountsWithSkippedCountAndLastEtag();
                     }
 
-                    if ((_buildVersion >= 4000 && _buildVersion <= 54133) || 
-                        (_buildVersion >= 6000 && _buildVersion <= 60035) ||
+                    if ((_buildVersion >= 40_000 && _buildVersion <= 54_133) || 
+                        (_buildVersion >= 60_000 && _buildVersion <= 60_035) ||
                         (_buildVersion >= 40 && _buildVersion < 54))
                     {
                         // prevent NRE, time series deleted ranges were added in 5.4.201 and 6.0.105 

--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -92,6 +92,13 @@ namespace Raven.Server.Smuggler.Migration
                         smugglerResult.TimeSeries = new SmugglerProgressBase.CountsWithSkippedCountAndLastEtag();
                     }
 
+                    if ((_buildVersion >= 4000 && _buildVersion <= 54133) || (_buildVersion >= 6000 && _buildVersion <= 60035))
+                    {
+                        // prevent NRE, time series deleted ranges were added in 5.4.201 and 6.0.105 
+                        smugglerResult.TimeSeriesDeletedRanges = new SmugglerProgressBase.CountsWithSkippedCountAndLastEtag();
+
+                    }
+
                     var importInfo = new ImportInfo
                     {
                         LastEtag = Math.Max(previousImportInfo?.LastEtag ?? 0, smugglerResult.GetLastEtag() + 1),


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22585

### Additional description

prevent NRE on `TimeSeriesDeletedRanges` when migrating from old server

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant
