### PR TITLE
RavenDB-22899 - Set the ReadTimeout and the WriteTimeout from a single place

### DIFF
--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -54,7 +54,7 @@ namespace Raven.Client.Util
                     var streamReadTimeout = _stream.ReadTimeout;
                     if (streamReadTimeout > 0)
                     {
-                        _readTimeout = streamReadTimeout;
+                        ReadTimeout = streamReadTimeout;
                         return;
                     }
 
@@ -65,7 +65,7 @@ namespace Raven.Client.Util
                     catch
                     {
                         if (streamReadTimeout <= _readTimeout)
-                            _readTimeout = streamReadTimeout;
+                            ReadTimeout = streamReadTimeout;
                         else
                             _canBaseStreamTimeoutOnRead = false;
                     }
@@ -89,7 +89,7 @@ namespace Raven.Client.Util
                     var streamWriteTimeout = _stream.WriteTimeout;
                     if (streamWriteTimeout > 0)
                     {
-                        _writeTimeout = streamWriteTimeout;
+                        WriteTimeout = streamWriteTimeout;
                         return;
                     }
                     try
@@ -99,7 +99,7 @@ namespace Raven.Client.Util
                     catch
                     {
                         if (streamWriteTimeout <= _writeTimeout)
-                            _writeTimeout = streamWriteTimeout;
+                            WriteTimeout = streamWriteTimeout;
                         else
                             _canBaseStreamTimeoutOnWrite = false;
                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22899/Subscription-errors-after-nightly-6.1-RavenDB-Client-update

### Additional description

The subscription connection is setting the network stream timeout to 30 seconds, but we haven't set `_minimumReadDelayTimeInMs` or `_minimumWriteDelayTimeInMs`. Due to recent changes in `StreamWithTimeout`, we didn't apply `CancelAfter` at the appropriate time.

It's set here:
https://github.com/ravendb/ravendb/blob/2b79129d7f38fdc039345dff3bb32cd692d50c9e/src/Raven.Client/Util/StreamWithTimeout.cs#L123
and here:
https://github.com/ravendb/ravendb/blob/2b79129d7f38fdc039345dff3bb32cd692d50c9e/src/Raven.Client/Util/StreamWithTimeout.cs#L136

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
