### PR TITLE
RavenDB-17789 - Fix ShouldStoreTotalDocumentsSizeInPerformanceHint_ForRevisions (v5.4)

### DIFF
--- a/src/Raven.Server/NotificationCenter/Paging.cs
+++ b/src/Raven.Server/NotificationCenter/Paging.cs
@@ -53,6 +53,9 @@ namespace Raven.Server.NotificationCenter
             if (_pagingTimer != null)
                 return;
 
+            if (ForTestingPurposes?.DisableTimer == true)
+                return;
+
             lock (_locker)
             {
                 if (_pagingTimer != null)
@@ -175,6 +178,21 @@ namespace Raven.Server.NotificationCenter
                         throw new ArgumentOutOfRangeException(nameof(type), type, null);
                 }
             }
+        }
+
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal sealed class TestingStuff
+        {
+            internal bool DisableTimer;
         }
 
         public void Dispose()

--- a/test/SlowTests/Issues/RavenDB_17018.cs
+++ b/test/SlowTests/Issues/RavenDB_17018.cs
@@ -159,6 +159,8 @@ namespace SlowTests.Issues
                 ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.PerformanceHints.MaxNumberOfResults)] = "1"
             }))
             {
+                var database = await GetDatabase(store.Database);
+                database.NotificationCenter.Paging.ForTestingPurposesOnly().DisableTimer = true;
 
                 using (var session = store.OpenSession())
                 {
@@ -202,16 +204,9 @@ namespace SlowTests.Issues
                         .Revisions
                         .GetFor<Company>("companies/1", pageSize: 4);
                 }
-                var database = await GetDatabase(store.Database);
-                
-                string reason;
-                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out reason);
-                if (outcome == false)
-                {
-                    // "Queue is empty" means that the UpdatePagingInternal already invoked by the Timer
-                    // Any other reason is Failure 
-                    Assert.Equal("Queue is empty", reason); 
-                }
+
+                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out string reason);
+                Assert.True(outcome, reason);
 
                 using (database.NotificationCenter.GetStored(out var actions))
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17789/SlowTests.Issues.RavenDB17018.ShouldStoreTotalDocumentsSizeInPerformanceHintForRevisions

### Additional description

SlowTests.Issues.RavenDB_17018.ShouldStoreTotalDocumentsSizeInPerformanceHint_ForRevisions Failed

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
