### PR TITLE
RavenDB-22741 : Prefixed Sharding - Add support for querying by prefix

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -442,6 +442,12 @@ namespace Raven.Client
                     }
 
                     internal const string ShardContextParameterName = "__shardContext";
+
+                    internal const string ShardContextDocumentIds = "DocumentIds";
+
+                    internal const string ShardContextPrefixes = "Prefixes";
+
+
                 }
             }
 

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Sharding.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Sharding.cs
@@ -12,13 +12,10 @@ public abstract partial class AbstractDocumentQuery<T, TSelf>
 
         builder.Invoke(builderImpl);
 
-        object shardContext;
-
-        if (builderImpl.DocumentIds.Count == 1)
-            shardContext = builderImpl.DocumentIds.First();
-        else
-            shardContext = builderImpl.DocumentIds;
-
-        QueryParameters.Add(Constants.Documents.Querying.Sharding.ShardContextParameterName, shardContext);
+        QueryParameters.Add(Constants.Documents.Querying.Sharding.ShardContextParameterName, new
+        {
+            builderImpl.DocumentIds,
+            builderImpl.Prefixes
+        });
     }
 }

--- a/src/Raven.Client/Documents/Session/Querying/Sharding/IQueryShardedContextBuilder.cs
+++ b/src/Raven.Client/Documents/Session/Querying/Sharding/IQueryShardedContextBuilder.cs
@@ -4,13 +4,39 @@ namespace Raven.Client.Documents.Session.Querying.Sharding;
 
 public interface IQueryShardedContextBuilder
 {
+    /// <summary>
+    /// Restricts the query execution to the specific shard where the document with the given ID resides.
+    /// This method ensures that the query is directed only to the shard that holds the document,
+    /// optimizing query performance by eliminating the need to query all shards.
+    /// </summary>
+    /// <param name="id">The ID of the document used to determine the shard to query</param>
     IQueryShardedContextBuilder ByDocumentId(string id);
 
+    /// <summary>
+    /// Restricts the query execution to the specific shards where the documents with the given IDs reside.
+    /// This method ensures that the query is directed only to the shards that hold the specified documents,
+    /// optimizing query performance by avoiding unnecessary queries to other shards.
+    /// </summary>
+    /// <param name="ids">A set of document IDs used to determine the shards to query</param>
     IQueryShardedContextBuilder ByDocumentIds(IEnumerable<string> ids);
 
+    /// <summary>
+    /// Restricts the query execution to only the shards associated with the specified prefix, as defined in the database's <see cref="PrefixedShardingSetting"/>.
+    /// This allows the query to be executed on a subset of shards, avoiding unnecessary queries to shards not relevant to the specified prefix.
+    /// </summary>
+    /// <param name="prefix">The document ID prefix used to determine which shards to query.
+    /// This prefix corresponds to the 'PrefixSetting' configured in the database record,
+    /// and only the shards associated with this prefix will be included in the query execution.</param>
     IQueryShardedContextBuilder ByPrefix(string prefix);
 
-    IQueryShardedContextBuilder ByPrefixes(IEnumerable<string> prefixes);
+    /// <summary>
+    /// Restricts the query execution to only the shards associated with the specified prefixes, as defined in the database's <see cref="PrefixedShardingSetting"/>.
+    /// This allows the query to be executed on a subset of shards, avoiding unnecessary queries to shards not relevant to the specified prefixes.
+    /// </summary>
+    /// <param name="prefixes">A collection of document ID prefixes used to determine which shards to query.
+    /// Each prefix corresponds to a 'PrefixSetting' configured in the database record, and only the shards 
+    /// associated with these prefixes will be included in the query execution.</param>
 
+    IQueryShardedContextBuilder ByPrefixes(IEnumerable<string> prefixes);
 
 }

--- a/src/Raven.Client/Documents/Session/Querying/Sharding/IQueryShardedContextBuilder.cs
+++ b/src/Raven.Client/Documents/Session/Querying/Sharding/IQueryShardedContextBuilder.cs
@@ -7,4 +7,10 @@ public interface IQueryShardedContextBuilder
     IQueryShardedContextBuilder ByDocumentId(string id);
 
     IQueryShardedContextBuilder ByDocumentIds(IEnumerable<string> ids);
+
+    IQueryShardedContextBuilder ByPrefix(string prefix);
+
+    IQueryShardedContextBuilder ByPrefixes(IEnumerable<string> prefixes);
+
+
 }

--- a/src/Raven.Client/Documents/Session/Querying/Sharding/QueryShardedContextBuilder.cs
+++ b/src/Raven.Client/Documents/Session/Querying/Sharding/QueryShardedContextBuilder.cs
@@ -7,6 +7,9 @@ internal sealed class QueryShardedContextBuilder : IQueryShardedContextBuilder
 {
     public HashSet<string> DocumentIds { get; } = new(StringComparer.OrdinalIgnoreCase);
 
+    public HashSet<string> Prefixes { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+
     public IQueryShardedContextBuilder ByDocumentId(string id)
     {
         DocumentIds.Add(id);
@@ -19,6 +22,22 @@ internal sealed class QueryShardedContextBuilder : IQueryShardedContextBuilder
         foreach (string id in ids)
         {
             DocumentIds.Add(id);
+        }
+
+        return this;
+    }
+
+    public IQueryShardedContextBuilder ByPrefix(string prefix)
+    {
+        Prefixes.Add(prefix);
+        return this;
+    }
+
+    public IQueryShardedContextBuilder ByPrefixes(IEnumerable<string> prefixes)
+    {
+        foreach (string prefix in prefixes)
+        {
+            Prefixes.Add(prefix);
         }
 
         return this;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22741/Prefixed-Sharding-Add-support-for-querying-by-prefix

### Additional description

Add support for `x.ShardContext(s => s.ByPrefix('users/'))` which will query only the shards that are listed in
the prefix setting for `users/`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
