### PR TITLE
RavenDB-22317 Extract field name in group by from more kinds of expression if possible

### DIFF
--- a/test/SlowTests/Issues/RavenDB-22317.cs
+++ b/test/SlowTests/Issues/RavenDB-22317.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22317 : RavenTestBase
+{
+    public RavenDB_22317(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIndexWithGroupByUsingMethod()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var foo1 = new Foo() { Day = DayOfWeek.Monday, Value = "Monday" };
+                var foo2 = new Foo() { Day = DayOfWeek.Friday, Value = "Friday" };
+                var foo3 = new Foo() { Day = DayOfWeek.Monday, Value = "Monday again" };
+                
+                session.Store(foo1);
+                session.Store(foo2);
+                session.Store(foo3);
+                
+                session.SaveChanges();
+                
+                var index = new FooIndex();
+            
+                index.Execute(store);
+            
+                Indexes.WaitForIndexing(store);
+                
+                var mondayResult = session.Query<FooIndex.Result, FooIndex>().Where(x => x.Day == DayOfWeek.Monday).ToList();
+                
+                Assert.Equal(1, mondayResult.Count);
+                
+                Assert.Equal(2, mondayResult.First().Values.Length);
+                
+                var fridayResult = session.Query<FooIndex.Result, FooIndex>().Where(x => x.Day == DayOfWeek.Friday).ToList();
+                
+                Assert.Equal(1, fridayResult.Count);
+                
+                Assert.Equal(1, fridayResult.First().Values.Length);
+            }
+        }
+    }
+    
+    private class Foo
+    {
+        public string Id { get; set; }
+
+        public DayOfWeek Day { get; set; }
+
+        public string Value { get; set; }
+    }
+
+    private class FooIndex : AbstractIndexCreationTask<Foo, FooIndex.Result>
+    {
+        public FooIndex()
+        {
+            Map = foos =>
+                from f in foos
+                select new Result { Day = f.Day, Values = new[] { f.Value }, };
+
+            Reduce = results =>
+                from result in results
+                group result by new { Day = IndexHelper.EnsureEnum(result.Day) }
+                into g
+                select new Result { Day = g.Key.Day, Values = g.SelectMany(x => x.Values).ToArray() };
+
+            AdditionalSources = new()
+            {
+                {
+                    "RavenEnumReduce", @"
+                    public static class IndexHelper 
+                    {
+                        public static string[] DaysOfWeek = new string[] { ""Sunday"", ""Monday"", ""Tuesday"", ""Wednesday"", ""Thursday"", ""Friday"", ""Saturday"" };
+                        public static string EnsureEnum(object value)
+                        {
+                            if (value is string s)
+                            {
+                                return s;
+                            }
+
+                            if (value is Sparrow.Json.LazyStringValue lsv)
+                            {
+                                return lsv.ToString();
+                            }
+
+                            return DaysOfWeek[(int)value];
+                        }
+                    }
+                    "
+                }
+            };
+        }
+
+        public class Result
+        {
+            public DayOfWeek Day { get; set; }
+            public string[] Values { get; set; }
+        }
+
+        private static class IndexHelper
+        {
+            public static DayOfWeek EnsureEnum(object value) => throw new Exception();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22317/Index-compiler-cannot-extract-Group-By-field-name

### Additional description

When extracting field names from `group by` expression with multiple fields, if it's not possible to extract field name from the expression, we should try to get it from `NameEquals` property.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
