### PR TITLE
RavenDB-22709 - Pull Replication Connection Failure When Two Sinks Have the Same Database Name

### DIFF
--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsHub.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsHub.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Raven.Client.Documents.Replication;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Documents.Operations.Replication
+{
+    public sealed class PullReplicationAsHub : ExternalReplication
+    {
+        public PullReplicationMode Mode = PullReplicationMode.HubToSink;
+
+        public PullReplicationAsHub()
+        {
+        }
+
+        public PullReplicationAsHub(string database, string connectionStringName) : base(database, connectionStringName)
+        {
+        }
+
+        public override ReplicationType GetReplicationType() => ReplicationType.PullAsHub;
+
+        public override bool IsEqualTo(ReplicationNode other)
+        {
+            if (other is PullReplicationAsHub hub)
+            {
+                return base.IsEqualTo(other) &&
+                       string.Equals(Url, hub.Url, StringComparison.OrdinalIgnoreCase) &&
+                       string.Equals(Name, hub.Name, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+
+        public override ulong GetTaskKey()
+        {
+            var hashCode = base.GetTaskKey();
+            return (hashCode * 397) ^ (ulong)Mode;
+        }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var djv = base.ToJson();
+            djv[nameof(Mode)] = Mode;
+            return djv;
+        }
+
+        public override DynamicJsonValue ToAuditJson()
+        {
+            var djv = base.ToAuditJson();
+            djv[nameof(Mode)] = Mode;
+            return djv;
+        }
+
+        public override string GetDefaultTaskName()
+        {
+            return $"Replication Hub for {Database}";
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -34,6 +34,7 @@ namespace Raven.Client.Documents.Operations.Replication
             if (other is PullReplicationAsSink sink)
             {
                 return base.IsEqualTo(other) &&
+                       string.Equals(Url, sink.Url, StringComparison.OrdinalIgnoreCase) &&
                        Mode == sink.Mode &&
                        string.Equals(HubName, sink.HubName) &&
                        string.Equals(CertificatePassword, sink.CertificatePassword) &&

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
@@ -85,9 +85,9 @@ namespace Raven.Client.Documents.Operations.Replication
             }
         }
 
-        public ExternalReplication ToExternalReplication(ReplicationInitialRequest request, long taskId)
+        public PullReplicationAsHub ToPullReplicationAsHub(ReplicationInitialRequest request, long taskId)
         {
-            return new ExternalReplication
+            return new PullReplicationAsHub
             {
                 Url = request.SourceUrl,
                 Database = request.Database,

--- a/src/Raven.Client/Documents/Replication/ReplicationNode.cs
+++ b/src/Raven.Client/Documents/Replication/ReplicationNode.cs
@@ -58,6 +58,7 @@ namespace Raven.Client.Documents.Replication
         {
             External,
             PullAsSink,
+            PullAsHub,
             Internal,
             Migration
         }

--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingPullReplicationHandler.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         // we need to associate this instance to the replication definition.
         public string PullReplicationDefinitionName;
 
-        public OutgoingPullReplicationHandlerAsHub(ReplicationLoader parent, DocumentDatabase database, ExternalReplication node, TcpConnectionInfo connectionInfo) : 
+        public OutgoingPullReplicationHandlerAsHub(ReplicationLoader parent, DocumentDatabase database, PullReplicationAsHub node, TcpConnectionInfo connectionInfo) : 
             base(parent, database, node, connectionInfo)
         {
         }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -422,7 +422,7 @@ namespace Raven.Server.Documents.Replication
                     $"PullReplicationDefinitionName '{initialRequest.PullReplicationDefinitionName}' does not match the pull replication definition name: {pullReplicationDefinition.Name}");
 
             var taskId = pullReplicationDefinition.TaskId; // every connection to this pull replication on the hub will have the same task id.
-            var externalReplication = pullReplicationDefinition.ToExternalReplication(initialRequest, taskId);
+            var externalReplication = pullReplicationDefinition.ToPullReplicationAsHub(initialRequest, taskId);
 
             var outgoingReplication = new OutgoingPullReplicationHandlerAsHub(this, Database, externalReplication, initialRequest.Info)
             {

--- a/test/SlowTests/Issues/RavenDB_22709.cs
+++ b/test/SlowTests/Issues/RavenDB_22709.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22709 : ReplicationTestBase
+    {
+        public RavenDB_22709(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task PullReplicationWithSinksWithSameDatabaseNameShouldWork()
+        {
+            var hubCluster = await CreateRaftClusterWithSsl(3);
+            var hubClusterCert = RegisterClientCertificate(hubCluster);
+
+            var sinkCluster = await CreateRaftClusterWithSsl(1);
+            var sinkClusterCert = RegisterClientCertificate(sinkCluster);
+
+            var sinkCluster2 = await CreateRaftClusterWithSsl(1);
+            var sinkClusterCert2 = RegisterClientCertificate(sinkCluster2);
+
+            using var hubStore = GetDocumentStore(new Options
+            {
+                Server = hubCluster.Leader,
+                ReplicationFactor = 3,
+                AdminCertificate = hubClusterCert,
+                ClientCertificate = hubClusterCert,
+                ModifyDatabaseName = s => "HubDB"
+            });
+            using var sinkStore1 = GetDocumentStore(new Options
+            {
+                Server = sinkCluster.Leader,
+                AdminCertificate = sinkClusterCert,
+                ClientCertificate = sinkClusterCert,
+                ModifyDatabaseName = s => "SinkDB"
+            });
+
+            using var sinkStore2 = GetDocumentStore(new Options
+            {
+                Server = sinkCluster2.Leader,
+                AdminCertificate = sinkClusterCert2,
+                ClientCertificate = sinkClusterCert2,
+                ModifyDatabaseName = s => "SinkDB"
+            });
+
+            var pullCert1 = new X509Certificate2(await File.ReadAllBytesAsync(hubCluster.Certificates.ClientCertificate2Path), (string)null, X509KeyStorageFlags.Exportable);
+            var pullCert2 = new X509Certificate2(await File.ReadAllBytesAsync(hubCluster.Certificates.ClientCertificate3Path), (string)null, X509KeyStorageFlags.Exportable);
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "both",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                WithFiltering = true,
+                PinToMentorNode = true,
+                MentorNode = "A"
+            }));
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("both", new ReplicationHubAccess
+            {
+                Name = "Sink1",
+                AllowedSinkToHubPaths = new[] { "*" },
+                AllowedHubToSinkPaths = new[] { "*" },
+                CertificateBase64 = Convert.ToBase64String(pullCert1.Export(X509ContentType.Cert)),
+            }));
+
+            await SetupSink(sinkStore1, "Sink1", pullCert1);
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("both", new ReplicationHubAccess
+            {
+                Name = "Sink2",
+                AllowedSinkToHubPaths = new[] { "*" },
+                AllowedHubToSinkPaths = new[] { "*" },
+                CertificateBase64 = Convert.ToBase64String(pullCert2.Export(X509ContentType.Cert)),
+            }));
+
+            await SetupSink(sinkStore2, "Sink2", pullCert2);
+
+            Assert.Equal(4, await WaitForValueAsync(async () =>
+            {
+                // 2 outgoing internal replication connections 
+                // 2 outgoing pull replication connections
+                var stats = await hubStore.Maintenance.ForNode("A").SendAsync(new GetReplicationPerformanceStatisticsOperation());
+                return stats.Outgoing.Length;
+            }, 4));
+
+            Assert.Equal(4, await WaitForValueAsync(async () =>
+            {
+                // 2 incoming internal replication connections 
+                // 2 incoming pull replication connections
+                var stats = await hubStore.Maintenance.ForNode("A").SendAsync(new GetReplicationPerformanceStatisticsOperation());
+                return stats.Incoming.Length;
+            }, 4));
+
+            X509Certificate2 RegisterClientCertificate((List<RavenServer> Nodes, RavenServer Leader, TestCertificatesHolder Certificates) cluster)
+            {
+                return Certificates.RegisterClientCertificate(cluster.Certificates.ServerCertificate.Value, cluster.Certificates
+                    .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: cluster.Leader);
+            }
+
+            async Task SetupSink(DocumentStore sinkStore, string accessName, X509Certificate2 pullCert)
+            {
+                await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Database = hubStore.Database,
+                    Name = hubStore.Database + "ConStr",
+                    TopologyDiscoveryUrls = hubStore.Urls
+                }));
+                await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+                {
+                    ConnectionStringName = hubStore.Database + "ConStr",
+                    Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                    CertificateWithPrivateKey = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx)),
+                    HubName = "both",
+                    AccessName = accessName,
+                    AllowedHubToSinkPaths = new[] { "*" },
+                    AllowedSinkToHubPaths = new[] { "*" }
+                }));
+            }
+        }
+    }
+}


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22709/Pull-Replication-Connection-Failure-When-Two-Sinks-Have-the-Same-Database-Name


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
