### PR TITLE
RavenDB-18513 - Revert revisions without configuration can make revisions orphaned

### DIFF
--- a/test/FastTests/Utils/RevisionsHelper.cs
+++ b/test/FastTests/Utils/RevisionsHelper.cs
@@ -1,11 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
-using Raven.Client.Documents.Session;
+using Raven.Client.Http;
+using Raven.Client.Json;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents.Revisions;
 using Sparrow.Json;
 
 namespace FastTests.Utils
@@ -113,5 +117,69 @@ namespace FastTests.Utils
                 return index;
             }
         }
+
+        public class RevertRevisionsOperation : IMaintenanceOperation<OperationIdResult>
+        {
+            private readonly RevertRevisionsRequest _request;
+
+            public RevertRevisionsOperation(DateTime time, long window)
+            {
+                _request = new RevertRevisionsRequest()
+                {
+                    Time = time,
+                    WindowInSec = window,
+                };
+            }
+
+            public RevertRevisionsOperation(DateTime time, long window, string[] collections) : this(time, window)
+            {
+                if (collections == null || collections.Length == 0)
+                    throw new InvalidOperationException("Collections array cant be null or empty.");
+                _request.Collections = collections;
+            }
+
+            public RevertRevisionsOperation(RevertRevisionsRequest request)
+            {
+                _request = request ?? throw new ArgumentNullException(nameof(request));
+            }
+
+            public RavenCommand<OperationIdResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new RevertRevisionsCommand(_request);
+            }
+
+            private class RevertRevisionsCommand : RavenCommand<OperationIdResult>
+            {
+                private readonly RevertRevisionsRequest _request;
+
+                public RevertRevisionsCommand(RevertRevisionsRequest request)
+                {
+                    _request = request;
+                }
+
+                public override bool IsReadRequest => false;
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/databases/{node.Database}/revisions/revert";
+
+                    return new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Post,
+                        Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_request, ctx)).ConfigureAwait(false))
+                    };
+                }
+
+                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+                {
+                    if (response == null)
+                        ThrowInvalidResponse();
+
+                    Result = DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<OperationIdResult>(response);
+                }
+            }
+        }
+
+
     }
 }

--- a/test/SlowTests/Issues/RavenDB-18513.cs
+++ b/test/SlowTests/Issues/RavenDB-18513.cs
@@ -32,7 +32,7 @@ public class RavenDB_18513 : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Revisions)]
-    public async Task Test()
+    public async Task RevertRevisionShouldntCreateOrphanedRevisions()
     {
         DateTime beforeStore = DateTime.UtcNow - TimeSpan.FromDays(1);
 
@@ -67,7 +67,7 @@ public class RavenDB_18513 : RavenTestBase
         var empyConfiguration = new RevisionsConfiguration();
         await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: empyConfiguration);
         // revert revision
-        var operation = await store.Maintenance.SendAsync(new RevertRevisionsOperation(beforeStore, 60));
+        var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(beforeStore, 60));
         await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false);
 
         using (var session = store.OpenAsyncSession())
@@ -94,57 +94,6 @@ public class RavenDB_18513 : RavenTestBase
     {
         public string Id { get; set; }
         public string Name { get; set; }
-    }
-
-    private class RevertRevisionsOperation : IMaintenanceOperation<OperationIdResult>
-    {
-        private readonly RevertRevisionsRequest _request;
-
-        public RevertRevisionsOperation(DateTime time, long window)
-        {
-            _request = new RevertRevisionsRequest() { Time = time, WindowInSec = window };
-        }
-
-        public RevertRevisionsOperation(RevertRevisionsRequest request)
-        {
-            _request = request ?? throw new ArgumentNullException(nameof(request));
-        }
-
-        public RavenCommand<OperationIdResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
-        {
-            return new RevertRevisionsCommand(_request);
-        }
-
-        private class RevertRevisionsCommand : RavenCommand<OperationIdResult>
-        {
-            private readonly RevertRevisionsRequest _request;
-
-            public RevertRevisionsCommand(RevertRevisionsRequest request)
-            {
-                _request = request;
-            }
-
-            public override bool IsReadRequest => false;
-
-            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-            {
-                url = $"{node.Url}/databases/{node.Database}/revisions/revert";
-
-                return new HttpRequestMessage
-                {
-                    Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_request, ctx)).ConfigureAwait(false))
-                };
-            }
-
-            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
-            {
-                if (response == null)
-                    ThrowInvalidResponse();
-
-                Result = DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<OperationIdResult>(response);
-            }
-        }
     }
 }
 

--- a/test/SlowTests/Issues/RavenDB-18513.cs
+++ b/test/SlowTests/Issues/RavenDB-18513.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Issues;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_18513 : RavenTestBase
+{
+    public RavenDB_18513(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Revisions)]
+    public async Task Test()
+    {
+        DateTime beforeStore = DateTime.UtcNow - TimeSpan.FromDays(1);
+
+        using var store = GetDocumentStore();
+        var configuration = new RevisionsConfiguration
+        {
+            Default = new RevisionsCollectionConfiguration
+            {
+                Disabled = false,
+                MinimumRevisionsToKeep = 100
+            }
+        };
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+        var user1 = new User { Id = "Users/1-A", Name = "Shahar" };
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(user1);
+            await session.SaveChangesAsync();
+
+            for (int i = 1; i <= 10; i++)
+            {
+                (await session.LoadAsync<User>(user1.Id)).Name = $"Shahar{i}";
+                await session.SaveChangesAsync();
+            }
+
+            var user1RevCount = await session.Advanced.Revisions.GetCountForAsync(user1.Id);
+            Assert.Equal(11, user1RevCount);
+        }
+
+        // delete configuration
+        var empyConfiguration = new RevisionsConfiguration();
+        await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: empyConfiguration);
+        // revert revision
+        var operation = await store.Maintenance.SendAsync(new RevertRevisionsOperation(beforeStore, 60));
+        await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<User>(user1.Id);
+            Assert.Null(doc); // user1 should be deleted
+
+            var user1RevCount = await session.Advanced.Revisions.GetCountForAsync(user1.Id);
+            Assert.Equal(user1RevCount, 12); // 11 revisions and 1 deleted revision
+
+            var revisionsMetadata = await session.Advanced.Revisions.GetMetadataForAsync(user1.Id);
+            var lastRevisionFlags = revisionsMetadata[0].GetString(Constants.Documents.Metadata.Flags);
+            string deleteRevisionsFlag = DocumentFlags.DeleteRevision.ToString();
+
+            // deleted doc && has revisions && last revisions isn't 'DeleteRevision' => doc has orphaned revisions
+            Assert.True(lastRevisionFlags.Contains(deleteRevisionsFlag));
+
+            string revertedFlag = DocumentFlags.Reverted.ToString();
+            Assert.True(lastRevisionFlags.Contains(revertedFlag));
+        }
+    }
+
+    private class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class RevertRevisionsOperation : IMaintenanceOperation<OperationIdResult>
+    {
+        private readonly RevertRevisionsRequest _request;
+
+        public RevertRevisionsOperation(DateTime time, long window)
+        {
+            _request = new RevertRevisionsRequest() { Time = time, WindowInSec = window };
+        }
+
+        public RevertRevisionsOperation(RevertRevisionsRequest request)
+        {
+            _request = request ?? throw new ArgumentNullException(nameof(request));
+        }
+
+        public RavenCommand<OperationIdResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        {
+            return new RevertRevisionsCommand(_request);
+        }
+
+        private class RevertRevisionsCommand : RavenCommand<OperationIdResult>
+        {
+            private readonly RevertRevisionsRequest _request;
+
+            public RevertRevisionsCommand(RevertRevisionsRequest request)
+            {
+                _request = request;
+            }
+
+            public override bool IsReadRequest => false;
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/revisions/revert";
+
+                return new HttpRequestMessage
+                {
+                    Method = HttpMethod.Post,
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_request, ctx)).ConfigureAwait(false))
+                };
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    ThrowInvalidResponse();
+
+                Result = DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<OperationIdResult>(response);
+            }
+        }
+    }
+}
+

--- a/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevertRevisionsByCollectionTests.cs
@@ -463,7 +463,7 @@ namespace SlowTests.Server.Documents.Revisions
                     await session.SaveChangesAsync();
                 }
 
-                var operation = await store.Maintenance.SendAsync(new RevertRevisionsOperation(last, 60, collections));
+                var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(last, 60, collections));
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
                 using (var session = store.OpenAsyncSession())
@@ -525,7 +525,7 @@ namespace SlowTests.Server.Documents.Revisions
                     await session.SaveChangesAsync();
                 }
 
-                var operation = await store.Maintenance.SendAsync(new RevertRevisionsOperation(last, 60, collections));
+                var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(last, 60, collections));
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
                 using (var session = store.OpenAsyncSession())
@@ -576,7 +576,7 @@ namespace SlowTests.Server.Documents.Revisions
                     await session.SaveChangesAsync();
                 }
 
-                var operation = await store.Maintenance.SendAsync(new RevertRevisionsOperation(last, 60, collections));
+                var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(last, 60, collections));
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
                 using (var session = store.OpenAsyncSession())
@@ -642,7 +642,7 @@ namespace SlowTests.Server.Documents.Revisions
                     session.SaveChanges();
                 }
 
-                var operation = await store.Maintenance.SendAsync(new RevertRevisionsOperation(last, 60, collections));
+                var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(last, 60, collections));
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
                 using (var session = store.OpenAsyncSession())
@@ -700,7 +700,7 @@ namespace SlowTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
 
-                var operation = await store.Maintenance.SendAsync(new RevertRevisionsOperation(last, 60, collections)); 
+                var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(last, 60, collections)); 
                 var result = await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
                 using (var session = store.OpenAsyncSession())
@@ -741,7 +741,7 @@ namespace SlowTests.Server.Documents.Revisions
                     await session.SaveChangesAsync();
                 }
 
-                var operation = await store.Maintenance.SendAsync(new RevertRevisionsOperation(last, 60));
+                var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(last, 60));
                 await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
                 using (var session = store.OpenAsyncSession())
@@ -759,67 +759,6 @@ namespace SlowTests.Server.Documents.Revisions
                     Assert.Equal("User Name", usersRevisions[0].Name);
                     Assert.Equal("Shahar", usersRevisions[1].Name);
                     Assert.Equal("User Name", usersRevisions[2].Name);
-                }
-            }
-        }
-
-        private class RevertRevisionsOperation : IMaintenanceOperation<OperationIdResult>
-        {
-            private readonly RevertRevisionsRequest _request;
-
-            public RevertRevisionsOperation(DateTime time, long window)
-            {
-                _request = new RevertRevisionsRequest() { 
-                    Time = time, 
-                    WindowInSec = window,
-                };
-            }
-
-            public RevertRevisionsOperation(DateTime time, long window, string[] collections) : this(time, window)
-            {
-                if(collections == null || collections.Length == 0)
-                    throw new InvalidOperationException("Collections array cant be null or empty.");
-                _request.Collections = collections;
-            }
-
-            public RevertRevisionsOperation(RevertRevisionsRequest request)
-            {
-                _request = request ?? throw new ArgumentNullException(nameof(request));
-            }
-
-            public RavenCommand<OperationIdResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
-            {
-                return new RevertRevisionsCommand(_request);
-            }
-
-            private class RevertRevisionsCommand : RavenCommand<OperationIdResult>
-            {
-                private readonly RevertRevisionsRequest _request;
-
-                public RevertRevisionsCommand(RevertRevisionsRequest request)
-                {
-                    _request = request;
-                }
-
-                public override bool IsReadRequest => false;
-
-                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-                {
-                    url = $"{node.Url}/databases/{node.Database}/revisions/revert";
-
-                    return new HttpRequestMessage
-                    {
-                        Method = HttpMethod.Post,
-                        Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_request, ctx)).ConfigureAwait(false))
-                    };
-                }
-
-                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
-                {
-                    if (response == null)
-                        ThrowInvalidResponse();
-
-                    Result = DocumentConventions.Default.Serialization.DefaultConverter.FromBlittable<OperationIdResult>(response);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-18513/Studio-must-condition-Revert-Revisions-on-enabling-Revisions-or-warn-users-that-documents-may-be-lost#focus=Comments-67-338543.0-0

### Additional description

Reverting document revisions to a time when it didn't exist, will delete the document,
the problem is that when this document has no revisions configuration, the 'Delete Revision' won't be created.
The solution I found best is to add a `delete revision` in that case, instead of checking if the document has a revisions configuration or not.
It prevents better revisions from becoming orphaned, and also there is a case that a document has no configuration because all its revisions are `force created` or `conflict`\`resolved` revisions.. in that case, we'll want to revert even docs that don't have revisions configuration, because any configuration didn't create their revisions.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
