### PR TITLE
RavenDB-22873 - Improve the deployment of multiple indexes

### DIFF
--- a/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
@@ -35,7 +35,7 @@ public abstract class AbstractIndexCreateController
 
     protected abstract string GetDatabaseName();
 
-    protected abstract SystemTime GetDatabaseTime();
+    public abstract SystemTime GetDatabaseTime();
 
     public abstract RavenConfiguration GetDatabaseConfiguration();
 
@@ -202,9 +202,9 @@ public abstract class AbstractIndexCreateController
         return ServerStore.Engine.CommandsVersionManager.CanPutCommand(nameof(PutIndexesCommand));
     }
 
-    public IndexBatchScope CreateIndexBatch()
+    public IndexBatchScope CreateIndexBatch(Action<(long Index, PutIndexesCommand SavedCommand)> onBatchSaved = null)
     {
-        return new IndexBatchScope(this, ServerStore, ServerStore.LicenseManager.GetNumberOfUtilizedCores());
+        return new IndexBatchScope(this, ServerStore, ServerStore.LicenseManager.GetNumberOfUtilizedCores(), onBatchSaved);
     }
 
     private void ValidateAnalyzers(IndexDefinition definition)
@@ -286,34 +286,38 @@ public abstract class AbstractIndexCreateController
         private readonly AbstractIndexCreateController _controller;
         private readonly ServerStore _serverStore;
         private readonly int _numberOfUtilizedCores;
+        private readonly Action<(long Index, PutIndexesCommand SavedCommand)> _onBatchSaved;
 
         private PutIndexesCommand _command;
         private readonly IndexDeploymentMode _defaultAutoDeploymentMode;
         private readonly IndexDeploymentMode _defaultStaticDeploymentMode;
+        private readonly int _historyRevisionsNumber;
 
-        public IndexBatchScope([System.Diagnostics.CodeAnalysis.NotNull] AbstractIndexCreateController controller, [NotNull] ServerStore serverStore, int numberOfUtilizedCores)
+        public IndexBatchScope([System.Diagnostics.CodeAnalysis.NotNull] AbstractIndexCreateController controller, [NotNull] ServerStore serverStore, int numberOfUtilizedCores, Action<(long Index, PutIndexesCommand SavedCommand)> onBatchSaved)
         {
             _controller = controller ?? throw new ArgumentNullException(nameof(controller));
             _serverStore = serverStore ?? throw new ArgumentNullException(nameof(serverStore));
             _numberOfUtilizedCores = numberOfUtilizedCores;
+            _onBatchSaved = onBatchSaved;
 
             var configuration = controller.GetDatabaseConfiguration();
 
             _defaultAutoDeploymentMode = configuration.Indexing.AutoIndexDeploymentMode;
             _defaultStaticDeploymentMode = configuration.Indexing.StaticIndexDeploymentMode;
+            _historyRevisionsNumber = configuration.Indexing.HistoryRevisionsNumber;
         }
 
-        public async ValueTask AddIndexAsync(IndexDefinitionBaseServerSide definition, string source, DateTime createdAt, string raftRequestId, int revisionsToKeep)
+        public async ValueTask AddIndexAsync(IndexDefinitionBaseServerSide definition, string source, DateTime createdAt, string raftRequestId)
         {
             if (_command == null)
-                _command = new PutIndexesCommand(_controller.GetDatabaseName(), source, createdAt, raftRequestId, revisionsToKeep, _defaultAutoDeploymentMode, _defaultStaticDeploymentMode);
+                _command = new PutIndexesCommand(_controller.GetDatabaseName(), source, createdAt, raftRequestId, _historyRevisionsNumber, _defaultAutoDeploymentMode, _defaultStaticDeploymentMode);
 
             if (definition == null)
                 throw new ArgumentNullException(nameof(definition));
 
             if (definition is MapIndexDefinition indexDefinition)
             {
-                await AddIndexAsync(indexDefinition.IndexDefinition, source, createdAt, raftRequestId, revisionsToKeep);
+                await AddIndexAsync(indexDefinition.IndexDefinition, source, createdAt, raftRequestId);
                 return;
             }
 
@@ -325,10 +329,10 @@ public abstract class AbstractIndexCreateController
             _command.Auto.Add(PutAutoIndexCommand.GetAutoIndexDefinition(autoDefinition, indexType));
         }
 
-        public async ValueTask AddIndexAsync(IndexDefinition definition, string source, DateTime createdAt, string raftRequestId, int revisionsToKeep)
+        public async ValueTask AddIndexAsync(IndexDefinition definition, string source, DateTime createdAt, string raftRequestId)
         {
             if (_command == null)
-                _command = new PutIndexesCommand(_controller.GetDatabaseName(), source, createdAt, raftRequestId, revisionsToKeep, _defaultAutoDeploymentMode, _defaultStaticDeploymentMode);
+                _command = new PutIndexesCommand(_controller.GetDatabaseName(), source, createdAt, raftRequestId, _historyRevisionsNumber, _defaultAutoDeploymentMode, _defaultStaticDeploymentMode);
 
             await _controller.ValidateStaticIndexAsync(definition);
 
@@ -381,6 +385,8 @@ public abstract class AbstractIndexCreateController
                 {
                     ThrowIndexCreationException(toe, $". Operation timed out after: {timeout}.");
                 }
+
+                _onBatchSaved?.Invoke((index, _command));
             }
             finally
             {

--- a/src/Raven.Server/Documents/Indexes/DatabaseIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/DatabaseIndexCreateController.cs
@@ -20,7 +20,7 @@ public class DatabaseIndexCreateController : AbstractIndexCreateController
 
     protected override string GetDatabaseName() => _database.Name;
 
-    protected override SystemTime GetDatabaseTime() => _database.Time;
+    public override SystemTime GetDatabaseTime() => _database.Time;
 
     public override RavenConfiguration GetDatabaseConfiguration() => _database.Configuration;
 

--- a/src/Raven.Server/Documents/Indexes/Sharding/ShardedIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/ShardedIndexCreateController.cs
@@ -25,7 +25,7 @@ public sealed class ShardedIndexCreateController : AbstractIndexCreateController
 
     protected override string GetDatabaseName() => _context.DatabaseName;
 
-    protected override SystemTime GetDatabaseTime() => _context.Time;
+    public override SystemTime GetDatabaseTime() => _context.Time;
 
     public override RavenConfiguration GetDatabaseConfiguration() => _context.Configuration;
 

--- a/src/Raven.Server/Smuggler/Documents/Actions/DatabaseIndexActions.cs
+++ b/src/Raven.Server/Smuggler/Documents/Actions/DatabaseIndexActions.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Elastic.Clients.Elasticsearch;
 using JetBrains.Annotations;
 using Org.BouncyCastle.Security.Certificates;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes;
-using Raven.Server.Documents.Indexes.Auto;
 using Raven.Server.Routing;
 using Raven.Server.Smuggler.Documents.Data;
 
@@ -41,7 +39,7 @@ public sealed class DatabaseIndexActions : IIndexActions
 
         if (_batch != null)
         {
-            await _batch.AddIndexAsync(indexDefinition, _source, _time.GetUtcNow(), RaftIdGenerator.DontCareId, _configuration.Indexing.HistoryRevisionsNumber);
+            await _batch.AddIndexAsync(indexDefinition, _source, _time.GetUtcNow(), RaftIdGenerator.DontCareId);
             await _batch.SaveIfNeeded();
             return;
         }
@@ -62,7 +60,7 @@ public sealed class DatabaseIndexActions : IIndexActions
 
         if (_batch != null)
         {
-            await _batch.AddIndexAsync(indexDefinition, _source, _time.GetUtcNow(), RaftIdGenerator.DontCareId, _configuration.Indexing.HistoryRevisionsNumber);
+            await _batch.AddIndexAsync(indexDefinition, _source, _time.GetUtcNow(), RaftIdGenerator.DontCareId);
             await _batch.SaveIfNeeded();
             return;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22873/Improve-the-deployment-of-multiple-indexes

### Additional description

The endpoint that executes `IndexCreation.CreateIndexes` currently deploys indexes one by one.
Deploying indexes one by one generates a separate task for each index that executes the HandleDatabaseRecordChanged. This results in significant pressure on the cluster.
The optimization is achieved by using the approach applied in Smuggler, where indexes are deployed in batches of 50.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
