### PR TITLE
RavenDB-22885 - Use the correct cancellation token for the operation

### DIFF
--- a/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsertHandler.cs
@@ -121,7 +121,7 @@ namespace Raven.Server.Documents.Handlers
 
                                     if (commandData.Type == CommandType.AttachmentPUT)
                                     {
-                                        commandData.AttachmentStream = await WriteAttachment(commandData.ContentLength, parser.GetBlob(commandData.ContentLength));
+                                        commandData.AttachmentStream = await WriteAttachment(commandData.ContentLength, parser.GetBlob(commandData.ContentLength), token);
                                     }
 
                                     (long size, int opsCount) = GetSizeAndOperationsCount(commandData);
@@ -217,7 +217,7 @@ namespace Raven.Server.Documents.Handlers
 
         private List<StreamsTempFile> _streamsTempFiles;
 
-        private async Task<BatchHandler.MergedBatchCommand.AttachmentStream> WriteAttachment(long size, Stream stream)
+        private async Task<BatchHandler.MergedBatchCommand.AttachmentStream> WriteAttachment(long size, Stream stream, CancellationToken token)
         {
             var attachmentStream = new BatchHandler.MergedBatchCommand.AttachmentStream();
 
@@ -238,8 +238,8 @@ namespace Raven.Server.Documents.Handlers
 
             using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
             {
-                attachmentStream.Hash = await AttachmentsStorageHelper.CopyStreamToFileAndCalculateHash(ctx, stream, attachmentStream.Stream, Database.DatabaseShutdown);
-                await attachmentStream.Stream.FlushAsync();
+                attachmentStream.Hash = await AttachmentsStorageHelper.CopyStreamToFileAndCalculateHash(ctx, stream, attachmentStream.Stream, token);
+                await attachmentStream.Stream.FlushAsync(token);
             }
 
             return attachmentStream;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22885/StressTests.Client.Attachments.BulkInsertAttachmentsStress.StoreManyAttachmentsAndDocsStresscount-1000-attachments-100-size

### Additional description

Use the correct cancellation token for the operation.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
