### PR TITLE
RavenDB-22366 - fix XML docs warnings in timeseries

### DIFF
--- a/src/Raven.Client/Documents/Session/ISessionDocumentTimeSeriesBase.cs
+++ b/src/Raven.Client/Documents/Session/ISessionDocumentTimeSeriesBase.cs
@@ -55,7 +55,7 @@ namespace Raven.Client.Documents.Session
         /// For details about named time series values, refer to: <inheritdoc cref="DocumentationUrls.Session.TimeSeries.NamedValues"/>.
         /// </remarks>
         /// <param name="entry">The time series arguments to append (timestamp, values, optional tag). <br/>
-        /// <typeparamref name="TimeSeriesEntry"/> is an object that aggregates the time series inputs, and <typeparamref name="T"/> indicates the value type.</param>
+        /// <see cref="TimeSeriesEntry"/> is an object that aggregates the time series inputs, and <typeparamref name="T"/> indicates the value type.</param>
         void Append(TimeSeriesEntry<T> entry);
     }
 
@@ -69,7 +69,7 @@ namespace Raven.Client.Documents.Session
         /// For details about named time series values, refer to: <inheritdoc cref="DocumentationUrls.Session.TimeSeries.NamedValues"/>.
         /// </remarks>
         /// <param name="entry">The time series arguments to append (timestamp and rollup values). <br/>
-        /// <typeparamref name="TimeSeriesRollupEntry"/> is an extension of <typeparamref name="TimeSeriesEntry"/>
+        /// <see cref="TimeSeriesRollupEntry{TValues}"/> is an extension of <see cref="TimeSeriesEntry"/>
         /// which contains the aggregated values of rollup time series [Min, Max, First, Last, Sum, Count, Average].</param>
         void Append(TimeSeriesRollupEntry<T> entry);
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22366/XML-docs-warnings-in-IncludeBuilder

### Additional description

fix warnings in comments

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
