### PR TITLE
RavenDB-22862 Throw exception on attempt to reset auto index side-by-side

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1167,6 +1167,9 @@ namespace Raven.Server.Documents.Indexes
             if (index == null)
                 IndexDoesNotExistException.ThrowFor(name);
 
+            if (index.Type is IndexType.AutoMap or IndexType.AutoMapReduce)
+                throw new NotSupportedException("Side by side index reset is not supported for auto indexes.");
+
             return indexResetMode switch
             {
                 IndexResetMode.InPlace => ResetIndexInternal(index),

--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1167,9 +1167,6 @@ namespace Raven.Server.Documents.Indexes
             if (index == null)
                 IndexDoesNotExistException.ThrowFor(name);
 
-            if (index.Type is IndexType.AutoMap or IndexType.AutoMapReduce)
-                throw new NotSupportedException("Side by side index reset is not supported for auto indexes.");
-
             return indexResetMode switch
             {
                 IndexResetMode.InPlace => ResetIndexInternal(index),
@@ -1526,6 +1523,9 @@ namespace Raven.Server.Documents.Indexes
         {
             if (index.Name.StartsWith(Constants.Documents.Indexing.SideBySideIndexNamePrefix))
                 throw new InvalidOperationException($"Index {index.Name} is already a side-by-side running index.");
+            
+            if (index.Type.IsAuto())
+                throw new NotSupportedException("Side by side index reset is not supported for auto indexes.");
             
             try
             {

--- a/test/SlowTests/Issues/RavenDB-22862.cs
+++ b/test/SlowTests/Issues/RavenDB-22862.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22862 : RavenTestBase
+{
+    public RavenDB_22862(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestIfSideBySideAutoIndexResetThrowsException()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                const string indexName = "Auto/Dtos/ByName";
+                
+                _ = session.Query<Dto>().Where(x => x.Name == "abc").ToList();
+                    
+                var exception = Assert.Throws<RavenException>(() => store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, indexResetMode: IndexResetMode.SideBySide)).ExecuteOnAll());
+
+                Assert.IsType<NotSupportedException>(exception.InnerException);
+                Assert.Contains("Side by side index reset is not supported for auto indexes.", exception.InnerException.Message);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22862/Disable-side-by-side-index-reset-for-auto-indexes

### Additional description

We want to throw relevant exception on attempt to reset auto index side-by-side

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
