### PR TITLE
RavenDB-22739 Fixing the concurrent modification / usage of DynamicJsonValue.ModificationsIndex in a static instance of AggressiveCachingPulseValue which resulted in sending invalid JSON via Changes API and missing invalidation of the cache in RavenDB Client

### DIFF
--- a/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
@@ -194,6 +194,9 @@ public abstract class AbstractChangesClientConnection<TOperationContext> : ILowM
                                 case BlittableJsonReaderObject bjro:
                                     context.Write(writer, bjro.CloneForConcurrentRead(context));
                                     break;
+                                case ChangesClientConnection.DatabaseChangeFactory cf:
+                                    context.Write(writer, cf.CreateJson());
+                                    break;
                             }
                             messagesCount++;
                             await writer.FlushAsync(DisposeToken);
@@ -676,5 +679,10 @@ public abstract class AbstractChangesClientConnection<TOperationContext> : ILowM
         }
 
         public void Dispose() => _onDispose?.Invoke(Value);
+    }
+
+    protected abstract class DatabaseChangeFactory
+    {
+        public abstract DynamicJsonValue CreateJson();
     }
 }

--- a/src/Raven.Server/Documents/Changes/ChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Changes/ChangesClientConnection.cs
@@ -186,10 +186,7 @@ namespace Raven.Server.Documents.Changes
         private static readonly SendQueueItem AggressiveCachingPulseValue = new()
         {
             AllowSkip = true,
-            ValueToSend = new DynamicJsonValue
-            {
-                ["Type"] = nameof(AggressiveCacheChange),
-            }
+            ValueToSend = new AggressiveCacheChangeFactory()
         };
 
         private void PulseAggressiveCaching()
@@ -475,6 +472,17 @@ namespace Raven.Server.Documents.Changes
             djv["WatchAllTimeSeriesOfDocument"] = _matchingAllDocumentTimeSeries.ToArray();
 
             return djv;
+        }
+
+        private class AggressiveCacheChangeFactory : DatabaseChangeFactory
+        {
+            public override DynamicJsonValue CreateJson()
+            {
+                return new DynamicJsonValue
+                {
+                    ["Type"] = nameof(AggressiveCacheChange),
+                };
+            }
         }
     }
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22739/AggressiveCacheChange-notifications-are-sent-as-corrupted-JSONs

### Additional description

`DynamicJsonValue` must not be read concurrently because of `ModificationsIndex ` modification:

https://github.com/ravendb/ravendb/blob/d1003fb35409b011878d7cd61220dc51312aa634/src/Sparrow/Json/Parsing/ObjectJsonParser.cs#L301

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
