### PR TITLE
RavenDB-22775-v6 - Test Hub/Sink Replication [for v6]

### DIFF
--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsHub.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsHub.cs
@@ -33,6 +33,7 @@ namespace Raven.Client.Documents.Operations.Replication
         public override ulong GetTaskKey()
         {
             var hashCode = base.GetTaskKey();
+            hashCode = (hashCode * 397) ^ CalculateStringHash(Url);
             return (hashCode * 397) ^ (ulong)Mode;
         }
 
@@ -50,9 +51,16 @@ namespace Raven.Client.Documents.Operations.Replication
             return djv;
         }
 
+        public override string ToString()
+        {
+            return $"Replication Hub to {FromString()}. " +
+                   $"Hub Task Name: '{Name}', " +
+                   $"Mode: '{Mode}'";
+        }
+
         public override string GetDefaultTaskName()
         {
-            return $"Replication Hub for {Database}";
+            return ToString();
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using Raven.Client.Documents.Replication;
 using Sparrow.Json.Parsing;
 
@@ -48,6 +49,7 @@ namespace Raven.Client.Documents.Operations.Replication
         {
             var hashCode = base.GetTaskKey();
             hashCode = (hashCode * 397) ^ (ulong)Mode;
+            hashCode = (hashCode * 397) ^ CalculateStringHash(Url);
             hashCode = (hashCode * 397) ^ CalculateStringHash(CertificateWithPrivateKey);
             hashCode = (hashCode * 397) ^ CalculateStringHash(CertificatePassword);
             return (hashCode * 397) ^ CalculateStringHash(HubName);
@@ -82,9 +84,22 @@ namespace Raven.Client.Documents.Operations.Replication
             return djv;
         }
 
+        public override string ToString()
+        {
+            var sb = new StringBuilder($"Replication Sink {FromString()}. " +
+                                       $"Hub Task Name: '{HubName}', " +
+                                       $"Connection String: '{ConnectionStringName}', " +
+                                       $"Mode: '{Mode}'");
+
+            if (string.IsNullOrEmpty(AccessName) == false)
+                sb.Append($", Access Name: '{AccessName}'");
+
+            return sb.ToString();
+        }
+
         public override string GetDefaultTaskName()
         {
-            return $"Replication Sink for {HubName}";
+            return ToString();
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
@@ -91,11 +91,12 @@ namespace Raven.Client.Documents.Operations.Replication
             {
                 Url = request.SourceUrl,
                 Database = request.Database,
-                Name = request.PullReplicationSinkTaskName,
+                Name = request.PullReplicationDefinitionName,
                 DelayReplicationFor = DelayReplicationFor,
                 MentorNode = MentorNode,
                 PinToMentorNode = PinToMentorNode,
-                TaskId = taskId
+                TaskId = taskId,
+                Mode = Mode
             };
         }
     }

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.cs
@@ -37,6 +37,7 @@ namespace Raven.Server.Documents.Replication.Incoming
                 AllowedPaths = pullReplicationParams?.AllowedPaths,
                 Mode = pullReplicationParams?.Mode ?? PullReplicationMode.None,
                 Name = pullReplicationParams?.Name,
+                SourceDatabaseName = replicatedLastEtag.SourceDatabaseName,
                 PreventDeletionsMode = pullReplicationParams?.PreventDeletionsMode,
                 Type = ReplicationLoader.PullReplicationParams.ConnectionType.Incoming
             };

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -276,12 +276,12 @@ namespace Raven.Server.Documents.Replication
                     break;
 
                 case RegisterReplicationHubAccessCommand reg:
-                    DisposeRelatedPullReplication(reg.HubName, reg.CertificateThumbprint);
+                    DisposeRelatedPullReplication(reg.HubName, reg.CertificateThumbprint, reg.Database);
                     break;
             }
             return Task.CompletedTask;
 
-            void DisposeRelatedPullReplication(string hub, string certThumbprint)
+            void DisposeRelatedPullReplication(string hub, string certThumbprint, string sourceDatabase = null)
             {
                 if (hub == null)
                     return;
@@ -291,7 +291,9 @@ namespace Raven.Server.Documents.Replication
                     if (repl is IncomingPullReplicationHandler pullHandler == false)
                         continue;
 
-                    if (string.Equals(pullHandler._incomingPullReplicationParams.Name, hub, StringComparison.OrdinalIgnoreCase) == false)
+                    if (string.Equals(pullHandler._incomingPullReplicationParams.Name, hub, StringComparison.OrdinalIgnoreCase) == false ||
+                        (string.IsNullOrEmpty(sourceDatabase) == false &&
+                         string.Equals(pullHandler._incomingPullReplicationParams.SourceDatabaseName, sourceDatabase, StringComparison.OrdinalIgnoreCase) == false))
                         continue;
 
                     if (certThumbprint != null && pullHandler.CertificateThumbprint != certThumbprint)
@@ -314,7 +316,9 @@ namespace Raven.Server.Documents.Replication
                     if (repl is OutgoingPullReplicationHandlerAsHub asHub == false)
                         continue;
 
-                    if (string.Equals(asHub.PullReplicationDefinitionName, hub, StringComparison.OrdinalIgnoreCase) == false)
+                    if (string.Equals(asHub.PullReplicationDefinitionName, hub, StringComparison.OrdinalIgnoreCase) == false ||
+                        (string.IsNullOrEmpty(sourceDatabase) == false &&
+                         string.Equals(sourceDatabase, repl.Destination.Database, StringComparison.OrdinalIgnoreCase) == false))
                         continue;
 
                     if (certThumbprint != null && asHub.CertificateThumbprint != certThumbprint)
@@ -588,6 +592,7 @@ namespace Raven.Server.Documents.Replication
         public sealed class PullReplicationParams
         {
             public string Name;
+            public string SourceDatabaseName;
             public string[] AllowedPaths;
             public PullReplicationMode Mode;
             public PreventDeletionsMode? PreventDeletionsMode;
@@ -1136,7 +1141,8 @@ namespace Raven.Server.Documents.Replication
                         TaskId = sink.TaskId,
                         ConnectionStringName = sink.ConnectionStringName,
                         HubName = sink.HubName,
-                        CertificateWithPrivateKey = sink.CertificateWithPrivateKey
+                        CertificateWithPrivateKey = sink.CertificateWithPrivateKey,
+                        AccessName = sink.AccessName
                     };
 
                     i += 1;

--- a/test/SlowTests/Issues/RavenDB-19967.cs
+++ b/test/SlowTests/Issues/RavenDB-19967.cs
@@ -249,7 +249,7 @@ namespace SlowTests.Issues
                 var sinkNotificationDetails = sinkDatabase.NotificationCenter.TombstoneNotifications.GetNotificationDetails(_notificationId);
                 Assert.Equal(1, sinkNotificationDetails.Count);
                 Assert.Equal("users", sinkNotificationDetails.First().Collection);
-                Assert.Equal($"Replication Sink for {taskName}", sinkNotificationDetails.First().Source);
+                Assert.Contains(taskName, sinkNotificationDetails.First().Source);
                 Assert.Equal(sinkTombstonesCount, sinkNotificationDetails.First().NumberOfTombstones);
                 Assert.Equal(sinkCreationTaskId.First().TaskId, sinkNotificationDetails.First().BlockerTaskId);
                 Assert.Equal(ITombstoneAware.TombstoneDeletionBlockerType.PullReplicationAsSink, sinkNotificationDetails.First().BlockerType);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22775/Test-Hub-Sink-Replication

### Additional description

for v6

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
