### PR TITLE
RavenDB-22605 Server-Side changes to enhance cluster debugging experience

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -31,7 +31,6 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 
-
 namespace Raven.Server.Documents.Handlers.Admin
 {
     public class RachisAdminHandler : ServerRequestHandler
@@ -154,12 +153,17 @@ namespace Raven.Server.Documents.Handlers.Admin
         {
             var start = GetStart();
             var take = GetPageSize(defaultPageSize: 1024);
+            var detailed = GetBoolValueQueryString("detailed", required: false) ?? false;
+            var debugView = ServerStore.Engine.DebugView();
 
             using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-            using (context.OpenReadTransaction())
-            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
             {
-                context.Write(writer, ServerStore.GetLogDetails(context, start, take));
+                using (context.OpenReadTransaction())
+                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
+                {
+                    debugView.PopulateLogs(context, start, take, detailed);
+                    context.Write(writer, debugView.ToJson());
+                }
             }
         }
 

--- a/src/Raven.Server/Rachis/Candidate.cs
+++ b/src/Raven.Server/Rachis/Candidate.cs
@@ -18,7 +18,9 @@ namespace Raven.Server.Rachis
     {
         private TaskCompletionSource<object> _stateChange = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly RachisConsensus _engine;
+        public RachisConsensus Engine => _engine;
         private List<CandidateAmbassador> _voters = new List<CandidateAmbassador>();
+        public List<CandidateAmbassador> Voters => _voters;
         private readonly ManualResetEvent _peersWaiting = new ManualResetEvent(false);
         private PoolOfThreads.LongRunningWork _longRunningWork;
         public long RunRealElectionAtTerm { get; private set; }
@@ -26,6 +28,7 @@ namespace Raven.Server.Rachis
         private readonly MultipleUseFlag _running = new MultipleUseFlag(true);
         public bool Running => _running.IsRaised();
         public volatile ElectionResult ElectionResult;
+        public RaftDebugView ToDebugView => new CandidateDebugView(this);
 
         public Candidate(RachisConsensus engine)
         {

--- a/src/Raven.Server/Rachis/CandidateAmbassador.cs
+++ b/src/Raven.Server/Rachis/CandidateAmbassador.cs
@@ -43,6 +43,7 @@ namespace Raven.Server.Rachis
         public string Tag => _tag;
 
         private RemoteConnection _connection;
+        public RemoteConnection Connection => _publishedConnection;
         private RemoteConnection _publishedConnection;
         public Exception LastException;
         public CandidateAmbassador(RachisConsensus engine, Candidate candidate, string tag, string url)
@@ -124,7 +125,7 @@ namespace Raven.Server.Rachis
                     {
                         Stream stream;
                         Action disconnect;
-                        TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures features;
+                        TcpConnectionHeaderMessage.SupportedFeatures features;
                         try
                         {
                             var connectTask = _engine.ConnectToPeer(_url, _tag, _engine.ClusterCertificate);
@@ -136,7 +137,7 @@ namespace Raven.Server.Rachis
 
                             stream = connection.Stream;
                             disconnect = connection.Disconnect;
-                            features = connection.SupportedFeatures.Cluster;
+                            features = connection.SupportedFeatures;
                         }
                         catch (Exception e)
                         {

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -31,18 +31,24 @@ namespace Raven.Server.Rachis
         private static int _uniqueId;
 
         private readonly RachisConsensus _engine;
+        public RachisConsensus Engine => _engine;
         private readonly long _term;
         private readonly RemoteConnection _connection;
+        public RemoteConnection Connection => _connection;
         private PoolOfThreads.LongRunningWork _followerLongRunningWork;
 
         private readonly string _debugName;
         private readonly RachisLogRecorder _debugRecorder;
+        public RachisLogRecorder DebugRecorder => _debugRecorder;
+        public FollowerDebugView.FollowerPhase Phase = FollowerDebugView.FollowerPhase.Initial;
+        public RaftDebugView ToDebugView => new FollowerDebugView(this);
 
         public Follower(RachisConsensus engine, long term, RemoteConnection remoteConnection)
         {
             _engine = engine;
             _connection = remoteConnection;
             _term = term;
+            engine.Follower = this;
 
             // this will give us a unique identifier for this follower
             var uniqueId = Interlocked.Increment(ref _uniqueId);
@@ -475,7 +481,8 @@ namespace Raven.Server.Rachis
             // at this point, the leader will send us a snapshot message
             // in most cases, it is an empty snapshot, then start regular append entries
             // the reason we send this is to simplify the # of states in the protocol
-
+            
+            Phase = FollowerDebugView.FollowerPhase.Snapshot;
             var snapshot = _connection.ReadInstallSnapshot(context);
             _debugRecorder.Record($"Got snapshot info: last included index:{snapshot.LastIncludedIndex} at term {snapshot.LastIncludedTerm}");
 
@@ -662,11 +669,16 @@ namespace Raven.Server.Rachis
                 if (ReadSnapshot(remoteReader, context, txw, dryRun: true, token) == false)
                     return false;
 
+                _debugRecorder.Record($"Finished reading the snapshot from stream with total size of {remoteReader.ReadSize}");
+                _debugRecorder.Record("Start applying the snapshot");
+
                 stream.Seek(0, SeekOrigin.Begin);
                 using (var fileReader = new StreamSnapshotReader(_debugRecorder, stream))
                 {
                     ReadSnapshot(fileReader, context, txw, dryRun: false, token);
                 }
+
+                _debugRecorder.Record("Finished applying the snapshot");
             }
 
             return true;
@@ -680,7 +692,6 @@ namespace Raven.Server.Rachis
 
             while (true)
             {
-                _debugRecorder.Record($"Read root type {(RootObjectType)type}");
                 token.ThrowIfCancellationRequested();
 
                 int size;
@@ -701,11 +712,12 @@ namespace Raven.Server.Rachis
 
                         if (dryRun == false)
                         {
+                            _debugRecorder.Record($"Install {treeName}");
                             txw.DeleteTree(treeName);
                             tree = txw.CreateTree(treeName);
                         }
 
-                        if (_connection.Features.MultiTree)
+                        if (_connection.Features.Cluster.MultiTree)
                             flags = (TreeFlags)reader.ReadInt32();
 
                         for (long i = 0; i < entries; i++)
@@ -777,6 +789,7 @@ namespace Raven.Server.Rachis
                             Slice.From(context.Allocator, reader.Buffer, 0, size, ByteStringType.Immutable,
                                 out Slice tableName);//The Slice will be freed on context close
                             var tableTree = txw.ReadTree(tableName, RootObjectType.Table);
+                            _debugRecorder.Record($"Install {tableName}");
 
                             // Get the table schema
                             var schemaSize = tableTree.GetDataSize(TableSchema.SchemasSlice);
@@ -1167,12 +1180,13 @@ namespace Raven.Server.Rachis
                     try
                     {
                         _engine.ForTestingPurposes?.LeaderLock?.HangThreadIfLocked();
-
+                        Phase = FollowerDebugView.FollowerPhase.Negotiation;
                         using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                         {
                             NegotiateWithLeader(context, (LogLengthNegotiation)obj);
                         }
 
+                        Phase = FollowerDebugView.FollowerPhase.Steady;
                         FollowerSteadyState();
                     }
                     catch (Exception e) when (RachisConsensus.IsExpectedException(e))

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -68,6 +68,7 @@ namespace Raven.Server.Rachis
         private string _lastSentMsg;
         private PoolOfThreads.LongRunningWork _followerAmbassadorLongRunningOperation;
         private RemoteConnection _connection;
+        public RemoteConnection Connection => _connection;
         private readonly MultipleUseFlag _running = new MultipleUseFlag(true);
         private readonly long _term;
 
@@ -190,7 +191,7 @@ namespace Raven.Server.Rachis
                                     var connection = connectTask.Result;
                                     var stream = connection.Stream;
                                     var disconnect = connection.Disconnect;
-                                    var con = new RemoteConnection(_tag, _engine.Tag, _term, stream, connection.SupportedFeatures.Cluster, disconnect);
+                                    var con = new RemoteConnection(_tag, _engine.Tag, _term, stream, connection.SupportedFeatures, disconnect);
                                     Interlocked.Exchange(ref _connection, con);
                                     
                                     ClusterTopology topology;
@@ -635,7 +636,7 @@ namespace Raven.Server.Rachis
                             if (_engine.ShouldSnapshot(rootIterator.CurrentKey, rootObjectType) == false)
                                 continue;
                             
-                            _debugRecorder.Record($"Start sending type: '{rootObjectType}'");
+                            _debugRecorder.Record($"Start sending: '{rootIterator.CurrentKey}'");
 
                             var currentTreeKey = rootIterator.CurrentKey;
                             binaryWriter.Write((int)rootObjectType);
@@ -652,7 +653,7 @@ namespace Raven.Server.Rachis
                                     CalculateTotalSize(ref items, ref totalSizeInBytes, sizeof(long));
 
                                     var type = tree.State.Flags;
-                                    if (_connection.Features.MultiTree)
+                                    if (_connection.Features.Cluster.MultiTree)
                                     {
                                         binaryWriter.Write((int)type);
                                         CalculateTotalSize(ref items, ref totalSizeInBytes, sizeof(int));
@@ -681,7 +682,7 @@ namespace Raven.Server.Rachis
 
                                                     case TreeFlags.MultiValueTrees:
 
-                                                        if (_connection.Features.MultiTree == false)
+                                                        if (_connection.Features.Cluster.MultiTree == false)
                                                             throw new NotSupportedException(
                                                                 $"The connection '{_connection}' doesn't support '{type}', please upgrade node '{_connection.Dest}'");
 

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -36,6 +36,7 @@ namespace Raven.Server.Rachis
     {
         private TaskCompletionSource<object> _topologyModification;
         private readonly RachisConsensus _engine;
+        public RachisConsensus Engine => _engine;
         private readonly string _threadName;
 
         public delegate object ConvertResultFromLeader(JsonOperationContext ctx, object result);
@@ -92,6 +93,7 @@ namespace Raven.Server.Rachis
         private MultipleUseFlag _running = new MultipleUseFlag();
         public bool Running => _running.IsRaised();
 
+        public RaftDebugView ToDebugView => new LeaderDebugView(this);
         public void Start(Dictionary<string, RemoteConnection> connections = null)
         {
             _running.Raise();
@@ -866,6 +868,8 @@ namespace Raven.Server.Rachis
                         }
                         context.Transaction.Commit();
                     }
+                    
+                    _engine.LastAppended = DateTime.UtcNow;
 
                     if (tasks.Count > 0)
                         _newEntry.Set();

--- a/src/Raven.Server/Rachis/LogSummary.cs
+++ b/src/Raven.Server/Rachis/LogSummary.cs
@@ -1,15 +1,33 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Rachis
 {
-    public class LogSummary
+    public class LogSummary : IDynamicJsonValueConvertible
     {
+        public DateTime? LastCommitedTime { get; set; }
+        public DateTime? LastAppendedTime { get; set; }
         public long CommitIndex { get; set; }
         public long LastTruncatedIndex { get; set; }
         public long LastTruncatedTerm { get; set; }
         public long FirstEntryIndex { get; set; }
         public long LastLogEntryIndex { get; set; }
-        public List<BlittableJsonReaderObject> Entries { get; set; }
+        public IEnumerable<RachisConsensus.RachisDebugLogEntry> Logs { get; set; }
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(LastAppendedTime)] = LastAppendedTime,
+                [nameof(LastCommitedTime)] = LastCommitedTime,
+                [nameof(CommitIndex)] = CommitIndex,
+                [nameof(LastTruncatedIndex)] = LastTruncatedIndex,
+                [nameof(LastTruncatedTerm)] = LastTruncatedTerm,
+                [nameof(FirstEntryIndex)] = FirstEntryIndex,
+                [nameof(LastLogEntryIndex)] = LastLogEntryIndex,
+                [nameof(Logs)] = new DynamicJsonArray(Logs)
+            };
+        }
     }
 }

--- a/src/Raven.Server/Rachis/RachisConsensus.Debug.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.Debug.cs
@@ -1,0 +1,441 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Raven.Client.Extensions;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Tcp;
+using Raven.Server.Rachis.Remote;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Binary;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Rachis;
+
+public abstract partial class RachisConsensus
+{
+    public class RachisDebug
+    {
+        public readonly ConcurrentDictionary<string, RachisTimingsHolder> TimingTracking = new ConcurrentDictionary<string, RachisTimingsHolder>();
+        public readonly ConcurrentQueue<string> StateChangeTracking = new ConcurrentQueue<string>();
+
+        public class RachisTimingsHolder
+        {
+            public ConcurrentQueue<RachisTimings> TimingTracking;
+            public DateTime Since = DateTime.UtcNow;
+        }
+
+        public bool IsInterVersionTest;
+
+        public RachisLogRecorder GetNewRecorder(string name)
+        {
+            var holder = new RachisTimingsHolder
+            {
+                TimingTracking = new ConcurrentQueue<RachisTimings>()
+            };
+
+            if (TimingTracking.TryAdd(name, holder) == false)
+            {
+                throw new ArgumentException($"Recorder with the name '{name}' already exists");
+            }
+            return new RachisLogRecorder(holder.TimingTracking);
+        }
+
+        public void RemoveRecorderOlderThan(DateTime after)
+        {
+            if (TimingTracking.IsEmpty)
+                return;
+
+            foreach (var item in TimingTracking)
+            {
+                if (item.Value.Since > after)
+                    continue;
+                TimingTracking.TryRemove(item.Key, out _);
+            }
+        }
+
+        public void RemoveRecorder(string name)
+        {
+            if (TimingTracking.Remove(name, out var q))
+            {
+                q.TimingTracking.Clear();
+            }
+        }
+
+        public DynamicJsonValue ToJson()
+        {
+            var timingTracking = new DynamicJsonValue();
+            foreach (var tuple in TimingTracking.ForceEnumerateInThreadSafeManner().OrderBy(x => x.Key))
+            {
+                var key = tuple.Key;
+                DynamicJsonArray inner;
+                timingTracking[key] = inner = new DynamicJsonArray();
+                foreach (var queue in tuple.Value.TimingTracking)
+                {
+                    inner.Add(new DynamicJsonArray(queue.Timings.OrderBy(x => x.At)));
+                }
+            }
+
+            var stateTracking = new DynamicJsonArray(StateChangeTracking);
+
+            return new DynamicJsonValue
+            {
+                [nameof(TimingTracking)] = timingTracking,
+                [nameof(StateChangeTracking)] = stateTracking
+            };
+        }
+    }
+
+    public readonly RachisDebug InMemoryDebug = new RachisDebug();
+
+    public DateTime? LastCommitted;
+    public DateTime? LastAppended;
+
+    public RaftDebugView DebugView()
+    {
+        switch (CurrentState)
+        {
+            case RachisState.Passive:
+                return new PassiveDebugView(this);
+            case RachisState.Candidate:
+                return Candidate.ToDebugView;
+            case RachisState.Follower:
+                return Follower.ToDebugView;
+            case RachisState.LeaderElect:
+            case RachisState.Leader:
+                return CurrentLeader.ToDebugView;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    public LogSummary GetLogDetails(ClusterOperationContext context, int start, int take, bool detailed)
+    {
+        GetLastTruncated(context, out var index, out var term);
+        var range = GetLogEntriesRange(context);
+        return new LogSummary
+        {
+            CommitIndex = GetLastCommitIndex(context),
+            LastTruncatedIndex = index,
+            LastTruncatedTerm = term,
+            FirstEntryIndex = range.Min,
+            LastLogEntryIndex = range.Max,
+            LastAppendedTime = LastAppended,
+            LastCommitedTime = LastCommitted,
+            Logs = GetLogEntries(context, range.Min, start, take, detailed)
+        };
+    }
+
+    public IEnumerable<RachisDebugLogEntry> GetLogEntries(ClusterOperationContext context, long first, int start, int take, bool detailed)
+    {
+        var reveredNextIndex = Bits.SwapBytes(first);
+        Span<byte> span = stackalloc byte[sizeof(long)];
+        if (BitConverter.TryWriteBytes(span, reveredNextIndex) == false)
+            throw new InvalidOperationException($"Couldn't convert {first} to span<byte>");
+
+        var table = context.Transaction.InnerTransaction.OpenTable(LogsTable, EntriesSlice);
+        using (Slice.From(context.Allocator, span, out Slice key))
+        {
+            foreach (var value in table.SeekByPrimaryKey(key, start))
+            {
+                if (take-- <= 0)
+                    yield break;
+
+                var entry = RachisDebugLogEntry.Create(context, value);
+                if (detailed == false)
+                {
+                    entry.Entry.Dispose();
+                    entry.Entry = null;
+                }
+
+                yield return entry;
+            }
+        }
+    }
+    
+    public class RachisDebugLogEntry : IDynamicJsonValueConvertible
+    {
+        public long Term { get; set; }
+        public long Index { get; set; }
+        public long SizeInBytes { get; set; }
+        public string CommandType { get; set; }
+        public DateTime? CreateAt { get; set; }
+        public BlittableJsonReaderObject Entry { get; set; }
+        public RachisEntryFlags Flags { get; set; }
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Term)] = Term,
+                [nameof(Index)] = Index,
+                [nameof(SizeInBytes)] = SizeInBytes,
+                [nameof(CommandType)] = CommandType,
+                [nameof(Flags)] = Flags,
+                [nameof(CreateAt)] = CreateAt,
+                [nameof(Entry)] = Entry,
+            };
+        }
+
+        internal static unsafe RachisDebugLogEntry Create(ClusterOperationContext context, Table.TableValueHolder value)
+        {
+            RachisDebugLogEntry entry = new()
+            {
+                Index = Bits.SwapBytes(*(long*)value.Reader.Read(0, out int size)),
+                Term = *(long*)value.Reader.Read(1, out size),
+                Entry = new BlittableJsonReaderObject(value.Reader.Read(2, out size), size, context),
+                SizeInBytes = size,
+                Flags = *(RachisEntryFlags*)value.Reader.Read(3, out size)
+            };
+
+            if (entry.Flags != RachisEntryFlags.StateMachineCommand) 
+                return entry;
+
+            entry.Entry.TryGet(nameof(CommandBase.Type), out string commandType);
+            entry.CommandType = commandType;
+
+            if (entry.Entry.TryGet(nameof(CommandBase.UniqueRequestId), out string raftUniqueId))
+            {
+                entry.CreateAt = RachisLogHistory.GetDateTimeByGuid(context, raftUniqueId);
+            }
+
+            return entry;
+        }
+    }
+}
+
+
+public abstract class RaftDebugView : IDynamicJsonValueConvertible
+{
+    private readonly RachisConsensus _engine;
+    public abstract string Role { get; }
+    
+    public long Term;
+    public RaftCommandsVersion CommandsVersion;
+    public DateTime Since;
+    public LogSummary Log;
+
+    protected RaftDebugView(RachisConsensus engine)
+    {
+        _engine = engine;
+        Term = engine.CurrentTerm;
+        CommandsVersion = new RaftCommandsVersion
+        {
+            Local = ClusterCommandsVersionManager.MyCommandsVersion,
+            Cluster = ClusterCommandsVersionManager.CurrentClusterMinimalVersion,
+        };
+        Since = engine.LastStateChangeTime;
+    }
+
+    public void PopulateLogs(ClusterOperationContext context, int start, int take, bool detailed)
+    {
+        Log = _engine.GetLogDetails(context, start, take, detailed);
+    }
+
+    public class PeerConnection(string destination) : IDynamicJsonValueConvertible
+    {
+        public string Destination = destination;
+
+        public virtual DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Destination)] = Destination
+            };
+        }
+    }
+
+    public class DetailedPeerConnection(string destination) : PeerConnection(destination)
+    {
+        public int Version;
+        public bool Compression;
+        public TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures Features;
+        public DateTime StartAt;
+        public DateTime LastSent;
+        public DateTime LastReceived;
+
+        public static PeerConnection FromRemoteConnection(string destination, RemoteConnection connection)
+        {
+            if (connection == null)
+                return new PeerConnection(destination);
+
+            return new DetailedPeerConnection(destination)
+            {
+                Destination = connection.Dest,
+                Version = connection.Features.ProtocolVersion,
+                Features = connection.Features.Cluster,
+                Compression = connection.Features.DataCompression,
+                StartAt = connection.Info.StartAt,
+                LastReceived = connection.Info.LastReceived,
+                LastSent = connection.Info.LastSent,
+            };
+        }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+            json[nameof(Version)] = Version;
+            json[nameof(Compression)] = Compression;
+            json[nameof(Features)] = new DynamicJsonValue
+            {
+                [nameof(Features.BaseLine)] = Features.BaseLine, 
+                [nameof(Features.MultiTree)] = Features.MultiTree
+            };
+            json[nameof(StartAt)] = StartAt;
+            json[nameof(LastSent)] = LastSent;
+            json[nameof(LastReceived)] = LastReceived;
+            return json;
+        }
+    }
+
+    public class RaftCommandsVersion : IDynamicJsonValueConvertible
+    {
+        public int Cluster;
+        public int Local;
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Cluster)] = Cluster,
+                [nameof(Local)] = Local,
+            };
+        }
+    }
+
+    public virtual DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(Role)] = Role,
+            [nameof(Term)] = Term,
+            [nameof(CommandsVersion)] = CommandsVersion.ToJson(),
+            [nameof(Since)] = Since,
+            [nameof(Log)] = Log?.ToJson()
+        };
+    }
+}
+
+public class PassiveDebugView(RachisConsensus engine) : RaftDebugView(engine)
+{
+    public override string Role => "Passive";
+}
+
+public class FollowerDebugView(Follower follower) : RaftDebugView(follower.Engine)
+{
+    public PeerConnection ConnectionToLeader = DetailedPeerConnection.FromRemoteConnection(follower.Connection.Dest, follower.Connection);
+    public List<RachisDebugMessage> RecentMessages = follower.DebugRecorder.Timings.ToList();
+    public FollowerPhase Phase = follower.Phase;
+    public enum FollowerPhase
+    {
+        Initial,
+        Negotiation,
+        Snapshot,
+        Steady
+    }
+    public override string Role => "Follower";
+
+    public override DynamicJsonValue ToJson()
+    {
+        var json = base.ToJson();
+        json[nameof(Phase)] = Phase;
+        json[nameof(ConnectionToLeader)] = ConnectionToLeader.ToJson();
+        json[nameof(RecentMessages)] = new DynamicJsonArray(RecentMessages);
+        return json;
+    }
+}
+
+public class LeaderDebugView(Leader leader) : RaftDebugView(leader.Engine)
+{
+    public override string Role => "Leader";
+    public string ElectionReason = leader.Engine.LastStateChangeReason;
+    public List<PeerConnection> ConnectionToPeers = leader.CurrentPeers.Select(p => DetailedPeerConnection.FromRemoteConnection(p.Key, p.Value.Connection)).ToList();
+    public override DynamicJsonValue ToJson()
+    {
+        var json = base.ToJson();
+        json[nameof(ElectionReason)] = ElectionReason;
+        json[nameof(ConnectionToPeers)] = new DynamicJsonArray(ConnectionToPeers);
+        return json;
+    }
+}
+
+public class CandidateDebugView(Candidate candidate) : RaftDebugView(candidate.Engine)
+{
+    public override string Role => "Candidate";
+    public string ElectionReason = candidate.Engine.LastStateChangeReason;
+    public List<PeerConnection> ConnectionToPeers = candidate.Voters.Select(p => DetailedPeerConnection.FromRemoteConnection(p.Tag, p.Connection)).ToList();
+
+    public override DynamicJsonValue ToJson()
+    {
+        var json = base.ToJson();
+        json[nameof(ElectionReason)] = ElectionReason;
+        json[nameof(ConnectionToPeers)] = new DynamicJsonArray(ConnectionToPeers);
+        return json;
+    }
+}
+
+
+public class RachisDebugMessage : IDynamicJsonValueConvertible
+{
+    public DateTime At = DateTime.UtcNow;
+    public string Message;
+    public long MsFromCycleStart;
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(At)] = At,
+            [nameof(MsFromCycleStart)] = MsFromCycleStart,
+            [nameof(Message)] = Message
+        };
+    }
+}
+
+public class RachisTimings
+{
+    public readonly ConcurrentBag<RachisDebugMessage> Timings = new ConcurrentBag<RachisDebugMessage>();
+}
+
+public class RachisLogRecorder
+{
+    private readonly ConcurrentQueue<RachisTimings> _queue;
+    private readonly Stopwatch _sp = Stopwatch.StartNew();
+    private RachisTimings _current;
+    public ConcurrentBag<RachisDebugMessage> Timings => _current.Timings;
+
+    public RachisLogRecorder(ConcurrentQueue<RachisTimings> queue)
+    {
+        _queue = queue;
+    }
+
+    public void Start()
+    {
+        _current = new RachisTimings();
+        _queue.LimitedSizeEnqueue(_current, 10);
+        Timings.Add(new RachisDebugMessage
+        {
+            Message = "Start",
+            MsFromCycleStart = 0
+        });
+        _sp.Restart();
+    }
+
+    public void Record(string message)
+    {
+        if (_current == null)
+            return; // ignore - shutting down
+
+        Timings.Add(new RachisDebugMessage
+        {
+            Message = message,
+            MsFromCycleStart = _sp.ElapsedMilliseconds
+        });
+    }
+}
+

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
@@ -36,7 +33,6 @@ using Voron;
 using Voron.Data;
 using Voron.Data.Tables;
 using Voron.Impl;
-using Sparrow.Collections;
 using Sparrow.Threading;
 using Size = Sparrow.Size;
 
@@ -81,7 +77,9 @@ namespace Raven.Server.Rachis
 
         public override long Apply(ClusterOperationContext context, long uptoInclusive, Leader leader, Stopwatch duration)
         {
-            return StateMachine.Apply(context, uptoInclusive, leader, _serverStore, duration);
+            var committedIndex = StateMachine.Apply(context, uptoInclusive, leader, _serverStore, duration);
+            LastCommitted = DateTime.UtcNow;
+            return committedIndex;
         }
 
         public void EnsureNodeRemovalOnDeletion(ClusterOperationContext context, long term, string nodeTag)
@@ -126,168 +124,15 @@ namespace Raven.Server.Rachis
             {
             }
         }
-
-        public IEnumerable<BlittableJsonReaderObject> GetLogEntries(ClusterOperationContext context, long first, int start, int take)
-        {
-            var reveredNextIndex = Bits.SwapBytes(first);
-            Span<byte> span = stackalloc byte[sizeof(long)];
-            if (BitConverter.TryWriteBytes(span, reveredNextIndex) == false)
-                throw new InvalidOperationException($"Couldn't convert {first} to span<byte>");
-
-            var table = context.Transaction.InnerTransaction.OpenTable(LogsTable, EntriesSlice);
-            using (Slice.From(context.Allocator, span, out Slice key))
-            {
-                foreach (var value in table.SeekByPrimaryKey(key, start))
-                {
-                    if (take-- <= 0)
-                        yield break;
-
-                    yield return FollowerAmbassador.BuildRachisEntryToSend(context, value);
-                }
-            }
-        }
     }
 
-    public class RachisLogEntry : IDynamicJsonValueConvertible
-    {
-        public DateTime At = DateTime.UtcNow;
-        public string Message;
-        public long MsFromCycleStart;
-
-        public DynamicJsonValue ToJson()
-        {
-            return new DynamicJsonValue
-            {
-                [nameof(At)] = At,
-                [nameof(MsFromCycleStart)] = MsFromCycleStart,
-                [nameof(Message)] = Message
-            };
-        }
-    }
-
-    public class RachisTimings
-    {
-        public readonly ConcurrentBag<RachisLogEntry> Timings = new ConcurrentBag<RachisLogEntry>();
-    }
-
-    public class RachisLogRecorder
-    {
-        private readonly ConcurrentQueue<RachisTimings> _queue;
-        private readonly Stopwatch _sp = Stopwatch.StartNew();
-        private RachisTimings _current;
-        private ConcurrentBag<RachisLogEntry> Timings => _current.Timings;
-
-        public RachisLogRecorder(ConcurrentQueue<RachisTimings> queue)
-        {
-            _queue = queue;
-        }
-
-        public void Start()
-        {
-            _current = new RachisTimings();
-            _queue.LimitedSizeEnqueue(_current, 10);
-            Timings.Add(new RachisLogEntry
-            {
-                Message = "Start",
-                MsFromCycleStart = 0
-            });
-            _sp.Restart();
-        }
-
-        public void Record(string message)
-        {
-            if (_current == null)
-                return; // ignore - shutting down
-
-            Timings.Add(new RachisLogEntry
-            {
-                Message = message,
-                MsFromCycleStart = _sp.ElapsedMilliseconds
-            });
-        }
-    }
-
-    public class RachisDebug
-    {
-        public readonly ConcurrentDictionary<string, RachisTimingsHolder> TimingTracking = new ConcurrentDictionary<string, RachisTimingsHolder>();
-        public readonly ConcurrentQueue<string> StateChangeTracking = new ConcurrentQueue<string>();
-
-        public class RachisTimingsHolder
-        {
-            public ConcurrentQueue<RachisTimings> TimingTracking;
-            public DateTime Since = DateTime.UtcNow;
-        }
-
-        public bool IsInterVersionTest;
-
-        public RachisLogRecorder GetNewRecorder(string name)
-        {
-            var holder = new RachisTimingsHolder
-            {
-                TimingTracking = new ConcurrentQueue<RachisTimings>()
-            };
-
-            if (TimingTracking.TryAdd(name, holder) == false)
-            {
-                throw new ArgumentException($"Recorder with the name '{name}' already exists");
-            }
-            return new RachisLogRecorder(holder.TimingTracking);
-        }
-
-        public void RemoveRecorderOlderThan(DateTime after)
-        {
-            if (TimingTracking.IsEmpty)
-                return;
-
-            foreach (var item in TimingTracking)
-            {
-                if (item.Value.Since > after)
-                    continue;
-                TimingTracking.TryRemove(item.Key, out _);
-            }
-        }
-
-        public void RemoveRecorder(string name)
-        {
-            if (TimingTracking.Remove(name, out var q))
-            {
-                q.TimingTracking.Clear();
-            }
-        }
-
-        public DynamicJsonValue ToJson()
-        {
-            var timingTracking = new DynamicJsonValue();
-            foreach (var tuple in TimingTracking.ForceEnumerateInThreadSafeManner().OrderBy(x => x.Key))
-            {
-                var key = tuple.Key;
-                DynamicJsonArray inner;
-                timingTracking[key] = inner = new DynamicJsonArray();
-                foreach (var queue in tuple.Value.TimingTracking)
-                {
-                    inner.Add(new DynamicJsonArray(queue.Timings.OrderBy(x => x.At)));
-                }
-            }
-
-            var stateTracking = new DynamicJsonArray(StateChangeTracking);
-
-            return new DynamicJsonValue
-            {
-                [nameof(TimingTracking)] = timingTracking,
-                [nameof(StateChangeTracking)] = stateTracking
-            };
-        }
-    }
-
-    public abstract class RachisConsensus : IDisposable
+    public abstract partial class RachisConsensus : IDisposable
     {
         internal abstract RachisStateMachine GetStateMachine();
 
         internal abstract RachisVersionValidation Validator { get; }
 
         public const string InitialTag = "?";
-
-        public readonly RachisDebug InMemoryDebug = new RachisDebug();
 
         public RachisState CurrentState
         {
@@ -408,7 +253,8 @@ namespace Raven.Server.Rachis
         private readonly ManualResetEventSlim _disposeEvent = new ManualResetEventSlim();
         private readonly Random _rand;
         private string _lastStateChangeReason;
-        public Candidate Candidate { get; private set; }
+        public Candidate Candidate { get; set; }
+        public Follower Follower { get; set; }
 
         protected RachisConsensus(CipherSuitesPolicy cipherSuitesPolicy, int? seed = null)
         {
@@ -550,6 +396,7 @@ namespace Raven.Server.Rachis
             SwitchToSingleLeaderAction?.Invoke(context);
 
             Candidate = null;
+            Follower = null;
             context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += tx =>
             {
                 if (tx is LowLevelTransaction llt && llt.Committed)
@@ -867,6 +714,7 @@ namespace Raven.Server.Rachis
             var sp = Stopwatch.StartNew();
 
             _currentLeader = null;
+
             LastStateChangeReason = stateChangedReason;
             var toDispose = new List<IDisposable>(_disposables);
             _disposables.Clear();
@@ -1731,7 +1579,7 @@ namespace Raven.Server.Rachis
                     LogHistory.InsertHistoryLog(context, entry.Index, entry.Term, entry.Entry);
                 }
             }
-
+            LastAppended = DateTime.UtcNow;
             Transaction.DebugDisposeReaderAfterTransaction(context.Transaction.InnerTransaction, lastTopology);
             return (lastTopology, lastTopologyIndex);
         }

--- a/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Rachis.Remote
         private string _destTag;
         private string _src;
         private readonly Stream _stream;
-        private readonly TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures _features;
+        private readonly TcpConnectionHeaderMessage.SupportedFeatures _features;
         private readonly JsonOperationContext.MemoryBuffer _buffer;
         private readonly JsonOperationContext _context;
         private readonly IDisposable _releaseBuffer;
@@ -34,14 +34,14 @@ namespace Raven.Server.Rachis.Remote
         public string Source => _src;
         public Stream Stream => _stream;
         public string Dest => _destTag;
-        public TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures Features => _features;
+        public TcpConnectionHeaderMessage.SupportedFeatures Features => _features;
 
-        public RemoteConnection(string src, long term, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures features, Action disconnect, [CallerMemberName] string caller = null)
+        public RemoteConnection(string src, long term, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures features, Action disconnect, [CallerMemberName] string caller = null)
             : this(dest: "?", src, term, stream,features, disconnect, caller)
         {
         }
 
-        public RemoteConnection(string dest, string src, long term, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures features, Action disconnect, [CallerMemberName] string caller = null)
+        public RemoteConnection(string dest, string src, long term, Stream stream, TcpConnectionHeaderMessage.SupportedFeatures features, Action disconnect, [CallerMemberName] string caller = null)
         {
             _destTag = dest;
             _src = src;

--- a/src/Raven.Server/Rachis/Remote/SnapshotReader.cs
+++ b/src/Raven.Server/Rachis/Remote/SnapshotReader.cs
@@ -72,12 +72,14 @@ namespace Raven.Server.Rachis.Remote
             return BitConverter.ToInt64(Buffer, 0);
         }
 
+        public Size ReadSize => new Size(_totalBytes, SizeUnit.Bytes);
+
         public virtual void ReadExactly(int size)
         {
             _totalBytes += size;
             if (++_readAttempts % 256 == 0)
             {
-                _logger.Record($"Read snapshot total size {new Size(_totalBytes, SizeUnit.Bytes)}");
+                _logger.Record($"Consumed {ReadSize} of the snapshot");
             }
 
             if (Buffer.Length < size)

--- a/src/Raven.Server/ServerWide/Commands/CommandBase.cs
+++ b/src/Raven.Server/ServerWide/Commands/CommandBase.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.ServerWide.Commands
 {
     public abstract class CommandBase
     {
-        public string Type;
+        public const string Type = nameof(Type);
         public virtual DynamicJsonValue ToJson(JsonOperationContext context)
         {
             var json = new DynamicJsonValue

--- a/src/Raven.Server/ServerWide/Commands/CommandBase.cs
+++ b/src/Raven.Server/ServerWide/Commands/CommandBase.cs
@@ -9,11 +9,12 @@ namespace Raven.Server.ServerWide.Commands
 {
     public abstract class CommandBase
     {
+        public string Type;
         public virtual DynamicJsonValue ToJson(JsonOperationContext context)
         {
             var json = new DynamicJsonValue
             {
-                ["Type"] = GetType().Name,
+                [nameof(Type)] = GetType().Name,
                 [nameof(UniqueRequestId)] = UniqueRequestId,
             };
 
@@ -43,7 +44,7 @@ namespace Raven.Server.ServerWide.Commands
 
         public static CommandBase CreateFrom(BlittableJsonReaderObject json)
         {
-            if (json.TryGet("Type", out string type) == false)
+            if (json.TryGet(nameof(Type), out string type) == false)
             {
                 throw new RachisApplyException("Command must contain 'Type' field.");
             }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3363,7 +3363,7 @@ namespace Raven.Server.ServerWide
                 }
 
                 var features = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Cluster, tcp.ProtocolVersion);
-                var remoteConnection = new RemoteConnection(_engine.Tag, _engine.CurrentTerm, tcp.Stream, features.Cluster, disconnect);
+                var remoteConnection = new RemoteConnection(_engine.Tag, _engine.CurrentTerm, tcp.Stream, features, disconnect);
 
                 _engine.AcceptNewConnection(remoteConnection, remoteEndpoint);
             }
@@ -3550,22 +3550,6 @@ namespace Raven.Server.ServerWide
             res[nameof(TcpConnectionInfo.Urls)] = array;
 
             return res;
-        }
-
-        public DynamicJsonValue GetLogDetails(ClusterOperationContext context, int start, int take)
-        {
-            RachisConsensus.GetLastTruncated(context, out var index, out var term);
-            var range = Engine.GetLogEntriesRange(context);
-            var json = new DynamicJsonValue
-            {
-                [nameof(LogSummary.CommitIndex)] = Engine.GetLastCommitIndex(context),
-                [nameof(LogSummary.LastTruncatedIndex)] = index,
-                [nameof(LogSummary.LastTruncatedTerm)] = term,
-                [nameof(LogSummary.FirstEntryIndex)] = range.Min,
-                [nameof(LogSummary.LastLogEntryIndex)] = range.Max,
-                [nameof(LogSummary.Entries)] = Engine.GetLogEntries(context, range.Min, start, take)
-            };
-            return json;
         }
 
         public IEnumerable<Client.ServerWide.Operations.MountPointUsage> GetMountPointUsageDetailsFor(StorageEnvironmentWithType environment, bool includeTempBuffers)

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -253,9 +253,13 @@ namespace Tests.Infrastructure
                 {
                     var stream = tcpClient.GetStream();
                     var remoteConnection = new RemoteConnection(rachis.Tag, rachis.CurrentTerm, stream,
-                        features: new TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures
+                        features: new TcpConnectionHeaderMessage.SupportedFeatures(TcpConnectionHeaderMessage.ClusterTcpVersion)
                         {
-                            MultiTree = true
+                            Cluster = new TcpConnectionHeaderMessage.SupportedFeatures.ClusterFeatures
+                            {
+                                BaseLine = true,
+                                MultiTree = true
+                            }
                         }, () => tcpClient.Client?.Disconnect(false));
 
                     rachis.AcceptNewConnection(remoteConnection, tcpClient.Client.RemoteEndPoint, hello =>

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -217,7 +217,7 @@ public partial class RavenTestBase
             return
                 $"{Environment.NewLine}Log for server '{server.ServerStore.NodeTag}':" +
                 $"{Environment.NewLine}Last notified Index '{server.ServerStore.Cluster.LastNotifiedIndex}':" +
-                $"{Environment.NewLine}{context.ReadObject(server.ServerStore.GetLogDetails(context, start: 0, take: int.MaxValue), "LogSummary/" + server.ServerStore.NodeTag)}" +
+                $"{Environment.NewLine}{context.ReadObject(server.ServerStore.Engine.GetLogDetails(context, start: 0, take: int.MaxValue, detailed: true).ToJson(), "LogSummary/" + server.ServerStore.NodeTag)}" +
                 $"{Environment.NewLine}{server.ServerStore.Engine.LogHistory.GetHistoryLogsAsString(context)}";
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22605

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant
Changes to the output format of debug EP
### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
