### PR TITLE
RavenDB-22777 Fix cut popovers in database creator

### DIFF
--- a/src/Raven.Studio/typescript/components/common/ConditionalPopover.tsx
+++ b/src/Raven.Studio/typescript/components/common/ConditionalPopover.tsx
@@ -23,7 +23,7 @@ export function ConditionalPopover(props: ConditionalPopoverProps) {
 
     return (
         <>
-            <div id={containerId} className="d-flex">
+            <div id={containerId} className="d-flex w-fit-content">
                 {children}
             </div>
 

--- a/src/Raven.Studio/typescript/components/common/LicenseRestrictedMessage.tsx
+++ b/src/Raven.Studio/typescript/components/common/LicenseRestrictedMessage.tsx
@@ -8,8 +8,8 @@ export function LicenseRestrictedMessage({ children }: PropsWithChildren) {
     return (
         <>
             {children}
-            <div className="text-center mt-2">
-                <a href={buyLink} target="_blank" className="btn btn-primary btn-xs rounded-pill">
+            <div className="mt-2">
+                <a href={buyLink} target="_blank" className="btn btn-primary btn-sm rounded-pill">
                     Licensing options <Icon icon="newtab" margin="ms-1" />
                 </a>
             </div>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/CreateDatabaseFromBackupStepBasicInfo.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/CreateDatabaseFromBackupStepBasicInfo.tsx
@@ -34,6 +34,7 @@ export default function CreateDatabaseFromBackupStepBasicInfo() {
                         name="basicInfoStep.databaseName"
                         id="DbName"
                         placeholder="Database Name"
+                        autoComplete="off"
                     />
                 </Col>
             </Row>

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/CreateDatabaseFromBackupStepSource.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/steps/source/CreateDatabaseFromBackupStepSource.tsx
@@ -159,7 +159,7 @@ function IsEncryptedField({ isRestorePointSnapshot, isRestorePointEncrypted }: I
                     ),
                 },
             ]}
-            popoverPlacement="left"
+            popoverPlacement="top"
         >
             <FormSwitch color="primary" control={control} name="sourceStep.isEncrypted" disabled={isEncryptionDisabled}>
                 <Icon icon="encryption" />

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepBasicInfo.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepBasicInfo.tsx
@@ -52,6 +52,7 @@ export default function CreateDatabaseRegularStepBasicInfo() {
                         name="basicInfoStep.databaseName"
                         placeholder="Database Name"
                         id="DbName"
+                        autoComplete="off"
                     />
                 </Col>
             </Row>
@@ -82,7 +83,7 @@ function IsEncryptedField() {
                         message: <AuthenticationOffMessage />,
                     },
                 ]}
-                popoverPlacement="left"
+                popoverPlacement="top"
             >
                 <FormSwitch
                     color="primary"

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepReplicationAndSharding.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepReplicationAndSharding.tsx
@@ -107,7 +107,7 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
                             <Icon id="ReplicationInfo" icon="info" color="info" margin="m-0" /> Available nodes:{" "}
                             <UncontrolledPopover
                                 target="ReplicationInfo"
-                                placement="left"
+                                placement="right"
                                 trigger="hover"
                                 className="bs5"
                             >
@@ -231,11 +231,11 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
                             message: (
                                 <LicenseRestrictedMessage>
                                     Current license doesn&apos;t include{" "}
-                                    <strong>Dynamic database distribution feature</strong>.
+                                    <strong className="text-info">Dynamic database distribution feature</strong>.
                                 </LicenseRestrictedMessage>
                             ),
                         }}
-                        popoverPlacement="left"
+                        popoverPlacement="top"
                     >
                         <FormSwitch
                             control={control}
@@ -266,7 +266,7 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
                                     "You need to select nodes manually because the encryption is enabled and there are more than 1 nodes in cluster.",
                             },
                         ]}
-                        popoverPlacement="left"
+                        popoverPlacement="top"
                     >
                         <FormSwitch
                             control={control}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/shared/EncryptionUnavailableMessage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/shared/EncryptionUnavailableMessage.tsx
@@ -6,7 +6,7 @@ export default function EncryptionUnavailableMessage() {
     return (
         <LicenseRestrictedMessage>
             Current license doesn&apos;t include{" "}
-            <strong className="text-primary nobr">
+            <strong className="text-info nobr">
                 <Icon icon="storage" addon="encryption" margin="m-0" /> Storage encryption
             </strong>
             .

--- a/src/Raven.Studio/wwwroot/Content/scss/bs5variables.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/bs5variables.scss
@@ -1158,8 +1158,8 @@ $popover-header-padding-y: 0.5rem !default;
 $popover-header-padding-x: $spacer !default;
 
 $popover-body-color: var(--#{$prefix}body-color) !default;
-$popover-body-padding-y: $spacer !default;
-$popover-body-padding-x: $spacer !default;
+$popover-body-padding-y: $gutter-sm !default;
+$popover-body-padding-x: $gutter-sm !default;
 
 $popover-arrow-width: 1rem !default;
 $popover-arrow-height: 0.5rem !default;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22777

### Additional description

Fixed positioning of popovers for new database creators to prevent them being cut on lower resolutions

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
