### PR TITLE
RavenDB-21247 Modified test to run on both sharded and single database

### DIFF
--- a/test/SlowTests/Issues/RavenDB-21247.cs
+++ b/test/SlowTests/Issues/RavenDB-21247.cs
@@ -49,17 +49,15 @@ public class RavenDB_21247 : RavenTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Querying)]
-    public async Task TestQueryCausingRequestLatencyWarning()
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task TestQueryCausingRequestLatencyWarning(Options options)
     {
         DoNotReuseServer();
 
-        var storeOptions = new Options()
-        {
-            ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.PerformanceHints.TooLongRequestThreshold)] = "0"
-        };
-
-        using (var store = GetDocumentStore(storeOptions))
+        options.ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.PerformanceHints.TooLongRequestThreshold)] = "0";
+        
+        using (var store = GetDocumentStore(options))
         {
             var db = await GetDatabase(store.Database);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21247/High-latency-queries-alert-doesnt-provide-query-parameters

### Additional description

Modified test to run on both sharded and single database

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
