### PR TITLE
RavenDB-22866 Indexes view: Change split Reset button to dropdown

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -366,7 +366,10 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                         )}
                         {hasDatabaseWriteAccess && (
                             <>
-                                <ResetIndexesButton resetIndex={resetIndex} isDropdownVisible={!isReplacement} />
+                                <ResetIndexesButton
+                                    resetIndex={resetIndex}
+                                    sideBySideDisabledReason={getSideBySideResetDisabledReason(index)}
+                                />
                                 <Button color="danger" onClick={deleteIndex} title="Delete the index">
                                     <Icon icon="trash" margin="m-0" />
                                 </Button>
@@ -559,3 +562,14 @@ function ReferencedCollections({ collections }: ReferencedCollectionsProps) {
 export default ReferencedCollections;
 
 const indexUniqueId = (index: IndexSharedInfo) => "index_" + index.name;
+
+function getSideBySideResetDisabledReason(index: IndexSharedInfo) {
+    if (IndexUtils.isSideBySide(index)) {
+        return "Replacement cannot be reset side by side";
+    }
+    if (IndexUtils.isAutoIndex(index)) {
+        return "Auto index cannot be reset side by side";
+    }
+
+    return null;
+}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexSelectActions.tsx
@@ -26,7 +26,6 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
     const {
         indexNames,
         selectedIndexes,
-        replacements,
         deleteSelectedIndexes,
         startSelectedIndexes,
         disableSelectedIndexes,
@@ -41,8 +40,6 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
     // TODO: IDK I just wanted it to compile
 
     const selectionState = genUtils.getSelectionState(indexNames, selectedIndexes);
-
-    const isResetDropdownVisible = !replacements.some((x) => selectedIndexes.includes(x.name));
 
     return (
         <div className="position-relative">
@@ -124,13 +121,7 @@ export default function IndexSelectAction(props: IndexSelectActionProps) {
                                 </DropdownItem>
                             </DropdownMenu>
                         </UncontrolledDropdown>
-
-                        <ResetIndexesButton
-                            resetIndex={resetSelectedIndexes}
-                            isDropdownVisible={isResetDropdownVisible}
-                            isRounded
-                        />
-
+                        <ResetIndexesButton isRounded resetIndex={resetSelectedIndexes} />
                         <Button
                             color="danger"
                             disabled={selectedIndexes.length === 0}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -60,6 +60,7 @@ export function IndexesPage(props: IndexesPageProps) {
         replacements,
         highlightCallback,
         confirmSetLockModeSelectedIndexes,
+        allIndexes,
         allIndexesCount,
         setIndexPriority,
         startIndexes,
@@ -82,7 +83,10 @@ export function IndexesPage(props: IndexesPageProps) {
     const disableSelectedIndexes = () => disableIndexes(getSelectedIndexes());
     const pauseSelectedIndexes = () => pauseIndexes(getSelectedIndexes());
     const resetSelectedIndexes = (mode?: Raven.Client.Documents.Indexes.IndexResetMode) => {
-        return resetIndexData.openConfirm(selectedIndexes, mode);
+        return resetIndexData.openConfirm(
+            allIndexes.filter((x) => selectedIndexes.includes(x.name)),
+            mode
+        );
     };
 
     const indexNames = getAllIndexes(groups, replacements).map((x) => x.name);

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
@@ -57,7 +57,7 @@ export default function IndexesPageList({
                             setLockMode={(l) => setIndexLockMode(index, l)}
                             globalIndexingStatus={globalIndexingStatus}
                             resetIndex={(mode?: Raven.Client.Documents.Indexes.IndexResetMode) =>
-                                resetIndexData.openConfirm([index.name], mode)
+                                resetIndexData.openConfirm([index], mode)
                             }
                             openFaulty={(location: databaseLocationSpecifier) => openFaulty(index, location)}
                             startIndexing={() => startIndexes([index])}
@@ -95,7 +95,9 @@ export default function IndexesPageList({
                                 setPriority={(p) => setIndexPriority(replacement, p)}
                                 setLockMode={(l) => setIndexLockMode(replacement, l)}
                                 globalIndexingStatus={globalIndexingStatus}
-                                resetIndex={() => resetIndexData.openConfirm([replacement.name], "InPlace")}
+                                resetIndex={(mode?: Raven.Client.Documents.Indexes.IndexResetMode) =>
+                                    resetIndexData.openConfirm([replacement], mode)
+                                }
                                 openFaulty={(location: databaseLocationSpecifier) => openFaulty(replacement, location)}
                                 startIndexing={() => startIndexes([replacement])}
                                 disableIndexing={() => disableIndexes([replacement])}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/partials/ResetIndexesButton.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/partials/ResetIndexesButton.tsx
@@ -1,40 +1,46 @@
 import classNames from "classnames";
+import { ConditionalPopover } from "components/common/ConditionalPopover";
 import { Icon } from "components/common/Icon";
 import React from "react";
-import { UncontrolledDropdown, Button, DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
+import { UncontrolledDropdown, DropdownToggle, DropdownMenu, DropdownItem } from "reactstrap";
 
 interface ResetIndexesButtonProps {
     resetIndex: (mode?: Raven.Client.Documents.Indexes.IndexResetMode) => void;
-    isDropdownVisible?: boolean;
     isRounded?: boolean;
+    sideBySideDisabledReason?: string;
 }
 
-export default function ResetIndexesButton({ resetIndex, isDropdownVisible, isRounded }: ResetIndexesButtonProps) {
+export default function ResetIndexesButton({
+    resetIndex,
+    isRounded,
+    sideBySideDisabledReason,
+}: ResetIndexesButtonProps) {
     return (
         <UncontrolledDropdown group>
-            <Button
-                onClick={() => resetIndex()}
-                title="Reset index (rebuild)"
-                color="warning"
-                className={classNames({ "rounded-pill": isRounded && !isDropdownVisible })}
-            >
+            <DropdownToggle caret color="warning" className={classNames({ "rounded-pill": isRounded })}>
                 <Icon icon="reset-index" margin="m-0" />
-            </Button>
-            {isDropdownVisible && (
-                <>
-                    <DropdownToggle className="dropdown-toggle" color="warning" />
-                    <DropdownMenu end>
-                        <DropdownItem onClick={() => resetIndex("InPlace")} title="Reset index in place">
-                            <Icon icon="reset-index" addon="arrow-down" />
-                            Reset in place
-                        </DropdownItem>
-                        <DropdownItem onClick={() => resetIndex("SideBySide")} title="Reset index side by side">
-                            <Icon icon="reset-index" addon="swap" />
-                            Reset side by side
-                        </DropdownItem>
-                    </DropdownMenu>
-                </>
-            )}
+            </DropdownToggle>
+            <DropdownMenu end>
+                <DropdownItem onClick={() => resetIndex("InPlace")} title="Reset index in place">
+                    <Icon icon="reset-index" addon="arrow-down" />
+                    Reset in place
+                </DropdownItem>
+                <ConditionalPopover
+                    conditions={{
+                        isActive: !!sideBySideDisabledReason,
+                        message: sideBySideDisabledReason,
+                    }}
+                >
+                    <DropdownItem
+                        onClick={() => resetIndex("SideBySide")}
+                        title="Reset index side by side"
+                        disabled={!!sideBySideDisabledReason}
+                    >
+                        <Icon icon="reset-index" addon="swap" />
+                        Reset side by side
+                    </DropdownItem>
+                </ConditionalPopover>
+            </DropdownMenu>
         </UncontrolledDropdown>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -48,11 +48,11 @@ type IndexEvent =
 
 export interface ResetIndexesData {
     confirmData: {
-        indexNames: string[];
-        mode?: Raven.Client.Documents.Indexes.IndexResetMode;
+        indexes: IndexSharedInfo[];
+        mode: Raven.Client.Documents.Indexes.IndexResetMode;
     };
-    onConfirm: (contexts: DatabaseActionContexts[]) => Promise<void>;
-    openConfirm: (indexNames: string[], mode?: Raven.Client.Documents.Indexes.IndexResetMode) => void;
+    onConfirm: (indexNames: string[], contexts: DatabaseActionContexts[]) => Promise<void>;
+    openConfirm: (indexes: IndexSharedInfo[], mode: Raven.Client.Documents.Indexes.IndexResetMode) => void;
     closeConfirm: () => void;
 }
 
@@ -83,11 +83,8 @@ export function useIndexesPage(stale: boolean) {
 
     const [resetIndexesConfirmData, setResetIndexesConfirmData] = useState<ResetIndexesData["confirmData"]>(null);
 
-    const openResetIndexConfirm = (indexNames: string[], mode?: Raven.Client.Documents.Indexes.IndexResetMode) => {
-        setResetIndexesConfirmData({
-            indexNames,
-            mode,
-        });
+    const openResetIndexConfirm = (indexes: IndexSharedInfo[], mode: Raven.Client.Documents.Indexes.IndexResetMode) => {
+        setResetIndexesConfirmData({ indexes, mode });
     };
 
     const closeResetIndexConfirm = () => {
@@ -564,12 +561,12 @@ export function useIndexesPage(stale: boolean) {
         }
     };
 
-    const onResetIndexConfirm = async (contexts: DatabaseActionContexts[]) => {
+    const onResetIndexConfirm = async (indexNames: string[], contexts: DatabaseActionContexts[]) => {
         eventsCollector.reportEvent("indexes", "reset");
         const resetRequests: Promise<void>[] = [];
         setResettingIndex(true);
 
-        for (const indexName of resetIndexesConfirmData.indexNames) {
+        for (const indexName of indexNames) {
             try {
                 for (const { nodeTag, shardNumbers } of contexts) {
                     const locations = ActionContextUtils.getLocations(nodeTag, shardNumbers);
@@ -734,6 +731,7 @@ export function useIndexesPage(stale: boolean) {
         swapNowProgress,
         highlightCallback,
         confirmSetLockModeSelectedIndexes,
+        allIndexes: stats.indexes,
         allIndexesCount: stats.indexes.length,
         setIndexPriority,
         getSelectedIndexes,

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/RestorePointField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/RestorePointField.tsx
@@ -92,7 +92,7 @@ export default function CreateDatabaseFromBackupRestorePoint({
                         options={restorePointsOptions}
                         components={{
                             GroupHeading: RestorePointGroupHeading,
-                            Option: RestorePointOption,
+                            Option: RestorePointOptionComponent,
                         }}
                         isLoading={isLoading}
                         isDisabled={isLoading || flatOptionsCount === 0 || formState.isSubmitting}
@@ -160,7 +160,7 @@ const RestorePointGroupHeading = (props: GroupHeadingProps<SelectOption<RestoreP
     );
 };
 
-function RestorePointOption(props: OptionProps<RestorePointOption>) {
+function RestorePointOptionComponent(props: OptionProps<RestorePointOption>) {
     const {
         data: { value, disabledReason },
     } = props;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22866/Indexes-view-Change-split-Reset-button-to-dropdown

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
