### PR TITLE
RavenDB-22750 IndexTimestamp and LastQueryTime are in UTC so we need to write them in a proper format in JSON

### DIFF
--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -30,6 +30,7 @@ using Raven.Server.Documents.Subscriptions;
 using Raven.Server.Documents.Subscriptions.Stats;
 using Raven.Server.Utils;
 using Sparrow;
+using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Voron.Data.BTrees;
@@ -748,11 +749,11 @@ namespace Raven.Server.Json
                 throw new NotSupportedException($"Cannot write query includes of '{includes.GetType()}' type in '{result.GetType()}'.");
 
             writer.WritePropertyName(nameof(result.IndexTimestamp));
-            writer.WriteString(result.IndexTimestamp.ToString(DefaultFormat.DateTimeFormatsToWrite));
+            writer.WriteString(result.IndexTimestamp.GetDefaultRavenFormat());
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(result.LastQueryTime));
-            writer.WriteString(result.LastQueryTime.ToString(DefaultFormat.DateTimeFormatsToWrite));
+            writer.WriteString(result.LastQueryTime.GetDefaultRavenFormat());
             writer.WriteComma();
 
             writer.WritePropertyName(nameof(result.IsStale));

--- a/test/SlowTests/Issues/RavenDB_22750.cs
+++ b/test/SlowTests/Issues/RavenDB_22750.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using SlowTests.Core.Utils.Entities;
+using SlowTests.Core.Utils.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22750 : RavenTestBase
+{
+    public RavenDB_22750(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public async Task IndexTimestamp_And_LastQueryTime_Needs_To_Have_DateTimeKind_Specified()
+    {
+        using (var store = GetDocumentStore())
+        {
+            await new Companies_ByEmployeeLastName().ExecuteAsync(store);
+
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.Query<Company, Companies_ByEmployeeLastName>()
+                    .Statistics(out var stats)
+                    .ToListAsync();
+
+                Assert.Equal(DateTimeKind.Utc, stats.IndexTimestamp.Kind);
+                Assert.Equal(DateTimeKind.Utc, stats.LastQueryTime.Kind);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22750

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
