### PR TITLE
RavenDB-22246: Introduce an option in TestDriver to throw if there is no license or license could not be activated (Specific breaking changes for v6.1)

### DIFF
--- a/src/Raven.Embedded/RavenServerRunner.cs
+++ b/src/Raven.Embedded/RavenServerRunner.cs
@@ -32,22 +32,22 @@ namespace Raven.Embedded
                 commandLineArgs.Add($"--Embedded.ParentProcessId={currentProcess.Id}");
             }
 
-            if (options.License != null)
+            if (options.Licensing != null)
             {
-                if (string.IsNullOrWhiteSpace(options.License.License) == false &&
-                    string.IsNullOrWhiteSpace(options.License.LicensePath) == false)
-                    throw new ArgumentException($"Only one of Licence options '{nameof(options.License.License)}' or '{nameof(options.License.LicensePath)}' should be specified");
+                if (string.IsNullOrWhiteSpace(options.Licensing.License) == false &&
+                    string.IsNullOrWhiteSpace(options.Licensing.LicensePath) == false)
+                    throw new ArgumentException($"Only one of Licence options '{nameof(options.Licensing.License)}' or '{nameof(options.Licensing.LicensePath)}' should be specified");
 
-                if (string.IsNullOrWhiteSpace(options.License.License) == false)
-                    commandLineArgs.Add($"--License={CommandLineArgumentEscaper.EscapeSingleArg(options.License.License)}");
-                else if (string.IsNullOrWhiteSpace(options.License.LicensePath) == false)
-                    commandLineArgs.Add($"--License.Path={CommandLineArgumentEscaper.EscapeSingleArg(options.License.LicensePath)}");
+                if (string.IsNullOrWhiteSpace(options.Licensing.License) == false)
+                    commandLineArgs.Add($"--License={CommandLineArgumentEscaper.EscapeSingleArg(options.Licensing.License)}");
+                else if (string.IsNullOrWhiteSpace(options.Licensing.LicensePath) == false)
+                    commandLineArgs.Add($"--License.Path={CommandLineArgumentEscaper.EscapeSingleArg(options.Licensing.LicensePath)}");
 
-                commandLineArgs.Add($"--License.Eula.Accepted={options.License.EulaAccepted}");
-                commandLineArgs.Add($"--License.DisableAutoUpdate={options.License.DisableAutoUpdate}");
-                commandLineArgs.Add($"--License.DisableAutoUpdateFromApi={options.License.DisableAutoUpdateFromApi}");
-                commandLineArgs.Add($"--License.DisableLicenseSupportCheck={options.License.DisableLicenseSupportCheck}");
-                commandLineArgs.Add($"--License.ThrowOnInvalidOrMissingLicense={options.License.ThrowOnInvalidOrMissingLicense}");
+                commandLineArgs.Add($"--License.Eula.Accepted={options.Licensing.EulaAccepted}");
+                commandLineArgs.Add($"--License.DisableAutoUpdate={options.Licensing.DisableAutoUpdate}");
+                commandLineArgs.Add($"--License.DisableAutoUpdateFromApi={options.Licensing.DisableAutoUpdateFromApi}");
+                commandLineArgs.Add($"--License.DisableLicenseSupportCheck={options.Licensing.DisableLicenseSupportCheck}");
+                commandLineArgs.Add($"--License.ThrowOnInvalidOrMissingLicense={options.Licensing.ThrowOnInvalidOrMissingLicense}");
             }
 
             commandLineArgs.Add("--Setup.Mode=None");

--- a/src/Raven.Embedded/RavenServerRunner.cs
+++ b/src/Raven.Embedded/RavenServerRunner.cs
@@ -32,22 +32,22 @@ namespace Raven.Embedded
                 commandLineArgs.Add($"--Embedded.ParentProcessId={currentProcess.Id}");
             }
 
-            if (options.LicenseConfiguration != null)
+            if (options.License != null)
             {
-                if (string.IsNullOrWhiteSpace(options.LicenseConfiguration.License) == false &&
-                    string.IsNullOrWhiteSpace(options.LicenseConfiguration.LicensePath) == false)
-                    throw new ArgumentException($"Only one of Licence options '{nameof(options.LicenseConfiguration.License)}' or '{nameof(options.LicenseConfiguration.LicensePath)}' should be specified");
+                if (string.IsNullOrWhiteSpace(options.License.License) == false &&
+                    string.IsNullOrWhiteSpace(options.License.LicensePath) == false)
+                    throw new ArgumentException($"Only one of Licence options '{nameof(options.License.License)}' or '{nameof(options.License.LicensePath)}' should be specified");
 
-                if (string.IsNullOrWhiteSpace(options.LicenseConfiguration.License) == false)
-                    commandLineArgs.Add($"--License={CommandLineArgumentEscaper.EscapeSingleArg(options.LicenseConfiguration.License)}");
-                else if (string.IsNullOrWhiteSpace(options.LicenseConfiguration.LicensePath) == false)
-                    commandLineArgs.Add($"--License.Path={CommandLineArgumentEscaper.EscapeSingleArg(options.LicenseConfiguration.LicensePath)}");
+                if (string.IsNullOrWhiteSpace(options.License.License) == false)
+                    commandLineArgs.Add($"--License={CommandLineArgumentEscaper.EscapeSingleArg(options.License.License)}");
+                else if (string.IsNullOrWhiteSpace(options.License.LicensePath) == false)
+                    commandLineArgs.Add($"--License.Path={CommandLineArgumentEscaper.EscapeSingleArg(options.License.LicensePath)}");
 
-                commandLineArgs.Add($"--License.Eula.Accepted={options.LicenseConfiguration.EulaAccepted}");
-                commandLineArgs.Add($"--License.DisableAutoUpdate={options.LicenseConfiguration.DisableAutoUpdate}");
-                commandLineArgs.Add($"--License.DisableAutoUpdateFromApi={options.LicenseConfiguration.DisableAutoUpdateFromApi}");
-                commandLineArgs.Add($"--License.DisableLicenseSupportCheck={options.LicenseConfiguration.DisableLicenseSupportCheck}");
-                commandLineArgs.Add($"--License.ThrowOnInvalidOrMissingLicense={options.LicenseConfiguration.ThrowOnInvalidOrMissingLicense}");
+                commandLineArgs.Add($"--License.Eula.Accepted={options.License.EulaAccepted}");
+                commandLineArgs.Add($"--License.DisableAutoUpdate={options.License.DisableAutoUpdate}");
+                commandLineArgs.Add($"--License.DisableAutoUpdateFromApi={options.License.DisableAutoUpdateFromApi}");
+                commandLineArgs.Add($"--License.DisableLicenseSupportCheck={options.License.DisableLicenseSupportCheck}");
+                commandLineArgs.Add($"--License.ThrowOnInvalidOrMissingLicense={options.License.ThrowOnInvalidOrMissingLicense}");
             }
 
             commandLineArgs.Add("--Setup.Mode=None");

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -21,11 +21,11 @@ namespace Raven.Embedded
 
         public string DotNetPath { get; set; } = "dotnet";
 
-        [Obsolete($"This property is no longer used and will be removed in the next version, please use '{nameof(LicenseConfiguration)}.{nameof(LicenseOptions.EulaAccepted)}' instead.")]
+        [Obsolete($"This property is no longer used and will be removed in the next version, please use '{nameof(License)}.{nameof(LicenseOptions.EulaAccepted)}' instead.")]
         public bool AcceptEula
         {
-            get => LicenseConfiguration.EulaAccepted;
-            set => LicenseConfiguration.EulaAccepted = value;
+            get => License.EulaAccepted;
+            set => License.EulaAccepted = value;
         }
 
         public string ServerUrl { get; set; }
@@ -39,6 +39,8 @@ namespace Raven.Embedded
         internal static ServerOptions Default = new ServerOptions();
 
         public SecurityOptions Security { get; private set; }
+
+        public LicenseOptions License { get; set; } = new();
 
         public ServerOptions Secured(string certificate, string certPassword = null)
         {
@@ -97,9 +99,7 @@ namespace Raven.Embedded
             public string ServerCertificateThumbprint { get; internal set; }
         }
 
-        public LicenseOptions LicenseConfiguration { get; set; } = new();
-
-        public class LicenseOptions
+        public sealed class LicenseOptions
         {
             public string License { get; set; }
             public string LicensePath { get; set; }
@@ -107,7 +107,7 @@ namespace Raven.Embedded
             public bool DisableAutoUpdate { get; set; }
             public bool DisableAutoUpdateFromApi { get; set; }
             public bool DisableLicenseSupportCheck { get; set; } = true;
-            public bool ThrowOnInvalidOrMissingLicense { get; set; } = true;
+            public bool ThrowOnInvalidOrMissingLicense { get; set; }
         }
     }
 }

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -21,11 +21,11 @@ namespace Raven.Embedded
 
         public string DotNetPath { get; set; } = "dotnet";
 
-        [Obsolete($"This property is no longer used and will be removed in the next version, please use '{nameof(License)}.{nameof(LicenseOptions.EulaAccepted)}' instead.")]
+        [Obsolete($"This property is no longer used and will be removed in the next version, please use '{nameof(Licensing)}.{nameof(LicensingOptions.EulaAccepted)}' instead.")]
         public bool AcceptEula
         {
-            get => License.EulaAccepted;
-            set => License.EulaAccepted = value;
+            get => Licensing.EulaAccepted;
+            set => Licensing.EulaAccepted = value;
         }
 
         public string ServerUrl { get; set; }
@@ -40,7 +40,7 @@ namespace Raven.Embedded
 
         public SecurityOptions Security { get; private set; }
 
-        public LicenseOptions License { get; set; } = new();
+        public LicensingOptions Licensing { get; set; } = new();
 
         public ServerOptions Secured(string certificate, string certPassword = null)
         {
@@ -99,7 +99,7 @@ namespace Raven.Embedded
             public string ServerCertificateThumbprint { get; internal set; }
         }
 
-        public sealed class LicenseOptions
+        public sealed class LicensingOptions
         {
             public string License { get; set; }
             public string LicensePath { get; set; }

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -107,9 +107,7 @@ namespace Raven.Embedded
             public bool DisableAutoUpdate { get; set; }
             public bool DisableAutoUpdateFromApi { get; set; }
             public bool DisableLicenseSupportCheck { get; set; } = true;
-            public bool ThrowOnInvalidOrMissingLicense { get; set; }
+            public bool ThrowOnInvalidOrMissingLicense { get; set; } = true;
         }
     }
-
-
 }

--- a/src/Raven.TestDriver/TestServerOptions.cs
+++ b/src/Raven.TestDriver/TestServerOptions.cs
@@ -7,7 +7,7 @@ namespace Raven.TestDriver
     {
         public TestServerOptions()
         {
-            License.ThrowOnInvalidOrMissingLicense = true;
+            Licensing.ThrowOnInvalidOrMissingLicense = true;
         }
 
         public static TestServerOptions UseFiddler()

--- a/src/Raven.TestDriver/TestServerOptions.cs
+++ b/src/Raven.TestDriver/TestServerOptions.cs
@@ -5,6 +5,11 @@ namespace Raven.TestDriver
 {
     public sealed class TestServerOptions : ServerOptions
     {
+        public TestServerOptions()
+        {
+            License.ThrowOnInvalidOrMissingLicense = true;
+        }
+
         public static TestServerOptions UseFiddler()
         {
             return new TestServerOptions

--- a/test/LicenseTests/LicenseOptionsTests.cs
+++ b/test/LicenseTests/LicenseOptionsTests.cs
@@ -339,7 +339,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_License.Path");
 
         options = CopyServerAndCreateOptions();
-        options.License.ThrowOnInvalidOrMissingLicense = throwOnInvalidOrMissingLicense;
+        options.Licensing.ThrowOnInvalidOrMissingLicense = throwOnInvalidOrMissingLicense;
 
         try
         {
@@ -401,8 +401,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         switch (licenseSource)
         {
             case LicenseSource.EnvironmentVariable:
-                Assert.Null(options.License.License);
-                Assert.Null(options.License.LicensePath);
+                Assert.Null(options.Licensing.License);
+                Assert.Null(options.Licensing.LicensePath);
 
                 Environment.SetEnvironmentVariable("RAVEN_License", license);
                 Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
@@ -412,8 +412,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
                 break;
 
             case LicenseSource.ServerOption:
-                options.License.License = license;
-                Assert.Null(options.License.LicensePath);
+                options.Licensing.License = license;
+                Assert.Null(options.Licensing.LicensePath);
 
                 Environment.SetEnvironmentVariable("RAVEN_License", null);
                 Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
@@ -434,8 +434,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         switch (licenseSource)
         {
             case LicenseSource.EnvironmentVariable:
-                Assert.Null(options.License.License);
-                Assert.Null(options.License.LicensePath);
+                Assert.Null(options.Licensing.License);
+                Assert.Null(options.Licensing.LicensePath);
 
                 Environment.SetEnvironmentVariable("RAVEN_License", null);
                 Environment.SetEnvironmentVariable("RAVEN_License.Path", licensePath);
@@ -445,8 +445,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
                 break;
 
             case LicenseSource.ServerOption:
-                options.License.LicensePath = licensePath;
-                Assert.Null(options.License.License);
+                options.Licensing.LicensePath = licensePath;
+                Assert.Null(options.Licensing.License);
 
                 Environment.SetEnvironmentVariable("RAVEN_License", null);
                 Environment.SetEnvironmentVariable("RAVEN_License.Path", null);

--- a/test/LicenseTests/LicenseOptionsTests.cs
+++ b/test/LicenseTests/LicenseOptionsTests.cs
@@ -339,7 +339,7 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         var originalLicensePath = Environment.GetEnvironmentVariable("RAVEN_License.Path");
 
         options = CopyServerAndCreateOptions();
-        options.LicenseConfiguration.ThrowOnInvalidOrMissingLicense = throwOnInvalidOrMissingLicense;
+        options.License.ThrowOnInvalidOrMissingLicense = throwOnInvalidOrMissingLicense;
 
         try
         {
@@ -401,8 +401,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         switch (licenseSource)
         {
             case LicenseSource.EnvironmentVariable:
-                Assert.Null(options.LicenseConfiguration.License);
-                Assert.Null(options.LicenseConfiguration.LicensePath);
+                Assert.Null(options.License.License);
+                Assert.Null(options.License.LicensePath);
 
                 Environment.SetEnvironmentVariable("RAVEN_License", license);
                 Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
@@ -412,8 +412,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
                 break;
 
             case LicenseSource.ServerOption:
-                options.LicenseConfiguration.License = license;
-                Assert.Null(options.LicenseConfiguration.LicensePath);
+                options.License.License = license;
+                Assert.Null(options.License.LicensePath);
 
                 Environment.SetEnvironmentVariable("RAVEN_License", null);
                 Environment.SetEnvironmentVariable("RAVEN_License.Path", null);
@@ -434,8 +434,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
         switch (licenseSource)
         {
             case LicenseSource.EnvironmentVariable:
-                Assert.Null(options.LicenseConfiguration.License);
-                Assert.Null(options.LicenseConfiguration.LicensePath);
+                Assert.Null(options.License.License);
+                Assert.Null(options.License.LicensePath);
 
                 Environment.SetEnvironmentVariable("RAVEN_License", null);
                 Environment.SetEnvironmentVariable("RAVEN_License.Path", licensePath);
@@ -445,8 +445,8 @@ public class LicenseOptionsEmbeddedTests : EmbeddedTestBase
                 break;
 
             case LicenseSource.ServerOption:
-                options.LicenseConfiguration.LicensePath = licensePath;
-                Assert.Null(options.LicenseConfiguration.License);
+                options.License.LicensePath = licensePath;
+                Assert.Null(options.License.License);
 
                 Environment.SetEnvironmentVariable("RAVEN_License", null);
                 Environment.SetEnvironmentVariable("RAVEN_License.Path", null);

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -551,6 +551,7 @@ namespace FastTests
                 var hasDataDirectory = options.CustomSettings != null && options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Core.DataDirectory));
                 var hasFeaturesAvailability = options.CustomSettings != null && options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability));
                 var hasRunInMemory = options.CustomSettings != null && options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Core.RunInMemory));
+                var hasThrowOnInvalidOrMissingLicense = options.CustomSettings != null && options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Licensing.ThrowOnInvalidOrMissingLicense));
 
                 configuration.Initialize();
 
@@ -590,6 +591,9 @@ namespace FastTests
 
                 if (options.DeletePrevious)
                     IOExtensions.DeleteDirectory(configuration.Core.DataDirectory.FullPath);
+
+                if (hasThrowOnInvalidOrMissingLicense == false)
+                    configuration.Licensing.ThrowOnInvalidOrMissingLicense = true;
 
                 var server = new RavenServer(configuration, options.Conventions)
                 {

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -551,7 +551,6 @@ namespace FastTests
                 var hasDataDirectory = options.CustomSettings != null && options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Core.DataDirectory));
                 var hasFeaturesAvailability = options.CustomSettings != null && options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability));
                 var hasRunInMemory = options.CustomSettings != null && options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Core.RunInMemory));
-                var hasThrowOnInvalidOrMissingLicense = options.CustomSettings != null && options.CustomSettings.ContainsKey(RavenConfiguration.GetKey(x => x.Licensing.ThrowOnInvalidOrMissingLicense));
 
                 configuration.Initialize();
 
@@ -591,9 +590,6 @@ namespace FastTests
 
                 if (options.DeletePrevious)
                     IOExtensions.DeleteDirectory(configuration.Core.DataDirectory.FullPath);
-
-                if (hasThrowOnInvalidOrMissingLicense == false)
-                    configuration.Licensing.ThrowOnInvalidOrMissingLicense = true;
 
                 var server = new RavenServer(configuration, options.Conventions)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22246

### Additional description

Setting of the configuration option `ThrowOnInvalidOrMissingLicense` value to `true` as default value.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed