### PR TITLE
RavenDB-22035 - Added wait for ResponsibleNode command to be applied in backup test area to prevent race

### DIFF
--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3172,7 +3172,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                         return onGoingTaskInfo != null &&
                                leaderServer.ServerStore.NodeTag == onGoingTaskInfo.MentorNode &&
                                onGoingTaskInfo.Error == null &&
-                               expectedNextBackupDateTime == onGoingTaskInfo.NextBackup.DateTime &&
+                               (int)((expectedNextBackupDateTime - onGoingTaskInfo.NextBackup.DateTime).TotalSeconds) == 0 &&
                                onGoingTaskInfo.OnGoingBackup != null &&
                                onGoingTaskInfo.TaskConnectionStatus == OngoingTaskConnectionStatus.Active;
                     }, expectedVal: true,
@@ -3182,7 +3182,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Assert.NotNull(onGoingTaskInfo);
                     Assert.True(leaderServer.ServerStore.NodeTag == onGoingTaskInfo.MentorNode, userMessage: $"The value of 'leaderServer.ServerStore.NodeTag': {leaderServer.ServerStore.NodeTag} is not equal to 'onGoingTaskInfo.MentorNode': {onGoingTaskInfo.MentorNode}.");
                     Assert.True(onGoingTaskInfo.Error == null, userMessage: $"The onGoingTaskInfo.Error is not null: {onGoingTaskInfo.Error}.");
-                    Assert.True(expectedNextBackupDateTime == onGoingTaskInfo.NextBackup.DateTime, userMessage: $"The 'expectedNextBackupDateTime': {expectedNextBackupDateTime} is not equal to 'onGoingTaskInfo.NextBackup.DateTime': {onGoingTaskInfo.NextBackup.DateTime}.");
+                    Assert.True((int)((expectedNextBackupDateTime - onGoingTaskInfo.NextBackup.DateTime).TotalSeconds) == 0, userMessage: $"The 'expectedNextBackupDateTime': {expectedNextBackupDateTime} is not equal to 'onGoingTaskInfo.NextBackup.DateTime': {onGoingTaskInfo.NextBackup.DateTime}.");
                     Assert.NotNull(onGoingTaskInfo.OnGoingBackup);
                     Assert.True(onGoingTaskInfo.TaskConnectionStatus == OngoingTaskConnectionStatus.Active, userMessage: $"The onGoingTaskInfo.TaskConnectionStatus is {onGoingTaskInfo.TaskConnectionStatus}, which is not {nameof(OngoingTaskConnectionStatus.Active)} as expected.");
 
@@ -3194,23 +3194,28 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                     // The next backup should be scheduled in almost 1 hour on the current periodic backup task
                     Raven.Server.Documents.PeriodicBackup.PeriodicBackup periodicBackup = null;
-                    TimeSpan nextBackup = default;
+                    NextBackup nextBackup = default;
                     WaitForValue(() =>
                     {
                         periodicBackup = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.Single(x => x.BackupStatus.TaskId == taskId);
-                        nextBackup = periodicBackup.GetNextBackup().TimeSpan;
+
+                        nextBackup = periodicBackup.GetNextBackup();
+
+                        if(nextBackup == null)
+                            return false;
 
                         return periodicBackup is { RunningTask: null, RunningBackupStatus: null } &&
-                               nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration;
+                               nextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup.TimeSpan <= delayDuration;
                     }, expectedVal: true,
-                         timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
+                         timeout: (int)TimeSpan.FromMinutes(2).TotalMilliseconds,
                          interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
 
+                    Assert.NotNull(nextBackup);
                     Assert.NotNull(periodicBackup);
                     Assert.Null(periodicBackup.RunningTask);
                     Assert.Null(periodicBackup.RunningBackupStatus);
-                    Assert.True(nextBackup > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup <= delayDuration,
-                        $"The NextBackup is set for: {nextBackup}, the delay duration with tolerance is: {delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}, and the actual delay duration is: {delayDuration}.");
+                    Assert.True(nextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup.TimeSpan <= delayDuration,
+                        $"The NextBackup is set for: {nextBackup.TimeSpan}, the delay duration with tolerance is: {delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000))}, and the actual delay duration is: {delayDuration}.");
 
                     await WaitForValueAsync(async () =>
                     {

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3197,9 +3197,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     NextBackup nextBackup = default;
                     WaitForValue(() =>
                     {
-                        periodicBackup = responsibleDatabase.PeriodicBackupRunner.PeriodicBackups.Single(x => x.BackupStatus.TaskId == taskId);
+                        periodicBackup = responsibleDatabase.PeriodicBackupRunner?.PeriodicBackups.Single(x => x.BackupStatus.TaskId == taskId);
 
-                        nextBackup = periodicBackup.GetNextBackup();
+                        nextBackup = periodicBackup?.GetNextBackup();
 
                         if(nextBackup == null)
                             return false;
@@ -3210,8 +3210,8 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                          timeout: (int)TimeSpan.FromMinutes(2).TotalMilliseconds,
                          interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
 
-                    Assert.NotNull(nextBackup);
                     Assert.NotNull(periodicBackup);
+                    Assert.NotNull(nextBackup);
                     Assert.Null(periodicBackup.RunningTask);
                     Assert.Null(periodicBackup.RunningBackupStatus);
                     Assert.True(nextBackup.TimeSpan > delayDuration.Subtract(TimeSpan.FromMilliseconds(sw.ElapsedMilliseconds + 1_000)) && nextBackup.TimeSpan <= delayDuration,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22035

### Additional description

The failing test times out on waiting for the timer of the backup to be updated.
In `UpdatePeriodicBackup` there is an optimization that skips setting the timer if the backup is already running (that is because after the backups finished, it will update the timer itself).
This code is called from `UpdateConfigurations` which gets triggered when there is a change in backup - in our case it is triggered by `UpdateResponsibleNodeForTasksCommand` (which is created in cluster observer).
That means that if the backup starts running before we reach the this code, then `UpdateTimer` will be skipped.
When the backup finishes and is supposed to reschedule a new timer, `RescheduleNextBackup` only updates next timer on the condition that there was a previous timer in place (there isn't. we skipped setting it).
So the timer will not be set.

In short - there is a race between running the backup and updating the timer due to new configuration.

Changes:
It was decided to add the fix to the testing environment.
Now waiting for the `UpdateResponsibleNodeForTasksCommand` to be applied fully - this includes running `UpdateConfigurations` to completion which updates the timer if needed.

There are additional changes in the test of DateTime comparisons that have been accidentally only pushed to [v6.0](https://github.com/ravendb/ravendb/pull/18820).
This PR includes them as well in the first commit.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
