### PR TITLE
RavenDB-22327 Enhanced logging clarity for Responsible Node information when stopping ETL Task. Added explanation for swiching a task to a different node. 

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -499,8 +499,7 @@ namespace Raven.Client.ServerWide
 
             var node = WhoseTaskIsIt(task, explanations);
 
-            if (node != null)
-                explanations?.Add($"Task belongs to node ({node})");
+            explanations?.Add(node != null ? $"Task belongs to node {node}" : "No responsible node has been found");
 
             return node;
         }

--- a/src/Raven.Client/ServerWide/DatabaseTopology.cs
+++ b/src/Raven.Client/ServerWide/DatabaseTopology.cs
@@ -461,29 +461,51 @@ namespace Raven.Client.ServerWide
         public string WhoseTaskIsIt(
             RachisState state,
             IDatabaseTask task,
-            Func<string> getLastResponsibleNode = null)
+            Func<string> getLastResponsibleNode = null,
+            List<string> explanations = null)
         {
             if (state == RachisState.Candidate || state == RachisState.Passive)
+            {
+                explanations?.Add($"Task doesn't belong to this node because the node is in '{state}' state");
                 return null;
+            }
+
+            explanations?.Add($"Node state is '{state}'");
 
             var mentorNode = task.GetMentorNode();
             if (mentorNode != null)
             {
                 if (Members.Contains(mentorNode))
+                {
+                    explanations?.Add($"Task belongs to mentor node ({mentorNode})");
                     return mentorNode;
-                
+                }
+
                 if (AllNodes.Contains(mentorNode) && task.IsPinnedToMentorNode())
+                {
+                    explanations?.Add($"Task is pinned to mentor node ({mentorNode})");
                     return mentorNode;
+                }
+
+                explanations?.Add($"Mentor node is {mentorNode}");
             }
 
             var lastResponsibleNode = getLastResponsibleNode?.Invoke();
             if (lastResponsibleNode != null)
+            {
+                explanations?.Add($"Task belongs to last responsible node ({lastResponsibleNode})");
                 return lastResponsibleNode;
+            }
 
-            return WhoseTaskIsIt(task);
+            var node = WhoseTaskIsIt(task, explanations);
+
+            if (node != null)
+                explanations?.Add($"Task belongs to node ({node})");
+
+            return node;
         }
 
-        internal string WhoseTaskIsIt(IDatabaseTask task)
+        internal string WhoseTaskIsIt(IDatabaseTask task, List<string> explanations = null)
         {
             var topology = new List<string>(Members);
             topology.AddRange(Promotables);
@@ -493,28 +515,34 @@ namespace Raven.Client.ServerWide
             if (task.IsResourceIntensive() && Members.Count > 1)
             {
                 // if resource intensive operation, we don't want to have it on the first node of the database topology
-                return FindNodeForIntensiveOperation(task.GetTaskKey(), topology);
+
+                explanations?.Add("Task is resource intensive");
+
+                return FindNodeForIntensiveOperation(task.GetTaskKey(), topology, explanations);
             }
 
-            return FindNode(task.GetTaskKey(), topology);
+            return FindNode(task.GetTaskKey(), topology, explanations);
         }
 
-        private string FindNodeForIntensiveOperation(ulong key, List<string> topology)
+        private string FindNodeForIntensiveOperation(ulong key, List<string> topology, List<string> explanations = null)
         {
             var firstNode = Members[0];
             topology.Remove(firstNode);
 
-            var node = FindNode(key, topology);
+            var node = FindNode(key, topology, explanations);
             if (node == null)
                 return firstNode;
 
             return node;
         }
 
-        private string FindNode(ulong key, List<string> topology)
+        private string FindNode(ulong key, List<string> topology, List<string> explanations = null)
         {
             if (topology.Count == 0)
+            {
+                explanations?.Add("Topology count is zero. Database is probably being deleted now");
                 return null; // this is probably being deleted now, no one is able to run tasks
+            }
 
             while (true)
             {
@@ -525,7 +553,10 @@ namespace Raven.Client.ServerWide
 
                 topology.RemoveAt(index);
                 if (topology.Count == 0)
+                {
+                    explanations?.Add("All nodes in the topology are probably in Rehab state");
                     return null; // all nodes in the topology are probably in rehab
+                }
 
                 // rehash so it will likely go to a different member in the cluster
                 key = Hashing.Mix(key);

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -464,7 +464,7 @@ namespace Raven.Server.Documents
                 {
                     try
                     {
-                        await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _databaseStateChange);
+                        await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _databaseStateChange, nameof(Initialize));
                         RachisLogIndexNotifications.NotifyListenersAbout(index, e: null);
                     }
                     catch (Exception e)
@@ -1540,7 +1540,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public async ValueTask StateChangedAsync(long index)
+        public async ValueTask StateChangedAsync(long index, string type, DatabasesLandlord.ClusterDatabaseChangeType changeType)
         {
             try
             {
@@ -1586,7 +1586,7 @@ namespace Raven.Server.Documents
 
                 ServerStore.DatabasesLandlord.ForTestingPurposes?.DelayNotifyFeaturesAboutStateChange?.Invoke();
 
-                await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _databaseStateChange);
+                await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _databaseStateChange, type, changeType);
 
                 RachisLogIndexNotifications.NotifyListenersAbout(index, e: null);
             }
@@ -1724,7 +1724,7 @@ namespace Raven.Server.Documents
                 record = _serverStore.Cluster.ReadDatabase(context, Name, out index);
             }
 
-            return DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _databaseStateChange);
+            return DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _databaseStateChange, nameof(RefreshFeaturesAsync));
         }
 
         private void InitializeFromDatabaseRecord(DatabaseRecord record)

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -852,7 +852,7 @@ namespace Raven.Server.Documents.ETL
             }
             else
             {
-                reason = "Task shouldn't be started on this node ";
+                reason = "Initialize";
             }
 
             return reason;

--- a/src/Raven.Server/Documents/ETL/EtlLoader.cs
+++ b/src/Raven.Server/Documents/ETL/EtlLoader.cs
@@ -86,7 +86,7 @@ namespace Raven.Server.Documents.ETL
 
         public void Initialize(DatabaseRecord record)
         {
-            LoadProcesses(record, record.RavenEtls, record.SqlEtls, record.OlapEtls, record.ElasticSearchEtls, record.QueueEtls, toRemove: null);
+            LoadProcesses(record, record.RavenEtls, record.SqlEtls, record.OlapEtls, record.ElasticSearchEtls, record.QueueEtls, toRemove: null, null, null);
         }
 
         public event Action<EtlProcess> ProcessAdded;
@@ -109,7 +109,8 @@ namespace Raven.Server.Documents.ETL
             List<OlapEtlConfiguration> newOlapDestinations,
             List<ElasticSearchEtlConfiguration> newElasticSearchDestinations,
             List<QueueEtlConfiguration> newQueueDestinations,
-            List<EtlProcess> toRemove)
+            List<EtlProcess> toRemove, Dictionary<string, string> responsibleNodes,
+            List<string> explanations)
         {
             lock (_loadProcessedLock)
             {
@@ -158,7 +159,9 @@ namespace Raven.Server.Documents.ETL
 
                 foreach (var process in newProcesses)
                 {
-                    process.Start();
+                    var reason = GetStartReason(responsibleNodes, explanations, process);
+
+                    process.Start(reason);
 
                     OnProcessAdded(process);
 
@@ -458,12 +461,13 @@ namespace Raven.Server.Documents.ETL
             ea.ThrowIfNeeded();
         }
 
-        private bool IsMyEtlTask<T, TConnectionString>(DatabaseRecord record, T etlTask, ref Dictionary<string, string> responsibleNodes)
+        private bool IsMyEtlTask<T, TConnectionString>(DatabaseRecord record, T etlTask, ref Dictionary<string, string> responsibleNodes, out List<string> explanations)
             where TConnectionString : ConnectionString
             where T : EtlConfiguration<TConnectionString>
         {
             var processState = GetProcessState(etlTask.Transforms, _database, etlTask.Name);
-            var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, record.Topology, etlTask, processState, _database.NotificationCenter);
+            explanations = new List<string>();
+            var whoseTaskIsIt = OngoingTasksUtils.WhoseTaskIsIt(_serverStore, record.Topology, etlTask, processState, _database.NotificationCenter, explanations);
 
             responsibleNodes[etlTask.Name] = whoseTaskIsIt;
 
@@ -483,9 +487,11 @@ namespace Raven.Server.Documents.ETL
 
             var responsibleNodes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+            List<string> explanations = null;
+
             foreach (var config in record.RavenEtls)
             {
-                if (IsMyEtlTask<RavenEtlConfiguration, RavenConnectionString>(record, config, ref responsibleNodes))
+                if (IsMyEtlTask<RavenEtlConfiguration, RavenConnectionString>(record, config, ref responsibleNodes, out explanations))
                 {
                     myRavenEtl.Add(config);
                 }
@@ -493,7 +499,7 @@ namespace Raven.Server.Documents.ETL
 
             foreach (var config in record.SqlEtls)
             {
-                if (IsMyEtlTask<SqlEtlConfiguration, SqlConnectionString>(record, config, ref responsibleNodes))
+                if (IsMyEtlTask<SqlEtlConfiguration, SqlConnectionString>(record, config, ref responsibleNodes, out explanations))
                 {
                     mySqlEtl.Add(config);
                 }
@@ -501,7 +507,7 @@ namespace Raven.Server.Documents.ETL
 
             foreach (var config in record.OlapEtls)
             {
-                if (IsMyEtlTask<OlapEtlConfiguration, OlapConnectionString>(record, config, ref responsibleNodes))
+                if (IsMyEtlTask<OlapEtlConfiguration, OlapConnectionString>(record, config, ref responsibleNodes, out explanations))
                 {
                     myOlapEtl.Add(config);
                 }
@@ -509,7 +515,7 @@ namespace Raven.Server.Documents.ETL
 
             foreach (var config in record.ElasticSearchEtls)
             {
-                if (IsMyEtlTask<ElasticSearchEtlConfiguration, ElasticSearchConnectionString>(record, config, ref responsibleNodes))
+                if (IsMyEtlTask<ElasticSearchEtlConfiguration, ElasticSearchConnectionString>(record, config, ref responsibleNodes, out explanations))
                 {
                     myElasticSearchEtl.Add(config);
                 }
@@ -517,7 +523,7 @@ namespace Raven.Server.Documents.ETL
 
             foreach (var config in record.QueueEtls)
             {
-                if (IsMyEtlTask<QueueEtlConfiguration, QueueConnectionString>(record, config, ref responsibleNodes))
+                if (IsMyEtlTask<QueueEtlConfiguration, QueueConnectionString>(record, config, ref responsibleNodes, out explanations))
                 {
                     myQueueEtl.Add(config);
                 }
@@ -672,7 +678,7 @@ namespace Raven.Server.Documents.ETL
                 }
             }
 
-            LoadProcesses(record, myRavenEtl, mySqlEtl, myOlapEtl, myElasticSearchEtl, myQueueEtl, toRemove.SelectMany(x => x.Value).ToList());
+            LoadProcesses(record, myRavenEtl, mySqlEtl, myOlapEtl, myElasticSearchEtl, myQueueEtl, toRemove.SelectMany(x => x.Value).ToList(), responsibleNodes, explanations);
 
             if (toRemove.Count == 0)
                 return;
@@ -692,7 +698,7 @@ namespace Raven.Server.Documents.ETL
 
                             using (process)
                             {
-                                string reason = GetStopReason(process, myRavenEtl, mySqlEtl, myOlapEtl, myElasticSearchEtl, myQueueEtl, responsibleNodes);
+                                string reason = GetStopReason(process, myRavenEtl, mySqlEtl, myOlapEtl, myElasticSearchEtl, myQueueEtl, responsibleNodes, explanations);
                                 process.Stop(reason);
                             }
                         }
@@ -745,7 +751,8 @@ namespace Raven.Server.Documents.ETL
             List<OlapEtlConfiguration> myOlapEtl,
             List<ElasticSearchEtlConfiguration> myElasticSearchEtl,
             List<QueueEtlConfiguration> myQueueEtl,
-            Dictionary<string, string> responsibleNodes)
+            Dictionary<string, string> responsibleNodes,
+            List<string> explanations)
         {
             EtlConfigurationCompareDifferences? differences = null;
             var transformationDiffs = new List<(string TransformationName, EtlConfigurationCompareDifferences Difference)>();
@@ -812,12 +819,40 @@ namespace Raven.Server.Documents.ETL
             {
                 if (responsibleNodes.TryGetValue(process.ConfigurationName, out var responsibleNode))
                 {
-                    reason += $"ETL was moved to another node. Responsible node is: {responsibleNode}";
+                    reason += "ETL was moved to another node. ";
+
+                    if (string.IsNullOrEmpty(responsibleNode) == false)
+                        reason += $"Responsible node is: {responsibleNode}. ";
+
+                    if (explanations != null)
+                        reason += $"(Node switch explanation: {string.Join(". ", explanations)}) ";
                 }
                 else
                 {
                     reason += $"ETL was deleted or moved to another node (no configuration named '{process.ConfigurationName}' was found). ";
                 }
+            }
+
+            return reason;
+        }
+
+        private string GetStartReason(Dictionary<string, string> responsibleNodes, List<string> explanations, EtlProcess process)
+        {
+            string reason;
+
+            if (responsibleNodes?.TryGetValue(process.ConfigurationName, out var responsibleNode) == true)
+            {
+                if (responsibleNode == _serverStore.NodeTag)
+                    reason = "The node is responsible for this task ";
+                else
+                    reason = $"Node {responsibleNode} should handle this task";
+
+                if (explanations is { Count: > 0 })
+                    reason += $"(Node selection explanation: {string.Join(". ", explanations)}) ";
+            }
+            else
+            {
+                reason = "Task shouldn't be started on this node ";
             }
 
             return reason;

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -72,7 +72,7 @@ namespace Raven.Server.Documents.ETL
 
         public TimeSpan? FallbackTime { get; protected set; }
 
-        public abstract void Start();
+        public abstract void Start(string reason);
 
         public abstract void Stop(string reason);
 
@@ -666,7 +666,7 @@ namespace Raven.Server.Documents.ETL
                 _waitForChanges.Set();
         }
 
-        public override void Start()
+        public override void Start(string reason)
         {
             if (_longRunningWork != null)
                 return;
@@ -695,7 +695,7 @@ namespace Raven.Server.Documents.ETL
             }, null, ThreadNames.ForEtlProcess(threadName, Tag, Name));
 
             if (Logger.IsOperationsEnabled)
-                Logger.Operations($"Starting {Tag} process: '{Name}'.");
+                Logger.Operations($"Starting {Tag} process: '{Name}'. Reason: {reason}");
 
         }
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -23,6 +23,7 @@ using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Utils;
 using Voron;
+using static Raven.Server.Documents.DatabasesLandlord;
 using DictionaryExtensions = Raven.Server.Extensions.DictionaryExtensions;
 
 namespace Raven.Server.Documents.Sharding
@@ -100,11 +101,11 @@ namespace Raven.Server.Documents.Sharding
 
         public IDisposable AllocateOperationContext(out JsonOperationContext context) => ServerStore.ContextPool.AllocateOperationContext(out context);
 
-        public async ValueTask UpdateDatabaseRecordAsync(DatabaseRecord record, long index)
+        public async ValueTask UpdateDatabaseRecordAsync(DatabaseRecord record, long index, string type, ClusterDatabaseChangeType changeType)
         {
             try
             {
-                await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _orchestratorStateChange);
+                await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(record, index, _orchestratorStateChange, type, changeType);
                 RachisLogIndexNotifications.NotifyListenersAbout(index, e: null);
             }
             catch (Exception e)
@@ -188,7 +189,7 @@ namespace Raven.Server.Documents.Sharding
             return Task.CompletedTask;
         }
 
-        public async ValueTask UpdateUrlsAsync(long index) => await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(_record, index, _urlUpdateStateChange);
+        public async ValueTask UpdateUrlsAsync(long index) => await DatabasesLandlord.NotifyFeaturesAboutStateChangeAsync(_record, index, _urlUpdateStateChange, nameof(UpdateUrlsAsync));
 
         public string DatabaseName => _record.DatabaseName;
 

--- a/src/Raven.Server/Utils/OngoingTasksUtils.cs
+++ b/src/Raven.Server/Utils/OngoingTasksUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.ServerWide;
@@ -15,7 +16,8 @@ internal static class OngoingTasksUtils
         DatabaseTopology databaseTopology,
         IDatabaseTask configuration,
         IDatabaseTaskStatus taskStatus,
-        AbstractNotificationCenter notificationCenter)
+        AbstractNotificationCenter notificationCenter,
+        List<string> explanations = null)
     {
         Debug.Assert(taskStatus is not PeriodicBackupStatus);
 
@@ -28,6 +30,7 @@ internal static class OngoingTasksUtils
                 if (lastResponsibleNode == null)
                 {
                     // first time this task is assigned
+                    explanations?.Add("There is no last responsible node. It's first time this task is assigned");
                     return null;
                 }
 
@@ -35,18 +38,25 @@ internal static class OngoingTasksUtils
                 {
                     // the topology doesn't include the last responsible node anymore
                     // we'll choose a different one
+                    explanations?.Add($"The topology ({string.Join(',', databaseTopology.AllNodes)}) doesn't include the last responsible node anymore. We'll choose a different one");
                     return null;
                 }
 
                 if (serverStore.LicenseManager.HasHighlyAvailableTasks() == false)
                 {
                     // can't redistribute, keep it on the original node
+
                     RaiseAlertIfNecessary(databaseTopology, configuration, lastResponsibleNode, serverStore, notificationCenter);
+
+                    explanations?.Add($"Keeping the task on last responsible node ({lastResponsibleNode}). Highly available tasks aren't available");
+
                     return lastResponsibleNode;
                 }
 
+                explanations?.Add($"Last responsible node is {lastResponsibleNode}. Redistributing task work since highly available tasks are supported");
+
                 return null;
-            });
+            }, explanations);
 
         return whoseTaskIsIt;
     }

--- a/test/SlowTests/Server/Documents/ETL/Raven/RDBS_85.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RDBS_85.cs
@@ -65,7 +65,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 process.BeforeActualLoad = null;
 
-                process.Start();
+                process.Start(null);
 
                 Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22327/Enhance-logging-clarity-for-Responsible-Node-information-in-ETL-Task-stoppage

### Additional description

https://github.com/ravendb/ravendb/pull/19142 applied to 6.0

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
