### PR TITLE
RavenDB-22605 add proxy to '/admin/cluster/log' EP

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -156,20 +156,8 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/admin/cluster/log", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]
         public async Task GetLogs()
         {
-            var start = GetStart();
-            var take = GetPageSize(defaultPageSize: 1024);
-            var detailed = GetBoolValueQueryString("detailed", required: false) ?? false;
-            var debugView = ServerStore.Engine.DebugView();
-
-            using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-            {
-                using (context.OpenReadTransaction())
-                await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
-                {
-                    debugView.PopulateLogs(context, start, take, detailed);
-                    context.Write(writer, debugView.ToJson());
-                }
-            }
+            using (var processor = new RachisAdminHandlerProcessorForGetClusterLogs(this)) 
+                await processor.ExecuteAsync();
         }
 
         [RavenAction("/admin/debug/cluster/history-logs", "GET", AuthorizationStatus.Operator, IsDebugInformationEndpoint = true)]

--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandlerProcessorForGetClusterLogs.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandlerProcessorForGetClusterLogs.cs
@@ -1,0 +1,78 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Http;
+using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.Rachis;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Server.Web;
+using Raven.Server.Web.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Admin;
+
+internal sealed class RachisAdminHandlerProcessorForGetClusterLogs : AbstractServerHandlerProxyReadProcessor<RaftDebugView>
+{
+    private const string DetailedParameter = "detailed";
+
+    private readonly bool _detailed;
+    private readonly int _take;
+    private readonly int _start;
+    public RachisAdminHandlerProcessorForGetClusterLogs([NotNull] RequestHandler requestHandler) : base(requestHandler)
+    {
+        _start = requestHandler.GetStart();
+        _take = requestHandler.GetPageSize(defaultPageSize: 1024);
+        _detailed = requestHandler.GetBoolValueQueryString(DetailedParameter, required: false) ?? false;
+    }
+
+    protected override bool SupportsCurrentNode => true;
+    protected override async ValueTask HandleCurrentNodeAsync()
+    {
+        var debugView = ServerStore.Engine.DebugView();
+
+        using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+        {
+            using (context.OpenReadTransaction())
+            await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
+            {
+                debugView.PopulateLogs(context, _start, _take, _detailed);
+                context.Write(writer, debugView.ToJson());
+            }
+        }
+    }
+
+    protected override ValueTask<RavenCommand<RaftDebugView>> CreateCommandForNodeAsync(string nodeTag, JsonOperationContext context) => 
+        ValueTask.FromResult<RavenCommand<RaftDebugView>>(new GetClusterLogsCommand(nodeTag, _start, _take, _detailed));
+
+    protected override Task HandleRemoteNodeAsync(ProxyCommand<RaftDebugView> command, JsonOperationContext context, OperationCancelToken token) => 
+        ServerStore.ClusterRequestExecutor.ExecuteAsync(command, context, token: token.Token);
+
+    private sealed class GetClusterLogsCommand : RavenCommand<RaftDebugView>
+    {
+        private readonly int _start;
+        private readonly int _take;
+        private readonly bool _detailed;
+
+        public GetClusterLogsCommand(string nodeTag, int start, int take, bool detailed)
+        {
+            _start = start;
+            _take = take;
+            _detailed = detailed;
+            SelectedNodeTag = nodeTag;
+        }
+
+        public override bool IsReadRequest => false;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/admin/cluster/log?{RequestHandler.StartParameter}={_start}&{RequestHandler.PageSizeParameter}={_take}&{DetailedParameter}={_detailed}";
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22605

### Additional description

add proxy to '/admin/cluster/log' EP

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
