### PR TITLE
RavenDB-21314 update database change vector upon replication heartbeat

### DIFF
--- a/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
+++ b/src/Raven.Client/Documents/Replication/Messages/ReplicationLatestEtagRequest.cs
@@ -8,6 +8,8 @@ namespace Raven.Client.Documents.Replication.Messages
 
         public string SourceDatabaseId { get; set; }
 
+        public string SourceDatabaseBase64Id { get; set; }
+
         public string SourceUrl { get; set; }
 
         public string SourceTag { get; set; }

--- a/src/Raven.Server/Documents/Replication/IncomingConnectionInfo.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingConnectionInfo.cs
@@ -7,6 +7,7 @@ namespace Raven.Server.Documents.Replication
     public class IncomingConnectionInfo : IEquatable<IncomingConnectionInfo>
     {
         public string SourceDatabaseId { get; set; }
+        public string SourceDatabaseBase64Id { get; set; }
 
         public string SourceDatabaseName { get; set; }
 
@@ -26,6 +27,7 @@ namespace Raven.Server.Documents.Replication
                 SourceUrl = message.SourceUrl,
                 SourceMachineName = message.SourceMachineName,
                 SourceDatabaseId = message.SourceDatabaseId,
+                SourceDatabaseBase64Id = message.SourceDatabaseBase64Id,
                 SourceTag = message.SourceTag
             };
         }

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -382,7 +382,7 @@ namespace Raven.Server.Documents.Replication
                                         $"with etag: {_lastDocumentEtag} (new) > {lastEtag} (old)");
                                 }
 
-                                var cmd = new MergedUpdateDatabaseChangeVectorCommand(changeVector, _lastDocumentEtag, ConnectionInfo.SourceDatabaseId,
+                                var cmd = new MergedUpdateDatabaseChangeVectorCommand(changeVector, _lastDocumentEtag, ConnectionInfo,
                                     _replicationFromAnotherSource, _incomingPullReplicationParams.Mode == PullReplicationMode.SinkToHub);
 
                                 if (_prevChangeVectorUpdate != null && _prevChangeVectorUpdate.IsCompleted == false)
@@ -996,15 +996,15 @@ namespace Raven.Server.Documents.Replication
         {
             private readonly string _changeVector;
             private readonly long _lastDocumentEtag;
-            private readonly string _sourceDatabaseId;
+            private readonly IncomingConnectionInfo _connectionInfo;
             private readonly AsyncManualResetEvent _trigger;
             private readonly bool _isHub;
 
-            public MergedUpdateDatabaseChangeVectorCommand(string changeVector, long lastDocumentEtag, string sourceDatabaseId, AsyncManualResetEvent trigger, bool isHub)
+            public MergedUpdateDatabaseChangeVectorCommand(string changeVector, long lastDocumentEtag, IncomingConnectionInfo connectionInfo, AsyncManualResetEvent trigger, bool isHub)
             {
                 _changeVector = changeVector;
                 _lastDocumentEtag = lastDocumentEtag;
-                _sourceDatabaseId = sourceDatabaseId;
+                _connectionInfo = connectionInfo;
                 _trigger = trigger;
                 _isHub = isHub;
             }
@@ -1012,10 +1012,10 @@ namespace Raven.Server.Documents.Replication
             protected override long ExecuteCmd(DocumentsOperationContext context)
             {
                 var operationsCount = 0;
-                var lastReplicatedEtag = DocumentsStorage.GetLastReplicatedEtagFrom(context, _sourceDatabaseId);
+                var lastReplicatedEtag = DocumentsStorage.GetLastReplicatedEtagFrom(context, _connectionInfo.SourceDatabaseId);
                 if (_lastDocumentEtag > lastReplicatedEtag)
                 {
-                    DocumentsStorage.SetLastReplicatedEtagFrom(context, _sourceDatabaseId, _lastDocumentEtag);
+                    DocumentsStorage.SetLastReplicatedEtagFrom(context, _connectionInfo.SourceDatabaseId, _lastDocumentEtag);
                     operationsCount++;
                 }
 
@@ -1025,7 +1025,18 @@ namespace Raven.Server.Documents.Replication
                 var current = context.LastDatabaseChangeVector ?? DocumentsStorage.GetDatabaseChangeVector(context);
                 var conflictStatus = ChangeVectorUtils.GetConflictStatus(_changeVector, current);
                 if (conflictStatus != ConflictStatus.Update)
+                {
+                    if (string.IsNullOrEmpty(_connectionInfo.SourceDatabaseBase64Id) == false)
+                    {
+                        var result = ChangeVectorUtils.TryUpdateChangeVector(_connectionInfo.SourceTag, _connectionInfo.SourceDatabaseBase64Id, _lastDocumentEtag, current);
+                        if (result.IsValid)
+                        {
+                            context.LastDatabaseChangeVector = result.ChangeVector;
+                        }
+                    }
+                    
                     return operationsCount;
+                }
 
                 operationsCount++;
 
@@ -1051,7 +1062,7 @@ namespace Raven.Server.Documents.Replication
                 {
                     ChangeVector = _changeVector,
                     LastDocumentEtag = _lastDocumentEtag,
-                    SourceDatabaseId = _sourceDatabaseId,
+                    IncomingConnectionInfo = _connectionInfo,
                     IsHub = _isHub
                 };
             }
@@ -1670,12 +1681,12 @@ namespace Raven.Server.Documents.Replication
     {
         public string ChangeVector;
         public long LastDocumentEtag;
-        public string SourceDatabaseId;
+        public IncomingConnectionInfo IncomingConnectionInfo;
         public bool IsHub;
 
         public IncomingReplicationHandler.MergedUpdateDatabaseChangeVectorCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
-            var command = new IncomingReplicationHandler.MergedUpdateDatabaseChangeVectorCommand(ChangeVector, LastDocumentEtag, SourceDatabaseId,
+            var command = new IncomingReplicationHandler.MergedUpdateDatabaseChangeVectorCommand(ChangeVector, LastDocumentEtag, IncomingConnectionInfo,
                 new AsyncManualResetEvent(), IsHub);
             return command;
         }

--- a/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/OutgoingReplicationHandler.cs
@@ -589,6 +589,7 @@ namespace Raven.Server.Documents.Replication
             {
                 ["Type"] = "GetLastEtag",
                 [nameof(ReplicationLatestEtagRequest.SourceDatabaseId)] = _database.DbId.ToString(),
+                [nameof(ReplicationLatestEtagRequest.SourceDatabaseBase64Id)] = _database.DbBase64Id,
                 [nameof(ReplicationLatestEtagRequest.SourceDatabaseName)] = _database.Name,
                 [nameof(ReplicationLatestEtagRequest.SourceUrl)] = _parent._server.GetNodeHttpServerUrl(),
                 [nameof(ReplicationLatestEtagRequest.SourceTag)] = _parent._server.NodeTag,

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -1075,6 +1075,10 @@ namespace Raven.Server.ServerWide.Maintenance
         {
             // check every node pair, and if one of them is lagging behind, move him to rehab
             reason = null;
+
+            if (ShouldGiveMoreTimeBeforeMovingToRehab(state.DatabaseTopology.NodesModifiedAt ?? DateTime.MinValue, databaseUpTime: null))
+                return true;
+
             var members = state.DatabaseTopology.Members;
             for (int i = 0; i < members.Count; i++)
             {

--- a/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
+++ b/test/SlowTests/Server/RecordingTransactionOperationsMergerTests.cs
@@ -656,7 +656,11 @@ namespace SlowTests.Server
                 await store.Maintenance.SendAsync(new StartTransactionsRecordingOperation(recordFilePath));
 
                 var command = new IncomingReplicationHandler.MergedUpdateDatabaseChangeVectorCommand(
-                    expectedChangeVector, 5, Guid.NewGuid().ToString(), new AsyncManualResetEvent(), isHub: false);
+                    expectedChangeVector, 5, new IncomingConnectionInfo
+                    {
+                        SourceDatabaseId = Guid.NewGuid().ToString(),
+                        SourceTag = "A"
+                    }, new AsyncManualResetEvent(), isHub: false);
 
                 var database = await Databases.GetDocumentDatabaseInstanceFor(store);
                 await database.TxMerger.Enqueue(command);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21314
https://issues.hibernatingrhinos.com/issue/RavenDB-22123

### Additional description

Artificial documents bumping local etag and aren't being replicated, so we wouldn't sync the database change vector between the nodes.
Given enough such documents it is possible to be moved into rehab state due to the "lagging behind" check.

To fix this issue we need to update our database change vector upon heartbeat and to give more grace time before moving a node into rehab due to being falling behind.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
We added new field to the `ReplicationLatestEtagRequest`, it this field doesn't exist we will fallback to the previous behavior. If the old node get this field, he is unaware of it and simply ignore it.
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
