### PR TITLE
RavenDB-22782: We are not accounting for memory allocated through the direct interface.

### DIFF
--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -980,11 +980,13 @@ namespace Sparrow.Server
             // We will allocate from the current segment.
             int allocationSize = length + sizeof(ByteStringStorage);
             int allocationUnit = Bits.PowerOf2(allocationSize);
+            _currentlyAllocated += allocationUnit;
+            
             if (allocationUnit <= _internalCurrent.SizeLeft)
             {
                 var byteString = Create(_internalCurrent.Current, length, allocationUnit, ByteStringType.Mutable);
                 _internalCurrent.Current += byteString._pointer->Size;
-
+                
                 output = byteString;
                 return new InternalScope(this, output);
             }
@@ -1004,6 +1006,8 @@ namespace Sparrow.Server
             // We will allocate from the current segment.
             int allocationSize = length + sizeof(ByteStringStorage);
             int allocationUnit = Bits.PowerOf2(allocationSize);
+            _currentlyAllocated += allocationUnit;
+            
             if (allocationUnit <= _internalCurrent.SizeLeft)
             {
                 var byteString = Create(_internalCurrent.Current, length, allocationUnit, type);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22782

### Additional description

The `AllocateDirect` is only used by Corax therefore this accounting never surfaced. On v6.2 this interface is used as an optimization and therefore the error showed up.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
