### PR TITLE
RDBQA-82 Handle AllowEncryptedDatabasesOverHttp in old database creator (v5.4)

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/resources/createDatabase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/createDatabase.ts
@@ -46,8 +46,8 @@ class createDatabase extends dialogViewModelBase {
     clusterNodes: clusterNode[] = [];
     
     encryptionSection: setupEncryptionKey;
-    isSecureServer = accessManager.default.secureServer();
-    allowEncryptedDatabasesOverHttp = accessManager.default.allowEncryptedDatabasesOverHttp();
+    isSecureServer = accessManager.default.secureServer;
+    allowEncryptedDatabasesOverHttp = accessManager.default.allowEncryptedDatabasesOverHttp;
     operationNotSupported: boolean;
     
     protected currentAdvancedSection = ko.observable<availableConfigurationSectionId>();
@@ -93,7 +93,12 @@ class createDatabase extends dialogViewModelBase {
 
         this.operationNotSupported = mode === "legacyMigration" && clusterTopologyManager.default.nodeInfo().OsInfo.Type !== "Windows";
         
-        const canCreateEncryptedDatabases = ko.pureComputed(() => this.isSecureServer && licenseModel.licenseStatus() && licenseModel.licenseStatus().HasEncryption);
+        const canCreateEncryptedDatabases = ko.pureComputed(() => 
+            (this.isSecureServer() || this.allowEncryptedDatabasesOverHttp())
+            && licenseModel.licenseStatus()
+            && licenseModel.licenseStatus().HasEncryption
+        );
+
         this.databaseModel = new databaseCreationModel(mode, canCreateEncryptedDatabases);
         this.recentPathsAutocomplete = new lastUsedAutocomplete("createDatabasePath", this.databaseModel.path.dataPath);
         this.dataExporterAutocomplete = new lastUsedAutocomplete("dataExporterPath", this.databaseModel.legacyMigration.dataExporterFullPath);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RDBQA-82/Add-option-to-run-encrypted-database-when-authentication-is-off

### Additional description

Fixes `isSecureServer` and `allowEncryptedDatabasesOverHttp` are not functions

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
