### PR TITLE
RavenDB-22817 - Persisting configuration should be ClusterAdmin operation

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -53,6 +53,8 @@ namespace Raven.Server.Documents.Handlers.Admin
                 var json = await context.ReadForMemoryAsync(RequestBodyStream(), "logs/configuration");
 
                 var configuration = JsonDeserializationServer.Parameters.SetLogsConfigurationParameters(json);
+                if (configuration.Persist)
+                    AssertCanPersistConfiguration();
 
                 if (configuration.RetentionTime == null)
                     configuration.RetentionTime = ServerStore.Configuration.Logs.RetentionTime?.AsTimeSpan;
@@ -66,8 +68,6 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                 if (configuration.Persist)
                 {
-                    AssertCanPersistConfiguration();
-
                     try
                     {
                         using var jsonFileModifier = SettingsJsonModifier.Create(context, ServerStore.Configuration.ConfigPath);
@@ -335,13 +335,13 @@ namespace Raven.Server.Documents.Handlers.Admin
                 var json = await context.ReadForMemoryAsync(RequestBodyStream(), "event-listener/configuration");
 
                 var configuration = JsonDeserializationServer.EventListenerConfiguration(json);
+                if (configuration.Persist)
+                    AssertCanPersistConfiguration();
 
                 EventListenerToLog.Instance.UpdateConfiguration(configuration);
 
                 if (configuration.Persist)
                 {
-                    AssertCanPersistConfiguration();
-
                     try
                     {
                         using var jsonFileModifier = SettingsJsonModifier.Create(context, ServerStore.Configuration.ConfigPath);

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminLogsHandler.cs
@@ -66,6 +66,8 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                 if (configuration.Persist)
                 {
+                    AssertCanPersistConfiguration();
+
                     try
                     {
                         using var jsonFileModifier = SettingsJsonModifier.Create(context, ServerStore.Configuration.ConfigPath);
@@ -338,6 +340,8 @@ namespace Raven.Server.Documents.Handlers.Admin
 
                 if (configuration.Persist)
                 {
+                    AssertCanPersistConfiguration();
+
                     try
                     {
                         using var jsonFileModifier = SettingsJsonModifier.Create(context, ServerStore.Configuration.ConfigPath);

--- a/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
@@ -99,6 +99,8 @@ namespace Raven.Server.TrafficWatch
 
                 if (configuration.Persist)
                 {
+                    AssertCanPersistConfiguration();
+
                     try
                     {
                         using var jsonFileModifier = SettingsJsonModifier.Create(context, ServerStore.Configuration.ConfigPath);

--- a/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
@@ -94,13 +94,13 @@ namespace Raven.Server.TrafficWatch
                 var json = await context.ReadForMemoryAsync(RequestBodyStream(), "traffic-watch/configuration");
 
                 var configuration = JsonDeserializationServer.Parameters.PutTrafficWatchConfigurationParameters(json);
+                if (configuration.Persist)
+                    AssertCanPersistConfiguration();
 
                 TrafficWatchToLog.Instance.UpdateConfiguration(configuration);
 
                 if (configuration.Persist)
                 {
-                    AssertCanPersistConfiguration();
-
                     try
                     {
                         using var jsonFileModifier = SettingsJsonModifier.Create(context, ServerStore.Configuration.ConfigPath);

--- a/src/Raven.Server/Web/ServerRequestHandler.cs
+++ b/src/Raven.Server/Web/ServerRequestHandler.cs
@@ -24,8 +24,8 @@ namespace Raven.Server.Web
             var authenticateConnection = HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection;
             if (authenticateConnection != null && authenticateConnection.Status != RavenServer.AuthenticationStatus.ClusterAdmin)
             {
-                throw new UnauthorizedAccessException($"Configuration was modified but couldn't be persistent because the authentication level is {authenticateConnection.Status}. " +
-                                                      "The configuration will be reverted on server restart.");
+                throw new UnauthorizedAccessException($"Configuration was modified but couldn't be persistent because the authentication level is {authenticateConnection.Status}, " +
+                                                      $"but can be only executed with authentication level of {nameof(RavenServer.AuthenticationStatus.ClusterAdmin)}");
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22817/Persisting-configuration-should-be-ClusterAdmin-operation

### Additional description

Persisting configuration should be `ClusterAdmin` operation.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
