### PR TITLE
RavenDB-22638 - Leak of SINK tags to the database change vector

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2103,15 +2103,17 @@ namespace Raven.Server.Documents
                         }
                         break;
                     case 2:
-                        if (expectedValues.Contains(cvArray[0].NodeTag) == false ||
+                        if ((expectedValues.Contains(cvArray[0].NodeTag) == false ||
                             expectedValues.Contains(cvArray[1].NodeTag) == false ||
-                            cvArray[0].NodeTag == cvArray[1].NodeTag)
+                            cvArray[0].NodeTag == cvArray[1].NodeTag) &&
+                            cvArray[0].NodeTag != ChangeVectorParser.SinkInt &&
+                            cvArray[1].NodeTag != ChangeVectorParser.SinkInt)
                         {
-                            Debug.Assert(false, $"FromClusterTransaction, expect RAFT or TRXN, {changeVector}");
+                            Debug.Assert(false, $"FromClusterTransaction, expect RAFT or TRXN or SINK, {changeVector}");
                         }
                         break;
                     default:
-                       Debug.Assert(false, $"FromClusterTransaction, expect change vector of length 1 or 2, {changeVector}");
+                        Debug.Assert(false, $"FromClusterTransaction, expect change vector of length 1 or 2, {changeVector}");
                         break;
                 }
             }

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -18,6 +18,7 @@ namespace Raven.Server.ServerWide.Context
             set
             {
                 value = value.StripTrxnTags();
+                value = value.StripSinkTags();
 
                 if (DbIdsToIgnore == null || DbIdsToIgnore.Count == 0 || string.IsNullOrEmpty(value))
                 {

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -370,6 +370,11 @@ namespace Raven.Server.Utils
             return from.StripTags(ChangeVectorParser.SinkTag, exclude);
         }
 
+        public static string StripSinkTags(this string from)
+        {
+            return from.StripTags(ChangeVectorParser.SinkTag, exclude: null);
+        }
+
         public static string StripTrxnTags(this string from)
         {
             return from.StripTags(ChangeVectorParser.TrxnTag, exclude: null);

--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -920,14 +920,14 @@ namespace SlowTests.Issues
             using (ctx.OpenReadTransaction())
             {
                 var sink1GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                Assert.Equal(3, sink1GlobalCv.ToChangeVector().Length);
+                Assert.Equal(2, sink1GlobalCv.ToChangeVector().Length);
             }
 
             using (sink2Db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
                 var sink2GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                Assert.Equal(3, sink2GlobalCv.ToChangeVector().Length);
+                Assert.Equal(2, sink2GlobalCv.ToChangeVector().Length);
             }
 
             async Task SetupSink(DocumentStore sinkStore)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22638/Leak-of-SINK-tags-to-the-database-change-vector

### Additional description

- Don't allow to have the `SINK` tag in the database change vector.
- Restore the `TRXN` tag when it's relevant on the node.
- fixing `Debug.Assert` that was verifying the `ClusterTransaction` flag.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
