### PR TITLE
RavenDB-20829 - add missing include ids to _knownMissingIds in subscription session [v5.4]

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1514,7 +1514,7 @@ more responsive application.
             _knownMissingIds.UnionWith(ids);
         }
 
-        internal void RegisterIncludes(BlittableJsonReaderObject includes)
+        internal void RegisterIncludes(BlittableJsonReaderObject includes, bool registerMissingIds = false)
         {
             if (NoTracking)
                 return;
@@ -1528,7 +1528,12 @@ more responsive application.
                 includes.GetPropertyByIndex(i, ref propertyDetails);
 
                 if (propertyDetails.Value is not BlittableJsonReaderObject json)
+                {
+                    if (registerMissingIds)
+                        RegisterMissing(propertyDetails.Name);
+
                     continue;
+                }
 
                 var newDocumentInfo = DocumentInfo.GetNewDocumentInfo(json);
                 if (newDocumentInfo.Metadata.TryGetConflict(out var conflict) && conflict)

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
@@ -154,7 +154,7 @@ namespace Raven.Client.Documents.Subscriptions
             if (_includes?.Count > 0)
             {
                 foreach (var item in _includes)
-                    s.RegisterIncludes(item);
+                    s.RegisterIncludes(item, registerMissingIds: true);
             }
 
             if (_counterIncludes?.Count > 0)

--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -55,7 +55,8 @@ namespace Raven.Server.Documents
         ResolveTimeSeriesConflict = 0x2000,
         ByTimeSeriesUpdate = 0x4000,
         LegacyDeleteMarker = 0x8000,
-        ForceRevisionCreation = 0x10000
+        ForceRevisionCreation = 0x10000,
+        AllowDataAsNull = 0x20000
     }
 
     public static class EnumExtensions

--- a/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/DocumentHandler.cs
@@ -280,7 +280,7 @@ namespace Raven.Server.Documents.Handlers
                     includeCompareExchangeValues?.Gather(document);
                 }
 
-                includeDocs.Fill(includes);
+                includeDocs.Fill(includes, includeMissingAsNull: false);
                 includeCompareExchangeValues?.Materialize(lastModifiedIndex);
 
                 var actualEtag = ComputeHttpEtags.ComputeEtagForDocuments(documents, includes, includeCounters, includeTimeSeries, includeCompareExchangeValues);

--- a/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/SubscriptionsHandler.cs
@@ -167,7 +167,7 @@ namespace Raven.Server.Documents.Handlers
                     writer.WriteComma();
                     writer.WritePropertyName("Includes");
                     var includes = new List<Document>();
-                    includeCmd.Fill(includes);
+                    includeCmd.Fill(includes, includeMissingAsNull: false);
                     await writer.WriteIncludesAsync(context, includes);
                     writer.WriteEndObject();
                 }

--- a/src/Raven.Server/Documents/Includes/IncludeDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeDocumentsCommand.cs
@@ -127,7 +127,7 @@ namespace Raven.Server.Documents.Includes
             }
         }
 
-        public void Fill(List<Document> result)
+        public void Fill(List<Document> result, bool includeMissingAsNull)
         {
             if (_includedIds == null || _includedIds.Count == 0)
                 return;
@@ -145,7 +145,19 @@ namespace Raven.Server.Documents.Includes
                 {
                     includedDoc = _storage.Get(_context, includedDocId);
                     if (includedDoc == null)
-                        continue;
+                        if (includedDoc == null)
+                        {
+                            if (includeMissingAsNull)
+                            {
+                                result.Add(new Document
+                                {
+                                    Id = _context.GetLazyString(includedDocId),
+                                    NonPersistentFlags = NonPersistentDocumentFlags.AllowDataAsNull
+                                });
+                            }
+
+                            continue;
+                        }
                 }
                 catch (DocumentConflictException e)
                 {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3364,7 +3364,7 @@ namespace Raven.Server.Documents.Indexes
 
                                 using (fillScope?.Start())
                                 {
-                                    includeDocumentsCommand.Fill(resultToFill.Includes);
+                                    includeDocumentsCommand.Fill(resultToFill.Includes, includeMissingAsNull: false);
                                     includeCompareExchangeValuesCommand?.Materialize(maxAllowedAtomicGuardIndex: null);
                                 }
 
@@ -3596,7 +3596,7 @@ namespace Raven.Server.Documents.Indexes
                                                 cmd.Gather(result.Results);
 
                                             using (includesScope?.For(nameof(QueryTimingsScope.Names.Fill)))
-                                                cmd.Fill(result.Includes);
+                                                cmd.Fill(result.Includes, includeMissingAsNull: false);
                                         }
                                     }
 

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -242,7 +242,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
                 using (fillScope?.Start())
                 {
-                    includeDocumentsCommand.Fill(resultToFill.Includes);
+                    includeDocumentsCommand.Fill(resultToFill.Includes, includeMissingAsNull: false);
 
                     includeCompareExchangeValuesCommand.Materialize(maxAllowedAtomicGuardIndex: null);
                 }

--- a/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/GraphQueryRunner.cs
@@ -188,7 +188,7 @@ namespace Raven.Server.Documents.Queries
                         }
                     }
 
-                    idc.Fill(final.Includes);
+                    idc.Fill(final.Includes, includeMissingAsNull: false);
 
                     final.TotalResults = final.Results.Count;
 

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -1012,7 +1012,7 @@ namespace Raven.Server.Documents.TcpHandlers
                                 if (includeDocumentsCommand != null && includeDocumentsCommand.HasIncludesIds())
                                 {
                                     var includes = new List<Document>();
-                                    includeDocumentsCommand.Fill(includes);
+                                    includeDocumentsCommand.Fill(includes, includeMissingAsNull: true);
                                     writer.WriteStartObject();
 
                                     writer.WritePropertyName(docsContext.GetLazyStringForFieldWithCaching(TypeSegment));

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1480,6 +1480,12 @@ namespace Raven.Server.Json
                 return;
             }
 
+            if (document.Data == null && document.NonPersistentFlags.Contain(NonPersistentDocumentFlags.AllowDataAsNull))
+            {
+                writer.WriteNull();
+                return;
+            }
+
             // Explicitly not disposing it, a single document can be
             // used multiple times in a single query, for example, due to projections
             // so we will let the context handle it, rather than handle it directly ourselves

--- a/test/SlowTests/Issues/RavenDB-11166.cs
+++ b/test/SlowTests/Issues/RavenDB-11166.cs
@@ -4,6 +4,7 @@ using FastTests;
 using FastTests.Utils;
 using Raven.Client.Documents.Subscriptions;
 using Sparrow.Server;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -266,6 +267,66 @@ select f(dog)
                             foreach (var item in batch.Items)
                             {
                                 s.Load<Person>(item.Result.Owner);
+                                var dog = s.Load<Dog>(item.Id);
+                                Assert.Same(dog, item.Result);
+                            }
+                            Assert.Equal(0, s.Advanced.NumberOfRequests);
+                        }
+                        mre.Set();
+                    });
+                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(60)));
+                    await sub.DisposeAsync();
+                    await r;// no error
+                }
+
+            }
+        }
+
+        // RavenDB-20829
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task CanUseSubscriptionWithIncludes2()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Person
+                    {
+                        Name = "Arava"
+                    }, "people/1");
+                    session.Store(new Dog
+                    {
+                        Name = "Oscar",
+                        Owner = "people/1"
+                    });
+                    session.Store(new Dog
+                    {
+                        Name = "Oscar2",
+                        Owner = "People/2"
+                    });
+                    session.SaveChanges();
+                }
+                var id = store.Subscriptions.Create(new SubscriptionCreationOptions
+                {
+                    Query = @"from Dogs include Owner"
+                });
+
+                using (var sub = store.Subscriptions.GetSubscriptionWorker<Dog>(id))
+                {
+                    var mre = new AsyncManualResetEvent();
+                    var r = sub.Run(batch =>
+                    {
+                        Assert.NotEmpty(batch.Items);
+                        using (var s = batch.OpenSession())
+                        {
+                            foreach (var item in batch.Items)
+                            {
+                                var owner = s.Load<Person>(item.Result.Owner);
+                                if (item.Result.Owner == "people/1")
+                                    Assert.NotNull(owner);
+                                else
+                                    Assert.Null(owner);
+
                                 var dog = s.Load<Dog>(item.Id);
                                 Assert.Same(dog, item.Result);
                             }


### PR DESCRIPTION
=### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20829
https://github.com/ravendb/ravendb/pull/19086

### Additional description

Add missing include ids to _knownMissingIds in subscription session

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
