### PR TITLE
RavenDB-22615 Fixed index syntax building for ListInitExpression

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -1300,10 +1300,8 @@ namespace Raven.Client.Documents.Indexes
                 Visit(node.NewExpression);
                 Out(" {");
             }
-            
             else if (isDictionaryType)
                 Out("new DynamicDictionary(new System.Collections.Generic.Dictionary<object, object>{");
-
             else
                 Out("new DynamicArray(new[] {");
             

--- a/test/SlowTests/Issues/RavenDB-22615.cs
+++ b/test/SlowTests/Issues/RavenDB-22615.cs
@@ -4,8 +4,6 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
-using Raven.Server.Documents.Indexes.Static;
-using Raven.Server.Documents.Indexes.Static.Linq;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -43,8 +41,7 @@ public class RavenDB_22615 : RavenTestBase
 
                 Assert.Equal(1, res.Count);
                 Assert.Equal(dto1.Id, res[0].Id);
-
-                /*
+                
                 var terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(DummyIndex.IndexEntry.SomeClassList), null));
 
                 Assert.Contains("{\"name\":\"name1\"}", terms);
@@ -61,7 +58,6 @@ public class RavenDB_22615 : RavenTestBase
                 Assert.Contains("{\"name\":\"name1\"}", terms);
                 Assert.Contains("{\"name\":\"name2\"}", terms);
                 Assert.Contains("{\"name\":\"name3\"}", terms);
-                */
             }
         }
     }
@@ -71,9 +67,9 @@ public class RavenDB_22615 : RavenTestBase
         public class IndexEntry
         {
             public List<string> StringList { get; set; }
-            //public List<SomeClass> SomeClassList { get; set; }
-            //public string FirstElementOfStringList { get; set; }
-            //public SomeClass FirstElementOfSomeClassList { get; set; }
+            public List<SomeClass> SomeClassList { get; set; }
+            public string FirstElementOfStringList { get; set; }
+            public SomeClass FirstElementOfSomeClassList { get; set; }
         }
         public DummyIndex()
         {
@@ -83,9 +79,9 @@ public class RavenDB_22615 : RavenTestBase
                 select new IndexEntry()
                 {
                     StringList = new List<string> { name, otherName },
-                    //SomeClassList = new List<SomeClass>() { new SomeClass() { Name = name } },
-                    //FirstElementOfStringList = new List<string>() { name }.First(),
-                    //FirstElementOfSomeClassList = new List<SomeClass>() { new SomeClass() { Name = name } }.First()
+                    SomeClassList = new List<SomeClass>() { new SomeClass() { Name = name } },
+                    FirstElementOfStringList = new List<string>() { name }.First(),
+                    FirstElementOfSomeClassList = new List<SomeClass>() { new SomeClass() { Name = name } }.First()
                 });
             
             StoreAllFields(FieldStorage.Yes);
@@ -169,12 +165,12 @@ public class RavenDB_22615 : RavenTestBase
     private class PropertyImage
     {
         public string PropertyId { get; set; }
-        public string? Url { get; set; }
+        public string Url { get; set; }
     }
     private class PropertyIndexResult
     {
         public string Id { get; set; }
-        public List<PropertyImage>? Images { get; set; } = [];
+        public List<PropertyImage> Images { get; set; } = [];
     }
     
     [RavenFact(RavenTestCategory.Indexes)]

--- a/test/SlowTests/Issues/RavenDB-22615.cs
+++ b/test/SlowTests/Issues/RavenDB-22615.cs
@@ -1,0 +1,225 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Documents.Indexes.Static;
+using Raven.Server.Documents.Indexes.Static.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22615 : RavenTestBase
+{
+    public RavenDB_22615(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIndexWithListInitExpression()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var index = new DummyIndex();
+            
+            index.Execute(store);
+
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto() { Names = new List<string>(){ "Name1", "Name2" } };
+                var dto2 = new Dto() { Names = new List<string>(){ "Name3" } };
+                
+                session.Store(dto1);
+                session.Store(dto2);
+                
+                session.SaveChanges();
+                
+                Indexes.WaitForIndexing(store);
+
+                var res = session.Query<DummyIndex.IndexEntry, DummyIndex>().Where(x => x.StringList.Contains("Name1")).ProjectInto<Dto>().ToList();
+
+                Assert.Equal(1, res.Count);
+                Assert.Equal(dto1.Id, res[0].Id);
+
+                /*
+                var terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(DummyIndex.IndexEntry.SomeClassList), null));
+
+                Assert.Contains("{\"name\":\"name1\"}", terms);
+                Assert.Contains("{\"name\":\"name2\"}", terms);
+                Assert.Contains("{\"name\":\"name3\"}", terms);
+                
+                res = session.Query<DummyIndex.IndexEntry, DummyIndex>().Where(x => x.FirstElementOfStringList == "Name3").ProjectInto<Dto>().ToList();
+                
+                Assert.Equal(1, res.Count);
+                Assert.Equal(dto2.Id, res[0].Id);
+                
+                terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(DummyIndex.IndexEntry.FirstElementOfSomeClassList), null));
+
+                Assert.Contains("{\"name\":\"name1\"}", terms);
+                Assert.Contains("{\"name\":\"name2\"}", terms);
+                Assert.Contains("{\"name\":\"name3\"}", terms);
+                */
+            }
+        }
+    }
+    
+    private class DummyIndex : AbstractMultiMapIndexCreationTask<Dto>
+    {
+        public class IndexEntry
+        {
+            public List<string> StringList { get; set; }
+            //public List<SomeClass> SomeClassList { get; set; }
+            //public string FirstElementOfStringList { get; set; }
+            //public SomeClass FirstElementOfSomeClassList { get; set; }
+        }
+        public DummyIndex()
+        {
+            AddMap<Dto>(dtos => from dto in dtos
+                from name in dto.Names
+                let otherName = "blabla"
+                select new IndexEntry()
+                {
+                    StringList = new List<string> { name, otherName },
+                    //SomeClassList = new List<SomeClass>() { new SomeClass() { Name = name } },
+                    //FirstElementOfStringList = new List<string>() { name }.First(),
+                    //FirstElementOfSomeClassList = new List<SomeClass>() { new SomeClass() { Name = name } }.First()
+                });
+            
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public List<string> Names { get; set; }
+    }
+
+    private class SomeClass
+    {
+        public string Name { get; set; }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestMultiMapReduceIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var property = new Property() { Status = 2137 };
+                
+                session.Store(property);
+                
+                var propertyImage = new PropertyImage() { PropertyId = property.Id, Url = "SomeUrl" };
+                
+                session.Store(propertyImage);
+                
+                session.SaveChanges();
+                
+                var index = new PropertiesIndex();
+                
+                index.Execute(store);
+            
+                Indexes.WaitForIndexing(store);
+
+                var res = session.Query<PropertyIndexResult, PropertiesIndex>().ToList();
+                
+                Assert.Equal(property.Id, res[0].Id);
+            }
+        }
+    }
+    
+    private class PropertiesIndex : AbstractMultiMapIndexCreationTask<PropertyIndexResult>
+    {
+        public PropertiesIndex()
+        {
+            AddMap<Property>(properties => from property in properties.Where(x => x.Status < 2)
+                select new PropertyIndexResult
+                {
+                    Id = property.Id,
+                    Images = new List<PropertyImage>()
+                });
+            AddMap<PropertyImage>(images => from image in images
+                select new PropertyIndexResult
+                {
+                    Id = image.PropertyId,
+                    Images = new List<PropertyImage> { image }
+                });
+    
+            Reduce = results => from result in results
+                group result by result.Id into g
+                select new PropertyIndexResult
+                {
+                    Id = g.Key,
+                    Images = g.SelectMany(x => x.Images ?? new List<PropertyImage>()).ToList()
+                };
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+    
+    private class Property
+    {
+        public long Status { get; set; }
+        public string Id { get; set; }
+    }
+    private class PropertyImage
+    {
+        public string PropertyId { get; set; }
+        public string? Url { get; set; }
+    }
+    private class PropertyIndexResult
+    {
+        public string Id { get; set; }
+        public List<PropertyImage>? Images { get; set; } = [];
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIndexUsingDictWithCustomClass()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto() { Names = new List<string>() { "Name1", "Name2" } };
+                var dto2 = new Dto() { Names = new List<string>() { "Name3" } };
+                
+                session.Store(dto1);
+                session.Store(dto2);
+                
+                session.SaveChanges();
+                
+                var index = new IndexWithDict();
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                var terms = store.Maintenance.Send(new GetTermsOperation(index.IndexName, nameof(IndexWithDict.IndexEntry.SomeDict), null));
+                
+                Assert.Equal(3, terms.Length);
+                Assert.Equal("{\"name1\":{\"@metadata\":{\"@collection\":\"dtos\",\"raven-clr-type\":\"slowtests.issues.ravendb_22615+dto, slowtests\"},\"names\":[\"name1\",\"name2\"]}}", terms[0]);
+                Assert.Equal("{\"name2\":{\"@metadata\":{\"@collection\":\"dtos\",\"raven-clr-type\":\"slowtests.issues.ravendb_22615+dto, slowtests\"},\"names\":[\"name1\",\"name2\"]}}", terms[1]);
+                Assert.Equal("{\"name3\":{\"@metadata\":{\"@collection\":\"dtos\",\"raven-clr-type\":\"slowtests.issues.ravendb_22615+dto, slowtests\"},\"names\":[\"name3\"]}}", terms[2]);
+            }
+        }
+    }
+
+    private class IndexWithDict : AbstractIndexCreationTask<Dto>
+    {
+        public class IndexEntry
+        {
+            public Dictionary<string, Dto> SomeDict { get; set; }
+        }
+        
+        public IndexWithDict()
+        {
+            Map = dtos => from dto in dtos
+                from name in dto.Names
+                select new IndexEntry() { SomeDict = new Dictionary<string, Dto>() { { name, dto } } };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22615/MultiMapReduce-index-error-Map-and-Reduce-function-types-should-be-identical

### Additional description

We want to correctly handle list and dictionary initialization (`ListInitExpression` node) in the index definition. 

The issue was that for types not known on the server (any user-defined class) we translated `Property = new List<CustomType>() { customTypeObject }` to `new {} { { customTypeObject } }`. We want to translate this into `new DynamicArray(new[] { customTypeObject })` instead. Same with dictionaries, but instead of `DynamicArray` we want to use `DynamicDictionary` and enclose each key-value pair in curly braces. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
