### PR TITLE
RavenDB-22589 - add missing dispose, dispose EtlTestBase properly

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
@@ -194,7 +194,7 @@ function loadTimeSeriesOfUsersBehavior(doc, ts)
             const double value = 58d;
             const string documentId = "users/1";
 
-            var src = GetDocumentStore(_options);
+            using var src = GetDocumentStore(_options);
             using (var session = src.OpenAsyncSession())
             {
                 var entity = new User { Name = "Joe Doe" };
@@ -693,14 +693,14 @@ function loadTimeSeriesOfUsersBehavior(docId, timeSeries)
 
             await AssertWaitForTrueAsync(async () =>
             {
-                var session = dest.OpenAsyncSession();
+                using var session = dest.OpenAsyncSession();
                 var user = await session.LoadAsync<User>(users[batchSize].Id);
                 return user.Name.EndsWith(changed);
             }, interval: _waitInterval);
 
             await AssertWaitForTrueAsync(async () =>
             {
-                var session = dest.OpenAsyncSession();
+                using var session = dest.OpenAsyncSession();
                 var ts = await session.TimeSeriesFor(users[0].Id, timeSeriesName).GetAsync(times[1], times[1]);
                 return ts.Length == 1;
             }, interval: _waitInterval);

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -763,6 +763,8 @@ namespace FastTests
 
         protected override void Dispose(ExceptionAggregator exceptionAggregator)
         {
+            Etl.Dispose();
+
             foreach (var store in CreatedStores)
             {
                 if (store.WasDisposed)
@@ -770,7 +772,6 @@ namespace FastTests
 
                 exceptionAggregator.Execute(store.Dispose);
             }
-            Etl.Dispose();
             CreatedStores.Clear();
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22589


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
