### PR TITLE
RavenDB-21816 - recreate disposed request executor in sharded subscription

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForGetSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/AbstractSubscriptionsHandlerProcessorForGetSubscription.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.ServerWide.Context;
@@ -47,14 +48,14 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
             }
         }
 
-        internal static void WriteGetAllResult(AsyncBlittableJsonTextWriterForDebug writer, IEnumerable<SubscriptionState> subscriptions, ClusterOperationContext context)
+        internal void WriteGetAllResult(AsyncBlittableJsonTextWriterForDebug writer, IEnumerable<SubscriptionState> subscriptions, ClusterOperationContext context)
         {
             writer.WriteStartObject();
             writer.WriteArray(context, "Results", subscriptions.Select(SubscriptionStateAsJson), (w, c, subscription) => c.Write(w, subscription));
             writer.WriteEndObject();
         }
 
-        private static DynamicJsonValue SubscriptionStateAsJson(SubscriptionState state)
+        protected virtual DynamicJsonValue SubscriptionStateAsJson(SubscriptionState state)
         {
             var json = new DynamicJsonValue
             {
@@ -93,10 +94,10 @@ namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
             if (subscriptionList == null)
                 return new DynamicJsonArray();
 
-            return new DynamicJsonArray(subscriptionList.Select(s => GetSubscriptionConnectionJson(s)));
+            return new DynamicJsonArray(subscriptionList.Select(GetSubscriptionConnectionJson));
         }
 
-        private static DynamicJsonValue GetSubscriptionConnectionJson(SubscriptionConnection x)
+        protected static DynamicJsonValue GetSubscriptionConnectionJson<T>(SubscriptionConnectionBase<T> x) where T : AbstractIncludesCommand
         {
             if (x == null)
                 return new DynamicJsonValue();

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/SubscriptionsHandlerProcessorForGetSubscription.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/SubscriptionsHandlerProcessorForGetSubscription.cs
@@ -1,46 +1,63 @@
-﻿using System.Collections.Generic;
-using System.Net;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
-using Raven.Client.Documents.Subscriptions;
 using Raven.Server.Documents.Subscriptions;
+using Raven.Server.Documents.TcpHandlers;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Parsing;
+using static Raven.Server.Documents.Subscriptions.SubscriptionStorage;
 
 namespace Raven.Server.Documents.Handlers.Processors.Subscriptions
 {
-    internal sealed class SubscriptionsHandlerProcessorForGetSubscription : AbstractSubscriptionsHandlerProcessorForGetSubscription<DatabaseRequestHandler, DocumentsOperationContext>
+    internal sealed class SubscriptionsHandlerProcessorForGetSubscription 
+        : AbstractSubscriptionsHandlerProcessorForGetSubscription<DatabaseRequestHandler, DocumentsOperationContext, SubscriptionGeneralDataAndStats>
     {
         public SubscriptionsHandlerProcessorForGetSubscription([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
         }
 
-        protected override IEnumerable<SubscriptionState> GetSubscriptions(ClusterOperationContext context, int start, int pageSize, bool history, bool running, long? id, string name)
+        protected override IEnumerable<SubscriptionGeneralDataAndStats> GetAllSubscriptions(ClusterOperationContext context, int start, int pageSize, bool history, bool running)
         {
-            IEnumerable<SubscriptionStorage.SubscriptionGeneralDataAndStats> subscriptions;
-            if (string.IsNullOrEmpty(name) && id == null)
-            {
-                subscriptions = running
-                    ? RequestHandler.Database.SubscriptionStorage.GetAllRunningSubscriptions(context, history, start, pageSize)
-                    : RequestHandler.Database.SubscriptionStorage.GetAllSubscriptions(context, history, start, pageSize);
-            }
-            else
-            {
-                var subscription = running
-                    ? RequestHandler.Database
-                        .SubscriptionStorage
-                        .GetRunningSubscription(context, id, name, history)
-                    : RequestHandler.Database
-                        .SubscriptionStorage
-                        .GetSubscription(context, id, name, history);
+           return running
+               ? RequestHandler.Database.SubscriptionStorage.GetAllRunningSubscriptions(context, history, start, pageSize)
+               : RequestHandler.Database.SubscriptionStorage.GetAllSubscriptions(context, history, start, pageSize);
+        }
 
-                if (subscription == null)
-                {
-                    HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                    return null;
-                }
+        protected override SubscriptionGeneralDataAndStats GetSubscriptionByName(ClusterOperationContext context, bool history, bool running, string name)
+        {
+            return RequestHandler.Database.SubscriptionStorage.GetSubscriptionWithDataByNameFromServerStore(context, name, history, running);
+        }
 
-                subscriptions = new[] {subscription};
-            }
-            return subscriptions;
+        protected override SubscriptionGeneralDataAndStats GetSubscriptionById(ClusterOperationContext context, bool history, bool running, long id)
+        {
+           return RequestHandler.Database.SubscriptionStorage.GetSubscriptionWithDataByIdFromServerStore(context, id, history, running);
+        }
+
+        protected override DynamicJsonValue SubscriptionStateAsJson(SubscriptionGeneralDataAndStats state)
+        {
+            var json = base.SubscriptionStateAsJson(state);
+
+            json[nameof(SubscriptionGeneralDataAndStats.Connections)] = GetSubscriptionConnectionsJson(state.Connections);
+            json[nameof(SubscriptionGeneralDataAndStats.RecentConnections)] = state.RecentConnections == null
+                ? Array.Empty<SubscriptionConnectionInfo>()
+                : state.RecentConnections.Select(r => r.ToJson());
+            json[nameof(SubscriptionGeneralDataAndStats.RecentRejectedConnections)] = state.RecentRejectedConnections == null
+                ? Array.Empty<SubscriptionConnectionInfo>()
+                : state.RecentRejectedConnections.Select(r => r.ToJson());
+            json[nameof(SubscriptionGeneralDataAndStats.CurrentPendingConnections)] = state.CurrentPendingConnections == null
+                ? Array.Empty<SubscriptionConnectionInfo>()
+                : state.CurrentPendingConnections.Select(r => r.ToJson());
+
+            return json;
+        }
+
+        private static DynamicJsonArray GetSubscriptionConnectionsJson(List<SubscriptionConnection> subscriptionList)
+        {
+            if (subscriptionList == null)
+                return new DynamicJsonArray();
+
+            return new DynamicJsonArray(subscriptionList.Select(GetSubscriptionConnectionJson));
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForGetSubscription.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Subscriptions/ShardedSubscriptionsHandlerProcessorForGetSubscription.cs
@@ -5,7 +5,12 @@ using System.Net;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Server.Documents.Handlers.Processors.Subscriptions;
+using Raven.Server.Documents.Sharding.Subscriptions;
+using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json.Parsing;
+using static Raven.Server.Documents.Sharding.ShardedDatabaseContext.ShardedSubscriptionsStorage;
+using static Raven.Server.Documents.Subscriptions.SubscriptionStorage;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Subscriptions
 {
@@ -15,42 +20,22 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Subscriptions
         {
         }
 
-        protected override IEnumerable<SubscriptionState> GetSubscriptions(ClusterOperationContext context, int start, int pageSize, bool history, bool running, long? id, string name)
+        protected override IEnumerable<ShardedSubscriptionData> GetSubscriptions(ClusterOperationContext context, int start, int pageSize, bool history, bool running, long? id, string name)
         {
-            if (history)
-                throw new ArgumentException(nameof(history) + " not supported");
-
-            var subscriptions = new List<SubscriptionState>();
+            IEnumerable<ShardedSubscriptionData> subscriptions;
             if (string.IsNullOrEmpty(name) && id == null)
             {
-                var allSubs = RequestHandler.DatabaseContext.SubscriptionsStorage.GetAllSubscriptionsFromServerStore(context, start, pageSize);
-                if (allSubs == null)
-                {
-                    HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                    return null;
-                }
-
-                if (running)
-                {
-                    foreach (var sub in allSubs)
-                    {
-                        var state = RequestHandler.DatabaseContext.SubscriptionsStorage.GetSubscriptionConnectionsState(context, sub.SubscriptionName);
-                        if (state != null)
-                        {
-                            subscriptions.Add(sub);
-                        }
-                    }
-                }
-                else
-                {
-                    subscriptions = allSubs.ToList();
-                }
+                subscriptions = running
+                    ? RequestHandler.DatabaseContext.SubscriptionsStorage.GetAllRunningSubscriptions(context, history, start, pageSize)
+                    : RequestHandler.DatabaseContext.SubscriptionsStorage.GetAllSubscriptions(context, history, start, pageSize);
             }
             else
             {
-                var subscription = id == null
-                    ? RequestHandler.DatabaseContext.SubscriptionsStorage.GetSubscriptionByName(context, name)
-                    : RequestHandler.DatabaseContext.SubscriptionsStorage.GetSubscriptionById(context, id.Value);
+                var subscription = running
+                    ? RequestHandler.DatabaseContext.SubscriptionsStorage
+                        .GetRunningSubscription(context, id, name, history)
+                    : RequestHandler.DatabaseContext.SubscriptionsStorage
+                        .GetSubscription(context, id, name, history);
 
                 if (subscription == null)
                 {
@@ -58,20 +43,50 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Subscriptions
                     return null;
                 }
 
-                if (running)
-                {
-                    var state = RequestHandler.DatabaseContext.SubscriptionsStorage.GetSubscriptionConnectionsState(context, subscription.SubscriptionName);
-                    if (state == null)
-                    {
-                        HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                        return null;
-                    }
-                }
-
-                subscriptions = new List<SubscriptionState> { subscription };
+                subscriptions = new[] { subscription };
             }
 
             return subscriptions;
+        }
+
+        protected override DynamicJsonValue SubscriptionStateAsJson(SubscriptionState state)
+        {
+            var json = base.SubscriptionStateAsJson(state);
+
+            if (state is ShardedSubscriptionData shardedSubscriptionData)
+            {
+                json[nameof(SubscriptionGeneralDataAndStats.Connections)] = GetSubscriptionConnectionsJson(shardedSubscriptionData.Connections);
+                json[nameof(SubscriptionGeneralDataAndStats.RecentConnections)] = shardedSubscriptionData.RecentConnections == null
+                    ? Array.Empty<SubscriptionConnectionInfo>()
+                    : shardedSubscriptionData.RecentConnections.Select(r => r.ToJson());
+                json[nameof(SubscriptionGeneralDataAndStats.RecentRejectedConnections)] = shardedSubscriptionData.RecentRejectedConnections == null
+                    ? Array.Empty<SubscriptionConnectionInfo>()
+                    : shardedSubscriptionData.RecentRejectedConnections.Select(r => r.ToJson());
+                json[nameof(SubscriptionGeneralDataAndStats.CurrentPendingConnections)] = shardedSubscriptionData.CurrentPendingConnections == null
+                    ? Array.Empty<SubscriptionConnectionInfo>()
+                    : shardedSubscriptionData.CurrentPendingConnections.Select(r => r.ToJson());
+                json[nameof(ShardedSubscriptionData.RecentShardedWorkers)] = shardedSubscriptionData.RecentShardedWorkers == null ? Array.Empty<ShardedSubscriptionWorkerInfo>() 
+                    : shardedSubscriptionData.RecentShardedWorkers.Select(x=>x.ToJson());
+                json[nameof(ShardedSubscriptionData.ShardedWorkers)] = GetShardedWorkersJson(shardedSubscriptionData.ShardedWorkers);
+            }
+
+            return json;
+        }
+
+        private static DynamicJsonArray GetSubscriptionConnectionsJson(List<OrchestratedSubscriptionConnection> subscriptionList)
+        {
+            if (subscriptionList == null)
+                return new DynamicJsonArray();
+
+            return new DynamicJsonArray(subscriptionList.Select(GetSubscriptionConnectionJson));
+        }
+
+        private static DynamicJsonArray GetShardedWorkersJson(IDictionary<string, ShardedSubscriptionWorker> subscriptionList)
+        {
+            if (subscriptionList == null)
+                return new DynamicJsonArray();
+
+            return new DynamicJsonArray(subscriptionList.Select(w => ShardedSubscriptionWorkerInfo.Create(w.Key, w.Value).ToJson()));
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/OrchestratedSubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/OrchestratedSubscriptionConnection.cs
@@ -21,6 +21,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Utils;
+using static Raven.Server.Documents.Subscriptions.ISubscriptionConnection;
 
 namespace Raven.Server.Documents.Sharding.Subscriptions
 {

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionConnectionsState.cs
@@ -32,6 +32,13 @@ public abstract class AbstractSubscriptionConnectionsState : IDisposable
     public string Query;
     public string LastChangeVectorSent;
 
+    protected readonly ConcurrentSet<SubscriptionConnectionInfo> _pendingConnections = new();
+    protected readonly ConcurrentQueue<SubscriptionConnectionInfo> _recentConnections = new();
+    protected readonly ConcurrentQueue<SubscriptionConnectionInfo> _rejectedConnections = new();
+    public IEnumerable<SubscriptionConnectionInfo> RecentConnections => _recentConnections;
+    public IEnumerable<SubscriptionConnectionInfo> RecentRejectedConnections => _rejectedConnections;
+    public IEnumerable<SubscriptionConnectionInfo> PendingConnections => _pendingConnections;
+
     protected AbstractSubscriptionConnectionsState(CancellationToken token)
     {
         CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
@@ -204,13 +211,6 @@ public abstract class AbstractSubscriptionConnectionsState<TSubscriptionConnecti
     public SubscriptionState SubscriptionState => _subscriptionState;
 
     public bool IsConcurrent => _connections.FirstOrDefault()?.Strategy == SubscriptionOpeningStrategy.Concurrent;
-
-    private readonly ConcurrentSet<SubscriptionConnectionInfo> _pendingConnections = new();
-    private readonly ConcurrentQueue<SubscriptionConnectionInfo> _recentConnections = new();
-    private readonly ConcurrentQueue<SubscriptionConnectionInfo> _rejectedConnections = new();
-    public IEnumerable<SubscriptionConnectionInfo> RecentConnections => _recentConnections;
-    public IEnumerable<SubscriptionConnectionInfo> RecentRejectedConnections => _rejectedConnections;
-    public IEnumerable<SubscriptionConnectionInfo> PendingConnections => _pendingConnections;
 
 
     private readonly SemaphoreSlim _subscriptionActivelyWorkingLock;

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionStorage.cs
@@ -16,6 +16,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Logging;
 using Sparrow.LowMemory;
+using static Raven.Server.Documents.Subscriptions.SubscriptionStorage;
 
 namespace Raven.Server.Documents.Subscriptions;
 
@@ -29,6 +30,7 @@ public abstract class AbstractSubscriptionStorage
     protected abstract string GetNodeFromState(SubscriptionState taskStatus);
     protected abstract DatabaseTopology GetTopology(ClusterOperationContext context);
     public abstract bool DropSingleSubscriptionConnection(long subscriptionId, string workerId, SubscriptionException ex);
+    public abstract SubscriptionState GetRunningSubscription(ClusterOperationContext context, long? id, string name, bool history);
 
     public abstract bool DisableSubscriptionTasks { get; }
     private readonly TimeSpan _waitForClusterStabilizationTimeout;
@@ -163,6 +165,18 @@ public abstract class AbstractSubscriptionStorage
         }
 
         return null;
+    }
+
+    public virtual SubscriptionState GetSubscriptionFromServerStore(ClusterOperationContext context, string name)
+    {
+        var subscriptionBlittable = _serverStore.Cluster.Read(context, SubscriptionState.GenerateSubscriptionItemKeyName(_databaseName, name));
+
+        if (subscriptionBlittable == null)
+            throw new SubscriptionDoesNotExistException($"Subscription with name '{name}' was not found in server store");
+
+        var subscriptionState = JsonDeserializationClient.SubscriptionState(subscriptionBlittable);
+
+        return subscriptionState;
     }
 
     public bool TryEnterSubscriptionsSemaphore()
@@ -393,6 +407,102 @@ public abstract class AbstractSubscriptionStorage<TState> : AbstractSubscription
         }
     }
 
+    protected static void SetSubscriptionHistory(AbstractSubscriptionConnectionsState subscriptionConnectionsState, SubscriptionDataAbstractBase subscriptionData)
+    {
+        subscriptionData.RecentConnections = subscriptionConnectionsState.RecentConnections;
+        subscriptionData.RecentRejectedConnections = subscriptionConnectionsState.RecentRejectedConnections;
+        subscriptionData.CurrentPendingConnections = subscriptionConnectionsState.PendingConnections;
+    }
+
+    protected SubscriptionState GetRunningSubscriptionInternal(ClusterOperationContext context, long? id, string name, bool history, out TState connectionsState)
+    {
+        SubscriptionState state;
+        if (string.IsNullOrEmpty(name) == false)
+        {
+            state = GetSubscriptionFromServerStore(context, name);
+        }
+        else if (id.HasValue)
+        {
+            name = GetSubscriptionNameById(context, id.Value);
+            state = GetSubscriptionFromServerStore(context, name);
+        }
+        else
+        {
+            throw new ArgumentNullException("Must receive either subscription id or subscription name in order to provide subscription data");
+        }
+
+        if (_subscriptions.TryGetValue(state.SubscriptionId, out connectionsState) == false)
+            return null;
+
+        if (connectionsState.IsSubscriptionActive() == false)
+            return null;
+
+        return state;
+    }
+
+    public virtual SubscriptionState GetSubscription(ClusterOperationContext context, long? id, string name, bool history)
+    {
+        SubscriptionState state;
+
+        if (string.IsNullOrEmpty(name) == false)
+        {
+            state = GetSubscriptionFromServerStore(context, name);
+        }
+        else if (id.HasValue)
+        {
+            state = GetSubscriptionFromServerStore(context, id.ToString());
+        }
+        else
+        {
+            throw new ArgumentNullException("Must receive either subscription id or subscription name in order to provide subscription data");
+        }
+
+        return state;
+    }
+
+    public IEnumerable<(SubscriptionState, TState)> GetAllRunningSubscriptionsInternal(ClusterOperationContext context, bool history, int start, int take)
+    {
+        foreach (var kvp in _subscriptions)
+        {
+            var subscriptionConnectionsState = kvp.Value;
+
+            if (subscriptionConnectionsState.IsSubscriptionActive() == false)
+                continue;
+
+            if (start > 0)
+            {
+                start--;
+                continue;
+            }
+
+            if (take-- <= 0)
+                yield break;
+
+            var state = GetSubscriptionFromServerStore(context, subscriptionConnectionsState.SubscriptionName);
+
+            yield return (state, subscriptionConnectionsState);
+        }
+    }
+
+    public virtual IEnumerable<SubscriptionState> GetAllSubscriptions(ClusterOperationContext context, bool history, int start, int take)
+    {
+        foreach (var keyValue in ClusterStateMachine.ReadValuesStartingWith(context, SubscriptionState.SubscriptionPrefix(_databaseName)))
+        {
+            if (start > 0)
+            {
+                start--;
+                continue;
+            }
+
+            if (take-- <= 0)
+                yield break;
+
+            var task = JsonDeserializationClient.SubscriptionState(keyValue.Value);
+
+            yield return task;
+        }
+    }
+
     public void LowMemoryOver()
     {
         // nothing to do here
@@ -408,5 +518,36 @@ public abstract class AbstractSubscriptionStorage<TState> : AbstractSubscription
         }
 
         aggregator.ThrowIfNeeded();
+    }
+
+    public abstract class SubscriptionDataAbstractBase : SubscriptionState
+    {
+        public IEnumerable<SubscriptionConnectionInfo> RecentConnections;
+        public IEnumerable<SubscriptionConnectionInfo> RecentRejectedConnections;
+        public IEnumerable<SubscriptionConnectionInfo> CurrentPendingConnections;
+    }
+
+    public class SubscriptionDataBase<T> : SubscriptionDataAbstractBase
+    {
+        public List<T> Connections;
+
+        public SubscriptionDataBase() { }
+
+        public SubscriptionDataBase(SubscriptionState @base)
+        {
+            Query = @base.Query;
+            ChangeVectorForNextBatchStartingPoint = @base.ChangeVectorForNextBatchStartingPoint;
+            SubscriptionId = @base.SubscriptionId;
+            SubscriptionName = @base.SubscriptionName;
+            ArchivedDataProcessingBehavior = @base.ArchivedDataProcessingBehavior;
+            MentorNode = @base.MentorNode;
+            PinToMentorNode = @base.PinToMentorNode;
+            NodeTag = @base.NodeTag;
+            LastBatchAckTime = @base.LastBatchAckTime;
+            LastClientConnectionTime = @base.LastClientConnectionTime;
+            Disabled = @base.Disabled;
+            ShardingState = @base.ShardingState;
+            RaftCommandIndex = @base.RaftCommandIndex;
+        }
     }
 }

--- a/src/Raven.Server/Documents/Subscriptions/ISubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/Subscriptions/ISubscriptionConnection.cs
@@ -37,4 +37,11 @@ public interface ISubscriptionConnection : IDisposable
     internal Task SendHeartBeatAsync(string reason);
 
     long LastModifiedIndex { get; }
+
+    public enum ConnectionStatus
+    {
+        Create,
+        Fail,
+        Info
+    }
 }

--- a/src/Raven.Server/Documents/Subscriptions/LiveSubscriptionPerformanceCollector.cs
+++ b/src/Raven.Server/Documents/Subscriptions/LiveSubscriptionPerformanceCollector.cs
@@ -286,7 +286,7 @@ namespace Raven.Server.Documents.Subscriptions
             using (Database.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
-                var subscription = Database.SubscriptionStorage.GetSubscription(context, null, subscriptionName, history: false);
+                var subscription = Database.SubscriptionStorage.GetSubscriptionWithDataByNameFromServerStore(context, subscriptionName, history: false, running: false);
                 _perSubscriptionConnectionStats.TryAdd(subscriptionName, new SubscriptionAndPerformanceConnectionStatsList(subscription));
                 
                 if (_perSubscriptionBatchStats.ContainsKey(subscriptionName))

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -25,6 +25,7 @@ using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
+using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
@@ -32,6 +33,7 @@ using Sparrow.Server;
 using Sparrow.Threading;
 using Sparrow.Utils;
 using Voron.Global;
+using ConnectionStatus = Raven.Server.Documents.Subscriptions.ISubscriptionConnection.ConnectionStatus;
 
 namespace Raven.Server.Documents.Subscriptions
 {
@@ -822,13 +824,6 @@ namespace Raven.Server.Documents.Subscriptions
             }
         }
 
-        public enum ConnectionStatus
-        {
-            Create,
-            Fail,
-            Info
-        }
-
         public sealed class StatusMessageDetails
         {
             public string DatabaseName;
@@ -836,7 +831,7 @@ namespace Raven.Server.Documents.Subscriptions
             public string SubscriptionType;
         }
 
-        protected string CreateStatusMessage(ConnectionStatus status, string info = null)
+        public string CreateStatusMessage(ConnectionStatus status, string info = null)
         {
             var message = GetStatusMessageDetails();
             var dbNameStr = message.DatabaseName;
@@ -847,13 +842,13 @@ namespace Raven.Server.Documents.Subscriptions
             switch (status)
             {
                 case ConnectionStatus.Create:
-                    m = $"[CREATE] Received a connection for {subsType}, {dbNameStr} from {clientType}";
+                    m = $"{DateTime.UtcNow.GetDefaultRavenFormat()}: [CREATE] Received a connection for {subsType}, {dbNameStr} from {clientType}";
                     break;
                 case ConnectionStatus.Fail:
-                    m = $"[FAIL] for {subsType}, {dbNameStr} from {clientType}";
+                    m = $"{DateTime.UtcNow.GetDefaultRavenFormat()}: [FAIL] for {subsType}, {dbNameStr} from {clientType}";
                     break;
                 case ConnectionStatus.Info:
-                    return $"[INFO] Update for {subsType}, {dbNameStr}, with {clientType}: {info}";
+                    return $"{DateTime.UtcNow.GetDefaultRavenFormat()}: [INFO] Update for {subsType}, {dbNameStr}, with {clientType}: {info}";
                 default:
                     throw new ArgumentOutOfRangeException(nameof(status), status, null);
             }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionsState.cs
@@ -20,6 +20,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Binary;
 using Voron;
+using ConnectionStatus = Raven.Server.Documents.Subscriptions.ISubscriptionConnection.ConnectionStatus;
 
 namespace Raven.Server.Documents.Subscriptions
 {
@@ -87,7 +88,7 @@ namespace Raven.Server.Documents.Subscriptions
                 return;
             }
 
-            connection.AddToStatusDescription("Starting to subscribe.");
+            connection.AddToStatusDescription(connection.CreateStatusMessage(ConnectionStatus.Info, "Starting to subscribe."));
 
             if (_subscriptionState == null)
             {

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnectionForShard.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnectionForShard.cs
@@ -16,6 +16,7 @@ using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Utils;
+using ConnectionStatus = Raven.Server.Documents.Subscriptions.ISubscriptionConnection.ConnectionStatus;
 
 namespace Raven.Server.Documents.TcpHandlers;
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3854,7 +3854,7 @@ namespace Raven.Server.ServerWide
             return doc;
         }
 
-        public static IEnumerable<(Slice Key, BlittableJsonReaderObject Value)> ReadValuesStartingWith<TTransaction>(TransactionOperationContext<TTransaction> context, string startsWithKey)
+        public static IEnumerable<(Slice Key, BlittableJsonReaderObject Value)> ReadValuesStartingWith<TTransaction>(TransactionOperationContext<TTransaction> context, string startsWithKey, long skip = 0L)
             where TTransaction : RavenTransaction
         {
             var startsWithKeyLower = startsWithKey.ToLowerInvariant();
@@ -3862,7 +3862,7 @@ namespace Raven.Server.ServerWide
             {
                 var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
 
-                foreach (var holder in items.SeekByPrimaryKeyPrefix(startsWithSlice, Slices.Empty, 0))
+                foreach (var holder in items.SeekByPrimaryKeyPrefix(startsWithSlice, Slices.Empty, skip))
                 {
                     var reader = holder.Value.Reader;
                     var size = GetDataAndEtagTupleFromReader(context, reader, out BlittableJsonReaderObject doc, out long _);

--- a/test/SlowTests/Client/Subscriptions/RavenDB-8464.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-8464.cs
@@ -82,7 +82,7 @@ namespace SlowTests.Client.Subscriptions
                     else
                     {
                         var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-                        var s = db.SubscriptionStorage.GetSubscription(context, null, subsId, false);
+                        var s = db.SubscriptionStorage.GetSubscriptionWithDataByNameFromServerStore(context, subsId, history: false, running: false);
                         Assert.Equal(cv, s.ChangeVectorForNextBatchStartingPoint);
                         Assert.Equal("From Shipments", s.Query);
                     }

--- a/test/SlowTests/Client/Subscriptions/RavenDB_7384.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_7384.cs
@@ -187,7 +187,7 @@ namespace SlowTests.Client.Subscriptions
             using (Server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
-                var subscriptionData = currentDatabase.SubscriptionStorage.GetSubscriptionFromServerStore(context, "Subs1");
+                var subscriptionData = currentDatabase.SubscriptionStorage.GetSubscriptionByName(context, "Subs1");
                 return subscriptionData.ChangeVectorForNextBatchStartingPoint;
             }
         }

--- a/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_9117.cs
@@ -69,7 +69,7 @@ namespace SlowTests.Client.Subscriptions
                 using (database.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    subscriptionState = database.SubscriptionStorage.GetSubscriptionFromServerStore(context, sn);
+                    subscriptionState = database.SubscriptionStorage.GetSubscriptionByName(context, sn);
                 }
 
                 var index = database.SubscriptionStorage.PutSubscription(new SubscriptionCreationOptions()

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -383,7 +383,7 @@ namespace SlowTests.Client.Subscriptions
                     using (database.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                     using (context.OpenReadTransaction())
                     {
-                        subscriptionState = database.SubscriptionStorage.GetSubscriptionFromServerStore(context, subscriptionId);
+                        subscriptionState = database.SubscriptionStorage.GetSubscriptionByName(context, subscriptionId);
                     }
                     var index = database.SubscriptionStorage.PutSubscription(new SubscriptionCreationOptions()
                     {
@@ -1613,7 +1613,7 @@ namespace SlowTests.Client.Subscriptions
                 var name = $"Subscription0";
                 var subscription = db
                     .SubscriptionStorage
-                    .GetRunningSubscription(context, null, name, false);
+                    .GetSubscriptionWithDataByNameFromServerStore(context, name, history: false, running: true);
                 Assert.NotNull(subscription);
                 db.SubscriptionStorage.DropSubscriptionConnections(subscription.SubscriptionId,
                     new SubscriptionClosedException("Dropped by Test"));

--- a/test/StressTests/Rachis/SubscriptionFailoverWithWaitingChainsStress.cs
+++ b/test/StressTests/Rachis/SubscriptionFailoverWithWaitingChainsStress.cs
@@ -202,7 +202,7 @@ namespace StressTests.Rachis
                 {
                     var subscription = db
                         .SubscriptionStorage
-                        .GetRunningSubscription(context, null, "Subscription" + k, false);
+                        .GetSubscriptionWithDataByNameFromServerStore(context, "Subscription" + k, history: false, running: true);
 
                     if (subscription != null)
                         Assert.Fail("no subscriptions should be alive at this point");
@@ -474,7 +474,7 @@ namespace StressTests.Rachis
                         var name = $"Subscription{k}";
                         var subscription = db
                             .SubscriptionStorage
-                            .GetRunningSubscription(context, null, name, false);
+                            .GetSubscriptionWithDataByNameFromServerStore(context, name, history: false, running: true);
 
                         if (subscription == null)
                         {
@@ -513,7 +513,7 @@ namespace StressTests.Rachis
                     {
                         subscription = db
                             .SubscriptionStorage
-                            .GetSubscription(context, id: null, name, history: false);
+                            .GetSubscriptionWithDataByNameFromServerStore(context, name, history: false, running: false);
                     }
                     catch (SubscriptionDoesNotExistException)
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21816/

### Additional description

* make sure to recreate the request executor used by shard subscription workers, since it may get disposed
* add missing recent subscriptions connections history and current connection  to `ShardedSubscriptionsHandlerProcessorForGetSubscription`
* add sharded workers history & current connected sharded workers to `ShardedSubscriptionsHandlerProcessorForGetSubscription`
* add time to recent subscription statuses

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
