### PR TITLE
RavenDB-22294 Fix include cmpXchg & atomic-guard (V6)

### DIFF
--- a/src/Raven.Client/Util/ClusterWideTransactionHelper.cs
+++ b/src/Raven.Client/Util/ClusterWideTransactionHelper.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+
+namespace Raven.Client.Util;
+
+internal static class ClusterWideTransactionHelper
+{
+    public static bool IsAtomicGuardKey(string id, out string docId)
+    {
+        if (IsAtomicGuardKey(id) == false)
+        {
+            docId = null;
+            return false;
+        }
+
+        docId = ExtractDocumentIdFromAtomicGuard(id);
+        return true;
+    }
+    
+    public static bool IsAtomicGuardKey(string key) => key.StartsWith(Constants.CompareExchange.RvnAtomicPrefix, StringComparison.OrdinalIgnoreCase);
+
+    public static string GetAtomicGuardKey(string docId) => Constants.CompareExchange.RvnAtomicPrefix + docId;
+    public static string GetAtomicGuardKey(ReadOnlyMemory<char> docId) => Constants.CompareExchange.RvnAtomicPrefix + docId;
+
+    public static string ExtractDocumentIdFromAtomicGuard(string key)
+    {
+        Debug.Assert(key.StartsWith(Constants.CompareExchange.RvnAtomicPrefix));
+        return key.Substring(Constants.CompareExchange.RvnAtomicPrefix.Length);
+    }
+}

--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -101,7 +101,13 @@ namespace Raven.Server.Config.Categories
         [TimeUnit(TimeUnit.Minutes)]
         [ConfigurationEntry("Cluster.CompareExchangeTombstonesCleanupIntervalInMin", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting CompareExchangeTombstonesCleanupInterval { get; set; }
-
+        
+        [Description("The maximum interval (in minutes) between checks for compare exchange tombstones performed by the cluster-wide transaction mechanism")]
+        [DefaultValue(5)]
+        [TimeUnit(TimeUnit.Minutes)]
+        [ConfigurationEntry("Cluster.MaxClusterTransactionCompareExchangeTombstoneCheckIntervalInMin", ConfigurationEntryScope.ServerWideOnly)]
+        public TimeSetting MaxClusterTransactionCompareExchangeTombstoneCheckInterval { get; set; }
+                           
         [Description("Maximum number of log entires to keep in the history log table.")]
         [DefaultValue(2048)]
         [ConfigurationEntry("Cluster.LogHistoryMaxEntries", ConfigurationEntryScope.ServerWideOnly)]

--- a/src/Raven.Server/Documents/DatabaseRaftIndexNotifications.cs
+++ b/src/Raven.Server/Documents/DatabaseRaftIndexNotifications.cs
@@ -20,7 +20,7 @@ public class DatabaseRaftIndexNotifications : AbstractRaftIndexNotifications<Raf
         if (await _clusterStateMachineLogIndexNotifications.WaitForTaskCompletion(index, waitingTask) == false)
             return false;
 
-        foreach (var error in _errors)
+        foreach (var error in Errors)
         {
             if (error.Index == index)
                 error.Exception.Throw(); // rethrow

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -271,28 +271,26 @@ namespace Raven.Server.Documents
 
             var database = await task;
 
-            switch (changeType)
-            {
-                case ClusterDatabaseChangeType.RecordChanged:
-                    await database.StateChangedAsync(index);
-                    if (type == ClusterStateMachine.SnapshotInstalled)
+                    switch (changeType)
                     {
-                        database.NotifyOnPendingClusterTransaction(index, changeType);
-                    }
-                    break;
+                        case ClusterDatabaseChangeType.RecordChanged:
+                            await database.StateChangedAsync(index);
+                            if (type == ClusterStateMachine.SnapshotInstalled)
+                            {
+                                database.NotifyOnPendingClusterTransaction();
+                            }
+                            break;
 
                 case ClusterDatabaseChangeType.ValueChanged:
                     await database.ValueChangedAsync(index, type, changeState);
                     break;
 
                 case ClusterDatabaseChangeType.PendingClusterTransactions:
-                case ClusterDatabaseChangeType.ClusterTransactionCompleted:
-
                     if (ForTestingPurposes?.BeforeHandleClusterTransactionOnDatabaseChanged != null)
                         await ForTestingPurposes.BeforeHandleClusterTransactionOnDatabaseChanged.Invoke(_serverStore);
 
                     database.SetIds(rawRecord);
-                    database.NotifyOnPendingClusterTransaction(index, changeType);
+                    database.NotifyOnPendingClusterTransaction();
                     break;
                 default:
                     ThrowUnknownClusterDatabaseChangeType(changeType);
@@ -1259,7 +1257,6 @@ namespace Raven.Server.Documents
             RecordRestored,
             ValueChanged,
             PendingClusterTransactions,
-            ClusterTransactionCompleted
         }
 
         public bool UnloadDirectly(StringSegment databaseName, DateTime? wakeup = null, [CallerMemberName] string caller = null)

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -8,7 +8,6 @@ using Raven.Client.Documents.Changes;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents;
 using Raven.Server.ServerWide;
-using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Binary;
@@ -17,6 +16,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.Tables;
+using Raven.Client.Util;
 using static Raven.Server.Documents.DocumentsStorage;
 using static Raven.Server.Documents.Schemas.Documents;
 using Constants = Raven.Client.Constants;
@@ -81,12 +81,12 @@ namespace Raven.Server.Documents
                 using (_serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext clusterContext))
                 using (clusterContext.OpenReadTransaction())
                 {
-                    var (indexFromCluster, val) = _parent._documentDatabase.CompareExchangeStorage.GetCompareExchangeValue(clusterContext, ClusterTransactionCommand.GetAtomicGuardKey(id));
+                    var (indexFromCluster, val) = _parent._documentDatabase.CompareExchangeStorage.GetCompareExchangeValue(clusterContext, ClusterWideTransactionHelper.GetAtomicGuardKey(id));
                     if (indexFromChangeVector != indexFromCluster)
                     {
                         throw new ConcurrencyException(
                             $"Cannot PUT document '{id}' because its change vector's cluster transaction index is set to {indexFromChangeVector} " +
-                            $"but the compare exchange guard ('{ClusterTransactionCommand.GetAtomicGuardKey(id)}') is {(val == null ? "missing" : $"set to {indexFromCluster}")}")
+                            $"but the compare exchange guard ('{ClusterWideTransactionHelper.GetAtomicGuardKey(id)}') is {(val == null ? "missing" : $"set to {indexFromCluster}")}")
                         {
                             Id = id
                         };

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/ClusterTransactionRequestProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/ClusterTransactionRequestProcessor.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Batches
         public override async Task WaitForDatabaseCompletion(Task<HashSet<string>> onDatabaseCompletionTask, long index, ClusterTransactionOptions options, CancellationToken token)
         {
             var database = RequestHandler.Database;
-            var lastCompleted = Interlocked.Read(ref database.LastCompletedClusterTransactionIndex);
+            var lastCompleted = database.ClusterWideTransactionIndexWaiter.LastIndex;
             HashSet<string> modifiedCollections = null;
             if (lastCompleted < index)
                 modifiedCollections = await onDatabaseCompletionTask; // already registered to the token

--- a/src/Raven.Server/Documents/Includes/IncludeCompareExchangeValuesCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeCompareExchangeValuesCommand.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using System.Diagnostics;
 using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Util;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -87,7 +89,7 @@ namespace Raven.Server.Documents.Includes
             _includedKeys.Add(id);
         }
 
-        public bool TryGetAtomicGuard(string key, long maxAllowedRaftId, out long index, out BlittableJsonReaderObject value)
+        public bool TryGetCompareExchange(string key, long? maxAtomicGuardIndex, out long index, out BlittableJsonReaderObject value)
         {
             index = -1;
             value = null;
@@ -97,18 +99,19 @@ namespace Raven.Server.Documents.Includes
 
             var result = _compareExchangeStorage.GetCompareExchangeValue(_serverContext, key);
 
-            if (result.Index > maxAllowedRaftId)
+            Debug.Assert(ClusterWideTransactionHelper.IsAtomicGuardKey(key) == false || maxAtomicGuardIndex.HasValue);
+            if (ClusterWideTransactionHelper.IsAtomicGuardKey(key) && maxAtomicGuardIndex.HasValue && result.Index > maxAtomicGuardIndex)
                 return false; // we are seeing partially committed value, skip it
 
             if (result.Index < 0)
                 return false;
-
+            
             index = result.Index;
             value = result.Value;
             return true;
         }
 
-        internal void Materialize(long maxAllowedRaftId)
+        internal void Materialize(long? maxAllowedAtomicGuardIndex)
         {
             if (_includedKeys == null || _includedKeys.Count == 0)
                 return;
@@ -118,12 +121,12 @@ namespace Raven.Server.Documents.Includes
                 if (string.IsNullOrEmpty(includedKey))
                     continue;
 
-                if (TryGetAtomicGuard(includedKey, maxAllowedRaftId, out var index, out var value) == false)
-                    continue;
-
+                var toAdd = TryGetCompareExchange(includedKey, maxAllowedAtomicGuardIndex, out var index, out var value)
+                    ? (index, value)
+                    : (-1, null);
+                
                 Results ??= new Dictionary<string, CompareExchangeValue<BlittableJsonReaderObject>>(StringComparer.OrdinalIgnoreCase);
-
-                Results.Add(includedKey, new CompareExchangeValue<BlittableJsonReaderObject>(includedKey, index, value));
+                Results.Add(includedKey, new CompareExchangeValue<BlittableJsonReaderObject>(includedKey, toAdd.index,  toAdd.value));
             }
         }
 

--- a/src/Raven.Server/Documents/Includes/IncludeCompareExchangeValuesCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeCompareExchangeValuesCommand.cs
@@ -121,12 +121,12 @@ namespace Raven.Server.Documents.Includes
                 if (string.IsNullOrEmpty(includedKey))
                     continue;
 
-                var toAdd = TryGetCompareExchange(includedKey, maxAllowedAtomicGuardIndex, out var index, out var value)
-                    ? (index, value)
-                    : (-1, null);
+                if (TryGetCompareExchange(includedKey, maxAllowedAtomicGuardIndex, out var index, out var value) == false
+                    && ClusterWideTransactionHelper.IsAtomicGuardKey(includedKey))
+                    continue;  
                 
                 Results ??= new Dictionary<string, CompareExchangeValue<BlittableJsonReaderObject>>(StringComparer.OrdinalIgnoreCase);
-                Results.Add(includedKey, new CompareExchangeValue<BlittableJsonReaderObject>(includedKey, toAdd.index,  toAdd.value));
+                Results.Add(includedKey, new CompareExchangeValue<BlittableJsonReaderObject>(includedKey, index,  value));
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3452,7 +3452,6 @@ namespace Raven.Server.Documents.Indexes
                                         token.Token);
                                 }
 
-                                long lastRaftId = DocumentDatabase.RachisLogIndexNotifications.LastModifiedIndex;
                                 try
                                 {
                                     var enumerator = documents.GetEnumerator();
@@ -3521,7 +3520,7 @@ namespace Raven.Server.Documents.Indexes
                                 using (fillScope?.Start())
                                 {
                                     includeDocumentsCommand.Fill(resultToFill.Includes, query.ReturnOptions?.MissingIncludeAsNull ?? false);
-                                    includeCompareExchangeValuesCommand?.Materialize(lastRaftId);
+                                    includeCompareExchangeValuesCommand?.Materialize(maxAllowedAtomicGuardIndex: null);
                                 }
 
                                 if (includeCountersCommand != null)

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -149,7 +149,6 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 var scannedResults = new Reference<int>();
                 IEnumerator<Document> enumerator;
 
-                var lastRaftId = Database.RachisLogIndexNotifications.LastModifiedIndex;
                 if (pulseReadingTransaction == false)
                 {
                     var documents = new CollectionQueryEnumerable(Database, Database.DocumentsStorage, fieldsToFetch, collection, query, queryScope, context.Documents,
@@ -243,7 +242,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 {
                     includeDocumentsCommand.Fill(resultToFill.Includes, query.ReturnOptions?.MissingIncludeAsNull ?? false);
 
-                    includeCompareExchangeValuesCommand.Materialize(lastRaftId);
+                    includeCompareExchangeValuesCommand.Materialize(maxAllowedAtomicGuardIndex: null);
                 }
 
                 if (includeCompareExchangeValuesCommand != null)

--- a/src/Raven.Server/Documents/RaftIndexWaiter.cs
+++ b/src/Raven.Server/Documents/RaftIndexWaiter.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Sparrow.Server;
+using Sparrow.Utils;
+
+namespace Raven.Server.Documents;
+
+public class RaftIndexWaiter : IDisposable
+{
+    private long _lastCompletedIndex;
+    private readonly AsyncManualResetEvent _notifiedListeners;
+
+    public long LastIndex => Interlocked.Read(ref _lastCompletedIndex);
+
+    public RaftIndexWaiter(CancellationToken token)
+    {
+        _notifiedListeners = new AsyncManualResetEvent(token);
+    }
+    
+    public void SetAndNotifyListenersIfHigher(long newIndex)
+    {
+        if (ThreadingHelper.InterlockedExchangeMax(ref _lastCompletedIndex, newIndex))
+        {
+            _notifiedListeners.SetAndResetAtomically();
+        }
+    }
+
+    public void NotifyListenersAboutError(Exception e)
+    {
+        _notifiedListeners.SetException(e);
+    }
+    
+    public async Task WaitAsync(long index, CancellationToken token)
+    {
+        while (true)
+        {
+            var waitAsync = _notifiedListeners.WaitAsync(token);
+            if (index <= LastIndex)
+                break;
+
+            if (token.IsCancellationRequested)
+                ThrowCanceledException(index);
+
+            await Task.WhenAny(waitAsync);
+            if(waitAsync.IsCanceled)
+                ThrowCanceledException(index);
+
+            await waitAsync;
+        }
+    }
+    
+    public async Task WaitAsync(long index, TimeSpan timeout)
+    {
+        while (true)
+        {
+            var waitAsync = _notifiedListeners.WaitAsync(timeout);
+            if (index <= LastIndex)
+                break;
+
+            if (await waitAsync == false)
+            {
+                var copy = LastIndex;
+                if (index <= copy)
+                    break;
+
+                ThrowTimeoutException(timeout, index, copy);
+            }
+        }
+    }
+
+    private void ThrowCanceledException(long index)
+    {
+        throw new OperationCanceledException($"Cancelled while waiting for task with index {index} to complete. Last commit index is: {LastIndex}.");
+    }
+    
+    private void ThrowTimeoutException(TimeSpan value, long index, long lastIndex)
+    {
+        throw new TimeoutException($"Waited for {value} for task with index {index} to complete. Last commit index is: {lastIndex}");
+    }
+
+    public void Dispose()
+    {
+        _notifiedListeners?.Dispose();
+    }
+}

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 //  <copyright file="RequestRouter.cs" company="Hibernating Rhinos LTD">
 //      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 //  </copyright>
@@ -405,9 +405,9 @@ namespace Raven.Server.Routing
                     {
                         if (context.Request.Headers.TryGetValue(Constants.Headers.LastKnownClusterTransactionIndex, out var value)
                             && long.TryParse(value, out var index)
-                            && index > reqCtx.Database.RachisLogIndexNotifications.LastModifiedIndex)
+                            && index > reqCtx.Database.ClusterWideTransactionIndexWaiter.LastIndex)
                         {
-                            await reqCtx.Database.RachisLogIndexNotifications.WaitForIndexNotification(index, context.RequestAborted).ConfigureAwait(false);
+                            await reqCtx.Database.ClusterWideTransactionIndexWaiter.WaitAsync(index, context.RequestAborted).ConfigureAwait(false);
                         }
 
                         await handler(reqCtx).ConfigureAwait(false);

--- a/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
+++ b/src/Raven.Server/ServerWide/AbstractRaftIndexNotifications.cs
@@ -4,7 +4,7 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Sparrow.Server;
+using Raven.Server.Documents;
 using Sparrow.Utils;
 
 namespace Raven.Server.ServerWide;
@@ -12,42 +12,33 @@ namespace Raven.Server.ServerWide;
 public abstract class AbstractRaftIndexNotifications<TNotification> : IDisposable
 where TNotification : RaftIndexNotification
 {
-    public long LastModifiedIndex;
-    protected readonly ConcurrentQueue<ErrorHolder> _errors = new ConcurrentQueue<ErrorHolder>();
+    protected readonly ConcurrentQueue<ErrorHolder> Errors = new ConcurrentQueue<ErrorHolder>();
     private readonly ConcurrentQueue<TNotification> _recentNotifications = new ConcurrentQueue<TNotification>();
     public int RecentNotificationsMaxEntries = 50;
-    private readonly AsyncManualResetEvent _notifiedListeners;
     private int _numberOfErrors;
+    private readonly RaftIndexWaiter _raftIndexWaiter;
+
+    public long LastModifiedIndex => _raftIndexWaiter.LastIndex;
 
     protected AbstractRaftIndexNotifications(CancellationToken token)
     {
-        _notifiedListeners = new AsyncManualResetEvent(token);
+        _raftIndexWaiter = new RaftIndexWaiter(token);
     }
 
     public virtual void Dispose()
     {
-        _notifiedListeners.Dispose();
+        _raftIndexWaiter.Dispose();
     }
 
     public async Task WaitForIndexNotification(long index, CancellationToken token)
     {
-        while (true)
+        try
         {
-            // first get the task, then wait on it
-            var waitAsync = _notifiedListeners.WaitAsync(token);
-
-            if (index <= Interlocked.Read(ref LastModifiedIndex))
-                break;
-
-            if (token.IsCancellationRequested)
-                ThrowCanceledException(index, LastModifiedIndex, isExecution: false);
-
-            if (await waitAsync == false)
-            {
-                var copy = Interlocked.Read(ref LastModifiedIndex);
-                if (index <= copy)
-                    break;
-            }
+            await _raftIndexWaiter.WaitAsync(index, token);
+        }
+        catch (OperationCanceledException)
+        {
+            ThrowCanceledException(index, _raftIndexWaiter.LastIndex);
         }
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -56,34 +47,25 @@ where TNotification : RaftIndexNotification
             if (await WaitForTaskCompletion(index, new Lazy<Task>(tcs.Task)))
                 return;
 
-            ThrowCanceledException(index, LastModifiedIndex, isExecution: true);
+            ThrowCanceledException(index, _raftIndexWaiter.LastIndex, isExecution: true);
         }
     }
 
     public async Task WaitForIndexNotification(long index, TimeSpan timeout)
     {
-        while (true)
+        try
         {
-            // first get the task, then wait on it
-            var waitAsync = _notifiedListeners.WaitAsync(timeout);
-
-            if (index <= Interlocked.Read(ref LastModifiedIndex))
-                break;
-
-            if (await waitAsync == false)
-            {
-                var copy = Interlocked.Read(ref LastModifiedIndex);
-                if (index <= copy)
-                    break;
-
-                ThrowTimeoutException(timeout, index, copy);
-            }
+            await _raftIndexWaiter.WaitAsync(index, timeout);
+        }
+        catch (TimeoutException)
+        {
+            ThrowTimeoutException(timeout, index, _raftIndexWaiter.LastIndex);
         }
 
         if (await WaitForTaskCompletion(index, new Lazy<Task>(TimeoutManager.WaitFor(timeout))))
             return;
 
-        ThrowTimeoutException(timeout, index, LastModifiedIndex, isExecution: true);
+        ThrowTimeoutException(timeout, index, _raftIndexWaiter.LastIndex, isExecution: true);
     }
 
     public abstract Task<bool> WaitForTaskCompletion(long index, Lazy<Task> waitingTask);
@@ -92,7 +74,7 @@ where TNotification : RaftIndexNotification
     {
         if (e != null)
         {
-            _errors.Enqueue(new ErrorHolder
+            Errors.Enqueue(new ErrorHolder
             {
                 Index = index,
                 Exception = ExceptionDispatchInfo.Capture(e)
@@ -100,13 +82,12 @@ where TNotification : RaftIndexNotification
 
             if (Interlocked.Increment(ref _numberOfErrors) > 25)
             {
-                _errors.TryDequeue(out _);
+                Errors.TryDequeue(out _);
                 Interlocked.Decrement(ref _numberOfErrors);
             }
         }
 
-        ThreadingHelper.InterlockedExchangeMax(ref LastModifiedIndex, index);
-        _notifiedListeners.SetAndResetAtomically();
+        _raftIndexWaiter.SetAndNotifyListenersIfHigher(index);
     }
 
     public void RecordNotification(TNotification notification)

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -301,7 +301,7 @@ namespace Raven.Server.ServerWide.Commands
                     case CommandType.CompareExchangeDELETE:
                         if (disableAtomicDocumentWrites == false)
                         {
-                            if (IsAtomicGuardKey(document.Id, out _))
+                            if (ClusterWideTransactionHelper.IsAtomicGuardKey(document.Id, out _))
                                 throw new CompareExchangeInvalidKeyException($"You cannot manipulate the atomic guard '{document.Id}' via the cluster-wide session");
                         }
                         break;
@@ -431,7 +431,7 @@ namespace Raven.Server.ServerWide.Commands
             {
                 var cmdType = dbCmd[nameof(ClusterTransactionDataCommand.Type)].ToString();
                 var docId = dbCmd[nameof(ClusterTransactionDataCommand.Id)].ToString();
-                var atomicGuardKey = GetAtomicGuardKey(docId);
+                var atomicGuardKey = ClusterWideTransactionHelper.GetAtomicGuardKey(docId);
                 var changeVector = dbCmd[nameof(ClusterTransactionDataCommand.ChangeVector)]?.ToString();
                 long changeVectorIndex = 0;
 
@@ -496,29 +496,7 @@ namespace Raven.Server.ServerWide.Commands
 
             return null;
         }
-
-        public static bool IsAtomicGuardKey(string id, out string docId)
-        {
-            if (id.StartsWith(Constants.CompareExchange.RvnAtomicPrefix) == false)
-            {
-                docId = null;
-                return false;
-            }
-
-            docId = id.Substring(Constants.CompareExchange.RvnAtomicPrefix.Length);
-            return true;
-        }
-
-        public static string GetAtomicGuardKey(string docId)
-        {
-            return Constants.CompareExchange.RvnAtomicPrefix + docId;
-        }
-
-        public static string GetAtomicGuardKey(ReadOnlyMemory<char> docId)
-        {
-            return Constants.CompareExchange.RvnAtomicPrefix + docId;
-        }
-
+        
         private struct CommandsPerShard
         {
             private readonly RawDatabaseRecord _record;
@@ -780,11 +758,11 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
-        public static unsafe ByteStringContext.InternalScope GetPrefix<TTransaction>(TransactionOperationContext<TTransaction> context, string database, out Slice prefixSlice, long? index = null)
+        public static unsafe ByteStringContext.InternalScope GetPrefix<TTransaction>(TransactionOperationContext<TTransaction> context, string database, out Slice prefixSlice, long? prevCount = null)
             where TTransaction : RavenTransaction
         {
             var maxSize = database.GetUtf8MaxSize() + sizeof(byte);
-            if (index.HasValue)
+            if (prevCount.HasValue)
                 maxSize += sizeof(long);
 
             var lowerBufferSize = database.Length * sizeof(char);
@@ -805,9 +783,9 @@ namespace Raven.Server.ServerWide.Commands
                     var dbLen = Encoding.UTF8.GetBytes(lowerBufferStart, database.Length, prefixBuffer.Ptr, prefixBuffer.Length);
                     prefixBuffer.Ptr[dbLen] = Separator;
                     var actualSize = dbLen + 1;
-                    if (index.HasValue)
+                    if (prevCount.HasValue)
                     {
-                        *(long*)(prefixBuffer.Ptr + actualSize) = Bits.SwapBytes(index.Value);
+                        *(long*)(prefixBuffer.Ptr + actualSize) = Bits.SwapBytes(prevCount.Value);
                         actualSize += sizeof(long);
                     }
                     prefixBuffer.Truncate(actualSize);

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -349,6 +349,7 @@ namespace Raven.Server.ServerWide.Maintenance
         {
             report.LastTransactionId = dbInstance.LastTransactionId;
             report.LastCompletedClusterTransaction = dbInstance.LastCompletedClusterTransaction;
+            report.LastClusterWideTransactionRaftIndex = dbInstance.ClusterWideTransactionIndexWaiter.LastIndex;
         }
 
         private static void FillIndexInfo(Index index, QueryOperationContext context, DateTime now, DatabaseStatusReport report)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -67,6 +67,7 @@ namespace Raven.Server.ServerWide.Maintenance
         public Dictionary<int, BucketReport> ReportPerBucket = new Dictionary<int, BucketReport>();
 
         public long LastCompareExchangeIndex { get; set; }
+        public long LastClusterWideTransactionRaftIndex { get; set; }
 
         public sealed class ObservedIndexStatus
         {
@@ -110,7 +111,8 @@ namespace Raven.Server.ServerWide.Maintenance
                 [nameof(ReportPerBucket)] = DynamicJsonValue.Convert(ReportPerBucket),
                 [nameof(Error)] = Error,
                 [nameof(UpTime)] = UpTime,
-                [nameof(LastCompareExchangeIndex)] = LastCompareExchangeIndex
+                [nameof(LastCompareExchangeIndex)] = LastCompareExchangeIndex,
+                [nameof(LastClusterWideTransactionRaftIndex)] = LastClusterWideTransactionRaftIndex
             };
             var indexStats = new DynamicJsonValue();
             foreach (var stat in LastIndexStats)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -704,7 +704,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
 
                     var hasReport = nodeReport.Report.TryGetValue(state.Name, out var report);
-                    Debug.Assert(hasReport, $"Could not find report for node '{nodeTag}' for database '{state.Name}'.");
+                    Debug.Assert(hasReport || nodeReport.Error != null, $"Could not find report for node '{nodeTag}' for database '{state.Name}'.");
                     // ReSharper disable once ConditionIsAlwaysTrueOrFalse
                     if (hasReport == false)
                         return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;

--- a/src/Raven.Server/ServerWide/RachisLogIndexNotifications.cs
+++ b/src/Raven.Server/ServerWide/RachisLogIndexNotifications.cs
@@ -37,7 +37,7 @@ public class RachisLogIndexNotifications : AbstractRaftIndexNotifications<Recent
         {
             // the task has already completed
             // let's check if we had errors in it
-            foreach (var error in _errors)
+            foreach (var error in Errors)
             {
                 if (error.Index == index)
                     error.Exception.Throw(); // rethrow

--- a/src/Raven.Server/Smuggler/Documents/Actions/AbstractDatabaseCompareExchangeActions.cs
+++ b/src/Raven.Server/Smuggler/Documents/Actions/AbstractDatabaseCompareExchangeActions.cs
@@ -77,7 +77,7 @@ namespace Raven.Server.Smuggler.Documents.Actions
                 _clusterTransactionCommandsSize.Set(0, SizeUnit.Bytes);
             }
 
-            if (ClusterTransactionCommand.IsAtomicGuardKey(key, out var docId) && TryHandleAtomicGuard(key, docId, value, existingDocument))
+            if (ClusterWideTransactionHelper.IsAtomicGuardKey(key, out var docId) && TryHandleAtomicGuard(key, docId, value, existingDocument))
                 return;
 
             _compareExchangeAddOrUpdateCommands.Add(new AddOrUpdateCompareExchangeCommand(_databaseName, key, value, 0, _context, RaftIdGenerator.DontCareId, fromBackup: true));

--- a/src/Raven.Server/Smuggler/Documents/Actions/DatabaseCompareExchangeActions.cs
+++ b/src/Raven.Server/Smuggler/Documents/Actions/DatabaseCompareExchangeActions.cs
@@ -92,7 +92,7 @@ internal class DatabaseCompareExchangeActions : AbstractDatabaseCompareExchangeA
             if (_backupKind is null or BackupKind.None)
             {
                 // waiting for the commands to be applied
-                await _database.RachisLogIndexNotifications.WaitForIndexNotification(_lastClusterTransactionIndex.Value, _token);
+                await _database.ClusterWideTransactionIndexWaiter.WaitAsync(_lastClusterTransactionIndex.Value, _token);
             }
             else
             {

--- a/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
@@ -227,7 +227,7 @@ namespace Raven.Server.Smuggler.Documents
 
             public async ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument)
             {
-                if (ClusterTransactionCommand.IsAtomicGuardKey(key, out var docId))
+                if (ClusterWideTransactionHelper.IsAtomicGuardKey(key, out var docId))
                 {
                     var shardNumber = DatabaseContext.GetShardNumberFor(_allocator, docId);
                     await _actions[shardNumber].WriteKeyValueAsync(key, value, existingDocument);
@@ -239,7 +239,7 @@ namespace Raven.Server.Smuggler.Documents
 
             public async ValueTask WriteTombstoneKeyAsync(string key)
             {
-                if (ClusterTransactionCommand.IsAtomicGuardKey(key, out var docId))
+                if (ClusterWideTransactionHelper.IsAtomicGuardKey(key, out var docId))
                 {
                     var shardNumber = DatabaseContext.GetShardNumberFor(_allocator, docId);
                     await _actions[shardNumber].WriteTombstoneKeyAsync(key);

--- a/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
@@ -6,10 +6,10 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.ServerWide;
+using Raven.Client.Util;
 using Raven.Server.Documents;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.ServerWide;
-using Raven.Server.ServerWide.Commands;
 using Raven.Server.Smuggler.Documents.Actions;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Documents.Processors;
@@ -212,7 +212,7 @@ namespace Raven.Server.Smuggler.Documents
 
                     try
                     {
-                        if (ClusterTransactionCommand.IsAtomicGuardKey(kvp.Key.Key, out _))
+                        if (ClusterWideTransactionHelper.IsAtomicGuardKey(kvp.Key.Key, out _))
                         {
                             await destinationActions.WriteKeyValueAsync(kvp.Key.Key, kvp.Value, existingDocument: null);
                         }
@@ -253,7 +253,7 @@ namespace Raven.Server.Smuggler.Documents
 
                     try
                     {
-                        if (ClusterTransactionCommand.IsAtomicGuardKey(kvp.Key.Key, out _))
+                        if (ClusterWideTransactionHelper.IsAtomicGuardKey(kvp.Key.Key, out _))
                         {
                             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Aviv, DevelopmentHelper.Severity.Normal,
                                 "RavenDB-19201 : handle atomic guard tombstones import");

--- a/src/Raven.Server/Smuggler/Documents/SingleShardDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/SingleShardDatabaseSmuggler.cs
@@ -61,7 +61,7 @@ namespace Raven.Server.Smuggler.Documents
 
         private bool SkipCompareExchange(CompareExchangeKey key)
         {
-            if (ClusterTransactionCommand.IsAtomicGuardKey(key.Key, out var docId))
+            if (ClusterWideTransactionHelper.IsAtomicGuardKey(key.Key, out var docId))
             {
                 var shardNumber = ShardHelper.GetShardNumberFor(_sharding, _allocator, docId);
                 return shardNumber != _index;

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -510,7 +510,7 @@ namespace Raven.Server.Smuggler.Documents
 
                     if (compareExchangeActions != null && item.Document.ChangeVector != null && item.Document.ChangeVector.Contains(ChangeVectorParser.TrxnTag))
                     {
-                        var key = ClusterTransactionCommand.GetAtomicGuardKey(item.Document.Id);
+                        var key = ClusterWideTransactionHelper.GetAtomicGuardKey(item.Document.Id);
                         await compareExchangeActions.WriteKeyValueAsync(key, null, item.Document);
                         continue;
                     }

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -19,9 +20,12 @@ using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Sharding;
+using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.Config.Settings;
 using Raven.Server.Documents;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
@@ -41,17 +45,17 @@ namespace SlowTests.Cluster
 
         protected override RavenServer GetNewServer(ServerCreationOptions options = null, [CallerMemberName] string caller = null)
         {
-            if (options == null)
-            {
-                options = new ServerCreationOptions();
-            }
+            options ??= new ServerCreationOptions();
+            options.CustomSettings ??= new Dictionary<string, string>();
 
-            if (options.CustomSettings == null)
-                options.CustomSettings = new Dictionary<string, string>();
+            if(options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)) == false)
+                options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "60";
+            
+            if(options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)) == false)
+                options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "10";
 
-            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.OperationTimeout)] = "60";
-            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "10";
-            options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "30000";
+            if(options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)) == false)
+                options.CustomSettings[RavenConfiguration.GetKey(x => x.Cluster.TcpConnectionTimeout)] = "30000";
 
             return base.GetNewServer(options, caller);
         }
@@ -1027,10 +1031,8 @@ namespace SlowTests.Cluster
                 var server = Servers[1];
                 var result1 = await DisposeServerAndWaitForFinishOfDisposalAsync(server);
 
-                using (var session = leaderStore.OpenAsyncSession(new SessionOptions
-                {
-                    TransactionMode = TransactionMode.ClusterWide
-                }))
+                const string id = "foo/bar/2";
+                using (var session = leaderStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
                     if (options.DatabaseMode == RavenDatabaseMode.Single)
                     {
@@ -1040,7 +1042,7 @@ namespace SlowTests.Cluster
                     Assert.Equal(leader.WebUrl, session.Advanced.RequestExecutor.Url);
                     session.Advanced.ClusterTransaction.CreateCompareExchangeValue("usernames/ayende", user1);
                     await session.StoreAsync(user3, "foo/bar");
-                    await session.StoreAsync(user1, "foo/bar/2");
+                    await session.StoreAsync(user1, id);
                     await session.SaveChangesAsync();
 
                     var user = (await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<User>("usernames/ayende")).Value;
@@ -1056,7 +1058,7 @@ namespace SlowTests.Cluster
 
                 using (var session = leaderStore.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
-                    session.Delete("foo/bar/2");
+                    session.Delete(id);
                     session.Advanced.WaitForIndexesAfterSaveChanges();
                     await session.SaveChangesAsync();
                 }
@@ -1084,7 +1086,9 @@ namespace SlowTests.Cluster
                 using (leader.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
                 using (ctx.OpenReadTransaction())
                 {
-                    lastRaftIndex = leader.ServerStore.Engine.GetLastCommitIndex(ctx);
+                    var documentDatabaseName = await GetDocumentDatabaseName(options, leaderStore, id);
+                    var database = await GetDatabase(leader, documentDatabaseName);
+                    lastRaftIndex = database.ClusterWideTransactionIndexWaiter.LastIndex;
                 }
 
                 // revive the SUT node
@@ -1145,12 +1149,10 @@ namespace SlowTests.Cluster
                             await leader.ServerStore.Engine.WaitForLeaveState(RachisState.Candidate, cts.Token);
                         }
 
-                        if (options.DatabaseMode == RavenDatabaseMode.Single)
-                        {
-                            var database = await Servers[1].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(leaderStore.Database);
-                            await database.RachisLogIndexNotifications.WaitForIndexNotification(lastRaftIndex, TimeSpan.FromSeconds(15));
-                        }
-
+                        var documentDatabaseName = await GetDocumentDatabaseName(options, revivedStore, id);
+                        var database = await GetDatabase(revived, documentDatabaseName);
+                        await database.ClusterWideTransactionIndexWaiter.WaitAsync(lastRaftIndex, TimeSpan.FromSeconds(15));
+                        
                         count = await WaitForValueAsync((async () =>
                         {
                             var list = await session.Advanced.Revisions.GetForAsync<User>("foo/bar");
@@ -1495,20 +1497,15 @@ namespace SlowTests.Cluster
 
                 using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
-                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(GetAtomicGuardKey("users/1")));
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(ClusterWideTransactionHelper.GetAtomicGuardKey("users/1")));
                     Assert.Contains($"'rvn-atomic/users/1' is an atomic guard and you cannot load it via the session", ex.Message);
                 }
 
                 using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
-                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue(GetAtomicGuardKey("users/2"), "foo");
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue(ClusterWideTransactionHelper.GetAtomicGuardKey("users/2"), "foo");
                     var ex = await Assert.ThrowsAsync<CompareExchangeInvalidKeyException>(() => session.SaveChangesAsync());
                     Assert.Contains($"You cannot manipulate the atomic guard 'rvn-atomic/users/2' via the cluster-wide session", ex.Message);
-                }
-
-                string GetAtomicGuardKey(string id)
-                {
-                    return $"{Constants.CompareExchange.RvnAtomicPrefix}{id}";
                 }
             }
         }
@@ -1589,5 +1586,659 @@ namespace SlowTests.Cluster
 
             return 0;
         }
+
+        class TestObj
+        {
+            public string Id { get; set; }
+            public string Prop { get; set; }
+            public string ExternalId { get; set; }
+        }
+
+        private class TestIndex : AbstractIndexCreationTask<TestObj>
+        {
+            public override string IndexName { get; }
+
+            public TestIndex(string name)
+            {
+                IndexName = name;
+                Map = testObjs => from user in testObjs
+                    select new { user.Prop };
+            }
+        }
+
+        private class TestCommand : DocumentMergedTransactionCommand
+        {
+            private readonly ManualResetEvent _manualResetEvent;
+            private readonly TimeSpan _timeout;
+
+            public TestCommand(ManualResetEvent manualResetEvent, TimeSpan timeout)
+            {
+                if (Debugger.IsAttached)
+                    timeout *= 10;
+                
+                _manualResetEvent = manualResetEvent;
+                _timeout = timeout;
+            }
+
+            protected override long ExecuteCmd(DocumentsOperationContext context)
+            {
+                _manualResetEvent.WaitOne(_timeout);
+                return 1;
+            }
+
+            public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ClusterTransaction_WhenLoadReturnEmptyAndCompareExchangeExit_ShouldStillThrowConcurrency(Options options, bool clusterTrxBefore)
+        {
+            const string id = "testObjs/1";
+            using var store = GetDocumentStore(options);
+
+            if (clusterTrxBefore)
+            {
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj());
+                await session.SaveChangesAsync();
+            }
+
+            using var mre = new ManualResetEvent(false);
+            try
+            {
+                var documentDatabaseName = await GetDocumentDatabaseName(options, store, id);
+                var database = await GetDatabase(documentDatabaseName);
+                var longCommandTask =  database.TxMerger.Enqueue(new TestCommand(mre, TimeSpan.FromSeconds(15)));
+                
+                var halfProcessedTask = Task.Run(async () =>
+                {
+                    using var session = store.OpenAsyncSession(new SessionOptions
+                    {
+                        TransactionMode = TransactionMode.ClusterWide
+                    });
+                    {
+                        await session.StoreAsync(new TestObj{Prop = "new 1"}, id);
+                        await session.SaveChangesAsync();
+                    }
+                });
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+
+                await Task.Delay(10);
+                //The origin issue occured if a cluster operation was made between the compare exchange operation to database operation
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex"));
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex2"));
+                
+                //Load can potentially also load the atomic guard and use it to generate the document change vector
+                Assert.Null(await session.LoadAsync<TestObj>(id));
+                await session.StoreAsync(new TestObj{ Prop = "new 2", Id = id });
+                Task shouldFailTask = session.SaveChangesAsync();
+                await Assert.ThrowsAnyAsync<ClusterTransactionConcurrencyException>( () => shouldFailTask);
+
+                mre.Set();
+                await Task.WhenAll(longCommandTask);
+                await halfProcessedTask;
+            }
+            finally
+            {
+                mre.Set();
+            }
+        }
+
+        private async Task<string> GetDocumentDatabaseName(Options options, IDocumentStore store, string id)
+        {
+            var shard = (options.DatabaseMode & RavenDatabaseMode.Single) != 0
+                ? ""
+                : $"${await Sharding.GetShardNumberForAsync(store, id)}";
+
+            var documentDatabaseName = $"{store.Database}{shard}";
+            return documentDatabaseName;
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task LoadAndIncludeClusterTrxCmpxchg_WhenCmpxchgIsFromLastClusterTransactionWithNoDatabaseCommand_ShouldGetCmpxchg(Options options)
+        {
+            const string cmpxchgId = "cmpxchg/0";
+            const string id = "testObjs/1";
+
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true}))
+            {
+                await session.StoreAsync(new TestObj{Prop = cmpxchgId }, id);
+                await session.SaveChangesAsync();
+            }
+            
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true}))
+            {
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(cmpxchgId, "some-value");
+                await session.SaveChangesAsync();
+            }
+            
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true}))
+            {
+                await session.LoadAsync<TestObj>(id, i => i.IncludeCompareExchangeValue(x => x.Prop));
+                var numberOfRequests = session.Advanced.NumberOfRequests;
+                var value = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(cmpxchgId);
+                Assert.NotNull(value);
+                Assert.Equal(numberOfRequests, session.Advanced.NumberOfRequests);
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task QueryAndIncludeClusterTrxCmpxchg_WhenDocumentsCommandsDidntFinished_ShouldNotReturnNull(Options options)
+        {
+            const string id1 = "testObjs/0";
+            const string id2 = "testObjs/1";
+            using var store = GetDocumentStore(options);
+            await store.ExecuteIndexAsync(new TestIndex("TestIndex"));
+
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new TestObj(), id1);
+                await session.SaveChangesAsync();
+            }
+            Indexes.WaitForIndexing(store);
+            
+            using var mre = new ManualResetEvent(false);
+            try
+            {
+                var documentDatabaseName = await GetDocumentDatabaseName(options, store, id2);
+                var database = await GetDatabase(documentDatabaseName);
+                var testCommandTask = database.TxMerger.Enqueue(new TestCommand(mre, TimeSpan.FromSeconds(15)));
+                
+                var halfProcessedTask = Task.Run(async () =>
+                {
+                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                    await session.StoreAsync(new TestObj { Prop = $"new 1", Id = id2 });
+                    session.Advanced.ClusterTransaction.CreateCompareExchangeValue(id1, "somevalue");
+                    await session.SaveChangesAsync();
+                });
+                
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                
+                await Task.Delay(10);
+                //The origin issue occured if a cluster operation was made between the compare exchange operation to database operation
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex2"));
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex3"));
+
+                _ = await session.Advanced
+                    .AsyncRawQuery<TestObj>(
+                        @"
+declare function incl(c) {
+    includes.cmpxchg($ce);
+    return c;
+}
+from index 'TestIndex' as c
+select incl(c)"
+                    )
+                    .AddParameter("ce", id1)
+                    .ToListAsync();
+                
+                var numberOfRequests = session.Advanced.NumberOfRequests;
+                Assert.NotNull(await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<object>(id1));
+                Assert.Equal(numberOfRequests, session.Advanced.NumberOfRequests);
+                
+                mre.Set();
+                await testCommandTask;
+                await halfProcessedTask;
+            }
+            finally
+            {
+                mre.Set();
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task QueryIndexAndIncludeClusterTrxCmpxchg_WhenModifiedButDocumentsCommandsDidntFinished_ShouldNotBeNull(Options options)
+        {
+            const string id1 = "testObjs/0";
+            const string id2 = "testObjs/1";
+            using var store = GetDocumentStore(options);
+            await store.ExecuteIndexAsync(new TestIndex("TestIndex"));
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true}))
+            {
+                await session.StoreAsync(new TestObj(), id1);
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(id1, "some-value");
+                await session.SaveChangesAsync();
+            }
+            Indexes.WaitForIndexing(store);
+            
+            using var mre = new ManualResetEvent(false);
+            try
+            {
+                var documentDatabaseName = await GetDocumentDatabaseName(options, store, id2);
+                var database = await GetDatabase(documentDatabaseName);
+                var testCommandTask = database.TxMerger.Enqueue(new TestCommand(mre, TimeSpan.FromSeconds(15)));
+
+                var halfProcessedTask = Task.Run(async () =>
+                {
+                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true });
+                    var cmpxchg = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(id1);
+                    cmpxchg.Value = "changed-value";
+                    await session.StoreAsync(new TestObj { Prop = $"new 1", Id = id2 });
+                    await session.SaveChangesAsync();
+                });
+                
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true });
+                
+                await Task.Delay(10);
+                //The origin issue occured if a cluster operation was made between the compare exchange operation to database operation
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex2"));
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex3"));
+
+                _ = await session.Advanced
+                    .AsyncRawQuery<TestObj>(
+                        @"
+declare function incl(c) {
+    includes.cmpxchg($ce);
+    return c;
+}
+from index 'TestIndex' as c
+select incl(c)"
+                    )
+                    .AddParameter("ce", id1)
+                    .ToListAsync();
+                
+                var numberOfRequests = session.Advanced.NumberOfRequests;
+                var compareExchangeValueAsync = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<object>(id1);
+                Assert.NotNull(compareExchangeValueAsync);
+                Assert.Equal(numberOfRequests, session.Advanced.NumberOfRequests);
+                
+                mre.Set();
+                await testCommandTask;
+                await halfProcessedTask;
+            }
+            finally
+            {
+                mre.Set();
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task QueryAndIncludeClusterTrxCmpxchg_WhenModifiedButDocumentsCommandsDidntFinished_ShouldNotBeNull(Options options)
+        {
+            const string id1 = "testObjs/0";
+            const string id2 = "testObjs/1";
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true}))
+            {
+                await session.StoreAsync(new TestObj(), id1);
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(id1, "some-value");
+                await session.SaveChangesAsync();
+            }
+            
+            using var mre = new ManualResetEvent(false);
+            try
+            {
+                var documentDatabaseName = await GetDocumentDatabaseName(options, store, id2);
+                var database = await GetDatabase(documentDatabaseName);
+                var testCommandTask = database.TxMerger.Enqueue(new TestCommand(mre, TimeSpan.FromSeconds(15)));
+
+                var halfProcessedTask = Task.Run(async () =>
+                {
+                    using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true });
+                    var cmpxchg = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(id1);
+                    cmpxchg.Value = "changed-value";
+                    await session.StoreAsync(new TestObj { Prop = $"new 1", Id = id2 });
+                    await session.SaveChangesAsync();
+                });
+                
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true });
+                
+                await Task.Delay(10);
+                //The origin issue occured if a cluster operation was made between the compare exchange operation to database operation
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex"));
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex2"));
+
+                _ = await session.Advanced
+                    .AsyncRawQuery<TestObj>(
+                        @"
+declare function incl(c) {
+    includes.cmpxchg($ce);
+    return c;
+}
+from TestObjs as c
+select incl(c)"
+                    )
+                    .AddParameter("ce", id1)
+                    .ToListAsync();
+                
+                var numberOfRequests = session.Advanced.NumberOfRequests;
+                var compareExchangeValueAsync = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<object>(id1);
+                Assert.NotNull(compareExchangeValueAsync);
+                Assert.Equal(numberOfRequests, session.Advanced.NumberOfRequests);
+                
+                mre.Set();
+                await testCommandTask;
+                await halfProcessedTask;
+            }
+            finally
+            {
+                mre.Set();
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task QueryIncludeCmpxchg_WhenEmpty_ShouldNotCreateAdditionalRequest(Options options)
+        {
+            const string notExistCmpxchgId = "not-exist";
+            using var store = GetDocumentStore(options); 
+            await store.ExecuteIndexAsync(new TestIndex("TestIndex"));
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new TestObj());
+                await session.SaveChangesAsync();
+            }
+            Indexes.WaitForIndexing(store);
+            
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                _ = await session.Advanced
+                    .AsyncRawQuery<TestObj>(
+                        @"
+declare function incl(c) {
+    includes.cmpxchg($ce);
+    return c;
+}
+from index 'TestIndex' as c
+select incl(c)"
+                    )
+                    .AddParameter("ce", notExistCmpxchgId)
+                    .ToListAsync();
+                
+                var numberOfRequests = session.Advanced.NumberOfRequests;
+                var cmpxchg = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<object>(notExistCmpxchgId);
+                Assert.Null(cmpxchg);
+                Assert.Equal(numberOfRequests, session.Advanced.NumberOfRequests);
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.CompareExchange | RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void LoadIncludeCmpxchg_WhenGet_ShouldNotTriggerAdditionalRequest(Options options)
+        {
+            const string docId = "testObjs/0";
+            const string cmpxchgId = "cmpxchg/0";
+
+            using (var store = GetDocumentStore(options))
+            {                
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new TestObj{Prop = cmpxchgId}, docId);
+                    session.SaveChanges();
+                    
+                    var test = store.Operations.Send(
+                        new PutCompareExchangeValueOperation<string>(cmpxchgId, "some content", 0));
+                    Assert.Equal(true, test.Successful);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    _ = session.Load<TestObj>(docId,
+                        includes => includes.IncludeCompareExchangeValue(x => x.Prop));
+                    
+                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                    _ = session.Advanced.ClusterTransaction.GetCompareExchangeValue<string>(cmpxchgId);
+                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                }
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task LoadClusterWideSession_WhenDeletedWithoutClusterWideSessionAndClusterWideTransactionInProcess_ShouldNotReturnAtomicGuard(Options options)
+        {
+            using var store = GetDocumentStore(options);
+            using var store2 = new DocumentStore{Urls = store.Urls, Database = store.Database}.Initialize();
+
+            const string id = "foo/bar";
+            using (var session = store.OpenAsyncSession(new SessionOptions
+                   {
+                       TransactionMode = TransactionMode.ClusterWide
+                   }))
+            {
+                await session.StoreAsync(new TestObj(), id);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete(id);
+                await session.SaveChangesAsync();
+            }
+
+            using var mre = new ManualResetEvent(false);
+            try
+            {
+                var documentDatabaseName = await GetDocumentDatabaseName(options, store, id);
+                var database = await GetDatabase(documentDatabaseName);
+                var testCommandTask = database.TxMerger.Enqueue(new TestCommand(mre, TimeSpan.FromSeconds(15)));
+
+                var halfProcessedTask = Task.Run(async () =>
+                {
+                    using var session = store.OpenAsyncSession(new SessionOptions
+                    {
+                        TransactionMode = TransactionMode.ClusterWide
+                    });
+                    {
+                        Assert.Null(await session.LoadAsync<TestObj>(id));
+                        await session.StoreAsync(new TestObj(), id);
+
+                        await session.SaveChangesAsync();
+                    }
+                });
+                using var session2 = store2.OpenAsyncSession(new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide
+                });
+
+                await Task.Delay(10);
+                //The origin issue occured if a cluster operation was made between the compare exchange operation to database operation
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex1"));
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex2"));
+
+                Assert.Null(await session2.LoadAsync<TestObj>(id));
+                await session2.StoreAsync(new TestObj(), id);
+                var shouldFailTask = session2.SaveChangesAsync();
+                await Assert.ThrowsAnyAsync<ClusterTransactionConcurrencyException>(() => shouldFailTask);
+
+                mre.Set();
+                await testCommandTask;
+                await halfProcessedTask;
+            }
+            finally
+            {
+                mre.Set();
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task DatabaseRequest_WhenHasLastClusterTransaction_ShouldWaitForIndex(Options options, bool withClusterTrxBefore)
+        {
+            const string id = "testObjs/0";
+            var cmpXchgKey = "cmpXchgKey";
+
+            var server = GetNewServer();
+            options.Server = server;
+            using var store = GetDocumentStore(options);
+            using var store2 = new DocumentStore{Urls = store.Urls, Database = store.Database}.Initialize();
+
+            if (withClusterTrxBefore)
+            {
+                using var session = store2.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj());
+                await session.SaveChangesAsync();
+            }
+            
+            using  (var session = store2.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(cmpXchgKey, "some-value");
+                await session.SaveChangesAsync();
+            }
+
+            var documentDatabaseName = await GetDocumentDatabaseName(options, store, id);
+            var database = await GetDatabase(server, documentDatabaseName);
+            var index = database.ClusterWideTransactionIndexWaiter.LastIndex + 5;
+            
+            store.SetLastTransactionIndex(store.Database, index);
+
+            var tcs = new CancellationTokenSource();
+            var shouldBeCompletedWhenReachIndexTask = Task.Run(async () =>
+            {
+                using var session = store.OpenAsyncSession();
+                await session.LoadAsync<TestObj>(id, tcs.Token);
+            });
+            
+            while(true)
+            {
+                using var session = store2.OpenAsyncSession(new SessionOptions{TransactionMode = TransactionMode.ClusterWide});
+                
+                // ReSharper disable once MethodSupportsCancellation
+                var cmpXchg = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(cmpXchgKey);
+                cmpXchg.Value = Guid.NewGuid().ToString();
+                // ReSharper disable once MethodSupportsCancellation
+                await session.SaveChangesAsync();
+                if(cmpXchg?.Index >= index)
+                    break;
+                // ReSharper disable once MethodSupportsCancellation
+                await Task.Delay(100);
+                Assert.False(shouldBeCompletedWhenReachIndexTask.IsCompleted);
+            }
+
+            tcs.CancelAfter(TimeSpan.FromSeconds(10));
+            await shouldBeCompletedWhenReachIndexTask;
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task DatabaseRequest_WhenLastClusterTrxWasDeleteCmpxchg_ShouldNotHang(Options options, bool withClusterTrxBefore)
+        {
+            const string id = "TestObjs/1";
+            var cmpXchgKey = "cmpXchgKey";
+
+            var server = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = new Dictionary<string, string>()
+                {
+                    [RavenConfiguration.GetKey(x => x.Cluster.SupervisorSamplePeriod)] = "50",
+                    [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
+                }
+            });
+
+            server.Configuration.Cluster.CompareExchangeTombstonesCleanupInterval = new TimeSetting(100, TimeUnit.Milliseconds);
+            options.Server = server;
+            using var store = GetDocumentStore(options);
+            using var store2 = new DocumentStore
+            {
+                Database = store.Database,
+                Urls = store.Urls
+            }.Initialize();
+
+            if (withClusterTrxBefore)
+            {
+                using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+                await session.StoreAsync(new TestObj(), "TestObjs/0");
+                await session.SaveChangesAsync();
+            }
+            
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(cmpXchgKey, "some-value");
+                await session.SaveChangesAsync();
+            }
+
+            var mre = new ManualResetEvent(false);
+            try
+            {
+                WaitForUserToContinueTheTest(store);
+                var documentDatabaseName = await GetDocumentDatabaseName(options, store, id);
+                var database = await GetDatabase(server, documentDatabaseName);
+                var testCommandTask = database.TxMerger.Enqueue(new TestCommand(mre, TimeSpan.FromSeconds(15)));
+
+                var executeClusterTransactionHangTask = Task.Run(async () =>
+                {
+                    //This task should hang the DocumentDatabase.ExecuteClusterTransaction
+                    // ReSharper disable once AccessToDisposedClosure
+                    using (var session = store2.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                    {
+                        await session.StoreAsync(new TestObj(), id);
+                        await session.SaveChangesAsync();
+                    }
+                });
+
+                await Task.Delay(1);
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex1"));
+                await store.ExecuteIndexAsync(new TestIndex("TestIndex2"));
+                
+                using  (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var cmpXchg = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(cmpXchgKey);
+                    session.Advanced.ClusterTransaction.DeleteCompareExchangeValue(cmpXchg);
+                    await session.SaveChangesAsync();
+                }
+            
+                await Task.Delay(1000);
+                
+                mre.Set();
+                await testCommandTask;
+                await executeClusterTransactionHangTask;
+            }
+            finally
+            {
+                mre.Set();
+            }
+            
+            using  (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                var tokenSource = new CancellationTokenSource();
+                tokenSource.CancelAfter(TimeSpan.FromSeconds(15));
+                
+                //For the test it can be any database request and should not hang
+                await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(cmpXchgKey, tokenSource.Token);
+            }
+        }
+        
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task DatabaseRequest_WhenWaitForIndexAndClusterTransactionHasError_ShouldThrow(Options options)
+        {
+            const string id = "testObjs/0";
+            
+            using var store = GetDocumentStore(options);
+            
+            var documentDatabaseName = await GetDocumentDatabaseName(options, store, id);
+            var database = await GetDatabase(documentDatabaseName);
+
+            store.SetLastTransactionIndex(store.Database, long.MaxValue);
+            
+            using var session = store.OpenAsyncSession();
+            var t = session.LoadAsync<TestObj>(id);
+            database.ClusterWideTransactionIndexWaiter.NotifyListenersAboutError(new TestException());
+            var exception = await Assert.ThrowsAnyAsync<RavenException>(() => t);
+            const string expected = "Exception of type 'SlowTests.Cluster.ClusterTransactionTests+TestException' was thrown";
+            Assert.Contains(expected, exception.Message);
+        }
+
+        private class TestException : Exception 
+        {
+            
+        }
+        
     }
 }

--- a/test/SlowTests/Issues/RavenDB-17872.cs
+++ b/test/SlowTests/Issues/RavenDB-17872.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Session;
-using Raven.Server.ServerWide.Commands;
+using Raven.Client.Util;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -262,9 +262,9 @@ namespace SlowTests.Issues
                 }
 
                 var compareExchangeValue =
-                    await store.Operations.SendAsync(new GetCompareExchangeValueOperation<AtomicGuard>(ClusterTransactionCommand.GetAtomicGuardKey("users/1")));
+                    await store.Operations.SendAsync(new GetCompareExchangeValueOperation<AtomicGuard>(ClusterWideTransactionHelper.GetAtomicGuardKey("users/1")));
                 compareExchangeValue.Metadata.Add(Constants.Documents.Metadata.Expires, DateTime.UtcNow.AddHours(1));
-                await store.Operations.SendAsync(new PutCompareExchangeValueOperation<AtomicGuard>(ClusterTransactionCommand.GetAtomicGuardKey("users/1"), compareExchangeValue.Value, compareExchangeValue.Index));
+                await store.Operations.SendAsync(new PutCompareExchangeValueOperation<AtomicGuard>(ClusterWideTransactionHelper.GetAtomicGuardKey("users/1"), compareExchangeValue.Value, compareExchangeValue.Index));
 
                 using (var session = store.OpenAsyncSession(new SessionOptions() { TransactionMode = TransactionMode.ClusterWide }))
                 {

--- a/test/SlowTests/Issues/RavenDB_14006.cs
+++ b/test/SlowTests/Issues/RavenDB_14006.cs
@@ -506,7 +506,7 @@ select incl(c)"
                     }
 
                     foreach (var database in databases)
-                        await database.RachisLogIndexNotifications.WaitForIndexNotification(lastClusterTxIndex, TimeSpan.FromSeconds(5));
+                        await database.ClusterWideTransactionIndexWaiter.WaitAsync(lastClusterTxIndex, TimeSpan.FromSeconds(5));
 
                     companies = session.Advanced
                         .RawQuery<Company>(

--- a/test/SlowTests/Issues/RavenDB_20150.cs
+++ b/test/SlowTests/Issues/RavenDB_20150.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
 using Raven.Server.Config;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
@@ -92,6 +93,13 @@ public class RavenDB_20150 : ClusterTestBase
                 }, true);
 
                 Assert.True(done);
+
+                //Running cluster transaction to immediately mark the tombstone as handled by the cluster transaction mechanism and allow cleaning it
+                using (var session = store.OpenAsyncSession(new SessionOptions{TransactionMode = TransactionMode.ClusterWide, DisableAtomicDocumentWritesInClusterWideTransaction = true}))
+                {
+                    await session.StoreAsync(new TestOjb());
+                    await session.SaveChangesAsync();
+                }
             }
 
             //unsuspend and wait for the tombstone cleaner
@@ -120,5 +128,10 @@ public class RavenDB_20150 : ClusterTestBase
                 Assert.Equal(0, numOfCompareExchanges);
             }
         }
+    }
+    
+    private class TestOjb
+    {
+        public string Id { get; set; }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_20206.cs
+++ b/test/SlowTests/Issues/RavenDB_20206.cs
@@ -63,7 +63,7 @@ public class RavenDB_20206 : RavenTestBase
             using (context.OpenReadTransaction())
             {
                 // clean tombstones
-                var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store1.Database, context);
+                var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store1.Database, server, true);
                 Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
             }
 
@@ -85,7 +85,7 @@ public class RavenDB_20206 : RavenTestBase
             using (context.OpenReadTransaction())
             {
                 // clean tombstones
-                var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store2.Database, context);
+                var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store2.Database, server, true);
                 Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
             }
 

--- a/test/SlowTests/Issues/RavenDB_20206.cs
+++ b/test/SlowTests/Issues/RavenDB_20206.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Server;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.ServerWide.Maintenance;
+using SlowTests.Utils;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -62,7 +63,7 @@ public class RavenDB_20206 : RavenTestBase
             using (context.OpenReadTransaction())
             {
                 // clean tombstones
-                var cleanupState = await CleanupCompareExchangeTombstonesAsync(server, store1.Database, context);
+                var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store1.Database, context);
                 Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
             }
 
@@ -84,7 +85,7 @@ public class RavenDB_20206 : RavenTestBase
             using (context.OpenReadTransaction())
             {
                 // clean tombstones
-                var cleanupState = await CleanupCompareExchangeTombstonesAsync(server, store2.Database, context);
+                var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store2.Database, context);
                 Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
             }
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
@@ -16,6 +16,7 @@ using Raven.Server.Config.Settings;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.ServerWide.Maintenance;
 using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Utils;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
 using Sparrow.Utils;
@@ -1189,7 +1190,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             using (var server = GetNewServer())
             {
                 options.Server = server;
-                using (var store = GetDocumentStore(new Options {Server = server}))
+                using (var store = GetDocumentStore(new Options { Server = server }))
                 {
                     Cluster.WaitForFirstCompareExchangeTombstonesClean(server);
                     var count = 1;
@@ -1198,7 +1199,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     for (int i = 0; i < number; i++)
                     {
                         var k = i % 20;
-                        var user = new User {Name = $"emoji_{i}"};
+                        var user = new User { Name = $"emoji_{i}" };
                         var str = "";
                         for (int j = 0; j < count; j++)
                         {
@@ -1268,7 +1269,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     using (context.OpenReadTransaction())
                     {
                         // clean tombstones
-                        var cleanupState = await CleanupCompareExchangeTombstones(server, store.Database, context);
+                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
                         Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                     }
 
@@ -1369,7 +1370,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     using (context.OpenReadTransaction())
                     {
                         // clean tombstones
-                        var cleanupState = await CleanupCompareExchangeTombstones(server, store.Database, context);
+                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
                         Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                     }
 
@@ -1440,7 +1441,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     var numOfCompareExchangeTombstones = server.ServerStore.Cluster.GetNumberOfCompareExchangeTombstones(context, store.Database);
                     Assert.Equal(1, numOfCompareExchangeTombstones);
 
-                    await CleanupCompareExchangeTombstones(server, store.Database, context);
+                    await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
                 }
                 using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                 using (context.OpenReadTransaction())
@@ -1471,7 +1472,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(1, numOfCompareExchangeTombstones);
 
                     // clean tombstones
-                    var cleanupState = await CleanupCompareExchangeTombstones(server, store.Database, context);
+                    var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
                     Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                 }
                 using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
@@ -1613,7 +1614,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         var numOfCompareExchangeTombstones = server.ServerStore.Cluster.GetNumberOfCompareExchangeTombstones(context, store.Database);
                         Assert.Equal(1, numOfCompareExchangeTombstones);
 
-                        var cleanupState = await CleanupCompareExchangeTombstones(server, store.Database, context);
+                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
                         Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.InvalidPeriodicBackupStatus, cleanupState);
                     }
                     using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
@@ -1674,7 +1675,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         Assert.Equal(1, numOfCompareExchangeTombstones);
 
                         // clean tombstones
-                        var cleanupState = await CleanupCompareExchangeTombstones(server, store.Database, context);
+                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
                         Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                     }
                     using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
@@ -1791,7 +1792,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(1, numOfCompareExchangeTombstones);
 
                     // clean tombstones
-                    var cleanupState = await CleanupCompareExchangeTombstones(server, store.Database, context);
+                    var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
                     Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                 }
                 using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
@@ -1269,7 +1269,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     using (context.OpenReadTransaction())
                     {
                         // clean tombstones
-                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
+                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store.Database, server, true);
                         Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                     }
 
@@ -1370,7 +1370,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     using (context.OpenReadTransaction())
                     {
                         // clean tombstones
-                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
+                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store.Database, server, true);
                         Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                     }
 
@@ -1441,7 +1441,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     var numOfCompareExchangeTombstones = server.ServerStore.Cluster.GetNumberOfCompareExchangeTombstones(context, store.Database);
                     Assert.Equal(1, numOfCompareExchangeTombstones);
 
-                    await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
+                    await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store.Database, server, true);
                 }
                 using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                 using (context.OpenReadTransaction())
@@ -1472,7 +1472,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(1, numOfCompareExchangeTombstones);
 
                     // clean tombstones
-                    var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
+                    var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store.Database, server, true);
                     Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                 }
                 using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
@@ -1614,7 +1614,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         var numOfCompareExchangeTombstones = server.ServerStore.Cluster.GetNumberOfCompareExchangeTombstones(context, store.Database);
                         Assert.Equal(1, numOfCompareExchangeTombstones);
 
-                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
+                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store.Database, server, true);
                         Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.InvalidPeriodicBackupStatus, cleanupState);
                     }
                     using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
@@ -1675,7 +1675,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         Assert.Equal(1, numOfCompareExchangeTombstones);
 
                         // clean tombstones
-                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
+                        var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store.Database, server, true);
                         Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                     }
                     using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
@@ -1792,7 +1792,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.Equal(1, numOfCompareExchangeTombstones);
 
                     // clean tombstones
-                    var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(server, store.Database, context);
+                    var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store.Database, server, true);
                     Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
                 }
                 using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))

--- a/test/SlowTests/Utils/CompareExchangeTombstonCleanerTestHelper.cs
+++ b/test/SlowTests/Utils/CompareExchangeTombstonCleanerTestHelper.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Server;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.ServerWide.Maintenance;
+using Xunit;
+
+namespace SlowTests.Utils;
+
+internal static class CompareExchangeTombstoneCleanerTestHelper
+{
+    public static async Task<ClusterObserver.CompareExchangeTombstonesCleanupState> Clean(RavenServer server, string database, ClusterOperationContext context)
+    {
+        CleanCompareExchangeTombstonesCommand cmd;
+        var serverStore = server.ServerStore;
+        using (var rawRecord = serverStore.Cluster.ReadRawDatabaseRecord(context, database))
+        {
+            var report = new Dictionary<string, DatabaseStatusReport>
+            {
+                { database, new DatabaseStatusReport { Name = database, LastClusterWideTransactionRaftIndex = long.MaxValue } }
+            };
+            var current = rawRecord.Topology.AllNodes.ToDictionary(x => x,
+                _ => new ClusterNodeStatusReport(new ServerReport(), report, ClusterNodeStatusReport.ReportStatus.Ok, null, DateTime.UtcNow, null));
+            var state = new ClusterObserver.DatabaseObservationState(database, rawRecord, rawRecord.Topology, serverStore.GetClusterTopology(context), current, null, 0,
+                0);
+            var mergedState = new ClusterObserver.MergedDatabaseObservationState(rawRecord, state);
+            cmd = serverStore.Observer.GetCompareExchangeTombstonesToCleanup(database, mergedState, context, out var cleanupState);
+            if (cleanupState != ClusterObserver.CompareExchangeTombstonesCleanupState.HasMoreTombstones)
+                return cleanupState;
+
+            Assert.NotNull(cmd);
+        }
+
+        var result = await serverStore.SendToLeaderAsync(cmd);
+        await serverStore.Cluster.WaitForIndexNotification(result.Index);
+
+        var hasMore = (bool)result.Result;
+        return hasMore
+            ? ClusterObserver.CompareExchangeTombstonesCleanupState.HasMoreTombstones
+            : ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones;
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22294
https://issues.hibernatingrhinos.com/issue/RavenDB-22258

### V5.4 PR
https://github.com/ravendb/ravendb/pull/18503

### Additional description

#### Atomic Guard
To allow to recreate an atomic-guard-protected document after deleting it by a non-cluster-wide transaction
we include its atomic guard when loading the document and with it, we set the right change vector in the batch request (`SaveChanges`).
The atomic guard must be associated with the result of the load - no document.
If a cluster transaction that recreates the is in process and its compare-exchange part is already finished but the document part is not we can't use this compare-exchange.
To avoid that we need to check the cluster part and the database part of the cluster transaction are aligned (for the loaded document).
Using `Database.RachisLogIndexNotifications.LastModifiedIndex` is problematic since it is modified in other places rather than after a cluster transaction is done.
To solve that we rely here on what was `Database.LastCompletedClusterTransactionIndex` and it was changed to a "waiter" object to allow waiting on it the the `RequestRouter".
If the `atomic guard` is newer than the max version allowed for the document we considered it as we didn't find the `atomic guard`.

#### Compare Exchange (cmpXchg)
Besides the atomic guard case, we also need to consider including compare-exchange.
While in the `atomic guard`, we can tread too new atomic guard like there is no atomic guard (we just need it to throw concurrency exception) 
for `compare exchange` we can't.
It will be very surprising to modify an `atomic guard` and then get a null after including it in a load.
The decision is to return the "too" new `compare exchange`.

#### The problem
Consider the following  (let's assume the `atomic guard` is disabled to simplify):
* A document with cmpXchg is created - **doc:v1 cmpXchg:v1**.
* Another cluster transaction is triggered but only the cmpXchg is completed - **doc:v1 cmpXchg:v2** 
* The client loads the document and includes the cmpXchg  - **doc:v1 cmpXchg:v2**.
* The client modifies the document and to ensure no concurrency the `compare exchange` is also modified.
* The client triggers `SaveChanges`

With the current implementation, doc version 3 will override doc version 2 with no concurrency exception.

#### To document
To deal with that the client must keep information in both the document and its `compare exchange` to validate they are aligned with each other.

#### Additional:
In this PR we also addressed the issue when we included a cmpXchg so getting it should not trigger additional requests.
This was handled for both existing and non-existent cmpXchg

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
