### PR TITLE
RavenDB-22683 - Error during replication

### DIFF
--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -452,6 +452,7 @@ namespace Raven.Server.Documents.Replication.Incoming
             {
                 SourceDatabaseId = ConnectionInfo.SourceDatabaseId,
                 SupportedFeatures = SupportedFeatures,
+                IncomingHandler = this,
                 Logger = Logger
             })
             {
@@ -690,6 +691,8 @@ namespace Raven.Server.Documents.Replication.Incoming
             internal ReplicationBatchItem[] ReplicatedItems { get; set; }
 
             internal Dictionary<Slice, AttachmentReplicationItem> ReplicatedAttachmentStreams { get; set; }
+
+            internal IAbstractIncomingReplicationHandler IncomingHandler { get; set; }
 
             public TcpConnectionHeaderMessage.SupportedFeatures SupportedFeatures { get; set; }
 

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -525,7 +525,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                         }
                         else
                         {
-                            Logger.Info("Failed to receive documents replication batch. This is not supposed to happen, and is likely a bug.", e);
+                            Logger.Info("Failed to receive documents replication batch.", e);
                         }
                     }
                     throw;

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -523,6 +523,10 @@ namespace Raven.Server.Documents.Replication.Incoming
                         {
                             Logger.Info("Replication batch contained missing attachments will request the batch to be re-sent with those attachments.", mae);
                         }
+                        else if (_cts.IsCancellationRequested || e.ExtractSingleInnerException() is ObjectDisposedException)
+                        {
+                            Logger.Info($"Shutting down the replication connection {FromToString}, likely because the sender has closed the connection.");
+                        }
                         else
                         {
                             Logger.Info("Failed to receive documents replication batch.", e);

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -749,7 +749,8 @@ namespace Raven.Server.Documents.Replication.Incoming
 
             private void RecordDatabaseChangeVector(DocumentsOperationContext context)
             {
-                if (context.DocumentDatabase.ReplicationLoader.IncomingHandlers.Any() == false)
+                var handlers = context.DocumentDatabase.ReplicationLoader.IncomingHandlers;
+                if (handlers == null || handlers.Any() == false)
                 {
                     if (_replicationInfo.Logger.IsInfoEnabled)
                         _replicationInfo.Logger.Info("Failed to retrieve incoming replication handler instance.");
@@ -764,13 +765,13 @@ namespace Raven.Server.Documents.Replication.Incoming
                     incomingHandler = context.DocumentDatabase.ReplicationLoader.IncomingHandlers.Single(i =>
                         i.ConnectionInfo.SourceDatabaseId == _replicationInfo.SourceDatabaseId);
                 }
-                catch (InvalidOperationException e)
+                catch (Exception e)
                 {
                     if (_replicationInfo.Logger.IsInfoEnabled)
                         _replicationInfo.Logger.Info(
                             $"Failed to retrieve a unique incoming replication handler instance for SourceDatabaseId: {_replicationInfo.SourceDatabaseId}.", e);
 
-                    throw;
+                    return;
                 }
 
                 var stats = incomingHandler.GetLatestReplicationPerformance();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22683

### Additional description

Fixes:
1. Error in `MergedDocumentReplicationCommand.RecordDatabaseChangeVector`: 
- Issue: Connection disposed due to a timeout or replication error, causing absence of `IncomingHandlers` or no matching `IncomingHandler`.
- Fix: Adjusted method to prevent throwing exceptions for `IncomingReplicationStats` under these conditions.
2. Misleading Error Message:
- Issue: The error message "This is not supposed to happen, and is likely a bug." was misleading, as connection disposal is an expected behavior.
- Fix: Removed the misleading error message to accurately reflect the non-critical nature of the event.
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
