### PR TITLE
RavenDB-22618 : import is stuck on Timeseries Deleted Ranges

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -149,6 +149,7 @@ namespace Raven.Server.Smuggler.Documents
             EnsureStepProcessed(result.Subscriptions, skipped);
             EnsureStepProcessed(result.TimeSeries, skipped);
             EnsureStepProcessed(result.ReplicationHubCertificates, skipped);
+            EnsureStepProcessed(result.TimeSeriesDeletedRanges, skipped);
 
             static void EnsureStepProcessed(SmugglerProgressBase.Counts counts, bool skipped)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22618

### Additional description

handle `TimeSeriesDeletedRanges` in `DatabaseSmuggler.EnsureProcessed`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

