### PR TITLE
RDBQA-82 Handle AllowEncryptedDatabasesOverHttp in new database creator (v6.0)

### DIFF
--- a/src/Raven.Studio/typescript/components/common/shell/accessManagerSlice.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/accessManagerSlice.ts
@@ -10,6 +10,7 @@ interface AccessManagerState {
     databaseAccess: EntityState<DatabaseAccessInfo, string>;
     securityClearance: SecurityClearance;
     isSecureServer: boolean;
+    isAllowEncryptedDatabasesOverHttp: boolean;
 }
 
 const databaseAccessAdapter = createEntityAdapter<DatabaseAccessInfo, string>({
@@ -22,6 +23,7 @@ const initialState: AccessManagerState = {
     databaseAccess: databaseAccessAdapter.getInitialState(),
     securityClearance: null,
     isSecureServer: true,
+    isAllowEncryptedDatabasesOverHttp: false,
 };
 
 export const accessManagerSlice = createSlice({
@@ -42,6 +44,9 @@ export const accessManagerSlice = createSlice({
         },
         onIsSecureServerSet: (state, action: PayloadAction<boolean>) => {
             state.isSecureServer = action.payload;
+        },
+        onIsAllowEncryptedDatabasesOverHttpSet: (state, action: PayloadAction<boolean>) => {
+            state.isAllowEncryptedDatabasesOverHttp = action.payload;
         },
     },
 });

--- a/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.ts
@@ -159,9 +159,12 @@ const selectGetCanHandleOperation = createSelector(
 );
 
 const selectIsSecureServer = (store: RootState) => store.accessManager.isSecureServer;
+const selectIsAllowEncryptedDatabasesOverHttp = (store: RootState) =>
+    store.accessManager.isAllowEncryptedDatabasesOverHttp;
 
 export const accessManagerSelectors = {
     isSecureServer: selectIsSecureServer,
+    isAllowEncryptedDatabasesOverHttp: selectIsAllowEncryptedDatabasesOverHttp,
     isOperatorOrAbove: selectIsOperatorOrAbove,
     isClusterAdminOrClusterNode: selectIsClusterAdminOrClusterNode,
     getHasDatabaseAdminAccess: selectGetHasDatabaseAccessAdmin,

--- a/src/Raven.Studio/typescript/components/common/shell/setup.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/setup.ts
@@ -95,6 +95,9 @@ function initRedux() {
     accessManager.default.secureServer.subscribe((isSecureServer) =>
         globalDispatch(accessManagerActions.onIsSecureServerSet(isSecureServer))
     );
+    accessManager.default.allowEncryptedDatabasesOverHttp.subscribe((isAllowEncryptedDatabasesOverHttp) =>
+        globalDispatch(accessManagerActions.onIsAllowEncryptedDatabasesOverHttpSet(isAllowEncryptedDatabasesOverHttp))
+    );
 }
 
 declare module "yup" {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepBasicInfo.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepBasicInfo.tsx
@@ -67,6 +67,7 @@ function IsEncryptedField() {
 
     const hasEncryption = useAppSelector(licenseSelectors.statusValue("HasEncryption"));
     const isSecureServer = useAppSelector(accessManagerSelectors.isSecureServer);
+    const isAllowEncryptedDatabasesOverHttp = useAppSelector(accessManagerSelectors.isAllowEncryptedDatabasesOverHttp);
 
     return (
         <div className="d-flex align-items-center justify-content-center">
@@ -77,7 +78,7 @@ function IsEncryptedField() {
                         message: <EncryptionUnavailableMessage />,
                     },
                     {
-                        isActive: !isSecureServer,
+                        isActive: !isAllowEncryptedDatabasesOverHttp && !isSecureServer,
                         message: <AuthenticationOffMessage />,
                     },
                 ]}
@@ -87,7 +88,11 @@ function IsEncryptedField() {
                     color="primary"
                     control={control}
                     name="basicInfoStep.isEncrypted"
-                    disabled={!hasEncryption || !isSecureServer || formState.isSubmitting}
+                    disabled={
+                        !hasEncryption ||
+                        (!isAllowEncryptedDatabasesOverHttp && !isSecureServer) ||
+                        formState.isSubmitting
+                    }
                 >
                     <Icon icon="encryption" />
                     Encrypt at Rest


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBQA-82/Add-option-to-run-encrypted-database-when-authentication-is-off

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
