### PR TITLE
RavenDB-22872 Ensure we comparing tombstone ID with a document tombstone

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2187,6 +2187,9 @@ namespace Raven.Server.Documents
 
             if (tombstoneKey[tombstoneKey.Size - ConflictedTombstoneOverhead] == SpecialChars.RecordSeparator)
             {
+                if (tombstoneKey.Size - ConflictedTombstoneOverhead != lowerId.Size)
+                    return false;
+
                 return Memory.CompareInline(tombstoneKey.Content.Ptr, lowerId.Content.Ptr, lowerId.Size) == 0;
             }
 

--- a/test/SlowTests/Issues/RavenDB_22872.cs
+++ b/test/SlowTests/Issues/RavenDB_22872.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Util;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22872 : ReplicationTestBase
+    {
+        public RavenDB_22872(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Attachments | RavenTestCategory.Replication)]
+        public async Task ProperCalculationOfTombstoneConflictedId()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var src = GetDocumentStore())
+            using (var dst = GetDocumentStore())
+            {
+                await SetupReplicationAsync(src, dst);
+                await EnsureReplicatingAsync(src, dst);
+
+                var config = Backup.CreateBackupConfiguration(backupPath);
+                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, dst);
+                var operation = new GetPeriodicBackupStatusOperation(backupTaskId);
+
+                var backupStatus = dst.Maintenance.Send(operation);
+                var backupOperationId = backupStatus.Status.LastOperationId;
+
+                var backupOperation = dst.Maintenance.Send(new GetOperationStateOperation(backupOperationId.Value));
+                Assert.Equal(OperationStatus.Completed, backupOperation.Status);
+
+                var backupResult = backupOperation.Result as BackupResult;
+                Assert.Equal(1, backupResult.Documents.ReadCount);
+
+                using (var session = src.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "karmel" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = src.OpenAsyncSession())
+                using (var ms = new MemoryStream(new byte[]{1,2,3,4}))
+                {
+                    session.Advanced.Attachments.Store("users/1", "attachment", ms, "text/csv");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = src.OpenAsyncSession())
+                {
+                    session.Advanced.Attachments.Delete("users/1", "attachment");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = src.OpenAsyncSession())
+                {
+                    session.Delete("users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                await EnsureReplicatingAsync(src, dst);
+
+                var lastEtag = dst.Maintenance.Send(new GetStatisticsOperation()).LastDocEtag;
+                await Backup.RunBackupAndReturnStatusAsync(Server, backupTaskId, dst, isFullBackup: false, expectedEtag: lastEtag);
+
+                // restore the database with a different name
+                var databaseName = $"restored_database-{Guid.NewGuid()}";
+
+                var backupLocation = Directory.GetDirectories(backupPath).First();
+
+                using (ReadOnly(backupLocation))
+                using (Backup.RestoreDatabase(dst, new RestoreBackupConfiguration
+                {
+                    BackupLocation = backupLocation,
+                    DatabaseName = databaseName
+                }))
+                {
+                   // making sure we can finish the restore
+                }
+            }
+        }
+
+        private static IDisposable ReadOnly(string path)
+        {
+            var files = Directory.GetFiles(path);
+            var attributes = new FileInfo(files[0]).Attributes;
+            foreach (string file in files)
+            {
+                File.SetAttributes(file, FileAttributes.ReadOnly);
+            }
+
+            return new DisposableAction(() =>
+            {
+                foreach (string file in files)
+                {
+                    File.SetAttributes(file, attributes);
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22872

### Additional description

In the same schema (different tables) we store tombstones for document and attachments.
We also support having multiple tombstones of the same document for different collections by adding record separator and the etag to the end of the tombstone ID. (e,g. `users/1|596`)

Since we support multiple tombstones we search the schema globally.
To check whether a given tombstone is really belongs to the document we compare the ids of them both.
Part of the check is doing this:
```
if (tombstoneKey[tombstoneKey.Size - ConflictedTombstoneOverhead] == SpecialChars.RecordSeparator)
{
    return Memory.CompareInline(tombstoneKey.Content.Ptr, lowerId.Content.Ptr, lowerId.Size) == 0;
}
```

The problem here is that attachment tombstone has the format of `lowerDocumentId|d|lowerName|hash|lowerContentType`
So if the `lowerContentType` is exactly the size of `ConflictedTombstoneOverhead` from above, we will identify an attachment tombstone as a document tombstone.

to avoid this we check the exact size as well by:
```
if (tombstoneKey.Size - ConflictedTombstoneOverhead != lowerId.Size)
    return false;
```

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
