### PR TITLE
RavenDB-22848 - StressTests.Issues.RavenDB_18420.ShouldRescheduleBackupTimerIfDocumentDatabaseFailedToLoad

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1106,6 +1106,9 @@ namespace Raven.Server.Documents
                 oldTimer.Dispose();
             }
 
+            if (idleDatabaseActivity == null)
+                return;
+
             var newTimer = new Timer(_ => NextScheduledActivityCallback(databaseName, idleDatabaseActivity), null, idleDatabaseActivity.DueTime, Timeout.Infinite);
             _wakeupTimers.AddOrUpdate(databaseName, _ => newTimer, (_, __) => newTimer);
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22848

### Additional description

If the database was disabled, and backup configuration addded, this triggred `UpdateResponsibleNodeForTasksCommand` -> `RescheduleTimerIfDatabaseIdleOnUpdatedResponsibleNode` -> `GetEarliestIdleDatabaseActivity` which returned `null` (becase db is disabled).
This `null` was then passed on to `RescheduleNextIdleDatabaseActivity` to set a new timer, but there is no `null` check there, so NRE was thrown.
Added a `null` check, so we do dispose the old timer but don't set a new one.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
