### PR TITLE
RavenDB-21273 - Fix Time Series license restrictions

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -290,7 +290,7 @@ namespace Raven.Server.ServerWide
             if (databaseRecord.TimeSeries == null)
                 return;
 
-            if (databaseRecord.TimeSeries.Collections.Count > 0 && databaseRecord.TimeSeries.Collections.All(x => x.Value.Disabled))
+            if (databaseRecord.TimeSeries.Collections.Count == 0 || databaseRecord.TimeSeries.Collections.All(x => x.Value.Disabled))
                 return;
 
             throw new LicenseLimitException(LimitType.TimeSeriesRollupsAndRetention, "Your license doesn't support adding Time Series Rollups And Retention feature.");

--- a/test/FastTests/Server/Basic/SampleData.cs
+++ b/test/FastTests/Server/Basic/SampleData.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Raven.Client.Documents.Smuggler;
 using Tests.Infrastructure;
 using Xunit.Abstractions;
 
@@ -15,7 +16,14 @@ namespace FastTests.Server.Basic
         {
             using (var store = GetDocumentStore())
             {
-                await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(operateOnTypes: 
+                    DatabaseItemType.Documents | 
+                    DatabaseItemType.RevisionDocuments |
+                    DatabaseItemType.Indexes |
+                    DatabaseItemType.CompareExchange |
+                    DatabaseItemType.Attachments |
+                    DatabaseItemType.CounterGroups |
+                    DatabaseItemType.TimeSeries));
             }
         }
     }

--- a/test/FastTests/Server/Basic/SampleData.cs
+++ b/test/FastTests/Server/Basic/SampleData.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace FastTests.Server.Basic
+{
+    public class SampleData : RavenTestBase
+    {
+        public SampleData(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Smuggler)]
+        public async Task CanCreateSampleData()
+        {
+            using (var store = GetDocumentStore())
+            {
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21273/Import-should-check-for-license-restrictions

### Additional description

Fix Time Series license restrictions.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
