### PR TITLE
RavenDB-22627 - Add studio and RevisionsForConflicts configuration to restore and add test to monitor new fields in the DatabaseRecord

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -821,6 +821,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     databaseRecord.IndexesHistory = smugglerDatabaseRecord.IndexesHistory;
                     databaseRecord.Refresh = smugglerDatabaseRecord.Refresh;
                     databaseRecord.Integrations = smugglerDatabaseRecord.Integrations;
+                    databaseRecord.Studio = smugglerDatabaseRecord.Studio;
 
                     // need to enable revisions before import
                     database.DocumentsStorage.RevisionsStorage.InitializeFromDatabaseRecord(smugglerDatabaseRecord);

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -62,6 +62,8 @@ namespace Raven.Server.ServerWide
 
         public static readonly Func<BlittableJsonReaderObject, RefreshConfiguration> RefreshConfiguration = GenerateJsonDeserializationRoutine<RefreshConfiguration>();
 
+        public static readonly Func<BlittableJsonReaderObject, StudioConfiguration> StudioConfiguration = GenerateJsonDeserializationRoutine<StudioConfiguration>();
+
         public static readonly Func<BlittableJsonReaderObject, PeriodicBackupConfiguration> PeriodicBackupConfiguration = GenerateJsonDeserializationRoutine<PeriodicBackupConfiguration>();
 
         public static readonly Func<BlittableJsonReaderObject, ServerWideBackupConfiguration> ServerWideBackupConfiguration = GenerateJsonDeserializationRoutine<ServerWideBackupConfiguration>();

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -443,12 +443,28 @@ namespace Raven.Server.Smuggler.Documents
                             _writer.WriteEndObject();
                         }
 
+                        if (databaseRecord.Studio != null)
+                        {
+                            _writer.WriteComma();
+                            _writer.WritePropertyName(nameof(databaseRecord.Studio));
 
+                            WriteStudioConfiguration(databaseRecord.Studio);
+                        }
 
                         break;
                 }
 
                 await _writer.MaybeFlushAsync();
+            }
+
+            private void WriteStudioConfiguration(StudioConfiguration studioConfiguration)
+            {
+                if (studioConfiguration == null)
+                {
+                    _writer.WriteNull();
+                    return;
+                }
+                _context.Write(_writer, studioConfiguration.ToJson());
             }
 
             private void WriteHubPullReplications(List<PullReplicationDefinition> hubPullReplications)

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -451,10 +451,28 @@ namespace Raven.Server.Smuggler.Documents
                             WriteStudioConfiguration(databaseRecord.Studio);
                         }
 
+                        if (databaseRecord.RevisionsForConflicts != null)
+                        {
+                            _writer.WriteComma();
+                            _writer.WritePropertyName(nameof(databaseRecord.RevisionsForConflicts));
+
+                            WriteRevisionsForConflictsConfiguration(databaseRecord.RevisionsForConflicts);
+                        }
+
                         break;
                 }
 
                 await _writer.MaybeFlushAsync();
+            }
+
+            private void WriteRevisionsForConflictsConfiguration(RevisionsCollectionConfiguration revisionsForConflictsConfiguration)
+            {
+                if (revisionsForConflictsConfiguration == null)
+                {
+                    _writer.WriteNull();
+                    return;
+                }
+                _context.Write(_writer, revisionsForConflictsConfiguration.ToJson());
             }
 
             private void WriteStudioConfiguration(StudioConfiguration studioConfiguration)

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Analysis;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.Configuration;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.ElasticSearch;
@@ -678,6 +679,20 @@ namespace Raven.Server.Smuggler.Documents
                         databaseRecord.IndexesHistory = null; // skip when we hit a error.
                         if (_log.IsInfoEnabled)
                             _log.Info("Wasn't able to import the IndexesHistory from smuggler file. Skipping.", e);
+                    }
+                }
+
+                if (reader.TryGet(nameof(databaseRecord.Studio), out BlittableJsonReaderObject studioConfig) &&
+                    studioConfig != null)
+                {
+                    try
+                    {
+                        databaseRecord.Studio = JsonDeserializationCluster.StudioConfiguration(studioConfig);
+                    }
+                    catch (Exception e)
+                    {
+                        if (_log.IsInfoEnabled)
+                            _log.Info("Wasn't able to import the studio configuration from smuggler file. Skipping.", e);
                     }
                 }
 

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -696,6 +696,19 @@ namespace Raven.Server.Smuggler.Documents
                     }
                 }
 
+                if (reader.TryGet(nameof(databaseRecord.RevisionsForConflicts), out BlittableJsonReaderObject revisionForConflicts) &&
+                    revisionForConflicts != null)
+                {
+                    try
+                    {
+                        databaseRecord.RevisionsForConflicts = JsonDeserializationCluster.RevisionsCollectionConfiguration(revisionForConflicts);
+                    }
+                    catch (Exception e)
+                    {
+                        if (_log.IsInfoEnabled)
+                            _log.Info("Wasn't able to import the RevisionsForConflicts configuration from smuggler file. Skipping.", e);
+                    }
+                }
             });
 
             return databaseRecord;

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -1183,6 +1183,10 @@ namespace SlowTests.Smuggler
                 long index = (await Server.ServerStore.SendToLeaderAsync(command)).Index;
                 await Server.ServerStore.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, index, TimeSpan.FromSeconds(30));
 
+                //add RevisionsForConflicts configuration
+                store.Maintenance.Server.Send(new ConfigureRevisionsForConflictsOperation(store.Database,
+                    new RevisionsCollectionConfiguration() { Disabled = false, MinimumRevisionAgeToKeep = TimeSpan.FromDays(5) }));
+
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(new User
@@ -1273,6 +1277,10 @@ namespace SlowTests.Smuggler
                     Assert.NotNull(record.Studio);
                     Assert.False(record.Studio.Disabled);
                     Assert.Equal(StudioConfiguration.StudioEnvironment.None, record.Studio.Environment);
+
+                    Assert.NotNull(record.RevisionsForConflicts);
+                    Assert.False(record.Disabled);
+                    Assert.Equal(TimeSpan.FromDays(5), record.RevisionsForConflicts.MinimumRevisionAgeToKeep);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22627

### Additional description

In continuation to https://github.com/ravendb/ravendb/pull/18951, added missing fields `StudioConfiguration` and `RevisionsForConflicts` to restore.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
