### PR TITLE
RavenDB-22357 Wrong db info in database list in studio

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.spec.tsx
@@ -5,8 +5,16 @@ import { composeStories } from "@storybook/react";
 import * as stories from "./DatabasesPage.stories";
 import { DatabasesStubs } from "test/stubs/DatabasesStubs";
 
-const { Single, Cluster, Sharded, DifferentNodeStates, WithLoadError, WithDifferentAccessLevel, WithOfflineNodes } =
-    composeStories(stories);
+const {
+    Single,
+    Cluster,
+    Sharded,
+    DifferentNodeStates,
+    WithLoadErrorOnSingleNode,
+    WithLoadErrorOnAllNodes,
+    WithDifferentAccessLevel,
+    WithOfflineNodes,
+} = composeStories(stories);
 
 const selectors = {
     clusterDatabaseName: DatabasesStubs.nonShardedClusterDatabase().name,
@@ -40,8 +48,8 @@ describe("DatabasesPage", function () {
         await screen.findByText("9 Indexing errors");
     });
 
-    it("can render load error", async () => {
-        const { screen, fireClick } = rtlRender(<WithLoadError />);
+    it("can render load error on single node", async () => {
+        const { screen, fireClick } = rtlRender(<WithLoadErrorOnSingleNode />);
 
         await screen.findByText(/Manage group/i);
 
@@ -50,6 +58,13 @@ describe("DatabasesPage", function () {
         const findAllDistributionDetailsTitle = await screen.findAllByTitle(/Expand distribution details/i);
 
         await fireClick(findAllDistributionDetailsTitle[0]);
+    });
+
+    it("can render load error on all nodes", async () => {
+        const { screen } = rtlRender(<WithLoadErrorOnAllNodes />);
+
+        // general info section is hidden
+        expect(screen.queryByClassName("icon-documents")).not.toBeInTheDocument();
     });
 
     it("can render sharded view", async () => {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.stories.tsx
@@ -82,13 +82,25 @@ export const WithDifferentAccessLevel: StoryFn<typeof DatabasesPage> = () => {
     return <DatabasesPage />;
 };
 
-export const WithLoadError: StoryFn<typeof DatabasesPage> = () => {
+export const WithLoadErrorOnSingleNode: StoryFn<typeof DatabasesPage> = () => {
     commonInit();
 
     const value = mockStore.databases.with_Cluster();
 
     mockServices.databasesService.withGetDatabasesState((tag) => getDatabaseNamesForNode(tag, value), {
         loadError: ["B"],
+    });
+
+    return <DatabasesPage />;
+};
+
+export const WithLoadErrorOnAllNodes: StoryFn<typeof DatabasesPage> = () => {
+    commonInit();
+
+    const value = mockStore.databases.with_Cluster();
+
+    mockServices.databasesService.withGetDatabasesState((tag) => getDatabaseNamesForNode(tag, value), {
+        loadError: ["A", "B", "C"],
     });
 
     return <DatabasesPage />;

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.spec.tsx
@@ -1,32 +1,129 @@
 ﻿import { DatabasesStubs } from "test/stubs/DatabasesStubs";
-import { findLatestBackup } from "components/pages/resources/databases/partials/ValidDatabasePropertiesPanel";
+import { exportedForTesting } from "components/pages/resources/databases/partials/ValidDatabasePropertiesPanel";
 import BackupInfo = Raven.Client.ServerWide.Operations.BackupInfo;
 import { toDatabaseLocalInfo } from "components/common/shell/databasesSlice";
+import { loadStatus, locationAwareLoadableData } from "components/models/common";
+import { DatabaseLocalInfo } from "components/models/databases";
 
-describe("findLatestBackup", () => {
-    it("get use latest backup", () => {
-        const rawStates = [
-            DatabasesStubs.studioDatabaseState("db1"),
-            DatabasesStubs.studioDatabaseState("db1"),
-            DatabasesStubs.studioDatabaseState("db1"),
-        ];
+const { findLatestBackup, getIsGeneralInfoVisible } = exportedForTesting;
 
-        const localInfos = rawStates.map((x) => toDatabaseLocalInfo(x, "A"));
+describe("ValidDatabasePropertiesPanel", () => {
+    describe("findLatestBackup", () => {
+        it("get use latest backup", () => {
+            const rawStates = [
+                DatabasesStubs.studioDatabaseState("db1"),
+                DatabasesStubs.studioDatabaseState("db1"),
+                DatabasesStubs.studioDatabaseState("db1"),
+            ];
 
-        localInfos[0].backupInfo = null;
-        localInfos[1].backupInfo = stubBackupInfo("2022-04-03T12:12:13.6136291Z");
-        localInfos[2].backupInfo = stubBackupInfo("2021-04-16T19:19:18.6136291Z");
+            const localInfos = rawStates.map((x) => toDatabaseLocalInfo(x, "A"));
 
-        const backup = findLatestBackup(localInfos);
-        expect(backup.LastBackup).toEqual("2022-04-03T12:12:13.6136291Z");
+            localInfos[0].backupInfo = null;
+            localInfos[1].backupInfo = stubBackupInfo("2022-04-03T12:12:13.6136291Z");
+            localInfos[2].backupInfo = stubBackupInfo("2021-04-16T19:19:18.6136291Z");
+
+            const backup = findLatestBackup(localInfos);
+            expect(backup.LastBackup).toEqual("2022-04-03T12:12:13.6136291Z");
+        });
+
+        function stubBackupInfo(date: string): BackupInfo {
+            return {
+                LastBackup: date,
+                BackupTaskType: "Periodic",
+                Destinations: [],
+                IntervalUntilNextBackupInSec: 0,
+            };
+        }
+    });
+
+    describe("getIsGeneralInfoVisible", () => {
+        describe("non-sharded", () => {
+            it("returns true if any of dbStates is successful without load error", () => {
+                const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
+                    getDatabaseLocalInfo("idle", null, { nodeTag: "A" }),
+                    getDatabaseLocalInfo("success", null, { nodeTag: "B" }),
+                    getDatabaseLocalInfo("idle", null, { nodeTag: "C" }),
+                ];
+
+                expect(getIsGeneralInfoVisible(dbStates, false)).toBe(true);
+            });
+
+            it("returns false if all dbStates are not successful", () => {
+                const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
+                    getDatabaseLocalInfo("loading", null, { nodeTag: "A" }),
+                    getDatabaseLocalInfo("idle", null, { nodeTag: "B" }),
+                    getDatabaseLocalInfo("failure", null, { nodeTag: "C" }),
+                ];
+
+                expect(getIsGeneralInfoVisible(dbStates, false)).toBe(false);
+            });
+
+            it("returns false if all dbStates have a load error", () => {
+                const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
+                    getDatabaseLocalInfo("success", "Some error 1", { nodeTag: "A" }),
+                    getDatabaseLocalInfo("success", "Some error 2", { nodeTag: "B" }),
+                    getDatabaseLocalInfo("success", "Some error 3", { nodeTag: "C" }),
+                ];
+
+                expect(getIsGeneralInfoVisible(dbStates, false)).toBe(false);
+            });
+        });
+
+        describe("sharded", () => {
+            it("returns true if any of dbStates for shard is successful without load error", () => {
+                const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
+                    getDatabaseLocalInfo("success", null, { nodeTag: "A", shardNumber: 0 }),
+                    getDatabaseLocalInfo("success", null, { nodeTag: "B", shardNumber: 1 }),
+                    getDatabaseLocalInfo("idle", null, { nodeTag: "C", shardNumber: 1 }),
+                ];
+
+                expect(getIsGeneralInfoVisible(dbStates, true)).toBe(true);
+            });
+
+            it("returns false if all dbStates for shard are not successful", () => {
+                const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
+                    getDatabaseLocalInfo("success", null, { nodeTag: "A", shardNumber: 0 }),
+                    getDatabaseLocalInfo("idle", null, { nodeTag: "B", shardNumber: 1 }),
+                    getDatabaseLocalInfo("failure", null, { nodeTag: "C", shardNumber: 1 }),
+                ];
+
+                expect(getIsGeneralInfoVisible(dbStates, true)).toBe(false);
+            });
+
+            it("returns false if all dbStates for shard have a load error", () => {
+                const dbState: locationAwareLoadableData<DatabaseLocalInfo>[] = [
+                    getDatabaseLocalInfo("success", null, { nodeTag: "A", shardNumber: 0 }),
+                    getDatabaseLocalInfo("success", "Some error 1", { nodeTag: "B", shardNumber: 1 }),
+                    getDatabaseLocalInfo("success", "Some error 2", { nodeTag: "C", shardNumber: 1 }),
+                ];
+
+                expect(getIsGeneralInfoVisible(dbState, true)).toBe(false);
+            });
+        });
+
+        function getDatabaseLocalInfo(
+            status: loadStatus,
+            loadError: string | null,
+            location: databaseLocationSpecifier
+        ): locationAwareLoadableData<DatabaseLocalInfo> {
+            return {
+                location,
+                status,
+                data: {
+                    loadError,
+                    databaseStatus: "Online",
+                    indexingStatus: "Running",
+                    documentsCount: 10,
+                    totalSize: null,
+                    tempBuffersSize: null,
+                    location,
+                    indexingErrors: null,
+                    alerts: null,
+                    performanceHints: null,
+                    name: "db",
+                    backupInfo: null,
+                },
+            };
+        }
     });
 });
-
-function stubBackupInfo(date: string): BackupInfo {
-    return {
-        LastBackup: date,
-        BackupTaskType: "Periodic",
-        Destinations: [],
-        IntervalUntilNextBackupInSec: 0,
-    };
-}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22357/Wrong-db-info-in-database-list-in-studio

### Additional description

Hides general database info if `/studio-tasks/databases/state?nodeTag=*` returns load error for all nodes

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
