### PR TITLE
RavenDB-20985 create new customSettings for each node

### DIFF
--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -796,7 +796,7 @@ namespace Tests.Infrastructure
             bool? shouldRunInMemory = null,
             int? leaderIndex = null,
             bool useSsl = false,
-            IDictionary<string, string> customSettings = null,
+            IDictionary<string, string> commonCustomSettings = null,
             List<IDictionary<string, string>> customSettingsList = null,
             bool watcherCluster = false,
             bool useReservedPorts = false,
@@ -820,12 +820,16 @@ namespace Tests.Infrastructure
 
             for (var i = 0; i < numberOfNodes; i++)
             {
+                IDictionary<string, string> customSettings;
                 if (customSettingsList == null)
                 {
-                    customSettings ??= new Dictionary<string, string>(DefaultClusterSettings)
+                    customSettings = new Dictionary<string, string>(commonCustomSettings ?? DefaultClusterSettings);
+                    
+                    var electionKey = RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout);
+                    if (customSettings.ContainsKey(electionKey) == false)
                     {
-                        [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = _electionTimeoutInMs.ToString(),
-                    };
+                        customSettings[electionKey] = _electionTimeoutInMs.ToString();
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20985

### Additional description

In some tests we modify the `customSettings`, so we don't want to share them between the cluster nodes

### Type of change

- [x] Test stabilization
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
