### PR TITLE
RavenDB-22502 Error modifying a document by a non-cluster session after it was created in a cluster-wide transaction

### DIFF
--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -256,6 +256,11 @@ namespace Raven.Server.Rachis
                             var myLastCommittedIndex = 0L;
                             entries.Clear();
                             _engine.ValidateTerm(_term);
+                            
+                            if (_engine.ForTestingPurposes?.NodeTagsToDisconnect?.Contains(_tag) == true)
+                            {
+                                throw new InvalidOperationException($"Exception was thrown for disconnecting  node {_tag} - For testing purposes.");
+                            }
 
                             using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22502

### Additional description

Loading a cluster-wide document that was sent by replication without having his atomic guard might be problematic if we try to save this document with a single node tx.

Since we don't have the guard on that node yet, we will throw a concurrency exception, although there is no concurrency issues. To fix it we will simply wait for the highest raft index of the documents in the tx, before sending it to the merger.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
Doesn't break any changes but, modify the behavior when saving a document that was create with a cluster-wide tx
Now it will wait for the highest raft index be applied before save changes in a single node tx.
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
