### PR TITLE
RavenDB-22720 Order of databases in the db switcher is reversed

### DIFF
--- a/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/databaseSwitcher/DatabaseSwitcher.tsx
+++ b/src/Raven.Studio/typescript/components/shell/studioSearchWithDatabaseSelector/databaseSwitcher/DatabaseSwitcher.tsx
@@ -12,21 +12,21 @@ import { DatabaseSwitcherOption } from "./databaseSwitcherTypes";
 export default function DatabaseSwitcher() {
     const allDatabases = useAppSelector(databaseSelectors.allDatabases);
 
-    // Disabled databases are always at the bottom
-    const options: DatabaseSwitcherOption[] = useMemo(
-        () =>
-            [...allDatabases]
-                .sort((a, b) => (a.isDisabled > b.isDisabled ? 1 : -1))
-                .map((db) => {
-                    return {
-                        value: db.name,
-                        isSharded: db.isSharded,
-                        environment: db.environment,
-                        isDisabled: db.isDisabled,
-                    };
-                }),
-        [allDatabases]
-    );
+    // Sorted by name. Disabled databases are always at the bottom
+    const options: DatabaseSwitcherOption[] = useMemo(() => {
+        const sortedByNameDatabases = allDatabases.sort((a, b) => a.name.localeCompare(b.name));
+        const sortedByStatusDatabases = [
+            ...sortedByNameDatabases.filter((item) => !item.isDisabled),
+            ...sortedByNameDatabases.filter((item) => item.isDisabled),
+        ];
+
+        return sortedByStatusDatabases.map((db) => ({
+            value: db.name,
+            isSharded: db.isSharded,
+            environment: db.environment,
+            isDisabled: db.isDisabled,
+        }));
+    }, [allDatabases]);
 
     const activeDatabaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const selectedDatabase = options.find((x) => x.value === activeDatabaseName);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22720/Order-of-databases-in-the-db-switcher-is-reversed

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
