### PR TITLE
RavenDB-22498 Add the ability to convert auto index to static

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForConvertAutoIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForConvertAutoIndex.cs
@@ -70,26 +70,22 @@ internal class IndexHandlerProcessorForConvertAutoIndex<TRequestHandler, TOperat
             switch (type)
             {
                 case ConversionOutputType.CsharpClass:
+                    var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex);
+
                     if (HasDownload())
-                    {
                         SetFileToDownload($"{sanitizedIndexName}.cs");
-                    }
 
                     await using (var writer = new StreamWriter(RequestHandler.ResponseBodyStream()))
-                    {
-                        var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex);
                         await writer.WriteLineAsync(result);
-                    }
                     break;
                 case ConversionOutputType.Json:
+                    var definition = AutoToStaticIndexConverter.Instance.ConvertToIndexDefinition(autoIndex);
+
                     if (HasDownload())
-                    {
                         SetFileToDownload($"{sanitizedIndexName}.json");
-                    }
 
                     await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
                     {
-                        var definition = AutoToStaticIndexConverter.Instance.ConvertToIndexDefinition(autoIndex);
                         writer.WriteStartObject();
 
                         writer.WritePropertyName("Indexes");

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForConvertAutoIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForConvertAutoIndex.cs
@@ -56,6 +56,8 @@ internal class IndexHandlerProcessorForConvertAutoIndex<TRequestHandler, TOperat
         var name = GetName();
         var type = GetConvertType();
 
+        HttpContext.Response.Headers[Constants.Headers.ContentType] = "text/plain;charset=utf-8";
+
         using (RequestHandler.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
         using (context.OpenReadTransaction())
         {

--- a/src/Raven.Studio/typescript/commands/database/index/getIndexAutoConvertCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/getIndexAutoConvertCommand.ts
@@ -1,0 +1,33 @@
+import commandBase from "commands/commandBase";
+import endpoints = require("endpoints");
+
+export interface IndexAutoConvertArgs {
+    name: string;
+    outputType: Raven.Server.Documents.Handlers.Processors.Indexes.ConversionOutputType;
+    download?: boolean;
+}
+
+export interface IndexAutoConvertToJsonResultsDto {
+    Indexes: Raven.Client.Documents.Indexes.IndexDefinition[];
+}
+
+export class getIndexAutoConvertCommand extends commandBase {
+    private readonly databaseName: string;
+    private readonly urlArgs: IndexAutoConvertArgs;
+
+    constructor(databaseName: string, urlArgs: IndexAutoConvertArgs) {
+        super();
+        this.databaseName = databaseName;
+        this.urlArgs = urlArgs;
+    }
+
+    execute(): JQueryPromise<string> {
+        const url = endpoints.databases.index.indexesAutoConvert + this.urlEncodeArgs(this.urlArgs);
+
+        return this.query<string>(url, null, this.databaseName, null, { dataType: "text" }).fail(
+            (response: JQueryXHR) => {
+                this.reportError("Failed to convert index", response.responseText, response.statusText);
+            }
+        );
+    }
+}

--- a/src/Raven.Studio/typescript/common/shell/databasesManager.ts
+++ b/src/Raven.Studio/typescript/common/shell/databasesManager.ts
@@ -16,6 +16,7 @@ import DatabaseUtils from "components/utils/DatabaseUtils";
 import getDatabasesForStudioCommand from "commands/resources/getDatabasesForStudioCommand";
 import getDatabaseForStudioCommand from "commands/resources/getDatabaseForStudioCommand";
 import StudioDatabaseInfo = Raven.Server.Web.System.Processors.Studio.StudioDatabasesHandlerForGetDatabases.StudioDatabaseInfo;
+import convertedIndexesToStaticStorage = require("common/storage/convertedIndexesToStaticStorage");
 
 class databasesManager {
 
@@ -39,7 +40,8 @@ class databasesManager {
         (q, n) => recentQueriesStorage.onDatabaseDeleted(q, n),
         (q, n) => starredDocumentsStorage.onDatabaseDeleted(q, n),
         (q, n) => savedPatchesStorage.onDatabaseDeleted(q, n),
-        (q, n) => mergedIndexesStorage.onDatabaseDeleted(q, n)
+        (q, n) => mergedIndexesStorage.onDatabaseDeleted(q, n),
+        (q, n) => convertedIndexesToStaticStorage.onDatabaseDeleted(q, n),
     ];
 
     getDatabaseByName(name: string): database {

--- a/src/Raven.Studio/typescript/common/storage/convertedIndexesToStaticStorage.ts
+++ b/src/Raven.Studio/typescript/common/storage/convertedIndexesToStaticStorage.ts
@@ -1,0 +1,64 @@
+﻿/// <reference path="../../../typings/tsd.d.ts" />
+
+import storageKeyProvider = require("common/storage/storageKeyProvider");
+
+interface StoredConvertedToStaticIndex {
+    definition: Raven.Client.Documents.Indexes.IndexDefinition;
+}
+
+class convertedIndexesToStaticStorage {
+    static getIndex(databaseName: string, indexName: string): StoredConvertedToStaticIndex | null {
+        const localStorageKey = convertedIndexesToStaticStorage.getLocalStorageKey(databaseName, indexName);
+        const index: StoredConvertedToStaticIndex = localStorage.getObject(localStorageKey);
+
+        if (!index) {
+            return null;
+        }
+
+        if ("definition" in index) {
+            return index;
+        } else {
+            throw new Error("Saved index definition has malformed format");
+        }
+    }
+
+    static saveIndex(databaseName: string, definition: Raven.Client.Documents.Indexes.IndexDefinition): string {
+        const indexName = "converted-to-static-" + new Date().getTime();
+        const localStorageKey = convertedIndexesToStaticStorage.getLocalStorageKey(databaseName, indexName);
+
+        const toStore: StoredConvertedToStaticIndex = {
+            definition,
+        };
+
+        localStorage.setObject(localStorageKey, toStore);
+
+        return indexName;
+    }
+
+    private static getStoragePrefixForDatabase(dbName: string) {
+        return storageKeyProvider.storageKeyFor("convertedToStaticIndex." + dbName);
+    }
+
+    private static getLocalStorageKey(databaseName: string, id: string) {
+        return convertedIndexesToStaticStorage.getStoragePrefixForDatabase(databaseName) + "." + id;
+    }
+
+    static onDatabaseDeleted(_: string, name: string) {
+        const prefix = convertedIndexesToStaticStorage.getStoragePrefixForDatabase(name);
+
+        const keysToDelete = [] as string[];
+
+        for (let i = 0; i < localStorage.length; i++) {
+            const key = localStorage.key(0);
+            if (key.startsWith(prefix)) {
+                keysToDelete.push(key);
+            }
+        }
+
+        keysToDelete.forEach((key) => {
+            localStorage.removeItem(key);
+        });
+    }
+}
+
+export = convertedIndexesToStaticStorage;

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/MergeIndexesCard.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/MergeIndexesCard.tsx
@@ -65,7 +65,7 @@ function MainPanel({ mergable }: MergeIndexesCardProps) {
             </div>
 
             {mergable.data.map((mergableGroup, groupKey) => (
-                <RichPanel key={"mergeGroup-" + mergableGroup.mergedIndexDefinition.Name} hover>
+                <RichPanel key={"mergeGroup-" + groupKey} hover>
                     <RichPanelHeader className="px-3 py-2 flex-wrap flex-row gap-3">
                         <div className="mt-1">
                             <Button

--- a/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
@@ -119,7 +119,9 @@ class indexDefinition {
         this.priority(dto.Priority);
         this.configuration(this.parseConfiguration(dto.Configuration));
 
-        this.additionalSources(Object.entries(dto.AdditionalSources).map(([name, code]) => additionalSource.create(name, code)));
+        if (dto.AdditionalSources) {
+            this.additionalSources(Object.entries(dto.AdditionalSources).map(([name, code]) => additionalSource.create(name, code)));
+        }
         
         if (dto.AdditionalAssemblies) {
             this.additionalAssemblies(dto.AdditionalAssemblies.map(assembly => new additionalAssembly(assembly)));

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/convertToStaticDialog.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/convertToStaticDialog.ts
@@ -1,0 +1,96 @@
+import dialog = require("plugins/dialog");
+import dialogViewModelBase = require("viewmodels/dialogViewModelBase");
+import {
+    getIndexAutoConvertCommand,
+    IndexAutoConvertArgs,
+    IndexAutoConvertToJsonResultsDto,
+} from "commands/database/index/getIndexAutoConvertCommand";
+import appUrl = require("common/appUrl");
+import router = require("plugins/router");
+import convertedIndexesToStaticStorage = require("common/storage/convertedIndexesToStaticStorage");
+import assertUnreachable from "components/utils/assertUnreachable";
+import fileDownloader = require("common/fileDownloader");
+
+type ConversionOutputType = Raven.Server.Documents.Handlers.Processors.Indexes.ConversionOutputType;
+
+class convertToStaticDialog extends dialogViewModelBase {
+    view = require("views/database/indexes/convertToStaticDialog.html");
+
+    readonly indexName: string;
+    readonly databaseName: string;
+
+    constructor(indexName: string, databaseName: string) {
+        super();
+
+        this.indexName = indexName;
+        this.databaseName = databaseName;
+
+        this.downloadConvertedIndex = this.downloadConvertedIndex.bind(this);
+        this.createNewStaticIndex = this.createNewStaticIndex.bind(this);
+    }
+
+    attached() {
+        // empty by design
+    }
+
+    close() {
+        dialog.close(this);
+    }
+
+    private getIndexDefinitionFromJson(result: string): Raven.Client.Documents.Indexes.IndexDefinition {
+        // right now we only support one index
+        return (JSON.parse(result) as IndexAutoConvertToJsonResultsDto).Indexes[0];
+    }
+
+    downloadConvertedIndex(outputType: ConversionOutputType) {
+        const args: IndexAutoConvertArgs = {
+            name: this.indexName,
+            outputType,
+            download: true,
+        };
+
+        new getIndexAutoConvertCommand(this.databaseName, args)
+            .execute()
+            .then((result, _, x) => {
+                const xhr = x as unknown as XMLHttpRequest;
+                const fileName = xhr.getResponseHeader("Content-Disposition").match(/filename="(.*?)"/)[1];
+
+                switch (outputType) {
+                    case "CsharpClass":
+                        fileDownloader.downloadAsTxt(result, fileName);
+                        break;
+                    case "Json":
+                        fileDownloader.downloadAsJson(this.getIndexDefinitionFromJson(result), fileName);
+                        break;
+                    default:
+                        assertUnreachable(outputType);
+                }
+            })
+            .always(() => {
+                this.close();
+            });
+    }
+
+    async createNewStaticIndex() {
+        const args: IndexAutoConvertArgs = {
+            name: this.indexName,
+            outputType: "Json",
+        };
+
+        try {
+            const convertedIndex = await new getIndexAutoConvertCommand(this.databaseName, args).execute();
+
+            const newIndexName = convertedIndexesToStaticStorage.saveIndex(
+                this.databaseName,
+                this.getIndexDefinitionFromJson(convertedIndex) 
+            );
+
+            const targetUrl = appUrl.forEditIndex(newIndexName, this.databaseName);
+            router.navigate(targetUrl);
+        } finally {
+            this.close();
+        }
+    }
+}
+
+export = convertToStaticDialog;

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/convertToStaticDialog.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/convertToStaticDialog.html
@@ -1,0 +1,37 @@
+<div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+        <div class="modal-header">
+            <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                <i class="icon-cancel"></i>
+            </button>
+            <h3 class="modal-title">Convert to static index</h3>
+        </div>
+        <div class="modal-body vstack gap-2">
+
+            <div class="form-group word-break">
+                <label class="control-label">Index Name</label>
+                <strong class="form-control-static" data-bind="text: indexName"></strong>
+            </div>
+            
+            <div class="hstack gap-2">
+                <button class="btn btn-primary" data-bind="click: createNewStaticIndex" title="Create static index">
+                    <i class="icon-index icon-addon-plus"></i> Create new static index
+                </button>
+                <button class="btn btn-secondary" data-bind="click: () => downloadConvertedIndex('Json')" title="Download static index as JSON">
+                    <i class="icon-download"></i> Download JSON
+                </button>
+                <button class="btn btn-secondary" data-bind="click: () => downloadConvertedIndex('CsharpClass')" title="Download static index as C# class">
+                    <i class="icon-download"></i> Download C# Class
+                </button>
+            </div>
+
+        </div>
+        <div class="modal-footer">
+            <div>
+                <button class="btn btn-default" data-bind="click: close" title="Close this dialog">
+                    <i class="icon-cancel"></i><span>Close</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
@@ -734,6 +734,12 @@
                                         <span>Optimize</span>
                                     </a>
                                 </li>
+                                <li title="Convert to static index">
+                                    <a href="#" data-bind="click: openConvertToStaticDialog">
+                                        <i class="icon-replace"></i>
+                                        <span>Convert to static</span>
+                                    </a>
+                                </li>
                             </ul>
                         </div>
                         <button class="btn btn-danger" data-bind="visible: isEditingExistingIndex, click: deleteIndex, requiredAccess: 'DatabaseReadWrite'" title="Delete this index">

--- a/test/SlowTests/Issues/RavenDB_22498.cs
+++ b/test/SlowTests/Issues/RavenDB_22498.cs
@@ -45,7 +45,7 @@ public class RavenDB_22498 : RavenTestBase
 
             var autoIndex = record.AutoIndexes.Values.First();
 
-            var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex, out _);
+            var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex);
 
             RavenTestHelper.AssertEqualRespectingNewLines("""
                                                           public class Index_Orders_ByEmployeeAndSearch_Company_AndShipTo_City : Raven.Client.Documents.Indexes.AbstractIndexCreationTask<Order>
@@ -99,7 +99,7 @@ public class RavenDB_22498 : RavenTestBase
 
             var autoIndex = record.AutoIndexes.Values.First();
 
-            var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex, out _);
+            var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex);
 
             RavenTestHelper.AssertEqualRespectingNewLines("""
                                                           public class Index_Orders_By_metadata_Is_Nice : Raven.Client.Documents.Indexes.AbstractIndexCreationTask<Order>
@@ -148,7 +148,7 @@ public class RavenDB_22498 : RavenTestBase
 
             var autoIndex = record.AutoIndexes.Values.First();
 
-            var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex, out _);
+            var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex);
 
             RavenTestHelper.AssertEqualRespectingNewLines("""
                                                           public class Index__empty_ByColl : Raven.Client.Documents.Indexes.AbstractIndexCreationTask<object>
@@ -202,7 +202,7 @@ public class RavenDB_22498 : RavenTestBase
 
             var autoIndex = record.AutoIndexes.Values.First();
 
-            var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex, out _);
+            var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex);
 
             RavenTestHelper.AssertEqualRespectingNewLines("""
                                                           public class Index_Orders_ByCountReducedByCompany : Raven.Client.Documents.Indexes.AbstractIndexCreationTask<Order, Index_Orders_ByCountReducedByCompany.Result>
@@ -287,7 +287,7 @@ public class RavenDB_22498 : RavenTestBase
                     IndexDefinition def = null;
                     try
                     {
-                        var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex, out _);
+                        var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex);
                         def = AutoToStaticIndexConverter.Instance.ConvertToIndexDefinition(autoIndex);
                     }
                     catch (NotSupportedException)

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -72,6 +72,7 @@ using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Handlers.Admin;
 using Raven.Server.Documents.Handlers.Batches;
 using Raven.Server.Documents.Handlers.Debugging;
+using Raven.Server.Documents.Handlers.Processors.Indexes;
 using Raven.Server.Documents.Indexes.Debugging;
 using Raven.Server.Documents.Indexes.IndexMerging;
 using Raven.Server.Documents.Indexes.Spatial;
@@ -328,6 +329,7 @@ namespace TypingsGenerator
             scripter.AddType(typeof(TestIndexParameters));
             scripter.AddType(typeof(TestIndexResult));
             scripter.AddType(typeof(IndexResetMode));
+            scripter.AddType(typeof(ConversionOutputType));
 
             // cluster
             scripter.AddType(typeof(ClusterTopology));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22498/Add-the-ability-to-convert-auto-index-to-static

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
