### PR TITLE
RavenDB-22873 - Improve the deployment of multiple indexes

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -196,7 +196,7 @@ namespace Raven.Server.Smuggler.Documents
             {
                 if (_batch != null)
                 {
-                    _batch.AddIndex(indexDefinition, _source, _database.Time.GetUtcNow(), RaftIdGenerator.DontCareId, _database.Configuration.Indexing.HistoryRevisionsNumber);
+                    _batch.AddIndex(indexDefinition, _source, _database.Time.GetUtcNow(), RaftIdGenerator.DontCareId);
                     AsyncHelpers.RunSync(_batch.SaveIfNeeded);
                     return;
                 }
@@ -208,7 +208,7 @@ namespace Raven.Server.Smuggler.Documents
             {
                 if (_batch != null)
                 {
-                    _batch.AddIndex(indexDefinition, _source, _database.Time.GetUtcNow(), RaftIdGenerator.DontCareId, _database.Configuration.Indexing.HistoryRevisionsNumber);
+                    _batch.AddIndex(indexDefinition, _source, _database.Time.GetUtcNow(), RaftIdGenerator.DontCareId);
                     AsyncHelpers.RunSync(_batch.SaveIfNeeded);
                     return;
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22873/Improve-the-deployment-of-multiple-indexes

### Additional description

The endpoint that executes `IndexCreation.CreateIndexes` currently deploys indexes one by one.
Deploying indexes one by one generates a separate task for each index that executes the HandleDatabaseRecordChanged. This results in significant pressure on the cluster.
The optimization is achieved by using the approach applied in Smuggler, where indexes are deployed in batches of 50.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
