### PR TITLE
RavenDB-22822 fix test and prevent reusing the same raft command instance

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -912,6 +912,9 @@ namespace Raven.Server.Rachis
         }
         public async Task<(long Index, object Result)> SendToLeaderAsync(CommandBase cmd, CancellationToken token = default)
         {
+            // prevent sending the same command _instance_, since it contain unmanaged parts
+            cmd.InUse.RaiseOrDie();
+
             //I think it is reasonable to expect timeout twice of error retry
             var timeoutTask = TimeoutManager.WaitFor(OperationTimeout, token);
             Exception requestException = null;

--- a/src/Raven.Server/ServerWide/Commands/CommandBase.cs
+++ b/src/Raven.Server/ServerWide/Commands/CommandBase.cs
@@ -4,6 +4,7 @@ using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Threading;
 
 namespace Raven.Server.ServerWide.Commands
 {
@@ -33,6 +34,9 @@ namespace Raven.Server.ServerWide.Commands
         // if string.Empty passed, it will be treated as don't care,
         // if (null) value is passed, it will be treated as a bug. (will throw an exception only in Debug builds to support old clients)
         public string UniqueRequestId;
+
+        [JsonDeserializationIgnore]
+        public SingleUseFlag InUse = new SingleUseFlag();
 
         public BlittableJsonReaderObject Raw;
 

--- a/test/RachisTests/CommandsTests.cs
+++ b/test/RachisTests/CommandsTests.cs
@@ -26,13 +26,19 @@ namespace RachisTests
             long lastIndex;
             using (leader.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             {
-                var cmd = new TestCommandWithRaftId("test", RaftIdGenerator.NewId())
+                var guid = RaftIdGenerator.NewId();
+                var cmd = new TestCommandWithRaftId("test", guid)
+                {
+                    RaftCommandIndex = 322
+                };
+
+                var cloned = new TestCommandWithRaftId("test", guid)
                 {
                     RaftCommandIndex = 322
                 };
 
                 var t = leader.SendToLeaderAsync(cmd);
-                await leader.SendToLeaderAsync(cmd);
+                await leader.SendToLeaderAsync(cloned);
 
                 // this should not throw timeout exception.
                 var exception = await Record.ExceptionAsync(async () => await t);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22822

### Additional description

Raft commands has now the `Raw` property which is a blittable. So we need to avoid working on the same command _instance_ in different threads

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
