### PR TITLE
RavenDB-22829 delay RefreshOutgoingTasks upon unstable cluster

### DIFF
--- a/src/Raven.Server/ServerWide/DeferrableTimeout.cs
+++ b/src/Raven.Server/ServerWide/DeferrableTimeout.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Sparrow.Threading;
+
+namespace Raven.Server.ServerWide;
+
+public class DeferrableTimeout
+{
+    public class Promise
+    {
+        private readonly TimeSpan _timeout;
+        private TaskCompletionSource _scheduled;
+        private readonly MultipleUseFlag _finished;
+        private DateTime _completeAt;
+
+        public Promise(TimeSpan timeout)
+        {
+            _timeout = timeout;
+            _finished = new MultipleUseFlag(raised: true);
+        }
+
+        public Result ScheduleOrDefer(out Task task) => ScheduleOrDefer(_timeout, out task);
+
+        private Result ScheduleOrDefer(TimeSpan deferBy, out Task task)
+        {
+            _completeAt = DateTime.UtcNow.Add(deferBy);
+            var prev = Interlocked.CompareExchange(ref _scheduled, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null);
+            task = _scheduled!.Task;
+
+            if (prev == null)
+            {
+                Promises.Enqueue(this);
+                return Result.Scheduled;
+            }
+
+            return Result.Deferred;
+        }
+
+        public void Reset() => _finished.Raise();
+
+        protected internal bool TryComplete(DateTime now)
+        {
+            if (_finished.IsRaised() == false)
+                return false;
+
+            if (now >= _completeAt)
+            {
+                _finished.Lower();
+                Interlocked.Exchange(ref _scheduled, null).TrySetResult();
+                return true;
+            }
+
+            return false;
+        }
+
+        public enum Result
+        {
+            Scheduled,
+            Deferred
+        }
+    }
+
+    private static readonly Timer QuarterSecondTimer = new Timer((_) =>
+    {
+        if (Promises.IsEmpty)
+            return;
+
+        var current = Interlocked.Exchange(ref Promises, new ConcurrentQueue<Promise>());
+        var now = DateTime.UtcNow;
+
+        while (current.TryDequeue(out var promise))
+        {
+            if (promise.TryComplete(now) == false)
+                Promises!.Enqueue(promise);
+        }
+    }, state: null, TimeSpan.FromMilliseconds(250), TimeSpan.FromMilliseconds(250));
+
+    private static ConcurrentQueue<Promise> Promises = new ConcurrentQueue<Promise>();
+}

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1004,14 +1004,39 @@ namespace Raven.Server.ServerWide
             if (state.From == RachisState.Passive || state.To == RachisState.Passive ||
                 state.From == RachisState.Candidate || state.To == RachisState.Candidate)
             {
-                ThreadPool.QueueUserWorkItem(async _ =>
-                {
-                    await RefreshOutgoingTasksAsync();
-                }, null);
+                // a special case when we have a transition of candidate -> candidate, we should skip the refresh
+                if (state.From == RachisState.Candidate && state.To == RachisState.Candidate)
+                    return;
+
+                Task.Run(RefreshOutgoingTasksAsync, ServerShutdown);
             }
         }
 
+        private readonly DeferrableTimeout.Promise _current = new DeferrableTimeout.Promise(TimeSpan.FromSeconds(15));
         private async Task RefreshOutgoingTasksAsync()
+        {
+            var r = _current.ScheduleOrDefer(out var task);
+            switch (r)
+            {
+                case DeferrableTimeout.Promise.Result.Scheduled:
+                    try
+                    {
+                        await task;
+                        await RefreshOutgoingTasksAsyncInternal();
+                    }
+                    finally
+                    {
+                        _current.Reset();
+                    }
+                    break;
+                case DeferrableTimeout.Promise.Result.Deferred:
+                    return;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private async Task RefreshOutgoingTasksAsyncInternal()
         {
             var tasks = new Dictionary<string, Task<DocumentDatabase>>();
             foreach (var db in DatabasesLandlord.DatabasesCache)
@@ -1044,6 +1069,7 @@ namespace Raven.Server.ServerWide
                     }
                 }
             }
+
         }
 
         public Dictionary<string, NodeStatus> GetNodesStatuses()

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1032,7 +1032,7 @@ namespace Raven.Server.ServerWide
                 case DeferrableTimeout.Promise.Result.Deferred:
                     return;
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException($"Not supported result type '{r}'");
             }
         }
 

--- a/test/SlowTests/Issues/RavenDB_22829_DeferrableTimerTests.cs
+++ b/test/SlowTests/Issues/RavenDB_22829_DeferrableTimerTests.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Nito.AsyncEx;
+using Raven.Server.ServerWide;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22829_DeferrableTimerTests : NoDisposalNeeded
+    {
+        public RavenDB_22829_DeferrableTimerTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData(1)]
+        [InlineData(10)]
+        public async Task ScheduleOnceDeferManyConcurrently(int promises)
+        {
+            var tasks = new List<Task>();
+            for (int i = 0; i < promises; i++)
+            {
+                var t = ScheduleOnceDeferMany();
+                tasks.Add(t);
+            }
+            await Task.WhenAll(tasks);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task CanReusePromise()
+        {
+            var counter = new State();
+            var p = new DeferrableTimeout.Promise(TimeSpan.FromMilliseconds(100));
+            for (int i = 1; i < 10; i++)
+            {
+                await ScheduleOnceDeferMany(counter, p);
+                Assert.Equal(i, counter.Count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task ReScheduleWhileWorking()
+        {
+            using (var tcs = new CancellationTokenSource(TimeSpan.FromSeconds(15)))
+            {
+                var p = new DeferrableTimeout.Promise(TimeSpan.FromMilliseconds(100));
+                
+                var counter = new State();
+                _ = ScheduleOnceDeferMany(counter, p);
+                await counter.WaitUntilScheduled.WaitAsync(tcs.Token);
+
+                var counter2 = new State();
+                var t = ScheduleOrDefer(p, counter2);
+                await counter2.WaitUntilScheduled.WaitAsync(tcs.Token);
+                var r = await t;
+                Assert.Equal(DeferrableTimeout.Promise.Result.Scheduled, r);
+            }
+        }
+
+        private static Task ScheduleOnceDeferMany() => ScheduleOnceDeferMany(new State(), new DeferrableTimeout.Promise(TimeSpan.FromMilliseconds(100)));
+
+        private static async Task ScheduleOnceDeferMany(State state, DeferrableTimeout.Promise p)
+        {
+            var tasks = new List<Task<DeferrableTimeout.Promise.Result>>();
+            for (int j = 0; j < 10; j++)
+            {
+                var t = Task.Run(() => ScheduleOrDefer(p, state));
+                tasks.Add(t);
+            }
+
+            await Task.WhenAll(tasks);
+
+            var dic = new Dictionary<DeferrableTimeout.Promise.Result, int>
+            {
+                [DeferrableTimeout.Promise.Result.Deferred] = 0,
+                [DeferrableTimeout.Promise.Result.Scheduled] = 0,
+            };
+            foreach (var task in tasks)
+            {
+                var r = await task;
+                dic[r]++;
+            }
+            Assert.Equal(1, dic[DeferrableTimeout.Promise.Result.Scheduled]);
+            Assert.Equal(9, dic[DeferrableTimeout.Promise.Result.Deferred]);
+        }
+
+        private static async Task<DeferrableTimeout.Promise.Result> ScheduleOrDefer(DeferrableTimeout.Promise p, State state)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+            var r = p.ScheduleOrDefer(out var t);
+            switch (r)
+            {
+                case DeferrableTimeout.Promise.Result.Scheduled:
+                    await t;
+                    break;
+                case DeferrableTimeout.Promise.Result.Deferred:
+                    return DeferrableTimeout.Promise.Result.Deferred;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            
+            state.WaitUntilScheduled.Set();
+            await Task.Delay(TimeSpan.FromMilliseconds(100)); // simulate some work
+            state.Count++; // this should be thread safe to do
+            state.WaitUntilScheduled.Reset();
+
+            p.Reset();
+            return DeferrableTimeout.Promise.Result.Scheduled;
+        }
+
+        private class State
+        {
+            public int Count;
+            public AsyncManualResetEvent WaitUntilScheduled = new AsyncManualResetEvent(false);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22829

### Additional description

Whenever we moved to or from a `Candidate` state we would trigger the `RefreshOutgoingTasks` to let the tasks respond to this change and shutdown in case moving into `Candidate` state or start in case of moving from the `Candidate` state.

In the real world it is a problem, because unstable clusters can rapidly and frequently change states, which lead to constant starting and stop of tasks and increase resource consumption in a situation when the cluster/servers are already in trouble.

So the change here is to delay and defer the `RefreshOutgoingTasks` upon state change.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
