### PR TITLE
RavenDB-22617 Fixing debug assertion. We do have the handling for Slice type

### DIFF
--- a/src/Corax/Querying/IndexSearcher.Aggregations.cs
+++ b/src/Corax/Querying/IndexSearcher.Aggregations.cs
@@ -60,7 +60,7 @@ public partial class IndexSearcher
     public IAggregationProvider BetweenAggregation<TValue>(in FieldMetadata field, TValue low, TValue high,
         UnaryMatchOperation leftSide = UnaryMatchOperation.GreaterThanOrEqual, UnaryMatchOperation rightSide = UnaryMatchOperation.LessThanOrEqual, bool forward = true)
     {
-        Debug.Assert(low is double or string, "value is double or string");
+        Debug.Assert(low is double or string or Slice, "value is double or string or Slice");
         
         if (typeof(TValue) == typeof(double))
         {


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22690/SlowTests.Issues.RavenDB10538.TestGeneratedFacetsTestoptions-DatabaseMode-Sharded-SearchEngineMode-Corax

https://issues.hibernatingrhinos.com/issue/RavenDB-22691/SlowTests.Issues.RavenDB9481.AggregateQueryTestoptions-DatabaseMode-Sharded-SearchEngineMode-Corax

### Additional description

Missing check in Debug.Assert

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
