### PR TITLE
RavenDB-22566 - Cannot cancel a restore of a snapshot

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -248,7 +248,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
                     Key = key
                 }, _cancellationToken);
 
-                return new RavenStorageClient.Blob(response.ResponseStream, ConvertMetadata(response.Metadata), response);
+                return new RavenStorageClient.Blob(response.ResponseStream, ConvertMetadata(response.Metadata), response.ContentLength, response);
             }
             catch (AmazonS3Exception e)
             {

--- a/src/Raven.Server/Documents/PeriodicBackup/Azure/LegacyRavenAzureClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Azure/LegacyRavenAzureClient.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.WebUtilities;
+using Raven.Client;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Util;
 using Raven.Server.Documents.PeriodicBackup.DirectUpload;
@@ -173,7 +174,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
                     {"x-ms-date", now.ToString("R")},
                     {"x-ms-version", AzureStorageVersion},
                     {"x-ms-blob-type", "BlockBlob"},
-                    {"Content-Length", stream.Length.ToString(CultureInfo.InvariantCulture)}
+                    {Constants.Headers.ContentLength, stream.Length.ToString(CultureInfo.InvariantCulture)}
                 }
             };
 
@@ -246,7 +247,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
                     {
                         {"x-ms-date", now.ToString("R")},
                         {"x-ms-version", AzureStorageVersion},
-                        {"Content-Length", subStream.Length.ToString(CultureInfo.InvariantCulture)}
+                        {Constants.Headers.ContentLength, subStream.Length.ToString(CultureInfo.InvariantCulture)}
                     }
                 };
 
@@ -304,7 +305,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
                 {
                     {"x-ms-date", now.ToString("R")},
                     {"x-ms-version", AzureStorageVersion},
-                    {"Content-Length", Encoding.UTF8.GetBytes(xmlString).Length.ToString(CultureInfo.InvariantCulture)}
+                    {Constants.Headers.ContentLength, Encoding.UTF8.GetBytes(xmlString).Length.ToString(CultureInfo.InvariantCulture)}
                 }
             };
 
@@ -438,7 +439,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
             var data = await response.Content.ReadAsStreamAsync();
             var headers = response.Headers.ToDictionary(x => x.Key, x => x.Value.FirstOrDefault());
 
-            if (response.Content.Headers.TryGetValues("Content-Length", out var values) == false)
+            if (response.Content.Headers.TryGetValues(Constants.Headers.ContentLength, out var values) == false)
                 throw new InvalidOperationException("Content-Length header is not present");
 
             var contentLength = values.FirstOrDefault();
@@ -832,7 +833,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
 
             if (httpContentHeaders != null)
             {
-                if (httpContentHeaders.TryGetValues("Content-Length", out IEnumerable<string> lengthValues))
+                if (httpContentHeaders.TryGetValues(Constants.Headers.ContentLength, out IEnumerable<string> lengthValues))
                     contentLength = lengthValues.First();
 
                 if (httpContentHeaders.TryGetValues("Content-Type", out IEnumerable<string> typeValues))
@@ -840,7 +841,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
             }
             else
             {
-                if (httpHeaders.TryGetValues("Content-Length", out IEnumerable<string> lengthValues))
+                if (httpHeaders.TryGetValues(Constants.Headers.ContentLength, out IEnumerable<string> lengthValues))
                     contentLength = lengthValues.First();
 
                 if (httpHeaders.TryGetValues("Content-Type", out IEnumerable<string> typeValues))

--- a/src/Raven.Server/Documents/PeriodicBackup/Azure/RavenAzureClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Azure/RavenAzureClient.cs
@@ -171,7 +171,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
             var properties = await blob.GetPropertiesAsync(cancellationToken: _cancellationToken);
             var response = await blob.DownloadAsync(cancellationToken: _cancellationToken);
 
-            return new RavenStorageClient.Blob(response.Value.Content, properties.Value.Metadata, response.Value);
+            return new RavenStorageClient.Blob(response.Value.Content, properties.Value.Metadata, response.Value.ContentLength, response.Value);
         }
 
         public void DeleteBlobs(List<string> blobsToDelete)

--- a/src/Raven.Server/Documents/PeriodicBackup/GoogleCloud/RavenGoogleCloudClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/GoogleCloud/RavenGoogleCloudClient.cs
@@ -150,6 +150,15 @@ namespace Raven.Server.Documents.PeriodicBackup.GoogleCloud
             );
         }
 
+        public async Task<Size> GetObjectSizeAsync(string fileName)
+        {
+            var obj = await GetObjectAsync(fileName);
+            if (obj.Size == null)
+                throw new InvalidOperationException("Size isn't available");
+
+            return new Size((long)obj.Size.Value, SizeUnit.Bytes);
+        }
+
         public Task DeleteObjectAsync(string fileName)
         {
             return _client.DeleteObjectAsync(

--- a/src/Raven.Server/Documents/PeriodicBackup/GoogleCloud/RavenGoogleCloudClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/GoogleCloud/RavenGoogleCloudClient.cs
@@ -152,6 +152,9 @@ namespace Raven.Server.Documents.PeriodicBackup.GoogleCloud
 
         public async Task<Size> GetObjectSizeAsync(string fileName)
         {
+            // Fetches the information about an object asynchronously.
+            // This does not retrieve the content of the object itself.
+
             var obj = await GetObjectAsync(fileName);
             if (obj.Size == null)
                 throw new InvalidOperationException("Size isn't available");

--- a/src/Raven.Server/Documents/PeriodicBackup/RavenStorageClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/RavenStorageClient.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using Raven.Server.Utils;
+using Sparrow;
 
 namespace Raven.Server.Documents.PeriodicBackup
 {
@@ -70,16 +71,19 @@ namespace Raven.Server.Documents.PeriodicBackup
         {
             private IDisposable _toDispose;
 
-            public Blob(Stream data, IDictionary<string, string> metadata, IDisposable toDispose = null)
+            public Blob(Stream data, IDictionary<string, string> metadata, long sizeInBytes, IDisposable toDispose = null)
             {
                 Data = data ?? throw new ArgumentNullException(nameof(data));
                 Metadata = metadata;
+                Size = new Size(sizeInBytes, SizeUnit.Bytes);
                 _toDispose = toDispose;
             }
 
             public Stream Data { get; }
 
             public IDictionary<string, string> Metadata { get; }
+
+            public Size Size { get; }
 
             public void Dispose()
             {

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetBlobAsync(filePath);
-            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(blob.Data, _configuration, _cancellationToken);
+            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _configuration, onProgress: null, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AzureRestorePoints.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Config;
@@ -14,10 +15,12 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
     public class AzureRestorePoints : RestorePointsBase
     {
         private readonly RavenConfiguration _configuration;
+        private readonly CancellationToken _cancellationToken;
         private readonly IRavenAzureClient _client;
-        public AzureRestorePoints(RavenConfiguration configuration, SortedList<DateTime, RestorePoint> sortedList, TransactionOperationContext context, AzureSettings azureSettings) : base(sortedList, context)
+        public AzureRestorePoints(RavenConfiguration configuration, SortedList<DateTime, RestorePoint> sortedList, TransactionOperationContext context, AzureSettings azureSettings, CancellationToken cancellationToken) : base(sortedList, context)
         {
             _configuration = configuration;
+            _cancellationToken = cancellationToken;
             _client = RavenAzureClient.Create(azureSettings, configuration.Backup);
         }
 
@@ -56,7 +59,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetBlobAsync(filePath);
-            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(blob.Data, _configuration);
+            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(blob.Data, _configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/GoogleCloudRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/GoogleCloudRestorePoints.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Config;
@@ -15,11 +16,13 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
     public class GoogleCloudRestorePoints : RestorePointsBase
     {
         private readonly RavenConfiguration _configuration;
+        private readonly CancellationToken _cancellationToken;
         private readonly RavenGoogleCloudClient _client;
 
-        public GoogleCloudRestorePoints(RavenConfiguration configuration, SortedList<DateTime, RestorePoint> sortedList, TransactionOperationContext context, GoogleCloudSettings client) : base(sortedList, context)
+        public GoogleCloudRestorePoints(RavenConfiguration configuration, SortedList<DateTime, RestorePoint> sortedList, TransactionOperationContext context, GoogleCloudSettings client, CancellationToken cancellationToken) : base(sortedList, context)
         {
             _configuration = configuration;
+            _cancellationToken = cancellationToken;
             _client = new RavenGoogleCloudClient(client, configuration.Backup);
         }
 
@@ -58,7 +61,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             Stream downloadObject = _client.DownloadObject(filePath);
-            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(downloadObject, _configuration);
+            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(downloadObject, _configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(downloadObject, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/GoogleCloudRestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/GoogleCloudRestorePoints.cs
@@ -61,8 +61,9 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             Stream downloadObject = _client.DownloadObject(filePath);
-            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(downloadObject, _configuration, _cancellationToken);
-            return new DeleteOnCloseZipArchive(downloadObject, ZipArchiveMode.Read);
+            var size = await _client.GetObjectSizeAsync(filePath);
+            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocallyAsync(downloadObject, size, _configuration, onProgress: null, _cancellationToken);
+            return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 
         protected override string GetFileName(string fullPath)

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -149,10 +149,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             var file = SafeFileStream.Create(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.Read,
                 32 * 1024, FileOptions.DeleteOnClose);
 
-            AssertFreeSpace(size, basePath.FullPath);
-
             try
             {
+                AssertFreeSpace(size, basePath.FullPath);
+
                 var sw = Stopwatch.StartNew();
                 var swForProgress = Stopwatch.StartNew();
                 long totalRead = 0;
@@ -206,8 +206,9 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             }
 
             // + we need to download the snapshot
+            // + we need to unzip the snapshot
             // + leave 1GB of free space
-            var freeSpaceNeeded = size + new Size(1, SizeUnit.Gigabytes);
+            var freeSpaceNeeded = 2 * size + new Size(1, SizeUnit.Gigabytes);
 
             if (freeSpaceNeeded > spaceInfo.TotalFreeSpace)
                 throw new DiskFullException($"There is not enough space on '{basePath}', we need at least {freeSpaceNeeded} in order to successfully copy the snapshot backup file locally. " +

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -159,7 +159,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
                 onProgress?.Invoke($"Copying ZipArchive locally, size: {size}");
 
-                stream.CopyTo(file, readCount =>
+                await stream.CopyToAsync(file, readCount =>
                 {
                     totalRead += readCount;
                     if (swForProgress.ElapsedMilliseconds > 5000)
@@ -169,7 +169,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     }
                 }, cancellationToken);
 
-                onProgress?.Invoke($"Copied ZipArchive locally, took: {sw.ElapsedMilliseconds:#,#;;0}ms");
+                onProgress?.Invoke($"Copied ZipArchive locally, took: {sw.Elapsed}");
 
                 file.Seek(0, SeekOrigin.Begin);
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreBackupTaskBase.cs
@@ -44,6 +44,7 @@ using Index = Raven.Server.Documents.Indexes.Index;
 using Sparrow;
 using Sparrow.Server.Exceptions;
 using Sparrow.Server.Utils;
+using System.Threading;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
@@ -130,10 +131,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
         protected async Task<Stream> CopyRemoteStreamLocally(Stream stream)
         {
-            return await CopyRemoteStreamLocally(stream, _serverStore.Configuration);
+            return await CopyRemoteStreamLocally(stream, _serverStore.Configuration, _operationCancelToken.Token);
         }
 
-        public static async Task<Stream> CopyRemoteStreamLocally(Stream stream, RavenConfiguration configuration)
+        public static async Task<Stream> CopyRemoteStreamLocally(Stream stream, RavenConfiguration configuration, CancellationToken cancellationToken)
         {
             if (stream.CanSeek)
                 return stream;
@@ -151,7 +152,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
             try
             {
-                await stream.CopyToAsync(file);
+                await stream.CopyToAsync(file, cancellationToken);
                 file.Seek(0, SeekOrigin.Begin);
 
                 return file;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Azure;
@@ -14,6 +15,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
     {
         private readonly IRavenAzureClient _client;
         private readonly string _remoteFolderName;
+
         public RestoreFromAzure(ServerStore serverStore, RestoreFromAzureConfiguration restoreFromConfiguration, string nodeTag, OperationCancelToken operationCancelToken) : base(serverStore, restoreFromConfiguration, nodeTag, operationCancelToken)
         {
             _client = RavenAzureClient.Create(restoreFromConfiguration.Settings, serverStore.Configuration.Backup);

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromAzure.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Azure;
@@ -28,10 +28,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return blob.Data;
         }
 
-        protected override async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
+        protected override async Task<ZipArchive> GetZipArchiveForSnapshot(string path, Action<string> onProgress)
         {
             var blob = await _client.GetBlobAsync(path);
-            var file = await CopyRemoteStreamLocally(blob.Data);
+            var file = await CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, onProgress);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromGoogleCloud.cs
@@ -27,10 +27,11 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return Task.FromResult(_client.DownloadObject(path));
         }
 
-        protected override async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
+        protected override async Task<ZipArchive> GetZipArchiveForSnapshot(string path, Action<string> onProgress)
         {
             Stream stream = _client.DownloadObject(path);
-            var file = await CopyRemoteStreamLocally(stream);
+            var size = await _client.GetObjectSizeAsync(path);
+            var file = await CopyRemoteStreamLocallyAsync(stream, size, onProgress);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromLocal.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.ServerWide;
-using Voron.Util.Settings;
 
 namespace Raven.Server.Documents.PeriodicBackup.Restore
 {
@@ -31,7 +30,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return Task.FromResult<Stream>(stream);
         }
 
-        protected override Task<ZipArchive> GetZipArchiveForSnapshot(string path)
+        protected override Task<ZipArchive> GetZipArchiveForSnapshot(string path, Action<string> onProgress)
         {
             return Task.FromResult(ZipFile.Open(path, ZipArchiveMode.Read, System.Text.Encoding.UTF8));
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -28,10 +28,10 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             return blob.Data;
         }
 
-        protected override async Task<ZipArchive> GetZipArchiveForSnapshot(string path)
+        protected override async Task<ZipArchive> GetZipArchiveForSnapshot(string path, Action<string> onProgress)
         {
             var blob = await _client.GetObjectAsync(path);
-            var file = await CopyRemoteStreamLocally(blob.Data);
+            var file = await CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, onProgress);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup.Aws;
-using Raven.Server.Indexing;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
@@ -76,7 +76,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetObjectAsync(filePath);
-            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(blob.Data, _configuration, _cancellationToken);
+            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocallyAsync(blob.Data, blob.Size, _configuration, onProgress: null, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/S3RestorePoints.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Config;
@@ -14,11 +15,13 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
     public class S3RestorePoints : RestorePointsBase
     {
         private readonly RavenConfiguration _configuration;
+        private readonly CancellationToken _cancellationToken;
         private readonly RavenAwsS3Client _client;
 
-        public S3RestorePoints(RavenConfiguration configuration, SortedList<DateTime, RestorePoint> sortedList, TransactionOperationContext context, S3Settings s3Settings) : base(sortedList, context)
+        public S3RestorePoints(RavenConfiguration configuration, SortedList<DateTime, RestorePoint> sortedList, TransactionOperationContext context, S3Settings s3Settings, CancellationToken cancellationToken) : base(sortedList, context)
         {
             _configuration = configuration;
+            _cancellationToken = cancellationToken;
             _client = new RavenAwsS3Client(s3Settings, configuration.Backup);
         }
 
@@ -73,7 +76,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         protected override async Task<ZipArchive> GetZipArchive(string filePath)
         {
             var blob = await _client.GetObjectAsync(filePath);
-            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(blob.Data, _configuration);
+            var file = await RestoreBackupTaskBase.CopyRemoteStreamLocally(blob.Data, _configuration, _cancellationToken);
             return new DeleteOnCloseZipArchive(file, ZipArchiveMode.Read);
         }
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -558,6 +558,7 @@ namespace Raven.Server.Web.System
         public async Task GetRestorePoints()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (var cancelToken = CreateBackgroundOperationToken())
             {
                 PeriodicBackupConnectionType connectionType;
                 var type = GetStringValuesQueryString("type", false).FirstOrDefault();
@@ -600,7 +601,7 @@ namespace Raven.Server.Web.System
 
                     case PeriodicBackupConnectionType.S3:
                         var s3Settings = JsonDeserializationServer.S3Settings(restorePathBlittable);
-                        using (var s3RestoreUtils = new S3RestorePoints(ServerStore.Configuration, sortedList, context, s3Settings))
+                        using (var s3RestoreUtils = new S3RestorePoints(ServerStore.Configuration, sortedList, context, s3Settings, cancelToken.Token))
                         {
                             await s3RestoreUtils.FetchRestorePoints(s3Settings.RemoteFolderName);
                         }
@@ -609,7 +610,7 @@ namespace Raven.Server.Web.System
 
                     case PeriodicBackupConnectionType.Azure:
                         var azureSettings = JsonDeserializationServer.AzureSettings(restorePathBlittable);
-                        using (var azureRestoreUtils = new AzureRestorePoints(ServerStore.Configuration, sortedList, context, azureSettings))
+                        using (var azureRestoreUtils = new AzureRestorePoints(ServerStore.Configuration, sortedList, context, azureSettings, cancelToken.Token))
                         {
                             await azureRestoreUtils.FetchRestorePoints(azureSettings.RemoteFolderName);
                         }
@@ -617,7 +618,7 @@ namespace Raven.Server.Web.System
 
                     case PeriodicBackupConnectionType.GoogleCloud:
                         var googleCloudSettings = JsonDeserializationServer.GoogleCloudSettings(restorePathBlittable);
-                        using (var googleCloudRestoreUtils = new GoogleCloudRestorePoints(ServerStore.Configuration, sortedList, context, googleCloudSettings))
+                        using (var googleCloudRestoreUtils = new GoogleCloudRestorePoints(ServerStore.Configuration, sortedList, context, googleCloudSettings, cancelToken.Token))
                         {
                             await googleCloudRestoreUtils.FetchRestorePoints(googleCloudSettings.RemoteFolderName);
                         }

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -557,7 +557,7 @@ namespace Raven.Server.Web.System
         public async Task GetRestorePoints()
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (var cancelToken = CreateBackgroundOperationToken())
+            using (var cancelToken = CreateHttpRequestBoundOperationToken())
             {
                 PeriodicBackupConnectionType connectionType;
                 var type = GetStringValuesQueryString("type", false).FirstOrDefault();

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -21,7 +21,6 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
-using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;
 using Raven.Client.Http;

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -334,7 +334,7 @@ namespace Voron.Impl.Backup
 
                 onProgress?.Invoke($"Restored file: '{entry.Name}' to: '{dst}', " +
                                    $"size: {new Size(totalRead, SizeUnit.Bytes)}, " +
-                                   $"took: {sw.ElapsedMilliseconds:#,#;;0}ms");
+                                   $"took: {sw.Elapsed}");
             }
         }
 

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Sparrow.Utils;
 
 namespace Voron.Impl.Backup
@@ -31,5 +32,17 @@ namespace Voron.Impl.Backup
             }
         }
 
+        public static async Task CopyToAsync(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
+        {
+            var readBuffer = new byte[DefaultBufferSize];
+
+            int count;
+            while ((count = await source.ReadAsync(readBuffer, 0, readBuffer.Length, cancellationToken)) != 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                onProgress?.Invoke(count);
+                await destination.WriteAsync(readBuffer, 0, count, cancellationToken);
+            }
+        }
     }
 }

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -17,7 +17,7 @@ namespace Voron.Impl.Backup
             try
             {
                 int count;
-                while ((count = source.Read(readBuffer, 0, readBuffer.Length)) != 0)
+                while ((count = source.Read(readBuffer, 0, DefaultBufferSize)) != 0)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     onProgress?.Invoke(count);
@@ -37,7 +37,7 @@ namespace Voron.Impl.Backup
             try
             {
                 int count;
-                while ((count = await source.ReadAsync(readBuffer, 0, readBuffer.Length, cancellationToken)) != 0)
+                while ((count = await source.ReadAsync(readBuffer, 0, DefaultBufferSize, cancellationToken)) != 0)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     onProgress?.Invoke(count);

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Aws.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Aws.cs
@@ -46,6 +46,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
 
                 var @object = await client.GetObjectAsync(key);
                 Assert.NotNull(@object);
+                Assert.True(@object.Size.GetValue(SizeUnit.Bytes) > 0);
 
                 using (var reader = new StreamReader(@object.Data))
                     Assert.Equal("231", await reader.ReadToEndAsync());

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Azure.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Azure.cs
@@ -10,6 +10,7 @@ using FastTests;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.PeriodicBackup.Azure;
+using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -108,6 +109,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     });
                 var blob = await holder.Client.GetBlobAsync(blobKey);
                 Assert.NotNull(blob);
+                Assert.True(blob.Size.GetValue(SizeUnit.Bytes) > 0);
 
                 using (var reader = new StreamReader(blob.Data))
                     Assert.Equal("123", reader.ReadToEnd());

--- a/test/SlowTests/Server/Documents/PeriodicBackup/GoogleCloud.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/GoogleCloud.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Server.Documents.PeriodicBackup.GoogleCloud;
+using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -132,6 +133,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     var obj = await client.GetObjectAsync(fileName);
                     Assert.Equal("value1", obj.Metadata["key1"]);
                     Assert.Equal("value2", obj.Metadata["key2"]);
+
+                    var size = await client.GetObjectSizeAsync(fileName);
+                    Assert.True(size.GetValue(SizeUnit.Bytes) > 0);
                 }
 
                 finally


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22566/Cannot-cancel-a-restore-of-a-snapshot

### Additional description

Port from 6.0: https://github.com/ravendb/ravendb/pull/18785
- Allow to cancel the restore when downloading the snapshot.
- Get the file size of the snapshot from the API.
- Add the progress of downloading the restore file.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
