### PR TITLE
RavenDB-21469 - Port from 6.0

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1544,10 +1544,6 @@ namespace Raven.Server
                 if (AuthorizedDatabases.TryGetValue(database, out mode) == false)
                     return false;
 
-                // Technically speaking, since this is per connection, this is single threaded. But I'm
-                // worried about race conditions here if we move to HTTP 2.0 at some point. At that point,
-                // we'll probably want to handle this concurrently, and the cost of adding it in this manner
-                // is pretty small for most cases anyway
                 var authorizedDatabases = new Dictionary<string, DatabaseAccess>(_caseSensitiveAuthorizedDatabases);
                     authorizedDatabases.TryAdd(database, mode);
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1548,10 +1548,10 @@ namespace Raven.Server
                 // worried about race conditions here if we move to HTTP 2.0 at some point. At that point,
                 // we'll probably want to handle this concurrently, and the cost of adding it in this manner
                 // is pretty small for most cases anyway
-                _caseSensitiveAuthorizedDatabases = new Dictionary<string, DatabaseAccess>(_caseSensitiveAuthorizedDatabases);
-                if (_caseSensitiveAuthorizedDatabases.TryAdd(database,mode) == false)
-                    return CheckAccess(mode, requireAdmin, requireWrite);
+                var authorizedDatabases = new Dictionary<string, DatabaseAccess>(_caseSensitiveAuthorizedDatabases);
+                    authorizedDatabases.TryAdd(database, mode);
 
+                _caseSensitiveAuthorizedDatabases = authorizedDatabases;
 
                 return CheckAccess(mode, requireAdmin, requireWrite);
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1548,10 +1548,10 @@ namespace Raven.Server
                 // worried about race conditions here if we move to HTTP 2.0 at some point. At that point,
                 // we'll probably want to handle this concurrently, and the cost of adding it in this manner
                 // is pretty small for most cases anyway
-                _caseSensitiveAuthorizedDatabases = new Dictionary<string, DatabaseAccess>(_caseSensitiveAuthorizedDatabases)
-                {
-                    {database, mode}
-                };
+                _caseSensitiveAuthorizedDatabases = new Dictionary<string, DatabaseAccess>(_caseSensitiveAuthorizedDatabases);
+                if (_caseSensitiveAuthorizedDatabases.TryAdd(database,mode) == false)
+                    return CheckAccess(mode, requireAdmin, requireWrite);
+
 
                 return CheckAccess(mode, requireAdmin, requireWrite);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21469/System.ArgumentException-An-item-with-the-same-key-has-already-been-added.-Key-DBNAME-at

### Additional description

Port from 6.0, https://github.com/ravendb/ravendb/pull/17553.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
