### PR TITLE
RavenDB-21777 Throwing exception when `Any` on enumerable has `and` using two different fields

### DIFF
--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1046,7 +1046,8 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
                             if (UsesKeyAndValue(left, right))
                                 continue;
                             
-                            throw new InvalidOperationException($"Using multiple fields inside method '{nameof(Enumerable.Any)}' can lead to unexpected query results.");
+                            throw new InvalidOperationException($"Using multiple fields inside method '{nameof(Enumerable.Any)}' can lead to unexpected query results for auto index. " +
+                                                                $"A static fanout index should be used instead.");
                         }
                     }
                 }

--- a/test/SlowTests/Issues/RavenDB-21777.cs
+++ b/test/SlowTests/Issues/RavenDB-21777.cs
@@ -16,7 +16,7 @@ public class RavenDB_21777 : RavenTestBase
     {
     }
 
-    private const string ExpectedExceptionMessage = "Using multiple fields inside method 'Any' can lead to unexpected query results.";
+    private const string ExpectedExceptionMessage = "Using multiple fields inside method 'Any' can lead to unexpected query results for auto index.";
 
     [RavenFact(RavenTestCategory.Querying)]
     public void TestEnumerableMethodCallAccessingMultipleFields()

--- a/test/SlowTests/Issues/RavenDB-21777.cs
+++ b/test/SlowTests/Issues/RavenDB-21777.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_21777 : RavenTestBase
+{
+    public RavenDB_21777(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private const string ExpectedExceptionMessage = "Using multiple fields inside method 'Any' can lead to unexpected query results.";
+
+    [RavenFact(RavenTestCategory.Querying)]
+    public void TestEnumerableMethodCallAccessingMultipleFields()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var m1 = new Member() { UserId = "abc", Role = Role.Contributor, Value = 21 };
+                var m2 = new Member() { UserId = "bcd", Role = Role.Contributor, Value = 37 };
+
+                var e1 = new Entity() { Name = "CoolName", Members = new List<Member>() { m1, m2 } };
+                
+                session.Store(m1);
+                session.Store(m2);
+                session.Store(e1);
+                
+                var ed1 = new EntityWithDict() { SomeDict = new Dictionary<string, int>{ { "a", 2 }, { "b", 1 } } };
+                
+                session.Store(ed1);
+                
+                session.SaveChanges();
+                
+                var r1 = session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.UserId == "abc"))
+                    .ToList();
+                
+                var r2 = session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.UserId == "abc") && x.Members.Any(y => y.Role == Role.Contributor) && x.Members.Any(y => y.Value == 37))
+                    .ToList();
+                
+                var r3 = session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.Value > 20 || y.Value.Equals(37)))
+                    .ToList();
+                
+                var r4 = session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.UserId.Equals("abc") || y.Value.Equals(37)))
+                    .ToList();
+                
+                // We have to stick to this behavior
+                var r5 = session.Query<EntityWithDict>()
+                    .Where(x => x.SomeDict.Any(kvp => kvp.Key == "a" && kvp.Value == 1))
+                    .ToList();
+                
+                Assert.NotEmpty(r1);
+                Assert.NotEmpty(r2);
+                Assert.NotEmpty(r3);
+                Assert.NotEmpty(r4);
+                Assert.NotEmpty(r5);
+                
+                var exception1 = Assert.Throws<InvalidOperationException>(() => session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.UserId == "abc" && y.Value == 37 || y.Role == Role.Contributor))
+                    .ToList());
+
+                Assert.Contains(ExpectedExceptionMessage, exception1.Message);
+                
+                var exception2 = Assert.Throws<InvalidOperationException>(() => session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.UserId.Equals("abc") && y.Value.Equals(37)))
+                    .ToList());
+                
+                Assert.Contains(ExpectedExceptionMessage, exception2.Message);
+                
+                var exception5 = Assert.Throws<InvalidOperationException>(() => session.Query<Entity>()
+                    .Where(x => x.Members.Any(y => y.Value > 20 && y.Value < 30 || y.Value.Equals(57) && y.UserId != "aaa"))
+                    .ToList());
+                
+                Assert.Contains(ExpectedExceptionMessage, exception5.Message);
+            }
+        }
+    }
+
+    private class Entity
+    {
+        public string Name { get; set; }
+        public List<Member> Members { get; set; }
+    }
+
+    private class Member
+    {
+        public string UserId { get; set; }
+        public int Value { get; set; }
+        public Role Role { get; set; }
+    }
+
+    private enum Role
+    {
+        Contributor
+    }
+
+    private class EntityWithDict
+    {
+        public Dictionary<string, int> SomeDict { get; set; }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Entity, DummyIndex.Result>
+    {
+        public class Result
+        {
+            public string Name { get; set; }
+            public string UserId { get; set; }
+            public Role Role { get; set; }
+            public int Value { get; set; }
+        }
+        
+        public DummyIndex()
+        {
+            Map = entities => from entity in entities
+                from member in entity.Members
+                select new { entity.Name, member.UserId, member.Role, member.Value };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21777/Wrong-RQL-generated-when-using-LINQ-.Any-that-contains-logical-AND-in-arrays

### Additional description

Using query such as
```csharp
var example = await session.Query<Entity>()
  .Where(x => x.Members.Any(y => y.UserId == UserId && y.Role == Role.Contributor))
  .ToArrayAsync();
```
may lead to results unexpected by the user. They expect results where a single object in `Members` list fulfills both conditions, but actually we do this check against a set of values from all objects on `Members` list. To avoid this, we'll throw an exception in such situation, but only for auto map index.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change - queries that currently rely on this behavior (even though it's incorrect) will stop working
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
