### PR TITLE
RavenDB-22672 A small text fix for OpenTelemetry configuration descriptions

### DIFF
--- a/src/Raven.Server/Config/Categories/MonitoringConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/MonitoringConfiguration.cs
@@ -104,32 +104,32 @@ namespace Raven.Server.Config.Categories
             [ConfigurationEntry("Monitoring.OpenTelemetry.ConsoleExporter", ConfigurationEntryScope.ServerWideOnly)]
             public bool ConsoleExporter { get; set; }
             
-            [Description("Expose metric related to server storage.")]
+            [Description("Expose metrics related to server storage.")]
             [DefaultValue(true)]
             [ConfigurationEntry("Monitoring.OpenTelemetry.Meters.Server.Storage.Enabled", ConfigurationEntryScope.ServerWideOnly)]
             public bool ServerStorage { get; set; }
             
-            [Description("Expose metric related to CPU credits.")]
+            [Description("Expose metrics related to CPU credits.")]
             [DefaultValue(false)]
             [ConfigurationEntry("Monitoring.OpenTelemetry.Meters.Server.CPUCredits.Enabled", ConfigurationEntryScope.ServerWideOnly)]
             public bool CPUCredits { get; set; }
             
-            [Description("Expose metric related to resources usage.")]
+            [Description("Expose metrics related to resources usage.")]
             [DefaultValue(true)]
             [ConfigurationEntry("Monitoring.OpenTelemetry.Meters.Server.Resources.Enabled", ConfigurationEntryScope.ServerWideOnly)]
             public bool Resources { get; set; }
 
-            [Description("Expose metric related to aggregated database statistics.")]
+            [Description("Expose metrics related to aggregated database statistics.")]
             [DefaultValue(true)]
             [ConfigurationEntry("Monitoring.OpenTelemetry.Meters.Server.TotalDatabases.Enabled", ConfigurationEntryScope.ServerWideOnly)]
             public bool TotalDatabases { get; set; }
             
-            [Description("Expose metric related to requests.")]
+            [Description("Expose metrics related to requests.")]
             [DefaultValue(true)]
             [ConfigurationEntry("Monitoring.OpenTelemetry.Meters.Server.Requests.Enabled", ConfigurationEntryScope.ServerWideOnly)]
             public bool Requests { get; set; }
             
-            [Description("Expose metric related to GC.")]
+            [Description("Expose metrics related to GC.")]
             [DefaultValue(false)]
             [ConfigurationEntry("Monitoring.OpenTelemetry.Meters.Server.GC.Enabled", ConfigurationEntryScope.ServerWideOnly)]
             public bool GcEnabled { get; set; }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22672/A-small-text-fix-for-OpenTelemetry-configuration-descriptions

### Additional description
e.g.:
`Expose metric related to resources usage` => `Expose metrics related to resources usage`

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed (handled in https://issues.hibernatingrhinos.com/issue/RDoc-2944/Review-Open-Telemetry-documentation)

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
