### PR TITLE
RavenDB-22794 Add comments for operations that implements IMaintenanceOperation

### DIFF
--- a/src/Raven.Client/Documents/Operations/GetCollectionStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetCollectionStatisticsOperation.cs
@@ -5,8 +5,17 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations
 {
+    /// <summary>
+    /// Retrieves collection statistics, including total count of documents and conflicts, 
+    /// and the number of documents per each collection.
+    /// </summary>
     public sealed class GetCollectionStatisticsOperation : IMaintenanceOperation<CollectionStatistics>
     {
+        /// <inheritdoc cref="GetCollectionStatisticsOperation"/>
+        public GetCollectionStatisticsOperation()
+        {
+        }
+
         public RavenCommand<CollectionStatistics> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
             return new GetCollectionStatisticsCommand();

--- a/src/Raven.Client/Documents/Operations/GetDetailedCollectionStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetDetailedCollectionStatisticsOperation.cs
@@ -5,8 +5,17 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations
 {
+    /// <summary>
+    /// Retrieves detailed collection statistics, providing in-depth information for each collection.
+    /// This includes the count of documents, total size, and sizes of documents, revisions, and tombstones.
+    /// </summary>
     public sealed class GetDetailedCollectionStatisticsOperation : IMaintenanceOperation<DetailedCollectionStatistics>
     {
+        /// <inheritdoc cref="GetDetailedCollectionStatisticsOperation"/>
+        public GetDetailedCollectionStatisticsOperation()
+        {
+        }
+
         public RavenCommand<DetailedCollectionStatistics> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
             return new GetDetailedCollectionStatisticsCommand();

--- a/src/Raven.Client/Documents/Operations/GetOperationStateOperation.cs
+++ b/src/Raven.Client/Documents/Operations/GetOperationStateOperation.cs
@@ -6,16 +6,23 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations
 {
+    /// <summary>
+    /// Retrieves the state of a specific operation by its ID, providing information such as the current status and progress.
+    /// </summary>
     public sealed class GetOperationStateOperation : IMaintenanceOperation<OperationState>
     {
         private readonly long _id;
         private readonly string _nodeTag;
 
+        /// <inheritdoc cref="GetOperationStateOperation"/>
+        /// <param name="id">The ID of the requested operation.</param>
         public GetOperationStateOperation(long id)
         {
             _id = id;
         }
 
+        /// <inheritdoc cref="GetOperationStateOperation(long)"/>
+        /// <param name="nodeTag">The node tag specifying which node should be queried for the operation's state.</param>
         public GetOperationStateOperation(long id, string nodeTag)
         {
             _id = id;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22794/Add-comments-for-operations-that-implements-IMaintenanceOperationT

### Additional description

Files in this PR:

- `GetCollectionStatisticsOperation (in Raven.Client.Documents.Operations)`
- `GetDetailedCollectionStatisticsOperation (in Raven.Client.Documents.Operations)`
- `GetOperationStateOperation (in Raven.Client.Documents.Operations)`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
