### PR TITLE
RavenDB-22359 Throw exception on LoadDocument with dynamic collection name

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -176,12 +176,13 @@ namespace Raven.Server.Documents.Indexes
 
             public const long PhraseQuerySupportInCoraxIndexes = 60_002;
             public const long StoreOnlySupportInCoraxIndexes = 60_003; // RavenDB-22369
-            public const long JavaScriptProperlyHandleDynamicFieldsIndexFields = 60_004; //RavenDB-22363
+            public const long JavaScriptProperlyHandleDynamicFieldsIndexFields = 60_004; // RavenDB-22363
+            public const long LoadDocumentWithDynamicCollectionNameShouldThrow = 60_005; // RavenDB-22359
 
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = JavaScriptProperlyHandleDynamicFieldsIndexFields;
+            public const long CurrentVersion = LoadDocumentWithDynamicCollectionNameShouldThrow;
 
             public static bool IsTimeTicksInJavaScriptIndexesSupported(long indexVersion)
             {

--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -177,7 +177,7 @@ namespace Raven.Server.Documents.Indexes
             public const long PhraseQuerySupportInCoraxIndexes = 60_002;
             public const long StoreOnlySupportInCoraxIndexes = 60_003; // RavenDB-22369
             public const long JavaScriptProperlyHandleDynamicFieldsIndexFields = 60_004; // RavenDB-22363
-            public const long LoadDocumentWithDynamicCollectionNameShouldThrow = 60_005; // RavenDB-22359
+            public const long LoadDocumentWithDynamicCollectionNameShouldThrow = 61_000; // RavenDB-22359
 
             /// <summary>
             /// Remember to bump this

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompilationCache.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompilationCache.cs
@@ -131,7 +131,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 case IndexType.Map:
                 case IndexType.MapReduce:
                 case IndexType.Faulty:
-                    index = IndexCompiler.Compile(definition);
+                    index = IndexCompiler.Compile(definition, indexVersion);
                     break;
                 case IndexType.JavaScriptMap:
                 case IndexType.JavaScriptMapReduce:

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -54,6 +54,8 @@ namespace Raven.Server.Documents.Indexes.Static
         [ThreadStatic]
         private static bool DisableMatchingAdditionalAssembliesByNameValue;
 
+        private static long IndexVersion { get; set; }
+
         static IndexCompiler()
         {
             AssemblyLoadContext.Default.Resolving += (ctx, name) =>
@@ -163,8 +165,10 @@ namespace Raven.Server.Documents.Indexes.Static
             return assemblyMetadata.GetReference();
         }
 
-        public static AbstractStaticIndexBase Compile(IndexDefinition definition)
+        public static AbstractStaticIndexBase Compile(IndexDefinition definition, long indexVersion)
         {
+            IndexVersion = indexVersion;
+            
             var cSharpSafeName = GetCSharpSafeName(definition.Name);
 
             var @class = CreateClass(cSharpSafeName, definition);
@@ -534,7 +538,7 @@ namespace Raven.Server.Documents.Indexes.Static
             var statements = new List<StatementSyntax>();
             var maps = definition.Maps.ToList();
             var fieldNamesValidator = new FieldNamesValidator();
-            var methodDetector = new MethodDetectorRewriter();
+            var methodDetector = new MethodDetectorRewriter(IndexVersion);
             var stackDepthRetriever = new StackDepthRetriever();
             var members = new SyntaxList<MemberDeclarationSyntax>();
             var maxDepthInRecursiveLinqQuery = 0;

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -54,8 +54,6 @@ namespace Raven.Server.Documents.Indexes.Static
         [ThreadStatic]
         private static bool DisableMatchingAdditionalAssembliesByNameValue;
 
-        private static long IndexVersion { get; set; }
-
         static IndexCompiler()
         {
             AssemblyLoadContext.Default.Resolving += (ctx, name) =>
@@ -167,11 +165,10 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public static AbstractStaticIndexBase Compile(IndexDefinition definition, long indexVersion)
         {
-            IndexVersion = indexVersion;
             
             var cSharpSafeName = GetCSharpSafeName(definition.Name);
 
-            var @class = CreateClass(cSharpSafeName, definition);
+            var @class = CreateClass(cSharpSafeName, definition, indexVersion);
 
             var compilationResult = CompileInternal(definition.Name, cSharpSafeName, @class, definition);
             var type = compilationResult.Type;
@@ -533,12 +530,12 @@ namespace Raven.Server.Documents.Indexes.Static
             }
         }
         
-        private static MemberDeclarationSyntax CreateClass(string name, IndexDefinition definition)
+        private static MemberDeclarationSyntax CreateClass(string name, IndexDefinition definition, long indexVersion)
         {
             var statements = new List<StatementSyntax>();
             var maps = definition.Maps.ToList();
             var fieldNamesValidator = new FieldNamesValidator();
-            var methodDetector = new MethodDetectorRewriter(IndexVersion);
+            var methodDetector = new MethodDetectorRewriter(indexVersion);
             var stackDepthRetriever = new StackDepthRetriever();
             var members = new SyntaxList<MemberDeclarationSyntax>();
             var maxDepthInRecursiveLinqQuery = 0;

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/MethodDetectorRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/MethodDetectorRewriter.cs
@@ -1,4 +1,5 @@
-﻿using Lucene.Net.Documents;
+﻿using System;
+using Lucene.Net.Documents;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -10,6 +11,13 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
     {
         public readonly IndexCompiler.IndexMethods Methods = new IndexCompiler.IndexMethods();
 
+        private static long IndexVersion { get; set; }
+        
+        public MethodDetectorRewriter(long indexVersion)
+        {
+            IndexVersion = indexVersion;
+        }
+
         public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
         {
             var expression = node.Expression.ToString();
@@ -20,6 +28,7 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
             {
                 case "this.LoadDocument":
                 case nameof(AbstractCommonApiForIndexes.LoadDocument):
+                    AssertLoadDocumentHasConstantCollectionName(node);
                     Methods.HasLoadDocument = true;
                     break;
                 case "this.TransformWith":
@@ -67,6 +76,17 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
         {
             Methods.HasGroupBy = true;
             return base.VisitGroupClause(node);
+        }
+
+        private static void AssertLoadDocumentHasConstantCollectionName(InvocationExpressionSyntax node)
+        {
+            if (node.ArgumentList.Arguments.Count == 2)
+            {
+                var collectionExpression = node.ArgumentList.Arguments[1].Expression;
+                
+                if (collectionExpression is not LiteralExpressionSyntax && IndexVersion >= IndexDefinitionBaseServerSide.IndexVersion.LoadDocumentWithDynamicCollectionNameShouldThrow)
+                    throw new ArgumentException("LoadDocument method has to be called with constant value as collection name");
+            }
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/MethodDetectorRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/MethodDetectorRewriter.cs
@@ -80,13 +80,10 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
 
         private static void AssertLoadDocumentHasConstantCollectionName(InvocationExpressionSyntax node)
         {
-            if (node.ArgumentList.Arguments.Count == 2)
-            {
-                var collectionExpression = node.ArgumentList.Arguments[1].Expression;
+            var collectionExpression = node.ArgumentList.Arguments[1].Expression;
                 
-                if (collectionExpression is not LiteralExpressionSyntax && IndexVersion >= IndexDefinitionBaseServerSide.IndexVersion.LoadDocumentWithDynamicCollectionNameShouldThrow)
-                    throw new ArgumentException("LoadDocument method has to be called with constant value as collection name");
-            }
+            if (collectionExpression is not LiteralExpressionSyntax && IndexVersion >= IndexDefinitionBaseServerSide.IndexVersion.LoadDocumentWithDynamicCollectionNameShouldThrow)
+                throw new ArgumentException("LoadDocument method has to be called with constant value as collection name");
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/MethodDetectorRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/MethodDetectorRewriter.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
     {
         public readonly IndexCompiler.IndexMethods Methods = new IndexCompiler.IndexMethods();
 
-        private static long IndexVersion { get; set; }
+        private long IndexVersion { get; set; }
         
         public MethodDetectorRewriter(long indexVersion)
         {
@@ -78,7 +78,7 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
             return base.VisitGroupClause(node);
         }
 
-        private static void AssertLoadDocumentHasConstantCollectionName(InvocationExpressionSyntax node)
+        private void AssertLoadDocumentHasConstantCollectionName(InvocationExpressionSyntax node)
         {
             var collectionExpression = node.ArgumentList.Arguments[1].Expression;
                 

--- a/test/SlowTests/Issues/RavenDB-22359.cs
+++ b/test/SlowTests/Issues/RavenDB-22359.cs
@@ -1,0 +1,78 @@
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions.Documents.Compilation;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.Static;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22359 : RavenTestBase
+{
+    public RavenDB_22359(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIndexesWithCorrectAndIncorrectCollectionName()
+    {
+        using (var store = GetDocumentStore())
+        {
+            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            {
+                Maps = { "from doc in docs.Orders\nselect new {\n    CompanyName = LoadDocument(doc.Company, \"Companies\").Name\n}" },
+                Type = IndexType.Map,
+                Name = "ShouldNotThrowIndex"
+            }));
+            
+            var ex = Assert.Throws<IndexCompilationException>(() => 
+                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Maps = { "from doc in docs.Orders\nselect new {\n    CompanyName = LoadDocument(doc.Company, doc.Company.Split('/')[0]).Name\n}" },
+                    Type = IndexType.Map,
+                    Name = "ShouldThrowIndex"
+                })));
+
+            Assert.Contains("LoadDocument method has to be called with constant value as collection name", ex.Message);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIndexesWithOldIndexVersion()
+    {
+        const long oldIndexVersion = IndexDefinitionBaseServerSide.IndexVersion.LoadDocumentWithDynamicCollectionNameShouldThrow - 1;
+        
+        var incorrectIndexDefinition = new IndexDefinition() { Name = "IncorrectIndex", Maps = {"from doc in docs.Orders\nselect new {\n    CompanyName = LoadDocument(doc.Company, doc.Company.Split('/')[0]).Name\n}"}};
+            
+        var correctIndexDefinition = new IndexDefinition() { Name = "CorrectIndex", Maps = {"from doc in docs.Orders\nselect new {\n    CompanyName = \"Companies\"\n}"}};
+            
+        var incorrectIndexBase = IndexCompiler.Compile(incorrectIndexDefinition, oldIndexVersion);
+            
+        Assert.NotNull(incorrectIndexBase);
+            
+        var correctIndexBase = IndexCompiler.Compile(correctIndexDefinition, oldIndexVersion);
+            
+        Assert.NotNull(correctIndexBase);
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIndexesWithNewIndexVersion()
+    {
+        const long newIndexVersion = IndexDefinitionBaseServerSide.IndexVersion.LoadDocumentWithDynamicCollectionNameShouldThrow;
+        
+        var incorrectIndexDefinition = new IndexDefinition() { Name = "IncorrectIndex", Maps = {"from doc in docs.Orders\nselect new {\n    CompanyName = LoadDocument(doc.Company, doc.Company.Split('/')[0]).Name\n}"}};
+            
+        var correctIndexDefinition = new IndexDefinition() { Name = "CorrectIndex", Maps = {"from doc in docs.Orders\nselect new {\n    CompanyName = \"Companies\"\n}"}};
+            
+        var correctIndexBase = IndexCompiler.Compile(correctIndexDefinition, newIndexVersion);
+            
+        Assert.NotNull(correctIndexBase);
+        
+        var ex = Assert.Throws<IndexCompilationException>(() => IndexCompiler.Compile(incorrectIndexDefinition, newIndexVersion));
+        
+        Assert.Contains("LoadDocument method has to be called with constant value as collection name", ex.Message);
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_7170.cs
+++ b/test/SlowTests/Issues/RavenDB_7170.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Documents.Compilation;
+using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,10 +20,12 @@ namespace SlowTests.Issues
         [Fact]
         public void Indexing_func_must_return_anonymous_object()
         {
-            var ex = Assert.Throws<IndexCompilationException>(() => IndexCompiler.Compile(new Bad_index_1().CreateIndexDefinition(), 0));
+            const long currentIndexVersion = IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion;
+            
+            var ex = Assert.Throws<IndexCompilationException>(() => IndexCompiler.Compile(new Bad_index_1().CreateIndexDefinition(), currentIndexVersion));
             Assert.Contains("Indexing function must return an anonymous object", ex.Message);
 
-            ex = Assert.Throws<IndexCompilationException>(() => IndexCompiler.Compile(new Bad_index_2().CreateIndexDefinition(), 0));
+            ex = Assert.Throws<IndexCompilationException>(() => IndexCompiler.Compile(new Bad_index_2().CreateIndexDefinition(), currentIndexVersion));
             Assert.Contains("Indexing function must return an anonymous object", ex.Message);
         }
 

--- a/test/SlowTests/Issues/RavenDB_7170.cs
+++ b/test/SlowTests/Issues/RavenDB_7170.cs
@@ -19,12 +19,11 @@ namespace SlowTests.Issues
         [Fact]
         public void Indexing_func_must_return_anonymous_object()
         {
-            var ex = Assert.Throws<IndexCompilationException>(() => IndexCompiler.Compile(new Bad_index_1().CreateIndexDefinition()));
+            var ex = Assert.Throws<IndexCompilationException>(() => IndexCompiler.Compile(new Bad_index_1().CreateIndexDefinition(), 0));
             Assert.Contains("Indexing function must return an anonymous object", ex.Message);
 
-            ex = Assert.Throws<IndexCompilationException>(() => IndexCompiler.Compile(new Bad_index_2().CreateIndexDefinition()));
+            ex = Assert.Throws<IndexCompilationException>(() => IndexCompiler.Compile(new Bad_index_2().CreateIndexDefinition(), 0));
             Assert.Contains("Indexing function must return an anonymous object", ex.Message);
-
         }
 
         private class Bad_index_1 : AbstractIndexCreationTask<DroneStateSnapshoot>

--- a/test/SlowTests/Server/Documents/Indexing/IndexCompilationTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/IndexCompilationTests.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Server.Documents.Indexing
                             Total = order.Lines.Sum(l => l.PricePerUnit)
                     }"
                 }
-            });
+            }, 0);
         }
     }
 }

--- a/test/SlowTests/Server/Documents/Indexing/IndexCompilationTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/IndexCompilationTests.cs
@@ -1,5 +1,6 @@
 ﻿using FastTests;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static;
 using Xunit;
 using Xunit.Abstractions;
@@ -26,7 +27,7 @@ namespace SlowTests.Server.Documents.Indexing
                             Total = order.Lines.Sum(l => l.PricePerUnit)
                     }"
                 }
-            }, 0);
+            }, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
         }
     }
 }

--- a/test/SlowTests/Tests/Indexes/LinqIndexesFromClient.cs
+++ b/test/SlowTests/Tests/Indexes/LinqIndexesFromClient.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Tests.Indexes
             }.ToIndexDefinition(DocumentConventions.Default);
 
             indexDefinition.Name = "Index1";
-            var index = (StaticIndexBase)IndexCompiler.Compile(indexDefinition, 0);
+            var index = (StaticIndexBase)IndexCompiler.Compile(indexDefinition, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
 
             var map = index.Maps.Values.First().First().Value.First();
 
@@ -108,7 +108,7 @@ namespace SlowTests.Tests.Indexes
             }.ToIndexDefinition(DocumentConventions.Default);
 
             indexDefinition.Name = "Index1";
-            IndexCompiler.Compile(indexDefinition, 0);
+            IndexCompiler.Compile(indexDefinition, IndexDefinitionBaseServerSide.IndexVersion.CurrentVersion);
         }
 
         private class Person

--- a/test/SlowTests/Tests/Indexes/LinqIndexesFromClient.cs
+++ b/test/SlowTests/Tests/Indexes/LinqIndexesFromClient.cs
@@ -44,7 +44,7 @@ namespace SlowTests.Tests.Indexes
             }.ToIndexDefinition(DocumentConventions.Default);
 
             indexDefinition.Name = "Index1";
-            var index = (StaticIndexBase)IndexCompiler.Compile(indexDefinition);
+            var index = (StaticIndexBase)IndexCompiler.Compile(indexDefinition, 0);
 
             var map = index.Maps.Values.First().First().Value.First();
 
@@ -108,7 +108,7 @@ namespace SlowTests.Tests.Indexes
             }.ToIndexDefinition(DocumentConventions.Default);
 
             indexDefinition.Name = "Index1";
-            IndexCompiler.Compile(indexDefinition);
+            IndexCompiler.Compile(indexDefinition, 0);
         }
 
         private class Person


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22359/Using-LoadDocument-with-dynamic-collection-name-should-throw-an-exception

### Additional description

Usage of `LoadDocument` with dynamic collection name isn't supported, so we should throw an exception for new indexes trying to load documents this way. We don't want to break existing indexes that rely on this, so we'll also check the index version before before throwing exception

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured - Checking index version before throwing exception
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
