### PR TITLE
RavenDB-22594 - Skip deleting the document entry if it's a new index

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -119,7 +119,9 @@ namespace Raven.Server.Documents.Indexes
                 }
                 else
                 {
-                    writer.Value.Delete(indexItem.LowerId, stats);
+                    if (indexItem.KnownToBeNew == false)
+                        writer.Value.Delete(indexItem.LowerId, stats);
+
                     writer.Value.IndexDocument(indexItem.LowerId, indexItem.LowerSourceDocumentId, first, stats, indexContext);
                     var numberOfOutputs = 1; // the first
                     do

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -92,7 +92,8 @@ namespace Raven.Server.Documents.Indexes
             {
                 if (it.MoveNext() == false)
                 {
-                    writer.Value.Delete(indexItem.LowerId, stats);
+                    if (indexItem.KnownToBeNew == false)
+                        writer.Value.Delete(indexItem.LowerId, stats);
 
                     shouldRollbackCurrentScope = false;
                     return 0; // no results at all
@@ -139,7 +140,7 @@ namespace Raven.Server.Documents.Indexes
                 if (shouldRollbackCurrentScope)
                     writer.Value.Delete(indexItem.LowerId, stats);
                 
-                if(it is IDisposable d)
+                if (it is IDisposable d)
                     d.Dispose();
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22594/New-index-shouldnt-delete-old-entries

### Additional description

Skip deleting the document entry if it's a new index.
We already do that for regular indexes. Adding this for fanout indexes.
https://github.com/ravendb/ravendb/blob/f04a50024039664485371ff97b0e961acff7c795/src/Raven.Server/Documents/Indexes/MapIndexBase.cs#L106

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
