### PR TITLE
RavenDB-22659 Cancelling the restore doesn't always delete the database

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractDatabaseOperationQueriesHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractDatabaseOperationQueriesHandlerProcessor.cs
@@ -75,7 +75,7 @@ internal abstract class AbstractDatabaseOperationQueriesHandlerProcessor : Abstr
             description,
             details,
             onProgress => operation(RequestHandler.Database.QueryRunner, options, onProgress, token),
-            token);
+            token: token);
 
         _ = task.ContinueWith(_ =>
         {

--- a/src/Raven.Server/Documents/Operations/AbstractOperations.cs
+++ b/src/Raven.Server/Documents/Operations/AbstractOperations.cs
@@ -40,7 +40,8 @@ public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
         string description,
         IOperationDetailedDescription detailedDescription,
         Func<Action<IOperationProgress>, Task<IOperationResult>> taskFactory,
-        OperationCancelToken token = null);
+        OperationCancelToken token = null,
+        string databaseName = null);
 
     protected Task<IOperationResult> AddOperationInternalAsync(AbstractOperation operation, Func<Action<IOperationProgress>, Task<IOperationResult>> taskFactory)
     {

--- a/src/Raven.Server/Documents/Operations/AbstractOperations.cs
+++ b/src/Raven.Server/Documents/Operations/AbstractOperations.cs
@@ -40,8 +40,8 @@ public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
         string description,
         IOperationDetailedDescription detailedDescription,
         Func<Action<IOperationProgress>, Task<IOperationResult>> taskFactory,
-        OperationCancelToken token = null,
-        string databaseName = null);
+        string resourceName = null,
+        OperationCancelToken token = null);
 
     protected Task<IOperationResult> AddOperationInternalAsync(AbstractOperation operation, Func<Action<IOperationProgress>, Task<IOperationResult>> taskFactory)
     {

--- a/src/Raven.Server/Documents/Operations/Operations.cs
+++ b/src/Raven.Server/Documents/Operations/Operations.cs
@@ -51,10 +51,10 @@ namespace Raven.Server.Documents.Operations
             string description,
             IOperationDetailedDescription detailedDescription,
             Func<Action<IOperationProgress>, Task<IOperationResult>> taskFactory,
-            OperationCancelToken token = null,
-            string databaseName = null)
+            string resourceName = null,
+            OperationCancelToken token = null)
         {
-            var operation = CreateOperationInstance(id, _databaseName ?? databaseName, operationType, description, detailedDescription, token);
+            var operation = CreateOperationInstance(id, _databaseName ?? resourceName, operationType, description, detailedDescription, token);
 
             return AddOperationInternalAsync(operation, taskFactory);
         }

--- a/src/Raven.Server/Documents/Operations/Operations.cs
+++ b/src/Raven.Server/Documents/Operations/Operations.cs
@@ -51,9 +51,10 @@ namespace Raven.Server.Documents.Operations
             string description,
             IOperationDetailedDescription detailedDescription,
             Func<Action<IOperationProgress>, Task<IOperationResult>> taskFactory,
-            OperationCancelToken token = null)
+            OperationCancelToken token = null,
+            string databaseName = null)
         {
-            var operation = CreateOperationInstance(id, _databaseName, operationType, description, detailedDescription, token);
+            var operation = CreateOperationInstance(id, _databaseName ?? databaseName, operationType, description, detailedDescription, token);
 
             return AddOperationInternalAsync(operation, taskFactory);
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ReshardingHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ReshardingHandler.cs
@@ -78,7 +78,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 }
                 result.Message = $"Finished resharding to shard {toShard} buckets [{fromBucket}-{toBucket}]";
                 return result;
-            }, token);
+            }, token: token);
 
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
@@ -56,7 +56,8 @@ public partial class ShardedDatabaseContext
             string description,
             IOperationDetailedDescription detailedDescription,
             Func<Action<IOperationProgress>, Task<IOperationResult>> taskFactory,
-            OperationCancelToken token = null)
+            OperationCancelToken token = null,
+            string databaseName = null)
         {
             var operation = CreateOperationInstance(id, _context.DatabaseName, operationType, description, detailedDescription, token);
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
@@ -56,8 +56,8 @@ public partial class ShardedDatabaseContext
             string description,
             IOperationDetailedDescription detailedDescription,
             Func<Action<IOperationProgress>, Task<IOperationResult>> taskFactory,
-            OperationCancelToken token = null,
-            string databaseName = null)
+            string resourceName = null,
+            OperationCancelToken token = null)
         {
             var operation = CreateOperationInstance(id, _context.DatabaseName, operationType, description, detailedDescription, token);
 

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -556,7 +556,7 @@ namespace Raven.Server.Web.System
                         using var restoreBackupTask = await RestoreUtils.CreateBackupTaskAsync(ServerStore, restoreConfiguration, restoreSource, operationId, cancelToken);
                         return await restoreBackupTask.ExecuteAsync(onProgress);
                     },
-                    token: cancelToken, restoreConfiguration.DatabaseName);
+                    restoreConfiguration.DatabaseName, token: cancelToken);
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -556,7 +556,7 @@ namespace Raven.Server.Web.System
                         using var restoreBackupTask = await RestoreUtils.CreateBackupTaskAsync(ServerStore, restoreConfiguration, restoreSource, operationId, cancelToken);
                         return await restoreBackupTask.ExecuteAsync(onProgress);
                     },
-                    token: cancelToken);
+                    token: cancelToken, restoreConfiguration.DatabaseName);
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ResponseBodyStream()))
                 {
@@ -626,10 +626,7 @@ namespace Raven.Server.Web.System
                             if (rawRecord == null)
                                 continue;
 
-                            if (rawRecord.DatabaseState == DatabaseStateStatus.RestoreInProgress)
-                                throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
-                                                                    $"process is in progress. In order to delete the database, " +
-                                                                    $"you can cancel the restore task from node {rawRecord.Topology.Members[0]}");
+                            AssertCanDeleteDatabase(databaseName, rawRecord.DatabaseState, rawRecord.Topology);
 
                             if (isShard && rawRecord.Sharding.Shards.ContainsKey(shardNumber) == false)
                             {
@@ -795,6 +792,34 @@ namespace Raven.Server.Web.System
             }
 
             return actualDeletionIndex;
+        }
+
+        private void AssertCanDeleteDatabase(string databaseName, DatabaseStateStatus state, DatabaseTopology topology)
+        {
+            if (state != DatabaseStateStatus.RestoreInProgress)
+                return;
+
+            var restoredOnNode = topology.Members.First(); // we restore only on one node
+            if (ServerStore.NodeTag != restoredOnNode)
+                throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
+                                                    $"process is in progress. In order to delete the database, " +
+                                                    $"you can cancel the restore task from node {topology.Members.First()}");
+
+            var operations = ServerStore.Operations.GetActive();
+            if (operations == null || operations.Count == 0)
+                return;
+
+            foreach (var operation in operations)
+            {
+                if (operation.Description.TaskType == OperationType.DatabaseRestore &&
+                    databaseName.Equals(operation.DatabaseName, StringComparison.OrdinalIgnoreCase) &&
+                    operation.IsCompleted() == false)
+                {
+                    throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
+                                                        $"process is in progress. In order to delete the database, " +
+                                                        $"you need cancel the restore task first");
+                }
+            }
         }
 
         [RavenAction("/admin/databases/disable", "POST", AuthorizationStatus.Operator)]

--- a/test/SlowTests/Issues/RavenDB-22659.cs
+++ b/test/SlowTests/Issues/RavenDB-22659.cs
@@ -1,0 +1,283 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22659 : ClusterTestBase
+    {
+        public RavenDB_22659(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task CanDeleteDatabaseWhenRestoreCancelled()
+        {
+            var mre = new ManualResetEvent(false);
+            var mre2 = new ManualResetEvent(false);
+            var backupPath = NewDataPath();
+            var db = "NewDatabase";
+            //Cluster with 2 nodes
+            var (nodes, leader) = await CreateRaftCluster(2);
+            await CreateDatabaseInCluster(db, 2, leader.WebUrl);
+            using (var store = new DocumentStore
+            {
+                Database = db,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Toli" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                //Backup
+                var backupOperation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                }));
+                var result = (BackupResult)await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                //Restore
+                var databaseName = $"{store.Database}_Restore";
+                RestoreBackupOperation restoreOperation =
+                    new RestoreBackupOperation(new RestoreBackupConfiguration
+                    { BackupLocation = Path.Combine(backupPath, result.LocalBackup.BackupDirectory), DatabaseName = databaseName });
+
+                foreach (var n in nodes)
+                {
+                    n.ServerStore.ForTestingPurposesOnly().RestoreDatabaseAfterSavingDatabaseRecord += () =>
+                    {
+                        mre.Set();
+                        mre2.WaitOne(); // Wait to ensure the restore process doesn't finish until we intentionally cancel it.
+                    };
+                }
+
+                var restoreTask = await store.Maintenance.Server.SendAsync(restoreOperation);
+
+                var nodeToTakeDown = nodes.First(x => x.ServerStore.NodeTag != restoreTask.NodeTag);
+                var remainingNode = nodes.First(x => x != nodeToTakeDown);
+
+                var res = mre.WaitOne(TimeSpan.FromSeconds(30)); // Wait to ensure the database record is written before disposing of one node.
+                Assert.True(res);
+
+                var disposedNode = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToTakeDown);
+                await restoreTask.KillAsync();
+                mre2.Set();
+
+                var database = await GetDatabase(remainingNode, store.Database);
+                WaitForValue(() =>
+                {
+                    var operation = database.ServerStore.Operations.GetOperation(restoreTask.Id);
+                    return operation.IsCompleted();
+                }, true);
+
+                var revivedNode = GetNewServer(new ServerCreationOptions
+                {
+                    DeletePrevious = false,
+                    RunInMemory = false,
+                    DataDirectory = disposedNode.DataDirectory,
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = disposedNode.Url
+                    }
+                });
+
+                nodes.Add(revivedNode);
+                Servers.Add(revivedNode);
+
+                using (remainingNode.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var topology = remainingNode.ServerStore.Engine.GetTopology(ctx);
+                    Assert.Equal(2, topology.AllNodes.Count);
+                }
+
+                await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, hardDelete: true));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task CannotDeleteDatabaseWhenRestoreCancelledOnNonResponsibleNode()
+        {
+            var mre = new ManualResetEvent(false);
+            var mre2 = new ManualResetEvent(false);
+            var backupPath = NewDataPath();
+            var db = "NewDatabase";
+            //Cluster with 2 nodes
+            var (nodes, leader) = await CreateRaftCluster(2);
+            await CreateDatabaseInCluster(db, 2, leader.WebUrl);
+            using (var store = new DocumentStore
+            {
+                Database = db,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Toli" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                //Backup
+                var backupOperation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                }));
+                var result = (BackupResult)await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                //Restore
+                var databaseName = $"{store.Database}_Restore";
+                RestoreBackupOperation restoreOperation =
+                    new RestoreBackupOperation(new RestoreBackupConfiguration
+                    { BackupLocation = Path.Combine(backupPath, result.LocalBackup.BackupDirectory), DatabaseName = databaseName });
+
+                foreach (var n in nodes)
+                {
+                    n.ServerStore.ForTestingPurposesOnly().RestoreDatabaseAfterSavingDatabaseRecord += () =>
+                    {
+                        mre.Set();
+                        mre2.WaitOne(); // Wait to ensure the restore process doesn't finish until we intentionally cancel it.
+                    };
+                }
+
+                var restoreTask = await store.Maintenance.Server.SendAsync(restoreOperation);
+
+                var nodeToTakeDown = nodes.First(x => x.ServerStore.NodeTag != restoreTask.NodeTag);
+                var remainingNode = nodes.First(x => x != nodeToTakeDown);
+
+                var res = mre.WaitOne(TimeSpan.FromSeconds(30)); // Wait to ensure the database record is written before disposing of one node.
+                Assert.True(res);
+
+                var disposedNode = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToTakeDown);
+                await restoreTask.KillAsync();
+                mre2.Set();
+
+                var database = await GetDatabase(remainingNode, store.Database);
+                WaitForValue(() =>
+                {
+                    var operation = database.ServerStore.Operations.GetOperation(restoreTask.Id);
+                    return operation.IsCompleted();
+                }, true);
+
+                var revivedNode = GetNewServer(new ServerCreationOptions
+                {
+                    DeletePrevious = false,
+                    RunInMemory = false,
+                    DataDirectory = disposedNode.DataDirectory,
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = disposedNode.Url
+                    }
+                });
+
+                nodes.Add(revivedNode);
+                Servers.Add(revivedNode);
+
+                using (remainingNode.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var topology = remainingNode.ServerStore.Engine.GetTopology(ctx);
+                    Assert.Equal(2, topology.AllNodes.Count);
+                }
+
+                using (var store2 = new DocumentStore { Database = db, Urls = new[] { revivedNode.WebUrl }, Conventions = new DocumentConventions { DisableTopologyUpdates = true } }.Initialize())
+                {
+                    var val = await WaitForValueAsync(async () => await store2.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName)) != null, true);
+                    Assert.True(val);
+
+                    var deleteException = await Assert.ThrowsAsync<RavenException>(async () =>
+                    {
+                        await store2.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, hardDelete: true));
+                    });
+                    Assert.Contains("In order to delete the database, you can cancel the restore task from node", deleteException.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport)]
+        public async Task CannotDeleteDatabaseInRestore()
+        {
+            var mre = new ManualResetEvent(false);
+            var mre2 = new ManualResetEvent(false);
+            var backupPath = NewDataPath();
+            var db = "NewDatabase";
+            //Cluster with 2 nodes
+            var (nodes, leader) = await CreateRaftCluster(2);
+            await CreateDatabaseInCluster(db, 2, leader.WebUrl);
+            using (var store = new DocumentStore
+            {
+                Database = db,
+                Urls = new[] { leader.WebUrl }
+            }.Initialize())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Toli" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                //Backup
+                var backupOperation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                }));
+                var result = (BackupResult)await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                //Restore
+                var databaseName = $"{store.Database}_Restore";
+                RestoreBackupOperation restoreOperation =
+                    new RestoreBackupOperation(new RestoreBackupConfiguration
+                    { BackupLocation = Path.Combine(backupPath, result.LocalBackup.BackupDirectory), DatabaseName = databaseName });
+
+                foreach (var n in nodes)
+                {
+                    n.ServerStore.ForTestingPurposesOnly().RestoreDatabaseAfterSavingDatabaseRecord += () =>
+                    {
+                        mre.Set();
+                        mre2.WaitOne(); // Wait to ensure the restore process doesn't finish until we intentionally cancel it.
+                    };
+                }
+
+                await store.Maintenance.Server.SendAsync(restoreOperation);
+
+                var res = mre.WaitOne(TimeSpan.FromSeconds(30));
+                Assert.True(res);
+
+                var deleteException = await Assert.ThrowsAsync<RavenException>(async () =>
+                {
+                    await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(databaseName, hardDelete: true));
+                });
+                Assert.Contains("while the restore process is in progress", deleteException.Message);
+                mre2.Set();
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_19693.cs
+++ b/test/SlowTests/Issues/RavenDB_19693.cs
@@ -28,7 +28,7 @@ public class RavenDB_19693 : RavenTestBase
             var database = await GetDatabase(store.Database);
             var operationId = database.Operations.GetNextOperationId();
             var token = new OperationCancelToken(database.DatabaseShutdown, CancellationToken.None);
-            _ = database.Operations.AddLocalOperation(operationId, OperationType.DumpRawIndexData, "Test Operation", detailedDescription: null, onProgress => DoWorkAsync(onProgress, TimeSpan.FromSeconds(2), token.Token), token);
+            _ = database.Operations.AddLocalOperation(operationId, OperationType.DumpRawIndexData, "Test Operation", detailedDescription: null, onProgress => DoWorkAsync(onProgress, TimeSpan.FromSeconds(2), token.Token), token: token);
 
             var operation = new Operation(store.GetRequestExecutor(), () => store.Changes(store.Database, Server.ServerStore.NodeTag), store.Conventions, operationId, Server.ServerStore.NodeTag);
 
@@ -48,7 +48,7 @@ public class RavenDB_19693 : RavenTestBase
             var database = await GetDatabase(store.Database);
             var operationId = database.Operations.GetNextOperationId();
             var token = new OperationCancelToken(database.DatabaseShutdown, CancellationToken.None);
-            _ = database.Operations.AddLocalOperation(operationId, OperationType.DumpRawIndexData, "Test Operation", detailedDescription: null, onProgress => DoWorkAsync(onProgress, TimeSpan.FromSeconds(5), token.Token), token);
+            _ = database.Operations.AddLocalOperation(operationId, OperationType.DumpRawIndexData, "Test Operation", detailedDescription: null, onProgress => DoWorkAsync(onProgress, TimeSpan.FromSeconds(5), token.Token), token: token);
 
             var operation = new Operation(store.GetRequestExecutor(), () => store.Changes(store.Database, Server.ServerStore.NodeTag), store.Conventions, operationId, Server.ServerStore.NodeTag);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22659

### Additional description

The issue occurred under the following scenario:

You have a 2-node cluster.
Start a database restore operation.
During the restore, take down one of the nodes (not the one handling the restore).
Cancel the restore process.
At this point, the database cannot be deleted because the cluster is not fully operational.
Bring the second node back online.
Attempt to delete the database.
When we tried to delete the database, we encountered an InvalidOperationException with the message: "Can't delete database 'test' while the restore process is in progress." As a result, the database could not be deleted.

To address this, we have now implemented a check to determine if the restore process is still active. This allows us to decide whether the database can be safely deleted or not.


V5.4 PR: https://github.com/ravendb/ravendb/pull/19199

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
