### PR TITLE
RavenDB-22605 Server-Side changes to enhance cluster debugging experience

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -152,11 +152,14 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/admin/cluster/log", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task GetLogs()
         {
+            var start = GetStart();
+            var take = GetPageSize(defaultPageSize: 1024);
+
             using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (context.OpenReadTransaction())
             await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
-                context.OpenReadTransaction();
-                context.Write(writer, ServerStore.GetLogDetails(context));
+                context.Write(writer, ServerStore.GetLogDetails(context, start, take));
             }
         }
 

--- a/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
@@ -292,14 +292,14 @@ namespace Raven.Server.Rachis.Remote
             }
         }
 
-        public SnapshotReader CreateReader()
+        public SnapshotReader CreateReader(RachisLogRecorder debugRecorder)
         {
-            return new RemoteSnapshotReader(this);
+            return new RemoteSnapshotReader(debugRecorder, this);
         }
 
-        public SnapshotReader CreateReaderToStream(Stream stream)
+        public SnapshotReader CreateReaderToStream(RachisLogRecorder debugRecorder, Stream stream)
         {
-            return new RemoteToStreamSnapshotReader(this, stream);
+            return new RemoteToStreamSnapshotReader(debugRecorder, this, stream);
         }
 
         public T Read<T>(JsonOperationContext context)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3539,16 +3539,10 @@ namespace Raven.Server.ServerWide
             return res;
         }
 
-        public DynamicJsonValue GetLogDetails(ClusterOperationContext context, int max = 100)
+        public DynamicJsonValue GetLogDetails(ClusterOperationContext context, int start, int take)
         {
             RachisConsensus.GetLastTruncated(context, out var index, out var term);
             var range = Engine.GetLogEntriesRange(context);
-            var entries = new DynamicJsonArray();
-            foreach (var entry in Engine.GetLogEntries(range.Min, context, max))
-            {
-                entries.Add(entry.ToString());
-            }
-
             var json = new DynamicJsonValue
             {
                 [nameof(LogSummary.CommitIndex)] = Engine.GetLastCommitIndex(context),
@@ -3556,7 +3550,7 @@ namespace Raven.Server.ServerWide
                 [nameof(LogSummary.LastTruncatedTerm)] = term,
                 [nameof(LogSummary.FirstEntryIndex)] = range.Min,
                 [nameof(LogSummary.LastLogEntryIndex)] = range.Max,
-                [nameof(LogSummary.Entries)] = entries
+                [nameof(LogSummary.Entries)] = Engine.GetLogEntries(context, range.Min, start, take)
             };
             return json;
         }

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -269,11 +269,11 @@ namespace Raven.Server.Web
             return GetIntValueQueryString(StartParameter, required: false) ?? defaultStart;
         }
 
-        protected int GetPageSize()
+        protected int GetPageSize(int defaultPageSize = int.MaxValue)
         {
             var pageSize = GetIntValueQueryString(PageSizeParameter, required: false);
             if (pageSize.HasValue == false)
-                return int.MaxValue;
+                return defaultPageSize;
 
             return pageSize.Value;
         }

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -217,7 +217,7 @@ public partial class RavenTestBase
             return
                 $"{Environment.NewLine}Log for server '{server.ServerStore.NodeTag}':" +
                 $"{Environment.NewLine}Last notified Index '{server.ServerStore.Cluster.LastNotifiedIndex}':" +
-                $"{Environment.NewLine}{context.ReadObject(server.ServerStore.GetLogDetails(context, max: int.MaxValue), "LogSummary/" + server.ServerStore.NodeTag)}" +
+                $"{Environment.NewLine}{context.ReadObject(server.ServerStore.GetLogDetails(context, start: 0, take: int.MaxValue), "LogSummary/" + server.ServerStore.NodeTag)}" +
                 $"{Environment.NewLine}{server.ServerStore.Engine.LogHistory.GetHistoryLogsAsString(context)}";
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22605

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
