### PR TITLE
RavenDB-22440 : flaky test adjustments 

### DIFF
--- a/test/StressTests/Server/Documents/ETL/Olap/LocalTestsStress.cs
+++ b/test/StressTests/Server/Documents/ETL/Olap/LocalTestsStress.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using Orders;
 using Parquet;
@@ -221,7 +220,7 @@ loadToOrders(partitionBy(key), o);
                 Assert.True(result.Success);
                 Assert.False(result.Disabled);
 
-                var database = await WaitForDatabaseToUnlockAsync(store, timeout: TimeSpan.FromMilliseconds(1000));
+                var database = await WaitForDatabaseToUnlockAsync(store, timeout: TimeSpan.FromSeconds(10));
                 Assert.NotNull(database);
 
                 var etlDone2 = WaitForEtl(database, (n, statistics) => statistics.LoadSuccesses != 0);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22440/StressTests.Server.Documents.ETL.Olap.LocalTestsStress.AfterDatabaseRestartEtlShouldRespectRunFrequency

### Additional description

 increase timeout when waiting for database to unlock


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Tests stabilization 

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant
