### PR TITLE
RavenDB-22809 using directly createdump for dump creation instead of DiagnosticsClient

### DIFF
--- a/scripts/linux/enable-debugging.sh
+++ b/scripts/linux/enable-debugging.sh
@@ -4,6 +4,7 @@ LD_SO_CONF_DIR='/etc/ld.so.conf.d/'
 
 DEFPATH=$( cd `dirname $0` && pwd )
 SERVER_DIR="$DEFPATH/Server"
+CREATEDUMP_PATH="$SERVER_DIR/createdump"
 RAVEN_DEBUG_PATH="$SERVER_DIR/Raven.Debug"
 LIB_MSCORDACCORE_DIR="$SERVER_DIR/libmscordaccore"
 LIB_MSCORDACCORE_SO="$SERVER_DIR/libmscordaccore.so"
@@ -62,7 +63,7 @@ echo "$LIB_MSCORDACCORE_DIR" > "$LD_SO_CONF_DIR/ravendb.conf"
 ldconfig
 echo "DONE"
 
-binList=("$RAVEN_DEBUG_PATH")
+binList=("$CREATEDUMP_PATH" "$RAVEN_DEBUG_PATH")
 for binFilePath in "${binList[@]}"
 do
     binFilename="$(basename $binFilePath)"

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -61,8 +61,8 @@ function CopyNativeBinariesRequiredForDebugging($buildOutputDir, $targetDir, $na
     Write-Host "Copy native binaries for debugging on POSIX."
 
     $nativeBinaries = @(
-        [io.path]::combine($buildOutputDir, "libmscordaccore.$nativeBinExtension")
-        #[io.path]::combine($buildOutputDir, "createdump")
+        [io.path]::combine($buildOutputDir, "libmscordaccore.$nativeBinExtension"),
+        [io.path]::combine($buildOutputDir, "createdump")
     );
 
     foreach ($asset in $nativeBinaries) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22809

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
