### PR TITLE
RavenDB-22539 Open path selector on input focus when empty

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Form.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, ReactNode, useState } from "react";
+import React, { ComponentProps, ReactNode, useRef, useState } from "react";
 import genUtils from "common/generalUtils";
 import { Checkbox, CheckboxProps, Radio, Switch } from "components/common/Checkbox";
 import { Control, ControllerProps, FieldPath, FieldValues, useController } from "react-hook-form";
@@ -13,7 +13,7 @@ import { GetOptionValue, GroupBase, InputActionMeta, OnChangeValue, OptionsOrGro
 import Select, { InputNotHidden, SelectValue } from "./select/Select";
 import DatePicker from "./DatePicker";
 import { Icon } from "components/common/Icon";
-import PathSelector, { PathSelectorProps } from "components/common/pathSelector/PathSelector";
+import PathSelector, { PathSelectorProps, PathSelectorStateRef } from "components/common/pathSelector/PathSelector";
 import { OmitIndexSignature } from "components/utils/common";
 
 type FormElementProps<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>> = Omit<
@@ -566,6 +566,14 @@ export function FormPathSelector<
         shouldUnregister,
     });
 
+    const pathSelectorStateRef = useRef<PathSelectorStateRef>(null);
+
+    const handleInputFocus = () => {
+        if (!formValuePath) {
+            pathSelectorStateRef.current.toggle();
+        }
+    };
+
     return (
         <div className="position-relative flex-grow-1">
             <div className="d-flex flex-grow-1">
@@ -579,6 +587,7 @@ export function FormPathSelector<
                         className="position-relative d-flex flex-grow-1"
                         placeholder={placeholder || "Enter path"}
                         disabled={disabled || formState.isSubmitting}
+                        onFocus={handleInputFocus}
                     />
                     <PathSelector
                         getPaths={getPaths}
@@ -588,6 +597,7 @@ export function FormPathSelector<
                         selectorTitle={selectorTitle}
                         disabled={disabled || formState.isSubmitting}
                         buttonClassName={classNames("input-btn", invalid && "me-3")}
+                        stateRef={pathSelectorStateRef}
                     />
                 </InputGroup>
             </div>

--- a/src/Raven.Studio/typescript/components/common/pathSelector/PathSelector.tsx
+++ b/src/Raven.Studio/typescript/components/common/pathSelector/PathSelector.tsx
@@ -5,9 +5,13 @@ import { LazyLoad } from "components/common/LazyLoad";
 import { LoadError } from "components/common/LoadError";
 import useBoolean from "components/hooks/useBoolean";
 import { useAsyncDebounce } from "components/utils/hooks/useAsyncDebounce";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useImperativeHandle, useState } from "react";
 import { AsyncStateStatus } from "react-async-hook";
 import { Button, Modal, ModalBody, FormGroup, Label, Input, ModalFooter, CloseButton } from "reactstrap";
+
+export interface PathSelectorStateRef {
+    toggle: () => void;
+}
 
 export interface PathSelectorProps<ParamsType extends unknown[] = unknown[]> {
     getPaths: (...args: ParamsType) => Promise<string[]>;
@@ -18,11 +22,20 @@ export interface PathSelectorProps<ParamsType extends unknown[] = unknown[]> {
     placeholder?: string;
     disabled?: boolean;
     buttonClassName?: string;
+    stateRef?: React.MutableRefObject<PathSelectorStateRef>;
 }
 
 export default function PathSelector<ParamsType extends unknown[] = unknown[]>(props: PathSelectorProps<ParamsType>) {
-    const { handleSelect, getPaths, getPathDependencies, defaultPath, buttonClassName, selectorTitle, disabled } =
-        props;
+    const {
+        handleSelect,
+        getPaths,
+        getPathDependencies,
+        defaultPath,
+        buttonClassName,
+        selectorTitle,
+        disabled,
+        stateRef,
+    } = props;
 
     const { value: isModalOpen, toggle: toggleIsModalOpen } = useBoolean(false);
     const [pathInput, setPathInput] = useState(defaultPath || "");
@@ -32,6 +45,10 @@ export default function PathSelector<ParamsType extends unknown[] = unknown[]>(p
     }, [defaultPath]);
 
     const asyncGetPaths = useAsyncDebounce(getPaths, getPathDependencies(pathInput));
+
+    useImperativeHandle(stateRef, () => ({
+        toggle: toggleIsModalOpen,
+    }));
 
     const { canGoBack, parentDir } = getParentPath(pathInput);
 


### PR DESCRIPTION
### Issue link

[RavenDB-22539](https://issues.hibernatingrhinos.com/issue/RavenDB-22539)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
