### PR TITLE
RavenDB-22531 - Fix OutOfCpuCredits Exception

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -375,10 +375,19 @@ namespace Raven.Server.ServerWide.Maintenance
                 // we take the last received and not the last successful.
                 // we don't want to reuse by mistake a successful report when we receive an 'unchanged' error.
                 var lastReport = ReceivedReport;
-                if (lastReport.Status != ClusterNodeStatusReport.ReportStatus.Ok)
+                switch (lastReport!.Status)
                 {
-                    throw new InvalidOperationException(
-                        $"We have databases with '{DatabaseStatus.NoChange}' status, but our last report from this node is '{lastReport.Status}'");
+                    case ClusterNodeStatusReport.ReportStatus.WaitingForResponse:
+                    case ClusterNodeStatusReport.ReportStatus.Timeout:
+                    case ClusterNodeStatusReport.ReportStatus.Error:
+                        throw new InvalidOperationException($"We have databases with '{DatabaseStatus.NoChange}' status, but our last report from this node is '{lastReport.Status}'");
+                    case ClusterNodeStatusReport.ReportStatus.Ok:
+                    case ClusterNodeStatusReport.ReportStatus.OutOfCredits:
+                    case ClusterNodeStatusReport.ReportStatus.EarlyOutOfMemory:
+                    case ClusterNodeStatusReport.ReportStatus.HighDirtyMemory:
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
                 }
 
                 foreach (var dbReport in unchangedReports)

--- a/test/SlowTests/Cluster/ClusterMaintenanceTest.cs
+++ b/test/SlowTests/Cluster/ClusterMaintenanceTest.cs
@@ -97,30 +97,5 @@ namespace SlowTests.Cluster
                 await task;
             }
         }
-
-        private async Task<string> ReadFromWebSocket(ArraySegment<byte> buffer, WebSocket source)
-        {
-            using (var ms = new MemoryStream())
-            {
-                WebSocketReceiveResult result;
-                do
-                {
-                    try
-                    {
-                        result = await source.ReceiveAsync(buffer, CancellationToken.None);
-                    }
-                    catch (Exception)
-                    {
-                        break;
-                    }
-                    ms.Write(buffer.Array, buffer.Offset, result.Count);
-                }
-                while (!result.EndOfMessage);
-                ms.Seek(0, SeekOrigin.Begin);
-
-                return new StreamReader(ms, Encoding.UTF8).ReadToEnd();
-            }
-        }
-
     }
 }

--- a/test/SlowTests/Issues/RavenDB-22531.cs
+++ b/test/SlowTests/Issues/RavenDB-22531.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using SlowTests.MailingList;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22531 : ClusterTestBase
+{
+    public RavenDB_22531(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private static readonly string ExpectedException = "System.InvalidOperationException: We have databases with 'NoChange' status, but our last report from this node is 'OutOfCredits'";
+
+    [RavenFact(RavenTestCategory.Cluster)]
+    public async Task Test()
+    {
+        using var server = GetNewServer();
+        using var store = GetDocumentStore(new Options()
+        {
+            Server = server
+        });
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var client = new ClientWebSocket();
+        var url = $"{server.WebUrl.Replace("http", "ws")}/admin/logs/watch";
+        await client.ConnectAsync(new Uri(url), cts.Token);
+
+        server.CpuCreditsBalance.BackgroundTasksAlertRaised.Raise();
+
+        
+        Assert.True(await CollectFromAdminLogs(client, maxChecks: 25, cts.Token), ExpectedException);
+    }
+
+
+    private async Task<bool> CollectFromAdminLogs(ClientWebSocket client, int maxChecks, CancellationToken token)
+    {
+        ArraySegment<byte> buffer = new ArraySegment<byte>(new byte[1024]);
+        var sb = new StringBuilder();
+        int i = 0;
+        while (i < maxChecks && token.IsCancellationRequested == false && client.State == WebSocketState.Open)
+        {
+            var value = await ReadFromWebSocket(buffer, client);
+            lock (sb)
+            {
+                sb.AppendLine(value);
+
+                if (sb.ToString().Contains(ExpectedException))
+                {
+                    return false;
+                }
+            }
+            i++;
+        }
+
+        return true;
+    }
+
+    private async Task<string> ReadFromWebSocket(ArraySegment<byte> buffer, WebSocket source)
+    {
+        using (var ms = new MemoryStream())
+        {
+            WebSocketReceiveResult result;
+            do
+            {
+                try
+                {
+                    result = await source.ReceiveAsync(buffer, CancellationToken.None);
+                }
+                catch (Exception)
+                {
+                    break;
+                }
+                ms.Write(buffer.Array, buffer.Offset, result.Count);
+            }
+            while (!result.EndOfMessage);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            return new StreamReader(ms, Encoding.UTF8).ReadToEnd();
+        }
+    }
+}
+

--- a/test/SlowTests/Issues/RavenDB-22531.cs
+++ b/test/SlowTests/Issues/RavenDB-22531.cs
@@ -23,7 +23,7 @@ public class RavenDB_22531 : ClusterTestBase
     private static readonly string ExpectedException = "System.InvalidOperationException: We have databases with 'NoChange' status, but our last report from this node is 'OutOfCredits'";
 
     [RavenFact(RavenTestCategory.Cluster)]
-    public async Task Test()
+    public async Task Shouldnt_Throw_Exception_About_CpuCredits_On_Update_NodeReport()
     {
         using var server = GetNewServer();
         using var store = GetDocumentStore(new Options()
@@ -65,28 +65,5 @@ public class RavenDB_22531 : ClusterTestBase
         return true;
     }
 
-    private async Task<string> ReadFromWebSocket(ArraySegment<byte> buffer, WebSocket source)
-    {
-        using (var ms = new MemoryStream())
-        {
-            WebSocketReceiveResult result;
-            do
-            {
-                try
-                {
-                    result = await source.ReceiveAsync(buffer, CancellationToken.None);
-                }
-                catch (Exception)
-                {
-                    break;
-                }
-                ms.Write(buffer.Array, buffer.Offset, result.Count);
-            }
-            while (!result.EndOfMessage);
-            ms.Seek(0, SeekOrigin.Begin);
-
-            return new StreamReader(ms, Encoding.UTF8).ReadToEnd();
-        }
-    }
 }
 

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -1284,30 +1284,6 @@ loadToOrders(orderData);
             }
         }
 
-        private async Task<string> ReadFromWebSocket(ArraySegment<byte> buffer, WebSocket source)
-        {
-            using (var ms = new MemoryStream())
-            {
-                WebSocketReceiveResult result;
-                do
-                {
-                    try
-                    {
-                        result = await source.ReceiveAsync(buffer, CancellationToken.None);
-                    }
-                    catch (Exception)
-                    {
-                        break;
-                    }
-                    ms.Write(buffer.Array, buffer.Offset, result.Count);
-                }
-                while (!result.EndOfMessage);
-                ms.Seek(0, SeekOrigin.Begin);
-
-                return new StreamReader(ms, Encoding.UTF8).ReadToEnd();
-            }
-        }
-
         private static void AssertCounts(int ordersCount, int orderLineCounts, string connectionString)
         {
             using (var con = new SqlConnection())

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Net.WebSockets;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
@@ -900,6 +902,30 @@ namespace FastTests
             }
 
             return sb.ToString();
+        }
+
+        public static async Task<string> ReadFromWebSocket(ArraySegment<byte> buffer, WebSocket source)
+        {
+            using (var ms = new MemoryStream())
+            {
+                WebSocketReceiveResult result;
+                do
+                {
+                    try
+                    {
+                        result = await source.ReceiveAsync(buffer, CancellationToken.None);
+                    }
+                    catch (Exception)
+                    {
+                        break;
+                    }
+                    ms.Write(buffer.Array, buffer.Offset, result.Count);
+                }
+                while (!result.EndOfMessage);
+                ms.Seek(0, SeekOrigin.Begin);
+
+                return new StreamReader(ms, Encoding.UTF8).ReadToEnd();
+            }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22531/Heartbeats-spam-upon-low-cpu-credits

### Additional description

The exception caused the heartbeats spam upon low CPU credits is
```
2024-08-06T12:47:22.6229009, 24, Information, Heartbeats supervisor from A to A in term 1, Raven.Server.ServerWide.Maintenance.ClusterMaintenanceSupervisor+ClusterNode, Exception was thrown while collecting info from A, EXCEPTION: System.InvalidOperationException: We have databases with 'NoChange' status, but our last report from this node is 'OutOfCredits'
   at Raven.Server.ServerWide.Maintenance.ClusterMaintenanceSupervisor.ClusterNode.UpdateNodeReportIfNeeded(ClusterNodeStatusReport nodeReport, List`1 unchangedReports) in D:\work\RavenDB-22531\sln\src\Raven.Server\ServerWide\Maintenance\ClusterMaintenanceSupervisor.cs:line 392
   at Raven.Server.ServerWide.Maintenance.ClusterMaintenanceSupervisor.ClusterNode.ListenToMaintenanceWorker() in D:\work\RavenDB-22531\sln\src\Raven.Server\ServerWide\Maintenance\ClusterMaintenanceSupervisor.cs:line 333
```
As we can see here:
![image](https://github.com/user-attachments/assets/b1fc83f1-0b55-4fb0-84f2-aaee592a6c92)
![image](https://github.com/user-attachments/assets/85f06008-2857-429e-9fe5-52e3b208e596)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
