### PR TITLE
RavenDB-20985 & RavenDB-18080 fix tests with address already in use

### DIFF
--- a/test/RachisTests/TopologyChangesTests.cs
+++ b/test/RachisTests/TopologyChangesTests.cs
@@ -56,8 +56,8 @@ namespace RachisTests
         [Fact]
         public async Task Adding_additional_node_that_goes_offline_and_then_online_should_still_work()
         {
-            var node4 = SetupServer(false, 53899);
-            var node5 = SetupServer(false, 53898);
+            var node4 = SetupServer();
+            var node5 = SetupServer();
             DisconnectFromNode(node4);
             DisconnectFromNode(node5);
             var leader = await CreateNetworkAndGetLeader(3);

--- a/test/SlowTests/Issues/RavenDB-18515.cs
+++ b/test/SlowTests/Issues/RavenDB-18515.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Issues
         [Fact]
         public async Task Can_Set_Pin_To_Node_Pull_Replication_As_Sink()
         {
-            var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(3, watcherCluster: true);
+            var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(3, watcherCluster: true, useReservedPorts: true);
 
             var followers = nodes.Where(s => s.ServerStore.NodeTag != leader.ServerStore.NodeTag).ToList();
 

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -699,9 +699,10 @@ namespace Tests.Infrastructure
             IDictionary<string, string> customSettings = null,
             List<IDictionary<string, string>> customSettingsList = null,
             bool watcherCluster = false,
+            bool useReservedPorts = false,
             [CallerMemberName] string caller = null)
         {
-            var result = await CreateRaftClusterInternalAsync(numberOfNodes, shouldRunInMemory, leaderIndex, useSsl: false, customSettings, customSettingsList, watcherCluster, caller);
+            var result = await CreateRaftClusterInternalAsync(numberOfNodes, shouldRunInMemory, leaderIndex, useSsl: false, customSettings, customSettingsList, watcherCluster, useReservedPorts, caller);
             return (result.Nodes, result.Leader);
         }
 
@@ -711,9 +712,10 @@ namespace Tests.Infrastructure
             int? leaderIndex = null,
             IDictionary<string, string> customSettings = null,
             List<IDictionary<string, string>> customSettingsList = null,
-            bool watcherCluster = false)
+            bool watcherCluster = false,
+            bool useReservedPorts = false)
         {
-            return CreateRaftClusterInternalAsync(numberOfNodes, shouldRunInMemory, leaderIndex, useSsl: true, customSettings, customSettingsList, watcherCluster);
+            return CreateRaftClusterInternalAsync(numberOfNodes, shouldRunInMemory, leaderIndex, useSsl: true, customSettings, customSettingsList, watcherCluster, useReservedPorts);
         }
 
         protected async Task<(RavenServer Leader, Dictionary<RavenServer, ProxyServer> Proxies)> CreateRaftClusterWithProxiesAsync(
@@ -797,6 +799,7 @@ namespace Tests.Infrastructure
             IDictionary<string, string> customSettings = null,
             List<IDictionary<string, string>> customSettingsList = null,
             bool watcherCluster = false,
+            bool useReservedPorts = false,
             [CallerMemberName] string caller = null)
         {
             string[] allowedNodeTags = { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z" };
@@ -831,14 +834,20 @@ namespace Tests.Infrastructure
 
                 string serverUrl;
 
+                var port = 0;
+                if (useReservedPorts)
+                {
+                    port = GetReservedPort();
+                }
+
                 if (useSsl)
                 {
-                    serverUrl = UseFiddlerUrl("https://127.0.0.1:0");
+                    serverUrl = UseFiddlerUrl($"https://127.0.0.1:{port}");
                     certificates = Certificates.SetupServerAuthentication(customSettings, serverUrl);
                 }
                 else
                 {
-                    serverUrl = UseFiddlerUrl("http://127.0.0.1:0");
+                    serverUrl = UseFiddlerUrl($"http://127.0.0.1:{port}");
                     customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl;
                 }
                 var co = new ServerCreationOptions
@@ -849,7 +858,7 @@ namespace Tests.Infrastructure
                     NodeTag = allowedNodeTags[i]
                 };
                 var server = GetNewServer(co, caller);
-                var port = Convert.ToInt32(server.ServerStore.GetNodeHttpServerUrl().Split(':')[2]);
+                port = Convert.ToInt32(server.ServerStore.GetNodeHttpServerUrl().Split(':')[2]);
                 var prefix = useSsl ? "https" : "http";
                 serverUrl = UseFiddlerUrl($"{prefix}://127.0.0.1:{port}");
                 Servers.Add(server);

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -178,9 +178,9 @@ namespace Tests.Infrastructure
             return sb.ToString();
         }
 
-        protected RachisConsensus<CountingStateMachine> SetupServer(bool bootstrap = false, int port = 0, int electionTimeout = 300, [CallerMemberName] string caller = null)
+        protected RachisConsensus<CountingStateMachine> SetupServer(bool bootstrap = false, int electionTimeout = 300, [CallerMemberName] string caller = null)
         {
-            var tcpListener = new TcpListener(IPAddress.Loopback, port);
+            var tcpListener = new TcpListener(IPAddress.Loopback, 0);
             tcpListener.Start();
             char ch;
             if (bootstrap)

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -76,6 +76,19 @@ namespace FastTests
 
         private IDictionary<string, string> _customServerSettings;
 
+        private static readonly int ReservedPortStartRange = 23000;
+        private static readonly int ReservedPortEndRange = 32000;
+        private static int LastUsedReservedPort = ReservedPortStartRange;
+
+        public static int GetReservedPort()
+        {
+            var port = Interlocked.Increment(ref LastUsedReservedPort);
+            if (port > ReservedPortEndRange)
+                throw new InvalidOperationException($"No more reserved ports left between [{ReservedPortStartRange} - {ReservedPortEndRange}], consider increase the range but be aware of ephemeral port range of each OS.");
+
+            return port;
+        }
+
         public static void IgnoreProcessorAffinityChanges(bool ignore)
         {
             LicenseManager.IgnoreProcessorAffinityChanges = ignore;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20985
https://issues.hibernatingrhinos.com/issue/RavenDB-18080

### Additional description

We shouldn't use hard coded ports, but let the OS pick one for us.
Only for a scenario when we need to revive a node, we need to ensure that his port is free, so we use a pool of such ports
`[23,000 - 32,000]`

since the dynamic ports on windows are
```
Protocol tcp Dynamic Port Range
---------------------------------
Start Port      : 49152
Number of Ports : 16384
```

and on linux 
```
Result: net.ipv4.ip_local_port_range = 32768	60999
```

So we want to pick port outside those ranges

### Type of change

- [x] Test stabilization
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
