### PR TITLE
RavenDB-21914 - ClusterWideTransaction_WhenStoreDocWithEmptyStringId_ShouldThrowInformativeError fails

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -306,18 +306,17 @@ namespace Raven.Server.ServerWide.Commands
                         }
                         break;
                     case CommandType.PUT:
+                        if (document.SeenAttachments)
+                            throw new NotSupportedException($"The document {document.Id} has attachments, this is not supported in cluster wide transaction.");
+
+                        if (document.SeenCounters)
+                            throw new NotSupportedException($"The document {document.Id} has counters, this is not supported in cluster wide transaction.");
+
+                        if (document.SeenTimeSeries)
+                            throw new NotSupportedException($"The document {document.Id} has time series, this is not supported in cluster wide transaction.");
+                        
+                        break;
                     case CommandType.DELETE:
-                        if (document.Type == CommandType.PUT)
-                        {
-                            if (document.SeenAttachments)
-                                throw new NotSupportedException($"The document {document.Id} has attachments, this is not supported in cluster wide transaction.");
-
-                            if (document.SeenCounters)
-                                throw new NotSupportedException($"The document {document.Id} has counters, this is not supported in cluster wide transaction.");
-
-                            if (document.SeenTimeSeries)
-                                throw new NotSupportedException($"The document {document.Id} has time series, this is not supported in cluster wide transaction.");
-                        }
                         break;
 
                     default:

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -1396,13 +1396,13 @@ namespace SlowTests.Cluster
                 {
                     TransactionMode = TransactionMode.ClusterWide
                 });
-
+            
                 var entity = new User { Id = id };
                 await session.StoreAsync(entity);
                 await session.SaveChangesAsync();
             });
-            Assert.True(ContainsRachisException(e));
-
+            Assert.True(ContainsRachisException(e), e.ToString());
+            
             static bool ContainsRachisException(Exception e)
             {
                 while (true)
@@ -1411,7 +1411,7 @@ namespace SlowTests.Cluster
                         return true;
                     if (e is AggregateException ae)
                         return ae.InnerExceptions.Any(ex => ContainsRachisException(ex));
-
+            
                     if (e.InnerException == null)
                         return false;
                     e = e.InnerException;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21914/SlowTests.Cluster.ClusterTransactionTests.ClusterWideTransactionWhenStoreDocWithEmptyStringIdShouldThrowInformativeErroroptions

### Additional description

Added debug info in case it fails again.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
