### PR TITLE
RavenDB-22560 Remove spare space from Create a database

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/CreateDatabaseFromBackupStepSource.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/CreateDatabaseFromBackupStepSource.tsx
@@ -88,7 +88,8 @@ export default function CreateDatabaseFromBackupStepSource() {
                     Disable ongoing tasks after restore
                 </FormSwitch>
                 <FormSwitch control={control} name="sourceStep.isSkipIndexes" color="primary">
-                    <Icon icon="index" /> Skip indexes
+                    <Icon icon="index" />
+                    Skip indexes
                 </FormSwitch>
                 <IsEncryptedField isFirstRestorePointSnapshot={isFirstRestorePointSnapshot} />
             </Collapse>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22560

### Additional description

Removed spare space from the pop-up

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
