### PR TITLE
RavenDB-22564 Added test for index with recurse

### DIFF
--- a/test/SlowTests/Issues/RavenDB-22564.cs
+++ b/test/SlowTests/Issues/RavenDB-22564.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22564 : RavenTestBase
+{
+    public RavenDB_22564(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIndexWithRecursion()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var index = new TestIndex();
+            
+            index.Execute(store);
+            
+            using (var session = store.OpenSession())
+            {
+                var o1 = new TestObj { Prop = "o1" };
+                var o2 = new TestObj { Prop = "o2" };
+                
+                session.Store(o1);
+                session.Store(o2);
+        
+                var o3 = new TestObj
+                {
+                    Prop = "o3",
+                    Children = new []
+                    {
+                        o1.Id,
+                        o2.Id
+                    }
+                };
+                
+                session.Store(o3);
+                
+                var o4 = new TestObj { Prop = "o4" };
+                var o5 = new TestObj { Prop = "o5" };
+                
+                session.Store(o4);
+                session.Store(o5);
+                
+                var o6 = new TestObj
+                {
+                    Prop = "o6",
+                    Children = new []
+                    {
+                        o4.Id,
+                        o5.Id
+                    }
+                };
+                
+                session.Store(o6);
+
+                session.Store(new TestObj { Prop = "o7", Children = new[] { o3.Id, o6.Id } });
+                session.SaveChanges();
+
+                Indexes.WaitForIndexing(store);
+            
+                var result = session.Query<TestIndex.Result, TestIndex>()
+                    .Where(x => x.Prop == "o7")
+                    .Select(x => x.Count)
+                    .ToList();
+                
+                Assert.Equal(7, result.First());
+            }
+        }
+    }
+    
+    private class TestObj
+    {
+        public string Id { get; set; }
+        public IEnumerable<string> Children { get; set; }
+        public string Prop { get; set; }
+    }
+
+    private class TestIndex : AbstractIndexCreationTask<TestObj, TestIndex.Result>
+    {
+        public class Result
+        {
+            public string Prop { get; set; }
+            public string Children { get; set; }
+            public int Count { get; set; }
+        }
+        public TestIndex()
+        {
+            Map = objs => from o in objs
+                let children = Recurse(o, x => LoadDocument<TestObj>(x.Children))
+                select new Result
+                {
+                    Prop = o.Prop, 
+                    Children = string.Join(", ", children.Where(x => x != null).Select(x => x.Prop)),
+                    Count = children.Count(x => x != null)
+                };
+        
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22564/Incorrect-Count-When-Using-Recurse-in-Index-Result-Is-Off-by-One

### Additional description

Loading document recursively can lead to nulls being returned for nodes with no children. It should be handled either in recurse function itself or during further processing of recurse results.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
