### PR TITLE
RavenDB-22742 - SlowTests.Server.Replication.PullReplicationTests.Upd…

### DIFF
--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -208,6 +208,7 @@ namespace SlowTests.Server.Replication
 
                 var pull = new PullReplicationAsSink(hub2.Database, $"ConnectionString2-{sink.Database}", definitionName2)
                 {
+                    Url = sink.Urls[0],
                     TaskId = pullTasks[0].TaskId
                 };
                 await AddWatcherToReplicationTopology(sink, pull, hub2.Urls);
@@ -299,6 +300,7 @@ namespace SlowTests.Server.Replication
 
                 var pull = new PullReplicationAsSink(hub.Database, $"ConnectionString-{sink.Database}", definitionName)
                 {
+                    Url = sink.Urls[0],
                     Disabled = true,
                     TaskId = pullTasks[0].TaskId
                 };
@@ -703,7 +705,7 @@ namespace SlowTests.Server.Replication
             var resList = new List<ModifyOngoingTaskResult>();
             foreach (var store in hub)
             {
-                var pull = new PullReplicationAsSink(store.Database, $"ConnectionString-{store.Database}", remoteName);
+                var pull = new PullReplicationAsSink(store.Database, $"ConnectionString-{store.Database}", remoteName) { Url = sink.Urls[0] };
                 if (certificate != null)
                 {
                     pull.CertificateWithPrivateKey = Convert.ToBase64String(certificate.Export(X509ContentType.Pfx));


### PR DESCRIPTION
…atePullReplicationOnSink & SlowTests.Server.Replication.PullReplicationTests.DisablePullReplicationOnSink

### Issue link
* https://issues.hibernatingrhinos.com/issue/RavenDB-22742/SlowTests.Server.Replication.PullReplicationTests.UpdatePullReplicationOnSink
* https://issues.hibernatingrhinos.com/issue/RavenDB-22743/SlowTests.Server.Replication.PullReplicationTests.DisablePullReplicationOnSink

### Additional description

Following the changes made in https://github.com/ravendb/ravendb/pull/18954, when creating a new `PullReplicationAsSink` object, we need to also define the `Url`. If the `Url` is not set, it will be `null`, causing the `IsEqual` function to return false.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
