### PR TITLE
RavenDB-22559 put database command should be redirect to the leader

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -608,19 +608,22 @@ namespace Raven.Server.Rachis
             return false;
         }
 
-        public async Task WaitForLeaderChange(CancellationToken cts)
+        public async Task WaitForLeaderChange(CancellationToken token) => await WaitForLeaderChange(LeaderTag, token);
+
+        public async Task<string> WaitForLeaderChange(string leader, CancellationToken token)
         {
-            var currentLeader = LeaderTag;
-            while (cts.IsCancellationRequested == false)
+            while (token.IsCancellationRequested == false)
             {
                 // we setup the wait _before_ checking the state
-                var task = _stateChanged.Task.WithCancellation(cts);
-
-                if (currentLeader != GetLeaderTag(safe: true))
-                    return;
+                var task = _stateChanged.Task.WithCancellation(token);
+                var current = GetLeaderTag(safe: true);
+                if (leader != current)
+                    return current;
 
                 await task;
             }
+
+            return null;
         }
 
         public async Task<bool> WaitForLeaveState(RachisState rachisState, CancellationToken cts)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3342,6 +3342,39 @@ namespace Raven.Server.ServerWide
             if (clusterTopology.Members.TryGetValue(engineLeaderTag, out string leaderUrl) == false)
                 throw new InvalidOperationException("Leader " + engineLeaderTag + " was not found in the topology members");
 
+            var requestExecutor = GetLeaderRequestExecutor(context, engineLeaderTag);
+
+            cmdJson.TryGet("Type", out string commandType);
+            var command = new PutRaftCommand(requestExecutor.Conventions, cmdJson, _engine.Url, commandType)
+            {
+                Timeout = cmd.Timeout
+            };
+
+            try
+            {
+                await requestExecutor.ExecuteAsync(command, context, token: token);
+            }
+            catch
+            {
+                reachedLeader.Value = command.HasReachLeader();
+                throw;
+            }
+
+            return (command.Result.RaftCommandIndex, command.Result.Data);
+        }
+        
+        public RequestExecutor GetLeaderRequestExecutor(TransactionOperationContext context, string leaderTag)
+        {
+            if (string.IsNullOrEmpty(leaderTag))
+                throw new NoLeaderException();
+
+            ClusterTopology clusterTopology;
+            using (context.OpenReadTransaction())
+                clusterTopology = _engine.GetTopology(context);
+
+            if (clusterTopology.Members.TryGetValue(leaderTag, out string leaderUrl) == false)
+                throw new InvalidOperationException("Leader " + leaderTag + " was not found in the topology members");
+
             var serverCertificateChanged = Interlocked.Exchange(ref _serverCertificateChanged, 0) == 1;
 
             if (_leaderRequestExecutor == null
@@ -3352,23 +3385,7 @@ namespace Raven.Server.ServerWide
                 Interlocked.Exchange(ref _leaderRequestExecutor, newExecutor);
             }
 
-            cmdJson.TryGet("Type", out string commandType);
-            var command = new PutRaftCommand(_leaderRequestExecutor.Conventions, cmdJson, _engine.Url, commandType)
-            {
-                Timeout = cmd.Timeout
-            };
-
-            try
-            {
-                await _leaderRequestExecutor.ExecuteAsync(command, context, token: token);
-            }
-            catch
-            {
-                reachedLeader.Value = command.HasReachLeader();
-                throw;
-            }
-
-            return (command.Result.RaftCommandIndex, command.Result.Data);
+            return _leaderRequestExecutor;
         }
 
         protected internal async Task WaitForExecutionOnSpecificNodeAsync(JsonOperationContext context, string node, long index)

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -20,6 +20,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Extensions;
@@ -193,15 +194,17 @@ namespace Raven.Server.Web.System
         public async Task Put()
         {
             var raftRequestId = GetRaftRequestIdFromQuery();
-
+            
             await ServerStore.EnsureNotPassiveAsync();
-            using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-            using (context.OpenReadTransaction())
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
                 var index = GetLongFromHeaders("ETag");
                 var replicationFactor = GetIntValueQueryString("replicationFactor", required: false) ?? 1;
                 var json = await context.ReadForDiskAsync(RequestBodyStream(), "Database Record");
                 var databaseRecord = JsonDeserializationCluster.DatabaseRecord(json);
+
+                if (await ProxyToLeaderIfNeeded(context, databaseRecord, replicationFactor, index))
+                    return;
 
                 if (LoggingSource.AuditLog.IsInfoEnabled)
                 {
@@ -298,6 +301,40 @@ namespace Raven.Server.Web.System
             }
         }
 
+        private async Task<bool> ProxyToLeaderIfNeeded(TransactionOperationContext context, DatabaseRecord databaseRecord, int replicationFactor, long? index)
+        {
+            var leaderTag = ServerStore.Engine.LeaderTag;
+            if (leaderTag == null)
+            {
+                using (var cts = CreateHttpRequestBoundTimeLimitedOperationToken(TimeSpan.FromSeconds(15)))
+                {
+                    leaderTag = await ServerStore.Engine.WaitForLeaderChange(leader: null, cts.Token);
+                }
+            }
+            if (leaderTag != ServerStore.NodeTag)
+            {
+                // proxy the command to the leader
+                var leaderRequestExecutor = ServerStore.GetLeaderRequestExecutor(context, leaderTag);
+                var command = new CreateDatabaseOperation.CreateDatabaseCommand(DocumentConventions.Default, databaseRecord, replicationFactor, index);
+                await leaderRequestExecutor.ExecuteAsync(command, context);
+                HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;
+
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
+                {
+                    context.Write(writer, new DynamicJsonValue
+                    {
+                        [nameof(DatabasePutResult.RaftCommandIndex)] = command.Result.RaftCommandIndex,
+                        [nameof(DatabasePutResult.Name)] = command.Result.Name,
+                        [nameof(DatabasePutResult.Topology)] = command.Result.Topology.ToJson(),
+                        [nameof(DatabasePutResult.NodesAddedTo)] = command.Result.NodesAddedTo
+                    });
+                }
+                return true;
+            }
+
+            return false;
+        }
+
         private void RecreateIndexes(string databaseName, DatabaseRecord databaseRecord)
         {
             var databaseConfiguration = ServerStore.DatabasesLandlord.CreateDatabaseConfiguration(databaseName, true, true, true, databaseRecord);
@@ -390,7 +427,7 @@ namespace Raven.Server.Web.System
             }
         }
 
-        private async Task<(long Index, DatabaseTopology Topology, List<string> Urls)> CreateDatabase(string name, DatabaseRecord databaseRecord, ClusterOperationContext context, int replicationFactor, long? index, string raftRequestId)
+        private async Task<(long Index, DatabaseTopology Topology, List<string> Urls)> CreateDatabase(string name, DatabaseRecord databaseRecord, TransactionOperationContext context, int replicationFactor, long? index, string raftRequestId)
         {
             var (newIndex, result) = await ServerStore.WriteDatabaseRecordAsync(name, databaseRecord, index, raftRequestId, replicationFactor: replicationFactor);
             await ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, newIndex);
@@ -406,16 +443,15 @@ namespace Raven.Server.Web.System
                     $"The database '{name}' was created but is not accessible, because one or more of the nodes on which this database was supposed to reside on, threw an exception.", e);
             }
 
-            var clusterTopology = ServerStore.GetClusterTopology(context);
-            var nodeUrlsAddedTo = new List<string>();
-            foreach (var member in members)
+            using (context.OpenReadTransaction())
             {
-                nodeUrlsAddedTo.Add(clusterTopology.GetUrlFromTag(member));
-            }
+                var clusterTopology = ServerStore.GetClusterTopology(context);
+                var nodeUrlsAddedTo = new List<string>();
+                foreach (var member in members)
+                {
+                    nodeUrlsAddedTo.Add(clusterTopology.GetUrlFromTag(member));
+                }
 
-            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-            using (ctx.OpenReadTransaction())
-            {
                 DatabaseTopology topology;
                 if (databaseRecord.IsSharded)
                 {
@@ -426,7 +462,7 @@ namespace Raven.Server.Web.System
                 }
                 else
                 {
-                    topology = ServerStore.Cluster.ReadDatabaseTopology(ctx, name);
+                    topology = ServerStore.Cluster.ReadDatabaseTopology(context, name);
                 }
                 return (newIndex, topology, nodeUrlsAddedTo);
             }
@@ -1254,9 +1290,8 @@ namespace Raven.Server.Web.System
             if (ResourceNameValidator.IsValidResourceName(databaseName, dataDirectoryThatWillBeUsed, out string errorMessage) == false)
                 throw new BadRequestException(errorMessage);
 
-            using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {
-                context.OpenReadTransaction();
                 await CreateDatabase(databaseName, configuration.DatabaseRecord, context, 1, null, RaftIdGenerator.NewId());
             }
 

--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -154,7 +154,18 @@ namespace RachisTests
             var (_, leader) = await CreateRaftCluster(5, leaderIndex: 0);
             var serverToDispose = Servers[1];
             await DisposeServerAndWaitForFinishOfDisposalAsync(serverToDispose);
-            Assert.Equal(WaitForValue(() => leader.ServerStore.GetNodesStatuses().Count(n => n.Value.Connected), 3), 3);
+
+            var actual = await WaitForValueAsync(async () =>
+            {
+                var count = -1;
+                await ActionWithLeader(l =>
+                {
+                    count = l.ServerStore.GetNodesStatuses().Count(n => n.Value.Connected);
+                });
+                return count;
+            }, 3);
+
+            Assert.Equal(3, actual);
 
             for (int i = 0; i < 5; i++)
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22559

### Additional description

cherry-pick from 5.4 version https://github.com/ravendb/ravendb/pull/18835

Only the leader knows the true liveness status of the nodes and can assign the topology properly

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
