### PR TITLE
RavenDB-22820 OpenTelemetry: Allows users to define the server instance ID via configuration.

### DIFF
--- a/src/Raven.Server/Config/Categories/MonitoringConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/MonitoringConfiguration.cs
@@ -54,6 +54,11 @@ namespace Raven.Server.Config.Categories
             [ConfigurationEntry("Monitoring.OpenTelemetry.Enabled", ConfigurationEntryScope.ServerWideOnly)]
             public bool Enabled { get; set; }
             
+            [Description("Sets the OpenTelemetry service instance ID. When it's not set, RavenDB will use public hostname; if not available, node tag will be used as the identifier.")]
+            [DefaultValue(null)]
+            [ConfigurationEntry("Monitoring.OpenTelemetry.ServiceInstanceId", ConfigurationEntryScope.ServerWideOnly)]
+            public string ServiceInstanceId { get; set; }
+            
             [Description("Indicates if RavenDB's OpenTelemetry metrics are enabled or not. Default: true")]
             [DefaultValue(true)]
             [ConfigurationEntry("Monitoring.OpenTelemetry.Meters.Server.Enabled", ConfigurationEntryScope.ServerWideOnly)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22820

### Additional description

Introducing configuration option to set server instance ID via configuration option.
Now, service instance id is retrieved in following manner:
1. Use the user's explicit name when available.
2. If the user has not defined an explicit name, we will use the public URL hostname, if available.
3. If the hostname is not available, try to use the node tag.
4. If the node tag is still not available, OpenTelemetry will not be initialized.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
