### PR TITLE
RavenDB-22510 fix a check that is relevant only when a document is migrated to a shard that already has an artificial tombstone

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -677,7 +677,7 @@ namespace Raven.Server.Documents
             else if (result.Tombstone != null)
             {
                 hasLocalClusterTx = result.Tombstone.Flags.Contain(DocumentFlags.FromClusterTransaction);
-                if (result.Tombstone.Flags.Contain(DocumentFlags.Artificial))
+                if (result.Tombstone.Flags.Contain(DocumentFlags.Artificial | DocumentFlags.FromResharding))
                     return ConflictStatus.Update;
                 local = result.Tombstone.ChangeVector;
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22510

### Additional description

When replicating a revision we check if that revision is a newer version of a document or tombstone, and in case it is we put it.
In this case we try to put the same deleted revision twice, and this due to a bug that we recognized an artificial tombstone as an `Update`  instead of a `Conflict`

This change is relevant only to 6.0, since this specific check was added here:
https://github.com/ravendb/ravendb/pull/15006/commits/19ac4ec2b47c76c31fe17e68d859a6b48eff0bf5

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
Checked on a problematic database and this seems to fix the replication
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

Was unable to write a test for this :(

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
