### PR TITLE
RavenDB-22617 Corax's facet performance

### DIFF
--- a/src/Corax/Querying/IndexSearcher.Aggregations.cs
+++ b/src/Corax/Querying/IndexSearcher.Aggregations.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Corax.Mappings;
+using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
+using Corax.Querying.Matches.TermProviders;
+using Voron;
+using Voron.Data.CompactTrees;
+using Voron.Data.Lookups;
+using Range = Corax.Querying.Matches.Meta.Range;
+
+namespace Corax.Querying;
+
+public partial class IndexSearcher
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public IAggregationProvider TextualAggregation(in FieldMetadata field, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
+    {
+        var compactTree = _fieldsTree.CompactTreeFor(field.FieldName);
+        return forward
+            ? new ExistsTermProvider<Lookup<CompactTree.CompactKeyLookup>.ForwardIterator>(this, compactTree, field, forAggregation: true)
+            : new ExistsTermProvider<Lookup<CompactTree.CompactKeyLookup>.BackwardIterator>(this, compactTree, field, forAggregation: true);
+    }
+
+    public IAggregationProvider LowAggregationBuilder<TValue>(in FieldMetadata field, TValue value, UnaryMatchOperation operation, bool forward)
+    {
+        Debug.Assert(value is double or string, "value is double or string");
+        Debug.Assert(operation is UnaryMatchOperation.LessThan or UnaryMatchOperation.LessThanOrEqual);
+        
+        return value switch
+        {
+            double d => BetweenAggregation(field, double.MinValue, d, UnaryMatchOperation.GreaterThanOrEqual, rightSide: operation,
+                forward),
+            string s => BetweenAggregation(field, Slices.BeforeAllKeys, EncodeAndApplyAnalyzer(default, s), UnaryMatchOperation.GreaterThanOrEqual,
+                operation, forward),
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
+        };
+    }
+
+    public IAggregationProvider GreaterAggregationBuilder<TValue>(in FieldMetadata field, TValue value, UnaryMatchOperation operation, bool forward)
+    {
+        Debug.Assert(operation is UnaryMatchOperation.GreaterThan or UnaryMatchOperation.GreaterThanOrEqual);
+        Debug.Assert(value is double or string, "value is double or string");
+        
+        return value switch
+        {
+            double d => BetweenAggregation(field, d, double.MaxValue, operation, rightSide: UnaryMatchOperation.LessThanOrEqual,
+                forward),
+            string s => BetweenAggregation(field, EncodeAndApplyAnalyzer(default, s), Slices.AfterAllKeys, operation,
+                UnaryMatchOperation.LessThanOrEqual, forward),
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
+        };
+    }
+    
+    public IAggregationProvider BetweenAggregation<TValue>(in FieldMetadata field, TValue low, TValue high,
+        UnaryMatchOperation leftSide = UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation rightSide = UnaryMatchOperation.LessThanOrEqual, bool forward = true)
+    {
+        Debug.Assert(low is double or string, "value is double or string");
+        
+        if (typeof(TValue) == typeof(double))
+        {
+            return (leftSide, rightSide) switch
+            {
+                // (x, y)
+                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThan) => AggregationRangeBuilder<Range.Exclusive, Range.Exclusive>(field, (double)(object)low,
+                    (double)(object)high, forward),
+
+                //<x, y)
+                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThan) => AggregationRangeBuilder<Range.Inclusive, Range.Exclusive>(field,
+                    (double)(object)low,
+                    (double)(object)high, forward),
+
+                //<x, y>
+                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual) => AggregationRangeBuilder<Range.Inclusive, Range.Inclusive>(field,
+                    (double)(object)low, (double)(object)high, forward),
+
+                //(x, y>
+                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThanOrEqual) => AggregationRangeBuilder<Range.Exclusive, Range.Inclusive>(field,
+                    (double)(object)low,
+                    (double)(object)high, forward),
+                _ => throw new ArgumentOutOfRangeException($"Unknown operation at {nameof(BetweenQuery)}.")
+            };
+        }
+
+        if (typeof(TValue) == typeof(string) || typeof(TValue) == typeof(Slice))
+        {
+            Slice leftValue;
+            Slice rightValue;
+
+            if (typeof(string) == typeof(TValue))
+            {
+                leftValue = EncodeAndApplyAnalyzer(default, (string)(object)low);
+                rightValue = EncodeAndApplyAnalyzer(default, (string)(object)high);
+            }
+            else
+            {
+                leftValue = (Slice)(object)low;
+                rightValue = (Slice)(object)high;
+            }
+
+            return (leftSide, rightSide) switch
+            {
+                // (x, y)
+                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThan) => AggregationRangeBuilder<Range.Exclusive, Range.Exclusive>(field,
+                    leftValue, rightValue, forward),
+
+                //<x, y)
+                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThan) => AggregationRangeBuilder<Range.Inclusive, Range.Exclusive>(field,
+                    leftValue, rightValue, forward),
+
+                //<x, y>
+                (UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation.LessThanOrEqual) => AggregationRangeBuilder<Range.Inclusive, Range.Inclusive>(
+                    field, leftValue, rightValue, forward),
+
+                //(x, y>
+                (UnaryMatchOperation.GreaterThan, UnaryMatchOperation.LessThanOrEqual) => AggregationRangeBuilder<Range.Exclusive, Range.Inclusive>(field,
+                    leftValue, rightValue, forward),
+
+                _ => throw new ArgumentOutOfRangeException($"Unknown operation at {nameof(BetweenQuery)}.")
+            };
+        }
+
+        throw new ArgumentException($"{typeof(TValue)} is not supported in {nameof(BetweenQuery)}");
+    }
+
+    private IAggregationProvider AggregationRangeBuilder<TLow, THigh>(in FieldMetadata field, Slice low, Slice high, bool forward)
+        where TLow : struct, Range.Marker
+        where THigh : struct, Range.Marker
+    {
+        var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
+        if (terms == null)
+            return new EmptyAggregationProvider();
+
+        return forward switch
+        {
+            true => new TermRangeProvider<Lookup<CompactTree.CompactKeyLookup>.ForwardIterator, TLow, THigh>(this, terms, field, low, high),
+            false => new TermRangeProvider<Lookup<CompactTree.CompactKeyLookup>.BackwardIterator, TLow, THigh>(this, terms, field, low, high)
+        };
+    }
+
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private IAggregationProvider AggregationRangeBuilder<TLow, THigh>(FieldMetadata field, double low, double high, bool forward)
+        where TLow : struct, Range.Marker
+        where THigh : struct, Range.Marker
+        => AggregationRangeBuilder<DoubleLookupKey, double, TLow, THigh>(field, new(low), new(high), forward);
+
+
+    private IAggregationProvider AggregationRangeBuilder<TLookupKey, TTermType, TLow, THigh>(FieldMetadata field, TLookupKey low, TLookupKey high, bool forward)
+        where TLow : struct, Range.Marker
+        where THigh : struct, Range.Marker
+        where TLookupKey : struct, ILookupKey
+    {
+        field = field.GetNumericFieldMetadata<TTermType>(Allocator);
+        var set = _fieldsTree?.LookupFor<TLookupKey>(field.FieldName);
+        if (set is null || set.NumberOfEntries == 0)
+            return new EmptyAggregationProvider();
+
+        return forward switch
+        {
+            true => new TermNumericRangeProvider<Lookup<TLookupKey>.ForwardIterator, TLow, THigh, TLookupKey>(this, set, field, low, high),
+            false => new TermNumericRangeProvider<Lookup<TLookupKey>.BackwardIterator, TLow, THigh, TLookupKey>(this, set, field, low, high)
+        };
+    }
+}

--- a/src/Corax/Querying/IndexSearcher.Aggregations.cs
+++ b/src/Corax/Querying/IndexSearcher.Aggregations.cs
@@ -18,7 +18,10 @@ public partial class IndexSearcher
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public IAggregationProvider TextualAggregation(in FieldMetadata field, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
     {
-        var compactTree = _fieldsTree.CompactTreeFor(field.FieldName);
+        var compactTree = _fieldsTree?.CompactTreeFor(field.FieldName);
+        if (compactTree is null)
+            return new EmptyAggregationProvider();
+        
         return forward
             ? new ExistsTermProvider<Lookup<CompactTree.CompactKeyLookup>.ForwardIterator>(this, compactTree, field, forAggregation: true)
             : new ExistsTermProvider<Lookup<CompactTree.CompactKeyLookup>.BackwardIterator>(this, compactTree, field, forAggregation: true);

--- a/src/Corax/Querying/Matches/EmptyAggregationProvider.cs
+++ b/src/Corax/Querying/Matches/EmptyAggregationProvider.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using Corax.Querying.Matches.Meta;
+
+namespace Corax.Querying.Matches;
+
+public struct EmptyAggregationProvider : IAggregationProvider
+{
+    public IDisposable AggregateByTerms(out List<string> terms, out Span<long> counts)
+    {
+        terms = null;
+        counts = Span<long>.Empty;
+        return null;
+    }
+
+    public long AggregateByRange()
+    {
+        return 0;
+    }
+}

--- a/src/Corax/Querying/Matches/Meta/IAggregationProvider.cs
+++ b/src/Corax/Querying/Matches/Meta/IAggregationProvider.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace Corax.Querying.Matches.Meta;
+
+public interface IAggregationProvider
+{
+    public IDisposable AggregateByTerms(out List<string> terms, out Span<long> counts);
+    public long AggregateByRange();
+
+}

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
@@ -1,16 +1,24 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Corax.Indexing;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
+using Corax.Utils;
+using Sparrow;
+using Sparrow.Compression;
+using Sparrow.Server;
 using Voron.Data.CompactTrees;
 using Voron.Data.Lookups;
 using Voron.Data.PostingLists;
 
 namespace Corax.Querying.Matches.TermProviders
 {
-    public struct ExistsTermProvider<TLookupIterator> : ITermProvider
+    public struct ExistsTermProvider<TLookupIterator> : ITermProvider, IAggregationProvider
         where TLookupIterator : struct, ILookupIterator
     {
+        private readonly long _numberOfTerms;
         private readonly CompactTree _tree;
         private readonly Querying.IndexSearcher _searcher;
         private readonly FieldMetadata _field;
@@ -23,8 +31,9 @@ namespace Corax.Querying.Matches.TermProviders
         private long _postingListId;
         
         private CompactTree.Iterator<TLookupIterator> _iterator;
+        private readonly CompactKey _compactKey;
 
-        public ExistsTermProvider(Querying.IndexSearcher searcher, CompactTree tree, in FieldMetadata field)
+        public ExistsTermProvider(Querying.IndexSearcher searcher, CompactTree tree, in FieldMetadata field, bool forAggregation = false)
         {
             _tree = tree;
             _field = field;
@@ -42,8 +51,15 @@ namespace Corax.Querying.Matches.TermProviders
                     _fetchNulls = true;
                 }
             }
+
+            if (forAggregation)
+            {
+                _compactKey = _searcher._transaction.LowLevelTransaction.AcquireCompactKey();
+                _compactKey.Initialize(_searcher._transaction.LowLevelTransaction);
+            }
             
             _iterator = tree.Iterate<TLookupIterator>();
+            _numberOfTerms = tree.NumberOfEntries;
             _iterator.Reset();
         }
 
@@ -72,7 +88,7 @@ namespace Corax.Querying.Matches.TermProviders
 
             _iterator.Reset();
         }
-
+        
         public bool Next(out TermMatch term)
         {
             if (_fetchNulls)
@@ -101,7 +117,7 @@ namespace Corax.Querying.Matches.TermProviders
                 return true;
             }
             
-            while (_iterator.MoveNext(out var compactKey, out _, out _))
+            while (_iterator.MoveNext(out var compactKey, out long _, out _))
             {
                 var key = compactKey.Decoded();
                 int termSize = key.Length;
@@ -127,5 +143,87 @@ namespace Corax.Querying.Matches.TermProviders
                                 { Constants.QueryInspectionNode.FieldName, _field.ToString() }
                             });
         }
+        
+        /// <summary>
+        /// Created for simple facet(FieldName) purposes. This is faster than normal since we're gathering all statistics in bulks.
+        /// </summary>
+        /// <param name="terms"></param>
+        /// <param name="counts"></param>
+        /// <returns></returns>
+        public unsafe IDisposable AggregateByTerms(out List<string> terms, out Span<long> counts)
+        {
+            terms = new List<string>(NumberOfTerms);
+            var scope = _searcher.Allocator.Allocate((sizeof(long) + sizeof(UnmanagedSpan)) * NumberOfTerms, out ByteString termsBuffer);
+            Span<long> termCount = termsBuffer.ToSpan<long>().Slice(0, NumberOfTerms);
+            var termIdx = 0;
+            
+            if (_fetchNulls)
+            {
+                terms.Add(Constants.ProjectionNullValue);
+                termCount[termIdx++] = _nullPostingList.State.NumberOfEntries;
+                _fetchNulls = false;
+            }
+
+            while (_iterator.MoveNext(_compactKey, out long postingListId, out _))
+            {
+                var key = _compactKey.Decoded();
+                int termSize = key.Length;
+                if (key.Length > 1)
+                {
+                    if (key[^1] == 0)
+                        termSize--;
+                }
+                
+                var term = Encodings.Utf8.GetString(key.Slice(0, termSize));
+                terms.Add(term);
+                
+                termCount[termIdx++] = postingListId;
+            }
+
+
+            var containersPtr = (UnmanagedSpan*)(termsBuffer.Ptr + (sizeof(long) * NumberOfTerms));
+            using var __ = _searcher.Allocator.Allocate(NumberOfTerms, out Span<long> containersIds);
+
+            if (_nullExists)
+                containersIds[0] = -1L;
+
+            for (int i = _nullExists ? 1 : 0; i < NumberOfTerms; ++i)
+            {
+                if ((termCount[i] & (long)TermIdMask.EnsureIsSingleMask) != 0)
+                {
+                    Debug.Assert((termCount[i] & (long)TermIdMask.PostingList) != 0 || (termCount[i] & (long)TermIdMask.SmallPostingList) != 0);
+                    containersIds[i] = EntryIdEncodings.GetContainerId(termCount[i]);
+                    continue;
+                }
+                
+                containersIds[i] = -1;
+            }
+            
+            
+            Voron.Data.Containers.Container.GetAll(_searcher._transaction.LowLevelTransaction, containersIds, containersPtr, -1, _searcher.Transaction.LowLevelTransaction.PageLocator);
+            
+            for (int i = _nullExists ? 1 : 0; i < NumberOfTerms; ++i)
+            {
+                var containerId = termCount[i];
+                
+                if ((containerId & (long)TermIdMask.PostingList) != 0)
+                    termCount[i] = ((PostingListState*)containersPtr[i].Address)->NumberOfEntries;
+                else if ((containerId & (long)TermIdMask.SmallPostingList) != 0)
+                    termCount[i] = VariableSizeEncoding.Read<long>(containersPtr[i].Address, out _);
+                else
+                    termCount[i] = 1;
+            }
+
+
+            counts = termCount;
+            return scope;
+        }
+
+        public long AggregateByRange()
+        {
+            throw new NotSupportedException($"{nameof(ExistsTermProvider<TLookupIterator>)} supports only terms aggregation.");
+        }
+        
+        private int NumberOfTerms => (int)_numberOfTerms + (_nullExists ? 1 : 0);
     }
 }

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
@@ -239,7 +239,7 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider, I
         NativeList<TermIdMask> postingListsType = new();
         postingListsType.Initialize(allocator);
         
-        while (_iterator.MoveNext(compactKey, out var termId, out var _))
+        while (_isEmpty == false && _iterator.MoveNext(compactKey, out var termId, out var _))
         {
             if (termId == _endContainerId)
             {
@@ -266,7 +266,7 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider, I
             }
         }
 
-        using var _ = allocator.Allocate((sizeof(UnmanagedSpan*)) * postingLists.Count, out ByteString containers);
+        using var _ = allocator.Allocate((sizeof(UnmanagedSpan)) * postingLists.Count, out ByteString containers);
         var containersPtr = (UnmanagedSpan*)containers.Ptr;
 
         Container.GetAll(_indexSearcher._transaction.LowLevelTransaction, postingLists.ToSpan(), containersPtr, singleMarker,

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
@@ -1,24 +1,32 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
+using Corax.Indexing;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
+using Corax.Utils;
+using Sparrow;
+using Sparrow.Compression;
+using Sparrow.Server;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Containers;
 using Voron.Data.Lookups;
+using Voron.Data.PostingLists;
+using Voron.Util;
 using Range = Corax.Querying.Matches.Meta.Range;
 
 namespace Corax.Querying.Matches.TermProviders;
 
 [DebuggerDisplay("{DebugView,nq}")]
-public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider
+public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider, IAggregationProvider
     where TLookupIterator : struct, ILookupIterator
     where TLow : struct, Range.Marker
     where THigh : struct, Range.Marker
 {
-    private readonly CompactTree _tree;
-    private readonly Querying.IndexSearcher _indexSearcher;
+    private readonly IndexSearcher _indexSearcher;
     private readonly FieldMetadata _field;
     private Slice _low, _high;
 
@@ -40,7 +48,6 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider
 
         _low = low;
         _high = high;
-        _tree = tree;
 
         // Optimization for unbounded ranges. We seek the proper term (depending on the iterator) and iterate through all left items.
         _skipRangeCheck = _isForward
@@ -55,7 +62,7 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider
     {
         CompactKey key;
         ReadOnlySpan<byte> termSlice;
-        
+
         var startKey = _isForward ? _low : _high;
         var finalKey = _isForward ? _high : _low;
 
@@ -66,7 +73,7 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider
             {
                 _isEmpty = true;
                 return; //empty set, we will go out of range immediately 
-}
+            }
 
             termSlice = key.Decoded();
             var shouldInclude = _isForward switch
@@ -97,7 +104,7 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider
                     Slice.From(_indexSearcher.Allocator, termSlice, out _high);
             }
         }
-        
+
         if (_skipRangeCheck)
         {
             // In this case we will accept all items left.
@@ -126,7 +133,7 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider
             true when typeof(THigh) == typeof(Range.Inclusive) && _high.Options != SliceOptions.AfterAllKeys && finalCmp > 0 => false,
             _ => true
         };
-        if(_shouldIncludeLastTerm == false && hasPreviousValue == false)
+        if (_shouldIncludeLastTerm == false && hasPreviousValue == false)
         {
             _isEmpty = true;
         }
@@ -150,7 +157,7 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider
         else
             _iterator.Reset();
     }
-    
+
     private bool ShouldSeek()
     {
         return _isForward switch
@@ -171,7 +178,7 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider
         if (termId == _endContainerId)
         {
             _isEmpty = true;
-            
+
             if (_shouldIncludeLastTerm == false)
                 goto ReturnEmpty;
         }
@@ -186,25 +193,101 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider
 
     public QueryInspectionNode Inspect()
     {
-        var lowValue = _low.Options is SliceOptions.BeforeAllKeys 
+        var lowValue = _low.Options is SliceOptions.BeforeAllKeys
             ? null
             : _low.ToString();
 
-        var highValue = _high.Options is SliceOptions.AfterAllKeys 
+        var highValue = _high.Options is SliceOptions.AfterAllKeys
             ? null
             : _high.ToString();
-        
+
         return new QueryInspectionNode(nameof(TermRangeProvider<TLookupIterator, TLow, THigh>),
             parameters: new Dictionary<string, string>()
             {
                 { Constants.QueryInspectionNode.FieldName, _field.ToString() },
-                { Constants.QueryInspectionNode.LowValue, lowValue},
-                { Constants.QueryInspectionNode.HighValue, highValue},
-                { Constants.QueryInspectionNode.LowOption, typeof(TLow).Name},
-                { Constants.QueryInspectionNode.HighOption, typeof(THigh).Name},
-                { Constants.QueryInspectionNode.IteratorDirection, Constants.QueryInspectionNode.IterationDirectionName<TLookupIterator>()}
+                { Constants.QueryInspectionNode.LowValue, lowValue },
+                { Constants.QueryInspectionNode.HighValue, highValue },
+                { Constants.QueryInspectionNode.LowOption, typeof(TLow).Name },
+                { Constants.QueryInspectionNode.HighOption, typeof(THigh).Name },
+                { Constants.QueryInspectionNode.IteratorDirection, Constants.QueryInspectionNode.IterationDirectionName<TLookupIterator>() }
             });
     }
 
     public string DebugView => Inspect().ToString();
+
+    public IDisposable AggregateByTerms(out List<string> terms, out Span<long> counts)
+    {
+        throw new NotImplementedException();
+    }
+
+    public unsafe long AggregateByRange()
+    {
+        //we do not support Long ranges since we want to perform aggregation on doubles 
+        const long singleMarker = -1L;
+        if (_isEmpty)
+        {
+            return 0;
+        }
+        
+        var allocator = _indexSearcher.Allocator;
+        CompactKey compactKey = new();
+        compactKey.Initialize(_indexSearcher._transaction.LowLevelTransaction);
+        
+        NativeList<long> postingLists = new();
+        postingLists.Initialize(allocator);
+        
+        NativeList<TermIdMask> postingListsType = new();
+        postingListsType.Initialize(allocator);
+        
+        while (_iterator.MoveNext(compactKey, out var termId, out var _))
+        {
+            if (termId == _endContainerId)
+            {
+                _isEmpty = true;
+
+                if (_shouldIncludeLastTerm == false)
+                    break;
+            }
+            
+            if ((termId & (long)TermIdMask.PostingList) != 0)
+            {
+                postingLists.Add(allocator, EntryIdEncodings.GetContainerId(termId));
+                postingListsType.Add(allocator, TermIdMask.PostingList);
+            }
+            else if ((termId & (long)TermIdMask.SmallPostingList) != 0)
+            {
+                postingLists.Add(allocator, EntryIdEncodings.GetContainerId(termId));
+                postingListsType.Add(allocator, TermIdMask.SmallPostingList);
+            }
+            else
+            {
+                postingLists.Add(allocator, singleMarker);
+                postingListsType.Add(allocator, TermIdMask.Single);
+            }
+        }
+
+        using var _ = allocator.Allocate((sizeof(UnmanagedSpan*)) * postingLists.Count, out ByteString containers);
+        var containersPtr = (UnmanagedSpan*)containers.Ptr;
+
+        Container.GetAll(_indexSearcher._transaction.LowLevelTransaction, postingLists.ToSpan(), containersPtr, singleMarker,
+            _indexSearcher._transaction.LowLevelTransaction.PageLocator);
+
+        long totalCount = 0;
+        for (int i = 0; i < postingLists.Count; ++i)
+        {
+            var localCount = (postingListsType[i]) switch
+            {
+                TermIdMask.PostingList => ((PostingListState*)(containersPtr[i].Address))->NumberOfEntries,
+                TermIdMask.SmallPostingList => VariableSizeEncoding.Read<long>(containersPtr[i].Address, out var _),
+                TermIdMask.Single => 1,
+                _ => throw new InvalidDataException($"Supported posting lists types are: 'PostingList', 'SmallPostingList', 'Single' but got {postingListsType[i]}")
+            };
+            
+            totalCount += localCount;
+        }
+
+        postingLists.Dispose(allocator);
+        postingListsType.Dispose(allocator);
+        return totalCount;
+    }
 }

--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatch.Simple.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using Corax.Mappings;
 using Corax.Querying.Matches;
+using Corax.Querying.Matches.Meta;
 using Corax.Querying.Matches.TermProviders;
 using Voron;
 using Voron.Data.Lookups;
@@ -86,6 +87,7 @@ public partial class IndexSearcher
             : MultiTermMatchBuilder<ExistsTermProvider<Lookup<CompactKeyLookup>.BackwardIterator>>(field, default(Slice), streamingEnabled: streamingEnabled, token: token);
     }
 
+    
     public MultiTermMatch RegexQuery(in FieldMetadata field, Regex regex, bool forward = true, bool streamingEnabled = false, in CancellationToken token = default)
     {
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -109,7 +109,7 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                     if (needToApplyAggregation)
                     {
                         //not supported yet.
-                        //todo:   ApplyAggregation(result.Value.Aggregations, collectionOfFacetValues, ref reader);
+                        throw new InvalidOperationException("Facet queries that need to apply aggregation should be handled via scanning reader. This code path is not supposed to be reached for such queries.");
                     }
 
                     continue;
@@ -140,6 +140,7 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                 if (needToApplyAggregation)
                 {
                     //not supported yet.
+                    throw new InvalidOperationException("Facet queries that need to apply aggregation should be handled via scanning reader. This code path is not supposed to be reached for such queries.");
                 }
 
                 token.ThrowIfCancellationRequested();

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexFacetReadOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexFacetReadOperationBase.cs
@@ -147,7 +147,7 @@ public abstract class IndexFacetReadOperationBase : IndexOperationBase
             }
             else
             {
-                allTerms = GetAllTermsSorted(result.Value.Options.TermSortMode, groups);
+                allTerms = GetAllTermsSorted(result.Value.Options.TermSortMode, result.Value.SortedIds, groups);
 
                 start = result.Value.Options.Start;
                 pageSize = Math.Min(allTerms.Count, result.Value.Options.PageSize);
@@ -216,17 +216,17 @@ public abstract class IndexFacetReadOperationBase : IndexOperationBase
         return (values, remainingTermsCount, remainingHits, valuesCount);
     }
 
-    internal static List<string> GetAllTermsSorted(FacetTermSortMode sortMode, Dictionary<string, FacetValues> values)
+    internal static List<string> GetAllTermsSorted(FacetTermSortMode sortMode, List<string> valueSortedIds, Dictionary<string, FacetValues> values)
     {
         List<string> allTerms;
 
         switch (sortMode)
         {
             case FacetTermSortMode.ValueAsc:
-                allTerms = new List<string>(values.OrderBy(x => x.Key).ThenBy(x => x.Value.Count).Select(x => x.Key));
+                allTerms = valueSortedIds ?? new List<string>(values.OrderBy(x => x.Key).ThenBy(x => x.Value.Count).Select(x => x.Key));
                 break;
             case FacetTermSortMode.ValueDesc:
-                allTerms = new List<string>(values.OrderByDescending(x => x.Key).ThenBy(x => x.Value.Count).Select(x => x.Key));
+                allTerms = valueSortedIds ?? new List<string>(values.OrderByDescending(x => x.Key).ThenBy(x => x.Value.Count).Select(x => x.Key));
                 break;
             case FacetTermSortMode.CountAsc:
                 allTerms = new List<string>(values.OrderBy(x => x.Value.Count).ThenBy(x => x.Key).Select(x => x.Key));

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedFacetedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedFacetedQueryOperation.cs
@@ -152,7 +152,7 @@ public sealed class ShardedFacetedQueryOperation : AbstractShardedQueryOperation
         {
             if (_options != null)
             {
-                List<string> allTerms = IndexFacetReadOperationBase.GetAllTermsSorted(_options.TermSortMode, _values);
+                List<string> allTerms = IndexFacetReadOperationBase.GetAllTermsSorted(_options.TermSortMode, null, _values);
 
                 var start = _options.Start;
                 var pageSize = Math.Min(allTerms.Count, _options.PageSize);

--- a/src/Voron/Data/CompactTrees/CompactTree.Iterator.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.Iterator.cs
@@ -77,7 +77,22 @@ namespace Voron.Data.CompactTrees
                     key = default;
                     return false;
                 }
+                
                 key = keyData.GetKey(_tree._inner);
+                return true;
+            }
+            
+            public unsafe bool MoveNext(CompactKey key, out long v, out bool hasPreviousValue)
+            {
+                
+                
+                if (_it.MoveNext(out CompactKeyLookup keyData, out v, out hasPreviousValue) == false)
+                {
+                    key = default;
+                    return false;
+                }
+                
+                keyData.FillKey(key, _tree._inner);
                 return true;
             }
         }

--- a/src/Voron/Data/CompactTrees/CompactTree.cs
+++ b/src/Voron/Data/CompactTrees/CompactTree.cs
@@ -98,6 +98,25 @@ public sealed partial class CompactTree : IPrepareForCommit
             Key.Set(keyLenInBits, keyPtr, parent.State.DictionaryId);
             return Key;
         }
+        
+        public void FillKey<T>(CompactKey key, Lookup<T> parent) where T : struct, ILookupKey
+        {
+            var llt = parent.Llt;
+
+            byte* keyPtr;
+            int keyLenInBits;
+            if (ContainerId == 0)
+            {
+                keyPtr = null;
+                keyLenInBits = 0;
+            }
+            else
+            {
+                GetEncodedKey(llt, ContainerId, out keyLenInBits, out keyPtr);
+            }
+            
+            key.Set(keyLenInBits, keyPtr, parent.State.DictionaryId);
+        }
 
         public void Init<T>(Lookup<T> parent) where T : struct, ILookupKey
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22617

### Additional description

for aggregations like:
`facet(Field)` or simple numerical ones like `facet(Field >= Number and Field <= Number2)` we will use index to produce the output.

Results (10M docs, ~5M unique textual terms `(Tag)` , 100K unique numbers `(Number)`)
`select facet(Tag)`:
Corax (before): ~55000ms
Corax : ~8500ms
Lucene: ~12500ms

`facet(Number)`
Corax (before): ~19000ms
Corax: ~40ms
Lucene: ~1300ms

`facet(Number >= 100 and Number <= 10000)`
Corax (before): ~12000ms
Corax: <1ms
Lucene: ~200ms


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
