### PR TITLE
RavenDB-22646 - Fix test RavenDB_22345.Handle_Outdated_Leader_On_RachisMergedCommand

### DIFF
--- a/test/SlowTests/Issues/RavenDB-22345.cs
+++ b/test/SlowTests/Issues/RavenDB-22345.cs
@@ -58,8 +58,7 @@ namespace SlowTests.Issues
                 await session.SaveChangesAsync(); // Fail: throws ConcurrencyException
             }
 
-
-            using (var session = store.OpenAsyncSession())
+            using (var session = followerStore.OpenAsyncSession())
             {
                 var u1 = await session.LoadAsync<User>(user1.Id);
                 Assert.NotNull(u1);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22646/SlowTests.Issues.RavenDB22345.HandleOutdatedLeaderOnRachisMergedCommand

### Additional description

Fix test RavenDB_22345.Handle_Outdated_Leader_On_RachisMergedCommand
The problem:
We have two document stores: one that stores a document to a follower db by cluster TX, and another that attempts to load the document from the leader cluster afterward.
In cluster TX (the follower), the SendToLeaderAsync (or SendToNode) method receives an 'OK' status from the leader for the raft command after the command is committed on the leader, but before the leader's database is notified. 
Consequently, when we call SaveChangesAsync in our test, it passes. 
However, when we attempt to load data from the leader, we receive 'null' because the leader's database has not yet been notified with the cluster TX.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
