### PR TITLE
RavenDB-22559 put database command should be redirect to the leader

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -585,19 +585,22 @@ namespace Raven.Server.Rachis
             return false;
         }
 
-        public async Task WaitForLeaderChange(CancellationToken cts)
+        public async Task WaitForLeaderChange(CancellationToken token) => await WaitForLeaderChange(LeaderTag, token);
+
+        public async Task<string> WaitForLeaderChange(string leader, CancellationToken token)
         {
-            var currentLeader = LeaderTag;
-            while (cts.IsCancellationRequested == false)
+            while (token.IsCancellationRequested == false)
             {
                 // we setup the wait _before_ checking the state
-                var task = _stateChanged.Task.WithCancellation(cts);
-
-                if (currentLeader != GetLeaderTag(safe: true))
-                    return;
+                var task = _stateChanged.Task.WithCancellation(token);
+                var current = GetLeaderTag(safe: true);
+                if (leader != current)
+                    return current;
 
                 await task;
             }
+
+            return null;
         }
 
         public async Task<bool> WaitForLeaveState(RachisState rachisState, CancellationToken cts)

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -152,7 +152,18 @@ namespace RachisTests
             var (_, leader) = await CreateRaftCluster(5, leaderIndex: 0);
             var serverToDispose = Servers[1];
             await DisposeServerAndWaitForFinishOfDisposalAsync(serverToDispose);
-            Assert.Equal(WaitForValue(() => leader.ServerStore.GetNodesStatuses().Count(n => n.Value.Connected), 3), 3);
+
+            var actual = await WaitForValueAsync(async () =>
+            {
+                var count = -1;
+                await ActionWithLeader(l =>
+                {
+                    count = l.ServerStore.GetNodesStatuses().Count(n => n.Value.Connected);
+                });
+                return count;
+            }, 3);
+
+            Assert.Equal(3, actual);
 
             for (int i = 0; i < 5; i++)
             {


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22559

### Additional description

Only the leader knows the true liveness status of the nodes and can assign the topology properly

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
