### PR TITLE
RavenDB-19877: Log a line in Operations when database is loaded (5.4)

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -66,7 +66,7 @@ namespace Raven.Server.Documents
     public class DocumentDatabase : IDisposable
     {
         private readonly ServerStore _serverStore;
-        private readonly Action<string> _addToInitLog;
+        private readonly Action<LogMode, string> _addToInitLog;
         private readonly Logger _logger;
         private readonly DisposeOnce<SingleAttempt> _disposeOnce;
         internal TestingStuff ForTestingPurposes;
@@ -77,7 +77,7 @@ namespace Raven.Server.Documents
 
         private readonly SemaphoreSlim _updateDatabaseRecordLocker = new SemaphoreSlim(1, 1);
         private readonly SemaphoreSlim _updateValuesLocker = new SemaphoreSlim(1, 1);
-        public Action<string> AddToInitLog => _addToInitLog;
+        public Action<LogMode, string> AddToInitLog => _addToInitLog;
 
         /// <summary>
         /// The current lock, used to make sure indexes have a unique names
@@ -109,7 +109,7 @@ namespace Raven.Server.Documents
             _lastIdleTicks = DateTime.MinValue.Ticks;
         }
 
-        public DocumentDatabase(string name, RavenConfiguration configuration, ServerStore serverStore, Action<string> addToInitLog)
+        public DocumentDatabase(string name, RavenConfiguration configuration, ServerStore serverStore, Action<LogMode, string> addToInitLog)
         {
             Name = name;
             _logger = LoggingSource.Instance.GetLogger<DocumentDatabase>(Name);
@@ -132,7 +132,7 @@ namespace Raven.Server.Documents
 
                 if (Configuration.Core.RunInMemory == false)
                 {
-                    _addToInitLog("Creating db.lock file");
+                    _addToInitLog(LogMode.Information, "Creating db.lock file");
                     _fileLocker = new FileLocker(Configuration.Core.DataDirectory.Combine("db.lock").FullPath);
                     _fileLocker.TryAcquireWriteLock(_logger);
 
@@ -141,7 +141,7 @@ namespace Raven.Server.Documents
                     if (DisableOngoingTasks)
                     {
                         var msg = $"MAINTENANCE WARNING: Found disable.tasks.marker file. All tasks will not start. Please remove the file and restart the '{Name}' database.";
-                        _addToInitLog(msg);
+                        _addToInitLog(LogMode.Information, msg);
                         if (_logger.IsOperationsEnabled)
                             _logger.Operations(msg);
                     }
@@ -313,19 +313,19 @@ namespace Raven.Server.Documents
             {
                 Configuration.CheckDirectoryPermissions();
 
-                _addToInitLog("Initializing NotificationCenter");
+                _addToInitLog(LogMode.Information, "Initializing NotificationCenter");
                 NotificationCenter.Initialize(this);
 
-                _addToInitLog("Initializing DocumentStorage");
+                _addToInitLog(LogMode.Information, "Initializing DocumentStorage");
                 DocumentsStorage.Initialize((options & InitializeOptions.GenerateNewDatabaseId) == InitializeOptions.GenerateNewDatabaseId);
 
-                _addToInitLog("Initializing ConfigurationStorage");
+                _addToInitLog(LogMode.Information, "Initializing ConfigurationStorage");
                 ConfigurationStorage.Initialize();
 
                 if ((options & InitializeOptions.SkipLoadingDatabaseRecord) == InitializeOptions.SkipLoadingDatabaseRecord)
                     return;
 
-                _addToInitLog("Loading Database");
+                _addToInitLog(LogMode.Information, "Loading Database");
 
                 MetricCacher.Initialize();
 
@@ -341,16 +341,16 @@ namespace Raven.Server.Documents
                 DatabaseGroupId ??= record!.Topology.DatabaseTopologyIdBase64;
                 ClusterTransactionId ??= record!.Topology.ClusterTransactionIdBase64;
 
-                _addToInitLog("Starting Transaction Merger");
+                _addToInitLog(LogMode.Information, "Starting Transaction Merger");
                 TxMerger.Start();
 
                 PeriodicBackupRunner = new PeriodicBackupRunner(this, _serverStore, wakeup);
 
-                _addToInitLog("Initializing IndexStore (async)");
+                _addToInitLog(LogMode.Information, "Initializing IndexStore (async)");
                 _indexStoreTask = IndexStore.InitializeAsync(record, index, _addToInitLog);
-                _addToInitLog("Initializing Replication");
+                _addToInitLog(LogMode.Information, "Initializing Replication");
                 ReplicationLoader?.Initialize(record, index);
-                _addToInitLog("Initializing ETL");
+                _addToInitLog(LogMode.Information, "Initializing ETL");
                 EtlLoader.Initialize(record);
 
                 try
@@ -371,7 +371,7 @@ namespace Raven.Server.Documents
                 DatabaseShutdown.ThrowIfCancellationRequested();
 
                 SubscriptionStorage.Initialize();
-                _addToInitLog("Initializing SubscriptionStorage completed");
+                _addToInitLog(LogMode.Information, "Initializing SubscriptionStorage completed");
 
                 TombstoneCleaner.Start();
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -182,7 +182,7 @@ namespace Raven.Server.Documents
 
         public DocumentsContextPool ContextPool;
 
-        public DocumentsStorage(DocumentDatabase documentDatabase, Action<string> addToInitLog)
+        public DocumentsStorage(DocumentDatabase documentDatabase, Action<LogMode, string> addToInitLog)
         {
             DocumentDatabase = documentDatabase;
             _name = DocumentDatabase.Name;
@@ -199,7 +199,7 @@ namespace Raven.Server.Documents
         public CountersStorage CountersStorage;
         public TimeSeriesStorage TimeSeriesStorage;
         public DocumentPutAction DocumentPut;
-        private readonly Action<string> _addToInitLog;
+        private readonly Action<LogMode, string> _addToInitLog;
 
         // this is used to remember the metadata about collections / documents for
         // common operations. It always points to the latest valid transaction and is updated by

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -803,7 +803,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public Task InitializeAsync(DatabaseRecord record, long raftIndex, Action<string> addToInitLog)
+        public Task InitializeAsync(DatabaseRecord record, long raftIndex, Action<LogMode, string> addToInitLog)
         {
             if (_initialized)
                 throw new InvalidOperationException($"{nameof(IndexStore)} was already initialized.");
@@ -1701,7 +1701,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        private void OpenIndexesFromRecord(DatabaseRecord record, long raftIndex, Action<string> addToInitLog)
+        private void OpenIndexesFromRecord(DatabaseRecord record, long raftIndex, Action<LogMode, string> addToInitLog)
         {
             var path = _documentDatabase.Configuration.Indexing.StoragePath;
 
@@ -1737,11 +1737,10 @@ namespace Raven.Server.Documents.Indexes
                 {
                     var sp = Stopwatch.StartNew();
 
-                    addToInitLog($"Initializing static index: `{name}`");
+                    addToInitLog(LogMode.Information, $"Initializing static index: `{name}`");
                     OpenIndex(path, indexPath, exceptions, name, startIndex, definition);
 
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Initialized static index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
+                    addToInitLog(LogMode.Information, $"Initialized static index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
                 }
             }
 
@@ -1759,11 +1758,10 @@ namespace Raven.Server.Documents.Indexes
                 {
                     var sp = Stopwatch.StartNew();
 
-                    addToInitLog($"Initializing auto index: `{name}`");
+                    addToInitLog(LogMode.Information, $"Initializing auto index: `{name}`");
                     OpenIndex(path, indexPath, exceptions, name, startIndex, definition);
 
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Initialized auto index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
+                    addToInitLog(LogMode.Information, $"Initialized auto index: `{name}`, took: {sp.ElapsedMilliseconds:#,#;;0}ms");
                 }
             }
 
@@ -1786,7 +1784,7 @@ namespace Raven.Server.Documents.Indexes
                         }
                         catch (Exception e)
                         {
-                            addToInitLog($"Could not start index '{index.Name}': {e}");
+                            addToInitLog(LogMode.Operations, $"Could not start index '{index.Name}': {e}");
                         }
                     });
 
@@ -1796,13 +1794,12 @@ namespace Raven.Server.Documents.Indexes
             // loading the new indexes
             var startIndexSp = Stopwatch.StartNew();
 
-            addToInitLog("Starting new indexes");
+            addToInitLog(LogMode.Information, "Starting new indexes");
             startIndex = _documentDatabase.Configuration.Indexing.IndexStartupBehavior != IndexingConfiguration.IndexStartupBehaviorType.Pause;
             var startedIndexes = HandleDatabaseRecordChange(record, raftIndex, startIndex);
 
-            addToInitLog($"Started {startedIndexes} new index{(startedIndexes > 1 ? "es" : string.Empty)}, took: {startIndexSp.ElapsedMilliseconds}ms");
-
-            addToInitLog($"IndexStore initialization is completed, took: {totalSp.ElapsedMilliseconds:#,#;;0}ms");
+            addToInitLog(LogMode.Information, $"Started {startedIndexes} new index{(startedIndexes > 1 ? "es" : string.Empty)}, took: {startIndexSp.ElapsedMilliseconds}ms");
+            addToInitLog(LogMode.Information, $"IndexStore initialization is completed, took: {totalSp.ElapsedMilliseconds:#,#;;0}ms");
 
             if (exceptions != null && exceptions.Count > 0)
                 throw new AggregateException("Could not load some of the indexes", exceptions);

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -308,11 +308,20 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                             databaseName, overwrite: false);
                     }
 
-                    var addToInitLog = new Action<string>(txt => // init log is not save in mem during RestoreBackup
+                    var addToInitLog = new Action<LogMode, string>((logMode, txt) => // init log is not save in mem during RestoreBackup
                     {
                         var msg = $"[RestoreBackup] {DateTime.UtcNow} :: Database '{databaseName}' : {txt}";
-                        if (Logger.IsInfoEnabled)
-                            Logger.Info(msg);
+
+                        switch (logMode)
+                        {
+                            case LogMode.Operations when Logger.IsOperationsEnabled:
+                                Logger.Operations(msg);
+                                break;
+
+                            case LogMode.Information when Logger.IsInfoEnabled:
+                                Logger.Info(msg);
+                                break;
+                        }
                     });
 
                     var configuration = _serverStore
@@ -399,7 +408,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
                     try
                     {
-                        await _serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName, addToInitLog: message => result.AddInfo(message));
+                        await _serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName, addToInitLog: (_, message) => result.AddInfo(message));
                     }
                     catch (Exception e)
                     {

--- a/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide;
+using Sparrow.Logging;
 using Voron;
 using Voron.Schema;
 
@@ -101,7 +102,7 @@ namespace Raven.Server.Storage.Schema
                 if (shouldAddToInitLog)
                 {
                     var msg = $"Started schema upgrade from version #{updater.From} to version #{updater.To}";
-                    _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
+                    _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(LogMode.Information, msg);
                 }
 
                 bool result =  updater.Update(new UpdateStep(transactions)
@@ -112,9 +113,9 @@ namespace Raven.Server.Storage.Schema
 
                 if (shouldAddToInitLog)
                 {
-
                     var msg = $"{(result ? "Finished" : "Failed to")} schema upgrade from version #{updater.From} to version #{updater.To}";
-                    _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
+                    var logMode = result ? LogMode.Information : LogMode.Operations;
+                    _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(logMode, msg);
                 }
 
                 return result;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -294,11 +294,19 @@ namespace Raven.Server.Web.System
                 return;
             }
 
-            var addToInitLog = new Action<string>(txt =>
+            var addToInitLog = new Action<LogMode, string>((logMode, txt) =>
             {
                 var msg = $"[Recreating indexes] {DateTime.UtcNow} :: Database '{databaseRecord.DatabaseName}' : {txt}";
-                if (Logger.IsInfoEnabled)
-                    Logger.Info(msg);
+                switch (logMode)
+                {
+                    case LogMode.Operations when Logger.IsOperationsEnabled:
+                        Logger.Operations(msg);
+                    break;
+
+                    case LogMode.Information when Logger.IsInfoEnabled:
+                        Logger.Info(msg);
+                    break;
+                }
             });
 
             using (var documentDatabase = new DocumentDatabase(databaseRecord.DatabaseName, databaseConfiguration, ServerStore, addToInitLog))

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -152,7 +152,7 @@ namespace Voron.Impl.Journal
             return journal;
         }
 
-        public bool RecoverDatabase(TransactionHeader* txHeader, Action<string> addToInitLog)
+        public bool RecoverDatabase(TransactionHeader* txHeader, Action<LogMode, string> addToInitLog)
         {
             // note, we don't need to do any concurrency here, happens as a single threaded
             // fashion on db startup
@@ -192,7 +192,7 @@ namespace Voron.Impl.Journal
             var deleteLastJournal = false;
             for (var journalNumber = journalToStartReadingFrom; journalNumber <= logInfo.CurrentJournal; journalNumber++)
             {
-                addToInitLog?.Invoke($"Recovering journal {journalNumber} (up to last journal {logInfo.CurrentJournal})");
+                addToInitLog?.Invoke(LogMode.Information, $"Recovering journal {journalNumber} (up to last journal {logInfo.CurrentJournal})");
                 var initialSize = _env.Options.InitialFileSize ?? _env.Options.InitialLogFileSize;
                 var journalRecoveryName = StorageEnvironmentOptions.JournalRecoveryName(journalNumber);
                 try
@@ -252,15 +252,17 @@ namespace Voron.Impl.Journal
                                 break;
                             }
                         }
-                        addToInitLog?.Invoke($"Journal {journalNumber} Recovered");
+                        addToInitLog?.Invoke(LogMode.Information, $"Journal {journalNumber} Recovered");
                     }
                 }
                 catch (InvalidJournalException)
                 {
                     if (_env.Options.IgnoreInvalidJournalErrors == true)
                     {
-                        addToInitLog?.Invoke(
-                            $"Encountered invalid journal {journalNumber} @ {_env.Options}. Skipping this journal and keep going the recovery operation because '{nameof(_env.Options.IgnoreInvalidJournalErrors)}' options is set");
+                        var msg =
+                            $"Encountered invalid journal {journalNumber} @ {_env.Options}. " +
+                            $"Skipping this journal and keep going the recovery operation because '{nameof(_env.Options.IgnoreInvalidJournalErrors)}' options is set";
+                        addToInitLog?.Invoke(LogMode.Information, msg);
                         continue;
                     }
 
@@ -285,7 +287,7 @@ namespace Voron.Impl.Journal
 
                     var overflowDetector = new RecoveryOverflowDetector();
 
-                    addToInitLog?.Invoke($"Validate checksum on {modifiedPages.Count} pages");
+                    addToInitLog?.Invoke(LogMode.Information, $"Validate checksum on {modifiedPages.Count} pages");
 
                     var sp = Stopwatch.StartNew();
 
@@ -296,7 +298,7 @@ namespace Voron.Impl.Journal
                         if (sp.Elapsed.TotalSeconds >= 60)
                         {
                             sp.Restart();
-                            addToInitLog?.Invoke($"Still calculating checksum... ({sortedPages.Length - i} out of {sortedPages.Length}");
+                            addToInitLog?.Invoke(LogMode.Information, $"Still calculating checksum... ({sortedPages.Length - i} out of {sortedPages.Length}");
                         }
 
                         using (tempTx) // release any resources, we just wanted to validate things
@@ -318,11 +320,11 @@ namespace Voron.Impl.Journal
                     }
 
                     sp.Stop();
-                    addToInitLog?.Invoke($"Validate of {sortedPages.Length} pages completed in {sp.Elapsed}");
+                    addToInitLog?.Invoke(LogMode.Information, $"Validate of {sortedPages.Length} pages completed in {sp.Elapsed}");
                 }
                 else
                 {
-                    addToInitLog?.Invoke($"SkipChecksumValidationOnDbLoading set to true. Skipping checksum validation of {modifiedPages.Count} pages.");
+                    addToInitLog?.Invoke(LogMode.Information, $"SkipChecksumValidationOnDbLoading set to true. Skipping checksum validation of {modifiedPages.Count} pages.");
                 }
             }
 
@@ -386,7 +388,7 @@ namespace Voron.Impl.Journal
                     // it must have at least one page for the next transaction header and one 4kb for data
                     CurrentFile = lastFile;
             }
-            addToInitLog?.Invoke($"Info: Current File = '{CurrentFile?.Number}', Position (4KB)='{CurrentFile?.WritePosIn4KbPosition}'. Require Header Update = {requireHeaderUpdate}");
+            addToInitLog?.Invoke(LogMode.Information, $"Info: Current File = '{CurrentFile?.Number}', Position (4KB)='{CurrentFile?.WritePosIn4KbPosition}'. Require Header Update = {requireHeaderUpdate}");
 
             if (requireHeaderUpdate)
             {
@@ -431,7 +433,7 @@ namespace Voron.Impl.Journal
 
             if (_env.Options.CopyOnWriteMode == false)
             {
-                addToInitLog?.Invoke($"Cleanup Newer Invalid Journal Files (Last Flushed Journal={lastProcessedJournal})");
+                addToInitLog?.Invoke(LogMode.Information, $"Cleanup Newer Invalid Journal Files (Last Flushed Journal={lastProcessedJournal})");
 
                 CleanupNewerInvalidJournalFiles(lastProcessedJournal);
             }
@@ -2261,4 +2263,3 @@ namespace Voron.Impl.Journal
     }
 
 }
-

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -282,10 +282,10 @@ namespace Voron
             var header = stackalloc TransactionHeader[1];
             bool hadIntegrityIssues;
 
-            Options.AddToInitLog?.Invoke("Starting Recovery");
+            Options.AddToInitLog?.Invoke(LogMode.Information, "Starting Recovery");
             hadIntegrityIssues = _journal.RecoverDatabase(header, Options.AddToInitLog);
             var successString = hadIntegrityIssues ? "(with integrity issues)" : "(successfully)";
-            Options.AddToInitLog?.Invoke($"Recovery Ended {successString}");
+            Options.AddToInitLog?.Invoke(LogMode.Information, $"Recovery Ended {successString}");
 
             if (hadIntegrityIssues)
             {

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -234,7 +234,7 @@ namespace Voron
 
         public Func<string, bool> ShouldUseKeyPrefix { get; set; }
 
-        public Action<string> AddToInitLog;
+        public Action<LogMode, string> AddToInitLog;
 
         public event Action<StorageEnvironmentOptions> OnDirectoryInitialize;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19877

### Additional description

Added Operations logs for database loading to provide visibility on successful loads from cache, load attempts, and creation of new databases when absent in cache. Each log includes the reason for the load and integrates the caller information for better traceability.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
