### PR TITLE
RavenDB-22859: Free space tracking

### DIFF
--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -195,10 +195,20 @@ public unsafe struct StreamBitArray
                 
                 continue;
             }
-            var mask = eq.ExtractMostSignificantBits();
-            var idx = BitOperations.TrailingZeroCount(mask) + i;
-            var item = _inner[idx];
-            count += BitOperations.TrailingZeroCount(~item);
+            for (int j =  i; j < i + Vector256<uint>.Count; j--)
+            {
+                if (_inner[j] == uint.MaxValue)
+                {
+                    count += 32;
+                    if (count >= max)
+                        return true;
+
+                    continue;
+                }
+
+                count += BitOperations.TrailingZeroCount(~_inner[j]);
+                break;
+            }
             break;
         }
 

--- a/src/Voron/VoronConfiguration.cs
+++ b/src/Voron/VoronConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Voron
+{
+    internal static class VoronConfiguration
+    {
+        // PERF: Because all those values are static readonly booleans that are defined during the process of loading the type,
+        // the JIT will detect them as such and will use the values instead. 
+        // https://alexandrnikitin.github.io/blog/jit-optimization-static-readonly-to-const/
+        
+        public static readonly bool FailFastForStability;
+
+        static VoronConfiguration()
+        {
+#if DEBUG
+            FailFastForStability = true;
+#else
+            if (Environment.GetEnvironmentVariable("RAVENDB_Voron_FailFast")?.ToLowerInvariant() == "true")
+            {
+                // We are enabling Voron fail-fast in release mode, this is useful to analyze corruptions even in
+                // release mode. 
+                FailFastForStability = true;
+            }
+#endif
+        }
+    }
+}

--- a/test/FastTests/Voron/NextGenPagers/Bugs.cs
+++ b/test/FastTests/Voron/NextGenPagers/Bugs.cs
@@ -1,8 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using FastTests.Voron.FixedSize;
+using Newtonsoft.Json;
 using Tests.Infrastructure;
 using Voron;
 using Voron.Data.BTrees;
+using Voron.Global;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,6 +16,33 @@ public class Bugs : StorageTest
 {
     public Bugs(ITestOutputHelper output) : base(output)
     {
+    }
+
+    
+    [RavenFact(RavenTestCategory.Voron)]
+    public void FreeSpaceShouldHandleAllocationsOnSectionBoundary()
+    {
+        using  var txw = Env.WriteTransaction();
+        long[] freePages =
+        [
+            3006, 3007, 3008, 3009, 3104, 3126, 3369, 3370, 3371, 3372, 3375, 3417, 3418, 3419, 3420, 3421, 3586, 3587, 3588, 3589, 3590, 3591, 3592, 3593, 3606, 3677,
+            3825, 3826, 3827, 3828, 3829, 3830, 3831, 3832, 3833, 3836, 3837, 3847, 3848, 3858, 3859, 3860, 3861, 3862, 3863, 3864, 3865, 3866, 3899, 3900, 3901, 3931,
+            3932, 3933, 4065, 4066, 4076, 4077, 4087, 4088, 4089, 4090, 4091, 4092, 4093, 4094, 4095, 4096, 4097, 4153, 4154, 4155, 4156, 4157, 4303, 4304, 4305, 4306,
+            4307, 4308, 4309, 4310, 4311, 4312, 4313, 4314, 4315, 4316, 4317, 4318, 4319, 4320, 4321, 4322, 4323, 4324, 4325, 4326, 4327, 4328, 4329, 4330, 4331, 4332,
+            4333, 4334, 4335, 4336, 4337, 4338, 4339, 4340, 4341, 4342, 4343, 4344, 4345, 4346, 4347, 4348, 4349, 4350, 4351, 4352, 4353, 4354, 4355, 4356, 4357, 4358,
+            4359, 4360, 4361, 4362, 4363, 4364, 4365, 4366, 4367, 4368, 4369, 4370, 4371, 4372, 4373, 4374, 4375, 4376, 4377, 4378, 4379, 4380, 4381
+        ];
+        foreach (long fp in freePages)
+        {
+            Env.FreeSpaceHandling.FreePage(txw.LowLevelTransaction, fp);
+        }
+
+        long? value = Env.FreeSpaceHandling.TryAllocateFromFreeSpace(txw.LowLevelTransaction, 16);
+        Assert.NotNull(value);
+        for (int i = 0; i < 16; i++)
+        {
+            Assert.Contains(value.Value + i, freePages);
+        }
     }
 
     [RavenFact(RavenTestCategory.Voron)]

--- a/test/SlowTests/SlowTests/MailingList/Jalchr3.cs
+++ b/test/SlowTests/SlowTests/MailingList/Jalchr3.cs
@@ -63,6 +63,8 @@ namespace SlowTests.SlowTests.MailingList
                             session.Store(user);
                         }
                         session.SaveChanges();
+                       
+                        Indexes.WaitForIndexing(store);
                     }
                 }
 

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -18,6 +18,7 @@ using SlowTests.Issues;
 using SlowTests.Server.Documents.PeriodicBackup;
 using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareEngine;
 using RachisTests;
+using SlowTests.SlowTests.MailingList;
 
 namespace Tryouts;
 
@@ -39,11 +40,16 @@ public static class Program
             try
             {
                 using (var testOutputHelper = new ConsoleTestOutputHelper())
-                using (var test = new AddNodeToClusterTests(testOutputHelper))
+                using (var test = new Jalchr3(testOutputHelper))
                 {
                     DebuggerAttachedTimeout.DisableLongTimespan = true;
                    
-                    await test.AddDatabaseOnDisconnectedNode ();
+                    test.Streaming_documents_will_respect_the_sorting_order(
+                        new RavenTestParameters
+                        {
+                            DatabaseMode = RavenDatabaseMode.Single, 
+                            SearchEngine = RavenSearchEngineMode.Lucene
+                        });
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22859

### Additional description
A failure in tracking free space causes as to fail randomly. Also added the ability to initiate the process with Voron in fail-fast mode which allow us to do selected debug tests in Release mode too. Should be used for running tests.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
