### PR TITLE
RavenDB-22931 ConditionalLoadAsync fix

### DIFF
--- a/test/SlowTests/Issues/Issue_19302.cs
+++ b/test/SlowTests/Issues/Issue_19302.cs
@@ -1,0 +1,74 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class Issue_19302 : RavenTestBase
+    {
+        public Issue_19302(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ConditionalLoadAsync_InSameSession(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "RavenDB" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                string cv;
+                using (var newSession = store.OpenAsyncSession())
+                {
+                    var user = await newSession.LoadAsync<User>("users/1");
+                    cv = newSession.Advanced.GetChangeVectorFor(user);
+                    Assert.NotNull(user);
+                    Assert.Equal(user.Name, "RavenDB");
+                    user.Name = "RavenDB Async";
+                    await newSession.SaveChangesAsync();
+
+                    var conditional = await newSession.Advanced.ConditionalLoadAsync<User>("users/1", cv);
+
+                    Assert.Equal(conditional.Entity.Name, "RavenDB Async");
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void ConditionalLoad_InSameSession(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "RavenDB" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                string cv;
+                using (var newSession = store.OpenSession())
+                {
+                    var user = newSession.Load<User>("users/1");
+                    cv = newSession.Advanced.GetChangeVectorFor(user);
+                    Assert.NotNull(user);
+                    Assert.Equal(user.Name, "RavenDB");
+                    user.Name = "RavenDB Sync";
+                    newSession.SaveChanges();
+
+                    var conditional = newSession.Advanced.ConditionalLoad<User>("users/1", cv);
+
+                    Assert.Equal(conditional.Entity.Name, "RavenDB Sync");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22931

### Additional description

The issue occurred because we attempted to invoke the AsyncTaskHolder twice, with one call nested inside the other.
The fix was to move the LoadAsync call outside the AsyncTaskHolder block. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
