### PR TITLE
RavenDB-22731 : Unexpected Behavior in Resharding with Prefix Configuration

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
@@ -29,6 +30,9 @@ namespace Raven.Server.ServerWide.Commands.Sharding
 
         public StartBucketMigrationCommand(int bucket, int destShard, string database, string prefix, string raftId) : base(database, raftId)
         {
+            if (bucket >= ShardHelper.NumberOfBuckets && string.IsNullOrEmpty(prefix))
+                throw new InvalidOperationException($"Bucket {bucket} belongs to a prefixed range, but 'prefix' parameter wasn't provided");
+
             Bucket = bucket;
             DestinationShard = destShard;
             Prefix = prefix;

--- a/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
@@ -28,19 +28,15 @@ namespace Raven.Server.ServerWide.Commands.Sharding
         {
         }
 
-        public StartBucketMigrationCommand(int bucket, int destShard, string database, string prefix, string raftId) : base(database, raftId)
+        public StartBucketMigrationCommand(int bucket, int? sourceShard, int destShard, string database, string prefix, string raftId) : base(database, raftId)
         {
             if (bucket >= ShardHelper.NumberOfBuckets && string.IsNullOrEmpty(prefix))
                 throw new InvalidOperationException($"Bucket {bucket} belongs to a prefixed range, but 'prefix' parameter wasn't provided");
 
+            SourceShard = sourceShard;
             Bucket = bucket;
             DestinationShard = destShard;
             Prefix = prefix;
-        }
-
-        public StartBucketMigrationCommand(int bucket, int sourceShard, int destShard, string database, string raftId) : this(bucket, destShard, database, prefix: null, raftId)
-        {
-            SourceShard = sourceShard;
         }
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.ServerWide
 
         public Task<(long Index, object Result)> StartBucketMigration(string database, int bucket, int toShard, string prefix, string raftId)
         {
-            var cmd = new StartBucketMigrationCommand(bucket, toShard, database, prefix, raftId ?? RaftIdGenerator.NewId());
+            var cmd = new StartBucketMigrationCommand(bucket, sourceShard: null, toShard, database, prefix, raftId ?? RaftIdGenerator.NewId());
             return _serverStore.SendToLeaderAsync(cmd);
         }
 

--- a/test/SlowTests/Sharding/Issues/RavenDB_22731.cs
+++ b/test/SlowTests/Sharding/Issues/RavenDB_22731.cs
@@ -1,0 +1,269 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Exceptions;
+using Raven.Client.Http;
+using Raven.Client.Json.Serialization;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Server.Utils;
+using SlowTests.Core.Utils.Entities;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Issues
+{
+    public class RavenDB_22731 : RavenTestBase
+    {
+        public RavenDB_22731(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task ReshardingEndpoint_ShouldThrowOnAttemptToMoveBucketFromPrefixedRange_ToShardNotInPrefixSetting()
+        {
+            using var store = Sharding.GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Sharding ??= new ShardingConfiguration();
+                    record.Sharding.Prefixed =
+                    [
+                        new PrefixedShardingSetting
+                        {
+                            Prefix = "users/",
+                            Shards = [0]
+                        }
+                    ];
+                }
+            });
+            {
+                const string id = "users/1";
+                const int destShard = 2; // not in prefix setting
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), id);
+                    await session.SaveChangesAsync();
+                }
+
+                var bucket = await Sharding.GetBucketAsync(store, id);
+
+                using (var session = store.OpenAsyncSession())
+                using (var context = JsonOperationContext.ShortTermSingleUse())
+                {
+                    var command = new StartReshardingCommand(store.Database, fromBucket: bucket, toBucket: bucket, destinationShard: destShard);
+                    await session.Advanced.RequestExecutor.ExecuteAsync(command, context);
+
+                    var op = new ServerWideOperation(session.Advanced.RequestExecutor, store.Conventions, command.Result.OperationId, command.Result.OperationNodeTag);
+
+                    var ex = await Assert.ThrowsAsync<RavenException>(async () => await op.WaitForCompletionAsync(TimeSpan.FromSeconds(60)));
+
+                    Assert.Contains($"Failed to start migration of bucket '{bucket}'. Destination shard {destShard} doesn't exist", ex.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task ReshardingEndpoint_CanMoveSingleBucket_FromPrefixedRange()
+        {
+            using var store = Sharding.GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Sharding ??= new ShardingConfiguration();
+                    record.Sharding.Prefixed =
+                    [
+                        new PrefixedShardingSetting
+                        {
+                            Prefix = "users/",
+                            Shards = [0, 2]
+                        }
+                    ];
+                }
+            });
+            {
+                const string id = "users/1";
+                const int sourceShard = 2;
+                const int destShard = 0;
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), id);
+                    await session.SaveChangesAsync();
+                }
+
+                var shardNum = await Sharding.GetShardNumberForAsync(store, id);
+                Assert.Equal(sourceShard, shardNum);
+
+                var bucket = await Sharding.GetBucketAsync(store, id);
+
+                using (var session = store.OpenAsyncSession())
+                using (var context = JsonOperationContext.ShortTermSingleUse())
+                {
+                    // prefix string is not specified in StartReshardingCommand
+                    // this should be handled on the server side - recognize that this bucket belongs to prefixed range, find the 
+                    // matching prefix setting, and verify that we have a valid destination shard
+
+                    var command = new StartReshardingCommand(store.Database, fromBucket: bucket, toBucket: bucket, destinationShard: destShard);
+                    await session.Advanced.RequestExecutor.ExecuteAsync(command, context);
+                }
+
+                await WaitForValueAsync(async () =>
+                {
+                    return shardNum = await Sharding.GetShardNumberForAsync(store, id);
+                }, expectedVal: destShard, timeout: 60_000);
+
+                Assert.Equal(destShard, shardNum);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding, Skip = "takes too long")]
+        public async Task ReshardingEndpoint_CanMoveRangeOfBuckets_FromPrefixed()
+        {
+            using var store = Sharding.GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Sharding ??= new ShardingConfiguration();
+                    record.Sharding.Prefixed =
+                    [
+                        new PrefixedShardingSetting
+                        {
+                            Prefix = "users/",
+                            Shards = [0, 2]
+                        }
+                    ];
+                }
+            });
+            {
+                const int destShard = 2;
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 100; i++)
+                    {
+                        await session.StoreAsync(new User(), $"users/{i}");
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                int userDocsInShard0 = -1;
+                using (var session = store.OpenSession(ShardHelper.ToShardName(store.Database, 0)))
+                {
+                    userDocsInShard0 = session.Query<User>().Count();
+                    Assert.True(userDocsInShard0 > 0);
+                }
+
+                var fromBucket = ShardHelper.NumberOfBuckets;
+                var toBucket = (int)(ShardHelper.NumberOfBuckets * 1.5);
+
+                using (var session = store.OpenAsyncSession())
+                using (var context = JsonOperationContext.ShortTermSingleUse())
+                {
+                    var command = new StartReshardingCommand(store.Database, fromBucket, toBucket, destinationShard: destShard);
+                    await session.Advanced.RequestExecutor.ExecuteAsync(command, context);
+
+                    await WaitForValueAsync(() =>
+                    {
+                        using (var session = store.OpenSession(ShardHelper.ToShardName(store.Database, 0)))
+                        {
+                            //userDocsInShard0 = session.Query<User>().Count();
+                            return userDocsInShard0 = session.Query<User>().Count();
+                        }
+                    }, expectedVal: 0, timeout: 120_000);
+
+                    Assert.Equal(0, userDocsInShard0);
+                }
+
+                using (var session = store.OpenAsyncSession(ShardHelper.ToShardName(store.Database, 2)))
+                {
+                    var userDocsInShard2 = session.Query<User>().Count();
+                    Assert.Equal(100, userDocsInShard2);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Sharding)]
+        public async Task StartBucketMigrationCommand_ShouldThrowOnAttemptToMoveBucketFromPrefixedRange_IfNoPrefixStringProvided()
+        {
+            using var store = Sharding.GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Sharding ??= new ShardingConfiguration();
+                    record.Sharding.Prefixed =
+                    [
+                        new PrefixedShardingSetting
+                        {
+                            Prefix = "users/",
+                            Shards = [0, 1]
+                        }
+                    ];
+                }
+            });
+            {
+                const string id = "users/1";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), id);
+                    await session.SaveChangesAsync();
+                }
+
+                var bucket = await Sharding.GetBucketAsync(store, id);
+
+                var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => 
+                    await Server.ServerStore.Sharding.StartBucketMigration(store.Database, bucket, toShard: 1));
+
+                Assert.Contains($"Bucket {bucket} belongs to a prefixed range, but 'prefix' parameter wasn't provided", ex.Message);
+            }
+        }
+
+        private class StartReshardingCommand : RavenCommand<OperationIdResult>
+        {
+            private readonly string _database;
+            private readonly int _fromBucket;
+            private readonly int _toBucket;
+            private readonly int _destinationShard;
+
+            public StartReshardingCommand(string database, int fromBucket, int toBucket, int destinationShard)
+            {
+                _database = database;
+                _fromBucket = fromBucket;
+                _toBucket = toBucket;
+                _destinationShard = destinationShard;
+            }
+
+            public override bool IsReadRequest => false;
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/admin/resharding/start?" +
+                      $"database={_database}&fromBucket={_fromBucket}&toBucket={_toBucket}&toShard={_destinationShard}";
+
+                return new HttpRequestMessage
+                {
+                    Method = HttpMethod.Post
+                };
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    ThrowInvalidResponse();
+
+                var result = JsonDeserializationClient.BackupDatabaseNowResult(response);
+                var operationIdResult = JsonDeserializationClient.OperationIdResult(response);
+
+                operationIdResult.OperationNodeTag ??= result.ResponsibleNode;
+                Result = operationIdResult.ForResult(result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22731/Unexpected-Behavior-in-Resharding-with-Prefix-Configuration

### Additional description

when moving bucket from a prefixed range, make sure that `prefix` parameter is passed and validate that the corresponding prefix configuration contains the destination shard

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
