### PR TITLE
RavenDB-22640 Enter doesn't work in ace editor

### DIFF
--- a/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/studioSearch/hooks/useStudioSearchKeyboardEvents.ts
+++ b/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/studioSearch/hooks/useStudioSearchKeyboardEvents.ts
@@ -53,11 +53,13 @@ export function useStudioSearchKeyboardEvents(props: UseStudioSearchKeyboardEven
             }
         };
 
-        document.addEventListener("keydown", handleEnterKey);
+        const current = inputRef.current;
+
+        current.addEventListener("keydown", handleEnterKey);
         return () => {
-            document.removeEventListener("keydown", handleEnterKey);
+            current.removeEventListener("keydown", handleEnterKey);
         };
-    }, [activeItem, setIsDropdownOpen]);
+    }, [inputRef, activeItem, setIsDropdownOpen]);
 
     // Handle keyboard navigation
     useEffect(() => {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22640/Enter-doesnt-work-in-ace-editor

### Additional description

Changes enter event listener from document to studio search input.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
