### PR TITLE
RavenDB-22686 bump Lucene,Corax,Documents and Server storage version to 61_000

### DIFF
--- a/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
@@ -14,15 +14,15 @@ namespace Raven.Server.Storage.Schema
     {
         internal sealed class CurrentVersion
         {
-            public const int ServerVersion = 60_000;
+            public const int ServerVersion = 61_000;
 
             public const int ConfigurationVersion = 50_000;
 
-            public const int DocumentsVersion = 60_000;
+            public const int DocumentsVersion = 61_000;
 
-            public const int LuceneIndexVersion = 60_000;
+            public const int LuceneIndexVersion = 61_000;
 
-            public const int CoraxIndexVersion = 60_000;
+            public const int CoraxIndexVersion = 61_000;
 
             public static (int Version, StorageType Type) GetIndexVersionAndStorageType(SearchEngineType type) => type switch
             {

--- a/src/Raven.Server/Storage/Schema/Updates/CoraxIndex/61000/From60000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/CoraxIndex/61000/From60000.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Raven.Server.Storage.Schema.Updates.CoraxIndex;
+
+public sealed class From60000 : ISchemaUpdate
+{
+    public int From => 60_000;
+
+    public int To => 61_000;
+
+    public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.CoraxIndex;
+
+    public bool Update(UpdateStep step)
+    {
+        return true;
+    }
+}

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/61000/From60000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/61000/From60000.cs
@@ -1,0 +1,14 @@
+﻿namespace Raven.Server.Storage.Schema.Updates.Documents
+{
+    public class From60000 : ISchemaUpdate
+    {
+        public int From => 60_000;
+        public int To => 61_000;
+        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.Documents;
+
+        public bool Update(UpdateStep step)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/61000/From60000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/LuceneIndex/61000/From60000.cs
@@ -1,0 +1,14 @@
+﻿namespace Raven.Server.Storage.Schema.Updates.LuceneIndex
+{
+    public class From60000 : ISchemaUpdate
+    {
+        public int From => 60_000;
+        public int To => 61_000;
+        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.LuceneIndex;
+
+        public bool Update(UpdateStep step)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Raven.Server/Storage/Schema/Updates/Server/61000/From60000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/61000/From60000.cs
@@ -1,0 +1,14 @@
+﻿namespace Raven.Server.Storage.Schema.Updates.Server
+{
+    public class From60000 : ISchemaUpdate
+    {
+        public int From => 60_000;
+        public int To => 61_000;
+        public SchemaUpgrader.StorageType StorageType => SchemaUpgrader.StorageType.Server;
+
+        public bool Update(UpdateStep step)
+        {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22686

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
