### PR TITLE
RavenDB-22076 Vector Search

### DIFF
--- a/src/Corax/Indexing/IIndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IIndexEntryBuilder.cs
@@ -11,6 +11,7 @@ public interface IIndexEntryBuilder
     void WriteNull(int fieldId, string path);
     void WriteNonExistingMarker(int fieldId, string path);
     void Write(int fieldId, ReadOnlySpan<byte> value);
+    void WriteVector(int fieldId, string path, ReadOnlySpan<byte> value);
     void Write(int fieldId, string path, ReadOnlySpan<byte> value);
     void Write(int fieldId, string path, string value);
     void Write(int fieldId, ReadOnlySpan<byte> value, long longValue, double dblValue);

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -278,6 +278,14 @@ public partial class IndexWriter
 
         public void Write(int fieldId, ReadOnlySpan<byte> value) => Write(fieldId, null, value);
 
+        public void WriteVector(int fieldId, string path, ReadOnlySpan<byte> value)
+        {
+            if (value.Length <= 0) return; // we don't index missing / empty vectors 
+            
+            var field = GetField(fieldId, path);
+            RegisterTerm(field, value, StoredFieldType.Raw);
+        }
+        
         public void Write(int fieldId, string path, ReadOnlySpan<byte> value)
         {
             var field = GetField(fieldId, path);

--- a/src/Corax/Querying/IndexSearcher.Search.cs
+++ b/src/Corax/Querying/IndexSearcher.Search.cs
@@ -385,4 +385,10 @@ public partial class IndexSearcher
         analyzer = a;
         return a;
     }
+
+    public IQueryMatch VectorQuery(FieldMetadata fieldMetadata, byte[] vectorToSearch, float minimumMatch)
+    {
+        long rootPageByFieldName = GetRootPageByFieldName(fieldMetadata.FieldName);
+        return new ExactVectorSearchMatch(this, _transaction, rootPageByFieldName, vectorToSearch, minimumMatch);
+    }
 }

--- a/src/Corax/Querying/IndexSearcher.Search.cs
+++ b/src/Corax/Querying/IndexSearcher.Search.cs
@@ -389,6 +389,9 @@ public partial class IndexSearcher
     public IQueryMatch VectorQuery(FieldMetadata fieldMetadata, byte[] vectorToSearch, float minimumMatch)
     {
         long rootPageByFieldName = GetRootPageByFieldName(fieldMetadata.FieldName);
+        if (rootPageByFieldName is -1)
+            return EmptyMatch();
+        
         return new ExactVectorSearchMatch(this, _transaction, rootPageByFieldName, vectorToSearch, minimumMatch);
     }
 }

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -121,6 +121,55 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         }
     }
     
+    public EntryTermsReaderEnumerator GetEntryTermsReader(Span<long> ids, PageLocator pageLocator)
+    {
+        if (_nullTermsMarkersLoaded == false)
+        {
+            InitializeNullTermsMarkers();
+        }
+
+        return new EntryTermsReaderEnumerator(this, ids, pageLocator);
+    }
+
+    public ref struct EntryTermsReaderEnumerator
+    {
+        private readonly IndexSearcher _searcher;
+        private ByteStringContext<ByteStringMemoryCache>.InternalScope _scope;
+        private readonly Span<UnmanagedSpan> _spans;
+        private int _index;
+
+        public EntryTermsReaderEnumerator(IndexSearcher searcher,Span<long> ids, PageLocator pageLocator)
+        {
+            _searcher = searcher;
+            _scope = searcher._transaction.Allocator.AllocateDirect(sizeof(UnmanagedSpan) * ids.Length, out var spanBuffer);
+            _spans = spanBuffer.ToSpan<UnmanagedSpan>();
+            
+            using var _ = searcher._transaction.Allocator.AllocateDirect(sizeof(long) * ids.Length, out var locationsBuffer);
+            var locations = locationsBuffer.ToSpan<long>();
+            searcher._entryIdToLocation.GetFor(ids, locations, -1);
+            Container.GetAll(searcher._transaction.LowLevelTransaction, locations, (UnmanagedSpan*)spanBuffer.Ptr, -1, pageLocator);
+            _index = -1;
+            Current = new(searcher._transaction.LowLevelTransaction, searcher._nullTermsMarkers, searcher._dictionaryId);
+        }
+
+        public bool MoveNext()
+        {
+            if (++_index >= _spans.Length)
+                return false;
+            
+            Current.Reuse(_spans[_index].Address, _spans[_index].Length);
+            return true;
+        }
+
+        public EntryTermsReader Current;
+
+        public void Dispose()
+        {
+            Current.Reset();
+            _scope.Dispose();
+        }
+    } 
+    
     public EntryTermsReader GetEntryTermsReader(long id, ref Page p)
     {
         if (_entryIdToLocation.TryGetValue(id, out var loc) == false)
@@ -597,13 +646,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     {
         if (_nullTermsMarkersLoaded == false)
         {
-            _nullTermsMarkersLoaded = true;
-            _nullTermsMarkers = new HashSet<long>();
-            
-            InitNullPostingList();
-            
-            if (_nullPostingListsTree != null)
-                LoadSpecialTermMarkers(_nullPostingListsTree, _nullTermsMarkers);
+            InitializeNullTermsMarkers();
         }
 
         if (_nonExistingTermsMarkersLoaded == false)
@@ -616,6 +659,17 @@ public sealed unsafe partial class IndexSearcher : IDisposable
             if (_nonExistingPostingListsTree != null)
                 LoadSpecialTermMarkers(_nonExistingPostingListsTree, _nonExistingTermsMarkers);
         }
+    }
+
+    private void InitializeNullTermsMarkers()
+    {
+        _nullTermsMarkersLoaded = true;
+        _nullTermsMarkers = new HashSet<long>();
+            
+        InitNullPostingList();
+            
+        if (_nullPostingListsTree != null)
+            LoadSpecialTermMarkers(_nullPostingListsTree, _nullTermsMarkers);
     }
 
     public static void LoadSpecialTermMarkers(Tree postingList, HashSet<long> termsMarkers)
@@ -635,8 +689,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
 
     private long GetRootPageByFieldName(Slice fieldName)
     {
-        var it = _fieldsTree.Iterate(false);
-        var result = _fieldsTree.Read(fieldName);
+        var result = _fieldsTree?.Read(fieldName);
         if (result is null)
             return -1;
         

--- a/src/Corax/Querying/Matches/ExactVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/ExactVectorSearchMatch.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Corax.Querying.Matches.Meta;
+using Corax.Utils;
+using Sparrow;
+using Voron;
+using Voron.Data.Lookups;
+using Voron.Impl;
+using Container = Voron.Data.Containers.Container;
+
+namespace Corax.Querying.Matches
+{
+    [DebuggerDisplay("{DebugView,nq}")]
+    public struct ExactVectorSearchMatch(IndexSearcher searcher, Transaction tx, long fieldRootPage, byte[] vectorToSearch, float minimumMatch)
+        : IQueryMatch
+    {
+        private readonly long _count = searcher.NumberOfEntries;
+        private Lookup<Int64LookupKey>.ForwardIterator _entriesPagesIt;
+        private bool _firstFill = true;
+        private PageLocator _pageLocator = new PageLocator();
+
+        public SkipSortingResult AttemptToSkipSorting()
+        {
+            return SkipSortingResult.SortingIsRequired;
+        }
+
+        public bool IsBoosting => false;
+        public long Count => _count;
+        public QueryCountConfidence Confidence => QueryCountConfidence.Low;
+
+        public int Fill(Span<long> matches)
+        {
+            if (_firstFill)
+            {
+                _entriesPagesIt = tx.LookupFor<Int64LookupKey>(Constants.IndexWriter.EntryIdToLocationSlice).Iterate();
+                _entriesPagesIt.Reset();
+                _firstFill = false;
+            }
+
+            int count;
+            do
+            {
+                count = _entriesPagesIt.FillKeys(matches);
+                if (count == 0)
+                    break;
+                count = AndWith(matches, count);
+            } while (count == 0);
+            return count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int AndWith(Span<long> buffer, int matches)
+        {
+            var matchIndex = 0;
+            Page lastPage = default;
+            for (int i = 0; i < matches; i++)
+            {
+                var reader = searcher.GetEntryTermsReader(buffer[i], ref lastPage);
+                if (ExactVectorMatch(reader))
+                {
+                    buffer[matchIndex++] = buffer[i];
+                }
+            }
+
+            return matchIndex;
+        }
+
+        private bool ExactVectorMatch(EntryTermsReader reader)
+        {
+            while (reader.FindNextStored(fieldRootPage))
+            {
+                var vector = reader.StoredField.Value.ToSpan();
+                if(vector.Length != vectorToSearch.Length)
+                    continue;
+
+                var similarity = SimilarityI8(vectorToSearch, vector);
+                if (similarity > minimumMatch)
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static unsafe float SimilarityI8(Span<byte> lhs, Span<byte> rhs)
+        {
+            // Code adapted from:
+            // https://github.com/dotnet/smartcomponents/blob/main/src/SmartComponents.LocalEmbeddings/EmbeddingI1.cs#L103
+
+            // The following approach to load the vectors is considerably faster than using a "fixed" block
+            ref var lhsRef = ref lhs[0];
+            var lhsPtr = (byte*)Unsafe.AsPointer(ref lhsRef);
+            ref var rhsRef = ref rhs[0];
+            var rhsPtr = (byte*)Unsafe.AsPointer(ref rhsRef);
+            var lhsPtrEnd = lhsPtr + lhs.Length;
+            var differences = 0;
+
+            // Process as many Vector256 blocks as possible
+            while (lhsPtr <= lhsPtrEnd - 32)
+            {
+                var lhsBlock = Vector256.Load(lhsPtr);
+                var rhsBlock = Vector256.Load(rhsPtr);
+                var xorBlock = Vector256.Xor(lhsBlock, rhsBlock).AsUInt64();
+
+                // This is 10x faster than any AVX2/SSE3 vectorized approach I could find (e.g.,
+                // avx2-lookup from https://stackoverflow.com/a/50082218). However I didn't try
+                // AVX512 approaches (vectorized popcnt) since hardware support is less common.
+                differences +=
+                    BitOperations.PopCount(xorBlock.GetElement(0)) +
+                    BitOperations.PopCount(xorBlock.GetElement(1)) +
+                    BitOperations.PopCount(xorBlock.GetElement(2)) +
+                    BitOperations.PopCount(xorBlock.GetElement(3));
+
+                lhsPtr += 32;
+                rhsPtr += 32;
+            }
+
+            // Process as many Vector128 blocks as possible
+            while (lhsPtr <= lhsPtrEnd - 16)
+            {
+                var lhsBlock = Vector128.Load(lhsPtr);
+                var rhsBlock = Vector128.Load(rhsPtr);
+                var xorBlock = Vector128.Xor(lhsBlock, rhsBlock).AsUInt64();
+
+                differences +=
+                    BitOperations.PopCount(xorBlock.GetElement(0)) +
+                    BitOperations.PopCount(xorBlock.GetElement(1));
+
+                lhsPtr += 16;
+                rhsPtr += 16;
+            }
+
+            // Process the remaining bytes
+            while (lhsPtr < lhsPtrEnd)
+            {
+                var left = *lhsPtr;
+                var right = *rhsPtr;
+                var xor = (byte)(left ^ right);
+                differences += BitOperations.PopCount(xor);
+                lhsPtr++;
+                rhsPtr++;
+            }
+
+            return 1 - (differences / (float)(lhs.Length * 8));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Score(Span<long> matches, Span<float> scores, float boostFactor)
+        {
+            Page lastPage = default;
+            for (int i = 0; i < matches.Length; i++)
+            {
+                scores[i] = 0;
+                var reader = searcher.GetEntryTermsReader(matches[i], ref lastPage);
+                while (reader.FindNextStored(fieldRootPage))
+                {
+                    var vector = reader.StoredField.Value.ToSpan();
+                    if (vector.Length != vectorToSearch.Length)
+                        continue;
+                    scores[i] = SimilarityI8(vectorToSearch, vector) * boostFactor;
+                    break;
+                }
+            }
+        }
+
+        public QueryInspectionNode Inspect()
+        {
+            return new QueryInspectionNode(nameof(ExactVectorSearchMatch),
+                parameters: new Dictionary<string, string>()
+                {
+                });
+        }
+
+        string DebugView => Inspect().ToString();
+    }
+}

--- a/src/Corax/Utils/EntryTermsReader.cs
+++ b/src/Corax/Utils/EntryTermsReader.cs
@@ -80,7 +80,7 @@ public unsafe struct EntryTermsReader
     private readonly HashSet<long> _nonExistingTermsMarkers;
     private readonly long _dicId;
     private byte* _cur;
-    private readonly byte* _end, _start;
+    private byte* _end, _start;
     private long _prevTerm;
     private long _prevLong;
 
@@ -114,6 +114,26 @@ public unsafe struct EntryTermsReader
         _prevLong = 0;
         Current = new();
         Current.Initialize(llt);
+    }
+
+    public EntryTermsReader(LowLevelTransaction llt, HashSet<long> nullTermsMarkers, long dicId)
+    {
+        _llt = llt;
+        _nullTermsMarkers = nullTermsMarkers;
+        _start = _cur;
+        _dicId = dicId;
+        Current = new();
+        Current.Initialize(llt);
+    }
+
+    public void Reuse(byte* cur, int size)
+    {
+        _start = _cur;
+        _cur = cur;
+        _start = cur;
+        _end = cur + size;
+        _prevTerm = 0;
+        _prevLong = 0;
     }
 
     public bool FindNextStored(long fieldRootPage)

--- a/src/Corax/Utils/EntryTermsReader.cs
+++ b/src/Corax/Utils/EntryTermsReader.cs
@@ -116,10 +116,11 @@ public unsafe struct EntryTermsReader
         Current.Initialize(llt);
     }
 
-    public EntryTermsReader(LowLevelTransaction llt, HashSet<long> nullTermsMarkers, long dicId)
+    public EntryTermsReader(LowLevelTransaction llt, HashSet<long> nullTermsMarkers,  HashSet<long> nonExistingTermsMarkers, long dicId)
     {
         _llt = llt;
         _nullTermsMarkers = nullTermsMarkers;
+        _nonExistingTermsMarkers = nonExistingTermsMarkers;
         _start = _cur;
         _dicId = dicId;
         Current = new();

--- a/src/Corax/Utils/EntryTermsReader.cs
+++ b/src/Corax/Utils/EntryTermsReader.cs
@@ -408,6 +408,7 @@ public unsafe struct EntryTermsReader
                 continue;
             }
 
+            // TODO: Handle vector here
             if (IsRaw)
             {
                 using var ctx = JsonOperationContext.ShortTermSingleUse();

--- a/src/Raven.Client/Documents/Indexes/FieldIndexing.cs
+++ b/src/Raven.Client/Documents/Indexes/FieldIndexing.cs
@@ -63,6 +63,11 @@ namespace Raven.Client.Documents.Indexes
         /// <summary>
         /// Index this field using the default internal analyzer: LowerCaseKeywordAnalyzer
         /// </summary>
-        Default = 1 << 4
+        Default = 1 << 4, 
+        
+        /// <summary>
+        /// Index this field for vector search using the default builtin model
+        /// </summary>
+        Vector = 1 << 5,
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndexDefinition.cs
@@ -2,10 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using Raven.Client;
-using Raven.Client.Documents.DataArchival;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Spatial;
-using Raven.Client.Documents.Operations.DataArchival;
 using Raven.Server.Extensions;
 using Raven.Server.Json;
 using Sparrow.Json;

--- a/src/Raven.Server/Documents/Indexes/AutoIndexNameFinder.cs
+++ b/src/Raven.Server/Documents/Indexes/AutoIndexNameFinder.cs
@@ -75,7 +75,7 @@ namespace Raven.Server.Documents.Indexes
             if (x.GroupByArrayBehavior == GroupByArrayBehavior.ByContent)
                 name = AutoIndexField.GetGroupByArrayContentAutoIndexFieldName(name).ToUpperFirstLetter();
 
-            if (x.Indexing == AutoFieldIndexing.Default || x.Indexing == AutoFieldIndexing.No)
+            if (x.Indexing is AutoFieldIndexing.Default or AutoFieldIndexing.No)
             {
                 if (x.Spatial != null)
                     return name
@@ -93,6 +93,9 @@ namespace Raven.Server.Documents.Indexes
 
             if (x.Indexing.HasFlag(AutoFieldIndexing.Search))
                 functions.Add(AutoIndexField.GetSearchAutoIndexFieldName(name).ToUpperFirstLetter());
+
+            if (x.Indexing.HasFlag(AutoFieldIndexing.Vector))
+                functions.Add(AutoIndexField.GetVectorAutoIndexFieldName(name).ToUpperFirstLetter());
 
             if (x.Indexing.HasFlag(AutoFieldIndexing.Highlighting))
                 functions.Add(AutoIndexField.GetHighlightingAutoIndexFieldName(name).ToUpperFirstLetter());

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -188,8 +188,14 @@ namespace Raven.Server.Documents.Indexes
                     string configurationKey = nameof(SearchEngineType);
                     string configurationName = _index.Type.IsAuto() ? RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType) : RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType);
 
-                    SearchEngineType defaultEngineType =
-                        _index.Type.IsAuto() ? _index.Configuration.AutoIndexingEngineType : _index.Configuration.StaticIndexingEngineType;
+                    SearchEngineType defaultEngineType = _index.Type.IsAuto() switch
+                    {
+                        // We only support Vectors in Corax, so if an auto-index is using it, let's already set it up as such, regardless
+                        // of what type of default storage engine is configured.
+                        true when _index.Definition.IndexFields.Any(x=>x.Value.Vector) => SearchEngineType.Corax,
+                        true => _index.Configuration.AutoIndexingEngineType,
+                        false => _index.Configuration.StaticIndexingEngineType
+                    };
 
                     if (defaultEngineType == SearchEngineType.None)
                         throw new InvalidDataException($"Default search engine is {SearchEngineType.None}. Please set {configurationName}.");

--- a/src/Raven.Server/Documents/Indexes/Persistence/ConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/ConverterBase.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Persistence.Corax;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents.Fields;
 using Raven.Server.Documents.Indexes.Static;
+using Raven.Server.Documents.Indexes.VectorSearch;
 using Raven.Server.Json;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -170,6 +171,10 @@ namespace Raven.Server.Documents.Indexes.Persistence
                         break;
                     case TimeOnly:
                         valueType = ValueType.TimeOnly;
+                        break;
+                    
+                    case VectorField:
+                        valueType = ValueType.Vector;
                         break;
 
                     default:
@@ -331,6 +336,8 @@ namespace Raven.Server.Documents.Indexes.Persistence
             DateOnly,
 
             TimeOnly,
+            
+            Vector,
             
             CoraxSpatialPointEntry,
             

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
@@ -62,9 +62,18 @@ public sealed class CoraxDocumentConverter : CoraxDocumentConverterBase
             else
             {
                 var successfulRead = BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, indexField.OriginalName ?? indexField.Name, out value);
-            
+
                 if (successfulRead)
-                    InsertRegularField(indexField, value, indexContext, builder, sourceDocument, out innerShouldSkip);
+                {
+                    if (indexField.Vector is false)
+                    {
+                        InsertRegularField(indexField, value, indexContext, builder, sourceDocument,  out innerShouldSkip);
+                    }
+                    else
+                    {
+                        InsertVectorFields(indexField, value, builder, sourceDocument);
+                    }
+                }
 
                 if (successfulRead == false || innerShouldSkip)
                     RegisterMissingFieldFor(indexField);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -27,6 +27,7 @@ using System.IO;
 using System.Text;
 using Corax.Indexing;
 using Raven.Server.Config;
+using Raven.Server.Documents.Indexes.VectorSearch;
 using Sparrow.Binary;
 using static Raven.Server.Config.Categories.IndexingConfiguration;
 
@@ -304,6 +305,11 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
                 @double = iConvertible.ToDouble(CultureInfo.InvariantCulture);
 
                 builder.Write(fieldId, path,  iConvertible.ToString(CultureInfo.InvariantCulture), @long, @double);
+                break;
+            
+            case ValueType.Vector:
+                var vectorBuffer = ((VectorField)value).Buffer;
+                builder.WriteVector(fieldId,path,  vectorBuffer);
                 break;
 
             case ValueType.Enumerable:

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
@@ -69,6 +69,11 @@ internal class CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
             // nothing to do
         }
 
+        public void WriteVector(int fieldId, string path, ReadOnlySpan<byte> value)
+        {
+            // nothing to do here
+        }
+
         public void Write(int fieldId, ReadOnlySpan<byte> value)
         {
             if (value.Length == 0)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -13,6 +13,7 @@ using Corax.Utils;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Corax;
 using Raven.Server.Documents.Indexes.Persistence.Corax.QueryOptimizer;
+using Raven.Server.Documents.Indexes.VectorSearch;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
 using Raven.Server.ServerWide.Context;
@@ -595,7 +596,9 @@ public static class CoraxQueryBuilder
                 case MethodType.Spatial_Intersects:
                     return HandleSpatial(builderParameters, me, methodType);
                 case MethodType.Vector_Search:
-                    return HandleVector(builderParameters, me);
+                    return HandleVectorSearch(builderParameters, me);
+                case MethodType.Vector_Nearest:
+                    return HandleVectorNearest(builderParameters, me);
                 case MethodType.Regex:
                     return HandleRegex(builderParameters, me, ref leftOnlyOptimization);
                 case MethodType.MoreLikeThis:
@@ -609,30 +612,56 @@ public static class CoraxQueryBuilder
         throw new InvalidQueryException("Unable to understand query", metadata.QueryText, queryParameters);
     }
 
-    private static IQueryMatch HandleVector(Parameters builderParameters, MethodExpression me)
+    private static IQueryMatch HandleVectorNearest(Parameters builderParameters, MethodExpression me)
     {
-        var fieldName = QueryBuilderHelper.ExtractIndexFieldName(builderParameters.Metadata.Query, builderParameters.QueryParameters, me.Arguments[0], builderParameters.Metadata);
-        var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(builderParameters.Allocator, fieldName, builderParameters.Index, builderParameters.IndexFieldsMapping,
-            builderParameters.FieldsToFetch, builderParameters.HasDynamics, builderParameters.DynamicFields, hasBoost: builderParameters.HasBoost);
         var (value, valueType) = QueryBuilderHelper.GetValue(builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters, (ValueExpression)me.Arguments[1]);
         var vector = valueType switch
         {
             ValueTokenType.String => Convert.FromBase64String(value.ToString()),
-            _ => throw new NotSupportedException("Vector on " + valueType)
+            _ => throw new NotSupportedException("Vector.Nearest on " + valueType)
         };
+        
+        return HandleVector(builderParameters, me, vector);
+    }
+    
+    private static IQueryMatch HandleVectorSearch(Parameters builderParameters, MethodExpression me)
+    {
+        var (value, valueType) = QueryBuilderHelper.GetValue(builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters, (ValueExpression)me.Arguments[1]);
+        var valueAsString = valueType switch
+        {
+            ValueTokenType.String =>value.ToString(),
+            _ => throw new NotSupportedException("Vector.Search() on " + valueType)
+        };
+        
+        return HandleVector(builderParameters, me, GenerateEmbeddings.UsingI8(valueAsString));
+    }
 
-         var minimumMatch = 0.95f;
+    private static IQueryMatch HandleVector(Parameters builderParameters, MethodExpression me, byte[] vector)
+    {
+        var metadata = builderParameters.Metadata;
+        var fieldName = QueryBuilderHelper.ExtractIndexFieldName(builderParameters.Metadata.Query, builderParameters.QueryParameters, me.Arguments[0], builderParameters.Metadata);
+        if (metadata.IsDynamic)
+        {
+            fieldName = new QueryFieldName(AutoIndexField.GetVectorAutoIndexFieldName(fieldName.Value), fieldName.IsQuoted);
+        }
 
-         if (me.Arguments.Count > 2)
-         {
-             (value, valueType) = QueryBuilderHelper.GetValue(builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters, (ValueExpression)me.Arguments[2]);
-             minimumMatch = valueType switch
-             {
-                 ValueTokenType.Long => (long)value,
-                 ValueTokenType.Double => (float)(double)value,
-                 _ => throw new NotSupportedException("vector.search() minimumMatch must be a float, but was: " + valueType)
-             };
-         }
+        var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(builderParameters.Allocator, fieldName, builderParameters.Index, builderParameters.IndexFieldsMapping,
+            builderParameters.FieldsToFetch, builderParameters.HasDynamics, builderParameters.DynamicFields, hasBoost: builderParameters.HasBoost);
+
+        var minimumMatch = 0.90f;
+
+        if (me.Arguments.Count > 2)
+        {
+            object value;
+            ValueTokenType valueType;
+            (value, valueType) = QueryBuilderHelper.GetValue(builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters, (ValueExpression)me.Arguments[2]);
+            minimumMatch = valueType switch
+            {
+                ValueTokenType.Long => (long)value,
+                ValueTokenType.Double => (float)(double)value,
+                _ => throw new NotSupportedException("vector.search() minimumMatch must be a float, but was: " + valueType)
+            };
+        }
         
         return builderParameters.IndexSearcher.VectorQuery(fieldMetadata, vector, minimumMatch);
     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -594,6 +594,8 @@ public static class CoraxQueryBuilder
                 case MethodType.Spatial_Disjoint:
                 case MethodType.Spatial_Intersects:
                     return HandleSpatial(builderParameters, me, methodType);
+                case MethodType.Vector_Search:
+                    return HandleVector(builderParameters, me);
                 case MethodType.Regex:
                     return HandleRegex(builderParameters, me, ref leftOnlyOptimization);
                 case MethodType.MoreLikeThis:
@@ -605,6 +607,34 @@ public static class CoraxQueryBuilder
         }
 
         throw new InvalidQueryException("Unable to understand query", metadata.QueryText, queryParameters);
+    }
+
+    private static IQueryMatch HandleVector(Parameters builderParameters, MethodExpression me)
+    {
+        var fieldName = QueryBuilderHelper.ExtractIndexFieldName(builderParameters.Metadata.Query, builderParameters.QueryParameters, me.Arguments[0], builderParameters.Metadata);
+        var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(builderParameters.Allocator, fieldName, builderParameters.Index, builderParameters.IndexFieldsMapping,
+            builderParameters.FieldsToFetch, builderParameters.HasDynamics, builderParameters.DynamicFields, hasBoost: builderParameters.HasBoost);
+        var (value, valueType) = QueryBuilderHelper.GetValue(builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters, (ValueExpression)me.Arguments[1]);
+        var vector = valueType switch
+        {
+            ValueTokenType.String => Convert.FromBase64String(value.ToString()),
+            _ => throw new NotSupportedException("Vector on " + valueType)
+        };
+
+         var minimumMatch = 0.95f;
+
+         if (me.Arguments.Count > 2)
+         {
+             (value, valueType) = QueryBuilderHelper.GetValue(builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters, (ValueExpression)me.Arguments[2]);
+             minimumMatch = valueType switch
+             {
+                 ValueTokenType.Long => (long)value,
+                 ValueTokenType.Double => (float)(double)value,
+                 _ => throw new NotSupportedException("vector.search() minimumMatch must be a float, but was: " + valueType)
+             };
+         }
+        
+        return builderParameters.IndexSearcher.VectorQuery(fieldMetadata, vector, minimumMatch);
     }
 
     private static IQueryMatch HandleIn(Parameters builderParameters, InExpression ie, bool exact)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/LuceneDocumentConverterBase.cs
@@ -132,6 +132,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
         {
             _storeValueField = new Field(storeValueFieldName, Array.Empty<byte>(), 0, 0, Field.Store.YES);
 
+            foreach ((var name, var field) in _fields)
+            {
+                if (field.Vector)
+                    throw new NotSupportedException("Vector Search is enabled only for Corax indexes, not Lucene. But was asked to index " + name + " as a vector");
+            }
+            
             Scope = new (storeValue, _storeValueField);
         }
 
@@ -347,6 +353,11 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents
                 }
 
                 return newFields;
+            }
+
+            if (valueType == ValueType.Vector)
+            {
+                throw new NotSupportedException("Vector operations are only supported in Corax indexes, not with Lucene indexes");
             }
 
             if (valueType == ValueType.DateOnly)

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -12,6 +12,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Persistence.Corax;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
 using Raven.Server.Documents.Indexes.Static.Spatial;
+using Raven.Server.Documents.Indexes.VectorSearch;
 using Raven.Server.NotificationCenter.Notifications;
 using Sparrow.Json;
 using Sparrow.Logging;
@@ -325,6 +326,23 @@ namespace Raven.Server.Documents.Indexes.Static
                     return r;
 
                 return null;
+            }
+        }
+
+        public object Vector(object value)
+        {
+            switch (value)
+            {
+                case LazyStringValue lsv:
+                    return new VectorField(Convert.FromBase64String(lsv));
+                case LazyCompressedStringValue lcsv:
+                    return new VectorField(Convert.FromBase64String(lcsv));
+                case string s:
+                    return new VectorField(Convert.FromBase64String(s));
+                case byte[] b:
+                    return new VectorField(b);
+                default:
+                    throw new NotSupportedException();
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -328,6 +328,25 @@ namespace Raven.Server.Documents.Indexes.Static
                 return null;
             }
         }
+     
+        public object VectorSearch(object value)
+        {
+            var str = value switch
+            {
+                LazyStringValue lsv => (string)lsv,
+                LazyCompressedStringValue lcsv => lcsv,
+                string s => s,
+                DynamicNullObject => null,
+                null => null,
+                _ => throw new NotSupportedException("Only strings are supported, but got: " + value?.GetType().FullName)
+            };
+
+            if (str is null)
+                return null;
+
+            return new VectorField(GenerateEmbeddings.UsingI8(str));
+        }
+
 
         public object Vector(object value)
         {

--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -1,0 +1,74 @@
+using SmartComponents.LocalEmbeddings;
+
+namespace Raven.Server.Documents.Indexes.VectorSearch;
+
+public class GenerateEmbeddings
+{
+    private static readonly LocalEmbedder Embedder = new();
+    
+    //TODO: Allocations!
+    public static byte[] UsingI8(string str)
+    {
+        var e = Embedder.Embed<EmbeddingI1>(str);
+        var arr = e.Buffer.ToArray();
+        return arr;
+    }
+
+#pragma warning disable SKEXP0070 // ignore experimental warning 
+    // private static readonly Lazy<BertOnnxTextEmbeddingGenerationService> EmbeddingGenerator = new(LoadOnnxModel);
+    // private static BertOnnxTextEmbeddingGenerationService LoadOnnxModel()
+    // {
+    //     // TODO: Figure out distribution model
+    //     // https://huggingface.co/SmartComponents/bge-micro-v2/resolve/72908b7/onnx/model_quantized.onnx
+    //     // https://huggingface.co/SmartComponents/bge-micro-v2/resolve/72908b7/vocab.txt
+    //     
+    //     return BertOnnxTextEmbeddingGenerationService.Create(
+    //         "C:\\Users\\ayende\\Downloads\\model_quantized.onnx",
+    //         vocabPath: "C:\\Users\\ayende\\Downloads\\vocab.txt",
+    //         new BertOnnxOptions { CaseSensitive = false, MaximumTokens = 512 });
+    // }
+    //
+    // public static byte[] UsingI8(string str)
+    // {
+    //     var service = EmbeddingGenerator.Value;
+    //     Task<IList<ReadOnlyMemory<float>>> generateEmbeddingsAsync = service.GenerateEmbeddingsAsync([str]);
+    //     ReadOnlyMemory<float> readOnlyMemory = generateEmbeddingsAsync.Result.Single();
+    //     var buffer = new byte[readOnlyMemory.Length / 8];
+    //     QuantizeI8(readOnlyMemory.Span, buffer);
+    //     return buffer;
+    // }
+    //
+    //
+    // private static void QuantizeI8(ReadOnlySpan<float> input, Span<byte> result)
+    // {
+    //     // https://github.com/dotnet/smartcomponents/blob/4dbb671443c84407b598a0104441afd1186d9a3a/src/SmartComponents.LocalEmbeddings/EmbeddingI1.cs
+    //     var inputLength = input.Length;
+    //     for (var j = 0; j < inputLength; j += 8)
+    //     {
+    //         // Vectorized approaches don't seem to get even close to the
+    //         // speed of doing it in this naive way
+    //         var sources = input.Slice(j, 8);
+    //         var sum = (byte)0;
+    //
+    //         if (float.IsPositive(sources[0])) { sum |= 128; }
+    //
+    //         if (float.IsPositive(sources[1])) { sum |= 64; }
+    //
+    //         if (float.IsPositive(sources[2])) { sum |= 32; }
+    //
+    //         if (float.IsPositive(sources[3])) { sum |= 16; }
+    //
+    //         if (float.IsPositive(sources[4])) { sum |= 8; }
+    //
+    //         if (float.IsPositive(sources[5])) { sum |= 4; }
+    //
+    //         if (float.IsPositive(sources[6])) { sum |= 2; }
+    //
+    //         if (float.IsPositive(sources[7])) { sum |= 1; }
+    //
+    //         result[j / 8] = sum;
+    //     }
+    // }
+
+#pragma warning restore SKEXP0070
+}

--- a/src/Raven.Server/Documents/Indexes/VectorSearch/VectorField.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/VectorField.cs
@@ -1,0 +1,3 @@
+namespace Raven.Server.Documents.Indexes.VectorSearch;
+
+public record VectorField(byte[] Buffer);

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMapping.cs
@@ -55,6 +55,9 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
                             if (field.HasHighlighting)
                                 indexField.Indexing |= AutoFieldIndexing.Highlighting;
+                            
+                            if (field.IsVector)
+                                indexField.Indexing |= AutoFieldIndexing.Vector;
 
                             if (field.Spatial != null)
                                 indexField.Spatial = new AutoSpatialOptions(field.Spatial);

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMappingItem.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryMappingItem.cs
@@ -15,11 +15,13 @@ namespace Raven.Server.Documents.Queries.Dynamic
             bool isExactSearch,
             bool hasHighlighting,
             bool hasSuggestions,
-            AutoSpatialOptions spatial)
+            AutoSpatialOptions spatial,
+            bool isVector)
         {
             Name = name;
             AggregationOperation = aggregationOperation;
             GroupByArrayBehavior = groupByArrayBehavior;
+            IsVector = isVector;
             HasHighlighting = hasHighlighting;
             HasSuggestions = hasSuggestions;
             IsSpecifiedInWhere = isSpecifiedInWhere;
@@ -38,6 +40,8 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
         public bool HasHighlighting;
 
+        public bool IsVector;
+
         public readonly bool IsSpecifiedInWhere;
 
         public readonly AutoSpatialOptions Spatial;
@@ -48,33 +52,33 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
         public static DynamicQueryMappingItem Create(QueryFieldName name, AggregationOperation aggregation)
         {
-            return new DynamicQueryMappingItem(name, aggregation, GroupByArrayBehavior.NotApplicable, false, false, false, false, false, null);
+            return new DynamicQueryMappingItem(name, aggregation, GroupByArrayBehavior.NotApplicable, false, false, false, false, false, null, false);
         }
 
         public static DynamicQueryMappingItem Create(QueryFieldName name, AggregationOperation aggregation, bool isFullTextSearch, bool isExactSearch, bool hasHighlighting, bool hasSuggestions, AutoSpatialOptions spatial)
         {
-            return new DynamicQueryMappingItem(name, aggregation, GroupByArrayBehavior.NotApplicable, false, isFullTextSearch, isExactSearch, hasHighlighting, hasSuggestions, spatial);
+            return new DynamicQueryMappingItem(name, aggregation, GroupByArrayBehavior.NotApplicable, false, isFullTextSearch, isExactSearch, hasHighlighting, hasSuggestions, spatial,false);
         }
 
         public static DynamicQueryMappingItem Create(QueryFieldName name, AggregationOperation aggregation, Dictionary<QueryFieldName, WhereField> whereFields)
         {
             if (whereFields.TryGetValue(name, out var whereField))
-                return new DynamicQueryMappingItem(name, aggregation, GroupByArrayBehavior.NotApplicable, true, whereField.IsFullTextSearch, whereField.IsExactSearch, false, false, whereField.Spatial);
+                return new DynamicQueryMappingItem(name, aggregation, GroupByArrayBehavior.NotApplicable, true, whereField.IsFullTextSearch, whereField.IsExactSearch, false, false, whereField.Spatial, whereField.IsVector);
 
-            return new DynamicQueryMappingItem(name, aggregation, GroupByArrayBehavior.NotApplicable, false, false, false, false, false, null);
+            return new DynamicQueryMappingItem(name, aggregation, GroupByArrayBehavior.NotApplicable, false, false, false, false, false, null, false);
         }
 
         public static DynamicQueryMappingItem CreateGroupBy(QueryFieldName name, GroupByArrayBehavior groupByArrayBehavior, Dictionary<QueryFieldName, WhereField> whereFields)
         {
             if (whereFields.TryGetValue(name, out var whereField))
-                return new DynamicQueryMappingItem(name, AggregationOperation.None, groupByArrayBehavior, true, whereField.IsFullTextSearch, whereField.IsExactSearch, false, false, whereField.Spatial);
+                return new DynamicQueryMappingItem(name, AggregationOperation.None, groupByArrayBehavior, true, whereField.IsFullTextSearch, whereField.IsExactSearch, false, false, whereField.Spatial, whereField.IsVector);
 
-            return new DynamicQueryMappingItem(name, AggregationOperation.None, groupByArrayBehavior, false, false, false, false, false, null);
+            return new DynamicQueryMappingItem(name, AggregationOperation.None, groupByArrayBehavior, false, false, false, false, false, null, false);
         }
 
         public static DynamicQueryMappingItem CreateGroupBy(QueryFieldName name, GroupByArrayBehavior groupByArrayBehavior, bool isSpecifiedInWhere, bool isFullTextSearch, bool isExactSearch)
         {
-            return new DynamicQueryMappingItem(name, AggregationOperation.None, groupByArrayBehavior, isSpecifiedInWhere: isSpecifiedInWhere, isFullTextSearch: isFullTextSearch, isExactSearch: isExactSearch, hasHighlighting: false, hasSuggestions: false, spatial: null);
+            return new DynamicQueryMappingItem(name, AggregationOperation.None, groupByArrayBehavior, isSpecifiedInWhere: isSpecifiedInWhere, isFullTextSearch: isFullTextSearch, isExactSearch: isExactSearch, hasHighlighting: false, hasSuggestions: false, spatial: null, isVector: false);
         }
 
         public void SetAggregation(AggregationOperation aggregation)

--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryToIndexMatcher.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryToIndexMatcher.cs
@@ -188,6 +188,11 @@ namespace Raven.Server.Documents.Queries.Dynamic
             {
                 if (definition.TryGetField(field.Name, out var indexField))
                 {
+                    if (field.IsVector && indexField.Indexing.HasFlag(AutoFieldIndexing.Vector) == false)
+                    {
+                        explanations?.Add(new Explanation(indexName, $"The following field is not vector searchable {indexField.Name}, while the query needs to vector.search() on it"));
+                        return new DynamicQueryMatchResult(indexName, DynamicQueryMatchType.Partial);
+                    }
                     if (field.IsFullTextSearch && indexField.Indexing.HasFlag(AutoFieldIndexing.Search) == false)
                     {
                         explanations?.Add(new Explanation(indexName, $"The following field is not searchable {indexField.Name}, while the query needs to search() on it"));

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -411,6 +411,9 @@ namespace Raven.Server.Documents.Queries
                         return HandleSpatial(query, me, metadata, parameters, methodType, factories.GetSpatialFieldFactory);
                     case MethodType.MoreLikeThis:
                         return new MatchAllDocsQuery();
+                    case MethodType.Vector_Search:
+                        throw new InvalidQueryException("Vector Search is not available for the Lucene indexing engine, only in the Corax indexing engine.", query.QueryText, parameters);
+                        break;
                     default:
                         QueryMethod.ThrowMethodNotSupported(methodType, metadata.QueryText, parameters);
                         return null; // never hit

--- a/src/Raven.Server/Documents/Queries/MethodType.cs
+++ b/src/Raven.Server/Documents/Queries/MethodType.cs
@@ -51,6 +51,7 @@
 
         Unknown,
         
-        Vector_Search
+        Vector_Search,
+        Vector_Nearest,
     }
 }

--- a/src/Raven.Server/Documents/Queries/MethodType.cs
+++ b/src/Raven.Server/Documents/Queries/MethodType.cs
@@ -49,6 +49,8 @@
 
         TimeSeries,
 
-        Unknown
+        Unknown,
+        
+        Vector_Search
     }
 }

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -526,7 +526,7 @@ public static class QueryBuilderHelper
         RuntimeHelpers.EnsureSufficientExecutionStack();
         FieldMetadata metadata;
 
-        //Sometimes index can contians Id property and its different than real document ID. We've to 
+        //Sometimes index can contains Id property and its different than real document ID. We've to 
         if ((fieldName.Equals(Constants.Documents.Indexing.Fields.DocumentIdMethodName, StringComparison.OrdinalIgnoreCase) && indexMapping.ContainsField(fieldName)) == false &&
             fieldName is Constants.Documents.Indexing.Fields.DocumentIdFieldName)
         {

--- a/src/Raven.Server/Documents/Queries/QueryMethod.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMethod.cs
@@ -50,6 +50,9 @@ namespace Raven.Server.Documents.Queries
             if (string.Equals(methodName, "sum", StringComparison.OrdinalIgnoreCase))
                 return MethodType.Sum;
 
+            if (string.Equals(methodName, "vector.search", StringComparison.OrdinalIgnoreCase))
+                return MethodType.Vector_Search;
+            
             if (string.Equals(methodName, "spatial.within", StringComparison.OrdinalIgnoreCase))
                 return MethodType.Spatial_Within;
 

--- a/src/Raven.Server/Documents/Queries/QueryMethod.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMethod.cs
@@ -53,6 +53,9 @@ namespace Raven.Server.Documents.Queries
             if (string.Equals(methodName, "vector.search", StringComparison.OrdinalIgnoreCase))
                 return MethodType.Vector_Search;
             
+            if (string.Equals(methodName, "vector.nearest", StringComparison.OrdinalIgnoreCase))
+                return MethodType.Vector_Nearest;
+
             if (string.Equals(methodName, "spatial.within", StringComparison.OrdinalIgnoreCase))
                 return MethodType.Spatial_Within;
 

--- a/src/Raven.Server/Documents/Queries/WhereField.cs
+++ b/src/Raven.Server/Documents/Queries/WhereField.cs
@@ -10,6 +10,8 @@ namespace Raven.Server.Documents.Queries
 
         public readonly bool IsExactSearch;
 
+        public bool IsVector;
+
         public WhereField(bool isFullTextSearch, bool isExactSearch, AutoSpatialOptions spatial)
         {
             Spatial = spatial;

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -124,6 +124,7 @@
     <PackageReference Include="Raven.CodeAnalysis" Version="1.0.11">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="SmartComponents.LocalEmbeddings" Version="0.1.0-preview10148" />
     <PackageReference Include="Snappier" Version="1.1.6" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -146,7 +146,7 @@ namespace Raven.Server.ServerWide.Context
 
         public TTransaction OpenReadTransaction()
         {
-            if (Transaction != null && Transaction.Disposed == false)
+            if (Transaction is { Disposed: false })
                 ThrowTransactionAlreadyOpened();
 
             Transaction = CreateReadTransaction();

--- a/src/Voron/Data/CompactTrees/CompactKey.cs
+++ b/src/Voron/Data/CompactTrees/CompactKey.cs
@@ -60,7 +60,18 @@ public sealed unsafe class CompactKey : IDisposable
     public void Initialize(LowLevelTransaction tx)
     {
         _owner = tx;
+        
+        StoragePool ??= ArrayPool<byte>.Create();
+        KeyMappingPool ??= ArrayPool<long>.Create();
 
+        _storage = StoragePool.Rent(2 * Constants.CompactTree.MaximumKeySize);
+        _keyMappingCache = KeyMappingPool.Rent(2 * MappingTableMask);
+        
+        Reuse();
+    }
+
+    public void Reuse()
+    {
         Dictionary = Invalid;
         _currentKeyIdx = Invalid;
         _decodedKeyIdx = Invalid;
@@ -68,12 +79,6 @@ public sealed unsafe class CompactKey : IDisposable
 
         _currentIdx = 0;
         MaxLength = 0;
-
-        StoragePool ??= ArrayPool<byte>.Create();
-        KeyMappingPool ??= ArrayPool<long>.Create();
-
-        _storage = StoragePool.Rent(2 * Constants.CompactTree.MaximumKeySize);
-        _keyMappingCache = KeyMappingPool.Rent(2 * MappingTableMask);
     }
 
     public void Reset()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22076 

### Additional description

First spike of adding vector search (ENN) to RavenDB. Meant to be initial implementation only, and will likely change singificantly.

### Indexing

* Can now use `Vector(float[])` or `Vector(base64String)` to register a vector to be searched later
* Can use `VectorSearch(string)` to have RavenDB generate the embeddings

### Queries

* Can use `vector.nearest(Field, $embedding)` to find the nearest vectors
* `order by score()` will use the distance from the query vector 
* Can use `vector.search(Field, 'some text')` to generate embedding and then search on that.

Vector search is enabled only for Croax, and is supported in both Auto index & Static indexes.