### PR TITLE
RavenDB-22794  - Add comments for operations that implements IMaintenanceOperation

### DIFF
--- a/src/Raven.Client/Documents/Operations/GetDetailedStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetDetailedStatisticsOperation.cs
@@ -6,14 +6,22 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations
 {
+    /// <summary>
+    /// Retrieves detailed database statistics, providing in-depth information such as the count of compare exchange entries,
+    /// compare exchange tombstones, and time series deleted ranges. It also includes base statistics like index information,
+    /// storage sizes, and other relevant metrics.
+    /// </summary>
     public sealed class GetDetailedStatisticsOperation : IMaintenanceOperation<DetailedDatabaseStatistics>
     {
         private readonly string _debugTag;
 
+        /// <inheritdoc cref="GetDetailedStatisticsOperation"/>
         public GetDetailedStatisticsOperation()
         {
         }
 
+        /// <inheritdoc cref = "GetDetailedStatisticsOperation" />
+        /// <param name="debugTag">An optional tag for enhanced logging or debugging purposes.</param>
         internal GetDetailedStatisticsOperation(string debugTag)
         {
             _debugTag = debugTag;

--- a/src/Raven.Client/Documents/Operations/GetEssentialStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetEssentialStatisticsOperation.cs
@@ -6,14 +6,21 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations;
 
+/// <summary>
+/// Retrieves essential database statistics, focusing on critical metrics such as
+/// the number of documents and document extensions, and essential index information.
+/// </summary>
 public sealed class GetEssentialStatisticsOperation : IMaintenanceOperation<EssentialDatabaseStatistics>
 {
     private readonly string _debugTag;
 
+    /// <inheritdoc cref="GetEssentialStatisticsOperation"/>
     public GetEssentialStatisticsOperation()
     {
     }
 
+    /// <inheritdoc cref="GetEssentialStatisticsOperation"/>
+    /// <param name="debugTag">An optional tag for enhanced logging or debugging purposes.</param>
     internal GetEssentialStatisticsOperation(string debugTag)
     {
         _debugTag = debugTag;

--- a/src/Raven.Client/Documents/Operations/GetStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetStatisticsOperation.cs
@@ -7,15 +7,23 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations
 {
+    /// <summary>
+    /// Retrieves database statistics. This operation provides various metrics about the database, such as the database change vector,
+    /// the number of documents, indexes, collections, and other relevant details.
+    /// </summary>
     public sealed class GetStatisticsOperation : IMaintenanceOperation<DatabaseStatistics>
     {
         private readonly string _debugTag;
         private readonly string _nodeTag;
 
+        /// <inheritdoc cref="GetStatisticsOperation"/>
         public GetStatisticsOperation()
         {
         }
 
+        /// <inheritdoc cref = "GetStatisticsOperation" />
+        /// <param name="debugTag">An optional tag for enhanced logging or debugging purposes.</param>
+        /// <param name="nodeTag">An optional node tag to target a specific server node.</param>
         internal GetStatisticsOperation(string debugTag, string nodeTag = null)
         {
             _debugTag = debugTag;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22794/Add-comments-for-operations-that-implements-IMaintenanceOperationT

### Additional description

Files in  this PR:
* `GetDetailedStatisticsOperation` (in `Raven.Client.Documents.Operations`)
* `GetEssentialStatisticsOperation` (in `Raven.Client.Documents.Operations`)
*  `GetStatisticsOperation` (in `Raven.Client.Documents.Operations`)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
