### PR TITLE
RavenDB-22627 - Missing database record properties on full backup restore - v6.0

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -46,7 +46,8 @@ namespace Raven.Client.Documents.Smuggler
                                                                                   DatabaseRecordItemType.QueueEtls |
                                                                                   DatabaseRecordItemType.IndexesHistory |
                                                                                   DatabaseRecordItemType.Refresh |
-                                                                                  DatabaseRecordItemType.DataArchival;
+                                                                                  DatabaseRecordItemType.DataArchival |
+                                                                                  DatabaseRecordItemType.QueueSinks;
 
         internal const DatabaseItemType OperateOnFirstShardOnly = DatabaseItemType.Indexes |
                                                               DatabaseItemType.DatabaseRecord |

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -457,6 +457,14 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     task.Disabled = true;
                 }
             }
+
+            if (databaseRecord.QueueSinks != null)
+            {
+                foreach (var task in databaseRecord.QueueSinks)
+                {
+                    task.Disabled = true;
+                }
+            }
         }
 
         private ClusterTopology GetClusterTopology()
@@ -567,6 +575,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     databaseRecord.Integrations = smugglerDatabaseRecord.Integrations;
                     databaseRecord.Studio = smugglerDatabaseRecord.Studio;
                     databaseRecord.RevisionsForConflicts = smugglerDatabaseRecord.RevisionsForConflicts;
+                    databaseRecord.DataArchival = smugglerDatabaseRecord.DataArchival;
+                    databaseRecord.QueueSinks = smugglerDatabaseRecord.QueueSinks;
                 };
             }
 

--- a/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
@@ -79,6 +79,11 @@ namespace Raven.Server.Smuggler.Documents
                 AddWarning(DatabaseRecordItemType.QueueEtls);
             }
 
+            if (databaseRecord.QueueSinks.Count > 0 && databaseRecordItemType.HasFlag(DatabaseRecordItemType.QueueSinks))
+            {
+                AddWarning(DatabaseRecordItemType.QueueSinks);
+            }
+
             //warn and remove mentor nodes
             foreach (var externalReplication in databaseRecord.ExternalReplications)
             {

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -19,6 +19,7 @@ using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Operations.QueueSink;
 using Raven.Client.Documents.Operations.Refresh;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.Revisions;
@@ -462,6 +463,13 @@ namespace Raven.Server.Smuggler.Documents
                             WriteQueueEtls(databaseRecord.QueueEtls);
                         }
 
+                        if (databaseRecordItemType.Contain(DatabaseRecordItemType.QueueSinks))
+                        {
+                            _writer.WriteComma();
+                            _writer.WritePropertyName(nameof(databaseRecord.QueueSinks));
+                            WriteQueueSinks(databaseRecord.QueueSinks);
+                        }
+
                         if (databaseRecord.Integrations != null)
                         {
                             _writer.WriteComma();
@@ -786,6 +794,27 @@ namespace Raven.Server.Smuggler.Documents
                         _writer.WriteComma();
                     first = false;
                     _context.Write(_writer, etl.ToJson());
+                }
+
+                _writer.WriteEndArray();
+            }
+
+            private void WriteQueueSinks(List<QueueSinkConfiguration> queueSinkConfiguration)
+            {
+                if (queueSinkConfiguration == null)
+                {
+                    _writer.WriteNull();
+                    return;
+                }
+                _writer.WriteStartArray();
+
+                var first = true;
+                foreach (var configuration in queueSinkConfiguration)
+                {
+                    if (first == false)
+                        _writer.WriteComma();
+                    first = false;
+                    _context.Write(_writer, configuration.ToJson());
                 }
 
                 _writer.WriteEndArray();

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -16,6 +16,7 @@ using Raven.Client.Documents.Operations.ETL.ElasticSearch;
 using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Client.Documents.Operations.QueueSink;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Queries.Sorting;
 using Raven.Client.Documents.Smuggler;
@@ -431,6 +432,24 @@ namespace Raven.Server.Smuggler.Documents
                     }
                 }
 
+                if (reader.TryGet(nameof(databaseRecord.QueueSinks), out BlittableJsonReaderArray queueSinks) &&
+                    queueSinks != null)
+                {
+                    databaseRecord.QueueSinks = new List<QueueSinkConfiguration>();
+                    foreach (BlittableJsonReaderObject queue in queueSinks)
+                    {
+                        try
+                        {
+                            databaseRecord.QueueSinks.Add(JsonDeserializationCluster.QueueSinkConfiguration(queue));
+                        }
+                        catch (Exception e)
+                        {
+                            if (_log.IsInfoEnabled)
+                                _log.Info("Wasn't able to import the Raven queue sinks configuration from smuggler file. Skipping.", e);
+                        }
+                    }
+                }
+                
                 if (reader.TryGet(nameof(databaseRecord.RavenConnectionStrings), out BlittableJsonReaderObject ravenConnectionStrings) &&
                     ravenConnectionStrings != null)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22627

### Additional description

DataArchival and QueueSinks configuration in the database record did not restore from backup.
Added the fields where they were missing in reading/writing the db record and other places.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
