### PR TITLE
RavenDB-22762 Modify `GetBackupFilesAndAssertCountAsync` to handle sharded database

### DIFF
--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -338,7 +338,7 @@ namespace RachisTests.DatabaseCluster
                 var backupStatus3 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
                 await backupStatus3.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
-                var files = await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 3, source.Database, backupStatus3.Id);
+                var files = await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 3, backupStatus3.Id, source.Database);
 
                 var smugglerOptions = new DatabaseSmugglerImportOptions();
                 DatabaseSmuggler.ConfigureOptionsForIncrementalImport(smugglerOptions);
@@ -452,7 +452,7 @@ namespace RachisTests.DatabaseCluster
                 var backupStatus2 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
                 await backupStatus2.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
-                await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 2, source.Database, backupStatus2.Id);
+                await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 2, backupStatus2.Id, source.Database);
                 
                 await documentStore.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), Directory.GetDirectories(backupPath).First());
             }
@@ -517,7 +517,7 @@ namespace RachisTests.DatabaseCluster
                 var backupStatus2 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
                 await backupStatus2.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
-                await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 2, source.Database, backupStatus2.Id);
+                await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 2, backupStatus2.Id, source.Database);
                 
                 await documentStore.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), Directory.GetDirectories(backupPath).First());
             }

--- a/test/SlowTests/Issues/RavenDB-21050.cs
+++ b/test/SlowTests/Issues/RavenDB-21050.cs
@@ -50,14 +50,15 @@ public class RavenDB_21050 : RavenTestBase
             await backupStatus2.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
             var path = Directory.GetDirectories(backupPath).First();
+            int? shardNumber = null;
             if (options.DatabaseMode == RavenDatabaseMode.Sharded)
             {
-                int shardNumber = await Sharding.GetShardNumberForAsync(source, id);
+                shardNumber = await Sharding.GetShardNumberForAsync(source, id);
                 path = Directory.GetDirectories(backupPath).First(p => p.Contains($"${shardNumber}"));
             }
 
-            await Backup.GetBackupFilesAndAssertCountAsync(path, 2, source.Database, backupStatus2.Id);
-
+            await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 2, backupStatus2.Id, source.Database, shardNumber);
+            
             var restoreConfig = new RestoreBackupConfiguration { BackupLocation = path, DatabaseName = destination.Database };
             using (Backup.RestoreDatabase(destination, restoreConfig))
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22762

### Additional description
Fix addition information to handle shared database

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test fix

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
