### PR TITLE
RavenDB-22807 - skip creating a delay task if not needed

### DIFF
--- a/src/Sparrow.Server/Utils/DiskStatsGetter/DiskStatsGetter.cs
+++ b/src/Sparrow.Server/Utils/DiskStatsGetter/DiskStatsGetter.cs
@@ -38,9 +38,12 @@ namespace Sparrow.Server.Utils.DiskStatsGetter
                     return null;
                 }
 
-                await Task.WhenAny(cache.Task, Task.Delay(_maxWait)).ConfigureAwait(false);
                 if (cache.Task.IsCompleted == false)
-                    return cache.Value;
+                {
+                    await Task.WhenAny(cache.Task, Task.Delay(_maxWait)).ConfigureAwait(false);
+                    if (cache.Task.IsCompleted == false)
+                        return cache.Value;
+                }
 
                 var prevValue = cache.Task.Result;
                 if (prevValue == GetStatsResult.Empty)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22807/Contention-on-the-Timer-for-the-CancellationToken

### Additional description

Skip creating a delay task if not needed.

Got the following stack trace for 2 threads:
```
"System.Private.CoreLib.il!System.Threading.TimerQueueTimer.Change(unsigned int32,unsigned int32)",
        "System.Private.CoreLib.il!System.Threading.Tasks.Task+DelayPromise..ctor(unsigned int32,class System.TimeProvider)",
        "Sparrow.Server!Sparrow.Server.Utils.DiskStatsGetter.DiskStatsGetter`1+<GetAsync>d__5[System.__Canon].MoveNext()",
```

This should be cached so most of the time we don't need to wait for the task to complete.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
