### PR TITLE
RavenDB-22753 Fixing IndexCreation.CreateIndexes() which ignored SearchEngineType

### DIFF
--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -252,6 +252,8 @@ namespace Raven.Client.Documents.Indexes
 
         DocumentConventions Conventions { get; set; }
 
+        SearchEngineType? SearchEngineType { get; }
+
         IndexDefinition CreateIndexDefinition();
 
         void Execute(IDocumentStore store, DocumentConventions conventions = null, string database = null);

--- a/src/Raven.Client/Documents/Indexes/IndexCreation.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexCreation.cs
@@ -103,6 +103,10 @@ namespace Raven.Client.Documents.Indexes
                         definition.Name = x.IndexName;
                         definition.Priority = x.Priority ?? IndexPriority.Normal;
                         definition.State = x.State ?? IndexState.Normal;
+
+                        if (x.SearchEngineType.HasValue) 
+                            definition.Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType] = x.SearchEngineType.Value.ToString();
+
                         return definition;
                     }
                     finally

--- a/test/SlowTests/Issues/RavenDB_22753.cs
+++ b/test/SlowTests/Issues/RavenDB_22753.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22753 : RavenTestBase
+{
+    public RavenDB_22753(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Indexes)]
+    public void MustSendSearchEngineType()
+    {
+        using var store = GetDocumentStore();
+
+        IndexCreation.CreateIndexes(new []
+        {
+            new Users_ByName()
+        }, store);
+
+        IndexDefinition[] indexDefinitions = store.Maintenance.Send(new GetIndexesOperation(0, 1));
+
+        Assert.Contains(Constants.Configuration.Indexes.IndexingStaticSearchEngineType, (IDictionary<string, string>) indexDefinitions[0].Configuration);
+        Assert.Equal("Corax", indexDefinitions[0].Configuration[Constants.Configuration.Indexes.IndexingStaticSearchEngineType]);
+    }
+
+    private class Users_ByName : AbstractIndexCreationTask<User>
+    {
+        public Users_ByName()
+        {
+            Map = users => from u in users select new { Name = u.Name, LastName = u.LastName };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22753/IndexCreation.CreateIndexes-ignores-SearchEngineType

### Additional description

The property `SearchEngineType` wasn't written to the index settings when an index was deployed with the usage of `IndexCreation.CreateIndexes()`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
