### PR TITLE
RavenDB-15852 - SlowTests.Server.Replication.ReplicationCleanTombston…

### DIFF
--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Server.Replication
 
                 Assert.Equal(1, WaitUntilHasTombstones(store2).Count);
 
-                EnsureReplicating(store1, store2);
+                await EnsureReplicatingAsync(store1, store2);
 
                 await storage1.TombstoneCleaner.ExecuteCleanup();
 

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -155,6 +155,12 @@ public partial class RavenTestBase
             return ShardHelper.ToShardName(databaseName ?? store.Database, shard);
         }
 
+        public ShardingConfiguration GetShardingConfiguration(IDocumentStore store, string database = null)
+        {
+            var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(database ?? store.Database));
+            return record.Sharding;
+        }
+
         public async Task<ShardingConfiguration> GetShardingConfigurationAsync(IDocumentStore store, string database = null)
         {
             var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database ?? store.Database));


### PR DESCRIPTION
…es.CleanTombstones

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15852/SlowTests.Server.Replication.ReplicationCleanTombstones.CleanTombstones

### Additional description

I wasn't able to reproduce the failure locally, but it seems the failure only occurs with sharded databases. The problem may arise from the `EnsureReplicating` method not handling sharding. I've updated it to `EnsureReplicatingAsync`, which I hope will help.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
