### PR TITLE
RavenDB-22787 More info on test failures

### DIFF
--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -222,6 +222,7 @@ namespace RachisTests.DatabaseCluster
 
                 var backupStatus = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
                 await backupStatus.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 1, source.Database, backupStatus.Id);
 
                 using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
@@ -236,6 +237,7 @@ namespace RachisTests.DatabaseCluster
 
                 var backupStatus2 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
                 await backupStatus2.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 2, source.Database, backupStatus2.Id);
 
                 using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
@@ -249,7 +251,6 @@ namespace RachisTests.DatabaseCluster
 
                 var backupStatus3 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
                 await backupStatus3.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
-                
                 var files = await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 3, source.Database, backupStatus3.Id);
 
                 var options = new DatabaseSmugglerImportOptions();
@@ -344,6 +345,7 @@ namespace RachisTests.DatabaseCluster
 
                 var backupStatus = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
                 await backupStatus.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 1, source.Database, backupStatus.Id);
 
                 using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
@@ -360,7 +362,6 @@ namespace RachisTests.DatabaseCluster
 
                 var backupStatus2 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
                 await backupStatus2.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
-
                 await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 2, source.Database, backupStatus2.Id);
                 
                 await documentStore.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), Directory.GetDirectories(backupPath).First());
@@ -415,6 +416,7 @@ namespace RachisTests.DatabaseCluster
 
                 var backupStatus = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
                 await backupStatus.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 1, source.Database, backupStatus.Id);
 
                 using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                 {
@@ -432,7 +434,6 @@ namespace RachisTests.DatabaseCluster
 
                 var backupStatus2 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
                 await backupStatus2.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
-
                 await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 2, source.Database, backupStatus2.Id);
                 
                 await documentStore.Smuggler.ImportIncrementalAsync(new DatabaseSmugglerImportOptions(), Directory.GetDirectories(backupPath).First());

--- a/test/SlowTests/Issues/RavenDB-21050.cs
+++ b/test/SlowTests/Issues/RavenDB-21050.cs
@@ -40,7 +40,8 @@ public class RavenDB_21050 : RavenTestBase
 
             var backupStatus = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
             await backupStatus.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
-
+            await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 1, source.Database, backupStatus.Id);
+            
             using (var session = source.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
             {
                 session.Delete(id);
@@ -49,7 +50,6 @@ public class RavenDB_21050 : RavenTestBase
 
             var backupStatus2 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
             await backupStatus2.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
-
             await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 2, source.Database, backupStatus2.Id);
 
             var restoreConfig = new RestoreBackupConfiguration { BackupLocation = Directory.GetDirectories(backupPath).First(), DatabaseName = destination.Database };


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22787

### Additional description
It seems that the first backup didn't create a backup file.
An assert was added to all backup to ensure they create a backup.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test Debug Info

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
