### PR TITLE
RavenDB-17789 - ShouldStoreTotalDocumentsSizeInPerformanceHint_ForRevisions fail

### DIFF
--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -383,13 +383,12 @@ namespace Raven.Server.Documents.Handlers
 
             HttpContext.Response.Headers["ETag"] = "\"" + actualChangeVector + "\"";
 
-            long loadedRevisionsCount;
-            long totalDocumentsSizeInBytes;
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("Results");
-                (loadedRevisionsCount, totalDocumentsSizeInBytes) = await writer.WriteDocumentsAsync(context, revisions, metadataOnly, token);
+                var (loadedRevisionsCount, totalDocumentsSizeInBytes) = await writer.WriteDocumentsAsync(context, revisions, metadataOnly, token);
+                AddPagingPerformanceHint(PagingOperationType.Revisions, nameof(GetRevisions), HttpContext.Request.QueryString.Value, loadedRevisionsCount, pageSize, sw.ElapsedMilliseconds, totalDocumentsSizeInBytes);
 
                 writer.WriteComma();
 
@@ -397,8 +396,6 @@ namespace Raven.Server.Documents.Handlers
                 writer.WriteInteger(count);
                 writer.WriteEndObject();
             }
-
-            AddPagingPerformanceHint(PagingOperationType.Revisions, nameof(GetRevisions), HttpContext.Request.QueryString.Value, loadedRevisionsCount, pageSize, sw.ElapsedMilliseconds, totalDocumentsSizeInBytes);
         }
 
         [RavenAction("/databases/*/revisions/resolved", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -383,12 +383,13 @@ namespace Raven.Server.Documents.Handlers
 
             HttpContext.Response.Headers["ETag"] = "\"" + actualChangeVector + "\"";
 
+            long loadedRevisionsCount;
+            long totalDocumentsSizeInBytes;
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
             {
                 writer.WriteStartObject();
                 writer.WritePropertyName("Results");
-                var (loadedRevisionsCount, totalDocumentsSizeInBytes) = await writer.WriteDocumentsAsync(context, revisions, metadataOnly, token);
-                AddPagingPerformanceHint(PagingOperationType.Revisions, nameof(GetRevisions), HttpContext.Request.QueryString.Value, loadedRevisionsCount, pageSize, sw.ElapsedMilliseconds, totalDocumentsSizeInBytes);
+                (loadedRevisionsCount, totalDocumentsSizeInBytes) = await writer.WriteDocumentsAsync(context, revisions, metadataOnly, token);
 
                 writer.WriteComma();
 
@@ -396,6 +397,8 @@ namespace Raven.Server.Documents.Handlers
                 writer.WriteInteger(count);
                 writer.WriteEndObject();
             }
+
+            AddPagingPerformanceHint(PagingOperationType.Revisions, nameof(GetRevisions), HttpContext.Request.QueryString.Value, loadedRevisionsCount, pageSize, sw.ElapsedMilliseconds, totalDocumentsSizeInBytes);
         }
 
         [RavenAction("/databases/*/revisions/resolved", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]

--- a/test/SlowTests/Issues/RavenDB_17018.cs
+++ b/test/SlowTests/Issues/RavenDB_17018.cs
@@ -205,7 +205,9 @@ namespace SlowTests.Issues
                         .GetFor<Company>("companies/1", pageSize: 4);
                 }
 
-                var outcome = database.NotificationCenter.Paging.UpdatePagingInternal(null, out string reason);
+                string reason = string.Empty;
+
+                var outcome = await WaitForValueAsync(() => database.NotificationCenter.Paging.UpdatePagingInternal(null, out reason), true);
                 Assert.True(outcome, reason);
 
                 using (database.NotificationCenter.GetStored(out var actions))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17789/SlowTests.Issues.RavenDB17018.ShouldStoreTotalDocumentsSizeInPerformanceHintForRevisions

### Additional description

SlowTests.Issues.RavenDB_17018.ShouldStoreTotalDocumentsSizeInPerformanceHint_ForRevisions Failed
The problem is that the `session.Advanced.Revisions.GetFor(...)` in the test is getting a response before the PerformanceHint is being added to NotificationCenter.
How to reproduce:
![image](https://github.com/user-attachments/assets/931a437a-2bd9-4728-8d7f-91faeb344ff3)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
