### PR TITLE
RavenDB-22827 Remove credentials from ConnectionStrings AuditJson

### DIFF
--- a/src/Raven.Client/Documents/Operations/ConnectionStrings/ConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ConnectionStrings/ConnectionString.cs
@@ -35,7 +35,10 @@ namespace Raven.Client.Documents.Operations.ConnectionStrings
 
         public virtual DynamicJsonValue ToAuditJson()
         {
-            return ToJson();
+            return new DynamicJsonValue
+            {
+                [nameof(Name)] = Name
+            };
         }
 
         public virtual bool IsEqual(ConnectionString connectionString)

--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
@@ -83,7 +83,7 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
 
         public override DynamicJsonValue ToAuditJson()
         {
-            DynamicJsonValue json = base.ToJson();
+            DynamicJsonValue json = base.ToAuditJson();
             
             json[nameof(Nodes)] = new DynamicJsonArray(Nodes);
             json[nameof(EnableCompatibilityMode)] = EnableCompatibilityMode;

--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticsearchConnectionString.cs
@@ -83,10 +83,11 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
 
         public override DynamicJsonValue ToAuditJson()
         {
-            DynamicJsonValue json = base.ToAuditJson();
+            DynamicJsonValue json = base.ToJson();
+            
             json[nameof(Nodes)] = new DynamicJsonArray(Nodes);
             json[nameof(EnableCompatibilityMode)] = EnableCompatibilityMode;
-
+            
             return json;
         }
     }

--- a/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapConnectionString.cs
@@ -141,7 +141,7 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
 
         public override DynamicJsonValue ToAuditJson()
         {
-            var json = base.ToJson();
+            var json = base.ToAuditJson();
             json[nameof(LocalSettings)] = LocalSettings?.ToAuditJson();
             json[nameof(S3Settings)] = S3Settings?.ToAuditJson();
             json[nameof(AzureSettings)] = AzureSettings?.ToAuditJson();

--- a/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapConnectionString.cs
@@ -141,7 +141,14 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
 
         public override DynamicJsonValue ToAuditJson()
         {
-            return ToJson();
+            var json = base.ToJson();
+            json[nameof(LocalSettings)] = LocalSettings?.ToAuditJson();
+            json[nameof(S3Settings)] = S3Settings?.ToAuditJson();
+            json[nameof(AzureSettings)] = AzureSettings?.ToAuditJson();
+            json[nameof(GlacierSettings)] = GlacierSettings?.ToAuditJson();
+            json[nameof(GoogleCloudSettings)] = GoogleCloudSettings?.ToAuditJson();
+            json[nameof(FtpSettings)] = FtpSettings?.ToAuditJson();
+            return json;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/KafkaConnectionSettings.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/KafkaConnectionSettings.cs
@@ -26,4 +26,15 @@ public class KafkaConnectionSettings
 
         return json;
     }
+    
+    public DynamicJsonValue ToAuditJson()
+    {
+        var json = new DynamicJsonValue
+        {
+            [nameof(BootstrapServers)] = BootstrapServers,
+            [nameof(UseRavenCertificate)] = UseRavenCertificate
+        };
+        
+        return json;
+    }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueConnectionString.cs
@@ -72,6 +72,12 @@ public class QueueConnectionString : ConnectionString
 
     public override DynamicJsonValue ToAuditJson()
     {
-        return ToJson();
+        var json = base.ToJson();
+        
+        json[nameof(BrokerType)] = BrokerType;
+        json[nameof(KafkaConnectionSettings)] = KafkaConnectionSettings?.ToAuditJson();
+        json[nameof(RabbitMqConnectionSettings)] = RabbitMqConnectionSettings?.ToAuditJson();
+
+        return json;
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueConnectionString.cs
@@ -72,7 +72,7 @@ public class QueueConnectionString : ConnectionString
 
     public override DynamicJsonValue ToAuditJson()
     {
-        var json = base.ToJson();
+        var json = base.ToAuditJson();
         
         json[nameof(BrokerType)] = BrokerType;
         json[nameof(KafkaConnectionSettings)] = KafkaConnectionSettings?.ToAuditJson();

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/RabbitMqConnectionSettings.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/RabbitMqConnectionSettings.cs
@@ -15,4 +15,9 @@ public class RabbitMqConnectionSettings
 
         return json;
     }
+
+    public DynamicJsonValue ToAuditJson()
+    {
+        return new DynamicJsonValue();
+    }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/RavenConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/RavenConnectionString.cs
@@ -66,7 +66,12 @@ namespace Raven.Client.Documents.Operations.ETL
 
         public override DynamicJsonValue ToAuditJson()
         {
-            return ToJson();
+            var json = base.ToAuditJson();
+            
+            json[nameof(Database)] = Database;
+            json[nameof(TopologyDiscoveryUrls)] = new DynamicJsonArray(TopologyDiscoveryUrls);
+            
+            return json;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
@@ -56,7 +56,10 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
         {
             var json = base.ToJson();
             
+            var databaseAndServer = SqlConnectionStringParser.GetDatabaseAndServerFromConnectionString(FactoryName, ConnectionString);
             json[nameof(FactoryName)] = FactoryName;
+            json["Database"] = databaseAndServer.Database;
+            json["Server"] = databaseAndServer.Server;
 
             return json;
         }

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
@@ -54,7 +54,11 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
 
         public override DynamicJsonValue ToAuditJson()
         {
-            return ToJson();
+            var json = base.ToJson();
+            
+            json[nameof(FactoryName)] = FactoryName;
+
+            return json;
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlConnectionString.cs
@@ -54,7 +54,7 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
 
         public override DynamicJsonValue ToAuditJson()
         {
-            var json = base.ToJson();
+            var json = base.ToAuditJson();
             
             var databaseAndServer = SqlConnectionStringParser.GetDatabaseAndServerFromConnectionString(FactoryName, ConnectionString);
             json[nameof(FactoryName)] = FactoryName;

--- a/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
@@ -308,7 +308,7 @@ namespace SlowTests.Server.Documents.ETL
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Logging)]
         public void ConnectionStringsAuditJsonDoesntIncludeCredentials()
         {
             var sqlConnectionString = new SqlConnectionString


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22827

### Additional description

This PR excludes vulnerable connection string information from AuditJson logs.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
