### PR TITLE
RavenDB-22657 Failed to import config to sink

### DIFF
--- a/src/Raven.Studio/typescript/common/certificateUtils.ts
+++ b/src/Raven.Studio/typescript/common/certificateUtils.ts
@@ -17,7 +17,7 @@ class certificateUtils {
     
     static extractCertificatesFromPkcs12(base64EncodedCertificate: string, password: string): string[] {
         const der = forge.util.decode64(base64EncodedCertificate);
-        const asn1 = forge.asn1.fromDer(der);
+        const asn1 = forge.asn1.fromDer(der, { parseAllBytes: false, strict: true, decodeBitStrings: true });
         const p12 = forge.pkcs12.pkcs12FromAsn1(asn1, password);
         
         const bags = p12.getBags({

--- a/src/Raven.Studio/typings/custom_node-forge.d.ts
+++ b/src/Raven.Studio/typings/custom_node-forge.d.ts
@@ -646,7 +646,7 @@ declare module "node-forge" {
         }
 
         function create(tagClass: Class, type: Type, constructed: boolean, value: Bytes | Asn1[]): Asn1;
-        function fromDer(bytes: Bytes | util.ByteBuffer, strict?: boolean): Asn1;
+        function fromDer(bytes: Bytes | util.ByteBuffer, options?: { strict?: boolean; parseAllBytes?: boolean; decodeBitStrings?: boolean; }): Asn1;
         function toDer(obj: Asn1): util.ByteBuffer;
         function oidToDer(oid: OID): util.ByteStringBuffer;
         function derToOid(der: util.ByteStringBuffer): OID;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22657/Failed-to-save-hub

### Additional description

https://issues.hibernatingrhinos.com/issue/RavenDB-22657/Failed-to-save-hub#focus=Comments-67-1054958.0-0

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
