### PR TITLE
RavenDB-19877: Log a line in Operations when database is loaded (6.0)

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -78,7 +78,7 @@ namespace Raven.Server.Documents
     public class DocumentDatabase : IDisposable
     {
         private readonly ServerStore _serverStore;
-        private readonly Action<string> _addToInitLog;
+        private readonly Action<LogMode, string> _addToInitLog;
         private readonly Logger _logger;
         private readonly DisposeOnce<SingleAttempt> _disposeOnce;
         internal TestingStuff ForTestingPurposes;
@@ -89,7 +89,7 @@ namespace Raven.Server.Documents
 
         private readonly SemaphoreSlim _updateValuesLocker = new(1, 1);
 
-        public Action<string> AddToInitLog => _addToInitLog;
+        public Action<LogMode, string> AddToInitLog => _addToInitLog;
 
         /// <summary>
         /// The current lock, used to make sure indexes have a unique names
@@ -121,7 +121,7 @@ namespace Raven.Server.Documents
             _lastIdleTicks = DateTime.MinValue.Ticks;
         }
 
-        public DocumentDatabase(string name, RavenConfiguration configuration, ServerStore serverStore, Action<string> addToInitLog)
+        public DocumentDatabase(string name, RavenConfiguration configuration, ServerStore serverStore, Action<LogMode, string> addToInitLog)
         {
             Name = name;
             _logger = LoggingSource.Instance.GetLogger<DocumentDatabase>(Name);
@@ -147,7 +147,7 @@ namespace Raven.Server.Documents
 
                 if (Configuration.Core.RunInMemory == false)
                 {
-                    _addToInitLog("Creating db.lock file");
+                    _addToInitLog(LogMode.Information, "Creating db.lock file");
                     _fileLocker = new FileLocker(Configuration.Core.DataDirectory.Combine("db.lock").FullPath);
                     _fileLocker.TryAcquireWriteLock(_logger);
 
@@ -156,7 +156,7 @@ namespace Raven.Server.Documents
                     if (DisableOngoingTasks)
                     {
                         var msg = $"MAINTENANCE WARNING: Found disable.tasks.marker file. All tasks will not start. Please remove the file and restart the '{Name}' database.";
-                        _addToInitLog(msg);
+                        _addToInitLog(LogMode.Information, msg);
                         if (_logger.IsOperationsEnabled)
                             _logger.Operations(msg);
                     }
@@ -207,7 +207,7 @@ namespace Raven.Server.Documents
 
         public readonly bool DisableOngoingTasks;
 
-        protected virtual DocumentsStorage CreateDocumentsStorage(Action<string> addToInitLog)
+        protected virtual DocumentsStorage CreateDocumentsStorage(Action<LogMode, string> addToInitLog)
         {
             return new DocumentsStorage(this, addToInitLog);
         }
@@ -384,21 +384,21 @@ namespace Raven.Server.Documents
 
                 InitializeCompareExchangeStorage();
 
-                _addToInitLog("Initializing NotificationCenter");
+                _addToInitLog(LogMode.Information, "Initializing NotificationCenter");
                 NotificationCenter.Initialize();
 
-                _addToInitLog("Initializing DocumentStorage");
+                _addToInitLog(LogMode.Information, "Initializing DocumentStorage");
                 DocumentsStorage.Initialize((options & InitializeOptions.GenerateNewDatabaseId) == InitializeOptions.GenerateNewDatabaseId);
-                _addToInitLog("Starting Transaction Merger");
+                _addToInitLog(LogMode.Information, "Starting Transaction Merger");
                 TxMerger.Initialize(DocumentsStorage.ContextPool, IsEncrypted, Is32Bits);
                 TxMerger.Start();
-                _addToInitLog("Initializing ConfigurationStorage");
+                _addToInitLog(LogMode.Information, "Initializing ConfigurationStorage");
                 ConfigurationStorage.Initialize();
 
                 if ((options & InitializeOptions.SkipLoadingDatabaseRecord) == InitializeOptions.SkipLoadingDatabaseRecord)
                     return;
 
-                _addToInitLog("Loading Database");
+                _addToInitLog(LogMode.Information, "Loading Database");
 
                 MetricCacher.Initialize();
 
@@ -418,11 +418,11 @@ namespace Raven.Server.Documents
                 ReplicationLoader = CreateReplicationLoader();
                 PeriodicBackupRunner = new PeriodicBackupRunner(this, _serverStore, wakeup);
 
-                _addToInitLog("Initializing IndexStore (async)");
+                _addToInitLog(LogMode.Information, "Initializing IndexStore (async)");
                 _indexStoreTask = IndexStore.InitializeAsync(record, index, _addToInitLog);
-                _addToInitLog("Initializing Replication");
+                _addToInitLog(LogMode.Information, "Initializing Replication");
                 ReplicationLoader?.Initialize(record, index);
-                _addToInitLog("Initializing ETL");
+                _addToInitLog(LogMode.Information, "Initializing ETL");
                 EtlLoader.Initialize(record);
                 QueueSinkLoader.Initialize(record);
 
@@ -446,7 +446,7 @@ namespace Raven.Server.Documents
 
                 DatabaseShutdown.ThrowIfCancellationRequested();
 
-                _addToInitLog("Initializing SubscriptionStorage completed");
+                _addToInitLog(LogMode.Information, "Initializing SubscriptionStorage completed");
 
                 TombstoneCleaner.Start();
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -83,7 +83,7 @@ namespace Raven.Server.Documents
         private static readonly Slice GlobalTreeSlice;
         private static readonly Slice GlobalChangeVectorSlice;
         private static readonly Slice GlobalFullChangeVectorSlice;
-        private readonly Action<string> _addToInitLog;
+        private readonly Action<LogMode, string> _addToInitLog;
 
         private readonly Logger _logger;
         private readonly string _name;
@@ -111,7 +111,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public DocumentsStorage(DocumentDatabase documentDatabase, Action<string> addToInitLog)
+        public DocumentsStorage(DocumentDatabase documentDatabase, Action<LogMode, string> addToInitLog)
         {
             DocumentDatabase = documentDatabase;
             SetDocumentsStorageSchemas();

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -228,11 +228,19 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected void CreateDocumentDatabase()
         {
             var configuration = CreateDatabaseConfiguration();
-            var addToInitLog = new Action<string>(txt => // init log is not save in mem during RestoreBackup
+            var addToInitLog = new Action<LogMode, string>((logMode, txt) => // init log is not save in mem during RestoreBackup
             {
                 var msg = $"[RestoreBackup] {DateTime.UtcNow} :: Database '{DatabaseName}' : {txt}";
-                if (Logger.IsInfoEnabled)
-                    Logger.Info(msg);
+
+                switch (logMode)
+                {
+                    case LogMode.Operations when Logger.IsOperationsEnabled:
+                        Logger.Operations(msg);
+                        break;
+                    case LogMode.Information when Logger.IsInfoEnabled:
+                        Logger.Info(msg);
+                        break;
+                }
             });
 
             Database = DatabasesLandlord.CreateDocumentDatabase(DatabaseName, configuration, ServerStore, addToInitLog);

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -42,7 +42,7 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
 
     public ShardedDocumentsMigrator DocumentsMigrator { get; private set; }
 
-    public ShardedDocumentDatabase(string name, RavenConfiguration configuration, ServerStore serverStore, Action<string> addToInitLog)
+    public ShardedDocumentDatabase(string name, RavenConfiguration configuration, ServerStore serverStore, Action<LogMode, string> addToInitLog)
         : base(name, configuration, serverStore, addToInitLog)
     {
         ShardNumber = ShardHelper.GetShardNumberFromDatabaseName(name);
@@ -65,7 +65,7 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
         _ = DocumentsMigrator.ExecuteMoveDocumentsAsync();
     }
 
-    protected override DocumentsStorage CreateDocumentsStorage(Action<string> addToInitLog)
+    protected override DocumentsStorage CreateDocumentsStorage(Action<LogMode, string> addToInitLog)
     {
         return ShardedDocumentsStorage = new ShardedDocumentsStorage(this, addToInitLog);
     }

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -7,6 +7,7 @@ using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Binary;
+using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
@@ -42,7 +43,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
         }
     }
 
-    public ShardedDocumentsStorage(ShardedDocumentDatabase documentDatabase, Action<string> addToInitLog) 
+    public ShardedDocumentsStorage(ShardedDocumentDatabase documentDatabase, Action<LogMode, string> addToInitLog)
         : base(documentDatabase, addToInitLog)
     {
         _documentDatabase = documentDatabase;

--- a/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide;
+using Sparrow.Logging;
 using Voron;
 using Voron.Schema;
 
@@ -112,7 +113,7 @@ namespace Raven.Server.Storage.Schema
                 if (shouldAddToInitLog)
                 {
                     var msg = $"Started schema upgrade from version #{updater.From} to version #{updater.To}";
-                    _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
+                    _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(LogMode.Information, msg);
                 }
 
                 bool result =  updater.Update(new UpdateStep(transactions)
@@ -125,7 +126,8 @@ namespace Raven.Server.Storage.Schema
                 {
 
                     var msg = $"{(result ? "Finished" : "Failed to")} schema upgrade from version #{updater.From} to version #{updater.To}";
-                    _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(msg);
+                    var logMode = result ? LogMode.Information : LogMode.Operations;
+                    _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(logMode, msg);
                 }
 
                 return result;

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -307,11 +307,19 @@ namespace Raven.Server.Web.System
                 return;
             }
 
-            var addToInitLog = new Action<string>(txt =>
+            var addToInitLog = new Action<LogMode, string>((logMode, txt) =>
             {
                 var msg = $"[Recreating indexes] {DateTime.UtcNow} :: Database '{databaseName}' : {txt}";
-                if (Logger.IsInfoEnabled)
-                    Logger.Info(msg);
+
+                switch (logMode)
+                {
+                    case LogMode.Operations when Logger.IsOperationsEnabled:
+                        Logger.Operations(msg);
+                        break;
+                    case LogMode.Information when Logger.IsInfoEnabled:
+                        Logger.Info(msg);
+                        break;
+                }
             });
 
             using (var documentDatabase = DatabasesLandlord.CreateDocumentDatabase(databaseName, databaseConfiguration, ServerStore, addToInitLog))

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -290,10 +290,10 @@ namespace Voron
         {
             var header = stackalloc TransactionHeader[1];
 
-            Options.AddToInitLog?.Invoke("Starting Recovery");
+            Options.AddToInitLog?.Invoke(LogMode.Information, "Starting Recovery");
             bool hadIntegrityIssues = _journal.RecoverDatabase(header, Options.AddToInitLog);
             var successString = hadIntegrityIssues ? "(with integrity issues)" : "(successfully)";
-            Options.AddToInitLog?.Invoke($"Recovery Ended {successString}");
+            Options.AddToInitLog?.Invoke(LogMode.Information, $"Recovery Ended {successString}");
 
             if (hadIntegrityIssues)
             {

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -236,7 +236,7 @@ namespace Voron
 
         public Func<string, bool> ShouldUseKeyPrefix { get; set; }
 
-        public Action<string> AddToInitLog;
+        public Action<LogMode, string> AddToInitLog;
 
         public event Action<StorageEnvironmentOptions> OnDirectoryInitialize;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19877

### Additional description

Added Operations logs for database loading to provide visibility on successful loads from cache, load attempts, and creation of new databases when absent in cache. Each log includes the reason for the load and integrates the caller information for better traceability.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
