### PR TITLE
RavenDB-22230 - CmpXchg item should only be created when index is 0

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -383,6 +383,11 @@ namespace Raven.Server.ServerWide.Commands
                 }
                 else
                 {
+                    if (Index != 0)
+                    {
+                        return new CompareExchangeResult { Index = 0 };
+                    }
+
                     if (ExpirationTicks != null)
                         CompareExchangeExpirationStorage.Put(context, keySlice, ExpirationTicks.Value);
 

--- a/test/SlowTests/Issues/RavenDB-22230.cs
+++ b/test/SlowTests/Issues/RavenDB-22230.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+public class RavenDB_22230 : RavenTestBase
+{
+    public RavenDB_22230(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.CompareExchange)]
+    public async Task TryCreateCompareExchangeWithNonZeroIndex()
+    {
+        using var store = GetDocumentStore();
+
+        var result0 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<string>("key/0", "test", 0));
+        Assert.True(result0.Successful);
+        result0 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<string>("key/0", "test0", result0.Index));
+        Assert.True(result0.Successful);
+        var value0 = (await store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>("key/0"))).Value;
+        Assert.Equal("test0", value0);
+
+        var result1 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<string>("key/1", "test", 0));
+        Assert.True(result1.Successful);
+        result1 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<string>("key/1", "test1", result1.Index+1));
+        Assert.False(result1.Successful);
+        var value1 = (await store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>("key/1"))).Value;
+        Assert.Equal("test", value1);
+
+        var result2 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<string>("key/2", "test", 123));
+        Assert.False(result2.Successful);
+        var value2 = await store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>("key/2"));
+        Assert.Equal(null, value2); // does not exist (Failed)
+    }
+}
+

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
@@ -1715,7 +1715,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 await Backup.RunBackupAsync(Server, backupTaskId, store, isFullBackup: false);
 
-                res = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<long>("dummy", 2L, res.Index));
+                res = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<long>("dummy", 2L, 0)); // compare exchange doesn't exist so we need to pass index 0
                 Assert.True(res.Successful);
 
                 using (var session = store.OpenAsyncSession())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22230/CmpXchg-item-should-only-be-created-when-index-is-0

### Additional description
A new cmpXchg item should only be created when the index param is set to 0.
To reproduce, for example:
Run the following put operation to create a new key "key/1" but with non-0 index, e.g. 123:
`store.Operations.Send(new PutCompareExchangeValueOperation<string>("key/1", "test", 123));`
_Actual Result_: A new cmpXchg item is added with key: "key/1" and value: "test".
_Expected Result_: Item should not be created since index was not 0.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
