### PR TITLE
RavenDB-22748 Store value `isSecureServer` is not updated for secured server

### DIFF
--- a/src/Raven.Studio/typescript/components/common/shell/accessManagerSlice.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/accessManagerSlice.ts
@@ -21,7 +21,7 @@ export const databaseAccessSelectors = databaseAccessAdapter.getSelectors();
 const initialState: AccessManagerState = {
     databaseAccess: databaseAccessAdapter.getInitialState(),
     securityClearance: null,
-    isSecureServer: false,
+    isSecureServer: true,
 };
 
 export const accessManagerSlice = createSlice({


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22748/Store-value-isSecureServer-is-not-updated-for-secured-server

### Additional description

The initial value in store was different from that in accessManager.secureServer. In the case of the sercured server, the value of accessManager.secureServer remains invariably true so it did not update the incorrectly defined value in the store.

I checked and now it works correctly for secured and unsecured server.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
