### PR TITLE
RavenDB-22630 Remove 'partitionKey' from RabbitMQ sample script

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/transformationScriptSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/transformationScriptSyntax.ts
@@ -197,7 +197,6 @@ loadToOrders(orderData, {  // load to the 'Orders' Topic with optional params
 
 loadToOrders(orderData, "routingKey", {  // load to the 'Orders' Exchange with optional params
     Id: id(this),
-    PartitionKey: id(this),
     Type: 'com.github.users',
     Source: '/registrations/direct-signup'
 });`;

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/transformationScriptSyntax.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/transformationScriptSyntax.html
@@ -75,7 +75,6 @@
                        <td>
                            <code>loadToUsers({ Name: 'Bob' }, {<br />
                                <span class="margin-left-lg">Id: ...,</span><br />
-                               <span class="margin-left-lg">PartitionKey: ...,</span><br />
                                <span class="margin-left-lg">Source: ...,</span><br />
                                <span class="margin-left-lg">Type: ...</span><br /> })
                            </code>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22630/Remove-partitionKey-from-RabbitMQ-sample-script

### Additional description
`partitionKey` is only supported by Kafka ETL
so removing it from the syntax example in the UI

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed - handled in https://issues.hibernatingrhinos.com/issue/RDoc-2882/Document-ETL-to-Azure-Queue-Storage

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
