### PR TITLE
RavendDB-22170 - RachisTests.AddNodeToClusterTests.ClientRequestExecutorTopologyWillUpdateWhenAddingNewNodeToCluster_RavenDB_20702

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1054,6 +1054,9 @@ namespace Raven.Server.Rachis
                 topologyJson.CopyTo(ptr);
             }
 
+            if (engine.ServerStore._lastClusterTopologyIndex < clusterTopology.Etag)
+                engine.ServerStore._lastClusterTopologyIndex = clusterTopology.Etag;
+
             context.Transaction.InnerTransaction.LowLevelTransaction.OnDispose += _ =>
             {
                 clusterTopology.AllNodes.TryGetValue(engine.Tag, out var key);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -126,7 +126,7 @@ namespace Raven.Server.ServerWide
 
         private RequestExecutor _leaderRequestExecutor;
 
-        private long _lastClusterTopologyIndex = -1;
+        internal long _lastClusterTopologyIndex = -1;
 
         public readonly RavenConfiguration Configuration;
         private readonly RavenServer _server;
@@ -1136,9 +1136,6 @@ namespace Raven.Server.ServerWide
 
         private void OnTopologyChangeInternal(ClusterTopology topology, Dictionary<string, NodeStatus> status = null)
         {
-            if (_lastClusterTopologyIndex < topology.Etag)
-                _lastClusterTopologyIndex = topology.Etag;
-
             NotificationCenter.Add(ClusterTopologyChanged.Create(topology, LeaderTag,
                 NodeTag, _engine.CurrentTerm, _engine.CurrentState, status ?? GetNodesStatuses(), LoadLicenseLimits()?.NodeLicenseDetails));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22170

### Additional description

Test failed because of a race that happened between adding a node and firing the request to the new node.
While we do wait in the test for the cluster topology to be changed, the code that updates `_lastClusterTopologyIndex` (used by studio to know when there is an update), it happens asynchronously in chained event.
Moved the code to a synchronous location.

Note: in the old async code, `_lastClusterTopologyIndex` would always update to the leader's topology index and not the local one. However, it seems more correct to represent the local cluster topology.
Checked manually to make sure some scenarios such as removing a node don't cause the removed node's studio to remain unupdated.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
