### PR TITLE
RavenDB-22806 Cannot filter current == null in revisions subscription

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/RevisionsSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/RevisionsSubscriptionProcessor.cs
@@ -43,6 +43,8 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
 
                 size += new Size(item.Current.Data?.Size ?? 0, SizeUnit.Bytes);
 
+                using (var oldCurData = item.Current.Data)
+                using (var oldPrevData = item.Previous?.Data)
                 using (item.Current)
                 using (item.Previous)
                 {

--- a/test/SlowTests/Client/Subscriptions/RevisionsSubscriptions.cs
+++ b/test/SlowTests/Client/Subscriptions/RevisionsSubscriptions.cs
@@ -465,6 +465,9 @@ select { Id: id(d.Current), Age: d.Current.Age }
             }
         }
 
+        private string _jsonString =
+                "{\r\n    \"BuildVersion\": 54,\r\n    \"DatabaseRecord\": {\r\n        \"DatabaseName\": \"test111\",\r\n        \"Encrypted\": false,\r\n        \"UnusedDatabaseIds\": [],\r\n        \"LockMode\": \"Unlock\",\r\n        \"ConflictSolverConfig\": null,\r\n        \"Settings\": [],\r\n        \"Revisions\": {\r\n            \"Default\": null,\r\n            \"Collections\": {\r\n                \"Orders\": {\r\n                    \"Disabled\": false,\r\n                    \"MinimumRevisionsToKeep\": null,\r\n                    \"MinimumRevisionAgeToKeep\": null,\r\n                    \"PurgeOnDelete\": false,\r\n                    \"MaximumRevisionsToDeleteUponDocumentUpdate\": null\r\n                }\r\n            }\r\n        },\r\n        \"TimeSeries\": {},\r\n        \"DocumentsCompression\": {\r\n            \"Collections\": [],\r\n            \"CompressAllCollections\": false,\r\n            \"CompressRevisions\": true\r\n        },\r\n        \"Expiration\": null,\r\n        \"Refresh\": null,\r\n        \"Client\": null,\r\n        \"Sorters\": {},\r\n        \"Analyzers\": {},\r\n          \"RavenConnectionStrings\": {},\r\n        \"SqlConnectionStrings\": {},\r\n        \"PeriodicBackups\": [],\r\n        \"ExternalReplications\": [],\r\n        \"RavenEtls\": [],\r\n        \"SqlEtls\": [],\r\n        \"HubPullReplications\": [],\r\n        \"SinkPullReplications\": [],\r\n        \"OlapConnectionStrings\": {},\r\n        \"OlapEtls\": [],\r\n        \"ElasticSearchConnectionStrings\": {},\r\n        \"ElasticSearchEtls\": [],\r\n        \"QueueConnectionStrings\": {},\r\n        \"QueueEtls\": []\r\n    },\r\n    \"Docs\": [],\r\n    \"RevisionDocuments\": [{\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }, {\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 2.0,\r\n                    \"Product\": \"products/33-A\",\r\n                    \"ProductName\": \"Geitost\",\r\n                    \"Quantity\": 25\r\n                }, {\r\n                    \"Discount\": 0.0,\r\n                    \"PricePerUnit\": 27.2000,\r\n                    \"Product\": \"products/60-A\",\r\n                    \"ProductName\": \"Camembert Pierrot\",\r\n                    \"Quantity\": 40\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:93-OSKWIRBEDEGoAxbEIiFJeQ\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:53.0456146Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }, {\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 2.0,\r\n                    \"Product\": \"products/33-A\",\r\n                    \"ProductName\": \"Geitost\",\r\n                    \"Quantity\": 25\r\n                }, {\r\n                    \"Discount\": 0.0,\r\n                    \"PricePerUnit\": 27.2000,\r\n                    \"Product\": \"products/60-A\",\r\n                    \"ProductName\": \"Camembert Pierrot\",\r\n                    \"Quantity\": 40\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:93-F9I6Egqwm0Kz+K0oFVIR9Q\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:53.0456146Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }, {\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 2.0,\r\n                    \"Product\": \"products/33-A\",\r\n                    \"ProductName\": \"Geitost\",\r\n                    \"Quantity\": 25\r\n                }, {\r\n                    \"Discount\": 0.0,\r\n                    \"PricePerUnit\": 27.2000,\r\n                    \"Product\": \"products/60-A\",\r\n                    \"ProductName\": \"Camembert Pierrot\",\r\n                    \"Quantity\": 40\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:2144-IG4VwBTOnkqoT/uwgm2OQg\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:53.8295488Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"City\": \"Charleroi\",\r\n                \"Region\": null,\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Country\": \"Belgium\",\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                }\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"Freight\": 51.3000,\r\n            \"Lines\": [],\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:3804-IG4VwBTOnkqoT/uwgm2OQg\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:53.9801503Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8000,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:5478-IG4VwBTOnkqoT/uwgm2OQg\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:54.1021446Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }, {\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 2.0000,\r\n                    \"Product\": \"products/33-A\",\r\n                    \"ProductName\": \"Geitost\",\r\n                    \"Quantity\": 25\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:5480-IG4VwBTOnkqoT/uwgm2OQg\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:54.1022519Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }, {\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 2.0,\r\n                    \"Product\": \"products/33-A\",\r\n                    \"ProductName\": \"Geitost\",\r\n                    \"Quantity\": 25\r\n                }, {\r\n                    \"Discount\": 0.0,\r\n                    \"PricePerUnit\": 27.2000,\r\n                    \"Product\": \"products/60-A\",\r\n                    \"ProductName\": \"Camembert Pierrot\",\r\n                    \"Quantity\": 40\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:5482-IG4VwBTOnkqoT/uwgm2OQg\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:54.1024494Z\"\r\n            }\r\n        }, {\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:2568-F9I6Egqwm0Kz+K0oFVIR9Q, A:13366-IG4VwBTOnkqoT/uwgm2OQg, A:2568-OSKWIRBEDEGoAxbEIiFJeQ, A:17614-jxcHZAmE70Kb2y3I+eaWdw\",\r\n                \"@flags\": \"HasRevisions, DeleteRevision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2024-01-18T12:12:36.5474797Z\"\r\n            }\r\n        }\r\n    ]\r\n}\r\n";
+
         [RavenTheory(RavenTestCategory.Subscriptions)]
         [InlineData(@"from Orders (Revisions = true) as docs
 select {
@@ -490,9 +493,7 @@ select {
 }")]
         public async Task CanReturnMetadataInRevisionsSubscription(string query)
         {
-            var jsonString =
-                "{\r\n    \"BuildVersion\": 54,\r\n    \"DatabaseRecord\": {\r\n        \"DatabaseName\": \"test111\",\r\n        \"Encrypted\": false,\r\n        \"UnusedDatabaseIds\": [],\r\n        \"LockMode\": \"Unlock\",\r\n        \"ConflictSolverConfig\": null,\r\n        \"Settings\": [],\r\n        \"Revisions\": {\r\n            \"Default\": null,\r\n            \"Collections\": {\r\n                \"Orders\": {\r\n                    \"Disabled\": false,\r\n                    \"MinimumRevisionsToKeep\": null,\r\n                    \"MinimumRevisionAgeToKeep\": null,\r\n                    \"PurgeOnDelete\": false,\r\n                    \"MaximumRevisionsToDeleteUponDocumentUpdate\": null\r\n                }\r\n            }\r\n        },\r\n        \"TimeSeries\": {},\r\n        \"DocumentsCompression\": {\r\n            \"Collections\": [],\r\n            \"CompressAllCollections\": false,\r\n            \"CompressRevisions\": true\r\n        },\r\n        \"Expiration\": null,\r\n        \"Refresh\": null,\r\n        \"Client\": null,\r\n        \"Sorters\": {},\r\n        \"Analyzers\": {},\r\n          \"RavenConnectionStrings\": {},\r\n        \"SqlConnectionStrings\": {},\r\n        \"PeriodicBackups\": [],\r\n        \"ExternalReplications\": [],\r\n        \"RavenEtls\": [],\r\n        \"SqlEtls\": [],\r\n        \"HubPullReplications\": [],\r\n        \"SinkPullReplications\": [],\r\n        \"OlapConnectionStrings\": {},\r\n        \"OlapEtls\": [],\r\n        \"ElasticSearchConnectionStrings\": {},\r\n        \"ElasticSearchEtls\": [],\r\n        \"QueueConnectionStrings\": {},\r\n        \"QueueEtls\": []\r\n    },\r\n    \"Docs\": [],\r\n    \"RevisionDocuments\": [{\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }, {\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 2.0,\r\n                    \"Product\": \"products/33-A\",\r\n                    \"ProductName\": \"Geitost\",\r\n                    \"Quantity\": 25\r\n                }, {\r\n                    \"Discount\": 0.0,\r\n                    \"PricePerUnit\": 27.2000,\r\n                    \"Product\": \"products/60-A\",\r\n                    \"ProductName\": \"Camembert Pierrot\",\r\n                    \"Quantity\": 40\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:93-OSKWIRBEDEGoAxbEIiFJeQ\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:53.0456146Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }, {\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 2.0,\r\n                    \"Product\": \"products/33-A\",\r\n                    \"ProductName\": \"Geitost\",\r\n                    \"Quantity\": 25\r\n                }, {\r\n                    \"Discount\": 0.0,\r\n                    \"PricePerUnit\": 27.2000,\r\n                    \"Product\": \"products/60-A\",\r\n                    \"ProductName\": \"Camembert Pierrot\",\r\n                    \"Quantity\": 40\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:93-F9I6Egqwm0Kz+K0oFVIR9Q\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:53.0456146Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }, {\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 2.0,\r\n                    \"Product\": \"products/33-A\",\r\n                    \"ProductName\": \"Geitost\",\r\n                    \"Quantity\": 25\r\n                }, {\r\n                    \"Discount\": 0.0,\r\n                    \"PricePerUnit\": 27.2000,\r\n                    \"Product\": \"products/60-A\",\r\n                    \"ProductName\": \"Camembert Pierrot\",\r\n                    \"Quantity\": 40\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:2144-IG4VwBTOnkqoT/uwgm2OQg\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:53.8295488Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"City\": \"Charleroi\",\r\n                \"Region\": null,\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Country\": \"Belgium\",\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                }\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"Freight\": 51.3000,\r\n            \"Lines\": [],\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:3804-IG4VwBTOnkqoT/uwgm2OQg\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:53.9801503Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8000,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:5478-IG4VwBTOnkqoT/uwgm2OQg\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:54.1021446Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }, {\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 2.0000,\r\n                    \"Product\": \"products/33-A\",\r\n                    \"ProductName\": \"Geitost\",\r\n                    \"Quantity\": 25\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:5480-IG4VwBTOnkqoT/uwgm2OQg\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:54.1022519Z\"\r\n            }\r\n        }, {\r\n            \"Company\": \"companies/76-A\",\r\n            \"Employee\": \"employees/4-A\",\r\n            \"Freight\": 51.3,\r\n            \"Lines\": [{\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 64.8,\r\n                    \"Product\": \"products/20-A\",\r\n                    \"ProductName\": \"Sir Rodney's Marmalade\",\r\n                    \"Quantity\": 40\r\n                }, {\r\n                    \"Discount\": 0.05,\r\n                    \"PricePerUnit\": 2.0,\r\n                    \"Product\": \"products/33-A\",\r\n                    \"ProductName\": \"Geitost\",\r\n                    \"Quantity\": 25\r\n                }, {\r\n                    \"Discount\": 0.0,\r\n                    \"PricePerUnit\": 27.2000,\r\n                    \"Product\": \"products/60-A\",\r\n                    \"ProductName\": \"Camembert Pierrot\",\r\n                    \"Quantity\": 40\r\n                }\r\n            ],\r\n            \"OrderedAt\": \"1996-07-09T00:00:00.0000000\",\r\n            \"RequireAt\": \"1996-08-06T00:00:00.0000000\",\r\n            \"ShipTo\": {\r\n                \"City\": \"Charleroi\",\r\n                \"Country\": \"Belgium\",\r\n                \"Line1\": \"Boulevard Tirou, 255\",\r\n                \"Line2\": null,\r\n                \"Location\": {\r\n                    \"Latitude\": 50.4062634,\r\n                    \"Longitude\": 4.4470125\r\n                },\r\n                \"PostalCode\": \"B-6000\",\r\n                \"Region\": null\r\n            },\r\n            \"ShipVia\": \"shippers/2-A\",\r\n            \"ShippedAt\": \"1996-07-11T00:00:00.0000000\",\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:5482-IG4VwBTOnkqoT/uwgm2OQg\",\r\n                \"@flags\": \"HasRevisions, Revision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2018-07-27T12:11:54.1024494Z\"\r\n            }\r\n        }, {\r\n            \"@metadata\": {\r\n                \"@collection\": \"Orders\",\r\n                \"@change-vector\": \"A:2568-F9I6Egqwm0Kz+K0oFVIR9Q, A:13366-IG4VwBTOnkqoT/uwgm2OQg, A:2568-OSKWIRBEDEGoAxbEIiFJeQ, A:17614-jxcHZAmE70Kb2y3I+eaWdw\",\r\n                \"@flags\": \"HasRevisions, DeleteRevision\",\r\n                \"@id\": \"orders/5-A\",\r\n                \"@last-modified\": \"2024-01-18T12:12:36.5474797Z\"\r\n            }\r\n        }\r\n    ]\r\n}\r\n";
-
+            var jsonString = _jsonString;
             using (var store = GetDocumentStore())
             {
                 using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(jsonString)))
@@ -599,18 +600,237 @@ select {
 
                     }
 
-                    metadata = (IDictionary<string, object>)((IDictionary<string, object>)results[revisions.Count - 1])["@metadata"];
                     var l = revisions.Last();
-                    Assert.Equal((string)metadata["@change-vector"], l.CurrentChangeVector);
-                    Assert.Equal((string)metadata["@change-vector"], l.CurrentMetadata["@change-vector"]);
-
-                    Assert.Equal((string)metadata["@id"], l.CurrentId);
-                    Assert.Equal((string)metadata["@id"], l.CurrentMetadata["@id"]);
+                    Assert.Null(l.Current);
+                    Assert.Null(l.CurrentMetadata);
+                    Assert.Null(l.CurrentId);
+                    Assert.Null(l.CurrentChangeVector);
 
                     Assert.NotNull(l.Previous);
                     Assert.NotNull(l.PreviousMetadata);
                     Assert.NotNull(l.PreviousId);
                     Assert.NotNull(l.PreviousChangeVector);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task CanReturnFilterRevisionsSubscriptionByCurrentIsNull()
+        {
+            string query = @"from Orders (Revisions = true) as docs
+                    where docs.Current == null
+                    select {
+                        Current: docs.Current,
+                        Previous: docs.Previous,
+                        CurrentMetadata: docs.Current[""@metadata""],
+                        PreviousMetadata: docs.Previous[""@metadata""],
+                        CurrentId: id(docs.Current),
+                        PreviousId: id(docs.Previous),
+                        CurrentChangeVector: docs.Current == null ? null : metadataFor(docs.Current)[""@change-vector""],
+                        PreviousChangeVector: docs.Previous == null ? null : metadataFor(docs.Previous)[""@change-vector""]
+                    }";
+
+            var jsonString = _jsonString;
+            using (var store = GetDocumentStore())
+            {
+                using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(jsonString)))
+                using (var zipStream = new GZipStream(ms, CompressionMode.Compress))
+                {
+                    zipStream.Flush();
+                    ms.Position = 0;
+                    var operation = await store.Smuggler.ForDatabase(store.Database)
+                        .ImportAsync(
+                            new DatabaseSmugglerImportOptions { OperateOnTypes = DatabaseItemType.RevisionDocuments }, ms);
+
+
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+
+                using (var context = JsonOperationContext.ShortTermSingleUse())
+                {
+                    var configuration = new RevisionsConfiguration
+                    {
+                        Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 5 },
+                        Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                        {
+                            ["Orders"] = new RevisionsCollectionConfiguration { Disabled = false }
+                        }
+                    };
+
+                    (long Index, object _) res = await Server.ServerStore.ModifyDatabaseRevisions(context,
+                        store.Database,
+                        DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(configuration,
+                            context), Guid.NewGuid().ToString());
+
+                    var documentDatabase = await GetDatabase(store.Database);
+
+                    await documentDatabase.RachisLogIndexNotifications.WaitForIndexNotification(res.Index, Server.ServerStore.Engine.OperationTimeout);
+                }
+
+                var subscriptionId = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions { Query = query });
+                var revisions = new HashSet<MyRevision>();
+                using (var sub = store.Subscriptions.GetSubscriptionWorker<MyRevision>(new SubscriptionWorkerOptions(subscriptionId)
+                       {
+                           TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(3)
+                       }))
+                {
+                    _ = sub.Run(x =>
+                    {
+                        foreach (var item in x.Items)
+                        {
+                            revisions.Add(item.Result);
+                        }
+                    });
+
+                    dynamic resultsObj1 = JsonConvert.DeserializeObject<ExpandoObject>(jsonString);
+
+                    List<dynamic> results = resultsObj1.RevisionDocuments;
+                    Assert.Equal(1, await WaitForValueAsync(() => revisions.Count, 1));
+
+                    var f = revisions.First();
+                    IDictionary<string, object> metadata = (IDictionary<string, object>)((IDictionary<string, object>)results[results.Count - 2])["@metadata"];
+
+                    Assert.Equal((string)metadata["@change-vector"], f.PreviousChangeVector);
+                    Assert.Equal((string)metadata["@change-vector"], f.PreviousMetadata["@change-vector"]);
+
+                    Assert.Equal((string)metadata["@id"], f.PreviousId);
+                    Assert.Equal((string)metadata["@id"], f.PreviousMetadata["@id"]);
+
+                    Assert.NotNull(f.Previous);
+                    Assert.NotNull(f.PreviousMetadata);
+                    Assert.NotNull(f.PreviousId);
+                    Assert.NotNull(f.PreviousChangeVector);
+
+
+                    Assert.Null(f.Current);
+                    Assert.Null(f.CurrentChangeVector);
+                    Assert.Null(f.CurrentId);
+                    Assert.Null(f.CurrentMetadata);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task CanReturnFilterRevisionsSubscriptionByCurrentIsNotNull()
+        {
+            string query = @"from Orders (Revisions = true) as docs
+                    where docs.Current != null
+                    select {
+                        Current: docs.Current,
+                        Previous: docs.Previous,
+                        CurrentMetadata: docs.Current[""@metadata""],
+                        PreviousMetadata: docs.Previous[""@metadata""],
+                        CurrentId: id(docs.Current),
+                        PreviousId: id(docs.Previous),
+                        CurrentChangeVector: docs.Current == null ? null : metadataFor(docs.Current)[""@change-vector""],
+                        PreviousChangeVector: docs.Previous == null ? null : metadataFor(docs.Previous)[""@change-vector""]
+                    }";
+
+            var jsonString = _jsonString;
+            using (var store = GetDocumentStore())
+            {
+                using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(jsonString)))
+                using (var zipStream = new GZipStream(ms, CompressionMode.Compress))
+                {
+                    zipStream.Flush();
+                    ms.Position = 0;
+                    var operation = await store.Smuggler.ForDatabase(store.Database)
+                        .ImportAsync(
+                            new DatabaseSmugglerImportOptions
+                            {
+                                OperateOnTypes = DatabaseItemType.RevisionDocuments
+                            }, ms);
+
+
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+
+                using (var context = JsonOperationContext.ShortTermSingleUse())
+                {
+                    var configuration = new RevisionsConfiguration
+                    {
+                        Default = new RevisionsCollectionConfiguration
+                        {
+                            Disabled = false,
+                            MinimumRevisionsToKeep = 5
+                        },
+                        Collections = new Dictionary<string, RevisionsCollectionConfiguration>
+                        {
+                            ["Orders"] = new RevisionsCollectionConfiguration
+                            {
+                                Disabled = false
+                            }
+                        }
+                    };
+
+                    (long Index, object _) res = await Server.ServerStore.ModifyDatabaseRevisions(context,
+                        store.Database,
+                        DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(configuration,
+                            context), Guid.NewGuid().ToString());
+
+                    var documentDatabase = await GetDatabase(store.Database);
+
+                    await documentDatabase.RachisLogIndexNotifications.WaitForIndexNotification(res.Index, Server.ServerStore.Engine.OperationTimeout);
+                }
+
+                var subscriptionId = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                {
+                    Query = query
+                });
+                var revisions = new HashSet<MyRevision>();
+                using (var sub = store.Subscriptions.GetSubscriptionWorker<MyRevision>(new SubscriptionWorkerOptions(subscriptionId)
+                {
+                    TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(3)
+                }))
+                {
+                    _ = sub.Run(x =>
+                    {
+                        foreach (var item in x.Items)
+                        {
+                            revisions.Add(item.Result);
+                        }
+                    });
+
+                    dynamic resultsObj1 = JsonConvert.DeserializeObject<ExpandoObject>(jsonString);
+
+                    List<dynamic> results = resultsObj1.RevisionDocuments;
+                    Assert.Equal(7, await WaitForValueAsync(() => revisions.Count, 7));
+
+                    var f = revisions.First();
+                    IDictionary<string, object> metadata = (IDictionary<string, object>)((IDictionary<string, object>)results[0])["@metadata"];
+
+                    Assert.Equal((string)metadata["@change-vector"], f.CurrentChangeVector);
+                    Assert.Equal((string)metadata["@change-vector"], f.CurrentMetadata["@change-vector"]);
+
+                    Assert.Equal((string)metadata["@id"], f.CurrentId);
+                    Assert.Equal((string)metadata["@id"], f.CurrentMetadata["@id"]);
+
+                    Assert.Null(f.Previous);
+                    Assert.Null(f.PreviousMetadata);
+                    Assert.Null(f.PreviousId);
+                    Assert.Null(f.PreviousChangeVector);
+
+                    for (int i = 1; i < revisions.Count; i++)
+                    {
+                        var r = revisions.ElementAt(i);
+
+                        metadata = (IDictionary<string, object>)((IDictionary<string, object>)results[i])["@metadata"];
+                        Assert.Equal((string)metadata["@change-vector"], r.CurrentChangeVector);
+                        Assert.Equal((string)metadata["@change-vector"], r.CurrentMetadata["@change-vector"]);
+                        Assert.Equal((string)metadata["@id"], r.CurrentId);
+                        Assert.Equal((string)metadata["@id"], r.CurrentMetadata["@id"]);
+                        IDictionary<string, object> prevMetadata = (IDictionary<string, object>)((IDictionary<string, object>)results[i - 1])["@metadata"];
+                        Assert.Equal((string)prevMetadata["@change-vector"], r.PreviousChangeVector);
+                        Assert.Equal((string)prevMetadata["@change-vector"], r.PreviousMetadata["@change-vector"]);
+
+                        Assert.Equal((string)prevMetadata["@id"], r.PreviousId);
+                        Assert.Equal((string)prevMetadata["@id"], r.PreviousMetadata["@id"]);
+                        Assert.NotNull(r.Previous);
+                        Assert.NotNull(r.PreviousMetadata);
+                        Assert.NotNull(r.PreviousId);
+                        Assert.NotNull(r.PreviousChangeVector);
+
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22806/Cannot-filter-current-null-in-revisions-subscription

### Additional description

* Fix regression introduced in [RavenDB-20010](https://issues.hibernatingrhinos.com/issue/RavenDB-20010/Missing-metadata-on-subscriptions-with-revisions-enabled)
* fix undisposed blittable
* 
### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
