### PR TITLE
RavenDB-22739 Fixing the concurrent modification / usage of DynamicJsonValue.ModificationsIndex in a static instance of AggressiveCachingPulseValue which resulted in sending invalid JSON via Changes API and missing invalidation of the cache in RavenDB Client

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2002,7 +2002,7 @@ namespace Raven.Server.Documents
 
             internal Action AfterSnapshotOfDocuments;
 
-            internal Action<DynamicJsonValue, WebSocket> OnNextMessageChangesApi;
+            internal Action<object, WebSocket> OnNextMessageChangesApi;
 
             internal bool SkipDrainAllRequests = false;
 

--- a/test/SlowTests/Issues/RavenDB_22739.cs
+++ b/test/SlowTests/Issues/RavenDB_22739.cs
@@ -1,0 +1,78 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22739 : RavenTestBase
+{
+    public RavenDB_22739(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task AggressiveCacheChangeNotificationShouldInvalidateCache()
+    {
+        using var store1 = GetDocumentStore();
+        using var store2 = new DocumentStore() { Urls = store1.Urls, Database = store1.Database }.Initialize();
+        using var store3 = new DocumentStore() { Urls = store1.Urls, Database = store1.Database }.Initialize();
+        using var store4 = new DocumentStore() { Urls = store1.Urls, Database = store1.Database }.Initialize();
+
+        var stores = new[] { store1, store2, store3, store4 };
+
+        using (var session = store1.OpenSession())
+        {
+            session.Store(new Item("Joe"), "items/1");
+            session.SaveChanges();
+        }
+
+        foreach (var store in stores)
+        {
+            using (await store.AggressivelyCacheAsync())
+            using (var session = store1.OpenSession())
+            {
+                var item = session.Load<Item>("items/1");
+
+                Assert.NotNull(item);
+            }
+        }
+
+        using (var session = store1.OpenSession())
+        {
+            session.Delete("items/1");
+            session.SaveChanges();
+        }
+
+        foreach (var store in stores)
+        {
+            using (await store.AggressivelyCacheAsync())
+            {
+                var retries = 3;
+
+                Item item;
+
+                do
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        item = session.Load<Item>("items/1");
+
+                        if (item is null)
+                            break;
+
+                        Thread.Sleep(500);
+                    }
+
+                } while (--retries > 0);
+
+                Assert.Null(item);                
+            }
+        }
+    }
+
+    private record Item(string Name);
+}

--- a/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
+++ b/test/SlowTests/Server/Documents/Notifications/ChangesTests.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -289,10 +290,9 @@ namespace SlowTests.Server.Documents.Notifications
             {
                 var database = await GetDatabase(Server, store.Database);
                 var count = 0;
-                database.ForTestingPurposesOnly().OnNextMessageChangesApi = (djv, webSocket) =>
+                database.ForTestingPurposesOnly().OnNextMessageChangesApi = (value, webSocket) =>
                 {
-                    var nameValue = djv.Properties.FirstOrDefault(x => x.Name == "Type");
-                    if (nameValue.Name == null || (string)nameValue.Value != nameof(AggressiveCacheChange))
+                    if (value != ChangesClientConnection.AggressiveCachingPulseValue.ValueToSend)
                         return;
 
                     if (++count == 1)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22739/AggressiveCacheChange-notifications-are-sent-as-corrupted-JSONs

### Additional description

Backport of https://github.com/ravendb/ravendb/pull/18991

Added a test case which was failing occasionally. When running it in Tryouts I was getting:

```
Xunit.Sdk.NullException: Assert.Null() Failure
Expected: (null)
Actual:   Item { Name = Joe }
   at Xunit.Assert.Null(Object object) in /_/src/xunit.assert/Asserts/NullAsserts.cs:line 44
   at SlowTests.Issues.RavenDB_22739.AggressiveCacheChangeNotificationShouldInvalidateCache() in D:\workspace\ravendb-5.4\test\SlowTests\Issues\RavenDB_22739.cs:line 71
   at Tryouts.Program.Main(String[] args) in D:\workspace\ravendb-5.4\test\Tryouts\Program.cs:line 35
```

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
