### PR TITLE
RavenDB-21991 - SlowTests.Server.Documents.PeriodicBackup.PeriodicBackupTestsSlow.ShouldRearrangeTheBackupTimer_IfItGot_ActiveByOtherNode_Then_ActiveByCurrentNode_WhileRunning

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3540,11 +3540,14 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     var responsibleDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
                     Assert.NotNull(responsibleDatabase);
                     
-                    var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store, opStatus: OperationStatus.InProgress);
+                    var backupTaskId = await Backup.UpdateConfigAsync(server, config, store);
                     var pb = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.FirstOrDefault();
                     Assert.NotNull(pb);
-                    Assert.True(pb.HasScheduledBackup(), "Backup is not scheduled");
-                    
+                    var backupScheduled = await WaitForValueAsync(() => pb.HasScheduledBackup(), true, timeout: 8000);
+                    Assert.True(backupScheduled, "Backup is not scheduled");
+
+                    await Backup.RunBackupAsync(server, backupTaskId, store, opStatus: OperationStatus.InProgress);
+
                     var record1 = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                     var backups1 = record1.PeriodicBackups;
                     Assert.Equal(1, backups1.Count);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21991

### Additional description

Test is waiting for the backup timer to be populated but this doesn't happen.
There was a race between updating the timer and populating the RunnningTask of the backup.
If there is already a running backup then a timer will not be set for this round - it will be set again when the backup finishes.
However, since we hold the backup in the test, the backup won't finish and the new timer will not be set.
Most runs were able to dodge this since the timer was updated before the backup task got populated.
Changed the test so we first only create the backup, wait for the timer to update, and only then do we actually run it.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
