### PR TITLE
RavenDB-22457 - Fixing test using read only memory

### DIFF
--- a/test/StressTests/Voron/HugeTransactions.cs
+++ b/test/StressTests/Voron/HugeTransactions.cs
@@ -241,7 +241,7 @@ namespace StressTests.Voron
             pager.EnsureContinuous(ref state, 0, bufferSizeInPages);
 
             Console.WriteLine($"AcquirePagePointer. Name: {scratchName}");
-            buffer = pager.AcquirePagePointer(state, ref txState, 0);
+            buffer = state.WriteAddress;
 
             return (pager, state);
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22457 

Fixing a test that used the readonly address instead of the write memory address