### PR TITLE
RavenDB-22644 Remove defaulting to Encrypt=Optional in MsSQL connection string

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -50,16 +50,6 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
             _commandBuilder = _providerFactory.InitializeCommandBuilder();
             _connection = _providerFactory.CreateConnection();
             var connectionString = etl.Configuration.Connection.ConnectionString;
-
-            if (_etl.Configuration.Connection.FactoryName == "System.Data.SqlClient" &&
-                SqlConnectionStringParser.GetConnectionStringValue(connectionString, new string[] { "Encrypt" }) == null)
-            {
-                // We want to ensure compatibility between deprecated System.Data.SqlClient (where Encrypt parameter defaults to false)
-                // and Microsoft.Data.SqlClient which defaults it to SqlConnectionEncryptOption.Mandatory. If no option is provided,
-                // we set it to SqlConnectionEncryptOption.Optional (equivalent of false).
-                connectionString = SqlConnectionStringUtil.GetConnectionStringWithOptionalEncrypt(connectionString);
-            }
-            
             _connection.ConnectionString = connectionString;
 
             OpenConnection(database, etl.Configuration.Name, etl.Configuration.ConnectionStringName);

--- a/src/Raven.Server/SqlMigration/MsSQL/MsSqlDatabaseMigrator.Migration.cs
+++ b/src/Raven.Server/SqlMigration/MsSQL/MsSqlDatabaseMigrator.Migration.cs
@@ -1,6 +1,4 @@
-﻿using Raven.Client.Documents.Operations.ETL.SQL;
-using Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters;
-using Raven.Server.SqlMigration.Schema;
+﻿using Raven.Server.SqlMigration.Schema;
 
 namespace Raven.Server.SqlMigration.MsSQL
 {
@@ -8,7 +6,7 @@ namespace Raven.Server.SqlMigration.MsSQL
     {
         protected override string FactoryName => "Microsoft.Data.SqlClient";
         
-        public MsSqlDatabaseMigrator(string connectionString) : base(OverrideConnectionStringIfNeeded(connectionString))
+        public MsSqlDatabaseMigrator(string connectionString) : base(connectionString)
         {
         }
 
@@ -79,14 +77,6 @@ namespace Raven.Server.SqlMigration.MsSQL
         protected override string GetSelectAllQueryForTable(string tableSchema, string tableName)
         {
             return "select * from " + QuoteTable(tableSchema, tableName);
-        }
-
-        private static string OverrideConnectionStringIfNeeded(string connectionString)
-        {
-            if (SqlConnectionStringParser.GetConnectionStringValue(connectionString, new string[] { "Encrypt" }) == null)
-                connectionString = SqlConnectionStringUtil.GetConnectionStringWithOptionalEncrypt(connectionString);
-
-            return connectionString;
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-22426.cs
+++ b/test/SlowTests/Issues/RavenDB-22426.cs
@@ -7,7 +7,6 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Server.SqlMigration;
-using SlowTests.Server.Documents.ETL;
 using SlowTests.Server.Documents.Migration;
 using Tests.Infrastructure;
 using Xunit;
@@ -31,7 +30,7 @@ public class RavenDB_22426 : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Etl)]
-    public void TestOldFactoryNameWithNoEncryptParameter()
+    public void TestOldFactoryName()
     {
         using (var store = GetDocumentStore())
         {
@@ -50,9 +49,7 @@ public class RavenDB_22426 : RavenTestBase
 
                 var etlDone = Etl.WaitForEtlToComplete(store, (n, s) => GetDtosCount(connectionString) == 1);
                 
-                var connectionStringWithoutEncryptOption = connectionString.Replace("Encrypt=Optional;", string.Empty);
-                
-                SetupSqlEtl(store, connectionStringWithoutEncryptOption, EtlScript);
+                SetupSqlEtl(store, connectionString, EtlScript);
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22644/Remove-defaulting-to-EncryptOptional-in-MsSQL-connection-string

### Additional description

Since v6.1, we don't want to append `Encrypt=Optional` to MsSQL connection string if the value wasn't provided by the user.
Because we're using `Microsoft.Data.SqlClient` v5.2.1 now, instead of `System.Data.SqlClient` (it's not supported anymore), the behavior for [Encrypt parameter](https://github.com/dotnet/SqlClient/blob/main/porting-cheat-sheet.md#functionality-changes) has changed. This means MsSQL connection strings without specified encryption option (whether boolean or enum) or certificate won't work anymore. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
