### PR TITLE
RavenDB-21464 - Consider Disable property on update subscription

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionCriteria.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionCriteria.cs
@@ -17,7 +17,7 @@ namespace Raven.Client.Documents.Subscriptions
         public string Query { get; set; }
         public string ChangeVector { get; set; }
         public string MentorNode { get; set; }
-        public bool Disabled { get; set; }
+        public virtual bool Disabled { get; set; }
         public virtual bool PinToMentorNode { get; set; }
     }
 
@@ -66,6 +66,20 @@ namespace Raven.Client.Documents.Subscriptions
         }
 
         internal bool PinToMentorNodeWasSet { get; set; }
+
+        private bool _disabled;
+
+        public override bool Disabled
+        {
+            get => _disabled;
+            set
+            {
+                _disabled = value;
+                DisabledWasSet = true;
+            }
+        }
+
+        internal bool DisabledWasSet { get; set; }
     }
 
     public class Revision<T> where T : class

--- a/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Client/Extensions/BlittableJsonTextWriterExtensions.cs
@@ -113,9 +113,13 @@ namespace Raven.Client.Extensions
 
             writer.WritePropertyName(nameof(options.MentorNode));
             writer.WriteString(options.MentorNode);
-            writer.WriteComma();
-            writer.WritePropertyName(nameof(options.Disabled));
-            writer.WriteBool(options.Disabled);
+
+            if (options.DisabledWasSet)
+            {
+                writer.WriteComma();
+                writer.WritePropertyName(nameof(options.Disabled));
+                writer.WriteBool(options.Disabled);
+            }
 
             writer.WriteEndObject();
         }

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -552,7 +552,8 @@ namespace Raven.Server.Documents.Handlers
             using (context.OpenReadTransaction())
             {
                 var json = await context.ReadForMemoryAsync(RequestBodyStream(), null);
-                bool pinToMentorNodeWasSet = json.TryGet(nameof(SubscriptionUpdateOptions.PinToMentorNode), out bool pinToMentorNode);
+                bool pinToMentorNodeWasSet = json.TryGet(nameof(SubscriptionUpdateOptions.PinToMentorNode), out bool _);
+                bool disabledWasSet = json.TryGet(nameof(SubscriptionUpdateOptions.Disabled), out bool _);
                 var options = JsonDeserializationServer.SubscriptionUpdateOptions(json);
 
                 var id = options.Id;
@@ -581,14 +582,14 @@ namespace Raven.Server.Documents.Handlers
                         if (id == null)
                         {
                             // subscription with such name doesn't exist, add new subscription
-                            await CreateInternal(json, options, context, id: null, disabled: false);
+                            await CreateInternal(json, options, context, id: null, options.Disabled);
                             return;
                         }
 
                         if (options.Name == null)
                         {
                             // subscription with such id doesn't exist, add new subscription using id
-                            await CreateInternal(json, options, context, id, disabled: false);
+                            await CreateInternal(json, options, context, id, options.Disabled);
                             return;
                         }
 
@@ -602,7 +603,7 @@ namespace Raven.Server.Documents.Handlers
                         catch (SubscriptionDoesNotExistException)
                         {
                             // subscription with such id or name doesn't exist, add new subscription using both name and id
-                            await CreateInternal(json, options, context, id, disabled: false);
+                            await CreateInternal(json, options, context, id, options.Disabled);
                             return;
                         }
                     }
@@ -621,6 +622,9 @@ namespace Raven.Server.Documents.Handlers
                 if (pinToMentorNodeWasSet == false)
                     options.PinToMentorNode = state.PinToMentorNode;
 
+                if (disabledWasSet == false)
+                    options.Disabled = state.Disabled;
+
                 if (options.Query == null)
                     options.Query = state.Query;
 
@@ -630,7 +634,7 @@ namespace Raven.Server.Documents.Handlers
                     return;
                 }
 
-                await CreateInternal(json, options, context, id, disabled: false);
+                await CreateInternal(json, options, context, id, options.Disabled);
             }
         }
 
@@ -639,7 +643,9 @@ namespace Raven.Server.Documents.Handlers
             bool gotChanges = options.Name != state.SubscriptionName
                               || options.ChangeVector != state.ChangeVectorForNextBatchStartingPoint
                               || options.MentorNode != state.MentorNode
-                              || options.Query != state.Query;
+                              || options.Query != state.Query
+                              || options.PinToMentorNode != state.PinToMentorNode
+                              || options.Disabled != state.Disabled;
 
             return gotChanges;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21464/Update-subscription-doesnt-update-Disabled

### Additional description

Make sure updating Disable property on update subscription actually works

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
