### PR TITLE
RavenDB-21316 - Update the API when the license is changed when using Let's Encrypt

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -512,7 +512,8 @@ namespace Raven.Server.Commercial
             if (response.IsSuccessStatusCode == false)
             {
                 var responseString = await response.Content.ReadAsStringAsync(_serverStore.ServerShutdown).ConfigureAwait(false);
-                throw new InvalidOperationException($"Cannot activate license because we failed to update the license for Let's Encrypt {responseString}");
+                throw GenerateLicenseLimit(LimitType.InvalidLicense, 
+                    $"Failed to activate the license. The license update for Let's Encrypt encountered an issue: {responseString}");
             }
         }
 

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -461,6 +461,7 @@ namespace Raven.Server.Commercial
             }
 
             ThrowIfCannotActivateLicense(licenseStatus);
+            await UpdateLicenseForLetsEncryptAsync(license);
 
             try
             {
@@ -479,7 +480,42 @@ namespace Raven.Server.Commercial
                 throw new InvalidOperationException("Could not save license!", e);
             }
         }
-        
+
+        private async Task UpdateLicenseForLetsEncryptAsync(License newLicense)
+        {
+            if (_serverStore.Configuration.Core.SetupMode != SetupMode.LetsEncrypt)
+                return;
+
+            var previousLicense = _serverStore.LoadLicense();
+            if (previousLicense == null)
+            {
+                // no license
+                return;
+            }
+
+            if (previousLicense.Id == newLicense.Id)
+            {
+                // same license id
+                return;
+            }
+
+            var updateInfo = new UpdateLicenseForLetsEncrypt
+            {
+                PreviousLicense = previousLicense,
+                NewLicense = newLicense
+            };
+
+            var response = await ApiHttpClient.Instance.PostAsync("/api/v2/license/update-lets-encrypt-license",
+                    new StringContent(JsonConvert.SerializeObject(updateInfo), Encoding.UTF8, "application/json"), _serverStore.ServerShutdown)
+                .ConfigureAwait(false);
+
+            if (response.IsSuccessStatusCode == false)
+            {
+                var responseString = await response.Content.ReadAsStringAsync(_serverStore.ServerShutdown).ConfigureAwait(false);
+                throw new InvalidOperationException($"Cannot activate license because we failed to update the license for Let's Encrypt {responseString}");
+            }
+        }
+
         private void ResetLicense(string error)
         {
             LicenseStatus = new LicenseStatus
@@ -497,7 +533,7 @@ namespace Raven.Server.Commercial
                 LicensedTo = licenseStatus.LicensedTo,
                 ErrorMessage = null,
                 Attributes = licenseStatus.Attributes,
-                FirstServerStartDate = LicenseStatus.FirstServerStartDate,
+                FirstServerStartDate = LicenseStatus.FirstServerStartDate
             };
         }
 

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -505,7 +505,7 @@ namespace Raven.Server.Commercial
                 NewLicense = newLicense
             };
 
-            var response = await ApiHttpClient.Instance.PostAsync("/api/v2/license/update-lets-encrypt-license",
+            var response = await ApiHttpClient.PostAsync("/api/v2/license/update-lets-encrypt-license",
                     new StringContent(JsonConvert.SerializeObject(updateInfo), Encoding.UTF8, "application/json"), _serverStore.ServerShutdown)
                 .ConfigureAwait(false);
 

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -513,7 +513,7 @@ namespace Raven.Server.Commercial
             {
                 var responseString = await response.Content.ReadAsStringAsync(_serverStore.ServerShutdown).ConfigureAwait(false);
                 throw GenerateLicenseLimit(LimitType.InvalidLicense, 
-                    $"Failed to activate the license. The license update for Let's Encrypt encountered an issue: {responseString}");
+                    $"Failed to activate the license. The license update for Let's Encrypt encountered an issue: {responseString}", addNotification: false);
             }
         }
 

--- a/src/Raven.Server/Commercial/UpdateLicenseForLetsEncrypt.cs
+++ b/src/Raven.Server/Commercial/UpdateLicenseForLetsEncrypt.cs
@@ -1,0 +1,8 @@
+namespace Raven.Server.Commercial;
+
+public class UpdateLicenseForLetsEncrypt
+{
+    public License PreviousLicense { get; set; }
+
+    public License NewLicense { get; set; }
+}

--- a/src/Raven.Studio/wwwroot/App/views/shell/registration.html
+++ b/src/Raven.Studio/wwwroot/App/views/shell/registration.html
@@ -73,14 +73,6 @@
                     <small data-bind="visible: !renewMessage() && renewWhenNotExpired()">
                         Paste here the renewed license key that you will receive in the email after clicking Renew.
                     </small>
-                    <div data-bind="visible: letsEncryptMode() && licenseType() !== 'None'" class="text-warning">
-                        <i class="icon-warning"></i>
-                        <small>Your certificate is from Let's Encrypt and is bound to your current license id:</small><br>
-                        <strong class="text-warning" data-bind="text: licenseId"></strong><br>
-                        <small>In order to be able to renew your Let's Encrypt certificate in the future,</small><br>
-                        <small>the new license must have the same id as the current one.</small><br>
-                        <small>Please contact support if you need to replace the license with a new id.</small>
-                    </div>
                     <div class="form-horizontal margin-top">
                         <div class="form-group" data-bind="validationElement: licenseKeyModel().key">
                             <div class="col-sm-12">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21316/Update-the-API-when-the-license-is-changed-when-using-Lets-Encrypt

### Additional description

Update the API when the license is changed when using Let's Encrypt.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
