### PR TITLE
RavenDB-22246: Introduce an option in TestDriver to throw if there is no license or license could not be activated

### DIFF
--- a/src/Raven.Embedded/RavenServerRunner.cs
+++ b/src/Raven.Embedded/RavenServerRunner.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Sparrow.Platform;
 using Sparrow.Utils;
@@ -30,7 +32,24 @@ namespace Raven.Embedded
                 commandLineArgs.Add($"--Embedded.ParentProcessId={currentProcess.Id}");
             }
 
-            commandLineArgs.Add($"--License.Eula.Accepted={options.AcceptEula}");
+            if (options.LicenseConfiguration != null)
+            {
+                if (string.IsNullOrWhiteSpace(options.LicenseConfiguration.License) == false &&
+                    string.IsNullOrWhiteSpace(options.LicenseConfiguration.LicensePath) == false)
+                    throw new ArgumentException($"Only one of Licence options '{nameof(options.LicenseConfiguration.License)}' or '{nameof(options.LicenseConfiguration.LicensePath)}' should be specified");
+
+                if (string.IsNullOrWhiteSpace(options.LicenseConfiguration.License) == false)
+                    commandLineArgs.Add($"--License={CommandLineArgumentEscaper.EscapeSingleArg(options.LicenseConfiguration.License)}");
+                else if (string.IsNullOrWhiteSpace(options.LicenseConfiguration.LicensePath) == false)
+                    commandLineArgs.Add($"--License.Path={CommandLineArgumentEscaper.EscapeSingleArg(options.LicenseConfiguration.LicensePath)}");
+
+                commandLineArgs.Add($"--License.Eula.Accepted={options.LicenseConfiguration.EulaAccepted}");
+                commandLineArgs.Add($"--License.DisableAutoUpdate={options.LicenseConfiguration.DisableAutoUpdate}");
+                commandLineArgs.Add($"--License.DisableAutoUpdateFromApi={options.LicenseConfiguration.DisableAutoUpdateFromApi}");
+                commandLineArgs.Add($"--License.DisableLicenseSupportCheck={options.LicenseConfiguration.DisableLicenseSupportCheck}");
+                commandLineArgs.Add($"--License.ThrowOnInvalidOrMissingLicense={options.LicenseConfiguration.ThrowOnInvalidOrMissingLicense}");
+            }
+
             commandLineArgs.Add("--Setup.Mode=None");
             commandLineArgs.Add($"--DataDir={CommandLineArgumentEscaper.EscapeSingleArg(options.DataDirectory)}");
             commandLineArgs.Add($"--Logs.Path={CommandLineArgumentEscaper.EscapeSingleArg(options.LogsPath)}");
@@ -143,6 +162,16 @@ namespace Raven.Embedded
 
         private static void RemoveEnvironmentVariables(ProcessStartInfo processStartInfo)
         {
+            if (ForTestingPurposes?.EnvironmentVariablesToCopyToInternalProcess != null)
+            {
+                var environmentVariablesToCopyToInternalProcess = Environment.GetEnvironmentVariables()
+                    .Cast<DictionaryEntry>()
+                    .Where(x => ForTestingPurposes.EnvironmentVariablesToCopyToInternalProcess.Contains(x.Key.ToString()));
+
+                foreach (DictionaryEntry envVar in environmentVariablesToCopyToInternalProcess)
+                    processStartInfo.EnvironmentVariables[envVar.Key.ToString()] = envVar.Value.ToString();
+            }
+
             if (processStartInfo.Environment == null || processStartInfo.Environment.Count == 0)
                 return;
 
@@ -160,6 +189,21 @@ namespace Raven.Embedded
 
             foreach (var key in variablesToRemove)
                 processStartInfo.Environment.Remove(key);
+        }
+
+        private static TestingStuff ForTestingPurposes;
+
+        internal static TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal class TestingStuff
+        {
+            internal List<string> EnvironmentVariablesToCopyToInternalProcess;
         }
     }
 }

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -21,7 +21,12 @@ namespace Raven.Embedded
 
         public string DotNetPath { get; set; } = "dotnet";
 
-        public bool AcceptEula { get; set; } = true;
+        [Obsolete($"This property is no longer used and will be removed in the next version, please use '{nameof(LicenseConfiguration)}.{nameof(LicenseOptions.EulaAccepted)}' instead.")]
+        public bool AcceptEula
+        {
+            get => LicenseConfiguration.EulaAccepted;
+            set => LicenseConfiguration.EulaAccepted = value;
+        }
 
         public string ServerUrl { get; set; }
 
@@ -80,7 +85,6 @@ namespace Raven.Embedded
             return this;
         }
 
-
         public sealed class SecurityOptions
         {
             internal SecurityOptions() { }
@@ -91,6 +95,19 @@ namespace Raven.Embedded
             public string CertificateLoadExec { get; internal set; }
             public string CertificateLoadExecArguments { get; internal set; }
             public string ServerCertificateThumbprint { get; internal set; }
+        }
+
+        public LicenseOptions LicenseConfiguration { get; set; } = new();
+
+        public class LicenseOptions
+        {
+            public string License { get; set; }
+            public string LicensePath { get; set; }
+            public bool EulaAccepted { get; set; }
+            public bool DisableAutoUpdate { get; set; }
+            public bool DisableAutoUpdateFromApi { get; set; }
+            public bool DisableLicenseSupportCheck { get; set; } = true;
+            public bool ThrowOnInvalidOrMissingLicense { get; set; }
         }
     }
 

--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -4,8 +4,11 @@ using System.Security;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
+using Amazon.Runtime.Internal.Util;
 using Newtonsoft.Json;
 using Raven.Client.Exceptions.Commercial;
+using Raven.Client.Properties;
 using Raven.Server.Commercial.LetsEncrypt;
 using Raven.Server.Config;
 using Raven.Server.Json;
@@ -16,6 +19,8 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.Server.Json.Sync;
+using Voron;
+using Logger = Sparrow.Logging.Logger;
 
 namespace Raven.Server.Commercial
 {
@@ -270,6 +275,214 @@ namespace Raven.Server.Commercial
 
             var licenseString = JsonConvert.SerializeObject(newLicense, Formatting.Indented);
             File.WriteAllText(_serverStore.Configuration.Licensing.LicensePath.FullPath, licenseString);
+        }
+
+        internal static bool TryValidateLicenseExpirationDate(License license, out DateTime expirationDate)
+        {
+            expirationDate = DateTime.MinValue;
+
+            if (license == null)
+                return false;
+
+            var licenseStatus = LicenseManager.GetLicenseStatus(license);
+            if (licenseStatus.Expiration.HasValue)
+                expirationDate = licenseStatus.Expiration.Value;
+
+            return expirationDate >= RavenVersionAttribute.Instance.ReleaseDate;
+        }
+
+        internal static void ValidateLicenseVersionOrThrow(License license, ServerStore serverStore, TransactionContextPool contextPool, bool usingApi = false)
+        {
+            var licenseStatus = LicenseManager.GetLicenseStatus(license);
+            if (licenseStatus.Version.Major >= 6 || licenseStatus.IsCloud)
+                return;
+
+            if (usingApi && serverStore.Server.Configuration.Licensing.DisableAutoUpdateFromApi == false)
+            {
+                var licenseFromApi = AsyncHelpers.RunSync(() => GetLicenseFromApi(license, contextPool, serverStore.ServerShutdown));
+                if (licenseFromApi != null)
+                {
+                    licenseStatus = LicenseManager.GetLicenseStatus(licenseFromApi);
+                    if (licenseStatus.Version.Major >= 6)
+                    {
+                        serverStore.LicenseManager.OnBeforeInitialize += () =>
+                            AsyncHelpers.RunSync(() =>
+                                serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure));
+                        return;
+                    }
+                }
+            }
+
+            var msg =
+                $"Your license ('{licenseStatus.Id}') version '{licenseStatus.Version}' doesn't allow you to upgrade to server version '{RavenVersionAttribute.Instance.FullVersion}'. " +
+                $"Please proceed to the https://ravendb.net/l/8O2YU1 website to perform the license upgrade first. ";
+
+            if (usingApi)
+            {
+                if (serverStore.Server.Configuration.Licensing.DisableAutoUpdateFromApi == false)
+                    msg += $"After the upgrade, if your server has access to {ApiHttpClient.ApiRavenDbNet}, your license will be automatically updated. ";
+                else
+                    msg += $"Please note that automatic license updates from {ApiHttpClient.ApiRavenDbNet} are disabled due to the '{RavenConfiguration.GetKey(x => x.Licensing.DisableAutoUpdateFromApi)}' option being set to 'true'. ";
+            }
+
+            msg += $"To update your license, you have the following options:{Environment.NewLine}" +
+                   $"1. Update the license via the configuration option '{RavenConfiguration.GetKey(x => x.Licensing.LicensePath)}' or '{RavenConfiguration.GetKey(x => x.Licensing.License)}'.{Environment.NewLine}" +
+                   $"2. Downgrade to the previous version of RavenDB, apply the new license, and then continue the update procedure.";
+
+            if (usingApi == false)
+                throw new LicenseLimitException(msg);
+
+            if (serverStore.Server.Configuration.Licensing.DisableAutoUpdateFromApi == false)
+            {
+                msg += $"{Environment.NewLine}3. Ensure your server has access to {ApiHttpClient.ApiRavenDbNet} for automatic license updates.";
+            }
+            else
+            {
+                msg += $"{Environment.NewLine}3. If you want to enable automatic license updates:{Environment.NewLine}" +
+                       $"   a. Set the '{RavenConfiguration.GetKey(x => x.Licensing.DisableAutoUpdateFromApi)}' option to 'false' in your server configuration.{Environment.NewLine}" +
+                       $"   b. Ensure your server has access to {ApiHttpClient.ApiRavenDbNet}.{Environment.NewLine}" +
+                       $"   c. Start the server again with the updated configuration.";
+            }
+
+            throw new LicenseLimitException(msg);
+        }
+
+        private static async Task<License> GetLicenseFromApi(License license, TransactionContextPool contextPool, CancellationToken token)
+        {
+            try
+            {
+                var response = await LicenseManager.GetUpdatedLicenseResponseMessage(license, contextPool, token)
+                    .ConfigureAwait(false);
+                var leasedLicense = await LicenseManager.ConvertResponseToLeasedLicense(response, token)
+                    .ConfigureAwait(false);
+                return leasedLicense.License;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static bool TryValidateAndHandleLicense(ServerStore serverStore, string licenseJson, Guid? inStorageLicenseId, LicenseVerificationErrorBuilder verificationErrorBuilder, TransactionContextPool contextPool)
+        {
+            if (TryDeserializeLicense(licenseJson, out var deserializedLicense) == false)
+            {
+                verificationErrorBuilder.AppendDeserializationErrorMessage(licenseJson);
+            }
+            else
+            {
+                if (TryValidateLicenseExpirationDate(deserializedLicense, out var deserializedLicenseExpirationDate))
+                {
+                    ValidateLicenseVersionOrThrow(deserializedLicense, serverStore, contextPool);
+                    serverStore.LicenseManager.OnBeforeInitialize += () => serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).Wait(serverStore.ServerShutdown);
+                    return true;
+                }
+
+                verificationErrorBuilder.AppendConfigurationLicenseExpiredMessage(inStorageLicenseId, deserializedLicense.Id, deserializedLicenseExpirationDate);
+            }
+
+            return false;
+        }
+
+        public class LicenseVerificationErrorBuilder
+        {
+            private readonly RavenConfiguration _configuration;
+            private readonly StorageEnvironment _storageEnvironment;
+            private readonly TransactionContextPool _contextPool;
+            private readonly StringBuilder _errorBuilder = new();
+            private bool _isInStorageLicenseExpired;
+            private string _configurationKeyInAction;
+
+            public LicenseVerificationErrorBuilder(RavenConfiguration configuration, StorageEnvironment storageEnvironment, TransactionContextPool contextPool)
+            {
+                _configuration = configuration;
+                _storageEnvironment = storageEnvironment;
+                _contextPool = contextPool;
+            }
+
+            public LicenseVerificationErrorBuilder()
+            {
+            }
+
+            public void AppendInStorageLicenseExpiredMessage(DateTime expirationDate)
+            {
+                _isInStorageLicenseExpired = true;
+
+                _errorBuilder.AppendLine("The RavenDB server cannot start due to an expired license. Please review the details below to resolve the issue:");
+                _errorBuilder.AppendLine($"- License Expiration Date: {FormattedDateTime(expirationDate)}");
+                _errorBuilder.AppendLine($"- Server Version Release Date: {FormattedDateTime(RavenVersionAttribute.Instance.ReleaseDate)}");
+            }
+
+            public void AppendLicenseMissingMessage()
+            {
+                _errorBuilder.AppendLine("The RavenDB server cannot start due to a missing license. Please review the details below to resolve the issue:");
+            }
+
+            public void AppendConfigurationKeyUsageAttempt(string configurationKey)
+            {
+                _configurationKeyInAction = configurationKey;
+
+                _errorBuilder.AppendLine();
+                _errorBuilder.AppendLine($"We attempted to obtain a valid license using the configuration key '{configurationKey}', but this process was not successful for the following reason:");
+            }
+
+            public void AppendFileReadErrorMessage(Exception e)
+            {
+                _errorBuilder.AppendLine("- An error occurred while trying to read the license from the file:");
+                _errorBuilder.AppendLine($"  {e.Message}");
+            }
+
+            public void AppendResolutionSuggestions()
+            {
+                AppendGeneralSuggestions();
+
+                // We can suggest a downgrade only if in-storage license is expired
+                if (_isInStorageLicenseExpired)
+                {
+                    // Getting build number from the license storage, just in case the license is expired and we have ability to downgrade
+                    var licenseStorage = new LicenseStorage();
+                    licenseStorage.Initialize(_storageEnvironment, _contextPool);
+                    var buildInfo = licenseStorage.GetBuildInfo();
+
+                    if (buildInfo != null)
+                        _errorBuilder.AppendLine($"- As a temporary measure, consider downgrading to the last working build ({buildInfo.FullVersion}).");
+                }
+
+                AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(_configuration.Licensing.ThrowOnInvalidOrMissingLicense, _isInStorageLicenseExpired);
+            }
+
+            public void AppendGeneralSuggestions()
+            {
+                _errorBuilder.AppendLine();
+                _errorBuilder.AppendLine("To resolve this issue, you may consider the following options:");
+                _errorBuilder.AppendLine("- Ensure your license key is correctly embedded in 'settings.json', set as an environment variable, or included in your 'ServerOptions' if using an embedded server or Raven.TestDriver.");
+                _errorBuilder.AppendLine("- Alternatively, check the 'License.Path' in your configuration to ensure it points to a valid 'license.json' file.");
+            }
+
+            public void AppendConfigurationLicenseExpiredMessage(Guid? inStorageLicenseId, Guid deserializedLicenseId, DateTime deserializedLicenseExpirationDate)
+            {
+                _errorBuilder.AppendLine(deserializedLicenseId == inStorageLicenseId
+                    ? "- The license obtained matches the in-storage license but is also expired."
+                    : $"- The license '{deserializedLicenseId}' obtained from '{_configurationKeyInAction}' has an expiration date of '{FormattedDateTime(deserializedLicenseExpirationDate)}' and is also expired.");
+            }
+
+            public void AppendDeserializationErrorMessage(string licenseContent)
+            {
+                if (string.IsNullOrWhiteSpace(licenseContent))
+                    _errorBuilder.AppendLine("- The license is not provided in the configuration or environment variable.");
+                else
+                    _errorBuilder.AppendLine($"- Could not parse the license content: '{licenseContent}'.");
+            }
+
+            public void AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(bool throwOnInvalidOrMissingLicenseOptionEnabled, bool isInStorageLicenseExpired)
+            {
+                if (throwOnInvalidOrMissingLicenseOptionEnabled && isInStorageLicenseExpired == false)
+                    _errorBuilder.AppendLine($"- Configure the '{RavenConfiguration.GetKey(x => x.Licensing.ThrowOnInvalidOrMissingLicense)}' option by setting it to 'False' to disable this strict licensing requirement for server startup.");
+            }
+
+            public override string ToString() => _errorBuilder.ToString();
+
+            private static string FormattedDateTime(DateTime dateTime) => dateTime.ToString("dd MMMM yyyy");
         }
     }
 }

--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -314,19 +314,18 @@ namespace Raven.Server.Commercial
                         }
                     }
                 }
-                else // The only way to update the license is to use the configuration option when the update from API is disabled
+
+                // The only way to update the license is to use the configuration option when the update from API is disabled
+                string licenseJson = GetLicenseJson(serverStore);
+                if (string.IsNullOrEmpty(licenseJson) == false && TryDeserializeLicense(licenseJson, out License localLicense))
                 {
-                    string licenseJson = GetLicenseJson(serverStore);
-                    if (string.IsNullOrEmpty(licenseJson) == false && TryDeserializeLicense(licenseJson, out License localLicense))
+                    licenseStatus = LicenseManager.GetLicenseStatus(localLicense);
+                    if (licenseStatus.Version.Major >= 6)
                     {
-                        licenseStatus = LicenseManager.GetLicenseStatus(localLicense);
-                        if (licenseStatus.Version.Major >= 6)
-                        {
-                            serverStore.LicenseManager.OnBeforeInitialize += () =>
-                                AsyncHelpers.RunSync(() =>
-                                    serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure));
-                            return;
-                        }
+                        serverStore.LicenseManager.OnBeforeInitialize += () =>
+                            AsyncHelpers.RunSync(() =>
+                                serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure));
+                        return;
                     }
                 }
             }

--- a/src/Raven.Server/Config/Categories/LicenseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/LicenseConfiguration.cs
@@ -47,7 +47,6 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("License.SkipLeasingErrorsLogging", ConfigurationEntryScope.ServerWideOnly)]
         public bool SkipLeasingErrorsLogging { get; set; }
 
-
         [Description("EXPERT ONLY. Disable automatic updating of the license")]
         [DefaultValue(false)]
         [ConfigurationEntry("License.DisableAutoUpdate", ConfigurationEntryScope.ServerWideOnly)]
@@ -58,10 +57,14 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("License.DisableAutoUpdateFromApi", ConfigurationEntryScope.ServerWideOnly)]
         public bool DisableAutoUpdateFromApi { get; set; }
 
-
         [Description("EXPERT ONLY. Disable checking the support options for the license")]
         [DefaultValue(false)]
         [ConfigurationEntry("License.DisableLicenseSupportCheck", ConfigurationEntryScope.ServerWideOnly)]
         public bool DisableLicenseSupportCheck { get; set; }
+
+        [Description("EXPERT ONLY. Throws an exception if the license cannot be activated or is not present")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("License.ThrowOnInvalidOrMissingLicense", ConfigurationEntryScope.ServerWideOnly)]
+        public bool ThrowOnInvalidOrMissingLicense { get; set; }
     }
 }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -22,7 +22,6 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.ResponseCompression;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -128,6 +127,8 @@ namespace Raven.Server
 
         internal Action<StorageEnvironment> BeforeSchemaUpgrade;
 
+        internal Action<StorageEnvironment> AfterDatabaseCreation;
+
         internal string DebugTag;
 
         internal CipherSuitesPolicy CipherSuitesPolicy => _httpsConnectionMiddleware?.CipherSuitesPolicy;
@@ -161,7 +162,10 @@ namespace Raven.Server
             _tcpContextPool = new JsonContextPool(Configuration.Memory.MaxContextSizeToKeep);
 
             // doing this before the schema upgrade to allow to downgrade in case we cannot start the server
-            BeforeSchemaUpgrade = x => VerifyLicense(x, ServerStore);
+            BeforeSchemaUpgrade = VerifyLicense;
+
+            if (Configuration.Licensing.ThrowOnInvalidOrMissingLicense)
+                AfterDatabaseCreation = VerifyLicense;
         }
 
         public TcpListenerStatus GetTcpServerStatus()
@@ -3059,149 +3063,54 @@ namespace Raven.Server
             ArrayPool<byte>.Shared.Return(buffer);
         }
 
-        private static void VerifyLicense(StorageEnvironment environment, ServerStore serverStore)
+        private void VerifyLicense(StorageEnvironment storageEnvironment)
         {
-            using (var contextPool = new TransactionContextPool(environment, serverStore.Configuration.Memory.MaxContextSizeToKeep))
+            using (var contextPool = new TransactionContextPool(storageEnvironment, ServerStore.Configuration.Memory.MaxContextSizeToKeep))
             {
-                var license = serverStore.LoadLicense(contextPool);
-                if (license == null)
+                var inStorageLicense = ServerStore.LoadLicense(contextPool);
+                if (inStorageLicense == null && ServerStore.Configuration.Licensing.ThrowOnInvalidOrMissingLicense == false)
                     return;
 
-                var licenseStatus = LicenseManager.GetLicenseStatus(license);
-
-                VerifyLicenseVersion(licenseStatus, license, serverStore, contextPool);
-                VerifyLicenseExpiration(licenseStatus, serverStore, environment, license, contextPool);
-            }
-        }
-
-        private static void VerifyLicenseVersion(LicenseStatus licenseStatus, License license, ServerStore serverStore, TransactionContextPool contextPool)
-        {
-            if (licenseStatus.Version.Major >= 6 || licenseStatus.IsCloud)
-                return;
-
-            var licenseFromApi = AsyncHelpers.RunSync(() => GetLicenseFromApi(license, contextPool, serverStore.ServerShutdown));
-            if (licenseFromApi != null)
-            {
-                licenseStatus = LicenseManager.GetLicenseStatus(licenseFromApi);
-                if (licenseStatus.Version.Major >= 6)
+                var errorBuilder = new LicenseHelper.LicenseVerificationErrorBuilder(ServerStore.Configuration, storageEnvironment, contextPool);
+                if (inStorageLicense == null)
                 {
-                    serverStore.LicenseManager.OnBeforeInitialize += () =>
-                        AsyncHelpers.RunSync(() => serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure));
-                    return;
-                }
-            }
-
-            var licenseJson = GetLicenseJson(serverStore, out _);
-            if (string.IsNullOrEmpty(licenseJson) == false &&
-                LicenseHelper.TryDeserializeLicense(licenseJson, out License localLicense))
-            {
-                licenseStatus = LicenseManager.GetLicenseStatus(localLicense);
-                if (licenseStatus.Version.Major >= 6)
-                {
-                    serverStore.LicenseManager.OnBeforeInitialize += () =>
-                        AsyncHelpers.RunSync(() =>
-                            serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure));
-                    return;
-                }
-            }
-
-            throw new LicenseLimitException($"Your license ('{licenseStatus.Id}') version '{licenseStatus.Version}' doesn't allow you to upgrade to server version '{RavenVersionAttribute.Instance.FullVersion}'. " +
-                                            $"Please proceed to the https://ravendb.net/l/8O2YU1 website to perform the license upgrade first. " +
-                                            $"After the upgrade, if your server has access to {ApiHttpClient.ApiRavenDbNet}, your license will be automatically updated. " +
-                                            $"In case of connectivity issues with {ApiHttpClient.ApiRavenDbNet} please either update the license via one of the configuration options '{RavenConfiguration.GetKey(x => x.Licensing.LicensePath)}', '{RavenConfiguration.GetKey(x => x.Licensing.License)}', " +
-                                            $"or downgrade to the previous version of RavenDB, apply the new license and continue the update procedure.");
-        }
-
-        private static async Task<License> GetLicenseFromApi(License license, TransactionContextPool contextPool, CancellationToken token)
-        {
-            try
-            {
-                var response = await LicenseManager.GetUpdatedLicenseResponseMessage(license, contextPool, token)
-                    .ConfigureAwait(false);
-                var leasedLicense = await LicenseManager.ConvertResponseToLeasedLicense(response, token)
-                    .ConfigureAwait(false);
-                return leasedLicense.License;
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        private static void VerifyLicenseExpiration(LicenseStatus licenseStatus, ServerStore serverStore, StorageEnvironment environment, License license, TransactionContextPool contextPool)
-        {
-            if (licenseStatus.Expiration >= RavenVersionAttribute.Instance.ReleaseDate)
-                return;
-
-            var licenseJson = GetLicenseJson(serverStore, out bool fromPath);
-
-            var errorMessage = $"Cannot start the RavenDB server because the expiration date of current license ({FormattedDateTime(licenseStatus.Expiration ?? DateTime.MinValue)}) " +
-                               $"is before the release date of this version ({FormattedDateTime(RavenVersionAttribute.Instance.ReleaseDate)})";
-
-            string expiredLicenseMessage = "";
-            if (string.IsNullOrEmpty(licenseJson) == false)
-            {
-                if (LicenseHelper.TryDeserializeLicense(licenseJson, out License localLicense))
-                {
-                    var localLicenseStatus = LicenseManager.GetLicenseStatus(localLicense);
-                    if (localLicenseStatus.Expiration >= RavenVersionAttribute.Instance.ReleaseDate)
-                    {
-                        serverStore.LicenseManager.OnBeforeInitialize += () => AsyncHelpers.RunSync(() =>
-                            serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure));
-                        return;
-                    }
-
-                    var configurationKey =
-                        fromPath ? RavenConfiguration.GetKey(x => x.Licensing.LicensePath) : RavenConfiguration.GetKey(x => x.Licensing.License);
-                    expiredLicenseMessage = localLicense.Id == license.Id
-                        ? ". You can update current license using the setting.json file"
-                        : $". The license '{localLicense.Id}' obtained from '{configurationKey}' with expiration date of '{FormattedDateTime(localLicenseStatus.Expiration ?? DateTime.MinValue)}' is also expired.";
+                    errorBuilder.AppendLicenseMissingMessage();
                 }
                 else
                 {
-                    errorMessage += ". Could not parse the license from setting.json file.";
-                    throw new LicenseExpiredException(errorMessage);
+                    if (LicenseHelper.TryValidateLicenseExpirationDate(inStorageLicense, out var expirationDate))
+                    {
+                        LicenseHelper.ValidateLicenseVersionOrThrow(inStorageLicense, ServerStore, contextPool, usingApi: true);
+                        return;
+                    }
+
+                    errorBuilder.AppendInStorageLicenseExpiredMessage(expirationDate);
                 }
-            }
 
-            var licenseStorage = new LicenseStorage();
-            licenseStorage.Initialize(environment, contextPool);
+                // Try to load the license using 'Licensing.License' configuration key
+                errorBuilder.AppendConfigurationKeyUsageAttempt(RavenConfiguration.GetKey(x => x.Licensing.License));
+                if (LicenseHelper.TryValidateAndHandleLicense(ServerStore, ServerStore.Configuration.Licensing.License, inStorageLicense?.Id, errorBuilder, contextPool))
+                    return;
 
-            var buildInfo = licenseStorage.GetBuildInfo();
-            if (buildInfo != null)
-                errorMessage += $" You can downgrade to the latest build that was working ({buildInfo.FullVersion})";
-            if (string.IsNullOrEmpty(expiredLicenseMessage) == false)
-                errorMessage += expiredLicenseMessage;
-            throw new LicenseExpiredException(errorMessage);
-
-            static string FormattedDateTime(DateTime dateTime)
-            {
-                return dateTime.ToString("dd MMMM yyyy");
-            }
-        }
-
-        private static string GetLicenseJson(ServerStore serverStore, out bool fromPath)
-        {
-            string licenseJson = null;
-            fromPath = false;
-            if (string.IsNullOrEmpty(serverStore.Configuration.Licensing.License) == false)
-            {
-                licenseJson = serverStore.Configuration.Licensing.License;
-            }
-            else if (File.Exists(serverStore.Configuration.Licensing.LicensePath.FullPath))
-            {
+                // Unsuccessful
+                // Let's try to load the license from the configuration using 'Licensing.LicensePath' configuration key
+                errorBuilder.AppendConfigurationKeyUsageAttempt(RavenConfiguration.GetKey(x => x.Licensing.LicensePath));
                 try
                 {
-                    licenseJson = File.ReadAllText(serverStore.Configuration.Licensing.LicensePath.FullPath);
-                    fromPath = true;
+                    var licenseContent = File.ReadAllText(ServerStore.Configuration.Licensing.LicensePath.FullPath);
+                    if (LicenseHelper.TryValidateAndHandleLicense(ServerStore, licenseContent, inStorageLicense?.Id, errorBuilder, contextPool))
+                        return;
                 }
-                catch
+                catch (Exception e)
                 {
-                    // expected
+                    errorBuilder.AppendFileReadErrorMessage(e);
                 }
-            }
 
-            return licenseJson;
+                // Suggest a possible solution
+                errorBuilder.AppendResolutionSuggestions();
+
+                throw new LicenseExpiredException(errorBuilder.ToString());
+            }
         }
     }
 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -792,6 +792,7 @@ namespace Raven.Server.ServerWide
             options.SchemaVersion = SchemaUpgrader.CurrentVersion.ServerVersion;
             options.SchemaUpgrader = SchemaUpgrader.Upgrader(SchemaUpgrader.StorageType.Server, null, null, this);
             options.BeforeSchemaUpgrade = _server.BeforeSchemaUpgrade;
+            options.AfterDatabaseCreation = _server.AfterDatabaseCreation;
             options.ForceUsing32BitsPager = Configuration.Storage.ForceUsing32BitsPager;
             options.EnablePrefetching = Configuration.Storage.EnablePrefetching;
             options.DiscardVirtualMemory = Configuration.Storage.DiscardVirtualMemory;

--- a/src/Raven.Studio/typescript/test/stubs/LicenseStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/LicenseStubs.ts
@@ -201,7 +201,7 @@ export class LicenseStubs {
             DisableAutoUpdateFromApi: false,
             SkipLeasingErrorsLogging: false,
             LicensePath: null,
-            ThrowOnInvalidOrMissingLicense: false
+            ThrowOnInvalidOrMissingLicense: false,
         };
     }
 

--- a/src/Raven.Studio/typescript/test/stubs/LicenseStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/LicenseStubs.ts
@@ -201,6 +201,7 @@ export class LicenseStubs {
             DisableAutoUpdateFromApi: false,
             SkipLeasingErrorsLogging: false,
             LicensePath: null,
+            ThrowOnInvalidOrMissingLicense: false
         };
     }
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -468,6 +468,8 @@ namespace Voron
                     tx.Commit();
                 }
             }
+
+            Options.AfterDatabaseCreation?.Invoke(this);
         }
 
         public IFreeSpaceHandling FreeSpaceHandling => _freeSpaceHandling;

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -183,6 +183,8 @@ namespace Voron
 
         public Action<StorageEnvironment> BeforeSchemaUpgrade { get; set; }
 
+        public Action<StorageEnvironment> AfterDatabaseCreation { get; set; }
+
         public ScratchSpaceUsageMonitor ScratchSpaceUsage { get; }
 
         public TimeSpan LongRunningFlushingWarning = TimeSpan.FromMinutes(5);

--- a/test/LicenseTests/LicenseOptionsTests.cs
+++ b/test/LicenseTests/LicenseOptionsTests.cs
@@ -1,0 +1,746 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using EmbeddedTests;
+using FastTests;
+using Raven.Client.Exceptions.Server;
+using Raven.Embedded;
+using Raven.Server.Commercial;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LicenseTests;
+
+[Collection("TestCollection.NonParallelTests")]
+public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
+{
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicence_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicence_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicencePath_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicence_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicence_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicencePath_ShouldWork()
+    {
+        StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicense_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+                StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicense_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicensePath_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_SystemEnvironmentVariableLicense_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+                StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_ServerOptionLicense_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Embedded | RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_ServerOptionLicensePath_ShouldThrow()
+    {
+        ServerOptions options = null;
+        var exception = Assert.Throws(typeof(AggregateException), () =>
+            StartEmbeddedServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(options.ServerDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<InvalidOperationException>(exception, expectedMessageBuilder);
+    }
+
+    private void StartEmbeddedServerLicenseOptionTest(bool throwOnInvalidOrMissingLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerOptions options)
+    {
+        var originalLicense = Environment.GetEnvironmentVariable("RAVEN_License");
+        var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_License.Path");
+
+        options = CopyServerAndCreateOptions();
+        options.LicenseConfiguration.ThrowOnInvalidOrMissingLicense = throwOnInvalidOrMissingLicense;
+
+        try
+        {
+            if (configurationKeyToTest == LicenseOptionTestHelper.LicenseConfigurationKey)
+            {
+                HandleLicenseOption(license, licenseSource, ref options);
+            }
+            else if (configurationKeyToTest == LicenseOptionTestHelper.LicensePathConfigurationKey)
+            {
+                HandleLicensePathOption(license, licenseSource, ref options);
+            }
+
+            CreateEmbeddedServer(options);
+        }
+        catch
+        {
+            Task.Delay(1000).Wait(); // wait to ensure the server is fully disposed
+            throw;
+        }
+        finally
+        {
+            AfterTestCleanup(originalLicense, originalLicensePath);
+        }
+    }
+
+    private static void HandleLicenseOption(string license, LicenseSource licenseSource, ref ServerOptions options)
+    {
+        switch (licenseSource)
+        {
+            case LicenseSource.EnvironmentVariable:
+                Assert.Null(options.LicenseConfiguration.License);
+                Assert.Null(options.LicenseConfiguration.LicensePath);
+
+                Environment.SetEnvironmentVariable("RAVEN_License", license);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), license);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            case LicenseSource.ServerOption:
+                options.LicenseConfiguration.License = license;
+                Assert.Null(options.LicenseConfiguration.LicensePath);
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(licenseSource), licenseSource, null);
+        }
+    }
+
+    private static void HandleLicensePathOption(string license, LicenseSource licenseSource, ref ServerOptions options)
+    {
+        string licensePath = LicenseOptionTestHelper.CreateLicenseJsonFile(options.ServerDirectory, license);
+
+        switch (licenseSource)
+        {
+            case LicenseSource.EnvironmentVariable:
+                Assert.Null(options.LicenseConfiguration.License);
+                Assert.Null(options.LicenseConfiguration.LicensePath);
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", licensePath);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), licensePath);
+                break;
+
+            case LicenseSource.ServerOption:
+                options.LicenseConfiguration.LicensePath = licensePath;
+                Assert.Null(options.LicenseConfiguration.License);
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(licenseSource), licenseSource, null);
+        }
+    }
+
+    private static void CreateEmbeddedServer(ServerOptions options)
+    {
+        RavenServerRunner.ForTestingPurposesOnly().EnvironmentVariablesToCopyToInternalProcess = new List<string> { "RAVEN_License", "RAVEN_License.Path" };
+
+        using (var embedded = new EmbeddedServer())
+        {
+            embedded.StartServer(options);
+        }
+    }
+
+    private static void AfterTestCleanup(string originalLicense, string originalLicensePath)
+    {
+        RavenServerRunner.ForTestingPurposesOnly().EnvironmentVariablesToCopyToInternalProcess = null;
+
+        Environment.SetEnvironmentVariable("RAVEN_License", originalLicense);
+        Environment.SetEnvironmentVariable("RAVEN_License.Path", originalLicensePath);
+    }
+}
+
+[Collection("TestCollection.NonParallelTests")]
+public class LicenseOptionsTestDriverTests : RavenTestBase
+{
+    public LicenseOptionsTestDriverTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicence_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicence_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceFalse_InvalidLicense_ServerOptionLicencePath_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: false, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicence_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicence_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_SystemEnvironmentVariableLicencePath_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_ValidLicense_ServerOptionLicencePath_ShouldWork()
+    {
+        StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.ValidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicense_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(Environment.CurrentDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicense_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(Environment.CurrentDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_InvalidLicense_ServerOptionLicensePath_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, LicenseOptionTestHelper.InvalidLicense, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(LicenseOptionTestHelper.InvalidLicense);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_SystemEnvironmentVariableLicense_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(Environment.CurrentDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_ServerOptionLicense_ShouldThrow()
+    {
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicenseConfigurationKey, out _));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        var readErrorException = new FileNotFoundException($"Could not find file '{Path.Combine(Environment.CurrentDirectory, "license.json")}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_SystemEnvironmentVariableLicensePath_ShouldThrow()
+    {
+        ServerCreationOptions options = null;
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.EnvironmentVariable, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        Assert.True(options.CustomSettings.TryGetValue("ForTestingPurposesLicensePath", out var licensePath));
+        var readErrorException = new FileNotFoundException($"Could not find file '{licensePath}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    [RavenFact(RavenTestCategory.Licensing)]
+    public void VerifyLicense_EnforceTrue_NoLicense_ServerOptionLicensePath_ShouldThrow()
+    {
+        ServerCreationOptions options = null;
+        var exception = Assert.Throws(typeof(ServerLoadFailureException), () =>
+            StartTestDriverServerLicenseOptionTest(throwOnInvalidOrMissingLicense: true, license: null, LicenseSource.ServerOption, LicenseOptionTestHelper.LicensePathConfigurationKey, out options));
+
+        var expectedMessageBuilder = new LicenseHelper.LicenseVerificationErrorBuilder();
+        expectedMessageBuilder.AppendLicenseMissingMessage();
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicenseConfigurationKey);
+        expectedMessageBuilder.AppendDeserializationErrorMessage(licenseContent: null);
+
+        expectedMessageBuilder.AppendConfigurationKeyUsageAttempt(LicenseOptionTestHelper.LicensePathConfigurationKey);
+        Assert.True(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.LicensePath), out var licensePath));
+        var readErrorException = new FileNotFoundException($"Could not find file '{licensePath}'.");
+        expectedMessageBuilder.AppendFileReadErrorMessage(readErrorException);
+
+        expectedMessageBuilder.AppendGeneralSuggestions();
+        expectedMessageBuilder.AppendSuggestionToDisableThrowOnInvalidOrMissingLicenseOption(throwOnInvalidOrMissingLicenseOptionEnabled: true, isInStorageLicenseExpired: false);
+
+        LicenseOptionTestHelper.AssertException<LicenseExpiredException>(exception, expectedMessageBuilder);
+    }
+
+    private void StartTestDriverServerLicenseOptionTest(bool throwOnInvalidOrMissingLicense, string license, LicenseSource licenseSource, string configurationKeyToTest, out ServerCreationOptions options)
+    {
+        var originalLicense = Environment.GetEnvironmentVariable("RAVEN_License");
+        var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_License.Path");
+
+        options = new ServerCreationOptions { CustomSettings = new Dictionary<string, string>() };
+        options.CustomSettings[RavenConfiguration.GetKey(x => x.Licensing.ThrowOnInvalidOrMissingLicense)] = throwOnInvalidOrMissingLicense.ToString();
+
+        try
+        {
+            if (configurationKeyToTest == LicenseOptionTestHelper.LicenseConfigurationKey)
+            {
+                HandleLicenseOption(license, licenseSource, ref options);
+            }
+            else if (configurationKeyToTest == LicenseOptionTestHelper.LicensePathConfigurationKey)
+            {
+                HandleLicensePathOption(license, licenseSource, ref options);
+            }
+
+            using (_ = GetNewServer(options))
+            {
+            }
+        }
+        catch
+        {
+            Task.Delay(1000).Wait(); // wait to ensure the server is fully disposed
+            throw;
+        }
+        finally
+        {
+            AfterTestCleanup(originalLicense, originalLicensePath);
+        }
+    }
+
+    internal static void HandleLicenseOption(string license, LicenseSource licenseSource, ref ServerCreationOptions options)
+    {
+        switch (licenseSource)
+        {
+            case LicenseSource.EnvironmentVariable:
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.License), out _));
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.LicensePath), out _));
+
+                Environment.SetEnvironmentVariable("RAVEN_License", license);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), license);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            case LicenseSource.ServerOption:
+                options.CustomSettings[RavenConfiguration.GetKey(x => x.Licensing.License)] = license;
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.LicensePath), out _));
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(licenseSource), licenseSource, null);
+        }
+    }
+
+    private void HandleLicensePathOption(string license, LicenseSource licenseSource, ref ServerCreationOptions options)
+    {
+        var dataPath = NewDataPath(forceCreateDir: true);
+        string licensePath = LicenseOptionTestHelper.CreateLicenseJsonFile(dataPath, license);
+
+        switch (licenseSource)
+        {
+            case LicenseSource.EnvironmentVariable:
+                options.CustomSettings["ForTestingPurposesLicensePath"] = licensePath;
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.License), out _));
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.LicensePath), out _));
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", licensePath);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), licensePath);
+                break;
+
+            case LicenseSource.ServerOption:
+                options.CustomSettings[RavenConfiguration.GetKey(x => x.Licensing.LicensePath)] = licensePath;
+                Assert.False(options.CustomSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Licensing.License), out _));
+
+                Environment.SetEnvironmentVariable("RAVEN_License", null);
+                Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
+
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License"), null);
+                Assert.Equal(Environment.GetEnvironmentVariable("RAVEN_License.Path"), null);
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(licenseSource), licenseSource, null);
+        }
+    }
+
+    private static void AfterTestCleanup(string originalLicense, string originalLicensePath)
+    {
+        Environment.SetEnvironmentVariable("RAVEN_License", originalLicense);
+        Environment.SetEnvironmentVariable("RAVEN_License.Path", originalLicensePath);
+    }
+}
+
+internal enum LicenseSource
+{
+    EnvironmentVariable,
+    ServerOption
+}
+
+[CollectionDefinition("TestCollection.NonParallelTests", DisableParallelization = true)]
+public class NonParallelRavenTestsCollection
+{
+    // just a definition to group tests to run in non-parallel mode
+}
+
+public static class LicenseOptionTestHelper
+{
+    internal const string InvalidLicense = "SomeInvalidLicense";
+    internal static readonly string LicenseConfigurationKey = RavenConfiguration.GetKey(x => x.Licensing.License);
+    internal static readonly string LicensePathConfigurationKey = RavenConfiguration.GetKey(x => x.Licensing.LicensePath);
+    internal static readonly string ValidLicense = Environment.GetEnvironmentVariable("RAVEN_LICENSE");
+
+    public static string CreateLicenseJsonFile(string directoryPath, string licenseToTest)
+    {
+        var licenseJsonPath = Path.Combine(directoryPath, "license.json");
+        if (File.Exists(licenseJsonPath))
+            File.Delete(licenseJsonPath);
+
+        if (string.IsNullOrWhiteSpace(licenseToTest))
+            return licenseJsonPath;
+
+        File.WriteAllText(licenseJsonPath, licenseToTest);
+
+        Assert.True(File.Exists(licenseJsonPath));
+        Assert.Equal(File.ReadAllText(licenseJsonPath), licenseToTest);
+
+        return licenseJsonPath;
+    }
+
+    internal static void AssertException<T>(Exception exception, LicenseHelper.LicenseVerificationErrorBuilder expectedMessageBuilder) where T:Exception
+    {
+        Assert.NotNull(exception.InnerException);
+        Assert.IsType<T>(exception.InnerException);
+        Assert.True(exception.InnerException.Message.Contains(expectedMessageBuilder.ToString()),
+            userMessage: $"Exception message: {exception.InnerException.Message}{Environment.NewLine}But expected message:{Environment.NewLine}{expectedMessageBuilder}");
+    }
+}

--- a/test/LicenseTests/LicenseTests.csproj
+++ b/test/LicenseTests/LicenseTests.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Raven.Client\Raven.Client.csproj" />
     <ProjectReference Include="..\..\src\Raven.Server\Raven.Server.csproj" />
+    <ProjectReference Include="..\EmbeddedTests\EmbeddedTests.csproj" />
     <ProjectReference Include="..\FastTests\FastTests.csproj" />
     <ProjectReference Include="..\Tests.Infrastructure\Tests.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Sparrow\Sparrow.csproj" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22246

### Additional description

Implementation of `LicenseOptions` within `ServerOptions`, including the six previously existing configurations:
- `License`
- `LicensePath`
- `EulaAccepted`
- `DisableAutoUpdate`
- `DisableAutoUpdateFromApi`
- `DisableLicenseSupportCheck`

Plus the introduction of a new configuration: `EnforceLicense`.

If `EnforceLicense` is set to true, the test or embedded server will not start if the license is not provided in `LicenseOptions` or if the provided license fails validation.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured:
The `ServerOptions.AcceptEula` option has been marked as obsolete and moved inside `ServerOptions.LicenseConfiguration` as `EulaAccepted`. Backward compatibility is achieved as follows:

```csharp
public bool AcceptEula
{
    get => LicenseConfiguration.EulaAccepted;
    set => LicenseConfiguration.EulaAccepted = value;
}
```
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed