### PR TITLE
RavenDB-22819 - Incorrect Operation ID Returned When StartBackupOperation Is Called While a Backup Is Already Running

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -502,6 +502,11 @@ namespace Raven.Client
             public const string CsvImportOptions = "csvImportOptions";
         }
 
+        internal static class Operations
+        {
+            public const long InvalidOperationId = -1;
+        }
+
         internal sealed class CompareExchange
         {
             private CompareExchange()

--- a/src/Raven.Client/Exceptions/Database/BackupAlreadyRunningException.cs
+++ b/src/Raven.Client/Exceptions/Database/BackupAlreadyRunningException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions.Database
+{
+    public sealed class BackupAlreadyRunningException : RavenException
+    {
+        public BackupAlreadyRunningException(string message)
+            : base(message)
+        {
+        }
+
+        public BackupAlreadyRunningException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Raven.Client/Exceptions/Database/BackupAlreadyRunningException.cs
+++ b/src/Raven.Client/Exceptions/Database/BackupAlreadyRunningException.cs
@@ -4,6 +4,9 @@ namespace Raven.Client.Exceptions.Database
 {
     public sealed class BackupAlreadyRunningException : RavenException
     {
+        public long OperationId;
+        public string NodeTag;
+
         public BackupAlreadyRunningException(string message)
             : base(message)
         {

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Client.Http;
@@ -131,6 +132,10 @@ namespace Raven.Client.Exceptions
                     break;
                 case RavenTimeoutException timeoutException:
                     json.TryGet(nameof(RavenTimeoutException.FailImmediately), out timeoutException.FailImmediately);
+                    break;
+                case BackupAlreadyRunningException backupAlreadyRunningException:
+                    json.TryGet(nameof(BackupAlreadyRunningException.OperationId), out backupAlreadyRunningException.OperationId);
+                    json.TryGet(nameof(BackupAlreadyRunningException.NodeTag), out backupAlreadyRunningException.NodeTag);
                     break;
             }
         }

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected abstract ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? startTime);
+        protected abstract ValueTask<(long, bool)> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? startTime);
 
         protected abstract long GetNextOperationId();
 
@@ -24,8 +24,8 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
             var isFullBackup = RequestHandler.GetBoolValueQueryString("isFullBackup", required: false) ?? true;
             var operationId = RequestHandler.GetLongQueryString("operationId", required: false) ?? GetNextOperationId();
             var startTime = RequestHandler.GetDateTimeQueryString("startTime", required: false);
-
-            var isResponsibleNode = await ScheduleBackupOperationAsync(taskId, isFullBackup, operationId, startTime);
+            
+            (operationId, var isResponsibleNode) = await ScheduleBackupOperationAsync(taskId, isFullBackup, operationId, startTime);
 
             if (isResponsibleNode)
             {

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected abstract ValueTask<(long, bool)> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? startTime);
+        protected abstract ValueTask<(long OperationId, bool IsResponsibleNode)> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? startTime);
 
         protected abstract long GetNextOperationId();
 

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using System.Net;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Raven.Client;
-using Raven.Client.Http;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Server.Web.Http;
 
 namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
 {
@@ -18,64 +19,23 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
         {
             return RequestHandler.Database.Operations.GetNextOperationId();
         }
-
-        protected override async ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? startTime)
+        
+        protected override async ValueTask<(long, bool)> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? startTime)
         {
-            // task id == raft index
-            // we must wait here to ensure that the task was actually created on this node
-            await ServerStore.Cluster.WaitForIndexNotification(taskId);
-
-            var nodeTag = RequestHandler.Database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
-            if (nodeTag == null)
-            {
-                // this can happen if the database was just created or if a new task that was just created
-                // we'll wait for the cluster observer to give more time for the database stats to become stable,
-                // and then we'll wait for the cluster observer to determine the responsible node for the backup
-
-                var task = Task.Delay(RequestHandler.Database.Configuration.Cluster.StabilizationTime.AsTimeSpan + RequestHandler.Database.Configuration.Cluster.StabilizationTime.AsTimeSpan);
-
-                while (true)
-                {
-                    if (Task.WaitAny(new[] { task }, millisecondsTimeout: 100) == 0)
-                    {
-                        throw new InvalidOperationException($"Couldn't find a node which is responsible for backup task id: {taskId}");
-                    }
-
-                    nodeTag = RequestHandler.Database.PeriodicBackupRunner.WhoseTaskIsIt(taskId);
-                    if (nodeTag != null)
-                        break;
-                }
-            }
+            var nodeTag = await BackupUtils.WaitAndGetResponsibleNodeAsync(taskId, RequestHandler.Database);
 
             if (nodeTag == ServerStore.NodeTag)
             {
-                RequestHandler.Database.PeriodicBackupRunner.StartBackupTask(taskId, isFullBackup, operationId, startTime);
-                return true;
+                operationId = RequestHandler.Database.PeriodicBackupRunner.StartBackupTask(taskId, isFullBackup, operationId, startTime);
+                return (operationId, true);
             }
 
-            RedirectToRelevantNode(nodeTag);
-            return false;
-        }
-
-        private void RedirectToRelevantNode(string nodeTag)
-        {
-            ClusterTopology topology;
-            using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-            using (context.OpenReadTransaction())
-            {
-                topology = ServerStore.GetClusterTopology(context);
-            }
-
-            var url = topology.GetUrlFromTag(nodeTag);
-            if (url == null)
-            {
-                throw new InvalidOperationException($"Couldn't find the node url for node tag: {nodeTag}");
-            }
-
-            var location = url + HttpContext.Request.Path + HttpContext.Request.QueryString;
-            HttpContext.Response.StatusCode = (int)HttpStatusCode.TemporaryRedirect;
-            HttpContext.Response.Headers.Remove(Constants.Headers.ContentType);
-            HttpContext.Response.Headers["Location"] = location;
+            //redirect
+            var cmd = new StartBackupOperation.StartBackupCommand(isFullBackup, taskId, operationId, startTime);
+            cmd.SelectedNodeTag = nodeTag;
+            await RequestHandler.ExecuteRemoteAsync(new ProxyCommand<OperationIdResult<StartBackupOperationResult>>(cmd, HttpContext.Response));
+            
+            return (operationId, false);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForGetRunningBackupOperationStatus.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForGetRunningBackupOperationStatus.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Http;
+using Raven.Client.Json.Serialization;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Raven.Server.Web.Http;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
+{
+    internal class OngoingTasksHandlerProcessorForGetRunningBackupOperationStatus : AbstractDatabaseHandlerProcessor<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public OngoingTasksHandlerProcessorForGetRunningBackupOperationStatus([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        public override async ValueTask ExecuteAsync()
+        {
+            var taskId = RequestHandler.GetLongQueryString("taskId");
+            
+            var responsibleNode = await BackupUtils.WaitAndGetResponsibleNodeAsync(taskId, RequestHandler.Database);
+
+            if (responsibleNode == ServerStore.NodeTag)
+            {
+                var backup = RequestHandler.Database.PeriodicBackupRunner.PeriodicBackups.FirstOrDefault(x => x.Configuration.TaskId == taskId);
+                if (backup == null)
+                {
+                    throw new InvalidOperationException($"Backup task id: {taskId} doesn't exist");
+                }
+
+                var result = new OperationIdResult()
+                {
+                    OperationNodeTag = responsibleNode,
+                    OperationId = backup.RunningTask?.Id ?? Constants.Operations.InvalidOperationId
+                };
+                
+                using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+                await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+                {
+                    writer.WriteStartObject();
+                    writer.WritePropertyName(nameof(OperationIdResult.OperationNodeTag));
+                    writer.WriteString(result.OperationNodeTag);
+                    writer.WriteComma();
+                    writer.WritePropertyName(nameof(OperationIdResult.OperationId));
+                    writer.WriteInteger(result.OperationId);
+                    writer.WriteEndObject();
+                }
+            }
+            else
+            {
+                //redirect
+                var cmd = new GetRunningBackupStatusCommand(taskId);
+                cmd.SelectedNodeTag = responsibleNode;
+                await RequestHandler.ExecuteRemoteAsync(new ProxyCommand<OperationIdResult>(cmd, HttpContext.Response));
+            }
+        }
+    }
+
+    internal sealed class GetRunningBackupStatusCommand : RavenCommand<OperationIdResult>
+    {
+        public override bool IsReadRequest => true;
+
+        private readonly long _taskId;
+
+        public GetRunningBackupStatusCommand(long taskId)
+        {
+            _taskId = taskId;
+        }
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/admin/backup/database/status?taskId={_taskId}";
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            var result = JsonDeserializationClient.OperationIdResult(response);
+            Result = result;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForGetRunningBackupOperationStatus.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/OngoingTasksHandlerProcessorForGetRunningBackupOperationStatus.cs
@@ -75,7 +75,7 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            url = $"{node.Url}/databases/{node.Database}/admin/backup/database/status?taskId={_taskId}";
+            url = $"{node.Url}/databases/{node.Database}/admin/backup/running?taskId={_taskId}";
 
             var request = new HttpRequestMessage
             {

--- a/src/Raven.Server/Documents/Operations/AbstractOperations.cs
+++ b/src/Raven.Server/Documents/Operations/AbstractOperations.cs
@@ -24,7 +24,7 @@ public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
     private readonly TimeSpan _maxCompletedTaskLifeTime;
 
     protected readonly ConcurrentDictionary<long, AbstractOperation> Active = new();
-    protected readonly ConcurrentDictionary<long, AbstractOperation> Completed = new();
+    internal readonly ConcurrentDictionary<long, AbstractOperation> Completed = new();
 
     protected AbstractOperations(IDocumentsChanges changes, TimeSpan maxCompletedTaskLifeTime)
     {

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
@@ -27,6 +28,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Collections;
 using Sparrow.Logging;
+using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
 using Constants = Raven.Client.Constants;
@@ -329,7 +331,8 @@ namespace Raven.Server.Documents.PeriodicBackup
                     if (_logger.IsOperationsEnabled)
                         _logger.Operations($"Could not start backup task '{periodicBackup.Configuration.TaskId}' because there is already a running backup '{runningTask.Id}'");
 
-                    return runningTask.Id;
+                    throw new BackupAlreadyRunningException(
+                        $"Could not start backup task '{periodicBackup.Configuration.TaskId}' because there is already a running backup under operation id '{runningTask.Id}'");
                 }
 
                 BackupUtils.CheckServerHealthBeforeBackup(_serverStore, periodicBackup.Configuration.Name);
@@ -507,8 +510,11 @@ namespace Raven.Server.Documents.PeriodicBackup
         {
             try
             {
-                _serverStore.ConcurrentBackupsCounter.FinishBackup(_originalDatabaseName, periodicBackup.Configuration.Name, periodicBackup.RunningBackupStatus, elapsed, _logger);
+                if (_forTestingPurposes?.HoldBackupFromFinishing != null)
+                    _forTestingPurposes.HoldBackupFromFinishing.WaitOne();
 
+                _serverStore.ConcurrentBackupsCounter.FinishBackup(_originalDatabaseName, periodicBackup.Configuration.Name, periodicBackup.RunningBackupStatus, elapsed, _logger);
+                
                 periodicBackup.RunningTask = null;
                 periodicBackup.CancelToken = null;
                 periodicBackup.RunningBackupStatus = null;
@@ -1094,6 +1100,8 @@ namespace Raven.Server.Documents.PeriodicBackup
             internal TaskCompletionSource<object> OnBackupTaskRunHoldBackupExecution;
 
             internal Action AfterBackupBatchCompleted;
+
+            internal ManualResetEvent HoldBackupFromFinishing;
         }
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -332,7 +332,11 @@ namespace Raven.Server.Documents.PeriodicBackup
                         _logger.Operations($"Could not start backup task '{periodicBackup.Configuration.TaskId}' because there is already a running backup '{runningTask.Id}'");
 
                     throw new BackupAlreadyRunningException(
-                        $"Could not start backup task '{periodicBackup.Configuration.TaskId}' because there is already a running backup under operation id '{runningTask.Id}'");
+                        $"Could not start backup task '{periodicBackup.Configuration.TaskId}' because there is already a running backup under operation id '{runningTask.Id}'")
+                    {
+                        OperationId = runningTask.Id,
+                        NodeTag = _serverStore.NodeTag
+                    };
                 }
 
                 BackupUtils.CheckServerHealthBeforeBackup(_serverStore, periodicBackup.Configuration.Name);

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected override async ValueTask<(long, bool)> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId,  DateTime? __)
+        protected override async ValueTask<(long OperationId, bool IsResponsibleNode)> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId,  DateTime? __)
         {
             var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
             
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
                 token.Dispose();
             });
 
-            return (operationId, true);
+            return (operationId, IsResponsibleNode: true);
         }
 
         protected override long GetNextOperationId()

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -31,7 +31,11 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
                 await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(new ShardedGetOperationIdForBackupOperation(RequestHandler.HttpContext, taskId));
             
             if (shardsOperationId != Constants.Operations.InvalidOperationId)
-                throw new BackupAlreadyRunningException($"Can't start backup with taskId {taskId} because it is already running under operation id {shardsOperationId}");
+                throw new BackupAlreadyRunningException($"Can't start backup with taskId {taskId} because it is already running under operation id {shardsOperationId}")
+                {
+                    OperationId = shardsOperationId,
+                    NodeTag = ServerStore.NodeTag
+                };
             
             // backup isn't running on any shard, use the operation id we got to create a new backup task
             var startTime = SystemTime.UtcNow;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/OngoingTasks/ShardedOngoingTasksHandlerProcessorForBackupDatabaseNow.cs
@@ -1,10 +1,17 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+using Raven.Client;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Exceptions.Database;
+using Raven.Client.Http;
 using Raven.Client.Util;
 using Raven.Server.Documents.Handlers.Processors.OngoingTasks;
+using Raven.Server.Documents.Sharding.Executors;
+using Raven.Server.Documents.Sharding.Operations;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
@@ -15,10 +22,18 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
         {
         }
 
-        protected override ValueTask<bool> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId, DateTime? _)
+        protected override async ValueTask<(long, bool)> ScheduleBackupOperationAsync(long taskId, bool isFullBackup, long operationId,  DateTime? __)
         {
             var token = RequestHandler.CreateTimeLimitedBackgroundOperationToken();
-
+            
+            // backup might be already running on one of the shards, get the current operation id from that shard if so
+            var shardsOperationId =
+                await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(new ShardedGetOperationIdForBackupOperation(RequestHandler.HttpContext, taskId));
+            
+            if (shardsOperationId != Constants.Operations.InvalidOperationId)
+                throw new BackupAlreadyRunningException($"Can't start backup with taskId {taskId} because it is already running under operation id {shardsOperationId}");
+            
+            // backup isn't running on any shard, use the operation id we got to create a new backup task
             var startTime = SystemTime.UtcNow;
             var t = RequestHandler.DatabaseContext.Operations.AddRemoteOperation<OperationIdResult<StartBackupOperationResult>, ShardedBackupResult, ShardedBackupProgress>(operationId,
                 Server.Documents.Operations.OperationType.DatabaseBackup,
@@ -26,18 +41,51 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.OngoingTasks
                 detailedDescription: null,
                 (_, shardNumber) => new StartBackupOperation.StartBackupCommand(isFullBackup, taskId, operationId, startTime),
                 token);
-
-            t.ContinueWith(_ =>
+            
+            _ = t.ContinueWith(_ =>
             {
                 token.Dispose();
             });
 
-            return ValueTask.FromResult(true);
+            return (operationId, true);
         }
 
         protected override long GetNextOperationId()
         {
             return RequestHandler.DatabaseContext.Operations.GetNextOperationId();
+        }
+
+        internal readonly struct ShardedGetOperationIdForBackupOperation : IShardedOperation<OperationIdResult, long>
+        {
+            private readonly long _taskId;
+            private readonly HttpContext _httpContext;
+
+            public ShardedGetOperationIdForBackupOperation(HttpContext httpContext, long taskId)
+            {
+                _taskId = taskId;
+                _httpContext = httpContext;
+            }
+
+            public HttpRequest HttpRequest => _httpContext.Request;
+
+            public long Combine(Dictionary<int, ShardExecutionResult<OperationIdResult>> results)
+            {
+                foreach (var (shardNumber, shardResult) in results)
+                {
+                    var operationIdResult = shardResult.Result;
+                    if (operationIdResult != null)
+                    {
+                        // if one of the backups is still running it will return its current operationId
+                        if (operationIdResult.OperationId != Constants.Operations.InvalidOperationId)
+                            return operationIdResult.OperationId;
+                    }
+                }
+                
+                return Constants.Operations.InvalidOperationId;
+            }
+
+            public RavenCommand<OperationIdResult> CreateCommandForShard(int shardNumber) => 
+                new GetRunningBackupStatusCommand(_taskId);
         }
     }
 }

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -382,6 +382,12 @@ namespace Raven.Server
 
             if (exception is ClusterTransactionConcurrencyException { ConcurrencyViolations: { } } ctxConcurrencyException)
                 djv[nameof(ClusterTransactionConcurrencyException.ConcurrencyViolations)] = new DynamicJsonArray(ctxConcurrencyException.ConcurrencyViolations.Select(c => c.ToJson()));
+
+            if (exception is BackupAlreadyRunningException backupAlreadyRunningException)
+            {
+                djv[nameof(BackupAlreadyRunningException.OperationId)] = backupAlreadyRunningException.OperationId;
+                djv[nameof(BackupAlreadyRunningException.NodeTag)] = backupAlreadyRunningException.NodeTag;
+            }
         }
 
         private static void MaybeSetExceptionStatusCode(HttpContext httpContext, ServerStore serverStore, Exception exception)

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -81,6 +81,13 @@ namespace Raven.Server.Web.System
                 await processor.ExecuteAsync();
         }
 
+        [RavenAction("/databases/*/admin/backup/database/status", "GET", AuthorizationStatus.DatabaseAdmin, CorsMode = CorsMode.Cluster)]
+        public async Task GetBackupRunningStatus()
+        {
+            using (var processor = new OngoingTasksHandlerProcessorForGetRunningBackupOperationStatus(this))
+                await processor.ExecuteAsync();
+        }
+
         [RavenAction("/databases/*/admin/backup", "POST", AuthorizationStatus.DatabaseAdmin, CorsMode = CorsMode.Cluster)]
         public async Task BackupDatabaseOnce()
         {

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -81,7 +81,7 @@ namespace Raven.Server.Web.System
                 await processor.ExecuteAsync();
         }
 
-        [RavenAction("/databases/*/admin/backup/database/status", "GET", AuthorizationStatus.DatabaseAdmin, CorsMode = CorsMode.Cluster)]
+        [RavenAction("/databases/*/admin/backup/running", "GET", AuthorizationStatus.DatabaseAdmin, CorsMode = CorsMode.Cluster)]
         public async Task GetBackupRunningStatus()
         {
             using (var processor = new OngoingTasksHandlerProcessorForGetRunningBackupOperationStatus(this))

--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -18,6 +18,7 @@ using Raven.Client.Documents.Operations.Expiration;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Database;
 using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Config;
@@ -306,8 +307,7 @@ namespace RachisTests.DatabaseCluster
                 long taskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store, opStatus: OperationStatus.InProgress);
 
                 // call StartBackupOperation - this will not start a new backup task for that id since we already have one running
-                var error = await Assert.ThrowsAnyAsync<RavenException>(() => store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: true, taskId)));
-                Assert.Contains("BackupAlreadyRunningException", error.Message);
+                await Assert.ThrowsAnyAsync<BackupAlreadyRunningException>(() => store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: true, taskId)));
             }
         }
 
@@ -356,8 +356,7 @@ namespace RachisTests.DatabaseCluster
                 }
 
                 // call StartBackupOperation - this should throw since we the backup is still running on shard 0
-                var error = await Assert.ThrowsAnyAsync<RavenException>(() => store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: true, taskId)));
-                Assert.Contains("BackupAlreadyRunningException", error.Message);
+                await Assert.ThrowsAnyAsync<BackupAlreadyRunningException>(() => store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: true, taskId)));
             }
         }
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3251,6 +3251,68 @@ namespace SlowTests.Server.Documents.PeriodicBackup
             }
         }
 
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster | RavenTestCategory.ChangesApi)]
+        public async Task StartingBackupOnNonResponsibleNodeShouldRedirectToResponsibleNode()
+        {
+            const int clusterSize = 3;
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var databaseName = GetDatabaseName();
+
+            var (nodes, leaderServer) = await CreateRaftCluster(clusterSize, leaderIndex: 0);
+            await CreateDatabaseInCluster(databaseName, clusterSize, leaderServer.WebUrl);
+
+            using (var responsibleStore = new DocumentStore
+            {
+                Urls = new[] { nodes[2].WebUrl },
+                Conventions = new DocumentConventions { DisableTopologyUpdates = true },
+                Database = databaseName
+            })
+            using (var otherStore = new DocumentStore()
+            {
+                Urls = new[] { nodes[1].WebUrl },
+                Database = databaseName
+            })
+            {
+                responsibleStore.Initialize();
+                otherStore.Initialize();
+
+                using (var session = responsibleStore.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                // responsible node will be nodes[2]
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* * * * *", mentorNode: nodes[2].ServerStore.NodeTag);
+                var taskId = await Backup.UpdateConfigAsync(nodes[1], config, responsibleStore);
+
+                var responsibleNode = Raven.Server.Utils.BackupUtils.GetResponsibleNodeTag(nodes[1].ServerStore, databaseName, taskId);
+                Assert.Equal(responsibleNode, nodes[2].ServerStore.NodeTag);
+
+                // we are going to send the next backup operation to the non-responsible node
+                await otherStore.Maintenance.Server.SendAsync(new ReorderDatabaseMembersOperation(databaseName,
+                    new List<string>() { nodes[1].ServerStore.NodeTag, nodes[0].ServerStore.NodeTag, nodes[2].ServerStore.NodeTag }));
+
+                var re = otherStore.GetRequestExecutor();
+                var updated = await re.UpdateTopologyAsync(
+                    new RequestExecutor.UpdateTopologyParameters(new ServerNode() { ClusterTag = nodes[1].ServerStore.NodeTag, Url = nodes[1].WebUrl, Database = databaseName}));
+                Assert.True(updated);
+
+                // wait for the preferred node be non-responsible node
+                var res = await WaitForValueAsync(async () =>
+                {
+                    var (_, preferredNode) = await re.GetPreferredNode();
+                    return preferredNode.ClusterTag != responsibleNode;
+                }, true);
+                Assert.True(res);
+
+                // start backup on a node diff than responsible node
+                var task = await otherStore.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: true, taskId));
+                await task.WaitForCompletionAsync(TimeSpan.FromSeconds(20));
+            }
+        }
+
         [Fact, Trait("Category", "Smuggler")]
         public async Task ShouldScheduleNextBackupAfterServerRestartCorrectly()
         {

--- a/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
+++ b/test/SlowTests/Sharding/Backup/ShardedBackupTests .cs
@@ -260,7 +260,7 @@ namespace SlowTests.Sharding.Backup
 
                     var taskId = databaseRecord.PeriodicBackups[0].TaskId;
                     if (databaseRecord.IsSharded)
-                        await Sharding.Backup.RunBackupAsync(store.Database, taskId, isFullBackup: true);
+                        await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: true);
                     else
                         await Backup.RunBackupAsync(Server, taskId, store, isFullBackup: true);
                 }
@@ -353,7 +353,7 @@ namespace SlowTests.Sharding.Backup
 
                     var taskId = databaseRecord.PeriodicBackups[0].TaskId;
                     if (databaseRecord.IsSharded)
-                        await Sharding.Backup.RunBackupAsync(store.Database, taskId, isFullBackup: true);
+                        await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: true);
                     else
                         await Backup.RunBackupAsync(Server, taskId, store, isFullBackup: true);
                 }

--- a/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
@@ -442,7 +442,7 @@ namespace SlowTests.Sharding.Backup
                     await session.SaveChangesAsync();
                 }
 
-                await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+                await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
                 Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                 var dirs = Directory.GetDirectories(backupPath);
@@ -608,7 +608,7 @@ namespace SlowTests.Sharding.Backup
                         await session.SaveChangesAsync();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, false);
+                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, false);
                     Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                     var sharding = await Sharding.GetShardingConfigurationAsync(store);
@@ -1191,7 +1191,7 @@ namespace SlowTests.Sharding.Backup
                     await session.SaveChangesAsync();
                 }
 
-                await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+                await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
                 Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                 // add more docs
@@ -1206,7 +1206,7 @@ namespace SlowTests.Sharding.Backup
                     session.SaveChanges();
                 }
 
-                await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+                await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
                 Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                 var dirs = Directory.GetDirectories(backupPath);
@@ -1321,7 +1321,7 @@ namespace SlowTests.Sharding.Backup
                         await session.SaveChangesAsync();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
                     Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                     // add more docs
@@ -1336,7 +1336,7 @@ namespace SlowTests.Sharding.Backup
                         session.SaveChanges();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
                     Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                     var sharding = await Sharding.GetShardingConfigurationAsync(store);
@@ -1454,7 +1454,7 @@ namespace SlowTests.Sharding.Backup
                         await session.SaveChangesAsync();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
                     Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                     // add more docs
@@ -1469,7 +1469,7 @@ namespace SlowTests.Sharding.Backup
                         session.SaveChanges();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
                     Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                     var sharding = await Sharding.GetShardingConfigurationAsync(store);
@@ -1587,7 +1587,7 @@ namespace SlowTests.Sharding.Backup
                         await session.SaveChangesAsync();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
                     Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                     // add more docs
@@ -1602,7 +1602,7 @@ namespace SlowTests.Sharding.Backup
                         session.SaveChanges();
                     }
 
-                    await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+                    await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
                     Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                     var sharding = await Sharding.GetShardingConfigurationAsync(store);
@@ -1727,7 +1727,7 @@ namespace SlowTests.Sharding.Backup
                     Assert.Equal(1, databaseRecord.PeriodicBackups.Count);
 
                     var taskId = databaseRecord.PeriodicBackups[0].TaskId;
-                    await Sharding.Backup.RunBackupAsync(store.Database, taskId, isFullBackup: true);
+                    await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: true);
 
                     Assert.True(WaitHandle.WaitAll(backupsDone, TimeSpan.FromMinutes(1)));
 

--- a/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ReshardingTests.cs
@@ -1037,7 +1037,7 @@ namespace SlowTests.Sharding.Cluster
                 // run backup again
                 waitHandles = await Sharding.Backup.WaitForBackupsToComplete(cluster.Nodes, store.Database);
 
-                await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, cluster.Nodes);
+                await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
                 Assert.True(WaitHandle.WaitAll(waitHandles, TimeSpan.FromMinutes(1)));
 
                 var dirs = Directory.GetDirectories(backupPath);

--- a/test/SlowTests/Sharding/Cluster/ShardedClusterObserverTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ShardedClusterObserverTests.cs
@@ -599,7 +599,7 @@ namespace SlowTests.Sharding.Cluster
                 await AssertCompareExchangesAsync(database, expectedCompareExchanges: 0, expectedTombstones: 3, nodes);
 
                 //run periodic backup on leader
-                await Sharding.Backup.RunBackupAsync(store.Database, backupTaskId, isFullBackup: false, new List<RavenServer>(){ leader });
+                await Sharding.Backup.RunBackupAsync(store, backupTaskId, isFullBackup: false);
 
                 //wait for periodic backup to finish running
                 var done = await WaitForValueAsync(() =>

--- a/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.ShardedBackupTestBase.cs
@@ -359,6 +359,8 @@ public partial class RavenTestBase
         {
             var result = await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
+            WaitForResponsibleNodeUpdateInCluster(store, servers, result.TaskId);
+
             await RunBackupAsync(store.Database, result.TaskId, isFullBackup, servers);
 
             return result.TaskId;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22819

### Additional description

When calling `StartBackupOperation` while backup was already runnning, the `operationId` that was returned was the wrong one. If the backup of the given taskId is running then we would want to return the `operationId` of the task runnning now, and track that one (like in 5.4). But instead we return the newly generated `opeartionId`.

Sharding:
In sharding there could be a situation where the backup task finished on 2 shards but still running on the 3rd. In which case, if we ran the `StartBackupOperation` at that point, the 2 shards will start a new backup task while the 3rd one keeps running the original and returns its `operationId`. Mismatch.

Changes:
It was decided we will throw an exception if we attempt to start a new backup operation that is already running.
In the sharded endpoint, before starting to send the backup command to all shards, we first send all of the shards a dedicated operation which will return the current operationId of the back if it is running. If at least one of the shards is still running it then we can throw an exception.
Note: The `StartBackupCommand` is repsonsible for checking on which node the backup resides and redirects there, so there was a need to extend this behavior to the dedicated endpoint that was added as well.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
