### PR TITLE
RavenDB-22819 - Incorrect Operation ID Returned When StartBackupOperation Is Called While a Backup Is Already Running

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/StartBackupOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/StartBackupOperation.cs
@@ -32,6 +32,7 @@ namespace Raven.Client.Documents.Operations.Backups
             private readonly long _taskId;
             private readonly long? _operationId;
             private readonly DateTime? _startTime;
+            private readonly bool _inProgressOnAnotherShard;
 
             public StartBackupCommand(bool? isFullBackup, long taskId)
             {
@@ -39,9 +40,10 @@ namespace Raven.Client.Documents.Operations.Backups
                 _taskId = taskId;
             }
 
-            internal StartBackupCommand(bool? isFullBackup, long taskId, long operationId, DateTime? startTime = null) : this(isFullBackup, taskId)
+            internal StartBackupCommand(bool? isFullBackup, long taskId, long operationId, bool inProgressOnAnotherShard, DateTime? startTime = null) : this(isFullBackup, taskId)
             {
                 _operationId = operationId;
+                _inProgressOnAnotherShard = inProgressOnAnotherShard;
                 _startTime = startTime;
             }
 
@@ -55,6 +57,8 @@ namespace Raven.Client.Documents.Operations.Backups
                     url += $"&operationId={_operationId}";
                 if (_startTime.HasValue)
                     url += $"&startTime={_startTime.Value.GetDefaultRavenFormat()}";
+                if (_inProgressOnAnotherShard)
+                    url += $"&inProgressOnAnotherShard=true";
 
                 var request = new HttpRequestMessage
                 {

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected abstract ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? startTime);
+        protected abstract ValueTask<(long, bool)> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, bool inProgressOnAnotherShard, DateTime? startTime);
 
         protected abstract long GetNextOperationId();
 
@@ -24,8 +24,9 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
             var isFullBackup = RequestHandler.GetBoolValueQueryString("isFullBackup", required: false) ?? true;
             var operationId = RequestHandler.GetLongQueryString("operationId", required: false) ?? GetNextOperationId();
             var startTime = RequestHandler.GetDateTimeQueryString("startTime", required: false);
+            var inProgressOnAnotherShard = RequestHandler.GetBoolValueQueryString("inProgressOnAnotherShard", required: false) ?? false;
 
-            var isResponsibleNode = await ScheduleBackupOperationAsync(taskId, isFullBackup, operationId, startTime);
+            (operationId, var isResponsibleNode) = await ScheduleBackupOperationAsync(taskId, isFullBackup, operationId, inProgressOnAnotherShard, startTime);
 
             if (isResponsibleNode)
             {

--- a/src/Raven.Server/Documents/Operations/AbstractOperations.cs
+++ b/src/Raven.Server/Documents/Operations/AbstractOperations.cs
@@ -20,11 +20,13 @@ namespace Raven.Server.Documents.Operations;
 public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
     where TOperation : AbstractOperation, new()
 {
+    internal const long InvalidOperationId = -1;
+
     private readonly IDocumentsChanges _changes;
     private readonly TimeSpan _maxCompletedTaskLifeTime;
 
     protected readonly ConcurrentDictionary<long, AbstractOperation> Active = new();
-    protected readonly ConcurrentDictionary<long, AbstractOperation> Completed = new();
+    internal readonly ConcurrentDictionary<long, AbstractOperation> Completed = new();
 
     protected AbstractOperations(IDocumentsChanges changes, TimeSpan maxCompletedTaskLifeTime)
     {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -1,10 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Http;
 using Raven.Client.Util;
 using Raven.Server.Documents.Handlers.Processors.OngoingTasks;
+using Raven.Server.Documents.Operations;
+using Raven.Server.Documents.Sharding.Executors;
+using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
@@ -15,29 +21,72 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected override ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? _)
+        protected override async ValueTask<(long, bool)> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, bool __, DateTime? _)
         {
             var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
 
+            // backup might be already running on one of the shards, get the old operation id if so
+            var actualOperationId = await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(new ShardedGetOperationIdForBackupOperation(RequestHandler.HttpContext, taskId, operationId, isFullBackup));
+            
+            // if we got the old operation id then the old backup is still running on one of the shards, we want to keep tracking it
+            bool inProgressOnAnotherShard = actualOperationId != operationId;
+
+            // if only some of the shards are running this backup, 
             var startTime = SystemTime.UtcNow;
-            var t = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartBackupOperationResult>, ShardedBackupResult, ShardedBackupProgress>(operationId,
+            var t = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartBackupOperationResult>, ShardedBackupResult, ShardedBackupProgress>(actualOperationId,
                 Server.Documents.Operations.OperationType.DatabaseBackup,
                 "Backup of sharded database : " + RequestHandler.DatabaseName,
                 detailedDescription: null,
-                (_, shardNumber) => new StartBackupOperation.StartBackupCommand(isFullBackup, taskId, operationId, startTime),
+                (_, shardNumber) => new StartBackupOperation.StartBackupCommand(isFullBackup, taskId, actualOperationId, inProgressOnAnotherShard, startTime),
                 token);
-
+            
             t.ContinueWith(_ =>
             {
                 token.Dispose();
             });
 
-            return ValueTask.FromResult(true);
+            return (actualOperationId, true);
         }
 
         protected override long GetNextOperationId()
         {
             return RequestHandler.DatabaseContext.Operations.GetNextOperationId();
+        }
+
+        internal readonly struct ShardedGetOperationIdForBackupOperation : IShardedOperation<OperationIdResult<StartBackupOperationResult>, long>
+        {
+            private readonly long _operationId;
+            private readonly long _taskId;
+            private readonly bool _isFullBackup;
+            private readonly HttpContext _httpContext;
+
+            public ShardedGetOperationIdForBackupOperation(HttpContext httpContext, long taskId, long operationId, bool isFullBackup)
+            {
+                _operationId = operationId;
+                _isFullBackup = isFullBackup;
+                _taskId = taskId;
+                _httpContext = httpContext;
+            }
+
+            public HttpRequest HttpRequest => _httpContext.Request;
+
+            public long Combine(Dictionary<int, ShardExecutionResult<OperationIdResult<StartBackupOperationResult>>> results)
+            {
+                foreach (var (shardNumber, shardResult) in results)
+                {
+                    if (shardResult.Result is OperationIdResult o)
+                    {
+                        // if one of the backups is still running it will return its current operationId which we will use to finish waiting on it
+                        if (o.OperationId != AbstractOperations<Server.Documents.Operations.Operation>.InvalidOperationId)
+                            return o.OperationId;
+                    }
+                }
+                
+                return _operationId;
+            }
+
+            public RavenCommand<OperationIdResult<StartBackupOperationResult>> CreateCommandForShard(int shardNumber) => 
+                new StartBackupOperation.StartBackupCommand(_isFullBackup, _taskId, inProgressOnAnotherShard: false, operationId: AbstractOperations<Server.Documents.Operations.Operation>.InvalidOperationId);
         }
     }
 }

--- a/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
@@ -359,6 +359,8 @@ public partial class RavenTestBase
         {
             var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
+            WaitForResponsibleNodeUpdateInCluster(store, servers, result.TaskId);
+
             await RunBackupAsync(store.Database, result.TaskId, isFullBackup, servers);
 
             return result.TaskId;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22819

### Additional description

When calling `StartBackupOperation` while backup was already runnning, the `operationId` that was returned was the wrong one. If the backup of the given taskId is running then we would want to return the `operationId` of the task runnning now, and track that one (like in 5.4). But instead we return the newly generated `opeartionId`.
Fixed: in regaular db endpoint - returning the original `opeartionId` if the backup is running.

Sharding:
In sharding there could be a situation where the backup task finished on 2 shards but still running on the 3rd. In which case, if we ran the `StartBackupOperation` at that point, the 2 shards will start a new backup task while the 3rd one keeps running the original and returns its `operationId`. Mismatch.
In addition, the `StartBackupCommand` is repsonsible for checking on which node the backup resides and redirects there, so there was a need to piggyback off this ep if I wanted to check which shard was still running the task. (creating a dedicated endpoint for the sake of figuring out the correct `operationId` will duplicate all this code)
Changes:
In the sharded endpoint, before starting to send the backup command to all shards, we first send them a `ShardedOperation` which checks which shard is running this backup. If at least one of the shards is still running it then the `ShardedOpeartion` will return its `operationId`.
At this point we still have to go ahead and send the `StartBackupOperation` to all the shards so that `AddRemoteOperation` is triggrered and the `operationId` is added to the orchestrator's `Operations` list, along with the entire `WaitForCompletion` mechanism. The only thing we want to avoid is a actually running the backup once we reach the regular endpoint.
`inProgressOnAnotherShard` was added in this case to prevent the backup from running again.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
