### PR TITLE
RavenDB-22530 When editing SQL ETL place a warning there that the connection string is using a factory that is depracated

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editSqlEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editSqlEtlTask.ts
@@ -192,7 +192,9 @@ class editSqlEtlTask extends viewModelBase {
     editedSqlTableSandbox = ko.observable<ongoingTaskSqlEtlTableModel>();
 
     possibleMentors = ko.observableArray<string>([]);
-    sqlEtlConnectionStringsNames = ko.observableArray<string>([]);
+    sqlEtlConnectionStrings = ko.observable<Record<string, Raven.Client.Documents.Operations.ETL.SQL.SqlConnectionString>>({});
+    sqlEtlConnectionStringsNames = ko.pureComputed(() => _.sortBy(Object.keys(this.sqlEtlConnectionStrings() ?? {}), (x: string) => x.toUpperCase()));
+    selectedConnectionStringFactoryName = ko.pureComputed(() => this.sqlEtlConnectionStrings()[this.editedSqlEtl().connectionStringName()]?.FactoryName);
 
     connectionStringDefined: KnockoutComputed<boolean>;
     testConnectionResult = ko.observable<Raven.Server.Web.System.NodeConnectionTestResult>();
@@ -295,8 +297,7 @@ class editSqlEtlTask extends viewModelBase {
         return new getConnectionStringsCommand(this.activeDatabase())
             .execute()
             .done((result: Raven.Client.Documents.Operations.ConnectionStrings.GetConnectionStringsResult) => {
-                const connectionStringsNames = Object.keys(result.SqlConnectionStrings);
-                this.sqlEtlConnectionStringsNames(_.sortBy(connectionStringsNames, x => x.toUpperCase()));
+                this.sqlEtlConnectionStrings(result.SqlConnectionStrings);
             });
     }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
@@ -85,8 +85,29 @@
                                         </li>
                                     </ul>
                                     <span class="help-block" data-bind="validationMessage: connectionStringName"></span>
+                                    <div class="has-warning" data-bind="visible: $root.selectedConnectionStringFactoryName() === 'MySql.Data.MySqlClient'">
+                                        <div class="help-block">
+                                            <i class="icon-warning"></i>
+                                            <span>
+                                                This connector is deprecated. 
+                                                MySqlConnector will be used instead. 
+                                                Please update Factory to: MySqlConnector.MySqlConnectorFactory.
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <div class="has-warning" data-bind="visible: $root.selectedConnectionStringFactoryName() === 'System.Data.SqlClient'">
+                                        <div class="help-block">
+                                            <i class="icon-warning"></i>
+                                            <span>
+                                                This connector is deprecated. 
+                                                Microsoft SqlClient will be used instead. 
+                                                Please update Factory to: Microsoft.Data.SqlClient.
+                                            </span>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
+                            
                             <div class="flex-horizontal">
                                 <div class="flex-grow margin-top">
                                     <button type="button" class="btn btn-info" data-bind="click: $root.toggleAdvancedArea">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22530/When-editing-SQL-ETL-place-a-warning-there-that-the-connection-string-is-using-a-factory-that-is-depracated

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
