### PR TITLE
RavenDB-22719 '_.remove' replaced with 'filter' bug

### DIFF
--- a/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
+++ b/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
@@ -47,7 +47,7 @@ class collectionsTracker {
     }
 
     private collectionsLoaded(collectionsStats: collectionsStats) {
-        const collections = collectionsStats.collections.filter(x => !x.documentCount());
+        const collections = collectionsStats.collections.filter(x => x.documentCount());
         
         collections.sort((a, b) => this.sortAlphaNumericCollection(a.name, b.name));
 

--- a/src/Raven.Studio/typescript/common/notifications/protractedCommandsDetector.ts
+++ b/src/Raven.Studio/typescript/common/notifications/protractedCommandsDetector.ts
@@ -23,7 +23,7 @@ class protractedCommandsDetector {
     private sync() {
         this.showSpinner(this.requestsInProgress.some(x => x.spinnerVisible));
 
-        this.requestsInProgress = this.requestsInProgress.filter(x => x.completed);
+        this.requestsInProgress = this.requestsInProgress.filter(x => !x.completed);
     }
 
     private showServerNotRespondingAlert() {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22719/.remove-replaced-with-filter-bug

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
