### PR TITLE
RavenDB-20829 - add missing include ids to _knownMissingIds in subscription session [v6.0]

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -305,6 +305,11 @@ namespace Raven.Client
 
                         internal const string ResultDataHash = "@data-hash";
                     }
+
+                    internal sealed class Subscription
+                    {
+                        internal const string NonPersistentFlags = "@non-persistent-flags";
+                    }
                 }
             }
 

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1506,7 +1506,7 @@ more responsive application.
             _knownMissingIds.UnionWith(ids);
         }
 
-        internal void RegisterIncludes(BlittableJsonReaderObject includes)
+        internal void RegisterIncludes(BlittableJsonReaderObject includes, bool registerMissingIds = false)
         {
             if (NoTracking)
                 return;
@@ -1520,7 +1520,12 @@ more responsive application.
                 includes.GetPropertyByIndex(i, ref propertyDetails);
 
                 if (propertyDetails.Value is not BlittableJsonReaderObject json)
+                {
+                    if (registerMissingIds)
+                        RegisterMissing(propertyDetails.Name);
+
                     continue;
+                }
 
                 var newDocumentInfo = DocumentInfo.GetNewDocumentInfo(json);
                 if (newDocumentInfo.Metadata.TryGetConflict(out var conflict) && conflict)

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
@@ -120,7 +120,7 @@ namespace Raven.Client.Documents.Subscriptions
             if (_includes?.Count > 0)
             {
                 foreach (var item in _includes)
-                    s.RegisterIncludes(item);
+                    s.RegisterIncludes(item, registerMissingIds: true);
             }
 
             if (_counterIncludes?.Count > 0)

--- a/src/Raven.Server/Documents/Includes/DatabaseIncludesCommandImpl.cs
+++ b/src/Raven.Server/Documents/Includes/DatabaseIncludesCommandImpl.cs
@@ -23,7 +23,7 @@ public class DatabaseIncludesCommandImpl : AbstractIncludesCommand
     public override ValueTask<(long count, long sizeInBytes)> WriteIncludedDocumentsInternalAsync(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, CancellationToken token)
     {
         var includes = new List<Document>();
-        IncludeDocumentsCommand.Fill(includes, includeMissingAsNull: false);
+        IncludeDocumentsCommand.Fill(includes, includeMissingAsNull: true);
         return writer.WriteIncludesAsync(context, includes, token);
     }
 

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -712,18 +712,18 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         QueryResult<List<T>, List<TIncludes>> result, bool metadataOnly, CancellationToken token)
     {
         var missingIncludeIdsByShard = ShardLocator.GetDocumentIdsByShards(context, databaseContext, missingIncludes);
-        await HandleMissingDocumentIncludesInternalAsync(context, request, databaseContext, result, metadataOnly, missingIncludeIdsByShard, token);
+        await HandleMissingDocumentIncludesInternalAsync(context, request, databaseContext, result, missingIds: null, metadataOnly, missingIncludeIdsByShard, token);
     }
 
     public static async ValueTask HandleMissingDocumentIncludesAsync<T, TIncludes>(JsonOperationContext context, HttpRequest request, ShardedDatabaseContext databaseContext, HashSet<string> missingIncludes,
-        QueryResult<List<T>, List<TIncludes>> result, bool metadataOnly, CancellationToken token)
+        QueryResult<List<T>, List<TIncludes>> result, HashSet<string> missingIds, bool metadataOnly, CancellationToken token)
     {
         var missingIncludeIdsByShard = ShardLocator.GetDocumentIdsByShards(databaseContext, missingIncludes);
-        await HandleMissingDocumentIncludesInternalAsync(context, request, databaseContext, result, metadataOnly, missingIncludeIdsByShard, token);
+        await HandleMissingDocumentIncludesInternalAsync(context, request, databaseContext, result, missingIds, metadataOnly, missingIncludeIdsByShard, token);
     }
 
     private static async Task HandleMissingDocumentIncludesInternalAsync<T, TIncludes>(JsonOperationContext context, HttpRequest request, ShardedDatabaseContext databaseContext,
-        QueryResult<List<T>, List<TIncludes>> result, bool metadataOnly, Dictionary<int, ShardLocator.IdsByShard<string>> missingIncludeIdsByShard,
+        QueryResult<List<T>, List<TIncludes>> result, HashSet<string> missingIds, bool metadataOnly, Dictionary<int, ShardLocator.IdsByShard<string>> missingIncludeIdsByShard,
         CancellationToken token)
     {
         var missingIncludesOp = new FetchDocumentsFromShardsOperation(context, request, databaseContext, missingIncludeIdsByShard, includePaths: null,
@@ -734,10 +734,14 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         var blittableIncludes = result.Includes as List<BlittableJsonReaderObject>;
         var documentIncludes = result.Includes as List<Document>;
 
-        foreach (var (_, missing) in missingResult.Result.Documents)
+        foreach (var (docId, missing) in missingResult.Result.Documents)
         {
             if (missing == null)
+            {
                 continue;
+            }
+
+            missingIds?.Add(docId);
 
             if (blittableIncludes != null)
                 blittableIncludes.Add(missing);

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionBatch.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionBatch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Raven.Client;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.Http;
@@ -109,11 +110,11 @@ public sealed class ShardedSubscriptionBatch : SubscriptionBatchBase<BlittableJs
             // we have non-existing included document, need to return null for them to the actual client
             _result.Includes.Add(Context.ReadObject(new DynamicJsonValue
             {
-                [Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                [Constants.Documents.Metadata.Key] = new DynamicJsonValue
                 {
-                    [Client.Constants.Documents.Metadata.Id] = id
-                },
-                [nameof(NonPersistentDocumentFlags)] = NonPersistentDocumentFlags.AllowDataAsNull.ToString()
+                    [Constants.Documents.Metadata.Id] = id,
+                    [Constants.Documents.Metadata.Sharding.Subscription.NonPersistentFlags] = nameof(NonPersistentDocumentFlags.AllowDataAsNull)
+                }
             }, id));
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionBatch.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedSubscriptionBatch.cs
@@ -10,6 +10,7 @@ using Raven.Server.Documents.Sharding.Operations.Queries;
 using Raven.Server.Documents.Sharding.Queries;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Sharding.Subscriptions;
@@ -67,11 +68,12 @@ public sealed class ShardedSubscriptionBatch : SubscriptionBatchBase<BlittableJs
     }
 
     private ShardedQueryResult _result;
+    private HashSet<string> _missingIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-    private ValueTask TryGatherMissingDocumentIncludesAsync(List<BlittableJsonReaderObject> list)
+    private async ValueTask TryGatherMissingDocumentIncludesAsync(List<BlittableJsonReaderObject> list)
     {
         if (list == null || list.Count == 0)
-            return ValueTask.CompletedTask;
+            return;
 
         _result = new ShardedQueryResult
         {
@@ -87,9 +89,33 @@ public sealed class ShardedSubscriptionBatch : SubscriptionBatchBase<BlittableJs
         }
 
         if (missingDocumentIncludes == null)
-            return ValueTask.CompletedTask;
+            return;
+        var processedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        await ShardedQueryProcessor.HandleMissingDocumentIncludesAsync(Context, request: null, _databaseContext, missingDocumentIncludes, _result, processedIds, metadataOnly: false, token: _databaseContext.DatabaseShutdown);
 
-        return ShardedQueryProcessor.HandleMissingDocumentIncludesAsync(Context, request: null, _databaseContext, missingDocumentIncludes, _result, metadataOnly: false, token: _databaseContext.DatabaseShutdown);
+        if (missingDocumentIncludes.Count - processedIds.Count == 0)
+        {
+            // all missing includes exists and were processed
+            return;
+        }
+
+        foreach (var id in missingDocumentIncludes)
+        {
+            if (processedIds.Contains(id))
+            {
+                continue;
+            }
+
+            // we have non-existing included document, need to return null for them to the actual client
+            _result.Includes.Add(Context.ReadObject(new DynamicJsonValue
+            {
+                [Client.Constants.Documents.Metadata.Key] = new DynamicJsonValue
+                {
+                    [Client.Constants.Documents.Metadata.Id] = id
+                },
+                [nameof(NonPersistentDocumentFlags)] = NonPersistentDocumentFlags.AllowDataAsNull.ToString()
+            }, id));
+        }
     }
 
     public void CloneIncludes(ClusterOperationContext context, OrchestratorIncludesCommandImpl includes)

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -412,11 +412,6 @@ namespace Raven.Server.Documents.TcpHandlers
             return SubscriptionBatchStatus.DocumentsSent;
         }
 
-        protected virtual void FillIncludedDocuments(DatabaseIncludesCommandImpl includeDocumentsCommand, List<Document> includes)
-        {
-            includeDocumentsCommand.IncludeDocumentsCommand.Fill(includes, includeMissingAsNull: false);
-        }
-
         protected virtual StatusMessageDetails GetDefault()
         {
             return new StatusMessageDetails

--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnectionForShard.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnectionForShard.cs
@@ -163,11 +163,6 @@ public sealed class SubscriptionConnectionForShard : SubscriptionConnection
         return state;
     }
 
-    protected override void FillIncludedDocuments(DatabaseIncludesCommandImpl includeDocumentsCommand, List<Document> includes)
-    {
-        includeDocumentsCommand.IncludeDocumentsCommand.Fill(includes, includeMissingAsNull: true);
-    }
-
     internal override async Task HandleBatchStatusAsync<TState, TConnection>(TState state, SubscriptionBatchStatus status, Stopwatch sendingCurrentBatchStopwatch, SubscriptionConnectionInUse markInUse, SubscriptionBatchStatsScope batchScope)
     {
         if (status == SubscriptionBatchStatus.ActiveMigration)

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1897,7 +1897,11 @@ namespace Raven.Server.Json
                 first = false;
 
                 writer.WritePropertyName(includeDoc.GetMetadata().GetId());
-                writer.WriteObject(includeDoc);
+
+                if (includeDoc.TryGet(nameof(NonPersistentDocumentFlags), out NonPersistentDocumentFlags flag) && flag.HasFlag(NonPersistentDocumentFlags.AllowDataAsNull))
+                    writer.WriteNull();
+                else
+                    writer.WriteObject(includeDoc);
 
                 await writer.MaybeOuterFlushAsync()
                             .ConfigureAwait(false);

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1896,9 +1896,10 @@ namespace Raven.Server.Json
                     writer.WriteComma();
                 first = false;
 
-                writer.WritePropertyName(includeDoc.GetMetadata().GetId());
+                var metadata = includeDoc.GetMetadata();
+                writer.WritePropertyName(metadata.GetId());
 
-                if (includeDoc.TryGet(nameof(NonPersistentDocumentFlags), out NonPersistentDocumentFlags flag) && flag.HasFlag(NonPersistentDocumentFlags.AllowDataAsNull))
+                if (metadata.TryGet(Constants.Documents.Metadata.Sharding.Subscription.NonPersistentFlags, out NonPersistentDocumentFlags flag) && flag.HasFlag(NonPersistentDocumentFlags.AllowDataAsNull))
                     writer.WriteNull();
                 else
                     writer.WriteObject(includeDoc);


### PR DESCRIPTION
=### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20829
https://github.com/ravendb/ravendb/pull/19085

### Additional description

Add missing include ids to _knownMissingIds in subscription session

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
