### PR TITLE
RavenDB-21771 - Add more GC events

### DIFF
--- a/src/Raven.Server/EventListener/EventListener.cs
+++ b/src/Raven.Server/EventListener/EventListener.cs
@@ -17,6 +17,7 @@ public class EventListener
                 public const string GCFinalizersBegin = "GCFinalizersBegin_V1";
                 public const string GCFinalizersEnd = "GCFinalizersEnd_V1";
                 public const string GCJoin = "GCJoin_V2";
+                public const string GCHeapStats = "GCHeapStats_V2";
             }
 
             public class Allocations

--- a/src/Raven.Server/EventListener/EventListener.cs
+++ b/src/Raven.Server/EventListener/EventListener.cs
@@ -16,6 +16,7 @@ public class EventListener
                 public const string GCRestartEnd = "GCRestartEEEnd_V1";
                 public const string GCFinalizersBegin = "GCFinalizersBegin_V1";
                 public const string GCFinalizersEnd = "GCFinalizersEnd_V1";
+                public const string GCJoin = "GCJoin_V2";
             }
 
             public class Allocations

--- a/src/Raven.Server/EventListener/EventListenerToLog.cs
+++ b/src/Raven.Server/EventListener/EventListenerToLog.cs
@@ -19,7 +19,8 @@ public class EventListenerToLog : IDynamicJson
         EventType.GCSuspend,
         EventType.GCRestart,
         EventType.GCFinalizers,
-        EventType.GCJoin
+        EventType.GCJoin,
+        EventType.GCHeapStats
     ];
     public static readonly HashSet<EventType> AllocationEvents = [EventType.Allocations];
     public static readonly HashSet<EventType> ContentionEvents = [EventType.Contention];

--- a/src/Raven.Server/EventListener/EventListenerToLog.cs
+++ b/src/Raven.Server/EventListener/EventListenerToLog.cs
@@ -14,7 +14,13 @@ public class EventListenerToLog : IDynamicJson
     private EventsListener _listener;
     private EventListenerConfiguration _configuration;
 
-    public static readonly HashSet<EventType> GcEvents = [EventType.GC, EventType.GCSuspend, EventType.GCRestart, EventType.GCFinalizers];
+    public static readonly HashSet<EventType> GcEvents = [
+        EventType.GC,
+        EventType.GCSuspend,
+        EventType.GCRestart,
+        EventType.GCFinalizers,
+        EventType.GCJoin
+    ];
     public static readonly HashSet<EventType> AllocationEvents = [EventType.Allocations];
     public static readonly HashSet<EventType> ContentionEvents = [EventType.Contention];
     public static readonly HashSet<EventType> ThreadEvents = [

--- a/src/Raven.Server/EventListener/EventType.cs
+++ b/src/Raven.Server/EventListener/EventType.cs
@@ -6,6 +6,7 @@ public enum EventType
     GCSuspend,
     GCRestart,
     GCFinalizers,
+    GCJoin,
     Allocations,
     Contention,
     ThreadPoolWorkerThreadStart,

--- a/src/Raven.Server/EventListener/EventType.cs
+++ b/src/Raven.Server/EventListener/EventType.cs
@@ -7,6 +7,7 @@ public enum EventType
     GCRestart,
     GCFinalizers,
     GCJoin,
+    GCHeapStats,
     Allocations,
     Contention,
     ThreadPoolWorkerThreadStart,

--- a/src/Raven.Server/EventListener/EventsListener.cs
+++ b/src/Raven.Server/EventListener/EventsListener.cs
@@ -160,6 +160,7 @@ public class EventsListener : AbstractEventListener
                 case EventType.GCSuspend:
                 case EventType.GCRestart:
                 case EventType.GCFinalizers:
+                case EventType.GCJoin:
                 case EventType.Allocations:
                     dotNetEventType = (dotNetEventType ?? DotNetEventType.GC) | DotNetEventType.GC;
                     break;

--- a/src/Raven.Server/EventListener/EventsListener.cs
+++ b/src/Raven.Server/EventListener/EventsListener.cs
@@ -161,6 +161,7 @@ public class EventsListener : AbstractEventListener
                 case EventType.GCRestart:
                 case EventType.GCFinalizers:
                 case EventType.GCJoin:
+                case EventType.GCHeapStats:
                 case EventType.Allocations:
                     dotNetEventType = (dotNetEventType ?? DotNetEventType.GC) | DotNetEventType.GC;
                     break;

--- a/src/Raven.Server/EventListener/GcEventsHandler.cs
+++ b/src/Raven.Server/EventListener/GcEventsHandler.cs
@@ -108,6 +108,14 @@ public class GcEventsHandler : AbstractEventsHandler<GcEventsHandler.GCEventBase
                 }
 
                 return true;
+
+            case EventListener.Constants.EventNames.GC.GCJoin:
+                if (EventTypes.Contains(EventType.GCJoin))
+                {
+                    OnEvent.Invoke(new GCJoinEvent(EventType.GCJoin, eventData));
+                }
+
+                return true;
         }
 
         return false;
@@ -263,6 +271,70 @@ public class GcEventsHandler : AbstractEventsHandler<GcEventsHandler.GCEventBase
                     return "Suspend for GC Prep";
                 case 0x7:
                     return "Suspend for debugger sweep";
+
+                default:
+                    return null;
+            }
+        }
+    }
+
+    public class GCJoinEvent : GCEventBase
+    {
+        public string JoinTime { get; set; }
+
+        public string JoinType { get; set; }
+
+        public GCJoinEvent(EventType type, EventWrittenEventArgs eventData) : base(type, eventData.TimeStamp, eventData)
+        {
+            var joinTime = (uint)eventData.Payload[1];
+            var joinType = (uint)eventData.Payload[2];
+
+            JoinTime = GetJoinTime(joinTime);
+            JoinType = GetJoinType(joinType);
+        }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var json = base.ToJson();
+            json[nameof(JoinTime)] = JoinTime;
+            json[nameof(JoinType)] = JoinType;
+            return json;
+        }
+
+        public override string ToString()
+        {
+            var str = base.ToString();
+            return $"{str}, join time: {JoinTime}, join type: {JoinType}";
+        }
+
+        private static string GetJoinTime(uint joinType)
+        {
+            switch (joinType)
+            {
+                case 0x0:
+                    return "Join Start";
+                case 0x1:
+                    return "Join End";
+
+                default:
+                    return null;
+            }
+        }
+
+        private static string GetJoinType(uint joinType)
+        {
+            switch (joinType)
+            {
+                case 0x0:
+                    return "Last Join";
+                case 0x1:
+                    return "Join";
+                case 0x2:
+                    return "Restart";
+                case 0x3:
+                    return "First Reverse Join";
+                case 0x4:
+                    return "Reverse Join";
 
                 default:
                     return null;

--- a/src/Raven.Server/EventListener/GcEventsListener.cs
+++ b/src/Raven.Server/EventListener/GcEventsListener.cs
@@ -10,9 +10,18 @@ public class GcEventsListener : AbstractEventListener
 
     public IReadOnlyCollection<GcEventsHandler.GCEventBase> Events => _events;
 
+    private readonly HashSet<EventType> _eventsToLog =
+    [
+        EventType.GC,
+        EventType.GCSuspend,
+        EventType.GCRestart,
+        EventType.GCFinalizers,
+        EventType.GCHeapStats
+    ];
+
     public GcEventsListener()
     {
-        _handler = new GcEventsHandler(e => _events.Add(e));
+        _handler = new GcEventsHandler(e => _events.Add(e), _eventsToLog);
         EnableEvents(DotNetEventType.GC);
     }
 

--- a/src/Raven.Studio/typescript/viewmodels/manage/configureEventListenerDialog.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/configureEventListenerDialog.ts
@@ -31,6 +31,8 @@ class configureEventListenerDialog extends dialogViewModelBase {
         "GCFinalizers",
         "GCRestart",
         "GCSuspend",
+        "GCJoin",
+        "GCHeapStats",
         "ThreadCreated",
         "ThreadCreating",
         "ThreadPoolMinMaxThreads",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21771/Slow-thread-suspension

### Additional description

Add more GC events for logging.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
