### PR TITLE
RavenDB-22659 Cancelling the restore doesn't always delete the database

### DIFF
--- a/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/QueriesHandler.cs
@@ -570,7 +570,7 @@ namespace Raven.Server.Documents.Handlers
                 Database,
                 indexName,
                 operationType,
-                onProgress => operation(Database.QueryRunner, options, onProgress, token), operationId, details, token);
+                onProgress => operation(Database.QueryRunner, options, onProgress, token), operationId, details, token: token);
 
             using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))

--- a/src/Raven.Server/Documents/Operations/Operations.cs
+++ b/src/Raven.Server/Documents/Operations/Operations.cs
@@ -101,8 +101,8 @@ namespace Raven.Server.Documents.Operations
             Func<Action<IOperationProgress>, Task<IOperationResult>> taskFactory,
             long id,
             IOperationDetailedDescription detailedDescription = null,
-            OperationCancelToken token = null,
-            string databaseName = null)
+            string resourceName = null,
+            OperationCancelToken token = null)
         {
             var operationState = new OperationState
             {
@@ -130,7 +130,7 @@ namespace Raven.Server.Documents.Operations
                 Description = operationDescription,
                 Token = token,
                 State = operationState,
-                DatabaseName = databaseName
+                DatabaseName = resourceName
             };
 
             object locker = new object();

--- a/src/Raven.Server/Documents/Operations/Operations.cs
+++ b/src/Raven.Server/Documents/Operations/Operations.cs
@@ -101,7 +101,8 @@ namespace Raven.Server.Documents.Operations
             Func<Action<IOperationProgress>, Task<IOperationResult>> taskFactory,
             long id,
             IOperationDetailedDescription detailedDescription = null,
-            OperationCancelToken token = null)
+            OperationCancelToken token = null,
+            string databaseName = null)
         {
             var operationState = new OperationState
             {
@@ -128,7 +129,8 @@ namespace Raven.Server.Documents.Operations
                 Id = id,
                 Description = operationDescription,
                 Token = token,
-                State = operationState
+                State = operationState,
+                DatabaseName = databaseName
             };
 
             object locker = new object();
@@ -307,6 +309,8 @@ namespace Raven.Server.Documents.Operations
             public DocumentDatabase Database;
 
             public bool Killable => Token != null;
+
+            public string DatabaseName;
 
             public DynamicJsonValue ToJson()
             {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -774,13 +774,7 @@ namespace Raven.Server.Web.System
                             if (rawRecord == null)
                                 continue;
 
-                            if (rawRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress)
-                            {
-                                if (CanDeleteDatabase(databaseName) == false)
-                                    throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
-                                                                        $"process is in progress. In order to delete the database, " +
-                                                                        $"you can cancel the restore task from node {rawRecord.Topology.Members[0]}");
-                            }
+                            AssertCanDeleteDatabase(databaseName, rawRecord.DatabaseState, rawRecord.Topology);
 
                             switch (rawRecord.LockMode)
                             {
@@ -926,23 +920,32 @@ namespace Raven.Server.Web.System
             }
         }
 
-        private bool CanDeleteDatabase(string databaseName)
+        private void AssertCanDeleteDatabase(string databaseName, DatabaseStateStatus state, DatabaseTopology topology)
         {
-            var operations = ServerStore.Operations.GetActive();
+            if (state != DatabaseStateStatus.RestoreInProgress)
+                return;
 
+            var restoredOnNode = topology.Members.First(); // we restore only on one node
+            if (ServerStore.NodeTag != restoredOnNode)
+                throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
+                                                    $"process is in progress. In order to delete the database, " +
+                                                    $"you can cancel the restore task from node {topology.Members.First()}");
+
+            var operations = ServerStore.Operations.GetActive();
             if (operations == null || operations.Count == 0)
-                return true;
+                return;
 
             foreach (var operation in operations)
             {
                 if (operation.Description.TaskType == Documents.Operations.Operations.OperationType.DatabaseRestore &&
-                    operation.DatabaseName == databaseName &&
+                    databaseName.Equals(operation.DatabaseName, StringComparison.OrdinalIgnoreCase) &&
                     operation.IsCompleted() == false)
                 {
-                    return false;
+                    throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
+                                                        $"process is in progress. In order to delete the database, " +
+                                                        $"you need cancel the restore task first");
                 }
             }
-            return true;
         }
 
         [RavenAction("/admin/databases/disable", "POST", AuthorizationStatus.Operator)]

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -707,7 +707,7 @@ namespace Raven.Server.Web.System
                     $"Database restore: {restoreBackupTask.RestoreFromConfiguration.DatabaseName}",
                     Documents.Operations.Operations.OperationType.DatabaseRestore,
                     taskFactory: onProgress => Task.Run(async () => await restoreBackupTask.Execute(onProgress), cancelToken.Token),
-                    id: operationId, token: cancelToken, databaseName: restoreBackupTask.RestoreFromConfiguration.DatabaseName);
+                    id: operationId, token: cancelToken, resourceName: restoreBackupTask.RestoreFromConfiguration.DatabaseName);
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -707,7 +707,7 @@ namespace Raven.Server.Web.System
                     $"Database restore: {restoreBackupTask.RestoreFromConfiguration.DatabaseName}",
                     Documents.Operations.Operations.OperationType.DatabaseRestore,
                     taskFactory: onProgress => Task.Run(async () => await restoreBackupTask.Execute(onProgress), cancelToken.Token),
-                    id: operationId, token: cancelToken);
+                    id: operationId, token: cancelToken, databaseName: restoreBackupTask.RestoreFromConfiguration.DatabaseName);
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
@@ -775,9 +775,12 @@ namespace Raven.Server.Web.System
                                 continue;
 
                             if (rawRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress)
-                                throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
-                                                                    $"process is in progress. In order to delete the database, " +
-                                                                    $"you can cancel the restore task from node {rawRecord.Topology.Members[0]}");
+                            {
+                                if (CanDeleteDatabase(databaseName) == false)
+                                    throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
+                                                                        $"process is in progress. In order to delete the database, " +
+                                                                        $"you can cancel the restore task from node {rawRecord.Topology.Members[0]}");
+                            }
 
                             switch (rawRecord.LockMode)
                             {
@@ -921,6 +924,25 @@ namespace Raven.Server.Web.System
                     });
                 }
             }
+        }
+
+        private bool CanDeleteDatabase(string databaseName)
+        {
+            var operations = ServerStore.Operations.GetActive();
+
+            if (operations == null || operations.Count == 0)
+                return true;
+
+            foreach (var operation in operations)
+            {
+                if (operation.Description.TaskType == Documents.Operations.Operations.OperationType.DatabaseRestore &&
+                    operation.DatabaseName == databaseName &&
+                    operation.IsCompleted() == false)
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         [RavenAction("/admin/databases/disable", "POST", AuthorizationStatus.Operator)]

--- a/test/SlowTests/Issues/RavenDB-22659.cs
+++ b/test/SlowTests/Issues/RavenDB-22659.cs
@@ -206,7 +206,7 @@ namespace SlowTests.Issues
 
                 using (var store2 = new DocumentStore { Database = db, Urls = new[] { revivedNode.WebUrl }, Conventions = new DocumentConventions { DisableTopologyUpdates = true } }.Initialize())
                 {
-                    var val = await WaitForValueAsync(async () => await store2.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName)) != null, true);
+                    var val = await WaitForValueAsync(async () => await store2.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName)) != null, true, 30_000);
                     Assert.True(val);
 
                     var deleteException = await Assert.ThrowsAsync<RavenException>(async () =>

--- a/test/SlowTests/Issues/RavenDB-22659.cs
+++ b/test/SlowTests/Issues/RavenDB-22659.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22659 : ClusterTestBase
+    {
+        public RavenDB_22659(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task CanDeleteDatabaseWhenRestoreCancelled()
+        {
+            var mre = new ManualResetEvent(false);
+            var mre2 = new ManualResetEvent(false);
+            var backupPath = NewDataPath();
+            var db = "NewDatabase";
+            //Cluster with 2 nodes
+            var (nodes, leader) = await CreateRaftCluster(2);
+            await CreateDatabaseInCluster(db, 2, leader.WebUrl);
+            using (var store = new DocumentStore
+            {
+                Database = db,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Toli" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                //Backup
+                var backupOperation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                }));
+                var result = (BackupResult)await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                //Restore
+                var databaseName = $"{store.Database}_Restore";
+                RestoreBackupOperation restoreOperation =
+                    new RestoreBackupOperation(new RestoreBackupConfiguration
+                        { BackupLocation = Path.Combine(backupPath, result.LocalBackup.BackupDirectory), DatabaseName = databaseName });
+
+                foreach (var n in nodes)
+                {
+                    n.ServerStore.ForTestingPurposesOnly().RestoreDatabaseAfterSavingDatabaseRecord += () =>
+                    {
+                        mre.Set();
+                        mre2.WaitOne(); // Wait to ensure the restore process doesn't finish until we intentionally cancel it.
+                    };
+                }
+
+                var restoreTask= await store.Maintenance.Server.SendAsync(restoreOperation);
+
+                var nodeToTakeDown = nodes.First(x => x.ServerStore.NodeTag != restoreTask.NodeTag);
+                var remainingNode = nodes.First(x => x != nodeToTakeDown);
+
+                var res = mre.WaitOne(TimeSpan.FromSeconds(30)); // Wait to ensure the database record is written before disposing of one node.
+                Assert.True(res);
+
+                var disposedNode = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToTakeDown);
+                await restoreTask.KillAsync();
+                mre2.Set();
+
+                var database = await GetDatabase(remainingNode, store.Database);
+                WaitForValue(() =>
+                {
+                    var operation = database.ServerStore.Operations.GetOperation(restoreTask.Id);
+                    return operation.IsCompleted();
+                }, true);
+
+                var revivedNode = GetNewServer(new ServerCreationOptions
+                {
+                    DeletePrevious = false,
+                    RunInMemory = false,
+                    DataDirectory = disposedNode .DataDirectory,
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = disposedNode .Url
+                    }
+                });
+
+                nodes.Add(revivedNode);
+                Servers.Add(revivedNode);
+
+                using (remainingNode.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var topology = remainingNode.ServerStore.Engine.GetTopology(ctx);
+                    Assert.Equal(2, topology.AllNodes.Count);
+                }
+
+                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, hardDelete: true));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task CannotDeleteDatabaseWhenRestoreCancelledOnNonResponsibleNode()
+        {
+            var mre = new ManualResetEvent(false);
+            var mre2 = new ManualResetEvent(false);
+            var backupPath = NewDataPath();
+            var db = "NewDatabase";
+            //Cluster with 2 nodes
+            var (nodes, leader) = await CreateRaftCluster(2);
+            await CreateDatabaseInCluster(db, 2, leader.WebUrl);
+            using (var store = new DocumentStore
+            {
+                Database = db,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Toli" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                //Backup
+                var backupOperation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                }));
+                var result = (BackupResult)await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                //Restore
+                var databaseName = $"{store.Database}_Restore";
+                RestoreBackupOperation restoreOperation =
+                    new RestoreBackupOperation(new RestoreBackupConfiguration
+                    { BackupLocation = Path.Combine(backupPath, result.LocalBackup.BackupDirectory), DatabaseName = databaseName });
+
+                foreach (var n in nodes)
+                {
+                    n.ServerStore.ForTestingPurposesOnly().RestoreDatabaseAfterSavingDatabaseRecord += () =>
+                    {
+                        mre.Set();
+                        mre2.WaitOne(); // Wait to ensure the restore process doesn't finish until we intentionally cancel it.
+                    };
+                }
+
+                var restoreTask = await store.Maintenance.Server.SendAsync(restoreOperation);
+
+                var nodeToTakeDown = nodes.First(x => x.ServerStore.NodeTag != restoreTask.NodeTag);
+                var remainingNode = nodes.First(x => x != nodeToTakeDown);
+
+                var res = mre.WaitOne(TimeSpan.FromSeconds(30)); // Wait to ensure the database record is written before disposing of one node.
+                Assert.True(res);
+
+                var disposedNode = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToTakeDown);
+                await restoreTask.KillAsync();
+                mre2.Set();
+
+                var database = await GetDatabase(remainingNode, store.Database);
+                WaitForValue(() =>
+                {
+                    var operation = database.ServerStore.Operations.GetOperation(restoreTask.Id);
+                    return operation.IsCompleted();
+                }, true);
+
+                var revivedNode = GetNewServer(new ServerCreationOptions
+                {
+                    DeletePrevious = false,
+                    RunInMemory = false,
+                    DataDirectory = disposedNode.DataDirectory,
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = disposedNode.Url
+                    }
+                });
+
+                nodes.Add(revivedNode);
+                Servers.Add(revivedNode);
+
+                using (remainingNode.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var topology = remainingNode.ServerStore.Engine.GetTopology(ctx);
+                    Assert.Equal(2, topology.AllNodes.Count);
+                }
+
+                var deleteException = await Assert.ThrowsAsync<RavenException>(async () =>
+                {
+                    await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, hardDelete: true, fromNode: revivedNode.ServerStore.NodeTag));
+                });
+                Assert.Contains("doesn't reside on node", deleteException.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task CannotDeleteDatabaseInRestore()
+        {
+            var mre = new ManualResetEvent(false);
+            var mre2 = new ManualResetEvent(false);
+            var backupPath = NewDataPath();
+            var db = "NewDatabase";
+            //Cluster with 2 nodes
+            var (nodes, leader) = await CreateRaftCluster(2);
+            await CreateDatabaseInCluster(db, 2, leader.WebUrl);
+            using (var store = new DocumentStore
+            {
+                Database = db,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Toli" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                //Backup
+                var backupOperation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                }));
+                var result = (BackupResult)await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                //Restore
+                var databaseName = $"{store.Database}_Restore";
+                RestoreBackupOperation restoreOperation =
+                    new RestoreBackupOperation(new RestoreBackupConfiguration
+                    { BackupLocation = Path.Combine(backupPath, result.LocalBackup.BackupDirectory), DatabaseName = databaseName });
+
+                foreach (var n in nodes)
+                {
+                    n.ServerStore.ForTestingPurposesOnly().RestoreDatabaseAfterSavingDatabaseRecord += () =>
+                    {
+                        mre.Set();
+                        mre2.WaitOne(); // Wait to ensure the restore process doesn't finish until we intentionally cancel it.
+                    };
+                }
+
+                await store.Maintenance.Server.SendAsync(restoreOperation);
+
+                var res = mre.WaitOne(TimeSpan.FromSeconds(30));
+                Assert.True(res);
+
+                var deleteException = await Assert.ThrowsAsync<RavenException>(async () =>
+                {
+                    await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, hardDelete: true));
+                });
+                Assert.Contains("while the restore process is in progress", deleteException.Message);
+                mre2.Set();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22659

### Additional description
The issue occurred under the following scenario:

You have a 2-node cluster.
Start a database restore operation.
During the restore, take down one of the nodes (not the one handling the restore).
Cancel the restore process.
At this point, the database cannot be deleted because the cluster is not fully operational.
Bring the second node back online.
Attempt to delete the database.
When we tried to delete the database, we encountered an InvalidOperationException with the message: "Can't delete database 'test' while the restore process is in progress." As a result, the database could not be deleted.

To address this, we have now implemented a check to determine if the restore process is still active. This allows us to decide whether the database can be safely deleted or not.

V6.0 PR : https://github.com/ravendb/ravendb/pull/19211


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
