### PR TITLE
RavenDB-22744 Report cluster trx index when NoChanges and update cluster trx index on other shard commands

### DIFF
--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -204,6 +204,7 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
                 if (MaxIndex >= 0)
                 {
                     _database.RachisLogIndexNotifications.NotifyListenersAbout(MaxIndex, null);
+                    _database.ClusterWideTransactionIndexWaiter.SetAndNotifyListenersIfHigher(MaxIndex);
                     _database._nextClusterCommand = MaxCommandCount;
                 }
             }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -401,6 +401,8 @@ namespace Raven.Server.ServerWide.Maintenance
 
                     previous.LastSentEtag = dbReport.LastSentEtag;
                     previous.LastCompareExchangeIndex = dbReport.LastCompareExchangeIndex;
+                    previous.LastCompletedClusterTransaction = dbReport.LastCompletedClusterTransaction;
+                    previous.LastClusterWideTransactionRaftIndex = dbReport.LastClusterWideTransactionRaftIndex;
                     previous.UpTime = dbReport.UpTime;
                     nodeReport.Report[dbName] = previous;
                 }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -251,7 +251,7 @@ namespace Raven.Server.ServerWide.Maintenance
                         var dbInstance = dbTask.Result;
                         var currentHash = dbInstance.GetEnvironmentsHash();
                         report.EnvironmentsHash = currentHash;
-                        report.LastCompareExchangeIndex = dbInstance.CompareExchangeStorage.GetLastCompareExchangeIndex(ctx);
+                        FillClusterTransactionInfo(ctx, dbInstance, report);
 
                         var documentsStorage = dbInstance.DocumentsStorage;
                         var indexStorage = dbInstance.IndexStore;
@@ -309,7 +309,6 @@ namespace Raven.Server.ServerWide.Maintenance
                             using (var context = QueryOperationContext.Allocate(dbInstance, needsServerContext: true))
                             {
                                 FillDocumentsInfo(prevDatabaseReport, dbInstance, report, context.Documents, documentsStorage);
-                                FillClusterTransactionInfo(report, dbInstance);
 
                                 if (indexStorage != null)
                                 {
@@ -345,9 +344,9 @@ namespace Raven.Server.ServerWide.Maintenance
             return result;
         }
 
-        private static void FillClusterTransactionInfo(DatabaseStatusReport report, DocumentDatabase dbInstance)
+        private void FillClusterTransactionInfo(ClusterOperationContext ctx, DocumentDatabase dbInstance, DatabaseStatusReport report)
         {
-            report.LastTransactionId = dbInstance.LastTransactionId;
+            report.LastCompareExchangeIndex = dbInstance.CompareExchangeStorage.GetLastCompareExchangeIndex(ctx);
             report.LastCompletedClusterTransaction = dbInstance.LastCompletedClusterTransaction;
             report.LastClusterWideTransactionRaftIndex = dbInstance.ClusterWideTransactionIndexWaiter.LastIndex;
         }
@@ -383,6 +382,7 @@ namespace Raven.Server.ServerWide.Maintenance
         private static void FillDocumentsInfo(DatabaseStatusReport prevDatabaseReport, DocumentDatabase dbInstance, DatabaseStatusReport report,
             DocumentsOperationContext context, DocumentsStorage documentsStorage)
         {
+            report.LastTransactionId = dbInstance.LastTransactionId;
             if (prevDatabaseReport?.LastTransactionId != null && prevDatabaseReport.LastTransactionId == dbInstance.LastTransactionId)
             {
                 report.LastEtag = prevDatabaseReport.LastEtag;


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22744

### Additional description
#### This PR addresses two key issues:
1.  The `ClusterMaintenanceWorker`'s report did not include the `ClusterWideTransactionIndex` when there were no changes in the database storage. As a result, this issue was blocking the compare-exchange tombstone cleanup process.

2. When a cluster-wide transaction does not affect a particular shard, the shard would not update its `ClusterWideTransactionIndex`. Consequently, any future requests to this shard would be blocked if the client has the up-to-date `ClusterWideTransactionIndex`.


### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
