### PR TITLE
RavenDB-22652 : Failed interversion tests for AddNode

### DIFF
--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -74,7 +74,7 @@ namespace InterversionTests
                             if (--retries == 0) 
                                 throw new InvalidOperationException($"failed to add node '{processNode.Url}' to the cluster", e);
                             
-                            await Task.Delay(10);
+                            await Task.Delay(500);
                             continue;
                         }
 

--- a/test/InterversionTests/MixedClusterTests.cs
+++ b/test/InterversionTests/MixedClusterTests.cs
@@ -124,6 +124,19 @@ namespace InterversionTests
         }
 
         [RavenMultiplatformTheory(RavenTestCategory.Interversion, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [InlineData("6.0.104")]
+        public async Task UpgradeDirectlyFrom60X(string latest)
+        {
+            var initialVersions = new[] { latest, latest, latest };
+            var upgradeTo = new List<string>
+            {
+                "current"
+            };
+            var suit = new Version60X(this);
+            await ExecuteUpgradeTest(initialVersions, upgradeTo, suit, suit, suit);
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.Interversion, RavenPlatform.Windows | RavenPlatform.Linux)]
         [InlineData("5.4.5")]
         [InlineData("5.4.109")]
         public async Task UpgradeDirectlyFrom54X(string latest)

--- a/test/Tests.Infrastructure/InterversionTest/UpgradeTestSuit.cs
+++ b/test/Tests.Infrastructure/InterversionTest/UpgradeTestSuit.cs
@@ -215,4 +215,11 @@ namespace Tests.Infrastructure.InterversionTest
                 stores[0].Database));
         }
     }
+
+    public class Version60X : Version54X
+    {
+        public Version60X(InterversionTestBase infrastructure) : base(infrastructure)
+        {
+        }
+    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22652/Failed-interversion-tests-for-AddNode

### Additional description

add retry mechanism for adding nodes to cluster, in order to avoid test failures due to `NoLeaderException`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Tests stabilization

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
