### PR TITLE
RavenDB-22627 - fix writing of Studio and RevisionsForConflicts fields in db record on restore

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -324,6 +324,22 @@ namespace Raven.Server.Smuggler.Documents
                     WriteIndexesHistory(databaseRecord.IndexesHistory);
                 }
 
+                if (databaseRecord.Studio != null)
+                {
+                    _writer.WriteComma();
+                    _writer.WritePropertyName(nameof(databaseRecord.Studio));
+
+                    WriteStudioConfiguration(databaseRecord.Studio);
+                }
+
+                if (databaseRecord.RevisionsForConflicts != null)
+                {
+                    _writer.WriteComma();
+                    _writer.WritePropertyName(nameof(databaseRecord.RevisionsForConflicts));
+
+                    WriteRevisionsForConflictsConfiguration(databaseRecord.RevisionsForConflicts);
+                }
+
                 switch (authorizationStatus)
                 {
                     case AuthorizationStatus.DatabaseAdmin:
@@ -441,22 +457,6 @@ namespace Raven.Server.Smuggler.Documents
                             }
 
                             _writer.WriteEndObject();
-                        }
-
-                        if (databaseRecord.Studio != null)
-                        {
-                            _writer.WriteComma();
-                            _writer.WritePropertyName(nameof(databaseRecord.Studio));
-
-                            WriteStudioConfiguration(databaseRecord.Studio);
-                        }
-
-                        if (databaseRecord.RevisionsForConflicts != null)
-                        {
-                            _writer.WriteComma();
-                            _writer.WritePropertyName(nameof(databaseRecord.RevisionsForConflicts));
-
-                            WriteRevisionsForConflictsConfiguration(databaseRecord.RevisionsForConflicts);
                         }
 
                         break;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22627

### Additional description

Fix mistake in code placement following PR https://github.com/ravendb/ravendb/pull/18959
Writing of `Studio` and `RevisionsForConflicts` configurations was written in the scope of `ClusterAdmin` authorization.
Took the code block out.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
