### PR TITLE
RavenDB-22696 Adding sharding prefixes when creating DB: Remove warning text

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepReplicationAndSharding.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepReplicationAndSharding.tsx
@@ -204,7 +204,7 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
                                     <br />
                                     <small className="text-muted">
                                         Manage document distribution by defining
-                                        <br />a prefix for document names
+                                        <br />a prefix for document IDs
                                     </small>
                                 </FormSwitch>
                             </Collapse>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/StepShardingPrefixes.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/StepShardingPrefixes.tsx
@@ -77,14 +77,6 @@ export default function StepShardingPrefixes() {
                 <Icon icon="plus" />
                 Add prefix
             </Button>
-
-            <div className="d-flex justify-content-center mt-3">
-                <Alert color="warning">
-                    Sharding prefixes can be defined only when creating a database, and cannot be modified.
-                    <br />
-                    Make sure everything is set up correctly.
-                </Alert>
-            </div>
         </div>
     );
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22696/Adding-sharding-prefixes-when-creating-DB-Remove-warning-text

### Additional description
Since you can add/delete prefixes for shards via operations:
```DeletePrefixedShardingSettingOperation, AddPrefixedShardingSettingOperation```

then it is better to remove this misleading text from the db creation view:
```...Sharding prefixes can be defined only when creating a database, and cannot be modified...```

### Type of change
- [x] Bug fix - Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed - handled in issue: 
https://issues.hibernatingrhinos.com/issue/RDoc-2924/Documentation-for-Shard-By-Prefix

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
