### PR TITLE
RavenDB-22744 Forcing the cluster wide transaction to mark the compare exchange tombstone as handled

### DIFF
--- a/test/SlowTests/Issues/RavenDB_20150.cs
+++ b/test/SlowTests/Issues/RavenDB_20150.cs
@@ -105,7 +105,7 @@ public class RavenDB_20150 : ClusterTestBase
             //unsuspend and wait for the tombstone cleaner
             leader.ServerStore.Observer.Suspended = false;
 
-            await WaitAndAssertForValueAsync(() => leader.ServerStore.Observer._lastTombstonesCleanupTimeInTicks > timeBeforeCxDeletion.Ticks, true);
+            await WaitAndAssertForGreaterThanAsync(() => Task.FromResult(leader.ServerStore.Observer._lastTombstonesCleanupTimeInTicks), timeBeforeCxDeletion.Ticks);
 
             //ensure compare exchange tombstones were deleted after the tombstone cleanup
             foreach (var node in nodes)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22744

### Additional description
After[ PR #18931](https://github.com/ravendb/ravendb/pull/18931), the cluster-wide transaction mechanism subscribes to the compare exchange tombstones. 
As a result, the tombstones weren't deleted before the mechanism marked them as handled.
Triggering a cluster-wide transaction ensures the tombstone is marked as handled.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test fix

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
