### PR TITLE
RavenDB-22682 Refactor accessManagerSlice

### DIFF
--- a/src/Raven.Studio/.prettierignore
+++ b/src/Raven.Studio/.prettierignore
@@ -32,3 +32,5 @@ wwwroot/icons
 typescript/configuration.ts 
 typescript/endpoints.ts
 typescript/icons.ts
+
+aceBuild

--- a/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.ts
@@ -1,0 +1,171 @@
+import { RootState } from "components/store";
+import SecurityClearance = Raven.Client.ServerWide.Operations.Certificates.SecurityClearance;
+import { createSelector, EntityState } from "@reduxjs/toolkit";
+import { DatabaseAccessInfo, databaseAccessSelectors } from "components/common/shell/accessManagerSlice";
+
+// If database name is not provided, it will use the active one
+interface GetAccessLevelArgs {
+    databaseAccess: EntityState<DatabaseAccessInfo, string>;
+    activeDatabaseName: string;
+    databaseName?: string;
+}
+
+interface GetEffectiveAccessLevelArgs extends GetAccessLevelArgs {
+    securityClearance: SecurityClearance;
+}
+
+// Getters
+
+function getDatabaseAccessLevel(args: GetAccessLevelArgs) {
+    return databaseAccessSelectors.selectById(args.databaseAccess, args.databaseName ?? args.activeDatabaseName)?.level;
+}
+
+function getIsOperatorOrAbove(securityClearance: SecurityClearance) {
+    return (
+        securityClearance === "ClusterAdmin" || securityClearance === "ClusterNode" || securityClearance === "Operator"
+    );
+}
+
+function getIsClusterAdminOrClusterNode(securityClearance: SecurityClearance) {
+    return securityClearance === "ClusterAdmin" || securityClearance === "ClusterNode";
+}
+
+const getEffectiveDatabaseAccessLevel = (args: GetEffectiveAccessLevelArgs) => {
+    const isOperatorOrAbove = getIsOperatorOrAbove(args.securityClearance);
+    if (isOperatorOrAbove) {
+        return "DatabaseAdmin";
+    }
+
+    return getDatabaseAccessLevel(args);
+};
+
+const getHasDatabaseAccessAdmin = (args: GetEffectiveAccessLevelArgs) => {
+    const effectiveDatabaseAccessLevel = getEffectiveDatabaseAccessLevel(args);
+    return effectiveDatabaseAccessLevel === "DatabaseAdmin";
+};
+
+const getHasDatabaseAccessWrite = (args: GetEffectiveAccessLevelArgs) => {
+    const effectiveDatabaseAccessLevel = getEffectiveDatabaseAccessLevel(args);
+    return effectiveDatabaseAccessLevel === "DatabaseAdmin" || effectiveDatabaseAccessLevel === "DatabaseReadWrite";
+};
+
+// Selectors
+
+const selectIsOperatorOrAbove = createSelector(
+    (store: RootState) => store.accessManager.securityClearance,
+    (securityClearance: SecurityClearance) => getIsOperatorOrAbove(securityClearance)
+);
+
+const selectIsClusterAdminOrClusterNode = createSelector(
+    (store: RootState) => store.accessManager.securityClearance,
+    (securityClearance: SecurityClearance) => getIsClusterAdminOrClusterNode(securityClearance)
+);
+
+const selectGetEffectiveDatabaseAccessLevel = createSelector(
+    [
+        (store: RootState) => store.accessManager.securityClearance,
+        (store: RootState) => store.accessManager.databaseAccess,
+        (store: RootState) => store.databases.activeDatabaseName,
+    ],
+    (
+        securityClearance: SecurityClearance,
+        databaseAccess: EntityState<DatabaseAccessInfo, string>,
+        activeDatabaseName: string
+    ) =>
+        (databaseName?: string) => {
+            return getEffectiveDatabaseAccessLevel({
+                securityClearance,
+                databaseAccess,
+                activeDatabaseName,
+                databaseName,
+            });
+        }
+);
+
+const selectGetHasDatabaseAccessAdmin = createSelector(
+    [
+        (store: RootState) => store.accessManager.securityClearance,
+        (store: RootState) => store.accessManager.databaseAccess,
+        (store: RootState) => store.databases.activeDatabaseName,
+    ],
+    (
+        securityClearance: SecurityClearance,
+        databaseAccess: EntityState<DatabaseAccessInfo, string>,
+        activeDatabaseName: string
+    ) =>
+        (databaseName?: string) => {
+            return getHasDatabaseAccessAdmin({ securityClearance, databaseAccess, activeDatabaseName, databaseName });
+        }
+);
+
+const selectGetHasDatabaseAccessWrite = createSelector(
+    [
+        (store: RootState) => store.accessManager.securityClearance,
+        (store: RootState) => store.accessManager.databaseAccess,
+        (store: RootState) => store.databases.activeDatabaseName,
+    ],
+    (
+        securityClearance: SecurityClearance,
+        databaseAccess: EntityState<DatabaseAccessInfo, string>,
+        activeDatabaseName: string
+    ) =>
+        (databaseName?: string) => {
+            return getHasDatabaseAccessWrite({ securityClearance, databaseAccess, activeDatabaseName, databaseName });
+        }
+);
+
+const selectGetCanHandleOperation = createSelector(
+    [
+        (store: RootState) => store.accessManager.securityClearance,
+        (store: RootState) => store.accessManager.databaseAccess,
+        (store: RootState) => store.databases.activeDatabaseName,
+    ],
+    (
+        securityClearance: SecurityClearance,
+        databaseAccess: EntityState<DatabaseAccessInfo, string>,
+        activeDatabaseName: string
+    ) =>
+        (requiredAccess: accessLevel, databaseName: string = null) => {
+            const actualAccessLevel = getIsOperatorOrAbove(securityClearance)
+                ? securityClearance
+                : getDatabaseAccessLevel({ databaseAccess, activeDatabaseName, databaseName });
+
+            if (!actualAccessLevel) {
+                return false;
+            }
+
+            const clusterAdminOrNode = actualAccessLevel === "ClusterAdmin" || actualAccessLevel === "ClusterNode";
+            const operator = actualAccessLevel === "Operator";
+            const dbAdmin = actualAccessLevel === "DatabaseAdmin";
+            const dbReadWrite = actualAccessLevel === "DatabaseReadWrite";
+            const dbRead = actualAccessLevel === "DatabaseRead";
+
+            switch (requiredAccess) {
+                case "ClusterAdmin":
+                case "ClusterNode":
+                    return clusterAdminOrNode;
+                case "Operator":
+                    return clusterAdminOrNode || operator;
+                case "DatabaseAdmin":
+                    return clusterAdminOrNode || operator || dbAdmin;
+                case "DatabaseReadWrite":
+                    return clusterAdminOrNode || operator || dbAdmin || dbReadWrite;
+                case "DatabaseRead":
+                    return clusterAdminOrNode || operator || dbAdmin || dbReadWrite || dbRead;
+                default:
+                    return false;
+            }
+        }
+);
+
+const selectIsSecureServer = (store: RootState) => store.accessManager.isSecureServer;
+
+export const accessManagerSelectors = {
+    isSecureServer: selectIsSecureServer,
+    isOperatorOrAbove: selectIsOperatorOrAbove,
+    isClusterAdminOrClusterNode: selectIsClusterAdminOrClusterNode,
+    getHasDatabaseAdminAccess: selectGetHasDatabaseAccessAdmin,
+    getHasDatabaseWriteAccess: selectGetHasDatabaseAccessWrite,
+    getEffectiveDatabaseAccessLevel: selectGetEffectiveDatabaseAccessLevel,
+    getCanHandleOperation: selectGetCanHandleOperation,
+};

--- a/src/Raven.Studio/typescript/components/common/shell/setup.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/setup.ts
@@ -14,6 +14,8 @@ import { services } from "hooks/useServices";
 import viewModelBase from "viewmodels/viewModelBase";
 import buildInfo = require("models/resources/buildInfo");
 import genUtils = require("common/generalUtils");
+import accessManager = require("common/shell/accessManager");
+import { accessManagerActions } from "components/common/shell/accessManagerSlice";
 
 let initialized = false;
 
@@ -86,6 +88,13 @@ function initRedux() {
     );
 
     changesContext.default.connectServerWideNotificationCenter();
+
+    accessManager.default.securityClearance.subscribe((securityClearance) =>
+        globalDispatch(accessManagerActions.onSecurityClearanceSet(securityClearance))
+    );
+    accessManager.default.secureServer.subscribe((isSecureServer) =>
+        globalDispatch(accessManagerActions.onIsSecureServerSet(isSecureServer))
+    );
 }
 
 declare module "yup" {

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -40,7 +40,7 @@ import useBoolean from "hooks/useBoolean";
 import { Icon } from "components/common/Icon";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import ResetIndexesButton from "components/pages/database/indexes/list/partials/ResetIndexesButton";
 
 export interface IndexPanelProps {
@@ -91,7 +91,7 @@ function getLockColor(index: IndexSharedInfo) {
 export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTMLDivElement>) {
     const { index, selected, toggleSelection, hasReplacement, globalIndexingStatus, resetIndex } = props;
 
-    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.hasDatabaseWriteAccess());
+    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.getHasDatabaseWriteAccess)();
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
 
     const { value: panelCollapsed, toggle: togglePanelCollapsed } = useBoolean(true);

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -22,7 +22,7 @@ import { useRavenLink } from "components/hooks/useRavenLink";
 import IndexesPageList, { IndexesPageListProps } from "./IndexesPageList";
 import IndexesPageLicenseLimits from "./IndexesPageLicenseLimits";
 import IndexesPageAboutView from "./IndexesPageAboutView";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import DatabaseUtils from "components/utils/DatabaseUtils";
 
@@ -35,7 +35,7 @@ export function IndexesPage(props: IndexesPageProps) {
     const { stale, indexName: indexToHighlight } = props;
 
     const db = useAppSelector(databaseSelectors.activeDatabase);
-    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.hasDatabaseWriteAccess());
+    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.getHasDatabaseWriteAccess)();
     const { reportEvent } = useEventsCollector();
 
     const { forCurrentDatabase: urls } = useAppUrls();

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/partials/NoIndexes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/partials/NoIndexes.tsx
@@ -2,11 +2,11 @@
 import { EmptySet } from "components/common/EmptySet";
 import { Button } from "reactstrap";
 import React from "react";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useAppSelector } from "components/store";
 
 export function NoIndexes() {
-    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.hasDatabaseWriteAccess());
+    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.getHasDatabaseWriteAccess)();
     const { forCurrentDatabase } = useAppUrls();
 
     return (

--- a/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
@@ -28,7 +28,7 @@ import FeatureAvailabilitySummaryWrapper, {
 import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNotAvailableInYourLicensePopover";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 export default function ClientDatabaseConfiguration() {
     const { manageServerService } = useServices();

--- a/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/ConflictResolution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/ConflictResolution.tsx
@@ -3,7 +3,7 @@ import { Button, Card, CardBody, Col, Row, UncontrolledTooltip } from "reactstra
 import { AboutViewHeading } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
 import { useAppDispatch, useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { HrHeader } from "components/common/HrHeader";
 import ConflictResolutionConfigPanel from "components/pages/database/settings/conflictResolution/ConflictResolutionConfigPanel";
 import { Switch } from "components/common/Checkbox";
@@ -31,7 +31,7 @@ export default function ConflictResolution() {
     const isDirty = useAppSelector(conflictResolutionSelectors.isDirty);
     const isSomeInEditMode = useAppSelector(conflictResolutionSelectors.isSomeInEditMode);
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const { databasesService } = useServices();
     const { reportEvent } = useEventsCollector();

--- a/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/ConflictResolutionConfigPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/conflictResolution/ConflictResolutionConfigPanel.tsx
@@ -25,7 +25,7 @@ import { SubmitHandler, useForm, useWatch } from "react-hook-form";
 import * as yup from "yup";
 import { FormAceEditor, FormSelectCreatable } from "components/common/Form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 interface ConflictResolutionConfigPanelProps {
     initialConfig: ConflictResolutionCollectionConfig;
@@ -33,7 +33,7 @@ interface ConflictResolutionConfigPanelProps {
 
 export default function ConflictResolutionConfigPanel({ initialConfig }: ConflictResolutionConfigPanelProps) {
     const dispatch = useAppDispatch();
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const allCollectionNames = useAppSelector(collectionsTrackerSelectors.collectionNames).filter(
         (x) => x !== "@empty" && x !== "@hilo"
     );
@@ -175,7 +175,7 @@ function PanelActions({
     reset: () => void;
 }) {
     const dispatch = useAppDispatch();
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const discard = () => {
         dispatch(conflictResolutionActions.discardEdit(configId));

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStrings.tsx
@@ -3,7 +3,7 @@ import { Button, Col, Row, UncontrolledTooltip } from "reactstrap";
 import { AboutViewHeading } from "components/common/AboutView";
 import { Icon } from "components/common/Icon";
 import { useAppDispatch, useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { ConnectionStringsInfoHub } from "./ConnectionStringsInfoHub";
 import EditConnectionStrings from "./EditConnectionStrings";
 import { LazyLoad } from "components/common/LazyLoad";
@@ -25,7 +25,7 @@ export default function ConnectionStrings(props: ConnectionStringsUrlParameters)
 
     const { hasNone: hasNoneInLicense } = useConnectionStringsLicense();
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const dispatch = useAppDispatch();
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStringsPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStringsPanel.tsx
@@ -9,7 +9,7 @@ import {
 import { Button, UncontrolledTooltip } from "reactstrap";
 import { Icon } from "components/common/Icon";
 import { Connection } from "./connectionStringsTypes";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useAppSelector } from "components/store";
 import { useAsyncCallback } from "react-async-hook";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
@@ -35,7 +35,7 @@ export default function ConnectionStringsPanel(props: ConnectionStringsPanelProp
     const isDeleteDisabled = connection.usedByTasks?.length > 0;
 
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const asyncDelete = useAsyncCallback(async () => {
         await tasksService.deleteConnectionString(databaseName, getDtoEtlType(connection.type), connection.name);

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStringsPanels.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/ConnectionStringsPanels.tsx
@@ -1,5 +1,5 @@
 import { HrHeader } from "components/common/HrHeader";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useAppSelector } from "components/store";
 import React from "react";
 import { useDispatch } from "react-redux";
@@ -17,7 +17,7 @@ interface ConnectionStringsPanelsProps {
 
 export default function ConnectionStringsPanels({ connections, connectionsType }: ConnectionStringsPanelsProps) {
     const dispatch = useDispatch();
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     if (connections.length === 0) {
         return null;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/KafkaConnectionString.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/KafkaConnectionString.tsx
@@ -15,7 +15,7 @@ import { yupObjectSchema } from "components/utils/yupUtils";
 import ConnectionTestError from "components/common/connectionTests/ConnectionTestError";
 import { useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type FormData = ConnectionFormData<KafkaConnection>;
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsSlice.ts
@@ -12,7 +12,7 @@ import {
     mapRavenConnectionsFromDto,
     mapSqlConnectionsFromDto,
 } from "./connectionStringsMapsFromDto";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import DatabaseUtils from "components/utils/DatabaseUtils";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 
@@ -151,7 +151,7 @@ const fetchData = createAsyncThunk<
     );
     const connectionStringsDto = await services.tasksService.getConnectionStrings(db.name);
 
-    const hasDatabaseAdminAccess = accessManagerSelectors.hasDatabaseAdminAccess(db.name)(state);
+    const hasDatabaseAdminAccess = accessManagerSelectors.getHasDatabaseAdminAccess(state)(db.name);
 
     return {
         ongoingTasksDto,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzers.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzers.tsx
@@ -9,7 +9,7 @@ import { useServices } from "components/hooks/useServices";
 import { useAppSelector } from "components/store";
 import { useAsync } from "react-async-hook";
 import { CounterBadge } from "components/common/CounterBadge";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { getLicenseLimitReachStatus, LicenseLimitReachStatus } from "components/utils/licenseLimitsUtils";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import LicenseRestrictedBadge from "components/common/LicenseRestrictedBadge";
@@ -21,7 +21,7 @@ import DatabaseCustomAnalyzersServerWideList from "components/pages/database/set
 
 export default function DatabaseCustomAnalyzers() {
     const db = useAppSelector(databaseSelectors.activeDatabase);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const { databasesService, manageServerService } = useServices();
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzersListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customAnalyzers/DatabaseCustomAnalyzersListItem.tsx
@@ -5,7 +5,7 @@ import {
 } from "components/common/customAnalyzers/editCustomAnalyzerValidation";
 import { SubmitHandler, useForm, useWatch } from "react-hook-form";
 import { useDirtyFlag } from "hooks/useDirtyFlag";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import useBoolean from "hooks/useBoolean";
@@ -47,7 +47,7 @@ export default function DatabaseCustomAnalyzersListItem(props: DatabaseCustomAna
 
     const isNew = !formState.defaultValues.name;
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const { value: isEditMode, toggle: toggleIsEditMode } = useBoolean(isNew);
 
@@ -186,7 +186,7 @@ function CustomAnalyzersActions({
     isSubmitting,
     asyncDeleteAnalyzer,
 }: CustomAnalyzersActionsProps) {
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     if (!hasDatabaseAdminAccess) {
         return isEditMode ? (

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorters.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSorters.tsx
@@ -10,7 +10,7 @@ import { useAppSelector } from "components/store";
 import { useAsync } from "react-async-hook";
 import { CounterBadge } from "components/common/CounterBadge";
 import FeatureNotAvailable from "components/common/FeatureNotAvailable";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { LicenseLimitReachStatus, getLicenseLimitReachStatus } from "components/utils/licenseLimitsUtils";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import LicenseRestrictedBadge from "components/common/LicenseRestrictedBadge";
@@ -22,7 +22,7 @@ import { databaseSelectors } from "components/common/shell/databaseSliceSelector
 
 export default function DatabaseCustomSorters() {
     const db = useAppSelector(databaseSelectors.activeDatabase);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const { databasesService, manageServerService } = useServices();
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersListItem.tsx
@@ -10,7 +10,7 @@ import {
     RichPanelDetails,
 } from "components/common/RichPanel";
 import DeleteCustomSorterConfirm from "components/common/customSorters/DeleteCustomSorterConfirm";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { throttledUpdateLicenseLimitsUsage } from "components/common/shell/setup";
 import useBoolean from "components/hooks/useBoolean";
 import { useDirtyFlag } from "components/hooks/useDirtyFlag";
@@ -51,7 +51,7 @@ export default function DatabaseCustomSortersListItem(props: DatabaseCustomSorte
 
     const isNew = !formState.defaultValues.name;
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const { value: isEditMode, toggle: toggleIsEditMode } = useBoolean(isNew);
     const { value: isTestMode, toggle: toggleIsTestMode } = useBoolean(false);
@@ -202,7 +202,7 @@ function CustomSortersActions({
     isSubmitting,
     asyncDeleteSorter,
 }: CustomSortersActionsProps) {
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     if (!hasDatabaseAdminAccess) {
         return isEditMode ? (

--- a/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersServerWideListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/customSorters/DatabaseCustomSortersServerWideListItem.tsx
@@ -6,7 +6,7 @@ import {
     RichPanelName,
     RichPanelActions,
 } from "components/common/RichPanel";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import useBoolean from "components/hooks/useBoolean";
 import DatabaseCustomSorterTest from "components/pages/database/settings/customSorters/DatabaseCustomSorterTest";
 import { useAppSelector } from "components/store";
@@ -20,7 +20,7 @@ interface DatabaseCustomSortersServerWideListItemProps {
 export default function DatabaseCustomSortersServerWideListItem({
     sorter,
 }: DatabaseCustomSortersServerWideListItemProps) {
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const { value: isTestMode, toggle: toggleIsTestMode } = useBoolean(false);
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/dataArchival/DataArchival.tsx
@@ -29,11 +29,11 @@ import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUti
 import FeatureNotAvailableInYourLicensePopover from "components/common/FeatureNotAvailableInYourLicensePopover";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import activeDatabaseTracker = require("common/shell/activeDatabaseTracker");
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 export default function DataArchival() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const hasDataArchival = useAppSelector(licenseSelectors.statusValue("HasDataArchival"));
 
     const { databasesService } = useServices();

--- a/src/Raven.Studio/typescript/components/pages/database/settings/databaseRecord/DatabaseRecord.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/databaseRecord/DatabaseRecord.tsx
@@ -6,7 +6,7 @@ import useConfirm from "components/common/ConfirmDialog";
 import classNames from "classnames";
 import FeatureNotAvailable from "components/common/FeatureNotAvailable";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import useBoolean from "components/hooks/useBoolean";
 import { Switch } from "components/common/Checkbox";
 import AceEditor from "components/common/AceEditor";

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentCompression/DocumentCompression.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentCompression/DocumentCompression.tsx
@@ -28,11 +28,11 @@ import { SelectOption } from "components/common/select/Select";
 import { useAppUrls } from "components/hooks/useAppUrls";
 import FormCollectionsSelect from "components/common/FormCollectionsSelect";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 export default function DocumentCompression() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const { databasesService } = useServices();
 
     const allCollectionNames = useAppSelector(collectionsTrackerSelectors.collectionNames).filter(

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -28,7 +28,7 @@ import DocumentRevisionsSelectActions from "./DocumentRevisionsSelectActions";
 import { StickyHeader } from "components/common/StickyHeader";
 import { useEventsCollector } from "components/hooks/useEventsCollector";
 import { useAppUrls } from "components/hooks/useAppUrls";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import FeatureAvailabilitySummaryWrapper, {
@@ -50,7 +50,7 @@ todo("Feature", "Damian", "Add the Revert revisions view");
 
 export default function DocumentRevisions() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const { value: isEnforceConfigurationModalOpen, toggle: toggleEnforceConfigurationModal } = useBoolean(false);
     const [editRevisionData, setEditRevisionData] = useState<EditRevisionData>(null);

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisionsConfigPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisionsConfigPanel.tsx
@@ -24,7 +24,7 @@ import { useAppDispatch, useAppSelector } from "components/store";
 import { Checkbox } from "components/common/Checkbox";
 import { useEventsCollector } from "components/hooks/useEventsCollector";
 import generalUtils from "common/generalUtils";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 interface DocumentRevisionsConfigPanelProps {
     config: DocumentRevisionsConfig;
@@ -36,7 +36,7 @@ interface DocumentRevisionsConfigPanelProps {
 export default function DocumentRevisionsConfigPanel(props: DocumentRevisionsConfigPanelProps) {
     const { config, onDelete, onToggle, onEdit } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const dispatch = useAppDispatch();
     const { reportEvent } = useEventsCollector();
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/revertRevisions/RevertRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/revertRevisions/RevertRevisions.tsx
@@ -1,4 +1,4 @@
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useAppSelector } from "components/store";
 import React from "react";
 import { useForm, useWatch } from "react-hook-form";
@@ -25,7 +25,7 @@ import activeDatabaseTracker = require("common/shell/activeDatabaseTracker");
 
 export default function RevertRevisions() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const { control, formState, handleSubmit, setValue } = useForm<RevertRevisionsFormData>({
         resolver: revertRevisionsYupResolver,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/integrations/IntegrationsAddNewButton.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/integrations/IntegrationsAddNewButton.tsx
@@ -1,5 +1,5 @@
 import { ConditionalPopover } from "components/common/ConditionalPopover";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useAppSelector } from "components/store";
 import { Icon } from "components/common/Icon";
 import React from "react";
@@ -14,7 +14,7 @@ interface IntegrationsAddNewButtonProps {
 export default function IntegrationsAddNewButton(props: IntegrationsAddNewButtonProps) {
     const { isLicenseUpgradeRequired, addNewUser } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     return (
         <ConditionalPopover

--- a/src/Raven.Studio/typescript/components/pages/database/settings/integrations/IntegrationsUserListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/integrations/IntegrationsUserListItem.tsx
@@ -12,7 +12,7 @@ import { Icon } from "components/common/Icon";
 import { FormInput } from "components/common/Form";
 import { HStack } from "components/common/HStack";
 import { SubmitHandler, useForm, useWatch } from "react-hook-form";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useAppSelector } from "components/store";
 import { useServices } from "components/hooks/useServices";
 import { useAsyncCallback } from "react-async-hook";
@@ -42,7 +42,7 @@ export default function IntegrationsUserList(props: IntegrationsUserListProps) {
     const { initialUsername, removeUser } = props;
 
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const { control, formState, handleSubmit, reset, setValue } = useForm<FormData>({
         resolver: formResolver,

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/backups/BackupsPage.tsx
@@ -27,7 +27,7 @@ import LicenseRestrictedBadge from "components/common/LicenseRestrictedBadge";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import DatabaseUtils from "components/utils/DatabaseUtils";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 interface manualBackupListModel {
     backupType: Raven.Client.Documents.Operations.Backups.BackupType;
@@ -141,8 +141,8 @@ function ManualBackup(props: ManualBackupProps) {
 
 export function BackupsPage() {
     const isClusterAdminOrClusterNode = useAppSelector(accessManagerSelectors.isClusterAdminOrClusterNode);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
-    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.hasDatabaseWriteAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
+    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.getHasDatabaseWriteAccess)();
 
     const { tasksService } = useServices();
     const [manualBackup, setManualBackup] = useState<loadableData<manualBackupListModel>>({

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
@@ -60,14 +60,14 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { useRavenLink } from "components/hooks/useRavenLink";
 import { throttledUpdateLicenseLimitsUsage } from "components/common/shell/setup";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { compareSets } from "common/typeUtils";
 
 export function OngoingTasksPage() {
     const db = useAppSelector(databaseSelectors.activeDatabase);
     const isClusterAdminOrClusterNode = useAppSelector(accessManagerSelectors.isClusterAdminOrClusterNode);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
-    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.hasDatabaseWriteAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
+    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.getHasDatabaseWriteAccess)();
 
     const { tasksService } = useServices();
     const [tasks, dispatch] = useReducer(ongoingTasksReducer, db, ongoingTasksReducerInitializer);

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ElasticSearchEtlPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ElasticSearchEtlPanel.tsx
@@ -25,7 +25,7 @@ import { OngoingEtlTaskDistribution } from "./OngoingEtlTaskDistribution";
 import { Collapse, Input } from "reactstrap";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type ElasticSearchEtlPanelProps = BaseOngoingTaskPanelProps<OngoingTaskElasticSearchEtlInfo>;
 
@@ -60,7 +60,7 @@ function Details(props: ElasticSearchEtlPanelProps & { canEdit: boolean }) {
 export function ElasticSearchEtlPanel(props: ElasticSearchEtlPanelProps & ICanShowTransformationScriptPreview) {
     const { data, showItemPreview, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const { forCurrentDatabase } = useAppUrls();
 
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ExternalReplicationPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ExternalReplicationPanel.tsx
@@ -22,7 +22,7 @@ import genUtils from "common/generalUtils";
 import { Collapse, Input } from "reactstrap";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type ExternalReplicationPanelProps = BaseOngoingTaskPanelProps<OngoingTaskExternalReplicationInfo>;
 
@@ -73,7 +73,7 @@ function Details(props: ExternalReplicationPanelProps & { canEdit: boolean }) {
 export function ExternalReplicationPanel(props: ExternalReplicationPanelProps) {
     const { data, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const { forCurrentDatabase } = useAppUrls();
 
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/KafkaEtlPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/KafkaEtlPanel.tsx
@@ -25,7 +25,7 @@ import { OngoingEtlTaskDistribution } from "./OngoingEtlTaskDistribution";
 import { Collapse, Input } from "reactstrap";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type KafkaEtlPanelProps = BaseOngoingTaskPanelProps<OngoingTaskKafkaEtlInfo>;
 
@@ -53,7 +53,7 @@ function Details(props: KafkaEtlPanelProps & { canEdit: boolean }) {
 export function KafkaEtlPanel(props: KafkaEtlPanelProps & ICanShowTransformationScriptPreview) {
     const { data, showItemPreview, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const { forCurrentDatabase } = useAppUrls();
 
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/KafkaSinkPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/KafkaSinkPanel.tsx
@@ -22,7 +22,7 @@ import {
 import { Collapse, Input } from "reactstrap";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type KafkaSinkPanelProps = BaseOngoingTaskPanelProps<OngoingTaskKafkaSinkInfo>;
 
@@ -48,7 +48,7 @@ function Details(props: KafkaSinkPanelProps & { canEdit: boolean }) {
 export function KafkaSinkPanel(props: KafkaSinkPanelProps) {
     const { data, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const { forCurrentDatabase } = useAppUrls();
 
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/OlapEtlPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/OlapEtlPanel.tsx
@@ -25,7 +25,7 @@ import { OngoingEtlTaskDistribution } from "./OngoingEtlTaskDistribution";
 import { Collapse, Input } from "reactstrap";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type OlapEtlPanelProps = BaseOngoingTaskPanelProps<OngoingTaskOlapEtlInfo>;
 
@@ -57,7 +57,7 @@ function Details(props: OlapEtlPanelProps & { canEdit: boolean }) {
 export function OlapEtlPanel(props: OlapEtlPanelProps & ICanShowTransformationScriptPreview) {
     const { data, showItemPreview, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const { forCurrentDatabase } = useAppUrls();
 
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/PeriodicBackupPanel.tsx
@@ -35,7 +35,7 @@ import { clusterSelectors } from "components/common/shell/clusterSlice";
 import useId from "hooks/useId";
 import activeDatabaseTracker = require("common/shell/activeDatabaseTracker");
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 interface PeriodicBackupPanelProps extends BaseOngoingTaskPanelProps<OngoingTaskPeriodicBackupInfo> {
     forceReload: () => void;
@@ -139,7 +139,7 @@ function Details(props: PeriodicBackupPanelProps) {
     const neverBackedUp = !data.shared.lastFullBackup;
 
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const backupNowVisible = data.shared.serverWide || hasDatabaseAdminAccess;
 
@@ -242,7 +242,7 @@ export function PeriodicBackupPanel(props: PeriodicBackupPanelProps) {
     const { data, allowSelect, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState, sourceView } =
         props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const { forCurrentDatabase } = useAppUrls();
 
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/RabbitMqEtlPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/RabbitMqEtlPanel.tsx
@@ -24,7 +24,7 @@ import { OngoingEtlTaskDistribution } from "./OngoingEtlTaskDistribution";
 import { Collapse, Input } from "reactstrap";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type RabbitMqEtlPanelProps = BaseOngoingTaskPanelProps<OngoingTaskRabbitMqEtlInfo>;
 
@@ -55,7 +55,7 @@ function Details(props: RabbitMqEtlPanelProps & { canEdit: boolean }) {
 export function RabbitMqEtlPanel(props: RabbitMqEtlPanelProps & ICanShowTransformationScriptPreview) {
     const { data, showItemPreview, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;
 
     const { forCurrentDatabase } = useAppUrls();

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/RabbitMqSinkPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/RabbitMqSinkPanel.tsx
@@ -21,7 +21,7 @@ import {
 import { Collapse, Input } from "reactstrap";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type RabbitMqSinkPanelProps = BaseOngoingTaskPanelProps<OngoingTaskRabbitMqSinkInfo>;
 
@@ -50,7 +50,7 @@ function Details(props: RabbitMqSinkPanelProps & { canEdit: boolean }) {
 export function RabbitMqSinkPanel(props: RabbitMqSinkPanelProps) {
     const { data, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const { forCurrentDatabase } = useAppUrls();
 
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/RavenEtlPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/RavenEtlPanel.tsx
@@ -24,7 +24,7 @@ import { OngoingEtlTaskDistribution } from "./OngoingEtlTaskDistribution";
 import { Collapse, Input } from "reactstrap";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type RavenEtlPanelProps = BaseOngoingTaskPanelProps<OngoingTaskRavenEtlInfo>;
 
@@ -70,7 +70,7 @@ function Details(props: RavenEtlPanelProps & { canEdit: boolean }) {
 export function RavenEtlPanel(props: RavenEtlPanelProps & ICanShowTransformationScriptPreview) {
     const { data, showItemPreview, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const { forCurrentDatabase } = useAppUrls();
 
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationHubDefinitionPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationHubDefinitionPanel.tsx
@@ -21,7 +21,7 @@ import { ReplicationHubConnectedSinkPanel } from "./ReplicationHubConnectedSinkP
 import genUtils from "common/generalUtils";
 import { Collapse, Input } from "reactstrap";
 import { EmptySet } from "components/common/EmptySet";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useAppSelector } from "components/store";
 
 interface ReplicationHubPanelProps extends BaseOngoingTaskPanelProps<OngoingTaskHubDefinitionInfo> {
@@ -59,7 +59,7 @@ function Details(props: ReplicationHubPanelProps & { canEdit: boolean }) {
 export function ReplicationHubDefinitionPanel(props: ReplicationHubPanelProps) {
     const { data, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const { forCurrentDatabase } = useAppUrls();
     const editUrl = forCurrentDatabase.editReplicationHub(data.shared.taskId)();

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationSinkPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/ReplicationSinkPanel.tsx
@@ -22,7 +22,7 @@ import {
 import { Collapse, Input } from "reactstrap";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type ReplicationSinkPanelProps = BaseOngoingTaskPanelProps<OngoingTaskReplicationSinkInfo>;
 
@@ -60,7 +60,7 @@ function Details(props: ReplicationSinkPanelProps & { canEdit: boolean }) {
 export function ReplicationSinkPanel(props: ReplicationSinkPanelProps) {
     const { data, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;
 
     const { forCurrentDatabase } = useAppUrls();

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/SqlEtlPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/SqlEtlPanel.tsx
@@ -25,7 +25,7 @@ import { OngoingEtlTaskDistribution } from "./OngoingEtlTaskDistribution";
 import { Collapse, Input } from "reactstrap";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type SqlEtlPanelProps = BaseOngoingTaskPanelProps<OngoingTaskSqlEtlInfo>;
 
@@ -57,7 +57,7 @@ function Details(props: SqlEtlPanelProps & { canEdit: boolean }) {
 export function SqlEtlPanel(props: SqlEtlPanelProps & ICanShowTransformationScriptPreview) {
     const { data, showItemPreview, toggleSelection, isSelected, onTaskOperation, isDeleting, isTogglingState } = props;
 
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess());
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
     const canEdit = hasDatabaseAdminAccess && !data.shared.serverWide;
 
     const { forCurrentDatabase } = useAppUrls();

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/SubscriptionPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/panels/SubscriptionPanel.tsx
@@ -27,7 +27,7 @@ import { FlexGrow } from "components/common/FlexGrow";
 import { Icon } from "components/common/Icon";
 import { SubscriptionConnectionsDetailsWithId } from "../OngoingTasksReducer";
 import { useAppSelector } from "components/store";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 type SubscriptionPanelProps = BaseOngoingTaskPanelProps<OngoingTaskSubscriptionInfo> & {
     refreshSubscriptionInfo: () => void;
@@ -228,7 +228,7 @@ export function SubscriptionPanel(props: SubscriptionPanelProps) {
         isTogglingState,
     } = props;
 
-    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.hasDatabaseWriteAccess());
+    const hasDatabaseWriteAccess = useAppSelector(accessManagerSelectors.getHasDatabaseWriteAccess)();
     const { forCurrentDatabase } = useAppUrls();
 
     const canEdit = hasDatabaseWriteAccess && !data.shared.serverWide;

--- a/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseSummary.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/about/partials/LicenseSummary.tsx
@@ -16,7 +16,7 @@ import forceLicenseUpdateCommand from "commands/licensing/forceLicenseUpdateComm
 import licenseModel from "models/auth/licenseModel";
 import useConfirm from "components/common/ConfirmDialog";
 import useId from "hooks/useId";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 interface LicenseSummaryProps {
     asyncCheckLicenseServerConnectivity: AsyncState<ConnectivityStatus>;

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
@@ -19,7 +19,7 @@ import { databaseSelectors } from "components/common/shell/databaseSliceSelector
 import { databasesViewSelectors } from "components/pages/resources/databases/store/databasesViewSelectors";
 import { StickyHeader } from "components/common/StickyHeader";
 import { Icon } from "components/common/Icon";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import CreateDatabase, { CreateDatabaseMode } from "./partials/create/CreateDatabase";
 
 interface DatabasesPageProps {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -29,7 +29,7 @@ import { DatabaseDistribution } from "components/pages/resources/databases/parti
 import { ValidDatabasePropertiesPanel } from "components/pages/resources/databases/partials/ValidDatabasePropertiesPanel";
 import { locationAwareLoadableData } from "components/models/common";
 import DatabaseUtils from "components/utils/DatabaseUtils";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import genUtils from "common/generalUtils";
 import databasesManager from "common/shell/databasesManager";
 import { AccessIcon } from "components/pages/resources/databases/partials/AccessIcon";
@@ -105,7 +105,9 @@ export function DatabasePanel(props: DatabasePanelProps) {
 
     //TODO: show commands errors!
 
-    const dbAccess: databaseAccessLevel = useAppSelector(accessManagerSelectors.effectiveDatabaseAccessLevel(db.name));
+    const getEffectiveDatabaseAccessLevel = useAppSelector(accessManagerSelectors.getEffectiveDatabaseAccessLevel);
+    const dbAccess = getEffectiveDatabaseAccessLevel(db.name);
+
     const localNodeTag = useAppSelector(clusterSelectors.localNodeTag);
 
     const { reportEvent } = useEventsCollector();
@@ -134,7 +136,7 @@ export function DatabasePanel(props: DatabasePanelProps) {
 
     const isOperatorOrAbove = useAppSelector(accessManagerSelectors.isOperatorOrAbove);
     const isSecureServer = useAppSelector(accessManagerSelectors.isSecureServer);
-    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.hasDatabaseAdminAccess(db.name));
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)(db.name);
 
     const canNavigateToDatabase = !db.isDisabled;
 

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesSelectActions.tsx
@@ -23,7 +23,7 @@ import {
 import { databaseActions } from "components/common/shell/databaseSliceActions";
 import genUtils = require("common/generalUtils");
 import useConfirm from "components/common/ConfirmDialog";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 
 interface DatabasesSelectActionsProps {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/NoDatabases.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/NoDatabases.tsx
@@ -5,7 +5,7 @@ import { FlexGrow } from "components/common/FlexGrow";
 import CreateDatabase, {
     CreateDatabaseMode,
 } from "components/pages/resources/databases/partials/create/CreateDatabase";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useAppSelector } from "components/store";
 
 export function NoDatabases() {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/CreateDatabaseFromBackupStepSource.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/CreateDatabaseFromBackupStepSource.tsx
@@ -11,7 +11,7 @@ import BackupSourceRavenCloud from "./BackupSourceRavenCloud";
 import BackupSourceAzure from "./BackupSourceAzure";
 import BackupSourceGoogleCloud from "components/pages/resources/databases/partials/create/formBackup/steps/source/BackupSourceGoogleCloud";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import AuthenticationOffMessage from "components/pages/resources/databases/partials/create/shared/AuthenticationOffMessage";
 import EncryptionUnavailableMessage from "components/pages/resources/databases/partials/create/shared/EncryptionUnavailableMessage";

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepBasicInfo.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepBasicInfo.tsx
@@ -1,6 +1,6 @@
 import { FormInput, FormSwitch } from "components/common/Form";
 import { Icon } from "components/common/Icon";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import { CreateDatabaseRegularFormData as FormData } from "../createDatabaseRegularValidation";
 import { useAppSelector } from "components/store";

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/ManageDatabaseGroupPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/ManageDatabaseGroupPage.tsx
@@ -16,7 +16,7 @@ import { Icon } from "components/common/Icon";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { SortableModeCounterProvider } from "./partials/useSortableModeCounter";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 function getDynamicDatabaseDistributionWarning(
     hasDynamicNodesDistribution: boolean,

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/NodeInfoComponent.tsx
@@ -23,7 +23,7 @@ import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { useAsyncCallback } from "react-async-hook";
 import { useServices } from "components/hooks/useServices";
 import useConfirm from "components/common/ConfirmDialog";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useAppSelector } from "components/store";
 
 interface OrchestratorInfoComponentProps {

--- a/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/useGroup.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageDatabaseGroup/partials/useGroup.ts
@@ -3,7 +3,7 @@ import { NodeInfo } from "components/models/databases";
 import { useAppSelector } from "components/store";
 import { clusterSelectors } from "components/common/shell/clusterSlice";
 import { useSortableModeCounter } from "./useSortableModeCounter";
-import { accessManagerSelectors } from "components/common/shell/accessManagerSlice";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 
 export function useGroup(nodes: NodeInfo[], initialFixOrder: boolean) {
     const [fixOrder, setFixOrder] = useState(initialFixOrder);

--- a/src/Raven.Studio/typescript/viewmodels/shell.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell.ts
@@ -306,9 +306,6 @@ class shell extends viewModelBase {
                         this.accessManager.secureServer(false);
                     }
                 }
-                
-                globalDispatch(accessManagerActions.onSecurityClearanceSet(this.accessManager.securityClearance()));
-                globalDispatch(accessManagerActions.onIsSecureServerSet(this.accessManager.secureServer()));
             })
             .then(() => this.onBootstrapFinishedTask.resolve(), () => this.onBootstrapFinishedTask.reject());
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22682/Add-canHandleOperation-selector-to-accessManager-slice

### Additional description

All selectors were created using `createSelector`. Thanks to this, the selected values ​​will be updated only when one of the dependencies changes. This helps us avoid unnecessary re-renders.

Sometimes we forgot to call the method and used it for conditional rendering, which always resulted in true. For example, the name hasDatabaseAccessAdmin suggested a boolean value when it was a function that returned boolean. From now on, all functions that we can select have the "get" prefix (in this case, getHasDatabaseAccessAdmin).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
