### PR TITLE
RavenDB-22400 - SlowTests.Client.ChangesApiFailover.ChangesApiMonitoringMultipleShouldNotFailAllWhenOneFailsOnFetch(options: DatabaseMode = Sharded , SearchEngineMode = Lucene)

### DIFF
--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
@@ -24,7 +24,7 @@ public partial class ShardedDatabaseContext
     {
         private readonly ShardedDatabaseContext _context;
 
-        private readonly ConcurrentDictionary<ShardedDatabaseIdentifier, DatabaseChanges> _changes = new();
+        internal readonly ConcurrentDictionary<ShardedDatabaseIdentifier, DatabaseChanges> _changes = new();
 
         public ShardedOperations([NotNull] ShardedDatabaseContext context)
             : base(context.Changes, PlatformDetails.Is32Bits || context.Configuration.Storage.ForceUsing32BitsPager


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22400

### Additional description

Test is supposed to bring down the server after asserting the database changes is connected. Then it would result in the excpected exception. However there was also a need to check that the database changes for the shards finished connecting as well. Otherwise, the test would bring down the server while we are still setting up the shards' connections, which resulted in a different error.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
