### PR TITLE
RavenDB-22821 Corax: Querying should use ReusableTokenStream instead TokenStream due to performance.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneAnalyzerAdapterForQuerying.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneAnalyzerAdapterForQuerying.cs
@@ -27,7 +27,7 @@ internal sealed unsafe class LuceneAnalyzerAdapterForQuerying : LuceneAnalyzerAd
             int currentOutputIdx = 0;
             var currentTokenIdx = 0;
 
-            using var stream = analyzer.TokenStream(null, reader);
+            var stream = analyzer.ReusableTokenStream(null, reader);
             do
             {
                 var offset = stream.GetAttribute<IOffsetAttribute>();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22821

### Additional description
41K `search` queries:
![image](https://github.com/user-attachments/assets/776b1d71-eb73-4030-ae56-cece99a31d90)

Source: https://github.com/ravendb/ravendb/pull/19134#discussion_r1725160900
### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed