### PR TITLE
RavenDB-22683 -  Error during replication [v54]

### DIFF
--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -616,6 +616,12 @@ namespace Raven.Server.Documents.Replication
                         {
                             _log.Info("Replication batch contained missing attachments will request the batch to be re-sent with those attachments.", mae);
                         }
+                        else if (_cts.IsCancellationRequested ||
+                                 e is ObjectDisposedException ||
+                                 (e is AggregateException && e.ExtractSingleInnerException() is ObjectDisposedException))
+                        {
+                            _log.Info($"Shutting down the replication connection {FromToString}, likely because the sender has closed the connection.");
+                        }
                         else
                         {
                             _log.Info("Failed to receive documents replication batch.", e);

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -616,9 +616,7 @@ namespace Raven.Server.Documents.Replication
                         {
                             _log.Info("Replication batch contained missing attachments will request the batch to be re-sent with those attachments.", mae);
                         }
-                        else if (_cts.IsCancellationRequested ||
-                                 e is ObjectDisposedException ||
-                                 (e is AggregateException && e.ExtractSingleInnerException() is ObjectDisposedException))
+                        else if (_cts.IsCancellationRequested || e.ExtractSingleInnerException() is ObjectDisposedException)
                         {
                             _log.Info($"Shutting down the replication connection {FromToString}, likely because the sender has closed the connection.");
                         }

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -618,7 +618,7 @@ namespace Raven.Server.Documents.Replication
                         }
                         else
                         {
-                            _log.Info("Failed to receive documents replication batch. This is not supposed to happen, and is likely a bug.", e);
+                            _log.Info("Failed to receive documents replication batch.", e);
                         }
                     }
                     throw;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22683

### Additional description
(https://github.com/ravendb/ravendb/pull/18937)
Misleading Error Message:
- Issue: The error message "This is not supposed to happen, and is likely a bug." was misleading, as connection disposal is an expected behavior.
- Fix: Removed the misleading error message to accurately reflect the non-critical nature of the even

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
