### PR TITLE
RavenDB-21771 - add event listener events to the log

### DIFF
--- a/src/Raven.Server/Config/Categories/ConfigurationCategoryType.cs
+++ b/src/Raven.Server/Config/Categories/ConfigurationCategoryType.cs
@@ -39,6 +39,7 @@ namespace Raven.Server.Config.Categories
         TrafficWatch,
         [Description("Export & Import")]
         ExportImport,
-        Etw
+        [Description("Event Listener")]
+        EventListener
     }
 }

--- a/src/Raven.Server/Config/Categories/ConfigurationCategoryType.cs
+++ b/src/Raven.Server/Config/Categories/ConfigurationCategoryType.cs
@@ -38,6 +38,7 @@ namespace Raven.Server.Config.Categories
         [Description("Traffic Watch")]
         TrafficWatch,
         [Description("Export & Import")]
-        ExportImport
+        ExportImport,
+        Etw
     }
 }

--- a/src/Raven.Server/Config/Categories/ConfigurationCategoryType.cs
+++ b/src/Raven.Server/Config/Categories/ConfigurationCategoryType.cs
@@ -39,7 +39,6 @@ namespace Raven.Server.Config.Categories
         TrafficWatch,
         [Description("Export & Import")]
         ExportImport,
-        [Description("Event Listener")]
-        EventListener
+        Debug
     }
 }

--- a/src/Raven.Server/Config/Categories/DebugConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DebugConfiguration.cs
@@ -5,7 +5,7 @@ using Raven.Server.EventListener;
 
 namespace Raven.Server.Config.Categories;
 
-[ConfigurationCategory(ConfigurationCategoryType.EventListener)]
+[ConfigurationCategory(ConfigurationCategoryType.Debug)]
 public class DebugConfiguration : ConfigurationCategory
 {
     [Description("Event listener logging mode.")]

--- a/src/Raven.Server/Config/Categories/DebugConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DebugConfiguration.cs
@@ -5,33 +5,33 @@ using Raven.Server.EventListener;
 
 namespace Raven.Server.Config.Categories;
 
-[ConfigurationCategory(ConfigurationCategoryType.Etw)]
-public class EventListenerConfiguration : ConfigurationCategory
+[ConfigurationCategory(ConfigurationCategoryType.EventListener)]
+public class DebugConfiguration : ConfigurationCategory
 {
     [Description("Event listener logging mode.")]
     [DefaultValue(EventListenerMode.Off)]
-    [ConfigurationEntry("EventListener.Mode", ConfigurationEntryScope.ServerWideOnly)]
+    [ConfigurationEntry("Debug.EventListener.Mode", ConfigurationEntryScope.ServerWideOnly)]
     public EventListenerMode EventListenerMode { get; set; }
 
     [Description("A semicolon-separated list of event types by which the event listener logging entities will be filtered. If not specified, event listener entities with any type will be included. Example list: \"GC;GCSuspend;GCRestart;GCFinalizers;Contention\".")]
     [DefaultValue(null)]
-    [ConfigurationEntry("EventListener.EventTypes", ConfigurationEntryScope.ServerWideOnly)]
+    [ConfigurationEntry("Debug.EventListener.EventTypes", ConfigurationEntryScope.ServerWideOnly)]
     public EventType[] EventTypes { get; set; }
 
     [Description("Minimum duration by which the event listenter logging entities will be filtered.")]
     [DefaultValue(0)]
     [TimeUnit(TimeUnit.Milliseconds)]
-    [ConfigurationEntry("EventListener.MinimumDurationInMs", ConfigurationEntryScope.ServerWideOnly)]
+    [ConfigurationEntry("Debug.EventListener.MinimumDurationInMs", ConfigurationEntryScope.ServerWideOnly)]
     public TimeSetting MinimumDuration { get; set; }
 
     [Description("The duration on which we'll collect the allocations info.")]
     [DefaultValue(5000)]
     [TimeUnit(TimeUnit.Milliseconds)]
-    [ConfigurationEntry("EventListener.AllocationsLoggingIntervalInMs", ConfigurationEntryScope.ServerWideOnly)]
+    [ConfigurationEntry("Debug.EventListener.AllocationsLoggingIntervalInMs", ConfigurationEntryScope.ServerWideOnly)]
     public TimeSetting AllocationsLoggingInterval { get; set; }
 
     [Description("Number of top allocation events to log")]
     [DefaultValue(5)]
-    [ConfigurationEntry("EventListener.AllocationsLoggingCount", ConfigurationEntryScope.ServerWideOnly)]
+    [ConfigurationEntry("Debug.EventListener.AllocationsLoggingCount", ConfigurationEntryScope.ServerWideOnly)]
     public int AllocationsLoggingCount { get; set; }
 }

--- a/src/Raven.Server/Config/Categories/EventListenerConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EventListenerConfiguration.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+using Raven.Client.ServerWide.Operations.EventListener;
+using Raven.Server.Config.Attributes;
+using Raven.Server.Config.Settings;
+using Raven.Server.EventListener;
+
+namespace Raven.Server.Config.Categories;
+
+[ConfigurationCategory(ConfigurationCategoryType.Etw)]
+public class EventListenerConfiguration : ConfigurationCategory
+{
+    [Description("Event listener logging mode.")]
+    [DefaultValue(EventListenerMode.Off)]
+    [ConfigurationEntry("EventListener.Mode", ConfigurationEntryScope.ServerWideOnly)]
+    public EventListenerMode EventListenerMode { get; set; }
+
+    [Description("A semicolon-separated list of event types by which the event listener logging entities will be filtered. If not specified, event listener entities with any type will be included. Example list: \"GC;GCSuspend;GCRestart;GCFinalizers;Contention\".")]
+    [DefaultValue(null)]
+    [ConfigurationEntry("EventListener.EventTypes", ConfigurationEntryScope.ServerWideOnly)]
+    public EventType[] EventTypes { get; set; }
+
+    [Description("Minimum duration by which the event listenter logging entities will be filtered.")]
+    [DefaultValue(0)]
+    [TimeUnit(TimeUnit.Milliseconds)]
+    [ConfigurationEntry("EventListener.MinimumDurationInMs", ConfigurationEntryScope.ServerWideOnly)]
+    public TimeSetting MinimumDuration { get; set; }
+}

--- a/src/Raven.Server/Config/Categories/EventListenerConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EventListenerConfiguration.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using Raven.Client.ServerWide.Operations.EventListener;
 using Raven.Server.Config.Attributes;
 using Raven.Server.Config.Settings;
 using Raven.Server.EventListener;
@@ -24,4 +23,15 @@ public class EventListenerConfiguration : ConfigurationCategory
     [TimeUnit(TimeUnit.Milliseconds)]
     [ConfigurationEntry("EventListener.MinimumDurationInMs", ConfigurationEntryScope.ServerWideOnly)]
     public TimeSetting MinimumDuration { get; set; }
+
+    [Description("The duration on which we'll collect the allocations info.")]
+    [DefaultValue(5000)]
+    [TimeUnit(TimeUnit.Milliseconds)]
+    [ConfigurationEntry("EventListener.AllocationsLoggingIntervalInMs", ConfigurationEntryScope.ServerWideOnly)]
+    public TimeSetting AllocationsLoggingInterval { get; set; }
+
+    [Description("Number of top allocation events to log")]
+    [DefaultValue(5)]
+    [ConfigurationEntry("EventListener.AllocationsLoggingCount", ConfigurationEntryScope.ServerWideOnly)]
+    public int AllocationsLoggingCount { get; set; }
 }

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -103,7 +103,7 @@ namespace Raven.Server.Config
 
         public TrafficWatchConfiguration TrafficWatch { get; }
 
-        public EventListenerConfiguration EventListener { get; }
+        public DebugConfiguration DebugConfiguration { get; }
 
         public ExportImportConfiguration ExportImport { get; }
 
@@ -156,7 +156,7 @@ namespace Raven.Server.Config
             Updates = new UpdatesConfiguration();
             Migration = new MigrationConfiguration();
             TrafficWatch = new TrafficWatchConfiguration();
-            EventListener = new EventListenerConfiguration();
+            DebugConfiguration = new DebugConfiguration();
             Integrations = new IntegrationsConfiguration();
             ExportImport = new ExportImportConfiguration();
         }
@@ -219,7 +219,7 @@ namespace Raven.Server.Config
             Updates.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             Migration.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             TrafficWatch.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
-            EventListener.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
+            DebugConfiguration.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             Integrations.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             ExportImport.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
 

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -103,6 +103,8 @@ namespace Raven.Server.Config
 
         public TrafficWatchConfiguration TrafficWatch { get; }
 
+        public EventListenerConfiguration EventListener { get; }
+
         public ExportImportConfiguration ExportImport { get; }
 
         internal string ConfigPath => _customConfigPath
@@ -154,6 +156,7 @@ namespace Raven.Server.Config
             Updates = new UpdatesConfiguration();
             Migration = new MigrationConfiguration();
             TrafficWatch = new TrafficWatchConfiguration();
+            EventListener = new EventListenerConfiguration();
             Integrations = new IntegrationsConfiguration();
             ExportImport = new ExportImportConfiguration();
         }
@@ -216,6 +219,7 @@ namespace Raven.Server.Config
             Updates.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             Migration.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             TrafficWatch.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
+            EventListener.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             Integrations.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             ExportImport.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
 

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -341,9 +341,11 @@ namespace Raven.Server.Documents.Handlers.Admin
                     try
                     {
                         using var jsonFileModifier = SettingsJsonModifier.Create(context, ServerStore.Configuration.ConfigPath);
-                        jsonFileModifier.SetOrRemoveIfDefault(configuration.EventListenerMode, x => x.EventListener.EventListenerMode);
-                        jsonFileModifier.CollectionSetOrRemoveIfDefault(configuration.EventTypes, x => x.EventListener.EventTypes);
-                        jsonFileModifier.SetOrRemoveIfDefault(configuration.MinimumDurationInMs, x => x.EventListener.MinimumDuration);
+                        jsonFileModifier.SetOrRemoveIfDefault(configuration.EventListenerMode, x => x.DebugConfiguration.EventListenerMode);
+                        jsonFileModifier.CollectionSetOrRemoveIfDefault(configuration.EventTypes, x => x.DebugConfiguration.EventTypes);
+                        jsonFileModifier.SetOrRemoveIfDefault(configuration.MinimumDurationInMs, x => x.DebugConfiguration.MinimumDuration);
+                        jsonFileModifier.SetOrRemoveIfDefault(configuration.AllocationsLoggingIntervalInMs, x => x.DebugConfiguration.AllocationsLoggingInterval);
+                        jsonFileModifier.SetOrRemoveIfDefault(configuration.AllocationsLoggingCount, x => x.DebugConfiguration.AllocationsLoggingCount);
                         await jsonFileModifier.ExecuteAsync();
                     }
                     catch (Exception e)

--- a/src/Raven.Server/EventListener/AbstractEventListener.cs
+++ b/src/Raven.Server/EventListener/AbstractEventListener.cs
@@ -6,27 +6,32 @@ namespace Raven.Server.EventListener;
 //https://devblogs.microsoft.com/dotnet/a-portable-way-to-get-gc-events-in-process-and-no-admin-privilege-with-10-lines-of-code-and-ability-to-dynamically-enable-disable-events/
 public abstract class AbstractEventListener : System.Diagnostics.Tracing.EventListener
 {
-    protected abstract DotNetEventType? EventKeywords { get; }
+    private EventSource _eventSourceDotNet;
 
     [Flags]
     public enum DotNetEventType
     {
         GC = 0x0000001,
-        Threading = 0x10000,
-        Exception = 0x8000,
+        //Threading = 0x10000,
+        //Exception = 0x8000,
         Contention = 0x4000
     }
 
-    private EventSource _eventSourceDotNet;
+    protected void EnableEvents(DotNetEventType dotNetEventType)
+    {
+        if (_eventSourceDotNet != null)
+            EnableEvents(_eventSourceDotNet, EventLevel.Verbose, (EventKeywords)dotNetEventType);
+    }
+
+    protected void DisableEvents()
+    {
+        DisableEvents(_eventSourceDotNet);
+    }
 
     protected override void OnEventSourceCreated(EventSource eventSource)
     {
         if (eventSource.Name.Equals("Microsoft-Windows-DotNETRuntime"))
         {
-            if (EventKeywords == null)
-                throw new InvalidOperationException($"{nameof(EventKeywords)} must be set!");
-
-            EnableEvents(eventSource, EventLevel.Verbose, (EventKeywords)EventKeywords);
             _eventSourceDotNet = eventSource;
         }
     }

--- a/src/Raven.Server/EventListener/AbstractEventListener.cs
+++ b/src/Raven.Server/EventListener/AbstractEventListener.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics.Tracing;
+
+namespace Raven.Server.EventListener;
+
+//https://devblogs.microsoft.com/dotnet/a-portable-way-to-get-gc-events-in-process-and-no-admin-privilege-with-10-lines-of-code-and-ability-to-dynamically-enable-disable-events/
+public abstract class AbstractEventListener : System.Diagnostics.Tracing.EventListener
+{
+    protected abstract DotNetEventType? EventKeywords { get; }
+
+    [Flags]
+    public enum DotNetEventType
+    {
+        GC = 0x0000001,
+        Threading = 0x10000,
+        Exception = 0x8000,
+        Contention = 0x4000
+    }
+
+    private EventSource _eventSourceDotNet;
+
+    protected override void OnEventSourceCreated(EventSource eventSource)
+    {
+        if (eventSource.Name.Equals("Microsoft-Windows-DotNETRuntime"))
+        {
+            if (EventKeywords == null)
+                throw new InvalidOperationException($"{nameof(EventKeywords)} must be set!");
+
+            EnableEvents(eventSource, EventLevel.Verbose, (EventKeywords)EventKeywords);
+            _eventSourceDotNet = eventSource;
+        }
+    }
+
+    public override void Dispose()
+    {
+        if (_eventSourceDotNet != null)
+            DisableEvents(_eventSourceDotNet);
+
+        base.Dispose();
+    }
+}

--- a/src/Raven.Server/EventListener/AbstractEventsHandler.cs
+++ b/src/Raven.Server/EventListener/AbstractEventsHandler.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace Raven.Server.EventListener;
+
+public abstract class AbstractEventsHandler<TEvent> where TEvent : Event
+{
+    protected abstract Action<TEvent> OnEvent { get; }
+
+    public abstract bool HandleEvent(EventWrittenEventArgs eventData);
+}
+
+public interface IDurationEvent
+{
+    public double DurationInMs { get; }
+}
+
+public class EventComparerByDuration : IComparer<IDurationEvent>
+{
+    public int Compare(IDurationEvent x, IDurationEvent y)
+    {
+        if (ReferenceEquals(x, y))
+            return 0;
+        if (ReferenceEquals(null, y))
+            return 1;
+        if (ReferenceEquals(null, x))
+            return -1;
+
+        return y.DurationInMs.CompareTo(x.DurationInMs);
+    }
+}

--- a/src/Raven.Server/EventListener/AbstractEventsHandler.cs
+++ b/src/Raven.Server/EventListener/AbstractEventsHandler.cs
@@ -4,29 +4,33 @@ using System.Diagnostics.Tracing;
 
 namespace Raven.Server.EventListener;
 
-public abstract class AbstractEventsHandler<TEvent> where TEvent : Event
+public interface IEventsHandler
 {
+    public bool HandleEvent(EventWrittenEventArgs eventData);
+
+    public void Update(HashSet<EventType> eventTypes, long minimumDurationInMs);
+}
+
+public abstract class AbstractEventsHandler<TEvent> : IEventsHandler where TEvent : Event
+{
+    protected HashSet<EventType> EventTypes { get; set; }
+
+    protected long MinimumDurationInMs { get; set; }
+
+    protected abstract HashSet<EventType> DefaultEventTypes { get; }
+
     protected abstract Action<TEvent> OnEvent { get; }
 
     public abstract bool HandleEvent(EventWrittenEventArgs eventData);
+
+    public void Update(HashSet<EventType> eventTypes, long minimumDurationInMs)
+    {
+        EventTypes = eventTypes ?? DefaultEventTypes;
+        MinimumDurationInMs = minimumDurationInMs;
+    }
 }
 
 public interface IDurationEvent
 {
     public double DurationInMs { get; }
-}
-
-public class EventComparerByDuration : IComparer<IDurationEvent>
-{
-    public int Compare(IDurationEvent x, IDurationEvent y)
-    {
-        if (ReferenceEquals(x, y))
-            return 0;
-        if (ReferenceEquals(null, y))
-            return 1;
-        if (ReferenceEquals(null, x))
-            return -1;
-
-        return y.DurationInMs.CompareTo(x.DurationInMs);
-    }
 }

--- a/src/Raven.Server/EventListener/AllocationsEventListener.cs
+++ b/src/Raven.Server/EventListener/AllocationsEventListener.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace Raven.Server.EventListener;
+
+public class AllocationsEventListener : AbstractEventListener
+{
+    private readonly Dictionary<string, AllocationsHandler.AllocationInfo> _allocations = new();
+    private readonly AllocationsHandler _handler;
+
+    public IReadOnlyCollection<AllocationsHandler.AllocationInfo> Allocations => _allocations.Values;
+
+    public AllocationsEventListener()
+    {
+        _handler = new AllocationsHandler(e =>
+        {
+            if (_allocations.TryGetValue(e.AllocationType, out var allocation) == false)
+            {
+                _allocations[e.AllocationType] = e;
+                return;
+            }
+
+            allocation.SmallObjectAllocations += e.SmallObjectAllocations;
+            allocation.NumberOfSmallObjectAllocations += e.NumberOfSmallObjectAllocations;
+            allocation.LargeObjectAllocations += e.LargeObjectAllocations;
+            allocation.NumberOfLargeObjectAllocations += e.NumberOfLargeObjectAllocations;
+        });
+
+        EnableEvents(DotNetEventType.GC);
+    }
+
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        if (eventData.EventName == null)
+            return;
+
+        _handler.HandleEvent(eventData);
+    }
+}

--- a/src/Raven.Server/EventListener/AllocationsHandler.cs
+++ b/src/Raven.Server/EventListener/AllocationsHandler.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using Sparrow;
+
+namespace Raven.Server.EventListener;
+
+public class AllocationsHandler : AbstractEventsHandler<AllocationsHandler.AllocationInfo>
+{
+    protected override HashSet<EventType> DefaultEventTypes => new HashSet<EventType>(EventListenerToLog.AllocationEvents);
+
+    protected override Action<AllocationInfo> OnEvent { get; }
+
+    internal const string AllocationEventName = "GCAllocationTick_V4";
+
+    public AllocationsHandler(Action<AllocationInfo> onEvent, HashSet<EventType> eventTypes = null, long minimumDurationInMs = 0)
+    {
+        Update(eventTypes, minimumDurationInMs);
+        OnEvent = onEvent;
+    }
+
+    public override bool HandleEvent(EventWrittenEventArgs eventData)
+    {
+        switch (eventData.EventName)
+        {
+            case AllocationEventName:
+                if (EventTypes.Contains(EventType.Allocations) == false)
+                    return true;
+
+                var type = (string)eventData.Payload[5];
+                var allocations = (ulong)eventData.Payload[3];
+                var smallObjectAllocation = (uint)eventData.Payload[1] == 0x0;
+
+                var allocation = new AllocationInfo
+                {
+                    AllocationType = type
+                };
+
+                if (smallObjectAllocation)
+                {
+                    allocation.SmallObjectAllocations = allocations;
+                    allocation.NumberOfSmallObjectAllocations++;
+                }
+                else
+                {
+                    allocation.LargeObjectAllocations = allocations;
+                    allocation.NumberOfLargeObjectAllocations++;
+                }
+
+                OnEvent.Invoke(allocation);
+
+                return true;
+        }
+
+        return false;
+    }
+
+    public class AllocationInfo : Event
+    {
+        public AllocationInfo() : base(EventType.Allocations)
+        {
+        }
+
+        private ulong? _allocations;
+
+        public string AllocationType;
+        public ulong SmallObjectAllocations;
+        public ulong LargeObjectAllocations;
+        public long NumberOfSmallObjectAllocations;
+        public long NumberOfLargeObjectAllocations;
+
+        public ulong Allocations
+        {
+            get
+            {
+                // used for ordering
+                _allocations ??= SmallObjectAllocations + LargeObjectAllocations;
+                return _allocations.Value;
+            }
+        }
+
+        public long NumberOfAllocations => NumberOfSmallObjectAllocations + NumberOfLargeObjectAllocations;
+
+        public override string ToString()
+        {
+            return $"type: {AllocationType}, allocations: {new Size((long)Allocations, SizeUnit.Bytes)}, count: {NumberOfAllocations}, " +
+                   $"small: {new Size((long)SmallObjectAllocations, SizeUnit.Bytes)}, large: {new Size((long)LargeObjectAllocations, SizeUnit.Bytes)}";
+        }
+    }
+}

--- a/src/Raven.Server/EventListener/AllocationsHandler.cs
+++ b/src/Raven.Server/EventListener/AllocationsHandler.cs
@@ -11,7 +11,6 @@ public class AllocationsHandler : AbstractEventsHandler<AllocationsHandler.Alloc
 
     protected override Action<AllocationInfo> OnEvent { get; }
 
-    internal const string AllocationEventName = "GCAllocationTick_V4";
 
     public AllocationsHandler(Action<AllocationInfo> onEvent, HashSet<EventType> eventTypes = null, long minimumDurationInMs = 0)
     {
@@ -23,7 +22,7 @@ public class AllocationsHandler : AbstractEventsHandler<AllocationsHandler.Alloc
     {
         switch (eventData.EventName)
         {
-            case AllocationEventName:
+            case EventListener.Constants.EventNames.Allocations.Allocation:
                 if (EventTypes.Contains(EventType.Allocations) == false)
                     return true;
 

--- a/src/Raven.Server/EventListener/ContentionEventsHandler.cs
+++ b/src/Raven.Server/EventListener/ContentionEventsHandler.cs
@@ -70,7 +70,7 @@ public class ContentionEventsHandler : AbstractEventsHandler<ContentionEventsHan
         public override string ToString()
         {
             var str = base.ToString();
-            return $"{str}, start time: {StartTime}, duration: {DurationInMs}";
+            return $"{str}, start time: {StartTime}, duration: {DurationInMs}ms";
         }
     }
 }

--- a/src/Raven.Server/EventListener/ContentionEventsHandler.cs
+++ b/src/Raven.Server/EventListener/ContentionEventsHandler.cs
@@ -23,12 +23,13 @@ public class ContentionEventsHandler : AbstractEventsHandler<ContentionEventsHan
     {
         switch (eventData.EventName)
         {
-            case "ContentionStart":
+            case EventListener.Constants.EventNames.Contention.ContentionStart:
                 if (EventTypes.Contains(EventType.Contention))
                     _contentionStarts[eventData.ActivityId] = DateTime.UtcNow;
+
                 return true;
 
-            case "ContentionStop":
+            case EventListener.Constants.EventNames.Contention.ContentionStop:
                 if (EventTypes.Contains(EventType.Contention) &&
                     _contentionStarts.TryGetValue(eventData.ActivityId, out var startTime))
                 {

--- a/src/Raven.Server/EventListener/ContentionEventsHandler.cs
+++ b/src/Raven.Server/EventListener/ContentionEventsHandler.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.EventListener;
+
+public class ContentionEventsHandler : AbstractEventsHandler<ContentionEventsHandler.ContentionEvent>
+{
+    protected override Action<ContentionEvent> OnEvent { get; }
+
+    private readonly Dictionary<Guid, DateTime> _contentionStarts = new ();
+
+    public ContentionEventsHandler(Action<ContentionEvent> onEvent)
+    {
+        OnEvent = onEvent;
+    }
+
+    public override bool HandleEvent(EventWrittenEventArgs eventData)
+    {
+        switch (eventData.EventName)
+        {
+            case "ContentionStart":
+                _contentionStarts[eventData.ActivityId] = DateTime.UtcNow;
+                return true;
+
+            case "ContentionStop":
+                if (_contentionStarts.TryGetValue(eventData.ActivityId, out var startTime))
+                {
+                    OnEvent.Invoke(new ContentionEvent(startTime, (double)eventData.Payload[2] / 1_000_000.0));
+                    _contentionStarts.Remove(eventData.ActivityId);
+                }
+
+                return true;
+        }
+
+        return false;
+    }
+
+    public class ContentionEvent : Event, IDurationEvent
+    {
+        public DateTime StartTime;
+
+        public double DurationInMs { get; }
+
+        public ContentionEvent(DateTime startTime, double durationInMs) : base(EventType.Contention)
+        {
+            StartTime = startTime;
+            DurationInMs = durationInMs;
+        }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+
+            json[nameof(StartTime)] = StartTime;
+            json[nameof(DurationInMs)] = DurationInMs;
+
+            return json;
+        }
+    }
+}

--- a/src/Raven.Server/EventListener/ContentionEventsListener.cs
+++ b/src/Raven.Server/EventListener/ContentionEventsListener.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace Raven.Server.EventListener;
+
+public class ContentionEventsListener : AbstractEventListener
+{
+    protected override DotNetEventType? EventKeywords => DotNetEventType.Contention;
+
+    private readonly ContentionEventsHandler _handler;
+    private List<ContentionEventsHandler.ContentionEvent> _events = new();
+
+    public IReadOnlyCollection<ContentionEventsHandler.ContentionEvent> Events => _events;
+
+    public ContentionEventsListener()
+    {
+        _handler = new ContentionEventsHandler(e => _events.Add(e));
+    }
+
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        if (eventData.EventName == null)
+            return;
+
+        _handler.HandleEvent(eventData);
+    }
+}

--- a/src/Raven.Server/EventListener/ContentionEventsListener.cs
+++ b/src/Raven.Server/EventListener/ContentionEventsListener.cs
@@ -5,8 +5,6 @@ namespace Raven.Server.EventListener;
 
 public class ContentionEventsListener : AbstractEventListener
 {
-    protected override DotNetEventType? EventKeywords => DotNetEventType.Contention;
-
     private readonly ContentionEventsHandler _handler;
     private List<ContentionEventsHandler.ContentionEvent> _events = new();
 
@@ -15,6 +13,7 @@ public class ContentionEventsListener : AbstractEventListener
     public ContentionEventsListener()
     {
         _handler = new ContentionEventsHandler(e => _events.Add(e));
+        EnableEvents(DotNetEventType.Contention);
     }
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)

--- a/src/Raven.Server/EventListener/Event.cs
+++ b/src/Raven.Server/EventListener/Event.cs
@@ -1,0 +1,21 @@
+﻿using Sparrow.Json.Parsing;
+
+namespace Raven.Server.EventListener;
+
+public abstract class Event : IDynamicJson
+{
+    public EventType Type { get; }
+
+    protected Event(EventType type)
+    {
+        Type = type;
+    }
+
+    public virtual DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(Type)] = Type
+        };
+    }
+}

--- a/src/Raven.Server/EventListener/Event.cs
+++ b/src/Raven.Server/EventListener/Event.cs
@@ -18,4 +18,9 @@ public abstract class Event : IDynamicJson
             [nameof(Type)] = Type
         };
     }
+
+    public override string ToString()
+    {
+        return $"Type: {Type}";
+    }
 }

--- a/src/Raven.Server/EventListener/EventComparerByDuration.cs
+++ b/src/Raven.Server/EventListener/EventComparerByDuration.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace Raven.Server.EventListener;
+
+public class EventComparerByDuration : IComparer<IDurationEvent>
+{
+    public int Compare(IDurationEvent x, IDurationEvent y)
+    {
+        if (ReferenceEquals(x, y))
+            return 0;
+        if (ReferenceEquals(null, y))
+            return 1;
+        if (ReferenceEquals(null, x))
+            return -1;
+
+        return y.DurationInMs.CompareTo(x.DurationInMs);
+    }
+}

--- a/src/Raven.Server/EventListener/EventListener.cs
+++ b/src/Raven.Server/EventListener/EventListener.cs
@@ -1,0 +1,33 @@
+﻿namespace Raven.Server.EventListener;
+
+public class EventListener
+{
+    public class Constants
+    {
+        public class EventNames
+        {
+            public class GC
+            {
+                public const string GCStart = "GCStart_V2";
+                public const string GCEnd = "GCEnd_V1";
+                public const string GCSuspendBegin = "GCSuspendEEBegin_V1";
+                public const string GCSuspendEnd = "GCSuspendEEEnd_V1";
+                public const string GCRestartBegin = "GCRestartEEBegin_V1";
+                public const string GCRestartEnd = "GCRestartEEEnd_V1";
+                public const string GCFinalizersBegin = "GCFinalizersBegin_V1";
+                public const string GCFinalizersEnd = "GCFinalizersEnd_V1";
+            }
+
+            public class Allocations
+            {
+                public const string Allocation = "GCAllocationTick_V4";
+            }
+
+            public class Contention
+            {
+                public const string ContentionStart = "ContentionStart";
+                public const string ContentionStop = "ContentionStop";
+            }
+        }
+    }
+}

--- a/src/Raven.Server/EventListener/EventListenerMode.cs
+++ b/src/Raven.Server/EventListener/EventListenerMode.cs
@@ -1,0 +1,8 @@
+﻿namespace Raven.Server.EventListener;
+
+public enum EventListenerMode
+{
+    None = 0,
+    Off,
+    ToLogFile
+}

--- a/src/Raven.Server/EventListener/EventListenerToLog.cs
+++ b/src/Raven.Server/EventListener/EventListenerToLog.cs
@@ -15,8 +15,9 @@ public class EventListenerToLog : IDynamicJson
     private EventListenerConfiguration _configuration;
 
     public static readonly HashSet<EventType> GcEvents = [EventType.GC, EventType.GCSuspend, EventType.GCRestart, EventType.GCFinalizers];
+    public static readonly HashSet<EventType> AllocationEvents = [EventType.Allocations];
     public static readonly HashSet<EventType> ContentionTypes = [EventType.Contention];
-    private static readonly HashSet<EventType> AllEvents = new(GcEvents.Concat(ContentionTypes));
+    private static readonly HashSet<EventType> AllEvents = new(GcEvents.Concat(ContentionTypes).Concat(AllocationEvents));
 
     private EventListenerToLog()
     {
@@ -46,12 +47,13 @@ public class EventListenerToLog : IDynamicJson
             else
             {
                 _listener ??= new EventsListener(effectiveEventTypes, _configuration.MinimumDurationInMs,
+                    _configuration.AllocationsLoggingIntervalInMs, _configuration.AllocationsLoggingCount,
                     onEvent: e =>
                     {
                         if (LogToFile)
                             Logger.Operations(e.ToString());
                     });
-                _listener.Update(effectiveEventTypes, _configuration.MinimumDurationInMs);
+                _listener.Update(effectiveEventTypes, _configuration.MinimumDurationInMs, _configuration.AllocationsLoggingIntervalInMs, _configuration.AllocationsLoggingCount);
             }
         }
         finally
@@ -67,6 +69,10 @@ public class EventListenerToLog : IDynamicJson
         public EventType[] EventTypes { get; set; }
 
         public long MinimumDurationInMs { get; set; }
+
+        public long AllocationsLoggingIntervalInMs { get; set; }
+
+        public int AllocationsLoggingCount { get; set; }
 
         public bool Persist { get; set; }
     }

--- a/src/Raven.Server/EventListener/EventListenerToLog.cs
+++ b/src/Raven.Server/EventListener/EventListenerToLog.cs
@@ -13,7 +13,7 @@ public class EventListenerToLog
     public static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenServerStartup>("EventListener");
     private readonly SemaphoreSlim _sm = new(1, 1);
 
-    private EventsToLogListener _listener;
+    private EventsListener _listener;
     private EventListenerMode _eventListenerMode;
 
     public static readonly HashSet<EventType> GcEvents = [EventType.GC, EventType.GCSuspend, EventType.GCRestart, EventType.GCFinalizers];
@@ -49,7 +49,7 @@ public class EventListenerToLog
             }
             else
             {
-                _listener ??= new EventsToLogListener(Logger, effectiveEventTypes, minimumDurationInMs);
+                _listener ??= new EventsListener(Logger, effectiveEventTypes, minimumDurationInMs);
                 _listener.Update(effectiveEventTypes, minimumDurationInMs);
             }
         }

--- a/src/Raven.Server/EventListener/EventListenerToLog.cs
+++ b/src/Raven.Server/EventListener/EventListenerToLog.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Raven.Client.ServerWide.Operations.EventListener;
+using Raven.Server.Config.Categories;
+using Raven.Server.Config.Settings;
+using Sparrow.Logging;
+
+namespace Raven.Server.EventListener;
+
+public class EventListenerToLog
+{
+    public static readonly Logger Logger = LoggingSource.Instance.GetLogger<RavenServerStartup>("EventListener");
+    private readonly SemaphoreSlim _sm = new(1, 1);
+
+    private EventsToLogListener _listener;
+    private EventListenerMode _eventListenerMode;
+
+    public static readonly HashSet<EventType> GcEvents = [EventType.GC, EventType.GCSuspend, EventType.GCRestart, EventType.GCFinalizers];
+    public static readonly HashSet<EventType> ContentionTypes = [EventType.Contention];
+    private static readonly HashSet<EventType> AllEvents = new(GcEvents.Concat(ContentionTypes));
+
+    private EventListenerToLog()
+    {
+    }
+
+    public static EventListenerToLog Instance = new();
+
+    public bool LogToFile => _eventListenerMode == EventListenerMode.ToLogFile && Logger.IsOperationsEnabled;
+
+    public void UpdateConfiguration(EventListenerConfiguration configuration)
+    {
+        _sm.Wait();
+
+        try
+        {
+            _eventListenerMode = configuration.EventListenerMode;
+            var eventTypes = configuration.EventTypes;
+            var minimumDurationInMs = configuration.MinimumDuration.GetValue(TimeUnit.Milliseconds);
+
+            var effectiveEventTypes = (eventTypes == null || eventTypes.Length == 0)
+                ? AllEvents
+                : new HashSet<EventType>(eventTypes);
+
+            if (LogToFile == false)
+            {
+                _listener?.Dispose();
+                _listener = null;
+            }
+            else
+            {
+                _listener ??= new EventsToLogListener(Logger, effectiveEventTypes, minimumDurationInMs);
+                _listener.Update(effectiveEventTypes, minimumDurationInMs);
+            }
+        }
+        finally
+        {
+            _sm.Release();
+        }
+    }
+}

--- a/src/Raven.Server/EventListener/EventType.cs
+++ b/src/Raven.Server/EventListener/EventType.cs
@@ -1,0 +1,10 @@
+﻿namespace Raven.Server.EventListener;
+
+public enum EventType
+{
+    GC,
+    GCSuspend,
+    GCRestart,
+    GCFinalizers,
+    Contention
+}

--- a/src/Raven.Server/EventListener/EventType.cs
+++ b/src/Raven.Server/EventListener/EventType.cs
@@ -6,5 +6,6 @@ public enum EventType
     GCSuspend,
     GCRestart,
     GCFinalizers,
-    Contention
+    Contention,
+    Allocations
 }

--- a/src/Raven.Server/EventListener/EventsListener.cs
+++ b/src/Raven.Server/EventListener/EventsListener.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
-using Sparrow.Logging;
 
 namespace Raven.Server.EventListener;
 
@@ -12,10 +11,10 @@ public class EventsListener : AbstractEventListener
     private readonly Dictionary<string, IEventsHandler> _handlerByEventName = new();
     private DotNetEventType _dotNetEventType;
 
-    public EventsListener(Logger logger, HashSet<EventType> eventTypes, long minimumDurationInMs)
+    public EventsListener(HashSet<EventType> eventTypes, long minimumDurationInMs, Action<Event> onEvent)
     {
-        _handlers.Add(new GcEventsHandler(e => logger.Operations(e.ToString()), eventTypes, minimumDurationInMs));
-        _handlers.Add(new ContentionEventsHandler(e => logger.Operations(e.ToString()), eventTypes, minimumDurationInMs));
+        _handlers.Add(new GcEventsHandler(onEvent, eventTypes, minimumDurationInMs));
+        _handlers.Add(new ContentionEventsHandler(onEvent, eventTypes, minimumDurationInMs));
 
         _dotNetEventType = GetDotNetEventTypes(eventTypes);
         EnableEvents(_dotNetEventType);

--- a/src/Raven.Server/EventListener/EventsListener.cs
+++ b/src/Raven.Server/EventListener/EventsListener.cs
@@ -26,14 +26,14 @@ public class EventsListener : AbstractEventListener
         _allocationsLoggingIntervalInMs = allocationsLoggingIntervalInMs;
         _allocationsLoggingCount = allocationsLoggingCount;
         _handlers.Add(new GcEventsHandler(onEvent, eventTypes, minimumDurationInMs));
-        _handlers.Add(new AllocationsHandler(OnEvent(onEvent), eventTypes, minimumDurationInMs));
+        _handlers.Add(new AllocationsHandler(OnAllocationEvent(onEvent), eventTypes, minimumDurationInMs));
         _handlers.Add(new ContentionEventsHandler(onEvent, eventTypes, minimumDurationInMs));
 
         _dotNetEventType = GetDotNetEventTypes(eventTypes);
         EnableEvents(_dotNetEventType);
     }
 
-    private Action<AllocationsHandler.AllocationInfo> OnEvent(Action<Event> onEvent)
+    private Action<AllocationsHandler.AllocationInfo> OnAllocationEvent(Action<Event> onEvent)
     {
         return e =>
         {

--- a/src/Raven.Server/EventListener/EventsListener.cs
+++ b/src/Raven.Server/EventListener/EventsListener.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Linq;
+using System.Text;
 
 namespace Raven.Server.EventListener;
 
@@ -11,13 +13,90 @@ public class EventsListener : AbstractEventListener
     private readonly Dictionary<string, IEventsHandler> _handlerByEventName = new();
     private DotNetEventType _dotNetEventType;
 
-    public EventsListener(HashSet<EventType> eventTypes, long minimumDurationInMs, Action<Event> onEvent)
+    private readonly Dictionary<string, AllocationsHandler.AllocationInfo> _allocations = new();
+    private readonly StringBuilder _sb = new();
+
+    private Stopwatch _stopwatchSinceLastAllocation;
+    private long _allocationsLoggingIntervalInMs;
+    private int _allocationsLoggingCount;
+    private readonly InternalEvent _internalEvent = new();
+
+    public EventsListener(HashSet<EventType> eventTypes, long minimumDurationInMs, long allocationsLoggingIntervalInMs, int allocationsLoggingCount, Action<Event> onEvent)
     {
+        _allocationsLoggingIntervalInMs = allocationsLoggingIntervalInMs;
+        _allocationsLoggingCount = allocationsLoggingCount;
         _handlers.Add(new GcEventsHandler(onEvent, eventTypes, minimumDurationInMs));
+        _handlers.Add(new AllocationsHandler(OnEvent(onEvent), eventTypes, minimumDurationInMs));
         _handlers.Add(new ContentionEventsHandler(onEvent, eventTypes, minimumDurationInMs));
 
         _dotNetEventType = GetDotNetEventTypes(eventTypes);
         EnableEvents(_dotNetEventType);
+    }
+
+    private Action<AllocationsHandler.AllocationInfo> OnEvent(Action<Event> onEvent)
+    {
+        return e =>
+        {
+            _stopwatchSinceLastAllocation ??= Stopwatch.StartNew();
+
+            if (_allocations.TryGetValue(e.AllocationType, out var allocation) == false)
+            {
+                _allocations[e.AllocationType] = e;
+            }
+            else
+            {
+                allocation.SmallObjectAllocations += e.SmallObjectAllocations;
+                allocation.NumberOfSmallObjectAllocations += e.NumberOfSmallObjectAllocations;
+                allocation.LargeObjectAllocations += e.LargeObjectAllocations;
+                allocation.NumberOfLargeObjectAllocations += e.NumberOfLargeObjectAllocations;
+            }
+
+            if (_stopwatchSinceLastAllocation.ElapsedMilliseconds >= _allocationsLoggingIntervalInMs)
+            {
+                var count = _allocationsLoggingCount;
+                _sb.Clear();
+
+                _sb.Append($"Top {_allocationsLoggingCount} allocations for the past {_allocationsLoggingIntervalInMs:#,#;;0}ms: ");
+                _sb.AppendLine();
+
+                var first = true;
+                foreach (var alloc in _allocations.Values.OrderByDescending(x => x.Allocations))
+                {
+                    if (first == false)
+                        _sb.AppendLine();
+
+                    first = false;
+                    
+                    _sb.Append(alloc);
+                    if (--count <= 0)
+                        break;
+                }
+
+                _internalEvent.SetString(_sb.ToString());
+                onEvent.Invoke(_internalEvent);
+                _stopwatchSinceLastAllocation.Restart();
+                _allocations.Clear();
+            }
+        };
+    }
+
+    private class InternalEvent : Event
+    {
+        private string _str;
+
+        public InternalEvent() : base(EventType.Allocations)
+        {
+        }
+
+        public void SetString(string str)
+        {
+            _str = str;
+        }
+
+        public override string ToString()
+        {
+            return _str;
+        }
     }
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
@@ -43,11 +122,20 @@ public class EventsListener : AbstractEventListener
         _handlerByEventName[eventData.EventName] = null;
     }
 
-    public void Update(HashSet<EventType> eventTypes, long minimumDurationInMs)
+    public void Update(HashSet<EventType> eventTypes, long minimumDurationInMs, long allocationsLoggingIntervalInMs, int allocationsLoggingCount)
     {
+        _allocationsLoggingIntervalInMs = allocationsLoggingIntervalInMs;
+        _allocationsLoggingCount = allocationsLoggingCount;
+
         foreach (var handler in _handlers)
         {
             handler.Update(eventTypes, minimumDurationInMs);
+        }
+
+        if (eventTypes.Contains(EventType.Allocations) == false)
+        {
+            _allocations.Clear();
+            _stopwatchSinceLastAllocation = null;
         }
 
         var newDotNetEventType = GetDotNetEventTypes(eventTypes);
@@ -71,6 +159,7 @@ public class EventsListener : AbstractEventListener
                 case EventType.GCSuspend:
                 case EventType.GCRestart:
                 case EventType.GCFinalizers:
+                case EventType.Allocations:
                     dotNetEventType = (dotNetEventType ?? DotNetEventType.GC) | DotNetEventType.GC;
                     break;
                 case EventType.Contention:

--- a/src/Raven.Server/EventListener/EventsToLogListener.cs
+++ b/src/Raven.Server/EventListener/EventsToLogListener.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using Sparrow.Logging;
+
+namespace Raven.Server.EventListener;
+
+public class EventsToLogListener : AbstractEventListener
+{
+    private readonly List<IEventsHandler> _handlers = new();
+    private DotNetEventType _dotNetEventType;
+
+    public EventsToLogListener(Logger logger, HashSet<EventType> eventTypes, long minimumDurationInMs)
+    {
+        _handlers.Add(new GcEventsHandler(e => logger.Operations(e.ToString()), eventTypes, minimumDurationInMs));
+        _handlers.Add(new ContentionEventsHandler(e => logger.Operations(e.ToString()), eventTypes, minimumDurationInMs));
+
+        _dotNetEventType = GetDotNetEventTypes(eventTypes);
+        EnableEvents(_dotNetEventType);
+    }
+
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        if (eventData.EventName == null)
+            return;
+
+        foreach (var handler in _handlers)
+        {
+            if (handler.HandleEvent(eventData))
+                return;
+        }
+    }
+
+    public void Update(HashSet<EventType> eventTypes, long minimumDurationInMs)
+    {
+        foreach (var handler in _handlers)
+        {
+            handler.Update(eventTypes, minimumDurationInMs);
+        }
+
+        var newDotNetEventType = GetDotNetEventTypes(eventTypes);
+        if (_dotNetEventType == newDotNetEventType)
+            return;
+
+        DisableEvents();
+        _dotNetEventType = newDotNetEventType;
+        EnableEvents(_dotNetEventType);
+    }
+
+    private static DotNetEventType GetDotNetEventTypes(HashSet<EventType> eventTypes)
+    {
+        DotNetEventType? dotNetEventType = null;
+
+        foreach (var eventType in eventTypes)
+        {
+            switch (eventType)
+            {
+                case EventType.GC:
+                case EventType.GCSuspend:
+                case EventType.GCRestart:
+                case EventType.GCFinalizers:
+                    dotNetEventType = (dotNetEventType ?? DotNetEventType.GC) | DotNetEventType.GC;
+                    break;
+                case EventType.Contention:
+                    dotNetEventType = (dotNetEventType ?? DotNetEventType.Contention) | DotNetEventType.Contention;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        if (dotNetEventType == null)
+            throw new InvalidOperationException($"Failed to determine which event type to log, {string.Join(", ", eventTypes.Select(et => et.ToString()))}");
+
+        return dotNetEventType.Value;
+    }
+}

--- a/src/Raven.Server/EventListener/GcEventsHandler.cs
+++ b/src/Raven.Server/EventListener/GcEventsHandler.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using Sparrow.Json.Parsing;
+using static Raven.Server.EventListener.GcEventsHandler;
+
+namespace Raven.Server.EventListener;
+
+public class GcEventsHandler : AbstractEventsHandler<GCEventBase>
+{
+    private Dictionary<long, (DateTime DateTime, uint Generation, uint Reason)> _timeGcStartByIndex = new();
+    private EventWrittenEventArgs _suspendData;
+    private DateTime? _timeGcRestartStart;
+    private DateTime? _timeGcFinalizersStart;
+
+    public GcEventsHandler(Action<GCEventBase> onEvent)
+    {
+        OnEvent = onEvent;
+    }
+
+    protected override Action<GCEventBase> OnEvent { get; }
+
+    public override bool HandleEvent(EventWrittenEventArgs eventData)
+    {
+        switch (eventData.EventName)
+        {
+            case "GCStart_V2":
+                var startIndex = long.Parse(eventData.Payload[0].ToString());
+                var generation = (uint)eventData.Payload[1];
+                var reason = (uint)eventData.Payload[2];
+                _timeGcStartByIndex[startIndex] = (eventData.TimeStamp, generation, reason);
+                return true;
+
+            case "GCEnd_V1":
+                var endIndex = long.Parse(eventData.Payload[0].ToString());
+
+                if (_timeGcStartByIndex.TryGetValue(endIndex, out var tuple))
+                {
+                    OnEvent.Invoke(new GCEvent(tuple.DateTime, eventData, endIndex, tuple.Generation, tuple.Reason));
+                    _timeGcStartByIndex.Remove(endIndex);
+                }
+                
+                return true;
+
+            case "GCSuspendEEBegin_V1":
+                _suspendData = eventData;
+                return true;
+
+            case "GCSuspendEEEnd_V1":
+                if (_suspendData != null)
+                {
+                    var index = (uint)_suspendData.Payload[1];
+                    var suspendReason = (uint)_suspendData.Payload[0];
+
+                    OnEvent.Invoke(new GCSuspendEvent(_suspendData.TimeStamp, eventData, index, suspendReason));
+                    _suspendData = null;
+                }
+
+                return true;
+
+            case "GCRestartEEBegin_V1":
+                _timeGcRestartStart = eventData.TimeStamp;
+                break;
+
+            case "GCRestartEEEnd_V1":
+                if (_timeGcRestartStart != null)
+                {
+                    OnEvent.Invoke(new GCEventBase(EventType.GCRestart, _timeGcRestartStart.Value, eventData));
+                    _timeGcRestartStart = null;
+                }
+
+                return true;
+
+            case "GCFinalizersBegin_V1":
+                _timeGcFinalizersStart = eventData.TimeStamp;
+                return true;
+
+            case "GCFinalizersEnd_V1":
+                if (_timeGcFinalizersStart != null)
+                {
+                    OnEvent.Invoke(new GCEventBase(EventType.GCFinalizers, _timeGcFinalizersStart.Value, eventData));
+                    _timeGcFinalizersStart = null;
+                }
+
+                return true;
+        }
+
+        return false;
+    }
+
+    public class GCEventBase : Event, IDurationEvent
+    {
+        private long OSThreadId { get; }
+
+        public DateTime Start { get; }
+
+        private DateTime End { get; }
+
+        private double? _durationInMs;
+
+        public GCEventBase(EventType type, DateTime start, EventWrittenEventArgs eventData) : base(type)
+        {
+            OSThreadId = eventData.OSThreadId;
+            Start = start;
+            End = eventData.TimeStamp;
+        }
+
+        public double DurationInMs
+        {
+            get
+            {
+                _durationInMs ??= (End.Ticks - Start.Ticks) / 10.0 / 1000.0;
+                return _durationInMs.Value;
+            }
+        }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+
+            json[nameof(OSThreadId)] = OSThreadId;
+            json[nameof(Start)] = Start;
+            json[nameof(End)] = End;
+            json[nameof(DurationInMs)] = DurationInMs;
+
+            return json;
+        }
+
+        public override string ToString()
+        {
+            return $"{Type}, duration: {DurationInMs}";
+        }
+    }
+
+    private class GCEvent : GCEventBase
+    {
+        private long Index { get; }
+
+        private uint Generation { get; }
+
+        private string Reason { get; }
+
+        public GCEvent(DateTime start, EventWrittenEventArgs eventData, long index, uint generation, uint reason)
+            : base(EventType.GC, start, eventData)
+        {
+            Index = index;
+            Generation = generation;
+            Reason = GetGcReason(reason);
+        }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+            json[nameof(Index)] = Index;
+            json[nameof(Generation)] = Generation;
+            json[nameof(Reason)] = Reason;
+            return json;
+        }
+
+        public override string ToString()
+        {
+            return $"{Type}, duration: {DurationInMs}, index: {Index}, generation: {Generation}, reason: {Reason}";
+        }
+
+        private static string GetGcReason(uint valueReason)
+        {
+            switch (valueReason)
+            {
+                case 0x0:
+                    return "Small object heap allocation";
+                case 0x1:
+                    return "Induced";
+                case 0x2:
+                    return "Low memory";
+                case 0x3:
+                    return "Empty";
+                case 0x4:
+                    return "Large object heap allocation";
+                case 0x5:
+                    return "Out of space (for small object heap)";
+                case 0x6:
+                    return "Out of space (for large object heap)";
+                case 0x7:
+                    return "Induced but not forced as blocking";
+
+                default:
+                    return null;
+            }
+        }
+    }
+
+    private class GCSuspendEvent : GCEventBase
+    {
+        public uint Index { get; }
+
+        private string Reason { get; }
+
+        public GCSuspendEvent(DateTime start, EventWrittenEventArgs eventData, uint index, uint reason)
+            : base(EventType.GCSuspend, start, eventData)
+        {
+            Index = index;
+            Reason = GetSuspendReason(reason);
+        }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+            json[nameof(Index)] = Index;
+            json[nameof(Reason)] = Reason;
+            return json;
+        }
+
+        public override string ToString()
+        {
+            return $"{Type}, duration: {DurationInMs}, index: {Index}, reason: {Reason}";
+        }
+
+        private static string GetSuspendReason(uint? suspendReason)
+        {
+            switch (suspendReason)
+            {
+                case 0x0:
+                    return "Suspend for Other";
+                case 0x1:
+                    return "Suspend for GC";
+                case 0x2:
+                    return "Suspend for AppDomain shutdown";
+                case 0x3:
+                    return "Suspend for code pitching";
+                case 0x4:
+                    return "Suspend for shutdown";
+                case 0x5:
+                    return "Suspend for debugger";
+                case 0x6:
+                    return "Suspend for GC Prep";
+                case 0x7:
+                    return "Suspend for debugger sweep";
+
+                default:
+                    return null;
+            }
+        }
+    }
+
+}

--- a/src/Raven.Server/EventListener/GcEventsHandler.cs
+++ b/src/Raven.Server/EventListener/GcEventsHandler.cs
@@ -14,7 +14,7 @@ public class GcEventsHandler : AbstractEventsHandler<GcEventsHandler.GCEventBase
 
     protected override HashSet<EventType> DefaultEventTypes => EventListenerToLog.GcEvents;
 
-    public GcEventsHandler(Action<GCEventBase> onEvent, HashSet<EventType> eventTypes = null, long minimumDurationInMs =0)
+    public GcEventsHandler(Action<GCEventBase> onEvent, HashSet<EventType> eventTypes = null, long minimumDurationInMs = 0)
     {
         Update(eventTypes, minimumDurationInMs);
         OnEvent = onEvent;
@@ -154,7 +154,7 @@ public class GcEventsHandler : AbstractEventsHandler<GcEventsHandler.GCEventBase
         public override string ToString()
         {
             var str = base.ToString();
-            return $"{str}, thread id: {OSThreadId}, duration: {DurationInMs}";
+            return $"{str}, thread id: {OSThreadId}, duration: {DurationInMs}ms";
         }
     }
 

--- a/src/Raven.Server/EventListener/GcEventsHandler.cs
+++ b/src/Raven.Server/EventListener/GcEventsHandler.cs
@@ -26,7 +26,7 @@ public class GcEventsHandler : AbstractEventsHandler<GcEventsHandler.GCEventBase
     {
         switch (eventData.EventName)
         {
-            case "GCStart_V2":
+            case EventListener.Constants.EventNames.GC.GCStart:
                 if (EventTypes.Contains(EventType.GC))
                 {
                     var startIndex = long.Parse(eventData.Payload[0].ToString());
@@ -37,7 +37,7 @@ public class GcEventsHandler : AbstractEventsHandler<GcEventsHandler.GCEventBase
                 
                 return true;
 
-            case "GCEnd_V1":
+            case EventListener.Constants.EventNames.GC.GCEnd:
                 if (EventTypes.Contains(EventType.GC))
                 {
                     var endIndex = long.Parse(eventData.Payload[0].ToString());
@@ -54,13 +54,13 @@ public class GcEventsHandler : AbstractEventsHandler<GcEventsHandler.GCEventBase
                 
                 return true;
 
-            case "GCSuspendEEBegin_V1":
+            case EventListener.Constants.EventNames.GC.GCSuspendBegin:
                 if (EventTypes.Contains(EventType.GCSuspend))
                     _suspendData = eventData;
 
                 return true;
 
-            case "GCSuspendEEEnd_V1":
+            case EventListener.Constants.EventNames.GC.GCSuspendEnd:
                 if (EventTypes.Contains(EventType.GCSuspend) && _suspendData != null)
                 {
                     var index = (uint)_suspendData.Payload[1];
@@ -75,12 +75,12 @@ public class GcEventsHandler : AbstractEventsHandler<GcEventsHandler.GCEventBase
 
                 return true;
 
-            case "GCRestartEEBegin_V1":
+            case EventListener.Constants.EventNames.GC.GCRestartBegin:
                 if (EventTypes.Contains(EventType.GCRestart))
                     _timeGcRestartStart = eventData.TimeStamp;
                 return true;
 
-            case "GCRestartEEEnd_V1":
+            case EventListener.Constants.EventNames.GC.GCRestartEnd:
                 if (EventTypes.Contains(EventType.GCRestart) && _timeGcRestartStart != null)
                 {
                     var @event = new GCEventBase(EventType.GCRestart, _timeGcRestartStart.Value, eventData);
@@ -92,12 +92,12 @@ public class GcEventsHandler : AbstractEventsHandler<GcEventsHandler.GCEventBase
 
                 return true;
 
-            case "GCFinalizersBegin_V1":
+            case EventListener.Constants.EventNames.GC.GCFinalizersBegin:
                 if (EventTypes.Contains(EventType.GCFinalizers))
                     _timeGcFinalizersStart = eventData.TimeStamp;
                 return true;
 
-            case "GCFinalizersEnd_V1":
+            case EventListener.Constants.EventNames.GC.GCFinalizersEnd:
                 if (EventTypes.Contains(EventType.GCFinalizers) && _timeGcFinalizersStart != null)
                 {
                     var @event = new GCEventBase(EventType.GCFinalizers, _timeGcFinalizersStart.Value, eventData);

--- a/src/Raven.Server/EventListener/GcEventsListener.cs
+++ b/src/Raven.Server/EventListener/GcEventsListener.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+
+namespace Raven.Server.EventListener;
+
+public class GcEventsListener : AbstractEventListener
+{
+    private readonly List<GcEventsHandler.GCEventBase> _events = new();
+    private readonly GcEventsHandler _handler;
+
+    protected override DotNetEventType? EventKeywords => DotNetEventType.GC;
+
+    public IReadOnlyCollection<GcEventsHandler.GCEventBase> Events => _events;
+
+    public GcEventsListener()
+    {
+        _handler = new GcEventsHandler(e => _events.Add(e));
+    }
+
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        if (eventData.EventName == null)
+            return;
+
+        _handler.HandleEvent(eventData);
+    }
+}

--- a/src/Raven.Server/EventListener/GcEventsListener.cs
+++ b/src/Raven.Server/EventListener/GcEventsListener.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 
 namespace Raven.Server.EventListener;
@@ -9,13 +8,12 @@ public class GcEventsListener : AbstractEventListener
     private readonly List<GcEventsHandler.GCEventBase> _events = new();
     private readonly GcEventsHandler _handler;
 
-    protected override DotNetEventType? EventKeywords => DotNetEventType.GC;
-
     public IReadOnlyCollection<GcEventsHandler.GCEventBase> Events => _events;
 
     public GcEventsListener()
     {
         _handler = new GcEventsHandler(e => _events.Add(e));
+        EnableEvents(DotNetEventType.GC);
     }
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -51,6 +51,7 @@ using Sparrow.Json;
 using FacetSetup = Raven.Client.Documents.Queries.Facets.FacetSetup;
 using Raven.Server.Documents.ETL.Providers.OLAP.Test;
 using Raven.Server.Documents.ETL.Providers.Queue.Test;
+using Raven.Server.EventListener;
 using Raven.Server.NotificationCenter;
 using BackupConfiguration = Raven.Client.Documents.Operations.Backups.BackupConfiguration;
 using MigrationConfiguration = Raven.Server.Smuggler.Migration.MigrationConfiguration;
@@ -229,6 +230,8 @@ namespace Raven.Server.Json
         internal static readonly Func<BlittableJsonReaderObject, AutoSpatialOptions> AutoSpatialOptions = GenerateJsonDeserializationRoutine<AutoSpatialOptions>();
 
         public static readonly Func<BlittableJsonReaderObject, BlockingTombstoneDetails> BlockingTombstoneDetails = GenerateJsonDeserializationRoutine<BlockingTombstoneDetails>();
+
+        public static readonly Func<BlittableJsonReaderObject, EventListenerToLog.EventListenerConfiguration> EventListenerConfiguration = GenerateJsonDeserializationRoutine<EventListenerToLog.EventListenerConfiguration>();
 
         public class Parameters
         {

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -13,6 +13,7 @@ using Raven.Server.Commercial;
 using Raven.Server.Config;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents.Indexes.Static.NuGet;
+using Raven.Server.EventListener;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.BackgroundTasks;
 using Raven.Server.TrafficWatch;
@@ -123,7 +124,8 @@ namespace Raven.Server
                 );
 
             TrafficWatchToLog.Instance.UpdateConfiguration(configuration.TrafficWatch);
-            
+            EventListenerToLog.Instance.UpdateConfiguration(configuration.EventListener);
+
             if (Logger.IsInfoEnabled)
                 Logger.Info($"Logging to {configuration.Logs.Path} set to {configuration.Logs.Mode} level.");
 

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -126,11 +126,11 @@ namespace Raven.Server
             TrafficWatchToLog.Instance.UpdateConfiguration(configuration.TrafficWatch);
             EventListenerToLog.Instance.UpdateConfiguration(new EventListenerToLog.EventListenerConfiguration
             {
-                EventListenerMode = configuration.EventListener.EventListenerMode,
-                EventTypes = configuration.EventListener.EventTypes,
-                MinimumDurationInMs = configuration.EventListener.MinimumDuration.GetValue(TimeUnit.Milliseconds),
-                AllocationsLoggingIntervalInMs = configuration.EventListener.AllocationsLoggingInterval.GetValue(TimeUnit.Milliseconds),
-                AllocationsLoggingCount = configuration.EventListener.AllocationsLoggingCount
+                EventListenerMode = configuration.DebugConfiguration.EventListenerMode,
+                EventTypes = configuration.DebugConfiguration.EventTypes,
+                MinimumDurationInMs = configuration.DebugConfiguration.MinimumDuration.GetValue(TimeUnit.Milliseconds),
+                AllocationsLoggingIntervalInMs = configuration.DebugConfiguration.AllocationsLoggingInterval.GetValue(TimeUnit.Milliseconds),
+                AllocationsLoggingCount = configuration.DebugConfiguration.AllocationsLoggingCount
             });
 
             if (Logger.IsInfoEnabled)

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -128,7 +128,9 @@ namespace Raven.Server
             {
                 EventListenerMode = configuration.EventListener.EventListenerMode,
                 EventTypes = configuration.EventListener.EventTypes,
-                MinimumDurationInMs = configuration.EventListener.MinimumDuration.GetValue(TimeUnit.Milliseconds)
+                MinimumDurationInMs = configuration.EventListener.MinimumDuration.GetValue(TimeUnit.Milliseconds),
+                AllocationsLoggingIntervalInMs = configuration.EventListener.AllocationsLoggingInterval.GetValue(TimeUnit.Milliseconds),
+                AllocationsLoggingCount = configuration.EventListener.AllocationsLoggingCount
             });
 
             if (Logger.IsInfoEnabled)

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -124,7 +124,12 @@ namespace Raven.Server
                 );
 
             TrafficWatchToLog.Instance.UpdateConfiguration(configuration.TrafficWatch);
-            EventListenerToLog.Instance.UpdateConfiguration(configuration.EventListener);
+            EventListenerToLog.Instance.UpdateConfiguration(new EventListenerToLog.EventListenerConfiguration
+            {
+                EventListenerMode = configuration.EventListener.EventListenerMode,
+                EventTypes = configuration.EventListener.EventTypes,
+                MinimumDurationInMs = configuration.EventListener.MinimumDuration.GetValue(TimeUnit.Milliseconds)
+            });
 
             if (Logger.IsInfoEnabled)
                 Logger.Info($"Logging to {configuration.Logs.Path} set to {configuration.Logs.Mode} level.");

--- a/src/Raven.Server/Web/System/AdminGcDebugHandler.cs
+++ b/src/Raven.Server/Web/System/AdminGcDebugHandler.cs
@@ -146,9 +146,12 @@ namespace Raven.Server.Web.System
 
             private readonly Dictionary<string, AllocationInfo> _allocations = new();
 
-            protected override DotNetEventType? EventKeywords => DotNetEventType.GC;
-
             public IReadOnlyCollection<AllocationInfo> Allocations => _allocations.Values;
+
+            public GcAllocationsEventListener()
+            {
+                EnableEvents(DotNetEventType.GC);
+            }
 
             public class AllocationInfo
             {

--- a/test/FastTests/Server/DebugMemoryTests.cs
+++ b/test/FastTests/Server/DebugMemoryTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Raven.Server.EventListener;
-using Raven.Server.Web.System;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,9 +12,39 @@ public class DebugMemoryTests : NoDisposalNeeded
     }
 
     [Fact]
-    public void Allocation_Debug_Event()
+    public void Debug_Events()
     {
-        Assert.True(Environment.Version.Major == 8 && AllocationsHandler.AllocationEventName == "GCAllocationTick_V4",
-            "Check if GCAllocationTick event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCStart == "GCStart_V2",
+            "Check if GCStart event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCEnd == "GCEnd_V1",
+            "Check if GCEnd event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCSuspendBegin == "GCSuspendEEBegin_V1",
+            "Check if GCSuspendBegin event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCSuspendEnd == "GCSuspendEEEnd_V1",
+            "Check if GCSuspendEnd event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCRestartBegin == "GCRestartEEBegin_V1",
+            "Check if GCRestartBegin event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCRestartEnd == "GCRestartEEEnd_V1",
+            "Check if GCRestartEnd event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCFinalizersBegin == "GCFinalizersBegin_V1",
+            "Check if GCFinalizersBegin event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCFinalizersEnd == "GCFinalizersEnd_V1",
+            "Check if GCFinalizersEnd event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.Allocations.Allocation == "GCAllocationTick_V4",
+            "Check if Allocation event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.Contention.ContentionStart == "ContentionStart",
+            "Check if ContentionStart event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.Contention.ContentionStop == "ContentionStop",
+            "Check if ContentionStop event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
     }
 }

--- a/test/FastTests/Server/DebugMemoryTests.cs
+++ b/test/FastTests/Server/DebugMemoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Raven.Server.EventListener;
 using Raven.Server.Web.System;
 using Xunit;
 using Xunit.Abstractions;
@@ -14,7 +15,7 @@ public class DebugMemoryTests : NoDisposalNeeded
     [Fact]
     public void Allocation_Debug_Event()
     {
-        Assert.True(Environment.Version.Major == 8 && AdminGcDebugHandler.GcAllocationsEventListener.AllocationEventName == "GCAllocationTick_V4",
+        Assert.True(Environment.Version.Major == 8 && AllocationsHandler.AllocationEventName == "GCAllocationTick_V4",
             "Check if GCAllocationTick event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-RavenDB-21771

### Additional description

Add GC, contention and allocations info to the log file.
- Off by default.
- Can enable each one separately.
- Filter by duration.
- Allocations are gathered by time (`AllocationsLoggingInterval`, default: 5 seconds) and outputing the top results which can be controlled by `AllocationsLoggingCount`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
