### PR TITLE
RavenDB-22502 Error modifying a document by a non-cluster session after it was created in a cluster-wide transaction

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -40,6 +40,8 @@ namespace Raven.Client
 
             public const string LastKnownClusterTransactionIndex = "Known-Raft-Index";
 
+            public const string DatabaseClusterTransactionId = "Database-Cluster-Tx-Id";
+
             public const string RefreshClientConfiguration = "Refresh-Client-Configuration";
 
             public const string Etag = "ETag";

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -37,6 +37,7 @@ using Raven.Client.Json.Serialization;
 using Raven.Client.Util;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Utils;
 
 namespace Raven.Client.Documents.Session
 {
@@ -2449,6 +2450,15 @@ more responsive application.
 
                 public void UpdateEntityDocumentInfo(DocumentInfo documentInfo, BlittableJsonReaderObject document)
                 {
+                    var clusterId = _session.SessionInfo?.ClusterTransactionId;
+                    if (clusterId is not null)
+                    {
+                        var clusterTxIndex = ClientChangeVectorUtils.GetEtagById(documentInfo.ChangeVector, clusterId);
+                        if (clusterTxIndex > 0)
+                        {
+                            _session.SessionInfo.LastClusterTransactionIndex = Math.Max(_session.SessionInfo.LastClusterTransactionIndex ?? 0, clusterTxIndex);
+                        }
+                    }
                     _documentInfosToUpdate.Add((documentInfo, document));
                 }
 

--- a/src/Raven.Client/Documents/Session/SessionInfo.cs
+++ b/src/Raven.Client/Documents/Session/SessionInfo.cs
@@ -42,6 +42,8 @@ namespace Raven.Client.Documents.Session
 
         public bool NoCaching { get; set; }
 
+        internal string ClusterTransactionId { get; set; }
+
         internal SessionInfo(InMemoryDocumentSessionOperations session, SessionOptions options, DocumentStoreBase documentStore, bool asyncCommandRunning)
         {
             if (documentStore is null)

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -984,6 +984,11 @@ namespace Raven.Client.Http
 
                         return; // we either handled this already in the unsuccessful response or we are throwing
                     }
+                    
+                    if (sessionInfo != null && response.Headers.TryGetValues(Constants.Headers.DatabaseClusterTransactionId, out var clusterTransactionId))
+                    {
+                        sessionInfo.ClusterTransactionId = clusterTransactionId.First();
+                    }
 
                     OnSucceedRequest?.Invoke(this, new SucceedRequestEventArgs(_databaseName, url, response, request, attemptNum));
                     responseDispose = await command.ProcessResponse(context, Cache, response, url).ConfigureAwait(false);

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2479,7 +2479,7 @@ namespace Raven.Server.Documents
             // case 1: incoming change vector A:10, RAFT:3          -> update    (although it is a conflict) 
             // case 2: incoming change vector A:10, RAFT:2          -> update    (although it is a conflict)
             // case 3: incoming change vector A:10, RAFT:1          -> already merged
-            var partOfClusterTx = remote.Contains(DocumentDatabase.ClusterTransactionId) || local.Contains(DocumentDatabase.ClusterTransactionId);
+            var partOfClusterTx = remote?.Contains(DocumentDatabase.ClusterTransactionId) == true || local?.Contains(DocumentDatabase.ClusterTransactionId) == true;
 
             if (originalStatus == ConflictStatus.Conflict && (HasUnusedDatabaseIds() || partOfClusterTx))
             {

--- a/src/Raven.Server/Rachis/FollowerAmbassador.cs
+++ b/src/Raven.Server/Rachis/FollowerAmbassador.cs
@@ -259,6 +259,11 @@ namespace Raven.Server.Rachis
                             entries.Clear();
                             _engine.ValidateTerm(_term);
 
+                            if (_engine.ForTestingPurposes?.NodeTagsToDisconnect?.Contains(_tag) == true)
+                            {
+                                throw new InvalidOperationException($"Exception was thrown for disconnecting  node {_tag} - For testing purposes.");
+                            }
+
                             using (_engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                             {
                                 AppendEntries appendEntries;

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -404,9 +404,15 @@ namespace Raven.Server.Routing
                             && long.TryParse(value, out var index)
                             && index > reqCtx.Database.ClusterWideTransactionIndexWaiter.LastIndex)
                         {
-                            var sp = Stopwatch.StartNew();
-                            await reqCtx.Database.ClusterWideTransactionIndexWaiter.WaitAsync(index, context.RequestAborted);
+                            Stopwatch sp = null;
                             if (RequestLogger.IsInfoEnabled)
+                            {
+                                sp = Stopwatch.StartNew();
+                            }
+
+                            await reqCtx.Database.ClusterWideTransactionIndexWaiter.WaitAsync(index, context.RequestAborted);
+                            
+                            if (RequestLogger.IsInfoEnabled && sp != null)
                             {
                                 RequestLogger.Info($"Took {sp} to wait for cluster transaction {index} (connId: {context.Connection.Id})");
                             }

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -48,6 +49,7 @@ namespace Raven.Server.Routing
         private readonly Trie<RouteInformation> _trie;
         private DateTime _lastAuthorizedNonClusterAdminRequestTime;
         private DateTime _lastRequestTimeUpdated;
+        private static Logger RequestLogger = LoggingSource.Instance.GetLogger<RequestRouter>("Http");
 
         public RequestRouter(Dictionary<string, RouteInformation> routes, RavenServer ravenServer)
         {
@@ -385,6 +387,7 @@ namespace Raven.Server.Routing
                 }
 
                 context.Response.Headers[Constants.Headers.ServerVersion] = RavenServerStartup.ServerVersionHeaderValue;
+                context.Response.Headers[Constants.Headers.DatabaseClusterTransactionId] = reqCtx.ClusterTransactionId;
 
                 if (reqCtx.Database != null)
                 {
@@ -401,7 +404,12 @@ namespace Raven.Server.Routing
                             && long.TryParse(value, out var index)
                             && index > reqCtx.Database.ClusterWideTransactionIndexWaiter.LastIndex)
                         {
+                            var sp = Stopwatch.StartNew();
                             await reqCtx.Database.ClusterWideTransactionIndexWaiter.WaitAsync(index, context.RequestAborted);
+                            if (RequestLogger.IsInfoEnabled)
+                            {
+                                RequestLogger.Info($"Took {sp} to wait for cluster transaction {index} (connId: {context.Connection.Id})");
+                            }
                         }
 
                         await handler(reqCtx);

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -263,23 +263,7 @@ namespace Raven.Server.Utils
                 .ToString();
         }
 
-        public static long GetEtagById(string changeVector, string id)
-        {
-            if (changeVector == null)
-                return 0;
-
-            if (id == null)
-                throw new ArgumentNullException(nameof(id));
-
-            var index = changeVector.IndexOf("-" + id, StringComparison.Ordinal);
-            if (index == -1)
-                return 0;
-
-            var end = index - 1;
-            var start = changeVector.LastIndexOf(":", end, StringComparison.Ordinal) + 1;
-
-            return long.Parse(changeVector.Substring(start, end - start + 1));
-        }
+        public static long GetEtagById(string changeVector, string id) => ClientChangeVectorUtils.GetEtagById(changeVector, id);
 
         public static string GetNodeTagById(string changeVector, string id)
         {

--- a/src/Raven.Server/Web/RequestHandlerContext.cs
+++ b/src/Raven.Server/Web/RequestHandlerContext.cs
@@ -11,5 +11,7 @@ namespace Raven.Server.Web
         public RouteMatch RouteMatch;
         public DocumentDatabase Database;
         public bool CheckForChanges = true;
+
+        public string ClusterTransactionId => Database?.ClusterTransactionId;
     }
 }

--- a/src/Sparrow/Utils/ClientChangeVectorUtils.cs
+++ b/src/Sparrow/Utils/ClientChangeVectorUtils.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Sparrow.Utils
+{
+    internal static class ClientChangeVectorUtils
+    {
+        public static long GetEtagById(string changeVector, string id)
+        {
+            if (changeVector == null)
+                return 0;
+
+            if (id == null)
+                throw new ArgumentNullException(nameof(id));
+
+            var index = changeVector.IndexOf("-" + id, StringComparison.Ordinal);
+            if (index == -1)
+                return 0;
+
+            var end = index - 1;
+            var start = changeVector.LastIndexOf(":", end, StringComparison.Ordinal) + 1;
+
+            return long.Parse(changeVector.Substring(start, end - start + 1));
+        }
+    }
+}

--- a/test/RachisTests/DatabaseCluster/ReplicationTests.cs
+++ b/test/RachisTests/DatabaseCluster/ReplicationTests.cs
@@ -1251,8 +1251,8 @@ namespace RachisTests.DatabaseCluster
                         session.SaveChanges();
                     }
                     controller.ReplicateOnce();
-                    Assert.False(await WaitForDocumentInClusterAsync<User>(new DatabaseTopology { Members = new List<string> { "A", "B" } }, store.Database, "users/3", null,
-                        TimeSpan.FromSeconds(10)));
+                    await WaitForDocumentInClusterAsync<User>(new DatabaseTopology { Members = new List<string> { "A", "B" } }, store.Database, "users/3", null,
+                        TimeSpan.FromSeconds(10), assertTo: false);
                 }
 
                 Assert.True(await WaitForDocumentInClusterAsync<User>(new DatabaseTopology { Members = new List<string> { "A", "B" } }, store.Database, "users/3", null,

--- a/test/SlowTests/Cluster/RavenDB_22502.cs
+++ b/test/SlowTests/Cluster/RavenDB_22502.cs
@@ -1,0 +1,269 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Client.ServerWide;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Cluster
+{
+    public class RavenDB_22502 : ReplicationTestBase
+    {
+        public RavenDB_22502(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ModifyClusterWideDocumentInNotUpToDateNode(Options options)
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3, watcherCluster: true, leaderIndex: 0);
+            var database = GetDatabaseName();
+
+            var o1 = options.Clone();
+            ModifyTopology(options, o1);
+            o1.ModifyDatabaseName = _ => database;
+            o1.Server = leader;
+            o1.DeleteDatabaseOnDispose = false;
+            var id = "users/1";
+
+            using (var store = GetDocumentStore(o1))
+            {
+                var watchers = nodes.Where(n => n != leader).Select(n => n.ServerStore.NodeTag).ToList();
+                leader.ServerStore.Engine.ForTestingPurposesOnly().NodeTagsToDisconnect = watchers;
+
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    await session.StoreAsync(new User(), id, cts.Token);
+                    try
+                    {
+                        await session.SaveChangesAsync(cts.Token);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        // can happen if we send the request to a watcher
+                    }
+                }
+
+                await WaitForDocumentInClusterAsync<User>(nodes, store.Database, id, predicate: null, TimeSpan.FromSeconds(10));
+            }
+
+            var o2 = options.Clone();
+            o2.ModifyDatabaseName = _ => database;
+            o2.Server = nodes.First(n => n != leader);
+            o2.CreateDatabase = false;
+
+            using (var store = GetDocumentStore(o2))
+            {
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+                using (var session = store.OpenAsyncSession())
+                {
+                    var u = await session.LoadAsync<User>(id, cts.Token);
+                    u.Age = 1;
+                    try
+                    {
+                        await Assert.ThrowsAsync<TaskCanceledException>(() => session.SaveChangesAsync(cts.Token));
+                    }
+                    finally
+                    {
+                        leader.ServerStore.Engine.ForTestingPurposesOnly().NodeTagsToDisconnect = null;
+                    }
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ModifyQueriedClusterWideDocumentInNotUpToDateNode(Options options)
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3, watcherCluster: true, leaderIndex: 0);
+            var database = GetDatabaseName();
+
+            var o1 = options.Clone();
+            ModifyTopology(options, o1);
+
+            o1.ModifyDatabaseName = _ => database;
+            o1.Server = leader;
+            o1.DeleteDatabaseOnDispose = false;
+            var id = "users/1";
+
+            using (var store = GetDocumentStore(o1))
+            {
+                await store.ExecuteIndexAsync(new MyUsers());
+                WaitForIndexingInTheCluster(store);
+
+                var watchers = nodes.Where(n => n != leader).Select(n => n.ServerStore.NodeTag).ToList();
+                leader.ServerStore.Engine.ForTestingPurposesOnly().NodeTagsToDisconnect = watchers;
+
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    await session.StoreAsync(new User(), id, cts.Token);
+                    try
+                    {
+                        await session.SaveChangesAsync(cts.Token);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        // can happen if we send the request to a watcher
+                    }
+                }
+
+                await WaitForDocumentInClusterAsync<User>(nodes, store.Database, id, predicate: null, TimeSpan.FromSeconds(15));
+                WaitForIndexingInTheCluster(store);
+            }
+
+            var o2 = options.Clone();
+            o2.ModifyDatabaseName = _ => database;
+            o2.Server = nodes.First(n => n != leader);
+            o2.CreateDatabase = false;
+
+            using (var store = GetDocumentStore(o2))
+            {
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3)))
+                using (var session = store.OpenAsyncSession())
+                {
+                    var r = session.Query<User>("MyUsers").ToListAsync(cts.Token);
+                    var u = r.Result.Single();
+                    u.Age = 1;
+                    try
+                    {
+                        await Assert.ThrowsAsync<TaskCanceledException>(() => session.SaveChangesAsync(cts.Token));
+                    }
+                    finally
+                    {
+                        leader.ServerStore.Engine.ForTestingPurposesOnly().NodeTagsToDisconnect = null;
+                    }
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task DeletedClusterWideAndRecreateInNormalTx(Options options)
+        {
+            var (nodes, leader) = await CreateRaftCluster(numberOfNodes: 3, watcherCluster: true, leaderIndex: 0);
+            var database = GetDatabaseName();
+
+            var o1 = options.Clone();
+            ModifyTopology(options, o1);
+
+            o1.ModifyDatabaseName = _ => database;
+            o1.Server = leader;
+            var id = "users/1";
+
+            using (var store = GetDocumentStore(o1))
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    await session.StoreAsync(new User(), id);
+                    await session.SaveChangesAsync();
+                }
+                
+                await WaitForDocumentInClusterAsync<User>(nodes, store.Database, id, predicate: null, TimeSpan.FromSeconds(10));
+
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    session.Delete(id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.SingleNode }))
+                {
+                    var u = await session.LoadAsync<User>(id);
+                    Assert.Null(u);
+
+                    await session.StoreAsync(new User(), id);
+                    await session.SaveChangesAsync();
+                }
+
+                await WaitForDocumentInClusterAsync<User>(nodes, store.Database, id, predicate: null, TimeSpan.FromSeconds(15));
+
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.SingleNode }))
+                {
+                    var u = await session.LoadAsync<User>(id);
+                    Assert.NotNull(u);
+                    u.Age = 10;
+                    await session.SaveChangesAsync();
+                }
+
+                await WaitForDocumentInClusterAsync<User>(nodes, store.Database, id, predicate: u => u.Age == 10, TimeSpan.FromSeconds(15));
+
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var u = await session.LoadAsync<User>(id);
+                    Assert.NotNull(u);
+                    u.Count = 10;
+                    await session.SaveChangesAsync();
+                }
+
+                await WaitForDocumentInClusterAsync<User>(nodes, store.Database, id, predicate: u => u.Count == 10, TimeSpan.FromSeconds(15));
+            }
+        }
+        
+        private static void ModifyTopology(Options original, Options @new)
+        {
+            if (original.DatabaseMode == RavenDatabaseMode.Single)
+            {
+                @new.ModifyDatabaseRecord = r => r.Topology = new DatabaseTopology
+                {
+                    Members = ["C", "B", "A"]
+                };
+            }
+            else
+            {
+                /*@new.ModifyDatabaseRecord = r =>
+                {
+                    r.Sharding = new ShardingConfiguration
+                    {
+                        Shards = new Dictionary<int, DatabaseTopology>
+                        {
+                            [0] = new DatabaseTopology
+                            {
+                                Members = ["C", "B", "A"]
+                            },
+                            [1] = new DatabaseTopology
+                            {
+                                Members = ["C", "B", "A"]
+                            },
+                            [2] = new DatabaseTopology
+                            {
+                                Members = ["C", "B", "A"]
+                            },
+                        },
+                      
+                        Orchestrator = new OrchestratorConfiguration
+                        {
+                            Topology = new OrchestratorTopology
+                            {
+                                Members = ["C", "B", "A"]
+                            }
+                        }
+                    };
+                };*/
+            }
+        }
+
+        private class MyUsers : AbstractIndexCreationTask<User>
+        {
+            public override string IndexName => "MyUsers";
+
+            public MyUsers()
+            {
+                Map = users => from user in users
+                    select new
+                    {
+                        user.Name
+                    };
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -471,13 +471,14 @@ namespace Tests.Infrastructure
         private async Task<bool> WaitForDocumentInClusterAsyncInternal<T>(string docId, Func<T, bool> predicate, TimeSpan timeout, List<DocumentStore> stores)
         {
             var tasks = new List<Task<bool>>();
-
             foreach (var store in stores)
                 tasks.Add(Task.Run(() => WaitForDocument(store, docId, predicate, (int)timeout.TotalMilliseconds)));
 
             await Task.WhenAll(tasks);
 
-            return tasks.All(x => x.Result);
+            var r = tasks.All(x => x.Result);
+            Assert.True(r, $"Document {docId} is missing on some nodes");
+            return true;
         }
 
         private List<DocumentStore> GetDocumentStores(IEnumerable<ServerNode> nodes, bool disableTopologyUpdates, X509Certificate2 certificate = null)

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -436,14 +436,14 @@ namespace Tests.Infrastructure
             }, true, timeout: timeout, interval: 333);
         }
 
-        protected async Task<bool> WaitForDocumentInClusterAsync<T>(DocumentSession session, string docId, Func<T, bool> predicate, TimeSpan timeout, X509Certificate2 certificate = null)
+        protected async Task<bool> WaitForDocumentInClusterAsync<T>(DocumentSession session, string docId, Func<T, bool> predicate, TimeSpan timeout, X509Certificate2 certificate = null, bool assertTo = true)
         {
             var nodes = session.RequestExecutor.TopologyNodes;
             var stores = GetDocumentStores(nodes, disableTopologyUpdates: true, certificate: certificate);
-            return await WaitForDocumentInClusterAsyncInternal(docId, predicate, timeout, stores);
+            return await WaitForDocumentInClusterAsyncInternal(docId, predicate, timeout, stores, assertTo);
         }
 
-        protected async Task<bool> WaitForDocumentInClusterAsync<T>(DatabaseTopology topology, string db, string docId, Func<T, bool> predicate, TimeSpan timeout, X509Certificate2 certificate = null)
+        protected async Task<bool> WaitForDocumentInClusterAsync<T>(DatabaseTopology topology, string db, string docId, Func<T, bool> predicate, TimeSpan timeout, X509Certificate2 certificate = null, bool assertTo = true)
         {
             var allNodes = topology.Members;
             var serversTopology = Servers.Where(s => allNodes.Contains(s.ServerStore.NodeTag));
@@ -453,22 +453,22 @@ namespace Tests.Infrastructure
                 Database = db
             });
             var stores = GetDocumentStores(nodes, disableTopologyUpdates: true, certificate: certificate);
-            return await WaitForDocumentInClusterAsyncInternal(docId, predicate, timeout, stores);
+            return await WaitForDocumentInClusterAsyncInternal(docId, predicate, timeout, stores, assertTo);
         }
 
-        protected async Task<bool> WaitForDocumentInClusterAsync<T>(IReadOnlyList<ServerNode> topology, string docId, Func<T, bool> predicate, TimeSpan timeout)
+        protected async Task<bool> WaitForDocumentInClusterAsync<T>(IReadOnlyList<ServerNode> topology, string docId, Func<T, bool> predicate, TimeSpan timeout, bool assertTo = true)
         {
             var stores = GetDocumentStores(topology, disableTopologyUpdates: true);
-            return await WaitForDocumentInClusterAsyncInternal(docId, predicate, timeout, stores);
+            return await WaitForDocumentInClusterAsyncInternal(docId, predicate, timeout, stores, assertTo);
         }
 
-        protected async Task<bool> WaitForDocumentInClusterAsync<T>(List<RavenServer> nodes, string database, string docId, Func<T, bool> predicate, TimeSpan timeout, X509Certificate2 certificate = null)
+        protected async Task<bool> WaitForDocumentInClusterAsync<T>(List<RavenServer> nodes, string database, string docId, Func<T, bool> predicate, TimeSpan timeout, X509Certificate2 certificate = null, bool assertTo = true)
         {
             var stores = GetDocumentStores(nodes, database, disableTopologyUpdates: true, certificate: certificate);
-            return await WaitForDocumentInClusterAsyncInternal(docId, predicate, timeout, stores);
+            return await WaitForDocumentInClusterAsyncInternal(docId, predicate, timeout, stores, assertTo);
         }
 
-        private async Task<bool> WaitForDocumentInClusterAsyncInternal<T>(string docId, Func<T, bool> predicate, TimeSpan timeout, List<DocumentStore> stores)
+        private async Task<bool> WaitForDocumentInClusterAsyncInternal<T>(string docId, Func<T, bool> predicate, TimeSpan timeout, List<DocumentStore> stores, bool assertTo = true)
         {
             var tasks = new List<Task<bool>>();
             foreach (var store in stores)
@@ -477,7 +477,7 @@ namespace Tests.Infrastructure
             await Task.WhenAll(tasks);
 
             var r = tasks.All(x => x.Result);
-            Assert.True(r, $"Document {docId} is missing on some nodes");
+            Assert.True(r == assertTo, assertTo ? $"Document {docId} is missing on some nodes" : $"Document {docId} is on all nodes");
             return true;
         }
 

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -870,6 +870,7 @@ namespace FastTests
                     ReplicationFactor = ReplicationFactor,
                     RunInMemory = RunInMemory,
                     Server = Server,
+                    DatabaseMode = DatabaseMode,
                     _descriptionBuilder = new StringBuilder(_descriptionBuilder.ToString())
                 };
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22502

### Additional description

There are 2 unrelated fixes in this PR (2 different commits)

1. Loading a cluster-wide document that was sent by replication without having his atomic guard might be problematic if we try to save this document with a single node tx.

Since we don't have the guard on that node yet, we will throw a concurrency exception, although there is no concurrency issues. To fix it exact the raft index from each document and wait for with the existing mechanism of last know raft.

(alternative version to https://github.com/ravendb/ravendb/pull/18804)

2. In case of a conflict between a newly created document in a normal tx and an outdated tombstone that was create by a cluster wide tx, we would have picked the tombstone.

This would resulted in one node having the new document while the other nodes will lack this document because the incoming replication would drop it, resulting in an inconsistency in the cluster. 
To resolve this we identify the conflict status for cluster tx document in a custom way (explained in the comment)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
