### PR TITLE
RavenDB-22577 Making sure that we'll wait for the completion of BlittableJsonContent.SerializeToStreamAsync after HttpClient.SendAsync has already completed

### DIFF
--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Extensions;
+using Raven.Client.Json;
 using Raven.Client.Util;
 using Sparrow;
 using Sparrow.Json;
@@ -93,11 +94,24 @@ namespace Raven.Client.Http
             throw new InvalidOperationException($"'{GetType()}' command must override the SetResponse method which expects response with the following type: {ResponseType}.");
         }
 
-        public virtual Task<HttpResponseMessage> SendAsync(HttpClient client, HttpRequestMessage request, CancellationToken token)
+        public virtual async Task<HttpResponseMessage> SendAsync(HttpClient client, HttpRequestMessage request, CancellationToken token)
         {
             // We must use HttpCompletionOption.ResponseHeadersRead otherwise the client will buffer the response
             // and we'll get OutOfMemoryException in huge responses (> 2GB).
-            return client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
+            try
+            {
+                return await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (request.Content is BlittableJsonContent bjc)
+                {
+                    var requestBodyTask = bjc.EnsureCompletedAsync();
+
+                    if (requestBodyTask.IsCompleted == false) 
+                        await requestBodyTask.ConfigureAwait(false);
+                }
+            }
         }
 
         public virtual void SetResponseRaw(HttpResponseMessage response, Stream stream, JsonOperationContext context)

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -3,12 +3,17 @@ using System.IO;
 using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Raven.Client.Json
 {
     internal class BlittableJsonContent : HttpContent
     {
+        private static readonly TaskCompletionSource<object> Sentinel = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private TaskCompletionSource<object> _tcs;
+
         private readonly Func<Stream, Task> _asyncTaskWriter;
 
         public BlittableJsonContent(Func<Stream, Task> writer)
@@ -17,20 +22,38 @@ namespace Raven.Client.Json
             Headers.ContentEncoding.Add("gzip");
         }
 
+        // In some cases a task returned by HttpClient.SendAsync may be completed before the call to the request content's SerializeToStreamAsync completes
+        // This method is used to wait for the completion of SerializeToStreamAsync
+        // https://github.com/dotnet/runtime/issues/107082
+        public Task EnsureCompletedAsync() =>
+            Interlocked.CompareExchange(ref _tcs, Sentinel, null) is null
+                ? Task.CompletedTask // SerializeToStreamAsync was never called
+                : _tcs!.Task;
+
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
-            // Immediately flush request stream to send headers
-            // https://github.com/dotnet/corefx/issues/39586#issuecomment-516210081
-            // https://github.com/dotnet/runtime/issues/96223#issuecomment-1865009861
-            await stream.FlushAsync().ConfigureAwait(false);
+            if (Interlocked.CompareExchange(ref _tcs, new(TaskCreationOptions.RunContinuationsAsynchronously), null) is not null)
+                throw new InvalidOperationException($"Already called previously, or called after {nameof(EnsureCompletedAsync)}");
+
+            try
+            {
+                // Immediately flush request stream to send headers
+                // https://github.com/dotnet/corefx/issues/39586#issuecomment-516210081
+                // https://github.com/dotnet/runtime/issues/96223#issuecomment-1865009861
+                await stream.FlushAsync().ConfigureAwait(false);
 
 #if NETSTANDARD2_0 || NETCOREAPP2_1
-            using (var gzipStream = new GZipStream(stream, CompressionMode.Compress, leaveOpen: true))
+                using (var gzipStream = new GZipStream(stream, CompressionMode.Compress, leaveOpen: true))
 #else
-            await using (var gzipStream = new GZipStream(stream, CompressionMode.Compress, leaveOpen: true))
+                await using (var gzipStream = new GZipStream(stream, CompressionMode.Compress, leaveOpen: true))
 #endif
+                {
+                    await _asyncTaskWriter(gzipStream).ConfigureAwait(false);
+                }
+            }
+            finally
             {
-                await _asyncTaskWriter(gzipStream).ConfigureAwait(false);
+                _tcs!.TrySetResult(null);
             }
         }
 


### PR DESCRIPTION
There are cases when this is possible e.g. in HTTP2 is done to allow for duplex communication.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22577

### Additional description

This fixes a race issue that made that we sometimes attempted to read blittables via already closed transaction / disposed JSON operation context.

According to https://github.com/dotnet/runtime/issues/107082:

> Yes, there are cases where the task returned by HttpClient.SendAsync may be completed before the call to the request content's SerializeToStreamAsync completes.

This was exactly our scenario. We were able to reproduce it with the usage of ETL tasks. Although we also saw similar crashes happened occasionally in the past. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
