### PR TITLE
RavenDB-22661 implemented cleanup mechanism for PoolOfThreads

### DIFF
--- a/src/Raven.Server/Utils/PoolOfThreads.cs
+++ b/src/Raven.Server/Utils/PoolOfThreads.cs
@@ -115,7 +115,7 @@ namespace Raven.Server.Utils
             }
 
             pooled.StartedAt = DateTime.UtcNow;
-            pooled.InPoolSince = null;
+            pooled.InPoolSince = DateTime.MinValue;
             return pooled.SetWorkForThread(action, state, threadInfo, nameToUse);
         }
 
@@ -135,7 +135,7 @@ namespace Raven.Server.Utils
 
         private static void ReleaseThread(PooledThread pooled)
         {
-            pooled.InPoolSince = null;
+            pooled.InPoolSince = DateTime.MinValue;
             pooled.SetWorkForThread(null, null, null, null);
         }
 
@@ -207,7 +207,7 @@ namespace Raven.Server.Utils
             }
         }
 
-        internal class PooledThread
+        internal class PooledThread : PooledItem
         {
             private static readonly FieldInfo ThreadFieldName;
 
@@ -227,8 +227,6 @@ namespace Raven.Server.Utils
             public long? ThreadMask { get; private set; }
 
             public DateTime StartedAt { get; internal set; }
-
-            public DateTime? InPoolSince;
 
             static PooledThread()
             {
@@ -423,6 +421,10 @@ namespace Raven.Server.Utils
                 ThreadMask = threadMask;
 
                 AffinityHelper.SetCustomThreadAffinity(this);
+            }
+
+            public override void Dispose()
+            {
             }
         }
     }

--- a/src/Raven.Server/Utils/PoolOfThreads.cs
+++ b/src/Raven.Server/Utils/PoolOfThreads.cs
@@ -149,14 +149,11 @@ namespace Raven.Server.Utils
         {
             const int minNumberOfItemsInPoolToPerformCleanupCheck = 64;
 
-            if (_pool.Count < minNumberOfItemsInPoolToPerformCleanupCheck)
+            if (_disposed)
                 return;
 
-            lock (this)
-            {
-                if (_disposed)
-                    return;
-            }
+            if (_pool.Count < minNumberOfItemsInPoolToPerformCleanupCheck)
+                return;
 
             try
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22661

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
