### PR TITLE
RavenDB-22246: Introduce an option in TestDriver to throw if there is no license or license could not be activated

### DIFF
--- a/src/Raven.Embedded/RavenServerRunner.cs
+++ b/src/Raven.Embedded/RavenServerRunner.cs
@@ -47,7 +47,7 @@ namespace Raven.Embedded
                 commandLineArgs.Add($"--License.DisableAutoUpdate={options.LicenseConfiguration.DisableAutoUpdate}");
                 commandLineArgs.Add($"--License.DisableAutoUpdateFromApi={options.LicenseConfiguration.DisableAutoUpdateFromApi}");
                 commandLineArgs.Add($"--License.DisableLicenseSupportCheck={options.LicenseConfiguration.DisableLicenseSupportCheck}");
-                commandLineArgs.Add($"--License.EnforceLicense={options.LicenseConfiguration.EnforceLicense}");
+                commandLineArgs.Add($"--License.ThrowOnInvalidOrMissingLicense={options.LicenseConfiguration.ThrowOnInvalidOrMissingLicense}");
             }
 
             commandLineArgs.Add("--Setup.Mode=None");

--- a/src/Raven.Embedded/RavenServerRunner.cs
+++ b/src/Raven.Embedded/RavenServerRunner.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Sparrow.Platform;
 using Sparrow.Utils;
@@ -30,7 +32,24 @@ namespace Raven.Embedded
                 commandLineArgs.Add($"--Embedded.ParentProcessId={currentProcess.Id}");
             }
 
-            commandLineArgs.Add($"--License.Eula.Accepted={options.AcceptEula}");
+            if (options.LicenseConfiguration != null)
+            {
+                if (string.IsNullOrWhiteSpace(options.LicenseConfiguration.License) == false &&
+                    string.IsNullOrWhiteSpace(options.LicenseConfiguration.LicensePath) == false)
+                    throw new ArgumentException($"Only one of Licence options '{nameof(options.LicenseConfiguration.License)}' or '{nameof(options.LicenseConfiguration.LicensePath)}' should be specified");
+
+                if (string.IsNullOrWhiteSpace(options.LicenseConfiguration.License) == false)
+                    commandLineArgs.Add($"--License={CommandLineArgumentEscaper.EscapeSingleArg(options.LicenseConfiguration.License)}");
+                else if (string.IsNullOrWhiteSpace(options.LicenseConfiguration.LicensePath) == false)
+                    commandLineArgs.Add($"--License.Path={CommandLineArgumentEscaper.EscapeSingleArg(options.LicenseConfiguration.LicensePath)}");
+
+                commandLineArgs.Add($"--License.Eula.Accepted={options.LicenseConfiguration.EulaAccepted}");
+                commandLineArgs.Add($"--License.DisableAutoUpdate={options.LicenseConfiguration.DisableAutoUpdate}");
+                commandLineArgs.Add($"--License.DisableAutoUpdateFromApi={options.LicenseConfiguration.DisableAutoUpdateFromApi}");
+                commandLineArgs.Add($"--License.DisableLicenseSupportCheck={options.LicenseConfiguration.DisableLicenseSupportCheck}");
+                commandLineArgs.Add($"--License.EnforceLicense={options.LicenseConfiguration.EnforceLicense}");
+            }
+
             commandLineArgs.Add("--Setup.Mode=None");
             commandLineArgs.Add($"--DataDir={CommandLineArgumentEscaper.EscapeSingleArg(options.DataDirectory)}");
             commandLineArgs.Add($"--Logs.Path={CommandLineArgumentEscaper.EscapeSingleArg(options.LogsPath)}");
@@ -143,6 +162,16 @@ namespace Raven.Embedded
 
         private static void RemoveEnvironmentVariables(ProcessStartInfo processStartInfo)
         {
+            if (ForTestingPurposes?.EnvironmentVariablesToCopyToInternalProcess != null)
+            {
+                var environmentVariablesToCopyToInternalProcess = Environment.GetEnvironmentVariables()
+                    .Cast<DictionaryEntry>()
+                    .Where(x => ForTestingPurposes.EnvironmentVariablesToCopyToInternalProcess.Contains(x.Key.ToString()));
+
+                foreach (DictionaryEntry envVar in environmentVariablesToCopyToInternalProcess)
+                    processStartInfo.EnvironmentVariables[envVar.Key.ToString()] = envVar.Value.ToString();
+            }
+
             if (processStartInfo.Environment == null || processStartInfo.Environment.Count == 0)
                 return;
 
@@ -160,6 +189,21 @@ namespace Raven.Embedded
 
             foreach (var key in variablesToRemove)
                 processStartInfo.Environment.Remove(key);
+        }
+
+        private static TestingStuff ForTestingPurposes;
+
+        internal static TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal class TestingStuff
+        {
+            internal List<string> EnvironmentVariablesToCopyToInternalProcess;
         }
     }
 }

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -21,7 +21,13 @@ namespace Raven.Embedded
 
         public string DotNetPath { get; set; } = "dotnet";
 
-        public bool AcceptEula { get; set; } = true;
+        [Obsolete(
+            $"This property is no longer used and will be removed in the next version, please use '{nameof(LicenseConfiguration)}.{nameof(LicenseOptions.EulaAccepted)}' instead.")]
+        public bool AcceptEula
+        {
+            get => LicenseConfiguration.EulaAccepted;
+            set => LicenseConfiguration.EulaAccepted = value;
+        }
 
         public string ServerUrl { get; set; }
 
@@ -46,10 +52,7 @@ namespace Raven.Embedded
             var cert = new X509Certificate2(certificate, certPassword);
             Security = new SecurityOptions
             {
-                CertificatePath = certificate,
-                CertificatePassword = certPassword,
-                ClientCertificate = cert,
-                ServerCertificateThumbprint = cert.Thumbprint
+                CertificatePath = certificate, CertificatePassword = certPassword, ClientCertificate = cert, ServerCertificateThumbprint = cert.Thumbprint
             };
 
             return this;
@@ -80,7 +83,6 @@ namespace Raven.Embedded
             return this;
         }
 
-
         public class SecurityOptions
         {
             internal SecurityOptions() { }
@@ -92,7 +94,18 @@ namespace Raven.Embedded
             public string CertificateLoadExecArguments { get; internal set; }
             public string ServerCertificateThumbprint { get; internal set; }
         }
+
+        public LicenseOptions LicenseConfiguration { get; set; } = new();
+
+        public class LicenseOptions
+        {
+            public string License { get; set; }
+            public string LicensePath { get; set; }
+            public bool EulaAccepted { get; set; }
+            public bool DisableAutoUpdate { get; set; }
+            public bool DisableAutoUpdateFromApi { get; set; }
+            public bool DisableLicenseSupportCheck { get; set; }
+            public bool EnforceLicense { get; set; }
+        }
     }
-
-
 }

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -104,8 +104,8 @@ namespace Raven.Embedded
             public bool EulaAccepted { get; set; }
             public bool DisableAutoUpdate { get; set; }
             public bool DisableAutoUpdateFromApi { get; set; }
-            public bool DisableLicenseSupportCheck { get; set; }
-            public bool EnforceLicense { get; set; }
+            public bool DisableLicenseSupportCheck { get; set; } = true;
+            public bool ThrowOnInvalidOrMissingLicense { get; set; }
         }
     }
 }

--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using Newtonsoft.Json;
 using Raven.Client.Exceptions.Commercial;
+using Raven.Client.Properties;
 using Raven.Server.Commercial.LetsEncrypt;
 using Raven.Server.Config;
 using Raven.Server.Json;
@@ -16,6 +17,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.Server.Json.Sync;
+using Voron;
 
 namespace Raven.Server.Commercial
 {
@@ -84,6 +86,20 @@ namespace Raven.Server.Commercial
             }
 
             return null;
+        }
+
+        internal static bool TryValidateLicenseExpirationDate(License license, out DateTime expirationDate)
+        {
+            expirationDate = DateTime.MinValue;
+
+            if (license == null)
+                return false;
+
+            var licenseStatus = LicenseManager.GetLicenseStatus(license);
+            if (licenseStatus.Expiration.HasValue)
+                expirationDate = licenseStatus.Expiration.Value;
+
+            return expirationDate >= RavenVersionAttribute.Instance.ReleaseDate;
         }
 
         public License TryGetLicenseFromPath(bool throwOnFailure)
@@ -270,6 +286,127 @@ namespace Raven.Server.Commercial
 
             var licenseString = JsonConvert.SerializeObject(newLicense, Formatting.Indented);
             File.WriteAllText(_serverStore.Configuration.Licensing.LicensePath.FullPath, licenseString);
+        }
+
+        public static bool TryValidateAndHandleLicense(ServerStore serverStore, string licenseJson, Guid? inStorageLicenseId, LicenseVerificationErrorBuilder verificationErrorBuilder)
+        {
+            if (TryDeserializeLicense(licenseJson, out var deserializedLicense) == false)
+            {
+                verificationErrorBuilder.AppendDeserializationErrorMessage(licenseJson);
+            }
+            else
+            {
+                if (TryValidateLicenseExpirationDate(deserializedLicense, out var deserializedLicenseExpirationDate))
+                {
+                    serverStore.LicenseManager.OnBeforeInitialize += () => serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).Wait(serverStore.ServerShutdown);
+                    return true;
+                }
+
+                verificationErrorBuilder.AppendConfigurationLicenseExpiredMessage(inStorageLicenseId, deserializedLicense.Id, deserializedLicenseExpirationDate);
+            }
+
+            return false;
+        }
+
+        public class LicenseVerificationErrorBuilder
+        {
+            private readonly RavenConfiguration _configuration;
+            private readonly StorageEnvironment _storageEnvironment;
+            private readonly TransactionContextPool _contextPool;
+            private readonly StringBuilder _errorBuilder = new();
+            private bool _isInStorageLicenseExpired;
+            private string _configurationKeyInAction;
+
+            public LicenseVerificationErrorBuilder(RavenConfiguration configuration, StorageEnvironment storageEnvironment, TransactionContextPool contextPool)
+            {
+                _configuration = configuration;
+                _storageEnvironment = storageEnvironment;
+                _contextPool = contextPool;
+            }
+
+            public LicenseVerificationErrorBuilder()
+            {
+            }
+
+            public void AppendInStorageLicenseExpiredMessage(DateTime expirationDate)
+            {
+                _isInStorageLicenseExpired = true;
+
+                _errorBuilder.AppendLine("The RavenDB server cannot start due to an expired license. Please review the details below to resolve the issue:");
+                _errorBuilder.AppendLine($"- License Expiration Date: {FormattedDateTime(expirationDate)}");
+                _errorBuilder.AppendLine($"- Server Version Release Date: {FormattedDateTime(RavenVersionAttribute.Instance.ReleaseDate)}");
+            }
+
+            public void AppendLicenseMissingMessage()
+            {
+                _errorBuilder.AppendLine("The RavenDB server cannot start due to a missing license. Please review the details below to resolve the issue:");
+            }
+
+            public void AppendConfigurationKeyUsageAttempt(string configurationKey)
+            {
+                _configurationKeyInAction = configurationKey;
+
+                _errorBuilder.AppendLine();
+                _errorBuilder.AppendLine($"We attempted to obtain a valid license using the configuration key '{configurationKey}', but this process was not successful for the following reason:");
+            }
+
+            public void AppendFileReadErrorMessage(Exception e)
+            {
+                _errorBuilder.AppendLine("- An error occurred while trying to read the license from the file:");
+                _errorBuilder.AppendLine($"  {e.Message}");
+            }
+
+            public void AppendResolutionSuggestions()
+            {
+                AppendGeneralSuggestions();
+
+                // We can suggest a downgrade only if in-storage license is expired
+                if (_isInStorageLicenseExpired)
+                {
+                    // Getting build number from the license storage, just in case the license is expired and we have ability to downgrade
+                    var licenseStorage = new LicenseStorage();
+                    licenseStorage.Initialize(_storageEnvironment, _contextPool);
+                    var buildInfo = licenseStorage.GetBuildInfo();
+
+                    if (buildInfo != null)
+                        _errorBuilder.AppendLine($"- As a temporary measure, consider downgrading to the last working build ({buildInfo.FullVersion}).");
+                }
+
+                AppendSuggestionToDisableEnforceLicense(_configuration.Licensing.EnforceLicense, _isInStorageLicenseExpired);
+            }
+
+            public void AppendGeneralSuggestions()
+            {
+                _errorBuilder.AppendLine();
+                _errorBuilder.AppendLine("To resolve this issue, you may consider the following options:");
+                _errorBuilder.AppendLine("- Ensure your license key is correctly embedded in 'settings.json', set as an environment variable, or included in your 'ServerOptions' if using an embedded server or Raven.TestDriver.");
+                _errorBuilder.AppendLine("- Alternatively, check the 'License.Path' in your configuration to ensure it points to a valid 'license.json' file.");
+            }
+
+            public void AppendConfigurationLicenseExpiredMessage(Guid? inStorageLicenseId, Guid deserializedLicenseId, DateTime deserializedLicenseExpirationDate)
+            {
+                _errorBuilder.AppendLine(deserializedLicenseId == inStorageLicenseId
+                    ? "- The license obtained matches the in-storage license but is also expired."
+                    : $"- The license '{deserializedLicenseId}' obtained from '{_configurationKeyInAction}' has an expiration date of '{FormattedDateTime(deserializedLicenseExpirationDate)}' and is also expired.");
+            }
+
+            public void AppendDeserializationErrorMessage(string licenseContent)
+            {
+                if (string.IsNullOrWhiteSpace(licenseContent))
+                    _errorBuilder.AppendLine("- The license is not provided in the configuration or environment variable.");
+                else
+                    _errorBuilder.AppendLine($"- Could not parse the license content: '{licenseContent}'.");
+            }
+
+            public void AppendSuggestionToDisableEnforceLicense(bool enforceLicenseEnabled, bool isInStorageLicenseExpired)
+            {
+                if (enforceLicenseEnabled && isInStorageLicenseExpired == false)
+                    _errorBuilder.AppendLine($"- Configure the '{RavenConfiguration.GetKey(x => x.Licensing.EnforceLicense)}' option by setting it to 'False' to disable this strict licensing requirement for server startup.");
+            }
+
+            public override string ToString() => _errorBuilder.ToString();
+
+            private static string FormattedDateTime(DateTime dateTime) => dateTime.ToString("dd MMMM yyyy");
         }
     }
 }

--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -372,7 +372,7 @@ namespace Raven.Server.Commercial
                         _errorBuilder.AppendLine($"- As a temporary measure, consider downgrading to the last working build ({buildInfo.FullVersion}).");
                 }
 
-                AppendSuggestionToDisableEnforceLicense(_configuration.Licensing.EnforceLicense, _isInStorageLicenseExpired);
+                AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(_configuration.Licensing.ThrowOnInvalidOrMissingLicense, _isInStorageLicenseExpired);
             }
 
             public void AppendGeneralSuggestions()
@@ -398,10 +398,10 @@ namespace Raven.Server.Commercial
                     _errorBuilder.AppendLine($"- Could not parse the license content: '{licenseContent}'.");
             }
 
-            public void AppendSuggestionToDisableEnforceLicense(bool enforceLicenseEnabled, bool isInStorageLicenseExpired)
+            public void AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(bool throwOnInvalidOrMissingLicenseOptionEnabled, bool isInStorageLicenseExpired)
             {
-                if (enforceLicenseEnabled && isInStorageLicenseExpired == false)
-                    _errorBuilder.AppendLine($"- Configure the '{RavenConfiguration.GetKey(x => x.Licensing.EnforceLicense)}' option by setting it to 'False' to disable this strict licensing requirement for server startup.");
+                if (throwOnInvalidOrMissingLicenseOptionEnabled && isInStorageLicenseExpired == false)
+                    _errorBuilder.AppendLine($"- Configure the '{RavenConfiguration.GetKey(x => x.Licensing.ThrowOnInvalidOrMissingLicense)}' option by setting it to 'False' to disable this strict licensing requirement for server startup.");
             }
 
             public override string ToString() => _errorBuilder.ToString();

--- a/src/Raven.Server/Config/Categories/LicenseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/LicenseConfiguration.cs
@@ -47,7 +47,6 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("License.SkipLeasingErrorsLogging", ConfigurationEntryScope.ServerWideOnly)]
         public bool SkipLeasingErrorsLogging { get; set; }
 
-
         [Description("EXPERT ONLY. Disable automatic updating of the license")]
         [DefaultValue(false)]
         [ConfigurationEntry("License.DisableAutoUpdate", ConfigurationEntryScope.ServerWideOnly)]
@@ -58,10 +57,14 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("License.DisableAutoUpdateFromApi", ConfigurationEntryScope.ServerWideOnly)]
         public bool DisableAutoUpdateFromApi { get; set; }
 
-
         [Description("EXPERT ONLY. Disable checking the support options for the license")]
         [DefaultValue(false)]
         [ConfigurationEntry("License.DisableLicenseSupportCheck", ConfigurationEntryScope.ServerWideOnly)]
         public bool DisableLicenseSupportCheck { get; set; }
+
+        [Description("EXPERT ONLY. Throws an exception if the license cannot be activated or is not present")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("License.EnforceLicense", ConfigurationEntryScope.ServerWideOnly)]
+        public bool EnforceLicense { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/LicenseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/LicenseConfiguration.cs
@@ -64,7 +64,7 @@ namespace Raven.Server.Config.Categories
 
         [Description("EXPERT ONLY. Throws an exception if the license cannot be activated or is not present")]
         [DefaultValue(false)]
-        [ConfigurationEntry("License.EnforceLicense", ConfigurationEntryScope.ServerWideOnly)]
-        public bool EnforceLicense { get; set; }
+        [ConfigurationEntry("License.ThrowOnInvalidOrMissingLicense", ConfigurationEntryScope.ServerWideOnly)]
+        public bool ThrowOnInvalidOrMissingLicense { get; set; }
     }
 }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -32,7 +32,6 @@ using Raven.Client.Exceptions.Security;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
-using Raven.Client.Properties;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
@@ -157,7 +156,7 @@ namespace Raven.Server
             // doing this before the schema upgrade to allow to downgrade in case we cannot start the server
             BeforeSchemaUpgrade = VerifyLicense;
 
-            if (Configuration.Licensing.EnforceLicense)
+            if (Configuration.Licensing.ThrowOnInvalidOrMissingLicense)
                 AfterDatabaseCreation = VerifyLicense;
         }
 
@@ -2977,7 +2976,7 @@ namespace Raven.Server
             using (var contextPool = new TransactionContextPool(storageEnvironment, ServerStore.Configuration.Memory.MaxContextSizeToKeep))
             {
                 var inStorageLicense = ServerStore.LoadLicense(contextPool);
-                if (inStorageLicense == null && ServerStore.Configuration.Licensing.EnforceLicense == false)
+                if (inStorageLicense == null && ServerStore.Configuration.Licensing.ThrowOnInvalidOrMissingLicense == false)
                     return;
 
                 var errorBuilder = new LicenseHelper.LicenseVerificationErrorBuilder(ServerStore.Configuration, storageEnvironment, contextPool);

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -124,6 +124,8 @@ namespace Raven.Server
 
         internal Action<StorageEnvironment> BeforeSchemaUpgrade;
 
+        internal Action<StorageEnvironment> AfterDatabaseCreation;
+
         internal string DebugTag;
 
         internal CipherSuitesPolicy CipherSuitesPolicy => _httpsConnectionMiddleware?.CipherSuitesPolicy;
@@ -153,7 +155,10 @@ namespace Raven.Server
             _tcpContextPool = new JsonContextPool(Configuration.Memory.MaxContextSizeToKeep);
 
             // doing this before the schema upgrade to allow to downgrade in case we cannot start the server
-            BeforeSchemaUpgrade = x => VerifyLicense(x, ServerStore);
+            BeforeSchemaUpgrade = VerifyLicense;
+
+            if (Configuration.Licensing.EnforceLicense)
+                AfterDatabaseCreation = VerifyLicense;
         }
 
         public TcpListenerStatus GetTcpServerStatus()
@@ -2967,79 +2972,50 @@ namespace Raven.Server
             ArrayPool<byte>.Shared.Return(buffer);
         }
 
-        internal static void VerifyLicense(StorageEnvironment storageEnvironment, ServerStore serverStore)
+        private void VerifyLicense(StorageEnvironment storageEnvironment)
         {
-            using (var contextPool = new TransactionContextPool(storageEnvironment, serverStore.Configuration.Memory.MaxContextSizeToKeep))
+            using (var contextPool = new TransactionContextPool(storageEnvironment, ServerStore.Configuration.Memory.MaxContextSizeToKeep))
             {
-                var license = serverStore.LoadLicense(contextPool);
-                if (license == null)
+                var inStorageLicense = ServerStore.LoadLicense(contextPool);
+                if (inStorageLicense == null && ServerStore.Configuration.Licensing.EnforceLicense == false)
                     return;
 
-                var licenseStatus = LicenseManager.GetLicenseStatus(license);
-                if (licenseStatus.Expiration >= RavenVersionAttribute.Instance.ReleaseDate)
+                var errorBuilder = new LicenseHelper.LicenseVerificationErrorBuilder(ServerStore.Configuration, storageEnvironment, contextPool);
+                if (inStorageLicense == null)
+                {
+                    errorBuilder.AppendLicenseMissingMessage();
+                }
+                else
+                {
+                    if (LicenseHelper.TryValidateLicenseExpirationDate(inStorageLicense, out var expirationDate))
+                        return;
+
+                    errorBuilder.AppendInStorageLicenseExpiredMessage(expirationDate);
+                }
+
+                // Try to load the license using 'Licensing.License' configuration key
+                errorBuilder.AppendConfigurationKeyUsageAttempt(RavenConfiguration.GetKey(x => x.Licensing.License));
+                if (LicenseHelper.TryValidateAndHandleLicense(ServerStore, ServerStore.Configuration.Licensing.License, inStorageLicense?.Id, errorBuilder))
                     return;
 
-                string licenseJson = null;
-                var fromPath = false;
-                if (string.IsNullOrEmpty(serverStore.Configuration.Licensing.License) == false)
+                // Unsuccessful
+                // Let's try to load the license from the configuration using 'Licensing.LicensePath' configuration key
+                errorBuilder.AppendConfigurationKeyUsageAttempt(RavenConfiguration.GetKey(x => x.Licensing.LicensePath));
+                try
                 {
-                    licenseJson = serverStore.Configuration.Licensing.License;
+                    var licenseContent = File.ReadAllText(ServerStore.Configuration.Licensing.LicensePath.FullPath);
+                    if (LicenseHelper.TryValidateAndHandleLicense(ServerStore, licenseContent, inStorageLicense?.Id, errorBuilder))
+                        return;
                 }
-                else if (File.Exists(serverStore.Configuration.Licensing.LicensePath.FullPath))
+                catch (Exception e)
                 {
-                    try
-                    {
-                        licenseJson = File.ReadAllText(serverStore.Configuration.Licensing.LicensePath.FullPath);
-                        fromPath = true;
-                    }
-                    catch
-                    {
-                        // expected
-                    }
+                    errorBuilder.AppendFileReadErrorMessage(e);
                 }
 
-                var errorMessage = $"Cannot start the RavenDB server because the expiration date of current license ({FormattedDateTime(licenseStatus.Expiration ?? DateTime.MinValue)}) " +
-                                   $"is before the release date of this version ({FormattedDateTime(RavenVersionAttribute.Instance.ReleaseDate)})";
+                // Suggest a possible solution
+                errorBuilder.AppendResolutionSuggestions();
 
-                string expiredLicenseMessage = "";
-                if (string.IsNullOrEmpty(licenseJson) == false)
-                {
-                    if (LicenseHelper.TryDeserializeLicense(licenseJson, out License localLicense))
-                    {
-                        var localLicenseStatus = LicenseManager.GetLicenseStatus(localLicense);
-                        if (localLicenseStatus.Expiration >= RavenVersionAttribute.Instance.ReleaseDate)
-                        {
-                            serverStore.LicenseManager.OnBeforeInitialize += () => AsyncHelpers.RunSync(() => serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure));
-                            return;
-                        }
-
-                        var configurationKey =
-                            fromPath ? RavenConfiguration.GetKey(x => x.Licensing.LicensePath) : RavenConfiguration.GetKey(x => x.Licensing.License);
-                        expiredLicenseMessage = localLicense.Id == license.Id
-                            ? ". You can update current license using the setting.json file"
-                            : $". The license '{localLicense.Id}' obtained from '{configurationKey}' with expiration date of '{FormattedDateTime(localLicenseStatus.Expiration ?? DateTime.MinValue)}' is also expired.";
-                    }
-                    else
-                    {
-                        errorMessage += ". Could not parse the license from setting.json file.";
-                        throw new LicenseExpiredException(errorMessage);
-                    }
-                }
-
-                var licenseStorage = new LicenseStorage();
-                licenseStorage.Initialize(storageEnvironment, contextPool);
-
-                var buildInfo = licenseStorage.GetBuildInfo();
-                if (buildInfo != null)
-                    errorMessage += $" You can downgrade to the latest build that was working ({buildInfo.FullVersion})";
-                if (string.IsNullOrEmpty(expiredLicenseMessage) == false)
-                    errorMessage += expiredLicenseMessage;
-                throw new LicenseExpiredException(errorMessage);
-
-                static string FormattedDateTime(DateTime dateTime)
-                {
-                    return dateTime.ToString("dd MMMM yyyy");
-                }
+                throw new LicenseExpiredException(errorBuilder.ToString());
             }
         }
     }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -763,6 +763,7 @@ namespace Raven.Server.ServerWide
             options.SchemaVersion = SchemaUpgrader.CurrentVersion.ServerVersion;
             options.SchemaUpgrader = SchemaUpgrader.Upgrader(SchemaUpgrader.StorageType.Server, null, null, this);
             options.BeforeSchemaUpgrade = _server.BeforeSchemaUpgrade;
+            options.AfterDatabaseCreation = _server.AfterDatabaseCreation;
             options.ForceUsing32BitsPager = Configuration.Storage.ForceUsing32BitsPager;
             options.EnablePrefetching = Configuration.Storage.EnablePrefetching;
             options.DiscardVirtualMemory = Configuration.Storage.DiscardVirtualMemory;

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -470,6 +470,7 @@ namespace Voron
                 }
             }
 
+            Options.AfterDatabaseCreation?.Invoke(this);
         }
 
         public IFreeSpaceHandling FreeSpaceHandling => _freeSpaceHandling;

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -181,6 +181,8 @@ namespace Voron
 
         public Action<StorageEnvironment> BeforeSchemaUpgrade { get; set; }
 
+        public Action<StorageEnvironment> AfterDatabaseCreation { get; set; }
+
         public ScratchSpaceUsageMonitor ScratchSpaceUsage { get; }
 
         public TimeSpan LongRunningFlushingWarning = TimeSpan.FromMinutes(5);

--- a/test/LicenseTests/LicenseOptionsTests.cs
+++ b/test/LicenseTests/LicenseOptionsTests.cs
@@ -20,49 +20,49 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicence_ShouldWork()
     {
-        StartEmbeddedServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicence_ShouldWork()
     {
-        StartEmbeddedServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
     {
-        StartEmbeddedServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicencePath_ShouldWork()
     {
-        StartEmbeddedServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicence_ShouldWork()
     {
-        StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicence_ShouldWork()
     {
-        StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
     {
-        StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicencePath_ShouldWork()
     {
-        StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
@@ -70,7 +70,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     {
         ServerOptions options = null;
         var exception = Assert.Throws(typeof(AggregateException), () =>
-                StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+                StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -83,7 +83,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
     }
@@ -93,7 +93,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     {
         ServerOptions options = null;
         var exception = Assert.Throws(typeof(AggregateException), () =>
-            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -106,7 +106,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
     }
@@ -114,9 +114,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
     {
-        ServerOptions options = null;
         var exception = Assert.Throws(typeof(AggregateException), () =>
-            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -128,7 +127,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
     }
@@ -136,9 +135,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicensePath_ShouldThrow()
     {
-        ServerOptions options = null;
         var exception = Assert.Throws(typeof(AggregateException), () =>
-            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -150,7 +148,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
     }
@@ -160,7 +158,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     {
         ServerOptions options = null;
         var exception = Assert.Throws(typeof(AggregateException), () =>
-                StartEmbeddedServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+                StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -173,7 +171,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
     }
@@ -183,7 +181,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     {
         ServerOptions options = null;
         var exception = Assert.Throws(typeof(AggregateException), () =>
-            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -196,7 +194,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
     }
@@ -206,7 +204,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     {
         ServerOptions options = null;
         var exception = Assert.Throws(typeof(AggregateException), () =>
-            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -219,7 +217,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
     }
@@ -229,7 +227,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
     {
         ServerOptions options = null;
         var exception = Assert.Throws(typeof(AggregateException), () =>
-            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -242,18 +240,18 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
     }
 
-    private void StartEmbeddedServerLicenseOptionTest(bool enforceLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerOptions options)
+    private void StartEmbeddedServerLicenseOptionTest(bool throwOnInvalidOrMissingLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerOptions options)
     {
         var originalLicense = Environment.GetEnvironmentVariable("RAVEN_License");
         var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_License.Path");
 
         options = CopyServerAndCreateOptions();
-        options.LicenseConfiguration.EnforceLicense = enforceLicense;
+        options.LicenseConfiguration.ThrowOnInvalidOrMissingLicense = throwOnInvalidOrMissingLicense;
 
         try
         {
@@ -372,56 +370,56 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
     [RavenFact(RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicence_ShouldWork()
     {
-        StartTestDriverServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicence_ShouldWork()
     {
-        StartTestDriverServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
     {
-        StartTestDriverServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicencePath_ShouldWork()
     {
-        StartTestDriverServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicence_ShouldWork()
     {
-        StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicence_ShouldWork()
     {
-        StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
     {
-        StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicencePath_ShouldWork()
     {
-        StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
     }
 
     [RavenFact(RavenTestCategory.Licensing)]
     public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicense_ShouldThrow()
     {
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
-            StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -434,7 +432,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
     }
@@ -443,7 +441,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
     public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicense_ShouldThrow()
     {
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
-            StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -456,7 +454,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
     }
@@ -465,7 +463,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
     public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
     {
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
-            StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -477,7 +475,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
     }
@@ -486,7 +484,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
     public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicensePath_ShouldThrow()
     {
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
-            StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -498,7 +496,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
     }
@@ -507,7 +505,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
     public void VerifyLicense_EnforceTrue_NoLicense_SystemEnvironmentVariableLicense_ShouldThrow()
     {
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
-            StartTestDriverServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -520,7 +518,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
     }
@@ -529,7 +527,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
     public void VerifyLicense_EnforceTrue_NoLicense_ServerOptionLicense_ShouldThrow()
     {
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
-            StartTestDriverServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -542,7 +540,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
     }
@@ -552,7 +550,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
     {
         ServerCreationOptions options = null;
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
-            StartTestDriverServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -566,7 +564,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
     }
@@ -576,7 +574,7 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
     {
         ServerCreationOptions options = null;
         var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
-            StartTestDriverServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
 
         var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
         expectedMessageBuilder.AppendLicenseMissingMessage();
@@ -590,18 +588,18 @@ public class LicenseOptionsTestDriverTests : RavenTestBase
         expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
 
         expectedMessageBuilder.AppendGeneralSuggestions();
-        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
 
         LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
     }
 
-    private void StartTestDriverServerLicenseOptionTest(bool enforceLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerCreationOptions options)
+    private void StartTestDriverServerLicenseOptionTest(bool throwOnInvalidOrMissingLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerCreationOptions options)
     {
         var originalLicense = Environment.GetEnvironmentVariable("RAVEN_License");
         var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_License.Path");
 
         options = new ServerCreationOptions { CustomSettings = new Dictionary<string, string>() };
-        options.CustomSettings[RavenConfiguration.GetKey(x => x.Licensing.EnforceLicense)] = enforceLicense.ToString();
+        options.CustomSettings[RavenConfiguration.GetKey(x => x.Licensing.ThrowOnInvalidOrMissingLicense)] = throwOnInvalidOrMissingLicense.ToString();
 
         try
         {

--- a/test/LicenseTests/LicenseOptionsTests.cs
+++ b/test/LicenseTests/LicenseOptionsTests.cs
@@ -1,0 +1,748 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using EmbeddedTests;
+using FastTests;
+using Raven.Client.Exceptions.Server;
+using Raven.Embedded;
+using Raven.Server.Commercial;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LicenseTests;
+
+[Collection("TestCollection.NonParallelTests")]
+public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
+{
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicence_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicence_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicencePath_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicence_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicence_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicencePath_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicense_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+                StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicense_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicensePath_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_SystemEnvironmentVariableLicense_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+                StartEmbeddedServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_ServerOptionLicense_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_ServerOptionLicensePath_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    private void StartEmbeddedServerLicenseOptionTest(bool enforceLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerOptions options)
+    {
+        var originalLicense = Environment.GetEnvironmentVariable("RAVEN_License");
+        var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_License.Path");
+
+        options = CopyServerAndCreateOptions();
+        options.LicenseConfiguration.EnforceLicense = enforceLicense;
+
+        try
+        {
+            if (configurationKeyToTest == LicenseOptionTestHelper.LicenseConfigurationKey)
+            {
+                HandleLicenseOption(license, licenseSource, ref options);
+            }
+            else if (configurationKeyToTest == LicenseOptionTestHelper.LicensePathConfigurationKey)
+            {
+                HandleLicensePathOption(license, licenseSource, ref options);
+            }
+
+            CreateEmbeddedServer(options);
+        }
+        catch
+        {
+            Task.Delay(1000).Wait(); // wait to ensure the server is fully disposed
+            throw;
+        }
+        finally
+        {
+            AfterTestCleanup(originalLicense, originalLicensePath);
+        }
+    }
+
+    private static void HandleLicenseOption(string license, LicenseSource licenseSource, ref ServerOptions options)
+    {
+        switch (licenseSource)
+        {
+            case LicenseSource.EnvironmentVariable:
+                Assert.Null(options.LicenseConfiguration.License);
+                Assert.Null(options.LicenseConfiguration.LicensePath);
+
+                Environment.SetEnvironmentVariable("RAVEN_License", license);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), license);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            case LicenseSource.ServerOption:
+                options.LicenseConfiguration.License = license;
+                Assert.Null(options.LicenseConfiguration.LicensePath);
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(licenseSource), licenseSource, null);
+        }
+    }
+
+    private static void HandleLicensePathOption(string license, LicenseSource licenseSource, ref ServerOptions options)
+    {
+        string licensePath = LicenseOptionTestHelper.CreateLicenseJsonFile(options.ServerDirectory, license);
+
+        switch (licenseSource)
+        {
+            case LicenseSource.EnvironmentVariable:
+                Assert.Null(options.LicenseConfiguration.License);
+                Assert.Null(options.LicenseConfiguration.LicensePath);
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", licensePath);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), licensePath);
+                break;
+
+            case LicenseSource.ServerOption:
+                options.LicenseConfiguration.LicensePath = licensePath;
+                Assert.Null(options.LicenseConfiguration.License);
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(licenseSource), licenseSource, null);
+        }
+    }
+
+    private static void CreateEmbeddedServer(ServerOptions options)
+    {
+        RavenServerRunner.ForTestingPurposesOnly().EnvironmentVariablesToCopyToInternalProcess = new List<string> { "RAVEN_License", "RAVEN_License.Path" };
+
+        using (var embedded = new EmbeddedServer())
+        {
+            embedded.StartServer(options);
+        }
+    }
+
+    private static void AfterTestCleanup(string originalLicense, string originalLicensePath)
+    {
+        RavenServerRunner.ForTestingPurposesOnly().EnvironmentVariablesToCopyToInternalProcess = null;
+
+        Environment.SetEnvironmentVariable("RAVEN_License", originalLicense);
+        Environment.SetEnvironmentVariable("RAVEN_License.Path", originalLicensePath);
+    }
+}
+
+[Collection("TestCollection.NonParallelTests")]
+public class LicenseOptionsTestDriverTests : RavenTestBase
+{
+    public LicenseOptionsTestDriverTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicence_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicence_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicencePath_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(enforceLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicence_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicence_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicencePath_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicense_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(Environment.CurrentDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicense_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(Environment.CurrentDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicensePath_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(enforceLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_SystemEnvironmentVariableLicense_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(Environment.CurrentDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_ServerOptionLicense_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(Environment.CurrentDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
+    {
+        ServerCreationOptions options = null;
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        Assert.True(options.CustomSettings.TryGetValue("ForTestingPurposesLicensePath", out var licensePath));
+        var readErrorException = new FileNotFoundException($"Could not find file '{licensePath}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_ServerOptionLicensePath_ShouldThrow()
+    {
+        ServerCreationOptions options = null;
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(enforceLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        Assert.True(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.LicensePath), out var licensePath));
+        var readErrorException = new FileNotFoundException($"Could not find file '{licensePath}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableEnforceLicense(enforceLicenseEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    private void StartTestDriverServerLicenseOptionTest(bool enforceLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerCreationOptions options)
+    {
+        var originalLicense = Environment.GetEnvironmentVariable("RAVEN_License");
+        var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_License.Path");
+
+        options = new ServerCreationOptions { CustomSettings = new Dictionary<string, string>() };
+        options.CustomSettings[RavenConfiguration.GetKey(x => x.Licensing.EnforceLicense)] = enforceLicense.ToString();
+
+        try
+        {
+            if (configurationKeyToTest == LicenseOptionTestHelper.LicenseConfigurationKey)
+            {
+                HandleLicenseOption(license, licenseSource, ref options);
+            }
+            else if (configurationKeyToTest == LicenseOptionTestHelper.LicensePathConfigurationKey)
+            {
+                HandleLicensePathOption(license, licenseSource, ref options);
+            }
+
+            using (_ = GetNewServer(options))
+            {
+            }
+        }
+        catch
+        {
+            Task.Delay(1000).Wait(); // wait to ensure the server is fully disposed
+            throw;
+        }
+        finally
+        {
+            AfterTestCleanup(originalLicense, originalLicensePath);
+        }
+    }
+
+    internal static void HandleLicenseOption(string license, LicenseSource licenseSource, ref ServerCreationOptions options)
+    {
+        switch (licenseSource)
+        {
+            case LicenseSource.EnvironmentVariable:
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.License), out _));
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.LicensePath), out _));
+
+                Environment.SetEnvironmentVariable("RAVEN_License", license);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), license);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            case LicenseSource.ServerOption:
+                options.CustomSettings[RavenConfiguration.GetKey(x => x.Licensing.License)] = license;
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.LicensePath), out _));
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(licenseSource), licenseSource, null);
+        }
+    }
+
+    private void HandleLicensePathOption(string license, LicenseSource licenseSource, ref ServerCreationOptions options)
+    {
+        var dataPath = NewDataPath(forceCreateDir: true);
+        string licensePath = LicenseOptionTestHelper.CreateLicenseJsonFile(dataPath, license);
+
+        switch (licenseSource)
+        {
+            case LicenseSource.EnvironmentVariable:
+                options.CustomSettings["ForTestingPurposesLicensePath"] = licensePath;
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.License), out _));
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.LicensePath), out _));
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", licensePath);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), licensePath);
+                break;
+
+            case LicenseSource.ServerOption:
+                options.CustomSettings[RavenConfiguration.GetKey(x => x.Licensing.LicensePath)] = licensePath;
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.License), out _));
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(licenseSource), licenseSource, null);
+        }
+    }
+
+    private static void AfterTestCleanup(string originalLicense, string originalLicensePath)
+    {
+        Environment.SetEnvironmentVariable("RAVEN_License", originalLicense);
+        Environment.SetEnvironmentVariable("RAVEN_License.Path", originalLicensePath);
+    }
+}
+
+internal enum LicenseSource
+{
+    EnvironmentVariable,
+    ServerOption
+}
+
+[CollectionDefinition("TestCollection.NonParallelTests", DisableParallelization = true)]
+public class NonParallelRavenTestsCollection
+{
+    // just a definition to group tests to run in non-parallel mode
+}
+
+public static class LicenseOptionTestHelper
+{
+    internal const string InvalidLicense = "SomeInvalidLicense";
+    internal static readonly string LicenseConfigurationKey = RavenConfiguration.GetKey(x => x.Licensing.License);
+    internal static readonly string LicensePathConfigurationKey = RavenConfiguration.GetKey(x => x.Licensing.LicensePath);
+    internal static readonly string ValidLicense = Environment.GetEnvironmentVariable("RAVEN_LICENSE");
+
+    public static string CreateLicenseJsonFile(string directoryPath, string licenseToTest)
+    {
+        var licenseJsonPath = Path.Combine(directoryPath, "license.json");
+        if (File.Exists(licenseJsonPath))
+            File.Delete(licenseJsonPath);
+
+        if (string.IsNullOrWhiteSpace(licenseToTest))
+            return licenseJsonPath;
+
+        File.WriteAllText(licenseJsonPath, licenseToTest);
+
+        Assert.True(File.Exists(licenseJsonPath));
+        Assert.Equal(File.ReadAllText(licenseJsonPath), licenseToTest);
+
+        return licenseJsonPath;
+    }
+
+    internal static void AssertException<T>(Exception exception, LicenseHelper.LicenseVerificationErrorBuilder expectedMessageBuilder) where T:Exception
+    {
+        Assert.NotNull(exception.InnerException);
+        Assert.IsType<T>(exception.InnerException);
+        Assert.True(exception.InnerException.Message.Contains(expectedMessageBuilder.ToString()),
+            userMessage: $"Exception message: {exception.InnerException.Message}{Environment.NewLine}But expected message:{Environment.NewLine}{expectedMessageBuilder}");
+    }
+}

--- a/test/LicenseTests/LicenseTests.csproj
+++ b/test/LicenseTests/LicenseTests.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Raven.Client\Raven.Client.csproj" />
     <ProjectReference Include="..\..\src\Raven.Server\Raven.Server.csproj" />
+    <ProjectReference Include="..\EmbeddedTests\EmbeddedTests.csproj" />
     <ProjectReference Include="..\FastTests\FastTests.csproj" />
     <ProjectReference Include="..\Tests.Infrastructure\Tests.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Sparrow\Sparrow.csproj" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22246

### Additional description

Implementation of `LicenseOptions` within `ServerOptions`, including the six previously existing configurations:
- `License`
- `LicensePath`
- `EulaAccepted`
- `DisableAutoUpdate`
- `DisableAutoUpdateFromApi`
- `DisableLicenseSupportCheck`

Plus the introduction of a new configuration: `EnforceLicense`.

If `EnforceLicense` is set to true, the test or embedded server will not start if the license is not provided in `LicenseOptions` or if the provided license fails validation.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured:
The `ServerOptions.AcceptEula` option has been marked as obsolete and moved inside `ServerOptions.LicenseConfiguration` as `EulaAccepted`. Backward compatibility is achieved as follows:

```csharp
public bool AcceptEula
{
    get => LicenseConfiguration.EulaAccepted;
    set => LicenseConfiguration.EulaAccepted = value;
}
```
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed