### PR TITLE
RavenDB-22767 - Dispose the documents transaction in case we fail to create the server store transaction

### DIFF
--- a/src/Raven.Server/Documents/Indexes/QueryOperationContext.cs
+++ b/src/Raven.Server/Documents/Indexes/QueryOperationContext.cs
@@ -58,11 +58,20 @@ namespace Raven.Server.Documents.Indexes
         public IDisposable OpenReadTransaction()
         {
             var documentsTx = Documents.OpenReadTransaction();
-            RavenTransaction serverTx = null;
-            if (Server != null)
-                serverTx = Server.OpenReadTransaction();
 
-            return new DisposeTransactions(documentsTx, serverTx);
+            try
+            {
+                RavenTransaction serverTx = null;
+                if (Server != null)
+                    serverTx = Server.OpenReadTransaction();
+
+                return new DisposeTransactions(documentsTx, serverTx);
+            }
+            catch
+            {
+                documentsTx.Dispose();
+                throw;
+            }
         }
 
         public void CloseTransaction()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22767/Scratch-buffers-arent-released

### Additional description

In case we fail to create the server store transaction, we need to dispose of the documents transaction.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
