### PR TITLE
RavenDB-21247 Pass query parameters to high latency warning

### DIFF
--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -58,6 +58,9 @@ namespace Raven.Server.Documents.Handlers
                         if (string.IsNullOrWhiteSpace(debug) == false)
                         {
                             await Debug(queryContext, debug, token, tracker, httpMethod);
+                            
+                            tracker.Dispose();
+                            
                             return;
                         }
 

--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -62,6 +62,8 @@ namespace Raven.Server.Documents.Handlers
                         }
 
                         await Query(queryContext, token, tracker, httpMethod);
+                        
+                        tracker.Dispose();
                     }
                 }
                 catch (Exception e)
@@ -79,10 +81,12 @@ namespace Raven.Server.Documents.Handlers
                                            HttpContext.Request.Path.Value +
                                            e.ToString();
                         }
+
                         tracker.Query = errorMessage;
                         if (TrafficWatchManager.HasRegisteredClients)
                             AddStringToHttpContext(errorMessage, TrafficWatchChangeType.Queries);
                     }
+
                     throw;
                 }
             }

--- a/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
+++ b/src/Raven.Server/Documents/Queries/IndexQueryServerSide.cs
@@ -297,7 +297,10 @@ namespace Raven.Server.Documents.Queries
         private static void SetupTracker(IndexQueryServerSide indexQuery, RequestTimeTracker tracker)
         {
             if (tracker != null)
+            {
                 tracker.Query = indexQuery.Query;
+                tracker.QueryParameters = indexQuery.QueryParameters;
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
+++ b/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.NotificationCenter
         private readonly string _source;
         private readonly bool _doPerformanceHintIfTooLong;
         private readonly Stopwatch _sw;
-        public bool IsDisposed;
+        private bool _isDisposed;
         
         public RequestTimeTracker(HttpContext context, Logger logger, DocumentDatabase database, string source, bool doPerformanceHintIfTooLong = true)
         {
@@ -43,10 +43,10 @@ namespace Raven.Server.NotificationCenter
 
         public void Dispose()
         {
-            if (IsDisposed)
+            if (_isDisposed)
                 return;
             
-            IsDisposed = true;
+            _isDisposed = true;
             
             if (_sw.Elapsed <= _database.Configuration.PerformanceHints.TooLongRequestThreshold.AsTimeSpan)
                 return;

--- a/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
+++ b/src/Raven.Server/NotificationCenter/RequestTimeTracker.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
 using Raven.Server.Documents;
+using Sparrow.Json;
 using Sparrow.Logging;
 
 namespace Raven.Server.NotificationCenter
@@ -16,6 +17,7 @@ namespace Raven.Server.NotificationCenter
         private readonly string _source;
         private readonly bool _doPerformanceHintIfTooLong;
         private readonly Stopwatch _sw;
+        public bool IsDisposed;
         
         public RequestTimeTracker(HttpContext context, Logger logger, DocumentDatabase database, string source, bool doPerformanceHintIfTooLong = true)
         {
@@ -37,9 +39,15 @@ namespace Raven.Server.NotificationCenter
         }
         
         public string Query { get; set; }
+        public BlittableJsonReaderObject QueryParameters { get; set; }
 
         public void Dispose()
         {
+            if (IsDisposed)
+                return;
+            
+            IsDisposed = true;
+            
             if (_sw.Elapsed <= _database.Configuration.PerformanceHints.TooLongRequestThreshold.AsTimeSpan)
                 return;
 
@@ -48,10 +56,12 @@ namespace Raven.Server.NotificationCenter
             
             try
             {
+                var queryWithParameters = $"{Query}\n{QueryParameters}";
+                
                 _database
                     .NotificationCenter
                     .RequestLatency
-                    .AddHint(_sw.ElapsedMilliseconds, _source, Query);
+                    .AddHint(_sw.ElapsedMilliseconds, _source, queryWithParameters);
             }
             catch (Exception e)
             {

--- a/test/SlowTests/Issues/RavenDB-21247.cs
+++ b/test/SlowTests/Issues/RavenDB-21247.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Conventions;
+using Raven.Server.Config;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Collections;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21247 : RavenTestBase
+{
+    public RavenDB_21247(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.None)]
+    public async Task TestAddHintMethod()
+    {
+        DoNotReuseServer();
+
+        using (var store = GetDocumentStore())
+        {
+            var db = await GetDatabase(store.Database);
+
+            db.NotificationCenter
+                .RequestLatency
+                .AddHint(5, "Query", "some query");
+
+            db.NotificationCenter
+                .RequestLatency
+                .UpdateRequestLatency(null);
+
+            var storedRequestLatencyDetails = db.NotificationCenter.RequestLatency
+                .GetRequestLatencyDetails();
+
+            Assert.Equal(1, storedRequestLatencyDetails.RequestLatencies.Count);
+
+            storedRequestLatencyDetails.RequestLatencies["Query"].TryDequeue(out RequestLatencyInfo result);
+
+            Assert.Equal("some query", result.Query);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public async Task TestQueryCausingRequestLatencyWarning()
+    {
+        DoNotReuseServer();
+
+        var storeOptions = new Options()
+        {
+            ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.PerformanceHints.TooLongRequestThreshold)] = "0"
+        };
+
+        using (var store = GetDocumentStore(storeOptions))
+        {
+            var db = await GetDatabase(store.Database);
+
+            using (var session = store.OpenSession())
+            {
+                var notificationsQueue = new AsyncQueue<DynamicJsonValue>();
+
+                using (db.NotificationCenter.TrackActions(notificationsQueue, null))
+                {
+                    Tuple<bool, DynamicJsonValue> notification;
+
+                    var res = session.Query<Dto>().Where(x => x.Name == "SomeName").ToList();
+
+                    Indexes.WaitForIndexing(store);
+                    
+                    do
+                    {
+                        notification = await notificationsQueue.TryDequeueAsync(TimeSpan.FromSeconds(5));
+                    } while (notification.Item1 == false || notification.Item2["Type"].ToString() != NotificationType.PerformanceHint.ToString());
+                    
+                    var notificationDetails = notification.Item2[nameof(AlertRaised.Details)] as DynamicJsonValue;
+                    
+                    using (var ctx = JsonOperationContext.ShortTermSingleUse())
+                    {
+                        var json = ctx.ReadObject(notificationDetails, "details");
+
+                        var detailsObject =
+                            DocumentConventions.DefaultForServer.Serialization.DefaultConverter.FromBlittable<RequestLatencyDetail>(json, "cpu_exhaustion_warning_details");
+                        
+                        detailsObject.RequestLatencies["Query"].TryDequeue(out RequestLatencyInfo requestLatencyInfo);
+                        
+                        Assert.Equal("from 'Dtos' where Name = $p0\n{\"p0\":\"SomeName\"}", requestLatencyInfo.Query);
+                    }
+                }
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21247/High-latency-queries-alert-doesnt-provide-query-parameters

### Additional description

We want to include query parameters in high latency warning 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
