### PR TITLE
RavenDB-22774 Add ContinuousIntegrationBuild=true property when running on CI & update nuget.exe

### DIFF
--- a/scripts/buildProjects.ps1
+++ b/scripts/buildProjects.ps1
@@ -38,32 +38,90 @@ function BuildServer ( $srcDir, $outDir, $target) {
     #    $commandArgs += '/p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true'
     #}
 
+    if ($env:RAVEN_IS_RUNNING_ON_CI){
+        $commandArgs += '/p:ContinuousIntegrationBuild=true'
+    }
+
     write-host -ForegroundColor Cyan "Publish server: $command $commandArgs"
     Invoke-Expression -Command "$command $commandArgs"
     CheckLastExitCode
 }
 
 function BuildClient ( $srcDir ) {
-    write-host "Building Client"
-    & dotnet build /p:SourceLinkCreate=true /p:GenerateDocumentationFile=true --no-incremental `
-        --configuration "Release" $srcDir;
+    $command = "dotnet" 
+    $commandArgs = @( "build" )
+
+    $commandArgs += "/p:SourceLinkCreate=true"
+    $commandArgs += "/p:GenerateDocumentationFile=true"
+    $commandArgs += "--no-incremental"
+    $commandArgs += @( "--configuration", "Release" )
+
+    if ($env:RAVEN_IS_RUNNING_ON_CI){
+        $commandArgs += '/p:ContinuousIntegrationBuild=true'
+    }
+    
+    $commandArgs += "$srcDir"
+
+    write-host -ForegroundColor Cyan "Building Client: $command $commandArgs"
+    Invoke-Expression -Command "$command $commandArgs"
     CheckLastExitCode
 }
 
 function BuildTestDriver ( $srcDir ) {
-    write-host "Building TestDriver"
-    & dotnet build /p:SourceLinkCreate=true /p:GenerateDocumentationFile=true --no-incremental `
-        --configuration "Release" $srcDir;
+    $command = "dotnet" 
+    $commandArgs = @( "build" )
+
+    $commandArgs += "/p:SourceLinkCreate=true"
+    $commandArgs += "/p:GenerateDocumentationFile=true"
+    $commandArgs += "--no-incremental"
+    $commandArgs += @( "--configuration", "Release" )
+
+    if ($env:RAVEN_IS_RUNNING_ON_CI){
+        $commandArgs += '/p:ContinuousIntegrationBuild=true'
+    }
+    
+    $commandArgs += "$srcDir"
+
+    write-host -ForegroundColor Cyan "Building TestDriver: $command $commandArgs"
+    Invoke-Expression -Command "$command $commandArgs"
     CheckLastExitCode
 }
 
 function BuildTypingsGenerator ( $srcDir ) {
-    & dotnet build --no-incremental --configuration "Release" $srcDir;
+    $command = "dotnet" 
+    $commandArgs = @( "build" )
+    $commandArgs += "--no-incremental"
+
+    $commandArgs += @( "--configuration", "Release" )
+
+    if ($env:RAVEN_IS_RUNNING_ON_CI){
+        $commandArgs += '/p:ContinuousIntegrationBuild=true'
+    }
+    
+    $commandArgs += "$srcDir"
+
+    write-host -ForegroundColor Cyan "Building TypingsGenerator: $command $commandArgs"
+    Invoke-Expression -Command "$command $commandArgs"
     CheckLastExitCode
 }
 
 function BuildSparrow ( $srcDir ) {
-    & dotnet build /p:SourceLinkCreate=true /p:GenerateDocumentationFile=true --configuration "Release" $srcDir;
+    $command = "dotnet" 
+    $commandArgs = @( "build" )
+
+    $commandArgs += "/p:SourceLinkCreate=true"
+    $commandArgs += "/p:GenerateDocumentationFile=true"
+    $commandArgs += "--no-incremental"
+    $commandArgs += @( "--configuration", "Release" )
+
+    if ($env:RAVEN_IS_RUNNING_ON_CI){
+        $commandArgs += '/p:ContinuousIntegrationBuild=true'
+    }
+    
+    $commandArgs += "$srcDir"
+
+    write-host -ForegroundColor Cyan "Building Sparrow: $command $commandArgs"
+    Invoke-Expression -Command "$command $commandArgs"
     CheckLastExitCode
 }
 
@@ -145,16 +203,32 @@ function BuildTool ( $toolName, $srcDir, $outDir, $target, $trim ) {
     #    $commandArgs += "/p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true /p:PublishTrimmed=$trim"
     #}
 
+    if ($env:RAVEN_IS_RUNNING_ON_CI){
+        $commandArgs += '/p:ContinuousIntegrationBuild=true'
+    }
+
     write-host -ForegroundColor Cyan "Publish ${toolName}: $command $commandArgs"
     Invoke-Expression -Command "$command $commandArgs"
     CheckLastExitCode
 }
 
 function BuildEmbedded ( $srcDir, $outDir, $framework) {
-    write-host "Building Embedded..."
-    & dotnet build /p:GenerateDocumentationFile=true --no-incremental `
-        --output $outDir `
-        --framework $framework `
-        --configuration "Release" $srcDir;
+    $command = "dotnet" 
+    $commandArgs = @( "build" )
+
+    $commandArgs += "/p:GenerateDocumentationFile=true"
+    $commandArgs += "--no-incremental"
+    $commandArgs += @( "--output", $outDir )
+    $commandArgs += @( "--framework", $framework )
+    $commandArgs += @( "--configuration", "Release" )
+
+    if ($env:RAVEN_IS_RUNNING_ON_CI){
+        $commandArgs += '/p:ContinuousIntegrationBuild=true'
+    }
+    
+    $commandArgs += "$srcDir"
+
+    write-host -ForegroundColor Cyan "Building Embedded: $command $commandArgs"
+    Invoke-Expression -Command "$command $commandArgs"
     CheckLastExitCode
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22774

### Additional description

In order to pass NuGet Deterministic check we have to create our packages with `ContinuousIntegrationBuild=true` property.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
