### PR TITLE
RavenDB-21912 fix test to wait for replicated documents to propagate

### DIFF
--- a/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
+++ b/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
@@ -423,10 +424,7 @@ namespace SlowTests.Server.Documents.Expiration
                 {DefaultFormat.DateTimeFormatsToRead[6], DateTimeKind.Utc},
             };
             Assert.Equal(utcFormats.Count, DefaultFormat.DateTimeFormatsToRead.Length);
-
-            var database2 = GetDatabaseName();
             var cluster = await CreateRaftCluster(3, watcherCluster: true, leaderIndex: 0);
-            await ShardingCluster.CreateShardedDatabaseInCluster(database2, replicationFactor: 2, cluster, shards: 3);
 
             var configuration = new ExpirationConfiguration
             {
@@ -434,19 +432,16 @@ namespace SlowTests.Server.Documents.Expiration
                 DeleteFrequencyInSec = 100
             };
 
-            using (var store = Sharding.GetDocumentStore(new Options
+            var options = Sharding.GetOptionsForCluster(cluster.Leader, 3, 2, 3);
+            options.ModifyDatabaseRecord += record =>
             {
-                Server = cluster.Leader,
-                CreateDatabase = false,
-                ModifyDatabaseName = _ => database2,
-                ModifyDatabaseRecord = record =>
+                if (compressed)
                 {
-                    if (compressed)
-                    {
-                        record.DocumentsCompression = new DocumentsCompressionConfiguration { CompressAllCollections = true, };
-                    }
-                },
-            }))
+                    record.DocumentsCompression = new DocumentsCompressionConfiguration { CompressAllCollections = true, };
+                }
+            };
+
+            using (var store = GetDocumentStore(options))
             {
                 foreach (var dateTimeFormat in utcFormats)
                 {
@@ -467,6 +462,7 @@ namespace SlowTests.Server.Documents.Expiration
                             var metadata = session.Advanced.GetMetadataFor(comp);
                             metadata[Constants.Documents.Metadata.Expires] = expiry.ToString(dateTimeFormat.Key);
                         }
+                        session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1, timeout: TimeSpan.FromSeconds(60));
                         session.SaveChanges();
                     }
 
@@ -483,6 +479,7 @@ namespace SlowTests.Server.Documents.Expiration
                                 var metadata = session.Advanced.GetMetadataFor(comp);
                                 metadata[Constants.Documents.Metadata.Expires] = expiry.ToString(dateTimeFormat.Key);
                             }
+                            session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 1, timeout: TimeSpan.FromSeconds(60));
                             session.SaveChanges();
                         }
 
@@ -526,7 +523,7 @@ namespace SlowTests.Server.Documents.Expiration
                         using (var session = store.OpenAsyncSession())
                         {
                             var company = await session.LoadAsync<Company>($"company/{i}");
-                            Assert.Null(company);
+                            Assert.True(company == null,$"ID: company/{i}, format: {dateTimeFormat.Key}, total: {numOfDocs}");
                         }
                     }
                 }

--- a/test/Tests.Infrastructure/ClusterTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.Sharding.cs
@@ -76,10 +76,10 @@ public partial class ClusterTestBase
             return new TTopology { Members = members };
         }
 
-        public async Task<IDictionary<string, List<DocumentDatabase>>> GetShardsDocumentDatabaseInstancesFor(IDocumentStore store, List<RavenServer> Nodes, string database = null)
+        public async Task<IDictionary<string, List<DocumentDatabase>>> GetShardsDocumentDatabaseInstancesFor(IDocumentStore store, List<RavenServer> nodes, string database = null)
         {
             var dbs = new Dictionary<string, List<DocumentDatabase>>();
-            foreach (var server in Nodes)
+            foreach (var server in nodes)
             {
                 dbs.Add(server.ServerStore.NodeTag, new List<DocumentDatabase>());
                 foreach (var task in server.ServerStore.DatabasesLandlord.TryGetOrCreateShardedResourcesStore(database ?? store.Database))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21912

### Additional description

Was unable to repro that, but from code reviewing it seems that the assertion can fail when not all docs has been replicated to all nodes in the case of `AllShardHaveDocs` is `false`

- Fix the test to be compressed
- Add `WaitForReplicationAfterSaveChanges` to ensure all docs has been replicated to all nodes

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
