### PR TITLE
RavenDB-22807 - Reduce the contention on the Timer for the CancellationToken

### DIFF
--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -168,6 +168,7 @@ namespace Raven.Client.Util
             if (_readCts == null)
             {
                 _readCts = cancellationToken == default ? new CancellationTokenSource() : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                _readCts.CancelAfter(_readTimeout);
                 _readSw = Stopwatch.StartNew();
 
 #if DEBUG
@@ -225,6 +226,7 @@ namespace Raven.Client.Util
             if (_writeCts == null)
             {
                 _writeCts = cancellationToken == default ? new CancellationTokenSource() : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                _writeCts.CancelAfter(_writeTimeout);
                 _writeSw = Stopwatch.StartNew();
 
 #if DEBUG
@@ -234,7 +236,7 @@ namespace Raven.Client.Util
             else if (_writeSw.ElapsedMilliseconds > MinimumReadDelayTimeInMs)
             {
                 _writeSw.Restart();
-                _writeCts.CancelAfter(_readTimeout);
+                _writeCts.CancelAfter(_writeTimeout);
 
 #if DEBUG
                 if (_requestWriteCts != cancellationToken)

--- a/src/Raven.Server/ServerWide/OperationCancelToken.cs
+++ b/src/Raven.Server/ServerWide/OperationCancelToken.cs
@@ -14,6 +14,7 @@ namespace Raven.Server.ServerWide
         private readonly TimeSpan _cancelAfter;
 
         public readonly CancellationToken Token;
+        private readonly long _minimumDelayTimeInMs;
 
         public OperationCancelToken(TimeSpan cancelAfter, CancellationToken token)
         {
@@ -22,6 +23,8 @@ namespace Raven.Server.ServerWide
             _cts = CancellationTokenSource.CreateLinkedTokenSource(token);
             _cancelAfter = cancelAfter;
             Token = _cts.Token;
+
+            _minimumDelayTimeInMs = GetMinimumDelayTime(cancelAfter);
             _cts.CancelAfter(cancelAfter);
         }
 
@@ -32,6 +35,8 @@ namespace Raven.Server.ServerWide
             _cts = CancellationTokenSource.CreateLinkedTokenSource(token1, token2);
             _cancelAfter = cancelAfter;
             Token = _cts.Token;
+
+            _minimumDelayTimeInMs = GetMinimumDelayTime(cancelAfter);
             _cts.CancelAfter(cancelAfter);
         }
 
@@ -55,16 +60,14 @@ namespace Raven.Server.ServerWide
             if (_cancelAfter == Timeout.InfiniteTimeSpan)
                 throw new InvalidOperationException("Cannot delay cancellation without timeout set.");
 
-            const int minimumDelayTime = 25;
-
-            if (_sw?.ElapsedMilliseconds < minimumDelayTime)
+            if (_sw?.ElapsedMilliseconds < _minimumDelayTimeInMs)
                 return;
 
             lock (this)
             {
                 if (_disposed)
                     return;
-                if (_sw?.ElapsedMilliseconds < minimumDelayTime)
+                if (_sw?.ElapsedMilliseconds < _minimumDelayTimeInMs)
                     return;
 
                 if (_sw == null)
@@ -106,6 +109,11 @@ namespace Raven.Server.ServerWide
             }
 
             _cts?.Dispose();
+        }
+
+        private static long GetMinimumDelayTime(TimeSpan timeSpan)
+        {
+            return Math.Max(250, (long)(timeSpan / 3).TotalMilliseconds);
         }
 
         private static void ValidateCancelAfter(TimeSpan cancelAfter)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22807/Contention-on-the-Timer-for-the-CancellationToken

### Additional description

To minimize contention on the internal .NET lock, we should reduce the frequency of extending the cancellation token.
The internal .NET lock for the timer is per core.
https://github.com/dotnet/runtime/blob/28f729b437590bd34bbdca79bd3f2b6a504b4dcb/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs#L51
https://github.com/dotnet/runtime/blob/28f729b437590bd34bbdca79bd3f2b6a504b4dcb/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs#L514

Test environment
Server: 3 cores, 4.96m documents, recording all contention events above 1ms.
Client: 7 concurrent streaming threads from an index, running for 1 minute

Before:
total read documents : 6,898,868
68 contention events, average contention: 54.42 ms

After:
total read: 7,070,370
42 contention events, average duration: 17.73 ms

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
