### PR TITLE
RavenDB-22606 Prevent appending to log if we are not the leader (didn't take office)

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/RachisAdminHandler.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.Handlers.Admin
                     var isClusterAdmin = IsClusterAdmin();
                     command.VerifyCanExecuteCommand(ServerStore, context, isClusterAdmin);
 
-                    var (etag, result) = await ServerStore.Engine.PutAsync(command);
+                    var (etag, result) = await ServerStore.Engine.SendToLeaderAsync(command);
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
                     var ms = context.CheckoutMemoryStream();
                     try
@@ -69,8 +69,8 @@ namespace Raven.Server.Documents.Handlers.Admin
                         {
                             context.Write(writer, new DynamicJsonValue
                             {
-                                [nameof(ServerStore.PutRaftCommandResult.RaftCommandIndex)] = etag,
-                                [nameof(ServerStore.PutRaftCommandResult.Data)] = result,
+                                [nameof(PutRaftCommand.PutRaftCommandResult.RaftCommandIndex)] = etag,
+                                [nameof(PutRaftCommand.PutRaftCommandResult.Data)] = result,
                             });
                         }
 

--- a/src/Raven.Server/Rachis/Leader.cs
+++ b/src/Raven.Server/Rachis/Leader.cs
@@ -524,12 +524,11 @@ namespace Raven.Server.Rachis
                 if (_engine.GetTermForKnownExisting(context, maxIndexOnQuorum) < Term)
                     return;// can't commit until at least one entry from our term has been published
 
-                changedFromLeaderElectToLeader = _engine.TakeOffice();
-
                 var sp = Stopwatch.StartNew();
                 maxIndexOnQuorum = _engine.Apply(context, maxIndexOnQuorum, this, sp);
-
                 context.Transaction.Commit();
+                
+                changedFromLeaderElectToLeader = _engine.TakeOffice();
 
                 var elapsed = sp.Elapsed;
                 if (RachisStateMachine.EnableDebugLongCommit && elapsed > TimeSpan.FromSeconds(5))

--- a/src/Raven.Server/Rachis/PutRaftCommand.cs
+++ b/src/Raven.Server/Rachis/PutRaftCommand.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Util;
+using Sparrow.Json;
+
+namespace Raven.Server.Rachis;
+
+public class PutRaftCommand : RavenCommand<PutRaftCommand.PutRaftCommandResult>, IRaftCommand
+{
+    private readonly BlittableJsonReaderObject _command;
+    private bool _reachedLeader;
+    public override bool IsReadRequest => false;
+
+    public bool HasReachLeader() => _reachedLeader;
+
+    private readonly string _source;
+    private readonly string _commandType;
+
+    public PutRaftCommand(BlittableJsonReaderObject command, string source, string commandType)
+    {
+        _command = command;
+        _source = source;
+        _commandType = commandType;
+    }
+
+    public override void OnResponseFailure(HttpResponseMessage response)
+    {
+        if (response.Headers.Contains("Reached-Leader") == false)
+            return;
+        _reachedLeader = response.Headers.GetValues("Reached-Leader").Contains("true");
+    }
+
+    public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+    {
+        url = $"{node.Url}/admin/rachis/send?source={_source}&commandType={_commandType}";
+        var request = new HttpRequestMessage
+        {
+            Method = HttpMethod.Post,
+            Content = new BlittableJsonContent(async stream =>
+            {
+                await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
+                {
+                    writer.WriteObject(_command);
+                }
+            })
+        };
+
+        return request;
+    }
+
+    public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+    {
+        Result = PutRaftCommandResultFunc(response);
+    }
+
+    public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
+
+    public class PutRaftCommandResult
+    {
+        public long RaftCommandIndex { get; set; }
+
+        public object Data { get; set; }
+    }
+
+    private static readonly Func<BlittableJsonReaderObject, PutRaftCommandResult> PutRaftCommandResultFunc = JsonDeserializationBase.GenerateJsonDeserializationRoutine<PutRaftCommandResult>();
+}

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -901,7 +901,7 @@ namespace Raven.Server.Rachis
             leader.Start(connections);
         }
 
-        public Task<(long Index, object Result)> PutAsync(CommandBase cmd)
+        private Task<(long Index, object Result)> PutToLeaderAsync(CommandBase cmd)
         {
             var leader = _currentLeader;
             if (leader == null || CurrentState != RachisState.Leader)
@@ -909,6 +909,112 @@ namespace Raven.Server.Rachis
 
             Validator.AssertPutCommandToLeader(cmd);
             return leader.PutAsync(cmd, cmd.Timeout ?? OperationTimeout);
+        }
+        public async Task<(long Index, object Result)> SendToLeaderAsync(CommandBase cmd, CancellationToken token = default)
+        {
+            //I think it is reasonable to expect timeout twice of error retry
+            var timeoutTask = TimeoutManager.WaitFor(OperationTimeout, token);
+            Exception requestException = null;
+            while (true)
+            {
+                token.ThrowIfCancellationRequested();
+
+                if (CurrentState == RachisState.Leader && CurrentLeader?.Running == true)
+                {
+                    try
+                    {
+                        return await PutToLeaderAsync(cmd);
+                    }
+                    catch (Exception e) when (e is ConcurrencyException || e is NotLeadingException)
+                    {
+                        // if the leader was changed during the PutAsync, we will retry.
+                        continue;
+                    }
+                }
+                if (CurrentState == RachisState.Passive)
+                {
+                    ThrowInvalidEngineState(cmd);
+                }
+
+                var logChange = WaitForHeartbeat();
+
+                var reachedLeader = new Reference<bool>();
+                var cachedLeaderTag = LeaderTag; // not actually working
+                try
+                {
+                    if (cachedLeaderTag == null || cachedLeaderTag == Tag)
+                    {
+                        await Task.WhenAny(logChange, timeoutTask);
+                        token.ThrowIfCancellationRequested();
+
+                        if (timeoutTask.IsCompleted)
+                            ThrowTimeoutException(cmd, requestException);
+
+                        continue;
+                    }
+
+                    using var _ = ContextPool.AllocateOperationContext(out ClusterOperationContext context);
+                    var response = await SendToNodeAsync(context, cachedLeaderTag, cmd, reachedLeader, token);
+                    return (response.Index, cmd.FromRemote(response.Result));
+                }
+                catch (Exception ex)
+                {
+                    if (Log.IsInfoEnabled)
+                        Log.Info($"Tried to send message to leader (reached: {reachedLeader.Value}), retrying", ex);
+
+                    if (reachedLeader.Value)
+                        throw;
+
+                    requestException = ex;
+                }
+
+                await Task.WhenAny(logChange, timeoutTask);
+                token.ThrowIfCancellationRequested();
+
+                if (timeoutTask.IsCompleted)
+                {
+                    ThrowTimeoutException(cmd, requestException);
+                }
+            }
+        }
+
+        private static void ThrowInvalidEngineState(CommandBase cmd)
+        {
+            throw new NotSupportedException("Cannot send command " + cmd.GetType().FullName + " to the cluster because this node is passive." + Environment.NewLine +
+                                            "Passive nodes aren't members of a cluster and require admin action (such as creating a db) " +
+                                            "to indicate that this node should create its own cluster");
+        }
+
+        private void ThrowTimeoutException(CommandBase cmd, Exception requestException)
+        {
+            throw new TimeoutException($"Could not send command {cmd.GetType().FullName} from {Tag} to leader because there is no leader, " +
+                                       $"and we timed out waiting for one after {OperationTimeout}", requestException);
+        }
+
+        private async Task<(long Index, object Result)> SendToNodeAsync(JsonOperationContext context, string engineLeaderTag, CommandBase cmd,
+            Reference<bool> reachedLeader, CancellationToken token)
+        {
+            var djv = cmd.ToJson(context);
+            var cmdJson = context.ReadObject(djv, "raft/command");
+
+            cmdJson.TryGet("Type", out string commandType);
+            var command = new PutRaftCommand(cmdJson, Url, commandType)
+            {
+                Timeout = cmd.Timeout
+            };
+
+            try
+            {
+                var requestExecutor = ServerStore.GetLeaderRequestExecutor(engineLeaderTag);
+                await requestExecutor.ExecuteAsync(command, context, token: token);
+            }
+            catch
+            {
+                reachedLeader.Value = command.HasReachLeader();
+                throw;
+            }
+
+            return (command.Result.RaftCommandIndex, command.Result.Data);
         }
 
         public void SwitchToCandidateStateOnTimeout()

--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -904,8 +904,8 @@ namespace Raven.Server.Rachis
         public Task<(long Index, object Result)> PutAsync(CommandBase cmd)
         {
             var leader = _currentLeader;
-            if (leader == null)
-                throw new NotLeadingException("Not a leader, cannot accept commands. " + _lastStateChangeReason);
+            if (leader == null || CurrentState != RachisState.Leader)
+                throw new NotLeadingException("Not a valid leader, cannot accept commands. " + _lastStateChangeReason);
 
             Validator.AssertPutCommandToLeader(cmd);
             return leader.PutAsync(cmd, cmd.Timeout ?? OperationTimeout);

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -685,7 +685,7 @@ namespace Raven.Server.ServerWide
             {
                 try
                 {
-                    serverStore.NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.UnrecoverableClusterError, $"{_parent.CurrentTerm}/{index}"), context.Transaction, sendNotificationEvenIfDoesntExist: false);
+                    serverStore.NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.UnrecoverableClusterError, $"{index}"), context.Transaction, sendNotificationEvenIfDoesntExist: false);
                 }
                 catch
                 {
@@ -702,11 +702,11 @@ namespace Raven.Server.ServerWide
                     {
                         serverStore.NotificationCenter.Add(AlertRaised.Create(
                             null,
-                            "Unrecoverable Cluster Error",
+                            $"Unrecoverable Cluster Error at Index {index}",
                             error,
                             AlertType.UnrecoverableClusterError,
                             NotificationSeverity.Error,
-                            key: $"{_parent.CurrentTerm}/{index}",
+                            key: $"{index}",
                             details: new ExceptionDetails(exception)));
                     }
                     catch

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -108,8 +108,6 @@ namespace Raven.Server.ServerWide
 
         public static readonly Func<BlittableJsonReaderObject, QueueEtlConfiguration> QueueEtlConfiguration = GenerateJsonDeserializationRoutine<QueueEtlConfiguration>();
 
-        public static readonly Func<BlittableJsonReaderObject, ServerStore.PutRaftCommandResult> PutRaftCommandResult = GenerateJsonDeserializationRoutine<ServerStore.PutRaftCommandResult>();
-
         public static readonly Func<BlittableJsonReaderObject, AddOrUpdateCompareExchangeCommand.CompareExchangeResult> CompareExchangeResult = GenerateJsonDeserializationRoutine<AddOrUpdateCompareExchangeCommand.CompareExchangeResult>();
 
         public static readonly Func<BlittableJsonReaderObject, AdminJsScript> AdminJsScript = GenerateJsonDeserializationRoutine<AdminJsScript>();

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -335,7 +335,7 @@ namespace Raven.Server.ServerWide.Maintenance
             {
                 foreach (var (cmd, updateReason) in cleanUnusedAutoIndexesCommands)
                 {
-                    await _engine.PutAsync(cmd);
+                    await _engine.SendToLeaderAsync(cmd);
                     AddToDecisionLog(cmd.DatabaseName, updateReason);
                 }
 
@@ -399,7 +399,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     ResponsibleNodePerDatabase = responsibleNodePerDatabase
                 }, RaftIdGenerator.NewId());
 
-                await _engine.PutAsync(command);
+                await _engine.SendToLeaderAsync(command);
             }
 
             if (deletions != null)
@@ -430,7 +430,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         throw new NotLeadingException("This node is no longer the leader, so abort the cleaning.");
                     }
 
-                    await _engine.PutAsync(cmd);
+                    await _engine.SendToLeaderAsync(cmd);
                 }
             }
         }
@@ -1714,7 +1714,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 throw new NotLeadingException("This node is no longer the leader, so we abort updating the database databaseTopology");
             }
 
-            return _engine.PutAsync(cmd);
+            return _engine.SendToLeaderAsync(cmd);
         }
 
         private Task<(long Index, object Result)> Delete(DeleteDatabaseCommand cmd)
@@ -1723,7 +1723,7 @@ namespace Raven.Server.ServerWide.Maintenance
             {
                 throw new NotLeadingException("This node is no longer the leader, so we abort the deletion command");
             }
-            return _engine.PutAsync(cmd);
+            return _engine.SendToLeaderAsync(cmd);
         }
 
         public void Dispose()

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3061,127 +3061,16 @@ namespace Raven.Server.ServerWide
                     cts.CancelAfter(cmd.Timeout.Value);
                 } 
 
-                using (ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                    return await SendToLeaderAsyncInternal(context, cmd, cts.Token);
+                return await Engine.SendToLeaderAsync(cmd, cts.Token);
             }
         }
 
-        private async Task<(long Index, object Result)> SendToLeaderAsyncInternal(TransactionOperationContext context, CommandBase cmd, CancellationToken token)
-        {
-            //I think it is reasonable to expect timeout twice of error retry
-            var timeoutTask = TimeoutManager.WaitFor(Engine.OperationTimeout, token);
-            Exception requestException = null;
-            while (true)
-            {
-                token.ThrowIfCancellationRequested();
-
-                if (_engine.CurrentState == RachisState.Leader && _engine.CurrentLeader?.Running == true)
-                {
-                    try
-                    {
-                        return await _engine.PutAsync(cmd);
-                    }
-                    catch (Exception e) when (e is ConcurrencyException || e is NotLeadingException)
-                    {
-                        // if the leader was changed during the PutAsync, we will retry.
-                        continue;
-                    }
-                }
-                if (_engine.CurrentState == RachisState.Passive)
-                {
-                    ThrowInvalidEngineState(cmd);
-                }
-
-                var logChange = _engine.WaitForHeartbeat();
-
-                var reachedLeader = new Reference<bool>();
-                var cachedLeaderTag = _engine.LeaderTag; // not actually working
-                try
-                {
-                    if (cachedLeaderTag == null)
-                    {
-                        await Task.WhenAny(logChange, timeoutTask);
-                        token.ThrowIfCancellationRequested();
-
-                        if (timeoutTask.IsCompleted)
-                            ThrowTimeoutException(cmd, requestException);
-
-                        continue;
-                    }
-
-                    var response = await SendToNodeAsync(context, cachedLeaderTag, cmd, reachedLeader, token);
-                    return (response.Index, cmd.FromRemote(response.Result));
-                }
-                catch (Exception ex)
-                {
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Tried to send message to leader (reached: {reachedLeader.Value}), retrying", ex);
-
-                    if (reachedLeader.Value)
-                        throw;
-
-                    requestException = ex;
-                }
-
-                await Task.WhenAny(logChange, timeoutTask);
-                token.ThrowIfCancellationRequested();
-
-                if (timeoutTask.IsCompleted)
-                {
-                    ThrowTimeoutException(cmd, requestException);
-                }
-            }
-        }
-
-        private static void ThrowInvalidEngineState(CommandBase cmd)
-        {
-            throw new NotSupportedException("Cannot send command " + cmd.GetType().FullName + " to the cluster because this node is passive." + Environment.NewLine +
-                                            "Passive nodes aren't members of a cluster and require admin action (such as creating a db) " +
-                                            "to indicate that this node should create its own cluster");
-        }
-
-        private void ThrowTimeoutException(CommandBase cmd, Exception requestException)
-        {
-            throw new TimeoutException($"Could not send command {cmd.GetType().FullName} from {NodeTag} to leader because there is no leader, " +
-                                       $"and we timed out waiting for one after {Engine.OperationTimeout}", requestException);
-        }
-
-        private async Task<(long Index, object Result)> SendToNodeAsync(TransactionOperationContext context, string engineLeaderTag, CommandBase cmd,
-            Reference<bool> reachedLeader, CancellationToken token)
-        {
-            var djv = cmd.ToJson(context);
-            var cmdJson = context.ReadObject(djv, "raft/command");
-
-            
-
-            cmdJson.TryGet("Type", out string commandType);
-            var command = new PutRaftCommand(cmdJson, _engine.Url, commandType)
-            {
-                Timeout = cmd.Timeout
-            };
-
-            try
-            {
-                var requestExecutor = GetLeaderRequestExecutor(context, engineLeaderTag);
-                await requestExecutor.ExecuteAsync(command, context, token: token);
-            }
-            catch
-            {
-                reachedLeader.Value = command.HasReachLeader();
-                throw;
-            }
-
-            return (command.Result.RaftCommandIndex, command.Result.Data);
-        }
-
-        public RequestExecutor GetLeaderRequestExecutor(TransactionOperationContext context, string leaderTag)
+        public RequestExecutor GetLeaderRequestExecutor(string leaderTag)
         {
             if (string.IsNullOrEmpty(leaderTag))
                 throw new NoLeaderException();
 
-            ClusterTopology clusterTopology;
-            using (context.OpenReadTransaction())
-                clusterTopology = _engine.GetTopology(context);
+            var clusterTopology = GetClusterTopology();
 
             if (clusterTopology.Members.TryGetValue(leaderTag, out string leaderUrl) == false)
                 throw new InvalidOperationException("Leader " + leaderTag + " was not found in the topology members");
@@ -3281,64 +3170,6 @@ namespace Raven.Server.ServerWide
             requestExecutor.DefaultTimeout = Engine.OperationTimeout;
 
             return requestExecutor;
-        }
-
-        private class PutRaftCommand : RavenCommand<PutRaftCommandResult>, IRaftCommand
-        {
-            private readonly BlittableJsonReaderObject _command;
-            private bool _reachedLeader;
-            public override bool IsReadRequest => false;
-
-            public bool HasReachLeader() => _reachedLeader;
-
-            private readonly string _source;
-            private readonly string _commandType;
-
-            public PutRaftCommand(BlittableJsonReaderObject command, string source, string commandType)
-            {
-                _command = command;
-                _source = source;
-                _commandType = commandType;
-            }
-
-            public override void OnResponseFailure(HttpResponseMessage response)
-            {
-                if (response.Headers.Contains("Reached-Leader") == false)
-                    return;
-                _reachedLeader = response.Headers.GetValues("Reached-Leader").Contains("true");
-            }
-
-            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-            {
-                url = $"{node.Url}/admin/rachis/send?source={_source}&commandType={_commandType}";
-                var request = new HttpRequestMessage
-                {
-                    Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream =>
-                    {
-                        await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
-                        {
-                            writer.WriteObject(_command);
-                        }
-                    })
-                };
-
-                return request;
-            }
-
-            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
-            {
-                Result = JsonDeserializationCluster.PutRaftCommandResult(response);
-            }
-
-            public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
-        }
-
-        public class PutRaftCommandResult
-        {
-            public long RaftCommandIndex { get; set; }
-
-            public object Data { get; set; }
         }
 
         public Task WaitForTopology(Leader.TopologyModification state, CancellationToken token)

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -287,7 +287,7 @@ namespace Raven.Server.Web.System
             }
         }
 
-        private async Task<bool> ProxyToLeaderIfNeeded(TransactionOperationContext context, DatabaseRecord databaseRecord, int replicationFactor, long? index)
+        private async Task<bool> ProxyToLeaderIfNeeded(JsonOperationContext context, DatabaseRecord databaseRecord, int replicationFactor, long? index)
         {
             var leaderTag = ServerStore.Engine.LeaderTag;
             if (leaderTag == null)
@@ -300,7 +300,7 @@ namespace Raven.Server.Web.System
             if (leaderTag != ServerStore.NodeTag)
             {
                 // proxy the command to the leader
-                var leaderRequestExecutor = ServerStore.GetLeaderRequestExecutor(context, leaderTag);
+                var leaderRequestExecutor = ServerStore.GetLeaderRequestExecutor(leaderTag);
                 var command = new CreateDatabaseOperation.CreateDatabaseCommand(databaseRecord, replicationFactor, index);
                 await leaderRequestExecutor.ExecuteAsync(command, context);
                 HttpContext.Response.StatusCode = (int)HttpStatusCode.Created;

--- a/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Auto/BasicAutoMapIndexing.cs
@@ -968,7 +968,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 Assert.Equal(config.SearchEngine.ToString(), database.Configuration.Indexing.AutoIndexingEngineType.ToString());
                 var index0 = await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Job", Storage = FieldStorage.No, Id = 1 } }), Guid.NewGuid().ToString());
 
-                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index0.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
+                await database.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(index0.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
 
                 var now = database.Time.GetUtcNow();
                 using (database.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
@@ -1147,7 +1147,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Normal);
                 WaitForIndex(database, index2.Name, index => index.State == IndexState.Idle);
 
-                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index2.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
+                await database.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(index2.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
 
                 now = database.Time.GetUtcNow();
                 database.Time.UtcDateTime = () =>
@@ -1209,8 +1209,8 @@ namespace FastTests.Server.Documents.Indexing.Auto
                 WaitForIndex(database, index1.Name, index => index.State == IndexState.Idle);
                 WaitForIndex(database, index2.Name, index => index.State == IndexState.Idle);
 
-                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index1.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
-                await database.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index2.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
+                await database.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(index1.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
+                await database.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(index2.Name, IndexState.Idle, database.Name, Guid.NewGuid().ToString()));
 
 
                 now = database.Time.GetUtcNow();
@@ -1278,7 +1278,7 @@ namespace FastTests.Server.Documents.Indexing.Auto
             var indexCleanupCommands = Server.ServerStore.Observer.GetUnusedAutoIndexes(state);
             foreach (var (cmd, _) in indexCleanupCommands)
             {
-                await Server.ServerStore.Engine.PutAsync(cmd);
+                await Server.ServerStore.Engine.SendToLeaderAsync(cmd);
             }
         }
 

--- a/test/RachisTests/BasicCluster.cs
+++ b/test/RachisTests/BasicCluster.cs
@@ -63,7 +63,7 @@ namespace RachisTests
             var leaderSelected = followers.Select(x => x.WaitForState(RachisState.Leader, CancellationToken.None).ContinueWith(_ => x)).ToArray();
             for (int i = 0; i < 10; i++)
             {
-                await a.PutAsync(new TestCommand { Name = "test", Value = i });
+                await a.SendToLeaderAsync(new TestCommand { Name = "test", Value = i });
             }
             foreach (var follower in followers)
             {
@@ -73,7 +73,7 @@ namespace RachisTests
             var leader = await await Task.WhenAny(leaderSelected);
             for (int i = 10; i < 20; i++)
             {
-                await leader.PutAsync(new TestCommand { Name = "test", Value = i });
+                await leader.SendToLeaderAsync(new TestCommand { Name = "test", Value = i });
             }
 
             followers = followers.Except(new[] { leader }).ToArray();
@@ -87,7 +87,7 @@ namespace RachisTests
             leader = await await Task.WhenAny(leaderSelected);
             for (int i = 20; i < 30; i++)
             {
-                await leader.PutAsync(new TestCommand { Name = "test", Value = i });
+                await leader.SendToLeaderAsync(new TestCommand { Name = "test", Value = i });
             }
 
             using (leader.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
@@ -124,7 +124,7 @@ namespace RachisTests
             {
                 for (int i = 0; i < 10; i++)
                 {
-                    await a.PutAsync(new TestCommand { Name = "test", Value = i });
+                    await a.SendToLeaderAsync(new TestCommand { Name = "test", Value = i });
                 }
             }
 
@@ -142,7 +142,7 @@ namespace RachisTests
 
             for (var i = 0; i < 5; i++)
             {
-                await a.PutAsync(new TestCommand { Name = "test", Value = i });
+                await a.SendToLeaderAsync(new TestCommand { Name = "test", Value = i });
             }
 
             var b = SetupServer();
@@ -151,7 +151,7 @@ namespace RachisTests
             long lastIndex = 0;
             for (var i = 0; i < 5; i++)
             {
-                var (etag, _) = await a.PutAsync(new TestCommand { Name = "test", Value = i + 5 });
+                var (etag, _) = await a.SendToLeaderAsync(new TestCommand { Name = "test", Value = i + 5 });
                 lastIndex = etag;
             }
 
@@ -176,10 +176,10 @@ namespace RachisTests
             var tasks = new List<Task>();
             for (var i = 0; i < 9; i++)
             {
-                tasks.Add(a.PutAsync(new TestCommand { Name = "test", Value = i }));
+                tasks.Add(a.SendToLeaderAsync(new TestCommand { Name = "test", Value = i }));
             }
 
-            var (lastIndex, _) = await a.PutAsync(new TestCommand { Name = "test", Value = 9 });
+            var (lastIndex, _) = await a.SendToLeaderAsync(new TestCommand { Name = "test", Value = 9 });
             var waitForCommitIndexChange = b.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, lastIndex);
             Assert.True(await waitForCommitIndexChange.WaitWithoutExceptionAsync(TimeSpan.FromSeconds(5)));
 
@@ -197,7 +197,7 @@ namespace RachisTests
 
             for (var i = 0; i < 10; i++)
             {
-                await rachis.PutAsync(new TestCommand { Name = "test", Value = i });
+                await rachis.SendToLeaderAsync(new TestCommand { Name = "test", Value = i });
             }
 
             using (rachis.ContextPool.AllocateOperationContext(out ClusterOperationContext context))

--- a/test/RachisTests/BasicTests.cs
+++ b/test/RachisTests/BasicTests.cs
@@ -37,7 +37,7 @@ namespace RachisTests
                     long index = 0;
                     await ActionWithLeader(async l =>
                     {
-                        (index, _) = await l.PutAsync(new TestCommand { Name = "test", Value = i });
+                        (index, _) = await l.SendToLeaderAsync(new TestCommand { Name = "test", Value = i });
                     });
                     lastIndex = index;
                 }

--- a/test/RachisTests/CommandsTests.cs
+++ b/test/RachisTests/CommandsTests.cs
@@ -31,8 +31,8 @@ namespace RachisTests
                     RaftCommandIndex = 322
                 };
 
-                var t = leader.PutAsync(cmd);
-                await leader.PutAsync(cmd);
+                var t = leader.SendToLeaderAsync(cmd);
+                await leader.SendToLeaderAsync(cmd);
 
                 // this should not throw timeout exception.
                 var exception = await Record.ExceptionAsync(async () => await t);
@@ -59,7 +59,7 @@ namespace RachisTests
             {
                 for (var i = 0; i < commandCount; i++)
                 {
-                    tasks.Add(leader.PutAsync(new TestCommand { Name = "test", Value = i }));
+                    tasks.Add(leader.SendToLeaderAsync(new TestCommand { Name = "test", Value = i }));
                 }
                 using (context.OpenReadTransaction())
                     lastIndex = leader.GetLastEntryIndex(context);
@@ -85,7 +85,7 @@ namespace RachisTests
             {
                 for (var i = 0; i < commandCount; i++)
                 {
-                    tasks.Add(leader.PutAsync(new TestCommand { Name = "test", Value = i }));
+                    tasks.Add(leader.SendToLeaderAsync(new TestCommand { Name = "test", Value = i }));
                 }
                 using (context.OpenReadTransaction())
                     lastIndex = leader.GetLastEntryIndex(context);
@@ -98,8 +98,8 @@ namespace RachisTests
             
             try
             {
-                var task = leader.PutAsync(new TestCommand { Name = "test", Value = commandCount });
-                Assert.True(await task.WaitWithoutExceptionAsync((int)leader.ElectionTimeout.TotalMilliseconds * 10));
+                var task = leader.CurrentLeader.PutAsync(new TestCommand { Name = "test", Value = commandCount },
+                    TimeSpan.FromMilliseconds(leader.ElectionTimeout.TotalMilliseconds * 10));
                 await task;
                 Assert.True(false, "We should have gotten an error");
             }

--- a/test/RachisTests/TopologyChangesTests.cs
+++ b/test/RachisTests/TopologyChangesTests.cs
@@ -151,8 +151,8 @@ namespace RachisTests
             var node2 = await CreateNetworkAndGetLeader(1);
             var url = node2.Url;
 
-            await node1.PutAsync(new TestCommand { Name = "test", Value = 10 });
-            await node2.PutAsync(new TestCommand { Name = "test", Value = 20 });
+            await node1.SendToLeaderAsync(new TestCommand { Name = "test", Value = 10 });
+            await node2.SendToLeaderAsync(new TestCommand { Name = "test", Value = 20 });
 
             string id;
             using (node1.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))

--- a/test/SlowTests/Issues/RavenDB-15890.cs
+++ b/test/SlowTests/Issues/RavenDB-15890.cs
@@ -138,7 +138,7 @@ namespace SlowTests.Issues
 
                 await ActionWithLeader(async l =>
                 {
-                    var (index, _) = await l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString()));
+                    var (index, _) = await l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString()));
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
                 });
 
@@ -195,7 +195,7 @@ namespace SlowTests.Issues
 
                 await ActionWithLeader(async l =>
                 {
-                    var (index, _) = await l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Error, database, Guid.NewGuid().ToString()));
+                    var (index, _) = await l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Error, database, Guid.NewGuid().ToString()));
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
                 });
 
@@ -250,7 +250,7 @@ namespace SlowTests.Issues
 
                 await ActionWithLeader(async l =>
                 {
-                    var (index, _) = await l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString()));
+                    var (index, _) = await l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString()));
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
                 });
 
@@ -304,7 +304,7 @@ namespace SlowTests.Issues
 
                 await ActionWithLeader(async l =>
                 {
-                    var (index, _) = await l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Error, database, Guid.NewGuid().ToString()));
+                    var (index, _) = await l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Error, database, Guid.NewGuid().ToString()));
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
                 });
 
@@ -358,7 +358,7 @@ namespace SlowTests.Issues
 
                 await ActionWithLeader(async l =>
                 {
-                    var (index, _) = await l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Idle, database, Guid.NewGuid().ToString()));
+                    var (index, _) = await l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Idle, database, Guid.NewGuid().ToString()));
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
                 });
 
@@ -407,7 +407,7 @@ namespace SlowTests.Issues
 
                 await ActionWithLeader(async l =>
                 {
-                    var (index, _) = await l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString()));
+                    var (index, _) = await l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString()));
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
                 });
 
@@ -429,7 +429,7 @@ namespace SlowTests.Issues
 
                 await ActionWithLeader(async l =>
                 {
-                    var (index, _) = await l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Normal, database, Guid.NewGuid().ToString()));
+                    var (index, _) = await l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Normal, database, Guid.NewGuid().ToString()));
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
                 });
 
@@ -451,7 +451,7 @@ namespace SlowTests.Issues
 
                 await ActionWithLeader(async l =>
                 {
-                    var (index, _) = await l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Error, database, Guid.NewGuid().ToString()));
+                    var (index, _) = await l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Error, database, Guid.NewGuid().ToString()));
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
                 });
 
@@ -467,7 +467,7 @@ namespace SlowTests.Issues
 
                 await ActionWithLeader(async l =>
                 {
-                    var (index, _) = await l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Normal, database, Guid.NewGuid().ToString()));
+                    var (index, _) = await l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Normal, database, Guid.NewGuid().ToString()));
                     await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
                 });
 
@@ -526,7 +526,7 @@ namespace SlowTests.Issues
                 var count = 0;
                 string info = "";
                
-                await ActionWithLeader((l) => l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString())),
+                await ActionWithLeader((l) => l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString())),
                     Servers);
 
                 foreach (var server in Servers)
@@ -610,7 +610,7 @@ namespace SlowTests.Issues
 
                 Assert.Equal(1, count);
 
-                await ActionWithLeader((l) => l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Normal, database, Guid.NewGuid().ToString())),
+                await ActionWithLeader((l) => l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Normal, database, Guid.NewGuid().ToString())),
                     Servers);
 
                 foreach (var server in Servers)
@@ -669,7 +669,7 @@ namespace SlowTests.Issues
                 }
 
                 // Disable index cluster wide
-                var (index, _) = await leader.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString()));
+                var (index, _) = await leader.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString()));
 
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
 
@@ -694,7 +694,7 @@ namespace SlowTests.Issues
                     Assert.Equal(IndexState.Normal, documentDatabase.IndexStore.GetIndex(indexName).State);
                 } 
                 //Change priority cluster wide
-                (index, _) = await leader.ServerStore.Engine.PutAsync(new SetIndexPriorityCommand(indexName, IndexPriority.Low, database, Guid.NewGuid().ToString()));
+                (index, _) = await leader.ServerStore.Engine.SendToLeaderAsync(new SetIndexPriorityCommand(indexName, IndexPriority.Low, database, Guid.NewGuid().ToString()));
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
 
                 foreach (var server in Servers)
@@ -761,7 +761,7 @@ namespace SlowTests.Issues
                 }
                 Assert.Equal(2, count);
                 //Change priority cluster wide
-                var (index, _) = await leader.ServerStore.Engine.PutAsync(new SetIndexPriorityCommand(indexName, IndexPriority.Low, database, Guid.NewGuid().ToString()));
+                var (index, _) = await leader.ServerStore.Engine.SendToLeaderAsync(new SetIndexPriorityCommand(indexName, IndexPriority.Low, database, Guid.NewGuid().ToString()));
 
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
                 count = 0;
@@ -806,7 +806,7 @@ namespace SlowTests.Issues
                 documentDatabase.IndexStore.StopIndex(indexName);
                 Assert.Equal(IndexRunningStatus.Paused, documentDatabase.IndexStore.GetIndex(indexName).Status);
 
-                var (index, _) = await leader.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString()));
+                var (index, _) = await leader.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Disabled, database, Guid.NewGuid().ToString()));
 
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
 
@@ -814,7 +814,7 @@ namespace SlowTests.Issues
                 Assert.Equal(IndexState.Disabled, documentDatabase.IndexStore.GetIndex(indexName).State);
 
                 // Enable index cluster wide
-                (index, _) = await leader.ServerStore.Engine.PutAsync(new SetIndexStateCommand(indexName, IndexState.Normal, database, Guid.NewGuid().ToString()));
+                (index, _) = await leader.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(indexName, IndexState.Normal, database, Guid.NewGuid().ToString()));
 
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(index, TimeSpan.FromSeconds(15));
 

--- a/test/SlowTests/Issues/RavenDB-20922.cs
+++ b/test/SlowTests/Issues/RavenDB-20922.cs
@@ -180,7 +180,7 @@ namespace SlowTests.Issues
                 var count = 0;
                 string info = "";
 
-                await ActionWithLeader((l) => l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index[0].Name, IndexState.Disabled, database, Guid.NewGuid().ToString())),
+                await ActionWithLeader((l) => l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(index[0].Name, IndexState.Disabled, database, Guid.NewGuid().ToString())),
                     Servers);
                 //Check index is disabled
                 await CheckIndexStateInTheCluster(database, index[0].Name, IndexState.Disabled);
@@ -252,7 +252,7 @@ namespace SlowTests.Issues
                 var count = 0;
                 string info = "";
 
-                await ActionWithLeader((l) => l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index.Name, IndexState.Disabled, database, Guid.NewGuid().ToString())),
+                await ActionWithLeader((l) => l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(index.Name, IndexState.Disabled, database, Guid.NewGuid().ToString())),
                     Servers);
                 //Check index is disabled
                 await CheckIndexStateInTheCluster(database, index.Name, IndexState.Disabled);
@@ -321,7 +321,7 @@ namespace SlowTests.Issues
 
                 Assert.Equal(1, count);
 
-                await ActionWithLeader((l) => l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index[0].Name, IndexState.Normal, database, Guid.NewGuid().ToString())),
+                await ActionWithLeader((l) => l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(index[0].Name, IndexState.Normal, database, Guid.NewGuid().ToString())),
                     Servers);
 
                 await CheckIndexStateInTheCluster(database, index[0].Name, IndexState.Normal);
@@ -362,7 +362,7 @@ namespace SlowTests.Issues
 
                 Assert.Equal(1, count);
 
-                await ActionWithLeader((l) => l.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index.Name, IndexState.Normal, database, Guid.NewGuid().ToString())),
+                await ActionWithLeader((l) => l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(index.Name, IndexState.Normal, database, Guid.NewGuid().ToString())),
                     Servers);
 
                 await CheckIndexStateInTheCluster(database, index.Name, IndexState.Normal);

--- a/test/SlowTests/RavenDB-14303.cs
+++ b/test/SlowTests/RavenDB-14303.cs
@@ -59,7 +59,7 @@ namespace SlowTests
                     var db = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                     var index = await db.IndexStore.CreateIndex(new AutoMapReduceIndexDefinition("Users", new[] { count, sum }, new[] { age }), Guid.NewGuid().ToString());
 
-                    await leader.ServerStore.Engine.PutAsync(new SetIndexStateCommand(index.Name, IndexState.Idle, db.Name, Guid.NewGuid().ToString()));
+                    await leader.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(index.Name, IndexState.Idle, db.Name, Guid.NewGuid().ToString()));
                     db.ServerStore.ForTestingPurposesOnly().StopIndex = true;
 
                     var addRes = await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database));

--- a/test/Tests.Infrastructure/RachisConsensusTestBase.cs
+++ b/test/Tests.Infrastructure/RachisConsensusTestBase.cs
@@ -327,7 +327,7 @@ namespace Tests.Infrastructure
         {
             for (var i = 0; i < numberOfCommands; i++)
             {
-                await ActionWithLeader(l => l.PutAsync(new TestCommand
+                await ActionWithLeader(l => l.SendToLeaderAsync(new TestCommand
                 {
                     Name = name,
                     Value = value
@@ -352,11 +352,11 @@ namespace Tests.Infrastructure
             List<Task> waitingList = new List<Task>();
             for (var i = 1; i <= numberOfCommands; i++)
             {
-                var task = leader.PutAsync(new TestCommand
+                var task = leader.CurrentLeader.PutAsync(new TestCommand
                 {
                     Name = name,
                     Value = value ?? i
-                });
+                }, Timeout.InfiniteTimeSpan);
 
                 waitingList.Add(task);
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22606

### Additional description

- Become leader only after successfully _committing_ logs.
- Avoid spamming notification center upon `UnrecoverableClusterError` by using only the raft index.
- Have a better separation between Rachis & ServerStore, moved all the logic of `SendToLeaderAsync` to `Rachis` and prevent directly putting commands to the leader log

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
