### PR TITLE
RavenDB-22613 Fix: Azure storage queue => Azure queue storage

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editAzureQueueStorageEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editAzureQueueStorageEtlTask.html
@@ -2,7 +2,7 @@
     <div class="align-items-center justify-content-between d-flex gap-2 margin-bottom-md padding-top-xs">
         <div class="flex-horizontal gap-2">
             <i class="icon-azure-queue-storage-etl"></i>
-            <h2 data-bind="text: $root.isAddingNewEtlTask() ? 'New Azure Storage Queue ETL' : 'Edit Azure Storage Queue ETL'" class="mb-0"></h2>
+            <h2 data-bind="text: $root.isAddingNewEtlTask() ? 'New Azure Queue Storage ETL' : 'Edit Azure Queue Storage ETL'" class="mb-0"></h2>
             <span class="badge license-restricted-badge enterprise" data-bind="if: !hasQueueEtl">Enterprise</span>
         </div>
         <div class="flex-end margin-right-xs" data-bind="react: $root.infoHubView"></div>
@@ -26,7 +26,7 @@
                         <div class="form-group margin-top">
                             <label for="taskName" class="control-label">Task Name</label>
                             <div class="flex-grow">
-                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the Azure Storage Queue ETL task (optional)" data-bind="textInput: taskName">
+                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the Azure Queue Storage ETL task (optional)" data-bind="textInput: taskName">
                             </div>
                         </div>
                         <div class="form-group">
@@ -71,7 +71,7 @@
                             <label class="control-label">&nbsp;</label>
                             <div class="toggle">
                                 <input id="createNewString" type="checkbox" data-bind="checked: $root.createNewConnectionString">
-                                <label for="createNewString">Create new Azure Storage Queue connection string</label>
+                                <label for="createNewString">Create new Azure Queue Storage connection string</label>
                             </div>
                         </div>
                         <div data-bind="collapse: $root.createNewConnectionString, with: $root.newConnectionString">


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22613/Fix-Azure-storage-queue-Azure-queue-storage

### Additional description
Unify title in all places to be: `Azure storage queue` => `Azure queue storage`

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed - work is in progress - See https://issues.hibernatingrhinos.com/issue/RDoc-2882/Document-ETL-to-Azure-Queue-Storage

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
