### PR TITLE
RavenDB-22703 NonExisting posting list index version check for v6.1

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexDefinitionBaseServerSide.cs
@@ -177,14 +177,18 @@ namespace Raven.Server.Documents.Indexes
             public const long PhraseQuerySupportInCoraxIndexes = 60_002;
             public const long StoreOnlySupportInCoraxIndexes = 60_003; // RavenDB-22369
             public const long JavaScriptProperlyHandleDynamicFieldsIndexFields = 60_004; // RavenDB-22363
-            public const long UseNonExistingPostingList = 60_005; // RavenDB-22703
-            public const long LoadDocumentWithDynamicCollectionNameShouldThrow = 61_000; // RavenDB-22359
+            public const long UseNonExistingPostingList_60 = 60_005; // RavenDB-22703
+
+            public const long Base61Version = 61_000;
+            
+            public const long LoadDocumentWithDynamicCollectionNameShouldThrow = Base61Version; // RavenDB-22359
             public const long CoraxComplexFieldIndexingBehavior = 61_001;
+            public const long UseNonExistingPostingList_61 = 61_002; // RavenDB-22703
 
             /// <summary>
             /// Remember to bump this
             /// </summary>
-            public const long CurrentVersion = CoraxComplexFieldIndexingBehavior;
+            public const long CurrentVersion = UseNonExistingPostingList_61;
 
             public static bool IsTimeTicksInJavaScriptIndexesSupported(long indexVersion)
             {
@@ -194,6 +198,14 @@ namespace Raven.Server.Documents.Indexes
                 }
 
                 return indexVersion >= TimeTicksSupportInJavaScriptIndexes_54;
+            }
+
+            public static bool IsNonExistingPostingListSupported(long indexVersion)
+            {
+                if (indexVersion >= Base61Version)
+                    return indexVersion >= UseNonExistingPostingList_61;
+
+                return indexVersion >= UseNonExistingPostingList_60;
             }
         }
     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -425,7 +425,8 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
 
     protected void RegisterMissingFieldFor(IndexField field)
     {
-        if (field.Id == CoraxConstants.IndexWriter.DynamicField || _index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.UseNonExistingPostingList)
+        if (field.Id == CoraxConstants.IndexWriter.DynamicField || 
+            IndexDefinitionBaseServerSide.IndexVersion.IsNonExistingPostingListSupported(_index.Definition.Version) == false)
             return;
         
         _nonExistingFieldsOfDocument.Add(field.Name);
@@ -433,7 +434,7 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
 
     protected void WriteNonExistingMarkerForMissingFields<TBuilder>(TBuilder builder) where TBuilder : IIndexEntryBuilder
     {
-        if (_index.Definition.Version < IndexDefinitionBaseServerSide.IndexVersion.UseNonExistingPostingList) 
+        if (IndexDefinitionBaseServerSide.IndexVersion.IsNonExistingPostingListSupported(_index.Definition.Version) == false) 
             return;
 
         foreach (var fieldName in _nonExistingFieldsOfDocument)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -280,7 +280,7 @@ public static class CoraxQueryBuilder
 
                 var indexVersion = builderParameters.Index.Definition.Version;
 
-                if (indexVersion >= IndexDefinitionBaseServerSide.IndexVersion.UseNonExistingPostingList)
+                if (IndexDefinitionBaseServerSide.IndexVersion.IsNonExistingPostingListSupported(indexVersion))
                 {
                     var queryWithNullAndNonExistingMatches = indexSearcher.IncludeNonExistingMatch(in sortBy.Field, queryWithNullMatches, sortBy.Ascending);
                     coraxQuery = queryWithNullAndNonExistingMatches;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22703/Fix-querying-documents-with-missing-fields-when-there-is-order-by-and-no-where-statement

### Additional description

NonExisting posting list index version check for v6.1

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
