### PR TITLE
RavenDB-22806 - Add ForgetAbout to enumerator used in subscription v6.0

### DIFF
--- a/src/Raven.Server/Documents/Subscriptions/Processor/RevisionsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Processor/RevisionsDatabaseSubscriptionProcessor.cs
@@ -166,10 +166,17 @@ namespace Raven.Server.Documents.Subscriptions.Processor
                 if (match == false)
                 {
                     reason = $"{item.Current.Id} filtered by criteria";
+                    transformResult.Dispose();
                     result.Document.Data?.Dispose();
                     result.Document.Data = null;
                     result.Status = SubscriptionBatchItemStatus.Skip;
                     return result;
+                }
+
+                if (transformResult.Location != result.Document.Data.Location)
+                {
+                    // was modified by patch
+                    transformResult.Dispose();
                 }
 
                 result.Status = SubscriptionBatchItemStatus.Send;

--- a/src/Raven.Server/Documents/Subscriptions/Sharding/ShardDocumentSubscriptionFetcher.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Sharding/ShardDocumentSubscriptionFetcher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Raven.Server.Documents.Subscriptions.Sharding;
@@ -9,7 +10,7 @@ public sealed class ShardDocumentSubscriptionFetcher : DocumentSubscriptionFetch
     {
     }
 
-    protected override IEnumerable<Document> FetchFromResend()
+    protected override IEnumerator<Document> FetchFromResend()
     {
         var records = new SortedDictionary<long, Document>();
         foreach (var document in base.FetchFromResend())
@@ -25,6 +26,7 @@ public sealed class ShardDocumentSubscriptionFetcher : DocumentSubscriptionFetch
                 }
 
                 records.Add(current.Etag, document);
+                DocsContext.Transaction.ForgetAbout(current);
             }
         }
 

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionFetcher.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionFetcher.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections.Generic;
 using Raven.Client;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils.Enumerators;
 using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Subscriptions
@@ -14,9 +16,9 @@ namespace Raven.Server.Documents.Subscriptions
             Logger = LoggingSource.Instance.GetLogger<SubscriptionFetcher<T>>(Database.Name);
         }
 
-        protected abstract IEnumerable<T> FetchByEtag();
+        protected abstract IEnumerator<T> FetchByEtag();
 
-        protected abstract IEnumerable<T> FetchFromResend();
+        protected abstract IEnumerator<T> FetchFromResend();
 
         public IEnumerable<T> GetEnumerator()
         {
@@ -95,26 +97,23 @@ namespace Raven.Server.Documents.Subscriptions
 
         }
 
-        protected override IEnumerable<(Document Previous, Document Current)> FetchByEtag()
+        protected override IEnumerator<(Document Previous, Document Current)> FetchByEtag()
         {
             return Collection switch
             {
-                Constants.Documents.Collections.AllDocumentsCollection =>
-                    Database.DocumentsStorage.RevisionsStorage.GetCurrentAndPreviousRevisionsForSubscriptionsFrom(DocsContext, StartEtag + 1, 0, long.MaxValue),
-                _ =>
+                Constants.Documents.Collections.AllDocumentsCollection => new TransactionForgetAboutCurrentPreviousRevisionEnumerator(
+                    Database.DocumentsStorage.RevisionsStorage.GetCurrentAndPreviousRevisionsForSubscriptionsFrom(DocsContext, StartEtag + 1, 0, long.MaxValue)
+                        .GetEnumerator(), DocsContext),
+                _ => new TransactionForgetAboutCurrentPreviousRevisionEnumerator(
                     Database.DocumentsStorage.RevisionsStorage.GetCurrentAndPreviousRevisionsForSubscriptionsFrom(DocsContext, new CollectionName(Collection), StartEtag + 1, long.MaxValue)
+                        .GetEnumerator(), DocsContext)
             };
         }
 
-        protected override IEnumerable<(Document Previous, Document Current)> FetchFromResend()
+        protected override IEnumerator<(Document Previous, Document Current)> FetchFromResend()
         {
-            foreach (var r in SubscriptionConnectionsState.GetRevisionsFromResend(ClusterContext, Active))
-            {
-                yield return (
-                    Database.DocumentsStorage.RevisionsStorage.GetRevision(DocsContext, r.Previous),
-                    Database.DocumentsStorage.RevisionsStorage.GetRevision(DocsContext, r.Current)
-                    );
-            }
+            return new TransactionForgetAboutCurrentPreviousRevisionEnumerator(SubscriptionConnectionsState.GetRevisionsFromResend(Database, ClusterContext, DocsContext, Active)
+                .GetEnumerator(), DocsContext);
         }
     }
 
@@ -125,23 +124,25 @@ namespace Raven.Server.Documents.Subscriptions
         {
         }
 
-        protected override IEnumerable<Document> FetchByEtag()
+        protected override IEnumerator<Document> FetchByEtag()
         {
             return Collection switch
             {
                 Constants.Documents.Collections.AllDocumentsCollection =>
-                    Database.DocumentsStorage.GetDocumentsFrom(DocsContext, StartEtag + 1, 0, long.MaxValue),
+                    new TransactionForgetAboutDocumentEnumerator(Database.DocumentsStorage.GetDocumentsFrom(DocsContext, StartEtag + 1, 0, long.MaxValue)
+                        .GetEnumerator(), DocsContext),
                 _ =>
-                    Database.DocumentsStorage.GetDocumentsFrom(
+                    new TransactionForgetAboutDocumentEnumerator(Database.DocumentsStorage.GetDocumentsFrom(
                         DocsContext,
                         Collection,
                         StartEtag + 1,
                         0,
                         long.MaxValue)
+                        .GetEnumerator(), DocsContext)
             };
         }
 
-        protected override IEnumerable<Document> FetchFromResend()
+        protected override IEnumerator<Document> FetchFromResend()
         {
             foreach (var record in SubscriptionConnectionsState.GetDocumentsFromResend(ClusterContext, Active))
             {

--- a/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutAbstractEnumerator.cs
+++ b/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutAbstractEnumerator.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Utils.Enumerators;
+
+public abstract class TransactionForgetAboutAbstractEnumerator<T> : IEnumerator<T>
+{
+    private readonly IEnumerator<T> _innerEnumerator;
+    protected readonly DocumentsOperationContext DocsContext;
+
+    protected TransactionForgetAboutAbstractEnumerator([NotNull] IEnumerator<T> innerEnumerator, [NotNull] DocumentsOperationContext docsContext)
+    {
+        _innerEnumerator = innerEnumerator;
+        DocsContext = docsContext;
+    }
+
+    protected abstract void ForgetAbout(T item);
+
+    public bool MoveNext()
+    {
+        ForgetAbout(Current);
+
+        if (_innerEnumerator.MoveNext() == false)
+            return false;
+
+        Current = _innerEnumerator.Current;
+
+        return true;
+    }
+
+    public void Reset()
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public T Current { get; private set; }
+
+    object IEnumerator.Current => Current;
+
+    public void Dispose()
+    {
+        _innerEnumerator.Dispose();
+    }
+}

--- a/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutCurrentPreviousRevisionEnumerator.cs
+++ b/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutCurrentPreviousRevisionEnumerator.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using JetBrains.Annotations;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Utils.Enumerators;
+
+public class TransactionForgetAboutCurrentPreviousRevisionEnumerator : TransactionForgetAboutAbstractEnumerator<(Document Previous, Document Current)>
+{
+    public TransactionForgetAboutCurrentPreviousRevisionEnumerator([NotNull] IEnumerator<(Document Previous, Document Current)> innerEnumerator, [NotNull] DocumentsOperationContext docsContext) : base(innerEnumerator, docsContext)
+    {
+    }
+
+    protected override void ForgetAbout((Document Previous, Document Current) item)
+    {
+        DocsContext.Transaction.ForgetAbout(item.Current);
+        DocsContext.Transaction.ForgetAbout(item.Previous);
+    }
+}

--- a/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutDocumentEnumerator.cs
+++ b/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutDocumentEnumerator.cs
@@ -1,45 +1,18 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using JetBrains.Annotations;
 using Raven.Server.Documents;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Utils.Enumerators;
 
-public class TransactionForgetAboutDocumentEnumerator : IEnumerator<Document>
+public class TransactionForgetAboutDocumentEnumerator : TransactionForgetAboutAbstractEnumerator<Document>
 {
-    private readonly IEnumerator<Document> _innerEnumerator;
-    private readonly DocumentsOperationContext _docsContext;
-
-    public TransactionForgetAboutDocumentEnumerator([NotNull] IEnumerator<Document> innerEnumerator, [NotNull] DocumentsOperationContext docsContext)
+    public TransactionForgetAboutDocumentEnumerator([NotNull] IEnumerator<Document> innerEnumerator, [NotNull] DocumentsOperationContext docsContext) : base(innerEnumerator, docsContext)
     {
-        _innerEnumerator = innerEnumerator;
-        _docsContext = docsContext;
     }
 
-    public bool MoveNext()
+    protected override void ForgetAbout(Document item)
     {
-        _docsContext.Transaction.ForgetAbout(Current);
-
-        if (_innerEnumerator.MoveNext() == false)
-            return false;
-
-        Current = _innerEnumerator.Current;
-
-        return true;
-    }
-
-    public void Reset()
-    {
-        throw new System.NotImplementedException();
-    }
-
-    public Document Current { get; private set; }
-
-    object IEnumerator.Current => Current;
-
-    public void Dispose()
-    {
-        _innerEnumerator.Dispose();
+        DocsContext.Transaction.ForgetAbout(Current);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22806

### Additional description

**cherry pick** 
https://github.com/ravendb/ravendb/pull/19124

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
