### PR TITLE
RavenDB-22857 - Remove Disposed Replication Handlers from _incoming/_…

### DIFF
--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -320,7 +320,7 @@ namespace Raven.Server.Documents.Replication
                 if (hub == null)
                     return;
 
-                foreach (var (_, repl) in _incoming)
+                foreach (var (key, repl) in _incoming)
                 {
                     if (string.Equals(repl._incomingPullReplicationParams.Name, hub, StringComparison.OrdinalIgnoreCase) == false ||
                         (string.IsNullOrEmpty(sourceDatabase) == false && 
@@ -335,6 +335,7 @@ namespace Raven.Server.Documents.Replication
                         if (_log.IsInfoEnabled)
                             _log.Info($"Resetting {repl.ConnectionInfo} for {hub} on {certThumbprint} because replication configuration changed. Will be reconnected.");
                         repl.Dispose();
+                        _incoming.TryRemove(key, out _);
                     }
                     catch
                     {
@@ -354,6 +355,7 @@ namespace Raven.Server.Documents.Replication
                     try
                     {
                         repl.Dispose();
+                        _outgoing.TryRemove(repl);
                     }
                     catch
                     {

--- a/test/SlowTests/Issues/RavenDB_22709.cs
+++ b/test/SlowTests/Issues/RavenDB_22709.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using FastTests;
@@ -8,6 +9,7 @@ using FastTests.Server.Replication;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server;
@@ -81,7 +83,7 @@ namespace SlowTests.Issues
                 CertificateBase64 = Convert.ToBase64String(pullCert1.Export(X509ContentType.Cert)),
             }));
 
-            await SetupSink(sinkStore1, "Sink1", pullCert1);
+            await SetupSink(sinkStore1, hubStore, "Sink1", pullCert1);
 
             await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("both", new ReplicationHubAccess
             {
@@ -91,49 +93,285 @@ namespace SlowTests.Issues
                 CertificateBase64 = Convert.ToBase64String(pullCert2.Export(X509ContentType.Cert)),
             }));
 
-            await SetupSink(sinkStore2, "Sink2", pullCert2);
+            await SetupSink(sinkStore2, hubStore, "Sink2", pullCert2);
 
-            Assert.Equal(4, await WaitForValueAsync(async () =>
+            // 2 outgoing internal replication connections 
+            // 2 outgoing pull replication connections
+
+            // 2 incoming internal replication connections 
+            // 2 incoming pull replication connections
+
+            var expectedConnections = 4;
+
+            await AssertOutgoingConnections(hubStore, expectedConnections);
+            await AssertIncomingConnections(hubStore, expectedConnections);
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task ShouldRemoveConnectionsAfterUpdatingMentorNodeForHubTask()
+        {
+            var hubCluster = await CreateRaftClusterWithSsl(3, watcherCluster: true, leaderIndex: 0);
+            var hubClusterCert = RegisterClientCertificate(hubCluster);
+
+            var sinkCluster = await CreateRaftClusterWithSsl(3, watcherCluster: true, leaderIndex: 0);
+            var sinkClusterCert = RegisterClientCertificate(sinkCluster);
+
+            using var hubStore = new DocumentStore
             {
-                // 2 outgoing internal replication connections 
-                // 2 outgoing pull replication connections
-                var stats = await hubStore.Maintenance.SendAsync(new GetReplicationPerformanceStatisticsOperation());
+                Urls = new[] { hubCluster.Leader.WebUrl },
+                Database = "HubDB",
+                Certificate = hubClusterCert,
+                Conventions = { DisableTopologyUpdates = true }
+            }.Initialize();
+
+            using var sinkStore = new DocumentStore
+            {
+                Urls = new[] { sinkCluster.Leader.WebUrl },
+                Database = "SinkDB",
+                Certificate = sinkClusterCert,
+                Conventions = { DisableTopologyUpdates = true }
+            }.Initialize();
+
+            await CreateDatabaseInCluster(hubStore.Database, replicationFactor: 3, leadersUrl: hubCluster.Leader.WebUrl, certificate: hubClusterCert);
+            await CreateDatabaseInCluster(sinkStore.Database, replicationFactor: 3, leadersUrl: sinkCluster.Leader.WebUrl, certificate: sinkClusterCert);
+
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(hubCluster.Certificates.ClientCertificate2Path), (string)null, X509KeyStorageFlags.Exportable);
+
+            var pullDefinition = new PullReplicationDefinition
+            {
+                Name = "both",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                WithFiltering = true,
+                PinToMentorNode = true,
+                MentorNode = hubCluster.Leader.ServerStore.NodeTag
+            };
+
+            var result = await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(pullDefinition));
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("both", new ReplicationHubAccess
+            {
+                Name = "Sink",
+                AllowedSinkToHubPaths = new[] { "*" },
+                AllowedHubToSinkPaths = new[] { "*" },
+                CertificateBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert)),
+            }));
+
+            await SetupSink(sinkStore, hubStore, "Sink", pullCert);
+
+            // 2 outgoing internal replication connections
+            // 1 outgoing pull replication connections
+
+            // 2 incoming internal replication connections
+            // 1 incoming pull replication connections
+
+            var expectedConnections = 3;
+
+            await AssertOutgoingConnections(hubStore, expectedConnections);
+            await AssertIncomingConnections(hubStore, expectedConnections);
+
+            pullDefinition.TaskId = result.TaskId;
+
+            await hubStore.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(pullDefinition.TaskId, OngoingTaskType.PullReplicationAsHub, disable: true));
+
+            pullDefinition.Disabled = false;
+            pullDefinition.MentorNode = hubCluster.Nodes.First(s => s.ServerStore.NodeTag != hubCluster.Leader.ServerStore.NodeTag).ServerStore.NodeTag;
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(pullDefinition));
+
+            foreach (var server in hubCluster.Nodes)
+            {
+                using (var store = new DocumentStore
+                {
+                    Urls = new[] { server.WebUrl },
+                    Database = "HubDB",
+                    Certificate = hubClusterCert,
+                    Conventions = { DisableTopologyUpdates = true }
+                }.Initialize())
+                {
+                    if (server.ServerStore.NodeTag != pullDefinition.MentorNode)
+                    {
+                        // 2 outgoing internal replication connections
+                        
+                        // 2 incoming internal replication connections
+
+                        expectedConnections = 2;
+                    }
+                    else
+                    {
+                        // 2 outgoing internal replication connections
+                        // 1 outgoing pull replication connections
+
+                        // 2 incoming internal replication connections
+                        // 1 incoming pull replication connections
+
+                        expectedConnections = 3;
+                    }
+
+                    await AssertOutgoingConnections(store, expectedConnections);
+                    await AssertIncomingConnections(store, expectedConnections);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task ShouldRemoveConnectionsAfterUpdatingResponsibleNodeForSinkTask()
+        {
+            var hubCluster = await CreateRaftClusterWithSsl(1);
+            var hubClusterCert = RegisterClientCertificate(hubCluster);
+
+            var sinkCluster = await CreateRaftClusterWithSsl(3, watcherCluster: true, leaderIndex: 0);
+            var sinkClusterCert = RegisterClientCertificate(sinkCluster);
+
+            using var hubStore = new DocumentStore
+            {
+                Urls = new[] { hubCluster.Leader.WebUrl },
+                Database = "HubDB",
+                Certificate = hubClusterCert,
+                Conventions = { DisableTopologyUpdates = true }
+            }.Initialize();
+
+            using var sinkStore = new DocumentStore
+            {
+                Urls = new[] { sinkCluster.Leader.WebUrl },
+                Database = "SinkDB",
+                Certificate = sinkClusterCert
+            }.Initialize();
+
+            await CreateDatabaseInCluster(hubStore.Database, replicationFactor: 1, leadersUrl: hubCluster.Leader.WebUrl, certificate: hubClusterCert);
+            await CreateDatabaseInCluster(sinkStore.Database, replicationFactor: 3, leadersUrl: sinkCluster.Leader.WebUrl, certificate: sinkClusterCert);
+
+            var pullCert = new X509Certificate2(await File.ReadAllBytesAsync(hubCluster.Certificates.ClientCertificate2Path), (string)null, X509KeyStorageFlags.Exportable);
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "both",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                WithFiltering = true,
+                PinToMentorNode = true,
+                MentorNode = hubCluster.Leader.ServerStore.NodeTag
+            }));
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("both", new ReplicationHubAccess
+            {
+                Name = "Sink",
+                AllowedSinkToHubPaths = new[] { "*" },
+                AllowedHubToSinkPaths = new[] { "*" },
+                CertificateBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert)),
+            }));
+
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = hubStore.Database,
+                Name = hubStore.Database + "ConStr",
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+
+            var sinkReplication = new PullReplicationAsSink
+            {
+                PinToMentorNode = true,
+                MentorNode = sinkCluster.Leader.ServerStore.NodeTag,
+                ConnectionStringName = hubStore.Database + "ConStr",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                CertificateWithPrivateKey = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx)),
+                HubName = "both",
+                AccessName = "Sink",
+                AllowedHubToSinkPaths = new[] { "*" },
+                AllowedSinkToHubPaths = new[] { "*" }
+            };
+
+            var result = await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(sinkReplication));
+
+            // 1 outgoing pull replication connections
+
+            // 1 incoming pull replication connections
+
+            var expectedConnections = 1;
+
+            await AssertOutgoingConnections(hubStore, expectedConnections);
+            await AssertIncomingConnections(hubStore, expectedConnections);
+
+            sinkReplication.TaskId = result.TaskId;
+            sinkReplication.MentorNode = sinkCluster.Nodes.First(s => s.WebUrl != sinkCluster.Leader.WebUrl).ServerStore.NodeTag;
+
+            await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(sinkReplication));
+
+            foreach (var server in sinkCluster.Nodes)
+            {
+                using (var store = new DocumentStore
+                {
+                    Urls = new[] { server.WebUrl },
+                    Database = "SinkDB",
+                    Certificate = sinkClusterCert,
+                    Conventions = { DisableTopologyUpdates = true }
+                }.Initialize())
+                {
+                    if (server.ServerStore.NodeTag != sinkReplication.MentorNode)
+                    {
+                        // 2 outgoing internal replication connections 
+
+                        // 2 incoming internal replication connections
+
+                        expectedConnections = 2;
+                    }
+                    else
+                    {
+                        // 2 outgoing internal replication connections
+                        // 1 outgoing pull replication connections
+
+                        // 2 incoming internal replication connections
+                        // 1 incoming pull replication connections
+
+                        expectedConnections = 3;
+                    }
+
+                    await AssertOutgoingConnections(store, expectedConnections);
+                    await AssertIncomingConnections(store, expectedConnections);
+                }
+            }
+        }
+
+        private X509Certificate2 RegisterClientCertificate((List<RavenServer> Nodes, RavenServer Leader, TestCertificatesHolder Certificates) cluster)
+        {
+            return Certificates.RegisterClientCertificate(cluster.Certificates.ServerCertificate.Value, cluster.Certificates
+                .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: cluster.Leader);
+        }
+
+        private async Task SetupSink(IDocumentStore sinkStore, IDocumentStore hubStore, string accessName, X509Certificate2 pullCert)
+        {
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = hubStore.Database,
+                Name = hubStore.Database + "ConStr",
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+            await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+            {
+                ConnectionStringName = hubStore.Database + "ConStr",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                CertificateWithPrivateKey = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx)),
+                HubName = "both",
+                AccessName = accessName,
+                AllowedHubToSinkPaths = new[] { "*" },
+                AllowedSinkToHubPaths = new[] { "*" }
+            }));
+        }
+
+        private async Task AssertOutgoingConnections(IDocumentStore store, int expectedConnections)
+        {
+            Assert.Equal(expectedConnections, await WaitForValueAsync(async () =>
+            {
+                var stats = await store.Maintenance.SendAsync(new GetReplicationPerformanceStatisticsOperation());
                 return stats.Outgoing.Length;
-            }, 4));
+            }, expectedConnections));
+        }
 
-            Assert.Equal(4, await WaitForValueAsync(async () =>
+        private async Task AssertIncomingConnections(IDocumentStore store, int expectedConnections)
+        {
+            Assert.Equal(expectedConnections, await WaitForValueAsync(async () =>
             {
-                // 2 incoming internal replication connections 
-                // 2 incoming pull replication connections
-                var stats = await hubStore.Maintenance.SendAsync(new GetReplicationPerformanceStatisticsOperation());
+                var stats = await store.Maintenance.SendAsync(new GetReplicationPerformanceStatisticsOperation());
                 return stats.Incoming.Length;
-            }, 4));
-
-            X509Certificate2 RegisterClientCertificate((List<RavenServer> Nodes, RavenServer Leader, TestCertificatesHolder Certificates) cluster)
-            {
-                return Certificates.RegisterClientCertificate(cluster.Certificates.ServerCertificate.Value, cluster.Certificates
-                    .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin, server: cluster.Leader);
-            }
-
-            async Task SetupSink(IDocumentStore sinkStore, string accessName, X509Certificate2 pullCert)
-            {
-                await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
-                {
-                    Database = hubStore.Database,
-                    Name = hubStore.Database + "ConStr",
-                    TopologyDiscoveryUrls = hubStore.Urls
-                }));
-                await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
-                {
-                    ConnectionStringName = hubStore.Database + "ConStr",
-                    Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
-                    CertificateWithPrivateKey = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx)),
-                    HubName = "both",
-                    AccessName = accessName,
-                    AllowedHubToSinkPaths = new[] { "*" },
-                    AllowedSinkToHubPaths = new[] { "*" }
-                }));
-            }
+            }, expectedConnections));
         }
     }
 }


### PR DESCRIPTION
…outgoing

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22857/Remove-Disposed-Replication-Handlers-from-incoming-outgoing


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
