### PR TITLE
RavenDB-20200: Fix for SlowTests.Issues.RavenDB_15409.DoNotCallUpdateLicenseLimitsCommandOnEveryLeaderChange

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -242,7 +242,7 @@ public partial class RavenTestBase
             server.ServerStore.Observer.Suspended = true;
         }
 
-        public async Task AssertNumberOfCommandsPerNode(long expectedNumberOfCommands, List<RavenServer> servers, string commandType, int timeout = 30_000, int interval = 1_000)
+        internal async Task<(bool, Dictionary<string, long>)> GetNumberOfCommandsPerNode(long expectedNumberOfCommands, List<RavenServer> servers, string commandType, int timeout = 30_000, int interval = 1_000)
         {
             var numberOfCommandsPerNode = new Dictionary<string, long>();
             var isExpectedNumberOfCommandsPerNode = await WaitForValueAsync(() =>
@@ -262,29 +262,31 @@ public partial class RavenTestBase
                 expectedVal: true,
                 timeout, interval);
 
-            Assert.True(isExpectedNumberOfCommandsPerNode, BuildErrorMessage());
-            
-            return;
-            string BuildErrorMessage()
+            bool allNodesHaveSameNumberOfCommands = numberOfCommandsPerNode.Values.Distinct().Count() == 1;
+            Assert.True(allNodesHaveSameNumberOfCommands, BuildErrorMessage(expectedNumberOfCommands, numberOfCommandsPerNode, servers));
+
+            return (isExpectedNumberOfCommandsPerNode, numberOfCommandsPerNode);
+        }
+
+        internal string BuildErrorMessage(long expectedNumberOfCommands, Dictionary<string, long> numberOfCommandsPerNode, List<RavenServer> servers)
+        {
+            var stringBuilder = new StringBuilder();
+
+            using (var context = JsonOperationContext.ShortTermSingleUse())
             {
-                var stringBuilder = new StringBuilder();
-
-                using (var context = JsonOperationContext.ShortTermSingleUse())
+                stringBuilder.AppendLine($"Expected number of commands per node: '{expectedNumberOfCommands}'. Actual number of commands per node: ");
+                foreach ((string nodeTag, long numberOfCommands) in numberOfCommandsPerNode)
                 {
-                    stringBuilder.AppendLine($"Expected number of commands per node: {expectedNumberOfCommands}. Actual number of commands per node: ");
-                    foreach ((string nodeTag, long numberOfCommands) in numberOfCommandsPerNode)
-                    {
-                        stringBuilder.AppendLine($"Node tag: '{nodeTag}' with actual number of commands: '{numberOfCommands}'. Commands:");
+                    stringBuilder.AppendLine($"Node tag: '{nodeTag}' with actual number of commands: '{numberOfCommands}'. Commands:");
 
-                        var server = servers.Find(x => x.ServerStore.NodeTag == nodeTag);
-                        var raftCommands = GetRaftCommands(server).Select(djv => context.ReadObject(djv, "raftCommand").ToString()).ToArray();
+                    var server = servers.Find(x => x.ServerStore.NodeTag == nodeTag);
+                    var raftCommands = GetRaftCommands(server).Select(djv => context.ReadObject(djv, "raftCommand").ToString()).ToArray();
 
-                        stringBuilder.AppendLine($"{string.Join($"{Environment.NewLine}\t", raftCommands)}");
-                    }
+                    stringBuilder.AppendLine($"{string.Join($"{Environment.NewLine}\t", raftCommands)}");
                 }
-
-                return stringBuilder.ToString();
             }
+
+            return stringBuilder.ToString();
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20200/

### Additional description

The reasons for the rare test failures are unrelated to the purpose of this test.

In the vast majority of test executions, the number of `UpdateLicenseLimitsCommand` executed during the cluster creation process equals the number of nodes in the cluster, as each node is expected to independently send its own details. Due to a race condition in the cluster, sometimes the number of `UpdateLicenseLimitsCommand` exceeds the number of nodes in the cluster by one. The test was adapted to account for this scenario, as such a race condition is acceptable.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed