### PR TITLE
RavenDB-22698 Making more strict the parsing of LazyStringParser.TryParseTimeSpan() by not skipping any characters when searching for '.' character separating milliseconds

### DIFF
--- a/src/Sparrow/Json/LazyStringParser.cs
+++ b/src/Sparrow/Json/LazyStringParser.cs
@@ -177,13 +177,9 @@ namespace Sparrow.Json
             if (len < indexOfDays + 1 + 8)
                 return false;
 
-            for (int i = indexOfDays + 1 + 8; i < len; i++)
+            if (buffer[indexOfDays + 1 + 8] == '.')
             {
-                if (buffer[i] == '.')
-                {
-                    indexOfMilliseconds = i;
-                    break;
-                }
+                indexOfMilliseconds = indexOfDays + 1 + 8;
             }
 
             if (indexOfMilliseconds == -1) // if we have ms then it will be validated below
@@ -480,13 +476,9 @@ namespace Sparrow.Json
             if (len < indexOfDays + 1 + 8)
                 return false;
 
-            for (int i = indexOfDays + 1 + 8; i < len; i++)
+            if (buffer[indexOfDays + 1 + 8] == '.')
             {
-                if (buffer[i] == '.')
-                {
-                    indexOfMilliseconds = i;
-                    break;
-                }
+                indexOfMilliseconds = indexOfDays + 1 + 8;
             }
 
             if (indexOfMilliseconds == -1) // if we have ms then it will be validated below

--- a/test/FastTests/Utils/TimeParsing.cs
+++ b/test/FastTests/Utils/TimeParsing.cs
@@ -41,15 +41,20 @@ namespace FastTests.Utils
         [InlineData("-2.21:07:32")]
         [InlineData("2.21:07:32.232")]
         [InlineData("333.21:07:32.232")]
+        [InlineData("12:11:02.")]
         public void CanParseValidTimeSpans(string dt)
         {
             var expected = TimeSpan.ParseExact(dt,"c", CultureInfo.InvariantCulture);
 
             var bytes = Encoding.UTF8.GetBytes(dt);
             fixed (byte* buffer = bytes)
+            fixed (char* str = dt)
             {
                 TimeSpan ts;
                 Assert.True(LazyStringParser.TryParseTimeSpan(buffer, bytes.Length, out ts));
+                Assert.Equal(expected, ts);
+
+                Assert.True(LazyStringParser.TryParseTimeSpan(str, dt.Length, out ts));
                 Assert.Equal(expected, ts);
             }
         }
@@ -58,6 +63,8 @@ namespace FastTests.Utils
         [InlineData("21:07:32 some text")]
         [InlineData("2.21:07:32 some text")]
         [InlineData("333.21:07:32.232 some text")]
+        [InlineData("00:00:00 some text.")]
+        [InlineData("00:00:00. some text")]
         public void WillNotParseAsTimeSpan(string dt)
         {
             TimeSpan expected;
@@ -66,9 +73,13 @@ namespace FastTests.Utils
 
             var bytes = Encoding.UTF8.GetBytes(dt);
             fixed (byte* buffer = bytes)
+            fixed (char* str = dt)
             {
                 TimeSpan ts;
                 Assert.False(LazyStringParser.TryParseTimeSpan(buffer, bytes.Length, out ts));
+                Assert.Equal(expected, ts);
+
+                Assert.False(LazyStringParser.TryParseTimeSpan(str, dt.Length, out ts));
                 Assert.Equal(expected, ts);
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22698

### Additional description

When parsing a string like `"00:00:00 some text."` we skipped ` some text` part and validated the entire string as valid `TimeSpan` (`00:00:00.` is valid `TimeSpan`)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
