### PR TITLE
RavenDB-22327 Enhanced logging clarity for `Responsible Node` information when stopping ETL Task. Added explanation for swiching a task to a different node.

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -480,8 +480,7 @@ namespace Raven.Client.ServerWide
 
             var node = WhoseTaskIsIt(task, explanations);
 
-            if (node != null)
-                explanations?.Add($"Task belongs to node ({node})");
+            explanations?.Add(node != null ? $"Task belongs to node {node}" : "No responsible node has been found");
 
             return node;
         }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -164,7 +164,7 @@ namespace Raven.Server.Documents
                     switch (changeType)
                     {
                         case ClusterDatabaseChangeType.RecordChanged:
-                            await database.StateChangedAsync(index);
+                            await database.StateChangedAsync(index, type, changeType);
                             if (type == ClusterStateMachine.SnapshotInstalled)
                             {
                                 database.NotifyOnPendingClusterTransaction();

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Documents.ETL
 
         public void Initialize(DatabaseRecord record)
         {
-            LoadProcesses(record, record.RavenEtls, record.SqlEtls, record.OlapEtls, record.ElasticSearchEtls, record.QueueEtls, toRemove: null);
+            LoadProcesses(record, record.RavenEtls, record.SqlEtls, record.OlapEtls, record.ElasticSearchEtls, record.QueueEtls, toRemove: null, null, null);
         }
 
         public event Action<EtlProcess> ProcessAdded;
@@ -108,7 +108,8 @@ namespace Raven.Server.Documents.ETL
             List<OlapEtlConfiguration> newOlapDestinations,
             List<ElasticSearchEtlConfiguration> newElasticSearchDestinations,
             List<QueueEtlConfiguration> newQueueDestinations,
-            List<EtlProcess> toRemove)
+            List<EtlProcess> toRemove, Dictionary<string, string> responsibleNodes,
+            List<string> explanations)
         {
             lock (_loadProcessedLock)
             {
@@ -157,7 +158,9 @@ namespace Raven.Server.Documents.ETL
 
                 foreach (var process in newProcesses)
                 {
-                    process.Start();
+                    var reason = GetStartReason(responsibleNodes, explanations, process);
+
+                    process.Start(reason);
 
                     OnProcessAdded(process);
 
@@ -456,12 +459,13 @@ namespace Raven.Server.Documents.ETL
             ea.ThrowIfNeeded();
         }
 
-        private bool IsMyEtlTask<T, TConnectionString>(DatabaseRecord record, T etlTask, ref Dictionary<string, string> responsibleNodes)
+        private bool IsMyEtlTask<T, TConnectionString>(DatabaseRecord record, T etlTask, ref Dictionary<string, string> responsibleNodes, out List<string> explanations)
             where TConnectionString : ConnectionString
             where T : EtlConfiguration<TConnectionString>
         {
             var processState = GetProcessState(etlTask.Transforms, _database, etlTask.Name);
-            var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, record.Topology, etlTask, processState, _database.NotificationCenter);
+            explanations = new List<string>();
+            var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, record.Topology, etlTask, processState, _database.NotificationCenter, explanations);
 
             responsibleNodes[etlTask.Name] = whoseTaskIsIt;
 
@@ -481,9 +485,11 @@ namespace Raven.Server.Documents.ETL
 
             var responsibleNodes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+            List<string> explanations = null;
+
             foreach (var config in record.RavenEtls)
             {
-                if (IsMyEtlTask<RavenEtlConfiguration, RavenConnectionString>(record, config, ref responsibleNodes))
+                if (IsMyEtlTask<RavenEtlConfiguration, RavenConnectionString>(record, config, ref responsibleNodes, out explanations))
                 {
                     myRavenEtl.Add(config);
                 }
@@ -491,7 +497,7 @@ namespace Raven.Server.Documents.ETL
 
             foreach (var config in record.SqlEtls)
             {
-                if (IsMyEtlTask<SqlEtlConfiguration, SqlConnectionString>(record, config, ref responsibleNodes))
+                if (IsMyEtlTask<SqlEtlConfiguration, SqlConnectionString>(record, config, ref responsibleNodes, out explanations))
                 {
                     mySqlEtl.Add(config);
                 }
@@ -499,7 +505,7 @@ namespace Raven.Server.Documents.ETL
 
             foreach (var config in record.OlapEtls)
             {
-                if (IsMyEtlTask<OlapEtlConfiguration, OlapConnectionString>(record, config, ref responsibleNodes))
+                if (IsMyEtlTask<OlapEtlConfiguration, OlapConnectionString>(record, config, ref responsibleNodes, out explanations))
                 {
                     myOlapEtl.Add(config);
                 }
@@ -507,7 +513,7 @@ namespace Raven.Server.Documents.ETL
 
             foreach (var config in record.ElasticSearchEtls)
             {
-                if (IsMyEtlTask<ElasticSearchEtlConfiguration, ElasticSearchConnectionString>(record, config, ref responsibleNodes))
+                if (IsMyEtlTask<ElasticSearchEtlConfiguration, ElasticSearchConnectionString>(record, config, ref responsibleNodes, out explanations))
                 {
                     myElasticSearchEtl.Add(config);
                 }
@@ -515,7 +521,7 @@ namespace Raven.Server.Documents.ETL
 
             foreach (var config in record.QueueEtls)
             {
-                if (IsMyEtlTask<QueueEtlConfiguration, QueueConnectionString>(record, config, ref responsibleNodes))
+                if (IsMyEtlTask<QueueEtlConfiguration, QueueConnectionString>(record, config, ref responsibleNodes, out explanations))
                 {
                     myQueueEtl.Add(config);
                 }
@@ -670,7 +676,7 @@ namespace Raven.Server.Documents.ETL
                 }
             }
 
-            LoadProcesses(record, myRavenEtl, mySqlEtl, myOlapEtl, myElasticSearchEtl, myQueueEtl, toRemove.SelectMany(x => x.Value).ToList());
+            LoadProcesses(record, myRavenEtl, mySqlEtl, myOlapEtl, myElasticSearchEtl, myQueueEtl, toRemove.SelectMany(x => x.Value).ToList(), responsibleNodes, explanations);
 
             if (toRemove.Count == 0)
                 return;
@@ -690,7 +696,7 @@ namespace Raven.Server.Documents.ETL
 
                             using (process)
                             {
-                                string reason = GetStopReason(process, myRavenEtl, mySqlEtl, myOlapEtl, myElasticSearchEtl, myQueueEtl, responsibleNodes);
+                                string reason = GetStopReason(process, myRavenEtl, mySqlEtl, myOlapEtl, myElasticSearchEtl, myQueueEtl, responsibleNodes, explanations);
                                 process.Stop(reason);
                             }
                         }
@@ -743,7 +749,8 @@ namespace Raven.Server.Documents.ETL
             List<OlapEtlConfiguration> myOlapEtl,
             List<ElasticSearchEtlConfiguration> myElasticSearchEtl,
             List<QueueEtlConfiguration> myQueueEtl,
-            Dictionary<string, string> responsibleNodes)
+            Dictionary<string, string> responsibleNodes,
+            List<string> explanations)
         {
             EtlConfigurationCompareDifferences? differences = null;
             var transformationDiffs = new List<(string TransformationName, EtlConfigurationCompareDifferences Difference)>();
@@ -810,12 +817,40 @@ namespace Raven.Server.Documents.ETL
             {
                 if (responsibleNodes.TryGetValue(process.ConfigurationName, out var responsibleNode))
                 {
-                    reason += $"ETL was moved to another node. Responsible node is: {responsibleNode}";
+                    reason += "ETL was moved to another node. ";
+
+                    if (string.IsNullOrEmpty(responsibleNode) == false)
+                        reason += $"Responsible node is: {responsibleNode}. ";
+
+                    if (explanations != null)
+                        reason += $"(Node switch explanation: {string.Join(". ", explanations)}) ";
                 }
                 else
                 {
                     reason += $"ETL was deleted or moved to another node (no configuration named '{process.ConfigurationName}' was found). ";
                 }
+            }
+
+            return reason;
+        }
+
+        private string GetStartReason(Dictionary<string, string> responsibleNodes, List<string> explanations, EtlProcess process)
+        {
+            string reason;
+
+            if (responsibleNodes?.TryGetValue(process.ConfigurationName, out var responsibleNode) == true)
+            {
+                if (responsibleNode == _serverStore.NodeTag)
+                    reason = "The node is responsible for this task ";
+                else
+                    reason = $"Node {responsibleNode} should handle this task";
+
+                if (explanations is { Count: > 0 })
+                    reason += $"(Node selection explanation: {string.Join(". ", explanations)}) ";
+            }
+            else
+            {
+                reason = "Task shouldn't be started on this node ";
             }
 
             return reason;

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -850,7 +850,7 @@ namespace Raven.Server.Documents.ETL
             }
             else
             {
-                reason = "Task shouldn't be started on this node ";
+                reason = "Initialize";
             }
 
             return reason;

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.ETL
 
         public TimeSpan? FallbackTime { get; protected set; }
 
-        public abstract void Start();
+        public abstract void Start(string reason);
 
         public abstract void Stop(string reason);
 
@@ -663,7 +663,7 @@ namespace Raven.Server.Documents.ETL
                 _waitForChanges.Set();
         }
 
-        public override void Start()
+        public override void Start(string reason)
         {
             if (_longRunningWork != null)
                 return;
@@ -692,7 +692,7 @@ namespace Raven.Server.Documents.ETL
             }, null, ThreadNames.ForEtlProcess(threadName, Tag, Name));
 
             if (Logger.IsOperationsEnabled)
-                Logger.Operations($"Starting {Tag} process: '{Name}'.");
+                Logger.Operations($"Starting {Tag} process: '{Name}'. Reason: {reason}");
 
         }
 

--- a/src/Raven.Server/Utils/OngoingTasksUtils.cs
+++ b/src/Raven.Server/Utils/OngoingTasksUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.ServerWide;
@@ -14,13 +15,14 @@ internal static class OngoingTasksUtils
         DatabaseTopology databaseTopology,
         IDatabaseTask configuration,
         IDatabaseTaskStatus taskStatus,
-        NotificationCenter.NotificationCenter notificationCenter)
+        NotificationCenter.NotificationCenter notificationCenter,
+        List<string> explanations = null)
     {
-        return WhoseTaskIsIt(serverStore, databaseTopology, serverStore.Engine.CurrentState, configuration, taskStatus, notificationCenter);
+        return WhoseTaskIsIt(serverStore, databaseTopology, serverStore.Engine.CurrentState, configuration, taskStatus, notificationCenter, explanations);
     }
 
     internal static string WhoseTaskIsIt(ServerStore serverStore, DatabaseTopology databaseTopology, RachisState currentState, IDatabaseTask configuration, IDatabaseTaskStatus taskStatus,
-        NotificationCenter.NotificationCenter notificationCenter)
+        NotificationCenter.NotificationCenter notificationCenter, List<string> explanations = null)
     {
         Debug.Assert(taskStatus is not PeriodicBackupStatus);
 
@@ -33,6 +35,7 @@ internal static class OngoingTasksUtils
                 if (lastResponsibleNode == null)
                 {
                     // first time this task is assigned
+                    explanations?.Add("There is no last responsible node. It's first time this task is assigned");
                     return null;
                 }
 
@@ -40,18 +43,25 @@ internal static class OngoingTasksUtils
                 {
                     // the topology doesn't include the last responsible node anymore
                     // we'll choose a different one
+                    explanations?.Add($"The topology ({string.Join(',', databaseTopology.AllNodes)}) doesn't include the last responsible node anymore. We'll choose a different one");
                     return null;
                 }
 
                 if (serverStore.LicenseManager.HasHighlyAvailableTasks() == false)
                 {
                     // can't redistribute, keep it on the original node
+
                     RaiseAlertIfNecessary(databaseTopology, configuration, lastResponsibleNode, serverStore, notificationCenter);
+
+                    explanations?.Add($"Keeping the task on last responsible node ({lastResponsibleNode}). Highly available tasks aren't available");
+
                     return lastResponsibleNode;
                 }
 
+                explanations?.Add($"Last responsible node is {lastResponsibleNode}. Redistributing task work since highly available tasks are supported");
+
                 return null;
-            });
+            }, explanations);
 
         return whoseTaskIsIt;
     }

--- a/test/SlowTests/Server/Documents/ETL/Raven/RDBS_85.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RDBS_85.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 process.BeforeActualLoad = null;
 
-                process.Start();
+                process.Start(null);
 
                 Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22327/Enhance-logging-clarity-for-Responsible-Node-information-in-ETL-Task-stoppage

### Additional description

Including info about actual reason of moving a task to a different node.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
