### PR TITLE
RavenDB-22734 -  StressTests.Issues.FilteredReplicationTestsStress.Si…

### DIFF
--- a/test/StressTests/Issues/FilteredReplicationTestsStress.cs
+++ b/test/StressTests/Issues/FilteredReplicationTestsStress.cs
@@ -140,14 +140,14 @@ namespace StressTests.Issues
             using (ctx.OpenReadTransaction())
             {
                 var sink1GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                Assert.Equal(3, sink1GlobalCv.ToChangeVector().Length);
+                Assert.Equal(2, sink1GlobalCv.ToChangeVector().Length);
             }
 
             using (sink2Db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
                 var sink2GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                Assert.Equal(3, sink2GlobalCv.ToChangeVector().Length);
+                Assert.Equal(2, sink2GlobalCv.ToChangeVector().Length);
             }
 
             await EnsureNoReplicationLoop(Server, hubStore.Database);
@@ -297,14 +297,14 @@ namespace StressTests.Issues
             using (ctx.OpenReadTransaction())
             {
                 var sink1GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                Assert.Equal(3, sink1GlobalCv.ToChangeVector().Length);
+                Assert.Equal(2, sink1GlobalCv.ToChangeVector().Length);
             }
 
             using (sink2Db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
             using (ctx.OpenReadTransaction())
             {
                 var sink2GlobalCv = DocumentsStorage.GetDatabaseChangeVector(ctx);
-                Assert.Equal(3, sink2GlobalCv.ToChangeVector().Length);
+                Assert.Equal(2, sink2GlobalCv.ToChangeVector().Length);
             }
 
             await EnsureNoReplicationLoop(Server, hubStore.Database);


### PR DESCRIPTION
…nks_should_not_update_hubs_change_vector_with_conflicts

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22734/StressTests.Issues.FilteredReplicationTestsStress.Sinksshouldnotupdatehubschangevectorwithconflicts

https://issues.hibernatingrhinos.com/issue/RavenDB-22735/StressTests.Issues.FilteredReplicationTestsStress.Sinksshouldnotupdatehubschangevectorwithconflicts2

### Additional description

Since we fixed the "SINK" tag leak in the database change vector (see https://github.com/ravendb/ravendb/pull/18926), we need to update the tests. Now, the change vector no longer includes the "SINK" part, so its length is 2 instead of 3.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
