### PR TITLE
RavenDB-22846 Cannot restore from backup if the default directory name has been changed

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupValidation.ts
@@ -52,8 +52,8 @@ export const restorePointSchema = yup.object({
     isIncremental: yup.boolean().required(),
     isEncrypted: yup.boolean().required(),
     filesToRestore: yup.number().required(),
-    databaseName: yup.string().required(),
-    nodeTag: yup.string().required(),
+    databaseName: yup.string().nullable(),
+    nodeTag: yup.string().nullable(),
     backupType: yup.string().required(),
 });
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22846

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
