### PR TITLE
RavenDB-22353 - Fix ShouldStoreTotalDocumentsSizeInPerformanceHint_ForRevisions test

### DIFF
--- a/test/SlowTests/Issues/RavenDB_17018.cs
+++ b/test/SlowTests/Issues/RavenDB_17018.cs
@@ -206,7 +206,12 @@ namespace SlowTests.Issues
                 
                 string reason;
                 var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out reason);
-                Assert.True(outcome, reason);
+                if (outcome == false)
+                {
+                    // "Queue is empty" means that the UpdatePagingInternal already invoked by the Timer
+                    // Any other reason is Failure 
+                    Assert.Equal("Queue is empty", reason); 
+                }
 
                 using (database.NotificationCenter.GetStored(out var actions))
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22353/SlowTests.Issues.RavenDB17018.ShouldStoreTotalDocumentsSizeInPerformanceHintForRevisions

### Additional description

The test was failing because Timer called `UpdatePagingInternal` before the test called it

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] Existing tests were modified
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
