### PR TITLE
RavenDB-22794 Add comments for operations that implements IMaintenanceOperation

### DIFF
--- a/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesOperation.cs
@@ -9,10 +9,17 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.TimeSeries
 {
+    /// <summary>
+    /// Configures time series settings (policies) for the database.
+    /// This operation allows you to configure multiple time series policies 
+    /// for various collections within the database.
+    /// </summary>
     public sealed class ConfigureTimeSeriesOperation : IMaintenanceOperation<ConfigureTimeSeriesOperationResult>
     {
         private readonly TimeSeriesConfiguration _configuration;
 
+        /// <inheritdoc cref="ConfigureTimeSeriesOperation"/>
+        /// <param name="configuration">The time series configuration to apply to the database. If null, an empty configuration will be used.</param>
         public ConfigureTimeSeriesOperation(TimeSeriesConfiguration configuration)
         {
             _configuration = configuration ?? new TimeSeriesConfiguration();

--- a/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesPolicyOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesPolicyOperation.cs
@@ -75,8 +75,10 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         }
     }
 
+    /// <inheritdoc cref="ConfigureTimeSeriesPolicyOperation"/>
     public sealed class ConfigureRawTimeSeriesPolicyOperation : ConfigureTimeSeriesPolicyOperation
     {
+        /// <inheritdoc cref="ConfigureTimeSeriesPolicyOperation(string, TimeSeriesPolicy)"/>
         public ConfigureRawTimeSeriesPolicyOperation(string collection, RawTimeSeriesPolicy config) : base(collection, config)
         {
         }

--- a/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesPolicyOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesPolicyOperation.cs
@@ -9,11 +9,17 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.TimeSeries
 {
+    /// <summary>
+    /// Configure a time series policy for a specific collection.
+    /// </summary>
     public class ConfigureTimeSeriesPolicyOperation : IMaintenanceOperation<ConfigureTimeSeriesOperationResult>
     {
         private readonly string _collection;
         private readonly TimeSeriesPolicy _config;
 
+        /// <inheritdoc cref="ConfigureTimeSeriesPolicyOperation"/>
+        /// <param name="collection">The name of the collection for which the time series policy is being configured.</param>
+        /// <param name="config">The time series policy configuration to apply to the collection.</param>
         public ConfigureTimeSeriesPolicyOperation(string collection, TimeSeriesPolicy config)
         {
             _collection = collection;

--- a/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesPolicyOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesPolicyOperation.cs
@@ -84,11 +84,17 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         }
     }
 
+    /// <summary>
+    /// Operation to remove a time series policy from a specific collection.
+    /// </summary>
     public sealed class RemoveTimeSeriesPolicyOperation : IMaintenanceOperation<ConfigureTimeSeriesOperationResult>
     {
         private readonly string _collection;
         private readonly string _name;
 
+        /// <inheritdoc cref="RemoveTimeSeriesPolicyOperation"/>
+        /// <param name="collection">The name of the collection from which the time series policy will be removed. Cannot be null.</param>
+        /// <param name="name">The name of the time series policy to remove. Cannot be null.</param>
         public RemoveTimeSeriesPolicyOperation(string collection, string name)
         {
             _collection = collection ?? throw new ArgumentNullException(nameof(name));

--- a/src/Raven.Client/ServerWide/Operations/Configuration/GetDatabaseSettingsOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Configuration/GetDatabaseSettingsOperation.cs
@@ -8,10 +8,16 @@ using Sparrow.Json;
 
 namespace Raven.Client.ServerWide.Operations.Configuration
 {
+    /// <summary>
+    /// Retrieves settings from the database record, including: Database topology, Ongoing task configurations, Index information, Revision settings, 
+    /// and other relevant database configurations.
+    /// </summary>
     public sealed class GetDatabaseSettingsOperation : IMaintenanceOperation<DatabaseSettings>
     {
         private readonly string _databaseName;
 
+        /// <inheritdoc cref="GetDatabaseSettingsOperation"/>
+        /// <param name="databaseName">The name of the database whose settings will be retrieved. Cannot be null.</param>
         public GetDatabaseSettingsOperation(string databaseName)
         {
             _databaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseName));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22794/Add-comments-for-operations-that-implements-IMaintenanceOperationT

### Additional description

Files in this PR:

- `GetDatabaseSettingsOperation (in Raven.Client.ServerWide.Operations.Configuration)`
- `ConfigureTimeSeriesPolicyOperation (in Raven.Client.Documents.Operations.TimeSeries)`
- `ConfigureRawTimeSeriesPolicyOperation (in Raven.Client.Documents.Operations.TimeSeries)`
- `RemoveTimeSeriesPolicyOperation (in Raven.Client.Documents.Operations.TimeSeries)`
- `ConfigureTimeSeriesOperation (in Raven.Client.Documents.Operations.TimeSeries)`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
