### PR TITLE
RavenDB-22701 - SlowTests.Server.Replication.ReplicationConflictsTests.DatabaseChangeVectorShouldBeIdentical

### DIFF
--- a/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
@@ -312,15 +312,19 @@ namespace SlowTests.Server.Replication
 
                 var db1 = await GetDatabase(store1.Database);
                 var db2 = await GetDatabase(store2.Database);
-                using (db1.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx1))
-                using (db2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx2))
-                using (ctx1.OpenReadTransaction())
-                using (ctx2.OpenReadTransaction())
+
+                await WaitAndAssertForValueAsync(() =>
                 {
-                    var cv1 = DocumentsStorage.GetDatabaseChangeVector(ctx1);
-                    var cv2 = DocumentsStorage.GetDatabaseChangeVector(ctx2);
-                    Assert.True(cv1.SequenceEqual(cv2));
-                }
+                    using (db1.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx1))
+                    using (db2.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx2))
+                    using (ctx1.OpenReadTransaction())
+                    using (ctx2.OpenReadTransaction())
+                    {
+                        var cv1 = DocumentsStorage.GetDatabaseChangeVector(ctx1);
+                        var cv2 = DocumentsStorage.GetDatabaseChangeVector(ctx2);
+                        return cv1.SequenceEqual(cv2);
+                    }
+                }, true);
             }
         }
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22701/SlowTests.Server.Replication.ReplicationConflictsTests.DatabaseChangeVectorShouldBeIdentical

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
