### PR TITLE
RavenDB-22634 : prevent creating a database with prefixed sharding in a mixed cluster of 6.1 & 6.0

### DIFF
--- a/test/InterversionTests/RavenDB-22634.cs
+++ b/test/InterversionTests/RavenDB-22634.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Sharding;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace InterversionTests
+{
+    public class RavenDB_22634 : MixedClusterTestBase
+    {
+        public RavenDB_22634(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Sharding, RavenPlatform.Windows, Skip = "WIP")]
+        public async Task MixedCluster_61_and_60_ShouldPreventCreatingDatabaseWithPrefixedSharding()
+        {
+            var (leader, peers, _) = await CreateMixedCluster([
+                "6.0.105",
+                "6.0.105"
+            ]);
+
+            using var leaderStore = new DocumentStore
+            {
+                Urls = [leader.WebUrl, peers[0].Url, peers[1].Url]
+            }.Initialize();
+
+            var dbRec = new DatabaseRecord("prefixed-db")
+            {
+                Sharding = new ShardingConfiguration
+                {
+                    Shards = new Dictionary<int, DatabaseTopology>
+                    {
+                        {0, new DatabaseTopology()},
+                        {1, new DatabaseTopology()},
+                        {2, new DatabaseTopology()}
+                    },
+                    Prefixed = [new PrefixedShardingSetting
+                    {
+                        Prefix = "orders/",
+                        Shards = [2]
+                    }]
+                }
+            };
+
+            var ex = await Assert.ThrowsAsync<RavenException>(async () =>
+                await leaderStore.Maintenance.Server.SendAsync(new CreateDatabaseOperation(dbRec)));
+
+            Assert.Contains("Some nodes in the cluster are running older versions of RavenDB that do not support the Prefixed Sharding feature", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22634/Prefixed-sharding-interversion-manual-testing

### Additional Description
- issue was discovered during manual testing of prefixed sharding in a mixed cluster mode
- when we had a 6.1 leader users were able to create a sharded database with prefixed configuration, but unable to update/add/delete prefixes because these operations are not supported in 6.0
- modified `AdmindatabasesHandler.Put` to throw on attempt to create a sharded database with prefixes when `CurrentClusterMinimalVersion` < 61_000 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
