### PR TITLE
RavenDB-22699 Move database switcher to left side

### DIFF
--- a/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/StudioSearchWithDatabaseSwitcher.tsx
+++ b/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/StudioSearchWithDatabaseSwitcher.tsx
@@ -7,8 +7,8 @@ import { InputGroup } from "reactstrap";
 export default function StudioSearchWithDatabaseSwitcher(props: { mainMenu: menu }) {
     return (
         <InputGroup>
-            <StudioSearch mainMenu={props.mainMenu} />
             <DatabaseSwitcher />
+            <StudioSearch mainMenu={props.mainMenu} />
         </InputGroup>
     );
 }

--- a/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/databaseSwitcher/DatabaseSwitcher.scss
+++ b/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/databaseSwitcher/DatabaseSwitcher.scss
@@ -7,14 +7,12 @@
     min-width: 300px;
     max-width: 300px;
     width: 300px;
-    border-top-right-radius: var(--bs-border-radius-pill) !important;
-    border-bottom-right-radius: var(--bs-border-radius-pill) !important;
+    border-radius: sizes.$border-radius-pill 0 0 sizes.$border-radius-pill !important;
 
     .react-select__control {
         min-height: 35px;
         height: 35px;
-        border-top-right-radius: var(--bs-border-radius-pill) !important;
-        border-bottom-right-radius: var(--bs-border-radius-pill) !important;
+        border-radius: sizes.$border-radius-pill 0 0 sizes.$border-radius-pill !important;
         background-color: colors.$panel-header-bg-var;
     }
 

--- a/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/studioSearch/StudioSearch.scss
+++ b/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/studioSearch/StudioSearch.scss
@@ -86,7 +86,7 @@
         }
     }
     &__input {
-        border-radius: sizes.$border-radius-pill 0 0 sizes.$border-radius-pill !important;
+        border-radius: 0 sizes.$border-radius-pill sizes.$border-radius-pill 0 !important;
         padding: 0 0 0 sizes.$gutter !important;
         min-height: 35px !important;
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22699/Omnisearch-current-selected-db-is-out-of-sight

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
