### PR TITLE
RavenDB-22883 - Use a single cancellation token for the entire write process of the response

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AttachmentHandler.cs
@@ -103,10 +103,14 @@ namespace Raven.Server.Documents.Handlers
                         attachment.Size = attachment.Stream.Length;
                         attachmentsStreams.Add(attachment.Stream);
                         WriteAttachmentDetails(writer, attachment, id);
+
+                        await writer.MaybeFlushAsync(Database.DatabaseShutdown);
                     }
 
                     writer.WriteEndArray();
                     writer.WriteEndObject();
+
+                    await writer.FlushAsync(Database.DatabaseShutdown);
                 }
 
                 using (context.GetMemoryBuffer(out var buffer))


### PR DESCRIPTION
…process of the response.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22883/StressTests.Client.Attachments.AttachmentsStreamStress.CanGetListOfHugeAttachmentsAndReadOrderedcount-3-size-2147516414

### Additional description

Use a single cancellation token for the entire write process of the response.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
