### PR TITLE
RavenDB-14963 - All revisions view (v7.0)

### DIFF
--- a/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Processors/AbstractStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.Processors;
+using Sparrow.Json;
+
+namespace Raven.Server.Web.Studio.Processors;
+
+internal abstract class AbstractStudioCollectionsHandlerProcessorForPreviewRevisions<TRequestHandler, TOperationContext> : AbstractHandlerProcessor<TRequestHandler>
+    where TOperationContext : JsonOperationContext
+    where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+{
+
+    protected readonly JsonContextPoolBase<TOperationContext> ContextPool;
+
+    protected string Collection;
+
+    protected AbstractStudioCollectionsHandlerProcessorForPreviewRevisions([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+    {
+        ContextPool = RequestHandler.ContextPool;
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        using (ContextPool.AllocateOperationContext(out TOperationContext context))
+        using (OpenReadTransaction(context))
+        using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
+        {
+            await InitializeAsync(context, token.Token);
+
+            if (NotModified(context, out var etag))
+            {
+                RequestHandler.HttpContext.Response.StatusCode = (int)HttpStatusCode.NotModified;
+                return;
+            }
+
+            if (etag != null)
+                HttpContext.Response.Headers[Constants.Headers.Etag] = "\"" + etag + "\"";
+
+            var count = await GetTotalCountAsync();
+
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+
+                writer.WritePropertyName(nameof(PreviewRevisionsResult.TotalResults));
+                writer.WriteInteger(count);
+                writer.WriteComma();
+
+                writer.WritePropertyName(nameof(PreviewRevisionsResult.Results));
+                await WriteItemsAsync(context, writer);
+
+                writer.WriteEndObject();
+            }
+
+        }
+    }
+
+    protected abstract IDisposable OpenReadTransaction(TOperationContext context);
+
+    protected abstract ValueTask<long> GetTotalCountAsync();
+
+    protected abstract bool NotModified(TOperationContext context, out string etag);
+
+    protected abstract Task WriteItemsAsync(TOperationContext context, AsyncBlittableJsonTextWriter writer);
+
+    protected virtual Task InitializeAsync(TOperationContext context, CancellationToken token)
+    {
+        Collection = RequestHandler.GetStringQueryString("collection", required: false);
+
+        return Task.CompletedTask;
+    }
+
+    protected sealed class PreviewRevisionsResult
+    {
+        public List<Document> Results;
+        public long TotalResults;
+    }
+}
+

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+using Raven.Client;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Http;
+using Raven.Client.Util;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Sharding.Executors;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
+using Raven.Server.Documents.Sharding.Operations;
+using Raven.Server.Documents.Sharding.Streaming;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Studio.Processors;
+using Sparrow.Json;
+using static Raven.Server.Documents.Sharding.ShardedDatabaseContext.ShardedStreaming;
+
+namespace Raven.Server.Web.Studio.Sharding.Processors;
+
+internal sealed class ShardedStudioCollectionsHandlerProcessorForPreviewRevisions : AbstractStudioCollectionsHandlerProcessorForPreviewRevisions<ShardedDatabaseRequestHandler,
+    TransactionOperationContext>
+{
+    private ShardedPagingContinuation _continuationToken;
+    private string _combinedHttpEtag;
+    private CombinedReadContinuationState _combinedReadState;
+
+    public ShardedStudioCollectionsHandlerProcessorForPreviewRevisions([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    protected override async Task WriteItemsAsync(TransactionOperationContext context, AsyncBlittableJsonTextWriter writer)
+    {
+        var shardItems = RequestHandler.DatabaseContext.Streaming.PagedShardedStream(
+            _combinedReadState,
+            "Results",
+            x => x,
+            RevisionLastModifiedComparer.Instance,
+            _continuationToken);
+
+        writer.WriteStartArray();
+
+        var first = true;
+        await foreach (var item in shardItems)
+        {
+            if (first)
+                first = false;
+            else
+                writer.WriteComma();
+
+            var json = item.Item;
+
+            if (json.TryGet(nameof(Document.Id), out string id) == false)
+                throw new InvalidOperationException("Revision does not contain 'Id' field.");
+
+            if (json.TryGet(nameof(Document.ChangeVector), out string changeVector) == false)
+                throw new InvalidOperationException($"Revision of \"{id}\" does not contain 'ChangeVector' field.");
+
+            if (json.TryGet(nameof(Document.Etag), out int etag) == false)
+                throw new InvalidOperationException($"Revision of \"{id}\" and change vector '{changeVector}' does not contain 'Etag' field.");
+
+            if (json.TryGet(nameof(Document.LastModified), out DateTime lastModified) == false)
+                throw new InvalidOperationException($"Revision of \"{id}\" and change vector '{changeVector}' does not contain 'LastModified' field.");
+
+            if (json.TryGet(nameof(Document.Flags), out DocumentFlags flags) == false)
+                throw new InvalidOperationException($"Revision of \"{id}\" and change vector '{changeVector}' does not contain 'Flags' field.");
+
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(nameof(Document.Id));
+            writer.WriteString(id);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(Document.Etag));
+            writer.WriteInteger(etag);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(Document.LastModified));
+            writer.WriteDateTime(lastModified, isUtc: true);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(Document.ChangeVector));
+            writer.WriteString(changeVector);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(Document.Flags));
+            writer.WriteString(flags.ToString());
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(ShardStreamItem<BlittableJsonReaderObject>.ShardNumber));
+            writer.WriteInteger(item.ShardNumber);
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+
+        writer.WriteComma();
+        writer.WritePropertyName(ContinuationToken.PropertyName);
+        writer.WriteString(_continuationToken.ToBase64(context));
+    }
+
+    protected override async Task InitializeAsync(TransactionOperationContext context, CancellationToken token)
+    {
+        await base.InitializeAsync(context, token);
+
+        _continuationToken = RequestHandler.ContinuationTokens.GetOrCreateContinuationToken(context);
+
+        var expectedEtag = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
+
+        var op = new ShardedRevisionsCollectionPreviewOperation(RequestHandler, Collection, expectedEtag, _continuationToken);
+        var result = await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(op, token);
+        if (result.StatusCode != (int)HttpStatusCode.NotModified)
+            _combinedReadState = await result.Result.InitializeAsync(RequestHandler.DatabaseContext, RequestHandler.AbortRequestToken);
+        _combinedHttpEtag = result.CombinedEtag;
+    }
+
+    protected override IDisposable OpenReadTransaction(TransactionOperationContext context) => null;
+
+    protected override async ValueTask<long> GetTotalCountAsync()
+    {
+        var result = await RequestHandler.DatabaseContext.Streaming.ReadCombinedLongAsync(_combinedReadState, nameof(PreviewRevisionsResult.TotalResults));
+        var total = 0L;
+        for (int i = 0; i < result.Span.Length; i++)
+        {
+            total += result.Span[i].Item;
+        }
+
+        return total;
+    }
+
+    public override void Dispose()
+    {
+        _combinedReadState?.Dispose();
+        _combinedReadState = null;
+
+        base.Dispose();
+    }
+
+    protected override bool NotModified(TransactionOperationContext context, out string httpEtag)
+    {
+        httpEtag = null;
+        var httpEtagFromRequest = RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch);
+
+        if (httpEtagFromRequest != null && httpEtagFromRequest == _combinedHttpEtag)
+            return true;
+
+        httpEtag = _combinedHttpEtag;
+        return false;
+    }
+
+    private readonly struct ShardedRevisionsCollectionPreviewOperation : IShardedStreamableOperation
+    {
+        private readonly ShardedDatabaseRequestHandler _handler;
+        private readonly string _collection;
+        private readonly ShardedPagingContinuation _continuationToken;
+
+        public ShardedRevisionsCollectionPreviewOperation(ShardedDatabaseRequestHandler handler, string collection, string etag, ShardedPagingContinuation continuationToken)
+        {
+            _handler = handler;
+            _collection = collection;
+            _continuationToken = continuationToken;
+            ExpectedEtag = etag;
+        }
+
+        public HttpRequest HttpRequest => _handler.HttpContext.Request;
+
+        public RavenCommand<StreamResult> CreateCommandForShard(int shardNumber)
+        {
+            return new ShardedRevisionsPreviewCommand(_collection, _continuationToken.Pages[shardNumber].Start, _continuationToken.PageSize);
+        }
+
+        private sealed class ShardedRevisionsPreviewCommand : RavenCommand<StreamResult>
+        {
+            private readonly string _collection;
+            private readonly int _start;
+            private readonly int _pageSize;
+
+            public ShardedRevisionsPreviewCommand(string collection, int start, int pageSize)
+            {
+                _collection = collection;
+                _start = start;
+                _pageSize = pageSize;
+            }
+
+            public override bool IsReadRequest => false;
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/studio/revisions/preview?{Web.RequestHandler.StartParameter}={_start}&{Web.RequestHandler.PageSizeParameter}={_pageSize}";
+
+                if (string.IsNullOrEmpty(_collection) == false)
+                    url += $"&collection={Uri.EscapeDataString(_collection)}";
+
+                var message = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get,
+                };
+
+                return message;
+            }
+
+            public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
+            {
+                var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
+
+                Result = new StreamResult
+                {
+                    Response = response,
+                    Stream = new StreamWithTimeout(responseStream)
+                };
+
+                return ResponseDisposeHandling.Manually;
+            }
+        }
+
+        public string ExpectedEtag { get; }
+
+        public CombinedStreamResult CombineResults(Dictionary<int, ShardExecutionResult<StreamResult>> results)
+        {
+            return new CombinedStreamResult { Results = results };
+        }
+    }
+}

--- a/src/Raven.Server/Web/Studio/Sharding/ShardedStudioCollectionsHandler.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/ShardedStudioCollectionsHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Handlers.Processors.Revisions;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Studio;
 using Raven.Server.Routing;
 using Raven.Server.Web.Studio.Sharding.Processors;
@@ -19,6 +20,13 @@ namespace Raven.Server.Web.Studio.Sharding
         public async Task Delete()
         {
             using (var processor = new ShardedStudioCollectionHandlerProcessorForDeleteCollection(this))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/studio/revisions/preview", "GET")]
+        public async Task PreviewRevisions()
+        {
+            using (var processor = new ShardedStudioCollectionsHandlerProcessorForPreviewRevisions(this))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.Processors.Revisions;
 using Raven.Server.Documents.Handlers.Processors.Studio;
 using Raven.Server.Routing;
 using Raven.Server.Web.Studio.Processors;
@@ -19,6 +20,13 @@ namespace Raven.Server.Web.Studio
         public async Task Delete()
         {
             using (var processor = new StudioCollectionHandlerProcessorForDeleteCollection(this))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenAction("/databases/*/studio/revisions/preview", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        public async Task PreviewRevisions()
+        {
+            using (var processor = new StudioCollectionsHandlerProcessorForPreviewRevisions(this))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/StudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.Studio.Processors;
+using Sparrow.Json;
+
+namespace Raven.Server.Web.Studio;
+
+internal sealed class StudioCollectionsHandlerProcessorForPreviewRevisions : AbstractStudioCollectionsHandlerProcessorForPreviewRevisions<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    private int _start;
+    private int _pageSize;
+    private long _totalResults;
+
+    public StudioCollectionsHandlerProcessorForPreviewRevisions([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    protected override async Task InitializeAsync(DocumentsOperationContext context, CancellationToken token)
+    {
+        await base.InitializeAsync(context, token);
+
+        _start = RequestHandler.GetStart();
+        _pageSize = RequestHandler.GetPageSize();
+
+        _totalResults = string.IsNullOrEmpty(Collection)
+            ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocuments(context)
+            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocumentsForCollection(context, Collection);
+    }
+
+    protected override IDisposable OpenReadTransaction(DocumentsOperationContext context)
+    {
+        return context.OpenReadTransaction();
+    }
+
+    protected override Task WriteItemsAsync(DocumentsOperationContext context, AsyncBlittableJsonTextWriter writer)
+    {
+        writer.WriteStartArray();
+
+        if (_totalResults > 0)
+        {
+            var revisions = string.IsNullOrEmpty(Collection)
+                ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrder(context, _start, _pageSize)
+                : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetRevisionsInReverseEtagOrderForCollection(context, Collection, _start, _pageSize);
+
+            var first = true;
+            foreach (var revision in revisions)
+            {
+                if (first)
+                    first = false;
+                else
+                    writer.WriteComma();
+
+                writer.WriteStartObject();
+
+                writer.WritePropertyName(nameof(Document.Id));
+                writer.WriteString(revision.Id);
+                writer.WriteComma();
+
+                writer.WritePropertyName(nameof(Document.Etag));
+                writer.WriteInteger(revision.Etag);
+                writer.WriteComma();
+
+                writer.WritePropertyName(nameof(Document.LastModified));
+                writer.WriteDateTime(revision.LastModified, true);
+                writer.WriteComma();
+
+                writer.WritePropertyName(nameof(Document.ChangeVector));
+                writer.WriteString(revision.ChangeVector);
+                writer.WriteComma();
+
+                writer.WritePropertyName(nameof(Document.Flags));
+                writer.WriteString(revision.Flags.ToString());
+
+                writer.WriteEndObject();
+            }
+        }
+
+        writer.WriteEndArray();
+        return Task.CompletedTask;
+    }
+
+    protected override ValueTask<long> GetTotalCountAsync()
+    {
+        return ValueTask.FromResult(_totalResults);
+    }
+
+    protected override bool NotModified(DocumentsOperationContext context, out string etag)
+    {
+        string changeVector;
+        etag = null;
+
+        changeVector = string.IsNullOrEmpty(Collection)
+            ? RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVector(context)
+            : RequestHandler.Database.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVectorForCollection(context, Collection);
+
+        if (changeVector != null)
+            etag = $"{changeVector}/{_totalResults}";
+
+        if (etag == null)
+            return false;
+
+        if (etag == RequestHandler.GetStringFromHeaders(Constants.Headers.IfNoneMatch))
+            return true;
+
+        return false;
+    }
+}
+

--- a/src/Raven.Studio/typescript/commands/database/documents/getRevisionsPreviewCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/getRevisionsPreviewCommand.ts
@@ -1,0 +1,56 @@
+import commandBase = require("commands/commandBase");
+import endpoints = require("endpoints");
+
+export interface RevisionsPreviewResultItem {
+    Id: string;
+    Etag: string;
+    LastModified: string;
+    ChangeVector: string;
+    Flags: string;
+    ShardNumber: number;
+}
+
+export default class getRevisionsPreviewCommand extends commandBase {
+    private readonly databaseName: string;
+    private readonly start: number;
+    private readonly pageSize: number;
+    private readonly continuationToken?: string;
+
+    constructor(databaseName: string, start: number, pageSize: number, continuationToken?: string) {
+        super();
+        this.databaseName = databaseName;
+        this.start = start;
+        this.pageSize = pageSize;
+        this.continuationToken = continuationToken;
+    }
+
+    execute(): JQueryPromise<pagedResultWithToken<RevisionsPreviewResultItem>> {
+        const url = endpoints.databases.studioCollections.studioRevisionsPreview + this.urlEncodeArgs(this.getArgsToUse());
+
+        return this.query(url, null, this.databaseName, this.resultsSelector).fail((response: JQueryXHR) => {
+            this.reportError("Failed to get revisions preview", response.responseText, response.statusText);
+        });
+    }
+
+    private getArgsToUse() {
+        if (this.continuationToken) {
+            return {
+                continuationToken: this.continuationToken
+            };
+        }
+
+        return {
+            start: this.start,
+            pageSize: this.pageSize
+        };
+    }
+
+    private resultsSelector(dto: resultsWithCountAndToken<RevisionsPreviewResultItem>): pagedResultWithToken<RevisionsPreviewResultItem> {
+        return {
+            items: dto.Results,
+            totalResultCount: dto.TotalResults,
+            continuationToken: dto.ContinuationToken,
+        };
+    };
+}
+

--- a/src/Raven.Studio/typescript/common/appUrl.ts
+++ b/src/Raven.Studio/typescript/common/appUrl.ts
@@ -30,6 +30,7 @@ class appUrl {
         clientConfiguration: ko.pureComputed(() => appUrl.forClientConfiguration(appUrl.currentDatabase())),
         studioConfiguration: ko.pureComputed(() => appUrl.forStudioConfiguration(appUrl.currentDatabase())),
         documents: ko.pureComputed(() => appUrl.forDocuments(null, appUrl.currentDatabase())),
+        allRevisions: ko.pureComputed(() => appUrl.forAllRevisions(appUrl.currentDatabase())),
         revisionsBin: ko.pureComputed(() => appUrl.forRevisionsBin(appUrl.currentDatabase())),
         conflicts: ko.pureComputed(() => appUrl.forConflicts(appUrl.currentDatabase())),
         identities: ko.pureComputed(() => appUrl.forIdentities(appUrl.currentDatabase())),
@@ -443,6 +444,11 @@ class appUrl {
         const collectionPart = collectionName ? "collection=" + encodeURIComponent(collectionName) : "";
         
         return "#databases/documents?" + collectionPart + appUrl.getEncodedDbPart(db);
+    }
+
+    static forAllRevisions(db: database): string {
+        const databasePart = appUrl.getEncodedDbPart(db);
+        return "#databases/documents/revisions/all?" + databasePart;
     }
 
     static forRevisionsBin(db: database): string {

--- a/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
+++ b/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
@@ -14,6 +14,7 @@ class collectionsTracker {
     collections = ko.observableArray<collection>();
 
     revisionsBin = ko.observable<collection>();
+    allRevisions = ko.observable<collection>();
 
     conflictsCount = ko.observable<number>();
 
@@ -41,8 +42,10 @@ class collectionsTracker {
     configureRevisions(db: database) {
         if (db.hasRevisionsConfiguration()) {
             this.revisionsBin(new collection(collection.revisionsBinCollectionName));
+            this.allRevisions(new collection(collection.allRevisionsCollectionName));
         } else {
             this.revisionsBin(null);
+            this.allRevisions(null);
         }
     }
 
@@ -110,6 +113,10 @@ class collectionsTracker {
 
     getRevisionsBinCollection() {
         return this.revisionsBin();
+    }
+
+    getAllRevisionsCollection() {
+        return this.allRevisions();
     }
 
     getAllDocumentsCollection() {

--- a/src/Raven.Studio/typescript/common/shell/menu/collectionMenuItem.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/collectionMenuItem.ts
@@ -21,6 +21,9 @@ class collectionMenuItem implements menuItem {
                 if (item.route === "databases/documents/revisions/bin" && coll.isRevisionsBin) {
                     return true;
                 }
+                if (item.route === "databases/documents/revisions/all" && coll.isAllRevisions) {
+                    return true;
+                }
 
                 if (item.route === "databases/documents") {
                     const instruction = router.activeInstruction();

--- a/src/Raven.Studio/typescript/common/shell/menu/items/documents.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/documents.ts
@@ -2,6 +2,8 @@
 import leafMenuItem = require("common/shell/menu/leafMenuItem");
 import collectionMenuItem = require("common/shell/menu/collectionMenuItem");
 import collectionsTracker = require("common/helpers/database/collectionsTracker");
+import AllRevisions from "components/pages/database/documents/allRevisions/AllRevisions";
+import { bridgeToReact } from "common/reactUtils";
 
 export = getDocumentsMenuItem;
 
@@ -17,6 +19,18 @@ function getDocumentsMenuItem(appUrls: computedAppUrls) {
             dynamicHash: appUrls.documents,
             search: {
                 alternativeTitles: ["Documents"]
+            }
+        }),
+        new leafMenuItem({
+            route: "databases/documents/revisions/all",
+            moduleId: bridgeToReact(AllRevisions, "shardedView"),
+            shardingMode: "allShards",
+            title: "All Revisions",
+            nav: false,
+            css: "icon-revisions",
+            dynamicHash: appUrls.allRevisions,
+            search: {
+                alternativeTitles: ["Revisions"]
             }
         }),
         new leafMenuItem({

--- a/src/Raven.Studio/typescript/components/common/virtualTable/VirtualTable.scss
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/VirtualTable.scss
@@ -109,12 +109,14 @@
             position: absolute;
             display: flex;
             width: 100%;
+            background-color: colors.$row-even-bg-var;
 
             td {
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 border-right: 1px solid colors.$border-color-light-var;
+                background-color: colors.$row-even-bg-var;
 
                 * {
                     overflow: hidden;
@@ -140,19 +142,11 @@
                 }
             }
 
-            &:nth-child(odd) {
+            &.is-odd {
                 background-color: colors.$row-bg-var;
 
                 td {
                     background-color: colors.$row-bg-var;
-                }
-            }
-
-            &:nth-child(even) {
-                background-color: colors.$row-even-bg-var;
-
-                td {
-                    background-color: colors.$row-even-bg-var;
                 }
             }
 

--- a/src/Raven.Studio/typescript/components/common/virtualTable/VirtualTable.tsx
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/VirtualTable.tsx
@@ -5,15 +5,25 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { ClassNameProps } from "components/models/common";
 import VirtualTableBodyWrapper, { VirtualTableBodyWrapperProps } from "./bits/VirtualTableBodyWrapper";
 import { virtualTableConstants } from "components/common/virtualTable/utils/virtualTableConstants";
+import classNames from "classnames";
+
+// Chrome/Edge can render up to 838 859 rows in a table
+// Firefox only up to 223 695 rows
+// If you want to render more rows, you need to use VirtualTableWithLazyLoading component along with useVirtualTableWithLazyLoading hook
+
+// May have performance problems but only in dev mode (prod build works fine)
 
 interface VirtualTableProps<T> extends Omit<VirtualTableBodyWrapperProps<T>, "tableContainerRef"> {
     overscan?: number;
+    tableContainerRef?: React.RefObject<HTMLDivElement>;
 }
 
 export default function VirtualTable<T>(props: VirtualTableProps<T> & ClassNameProps) {
     const { table, className, heightInPx = 300, overscan = 5, isLoading = false } = props;
 
-    const tableContainerRef = useRef<HTMLDivElement>(null);
+    const innerTableContainerRef = useRef<HTMLDivElement>(null);
+    const tableContainerRef = props.tableContainerRef ?? innerTableContainerRef;
+
     const { rows } = table.getRowModel();
 
     const rowVirtualizer = useVirtualizer({
@@ -45,7 +55,9 @@ export default function VirtualTable<T>(props: VirtualTableProps<T> & ClassNameP
                             key={row.id}
                             style={{
                                 transform: `translateY(${virtualRow.start}px)`,
+                                height: `${virtualRow.size}px`,
                             }}
+                            className={classNames({ "is-odd": virtualRow.index % 2 !== 0 })}
                         >
                             {row.getVisibleCells().map((cell) => (
                                 <td

--- a/src/Raven.Studio/typescript/components/common/virtualTable/VirtualTableWithLazyLoading.tsx
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/VirtualTableWithLazyLoading.tsx
@@ -3,6 +3,9 @@ import { flexRender } from "@tanstack/react-table";
 import { ClassNameProps } from "components/models/common";
 import { virtualTableConstants } from "components/common/virtualTable/utils/virtualTableConstants";
 import VirtualTableBodyWrapper, { VirtualTableBodyWrapperProps } from "./bits/VirtualTableBodyWrapper";
+import classNames from "classnames";
+
+// Use it along with useVirtualTableWithLazyLoading hook
 
 export interface VirtualTableWithLazyLoadingProps<T> extends VirtualTableBodyWrapperProps<T> {
     bodyHeightInPx: number;
@@ -40,6 +43,9 @@ export default function VirtualTableWithLazyLoading<T>(props: VirtualTableWithLa
                                 height: virtualTableConstants.defaultRowHeightInPx,
                                 transform: `translateY(${positionY}px)`,
                             }}
+                            className={classNames({
+                                "is-odd": Math.round(positionY / virtualTableConstants.defaultRowHeightInPx) % 2 !== 0,
+                            })}
                         >
                             {row.getVisibleCells().map((cell) => (
                                 <td

--- a/src/Raven.Studio/typescript/components/common/virtualTable/bits/VirtualTableHead.tsx
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/bits/VirtualTableHead.tsx
@@ -1,4 +1,4 @@
-import { Table as TanstackTable, flexRender } from "@tanstack/react-table";
+import { Column, Table as TanstackTable, flexRender } from "@tanstack/react-table";
 import classNames from "classnames";
 
 interface VirtualTableHeadProps<T> {
@@ -22,7 +22,7 @@ export default function VirtualTableHead<T>({ table }: VirtualTableHeadProps<T>)
                                 className={classNames("position-relative", {
                                     "cursor-pointer select-none": header.column.getCanSort(),
                                 })}
-                                title={`Sort by ${header.column.columnDef.header}`}
+                                title={getHeaderTitle(header.column)}
                             >
                                 {flexRender(header.column.columnDef.header, header.getContext())}
 
@@ -53,4 +53,24 @@ export default function VirtualTableHead<T>({ table }: VirtualTableHeadProps<T>)
             ))}
         </thead>
     );
+}
+
+function getHeaderTitle<T>(column: Column<T, unknown>): string {
+    const { columnDef } = column;
+
+    const getTitle = (): string => {
+        if (typeof columnDef.header === "string") {
+            return columnDef.header;
+        }
+        if ("accessorKey" in columnDef && typeof columnDef.accessorKey === "string") {
+            return columnDef.accessorKey;
+        }
+        return columnDef.id;
+    };
+
+    if (column.getCanSort()) {
+        return `Sort by ${getTitle()}`;
+    }
+
+    return getTitle();
 }

--- a/src/Raven.Studio/typescript/components/common/virtualTable/cells/CellDocumentValue.tsx
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/cells/CellDocumentValue.tsx
@@ -30,10 +30,6 @@ export default function CellDocumentValue({
                 extractedCollectionName.startsWith(collection.toLowerCase())
             );
 
-            if (!matchedCollection) {
-                return null;
-            }
-
             return appUrl.forEditDoc(cellValue, databaseName, matchedCollection);
         }
 

--- a/src/Raven.Studio/typescript/components/common/virtualTable/hooks/useVirtualTableWithToken.ts
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/hooks/useVirtualTableWithToken.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from "react";
+import { useAsync, useAsyncCallback } from "react-async-hook";
+import { virtualTableConstants } from "../utils/virtualTableConstants";
+
+// Use it along with VirtualTable component
+
+// It is possible to exceed the maximum height of an element in the browser,
+// but for 223 695 rows (firefox limit) it would require scrolling to the bottom over 2 000 times,
+// so we can ignore this limitation
+
+type FetchData<T extends pagedResultWithToken<unknown>> = (
+    skip: number,
+    take: number,
+    continuationToken?: string
+) => Promise<T>;
+
+interface UseVirtualTableWithTokenProps<T extends pagedResultWithToken<unknown>> {
+    fetchData: FetchData<T>;
+    initialOverscan?: number;
+}
+
+export function useVirtualTableWithToken<T extends pagedResultWithToken<unknown>>({
+    fetchData,
+    initialOverscan = 50,
+}: UseVirtualTableWithTokenProps<T>) {
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+
+    const initialItemsCount = Math.ceil(window.innerHeight / defaultRowHeightInPx) + initialOverscan;
+
+    const [dataArray, setDataArray] = useState<T["items"]>([]);
+    const [continuationToken, setContinuationToken] = useState<string>();
+    const [totalResultCount, setTotalResultCount] = useState<number>(0);
+
+    const asyncLoadInitialData = useAsync(async () => {
+        const result = await fetchData(0, initialItemsCount);
+
+        setDataArray(result.items);
+        setContinuationToken(result.continuationToken);
+        setTotalResultCount(result.totalResultCount);
+    }, []);
+
+    const asyncLoadData = useAsyncCallback(async () => {
+        const result = await fetchData(null, null, continuationToken);
+
+        setDataArray((prev) => [...prev, ...result.items]);
+        setContinuationToken(result.continuationToken);
+        setTotalResultCount(result.totalResultCount);
+    });
+
+    // Handle scroll
+    useEffect(() => {
+        if (!tableContainerRef.current) {
+            return;
+        }
+        let isFetching = false;
+
+        const handleScroll = async (e: Event) => {
+            if (totalResultCount > 0 && totalResultCount === dataArray.length) {
+                return;
+            }
+
+            const target = e.target as HTMLDivElement;
+            const positionToFetch = target.scrollHeight - target.clientHeight - defaultRowHeightInPx;
+
+            if (target.scrollTop >= positionToFetch) {
+                if (isFetching) {
+                    return;
+                }
+
+                isFetching = true;
+                await asyncLoadData.execute();
+            } else {
+                isFetching = false;
+            }
+        };
+
+        const current = tableContainerRef.current;
+        current.addEventListener("scroll", handleScroll);
+
+        return () => {
+            current.removeEventListener("scroll", handleScroll);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return {
+        dataArray,
+        componentProps: {
+            tableContainerRef,
+            isLoading: asyncLoadInitialData.loading || asyncLoadData.loading,
+        },
+    };
+}
+
+const { defaultRowHeightInPx } = virtualTableConstants;

--- a/src/Raven.Studio/typescript/components/common/virtualTable/utils/virtualTableUtils.ts
+++ b/src/Raven.Studio/typescript/components/common/virtualTable/utils/virtualTableUtils.ts
@@ -3,10 +3,11 @@ import { virtualTableConstants } from "components/common/virtualTable/utils/virt
 interface TableBodyWidthOptions {
     isWithoutTablePadding?: boolean;
     isWithoutTableScrollbar?: boolean;
+    isWithRightSpace?: boolean;
 }
 
 function getTableBodyWidth(containerWidth = 0, options: TableBodyWidthOptions = {}) {
-    const { isWithoutTablePadding = true, isWithoutTableScrollbar = true } = options;
+    const { isWithoutTablePadding = true, isWithoutTableScrollbar = true, isWithRightSpace = true } = options;
 
     if (containerWidth === 0) {
         containerWidth = $(".react-container")[0]?.clientWidth ?? window.innerWidth;
@@ -18,6 +19,9 @@ function getTableBodyWidth(containerWidth = 0, options: TableBodyWidthOptions = 
     }
     if (isWithoutTableScrollbar) {
         containerWidth -= virtualTableConstants.scrollbarWidthInPx;
+    }
+    if (isWithRightSpace) {
+        containerWidth -= 20; // some space to avoid horizontal scroll
     }
 
     return containerWidth;

--- a/src/Raven.Studio/typescript/components/pages/database/documents/allRevisions/AllRevisions.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/allRevisions/AllRevisions.spec.tsx
@@ -1,0 +1,24 @@
+import { rtlRender } from "test/rtlTestUtils";
+import { composeStories } from "@storybook/react";
+import * as Stories from "./AllRevisions.stories";
+
+const { AllRevisionsStory } = composeStories(Stories);
+
+describe("AllRevisions", () => {
+    beforeAll(() => {
+        Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+            configurable: true,
+            value: 500,
+        });
+    });
+
+    it("can render", async () => {
+        const { screen } = rtlRender(<AllRevisionsStory />);
+
+        expect(await screen.findByText(/Id/i)).toBeInTheDocument();
+    });
+});

--- a/src/Raven.Studio/typescript/components/pages/database/documents/allRevisions/AllRevisions.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/allRevisions/AllRevisions.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { withStorybookContexts, withBootstrap5 } from "test/storybookTestUtils";
+import AllRevisions from "./AllRevisions";
+import { mockServices } from "test/mocks/services/MockServices";
+import { mockStore } from "test/mocks/store/MockStore";
+
+export default {
+    title: "Pages/Database/Documents/AllRevisions",
+    decorators: [withStorybookContexts, withBootstrap5],
+} satisfies Meta;
+
+export const AllRevisionsStory: StoryObj = {
+    name: "All Revisions",
+    render: () => {
+        mockStore.databases.withActiveDatabase();
+        mockServices.databasesService.withRevisionsPreview();
+
+        return (
+            <div style={{ height: "500px" }}>
+                <AllRevisions />
+            </div>
+        );
+    },
+};

--- a/src/Raven.Studio/typescript/components/pages/database/documents/allRevisions/AllRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/allRevisions/AllRevisions.tsx
@@ -1,0 +1,144 @@
+import { useReactTable, getCoreRowModel, ColumnDef } from "@tanstack/react-table";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import SizeGetter from "components/common/SizeGetter";
+import { virtualTableUtils } from "components/common/virtualTable/utils/virtualTableUtils";
+import { useServices } from "components/hooks/useServices";
+import { useAppSelector } from "components/store";
+import CellDocumentValue from "components/common/virtualTable/cells/CellDocumentValue";
+import { CellWithCopyWrapper } from "components/common/virtualTable/cells/CellWithCopy";
+import { Icon } from "components/common/Icon";
+import VirtualTable from "components/common/virtualTable/VirtualTable";
+import { useVirtualTableWithToken } from "components/common/virtualTable/hooks/useVirtualTableWithToken";
+import VirtualTableWithLazyLoading from "components/common/virtualTable/VirtualTableWithLazyLoading";
+import { RevisionsPreviewResultItem } from "commands/database/documents/getRevisionsPreviewCommand";
+import { useMemo } from "react";
+import { useVirtualTableWithLazyLoading } from "components/common/virtualTable/hooks/useVirtualTableWithLazyLoading";
+
+interface AllRevisionsWithSizeProps {
+    width: number;
+    height: number;
+}
+
+export default function AllRevisions() {
+    return (
+        <div className="content-padding">
+            <SizeGetter
+                isHeighRequired
+                render={({ width, height }) => <AllRevisionsWithSize width={width} height={height} />}
+            />
+        </div>
+    );
+}
+
+function AllRevisionsWithSize({ width, height }: AllRevisionsWithSizeProps) {
+    const isSharded = useAppSelector(databaseSelectors.activeDatabase)?.isSharded;
+
+    const tableProps = {
+        width: virtualTableUtils.getTableBodyWidth(width),
+        height: height,
+    };
+
+    return isSharded ? <AllRevisionsTableSharded {...tableProps} /> : <AllRevisionsTableNonSharded {...tableProps} />;
+}
+
+function AllRevisionsTableNonSharded({ width, height }: AllRevisionsWithSizeProps) {
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const { databasesService } = useServices();
+
+    const { dataPreview, componentProps } = useVirtualTableWithLazyLoading({
+        fetchData: (skip: number, take: number) => {
+            if (databaseName) {
+                return databasesService.getRevisionsPreview(databaseName, skip, take);
+            }
+        },
+    });
+
+    const columns = useMemo(() => getColumnDefs(databaseName, width, false), [databaseName, width]);
+
+    const table = useReactTable({
+        defaultColumn: {
+            enableSorting: false,
+        },
+        columns,
+        data: dataPreview,
+        columnResizeMode: "onChange",
+        getCoreRowModel: getCoreRowModel(),
+    });
+
+    return <VirtualTableWithLazyLoading {...componentProps} table={table} heightInPx={height} />;
+}
+
+function AllRevisionsTableSharded({ width, height }: AllRevisionsWithSizeProps) {
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const { databasesService } = useServices();
+
+    const { dataArray, componentProps } = useVirtualTableWithToken({
+        fetchData: (skip: number, take: number, continuationToken?: string) =>
+            databasesService.getRevisionsPreview(databaseName, skip, take, continuationToken),
+    });
+
+    const columns = useMemo(() => getColumnDefs(databaseName, width, true), [databaseName, width]);
+
+    const table = useReactTable({
+        defaultColumn: {
+            enableSorting: false,
+        },
+        columns,
+        data: dataArray,
+        columnResizeMode: "onChange",
+        getCoreRowModel: getCoreRowModel(),
+    });
+
+    return <VirtualTable {...componentProps} table={table} heightInPx={height} />;
+}
+
+const getColumnDefs = (
+    databaseName: string,
+    tableBodyWidth: number,
+    isSharded?: boolean
+): ColumnDef<RevisionsPreviewResultItem>[] => {
+    const sizeProvider = virtualTableUtils.getCellSizeProvider(tableBodyWidth);
+
+    const columns: ColumnDef<RevisionsPreviewResultItem>[] = [
+        {
+            accessorKey: "Id",
+            cell: ({ getValue }) => (
+                <CellDocumentValue value={getValue<string>()} databaseName={databaseName} hasHyperlinkForIds />
+            ),
+            size: sizeProvider(30),
+        },
+        {
+            accessorKey: "Etag",
+            cell: CellWithCopyWrapper,
+            size: sizeProvider(10),
+        },
+        {
+            header: "Change Vector",
+            accessorKey: "ChangeVector",
+            cell: CellWithCopyWrapper,
+            size: sizeProvider(25),
+        },
+        {
+            header: "Last Modified",
+            accessorKey: "LastModified",
+            cell: CellWithCopyWrapper,
+            size: sizeProvider(25),
+        },
+    ];
+
+    if (isSharded) {
+        columns.push({
+            id: "ShardNumber",
+            header: () => (
+                <span>
+                    <Icon icon="shard" /> Shard
+                </span>
+            ),
+            accessorKey: "ShardNumber",
+            cell: CellWithCopyWrapper,
+            size: sizeProvider(10),
+        });
+    }
+
+    return columns;
+};

--- a/src/Raven.Studio/typescript/components/services/DatabasesService.ts
+++ b/src/Raven.Studio/typescript/components/services/DatabasesService.ts
@@ -63,6 +63,7 @@ import distributeSecretCommand = require("commands/database/secrets/distributeSe
 import saveCustomAnalyzerCommand from "commands/database/settings/saveCustomAnalyzerCommand";
 import getDocumentsPreviewCommand = require("commands/database/documents/getDocumentsPreviewCommand");
 import getDocumentsMetadataByIDPrefixCommand = require("commands/database/documents/getDocumentsMetadataByIDPrefixCommand");
+import getRevisionsPreviewCommand from "commands/database/documents/getRevisionsPreviewCommand";
 
 export default class DatabasesService {
     async setLockMode(databaseNames: string[], newLockMode: DatabaseLockMode) {
@@ -294,5 +295,9 @@ export default class DatabasesService {
 
     async getDocumentsMetadataByIDPrefix(...args: ConstructorParameters<typeof getDocumentsMetadataByIDPrefixCommand>) {
         return new getDocumentsMetadataByIDPrefixCommand(...args).execute();
+    }
+
+    async getRevisionsPreview(...args: ConstructorParameters<typeof getRevisionsPreviewCommand>) {
+        return new getRevisionsPreviewCommand(...args).execute();
     }
 }

--- a/src/Raven.Studio/typescript/components/utils/docsHashes.ts
+++ b/src/Raven.Studio/typescript/components/utils/docsHashes.ts
@@ -94,4 +94,5 @@ export const docsHashes: Record<string, StringWithAutocomplete<"MISSING_DOCS">> 
     "admin/settings/debug/advanced/recordTransactionCommands": "MISSING_DOCS",
     "admin/settings/debug/advanced/replayTransactionCommands": "MISSING_DOCS",
     about: "MISSING_DOCS",
+    "databases/documents/revisions/all": "MISSING_DOCS",
 };

--- a/src/Raven.Studio/typescript/models/database/documents/collection.ts
+++ b/src/Raven.Studio/typescript/models/database/documents/collection.ts
@@ -3,6 +3,7 @@ import { Collection } from "components/common/shell/collectionsTrackerSlice";
 
 class collection {
     static readonly allDocumentsCollectionName = "All Documents";
+    static readonly allRevisionsCollectionName = "All Revisions";
     static readonly revisionsBinCollectionName = "Revisions Bin";
     static readonly hiloCollectionName = "@hilo";
 
@@ -40,6 +41,10 @@ class collection {
 
     get isAllDocuments() {
         return this.name === collection.allDocumentsCollectionName;
+    }
+
+    get isAllRevisions() {
+        return this.name === collection.allRevisionsCollectionName;
     }
     
     get isRevisionsBin() {

--- a/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
+++ b/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
@@ -11,6 +11,7 @@ import SorterDefinition = Raven.Client.Documents.Queries.Sorting.SorterDefinitio
 import AnalyzerDefinition = Raven.Client.Documents.Indexes.Analysis.AnalyzerDefinition;
 import DataArchival = Raven.Client.Documents.Operations.DataArchival.DataArchivalConfiguration;
 import document from "models/database/documents/document";
+import { RevisionsPreviewResultItem } from "commands/database/documents/getRevisionsPreviewCommand";
 
 interface WithGetDatabasesStateOptions {
     loadError?: string[];
@@ -169,5 +170,9 @@ export default class MockDatabasesService extends AutoMockService<DatabasesServi
             dto,
             DatabasesStubs.documentsMetadataByIDPrefix()
         );
+    }
+
+    withRevisionsPreview(dto?: MockedValue<pagedResultWithToken<RevisionsPreviewResultItem>>) {
+        return this.mockResolvedValue(this.mocks.getRevisionsPreview, dto, DatabasesStubs.revisionsPreview());
     }
 }

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -13,6 +13,7 @@ import RevisionsCollectionConfiguration = Raven.Client.Documents.Operations.Revi
 import SorterDefinition = Raven.Client.Documents.Queries.Sorting.SorterDefinition;
 import AnalyzerDefinition = Raven.Client.Documents.Indexes.Analysis.AnalyzerDefinition;
 import document from "models/database/documents/document";
+import { RevisionsPreviewResultItem } from "commands/database/documents/getRevisionsPreviewCommand";
 
 export class DatabasesStubs {
     private static genericDatabaseInfo(name: string): StudioDatabaseInfo {
@@ -950,5 +951,29 @@ return docs[0];`,
                 },
             },
         ];
+    }
+
+    static revisionsPreview(): pagedResultWithToken<RevisionsPreviewResultItem> {
+        return {
+            items: [
+                {
+                    ChangeVector: "A:2568-F9I6Egqwm0Kz+K0oFVIR9Q",
+                    Id: "doc/1-A",
+                    Etag: "2568",
+                    Flags: "HasRevisions",
+                    LastModified: "2018-07-27T12:11:53.0447651Z",
+                    ShardNumber: null,
+                },
+                {
+                    ChangeVector: "A:2569-F9I6Egqwm0Kz+K0oFVIR9Q",
+                    Id: "doc/2-A",
+                    Etag: "2569",
+                    Flags: "HasRevisions",
+                    LastModified: "2018-07-27T12:11:53.0451613Z",
+                    ShardNumber: null,
+                },
+            ],
+            totalResultCount: 2,
+        };
     }
 }

--- a/src/Raven.Studio/typescript/viewmodels/shell.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell.ts
@@ -532,6 +532,10 @@ class shell extends viewModelBase {
     urlForRevisionsBin() {
         return appUrl.forRevisionsBin(this.activeDatabase());
     }
+
+    urlForAllRevisions() {
+        return appUrl.forAllRevisions(this.activeDatabase());
+    }
     
     urlForCertificates() {
         return appUrl.forCertificates();

--- a/src/Raven.Studio/typings/_studio/computedAppUrls.d.ts
+++ b/src/Raven.Studio/typings/_studio/computedAppUrls.d.ts
@@ -11,6 +11,7 @@ interface computedAppUrls {
     clientConfiguration: KnockoutComputed<string>;
     studioConfiguration: KnockoutComputed<string>;
     documents: KnockoutComputed<string>;
+    allRevisions: KnockoutComputed<string>;
     revisionsBin: KnockoutComputed<string>;
     conflicts: KnockoutComputed<string>;
     patch: KnockoutComputed<string>;

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -458,8 +458,7 @@ interface pagedResultWithToken<T> extends pagedResult<T> {
     continuationToken?: string;
 }
 
-interface pagedResultWithTokenAndSkippedResults<T> extends pagedResult<T> {
-    continuationToken?: string;
+interface pagedResultWithTokenAndSkippedResults<T> extends pagedResultWithToken<T> {
     scannedResults?: number;
 }
 

--- a/src/Raven.Studio/wwwroot/App/views/shell.html
+++ b/src/Raven.Studio/wwwroot/App/views/shell.html
@@ -58,6 +58,15 @@
             <!-- /ko -->
         </li>
         <li>
+            <!-- ko with: $root.collectionsTracker.getAllRevisionsCollection() -->
+            <a data-bind="click: $parent.menu.navigate.bind($parent.menu), attr: { href: $root.urlForAllRevisions() }, 
+                          css: { 'active': $parent.item.isOpen($parent.menu.activeItem, $data) }">
+                <i class="icon-revisions"></i>
+                <span>All Revisions</span>
+            </a>
+            <!-- /ko -->
+        </li>
+        <li>
             <!-- ko with: $root.collectionsTracker.getRevisionsBinCollection() -->
             <a data-bind="click: $parent.menu.navigate.bind($parent.menu), attr: { href: $root.urlForRevisionsBin() }, 
                           css: { 'active': $parent.item.isOpen($parent.menu.activeItem, $data) }">

--- a/src/Raven.Studio/wwwroot/Content/css/root.less
+++ b/src/Raven.Studio/wwwroot/Content/css/root.less
@@ -87,6 +87,16 @@ body {
             height: 100%;
             width: 100%;
 
+            .durandal-wrapper {
+                width: 100%;
+                height: 100%;
+            }
+
+            .shard-aware-container {
+                width: 100%;
+                height: 100%;
+            }
+
             .react-container {
                 height: 100%;
                 width: 100%;

--- a/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
@@ -646,3 +646,8 @@ $filtering-input-bg: $toggle-bg !default;
         background: #{$striped-bg};
     }
 }
+
+.content-padding {
+    width: 100%;
+    height: 100%;
+}

--- a/test/SlowTests/Issues/RavenDB-14963.cs
+++ b/test/SlowTests/Issues/RavenDB-14963.cs
@@ -1,0 +1,275 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Exceptions;
+using Raven.Client.Http;
+using Raven.Client.ServerWide;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using Task = System.Threading.Tasks.Task;
+using Web = Raven.Server.Web;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_14963 : RavenTestBase
+{
+    public RavenDB_14963(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Revisions | RavenTestCategory.Voron)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public async Task TestAllRevisionsView(Options options, bool compression)
+    {
+        if (compression)
+        {
+            options.ModifyDatabaseRecord += r =>
+            {
+                r.DocumentsCompression = new DocumentsCompressionConfiguration
+                {
+                    CompressAllCollections = true,
+                    CompressRevisions = true
+                };
+            };
+        }
+
+        using var store = GetDocumentStore(options);
+
+        var list = await Initialize(store);
+        if (options.DatabaseMode == RavenDatabaseMode.Single)
+        {
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                var usersLastCv = db.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVectorForCollection(ctx, "Users");
+                var docsLastCv = db.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVectorForCollection(ctx, "Docs");
+                var lastCv = db.DocumentsStorage.RevisionsStorage.GetLastRevisionChangeVector(ctx);
+
+                Assert.Equal(lastCv, docsLastCv);
+
+                var lastEtag = Convert.ToInt64(lastCv.Split(":")[1].Split("-")[0]);
+                var lastUsersEtag = Convert.ToInt64(usersLastCv.Split(":")[1].Split("-")[0]);
+
+                Assert.True(lastEtag > lastUsersEtag, $"lastCv {lastCv}, lastEtag {lastEtag}, usersLastCv: {usersLastCv}, lastUsersEtag {lastUsersEtag}");
+
+            }
+        }
+
+        await AssertResultsAsync(store, list, totalResults: 8, start: 0, pageSize: 3);
+        await AssertResultsAsync(store, list, totalResults: 8, start: 1, pageSize: 3);
+        await AssertResultsAsync(store, list, totalResults: 8, start: 2, pageSize: 3);
+        await AssertResultsAsync(store, list, totalResults: 8, start: 0, pageSize: 8);
+
+        await AssertResultsAsync(store, list, totalResults: 0, start: 0, pageSize: 8, "Companies");
+
+        await AssertResultsAsync(store, list, totalResults: 4, start: 0, pageSize: 2, "Users");
+        await AssertResultsAsync(store, list, totalResults: 4, start: 1, pageSize: 2, "Users");
+        await AssertResultsAsync(store, list, totalResults: 4, start: 2, pageSize: 2, "Users");
+        await AssertResultsAsync(store, list, totalResults: 4, start: 3, pageSize: 2, "Users");
+
+        await AssertResultsAsync(store, list, totalResults: 4, start: 0, pageSize: 2, "Docs");
+        await AssertResultsAsync(store, list, totalResults: 4, start: 1, pageSize: 2, "Docs");
+        await AssertResultsAsync(store, list, totalResults: 4, start: 2, pageSize: 2, "Docs");
+        await AssertResultsAsync(store, list, totalResults: 4, start: 3, pageSize: 2, "Docs");
+    }
+
+
+    private async Task<List<(string Id, string Name)>> Initialize(DocumentStore store)
+    {
+        var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false } };
+        await RevisionsHelper.SetupRevisionsAsync(store, configuration: configuration);
+
+        var list = new List<(string Id, string Name)>();
+
+        for (int i = 0; i < 2; i++)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = i.ToString() }, "Users/1");
+                list.Add(("Users/1", i.ToString()));
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = i.ToString() }, "Users/2");
+                list.Add(("Users/2", i.ToString()));
+                await session.SaveChangesAsync();
+            }
+        }
+
+        for (int i = 0; i < 2; i++)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Doc { Name = i.ToString() }, "Docs/1");
+                list.Add(("Docs/1", i.ToString()));
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Doc { Name = i.ToString() }, "Docs/2");
+                list.Add(("Docs/2", i.ToString()));
+                await session.SaveChangesAsync();
+            }
+        }
+
+        list.Reverse();
+
+        return list;
+    }
+
+    private async Task AssertResultsAsync(DocumentStore store, List<(string Id, string Name)> list,
+        int totalResults, int start, int pageSize, string collection = null)
+    {
+        var results = await store.Maintenance.SendAsync(new RevisionsCollectionPreviewOperation(collection, start, pageSize));
+        Assert.Equal(totalResults, results.TotalResults);
+        Assert.True(pageSize >= results.Results.Count);
+
+        if (collection != null)
+            list = list.Where(info => info.Id.StartsWith(collection)).ToList();
+        
+        list = list.Skip(start).Take(pageSize).ToList();
+        Assert.Equal(results.Results.Count, list.Count);
+
+        for (int i = 0; i < list.Count; i++)
+        {
+            var result = results.Results[i];
+            var info = list[i];
+
+            Assert.Equal(info.Id, result.Id);
+
+            string name = null;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.Advanced.Revisions.GetAsync<dynamic>(result.ChangeVector);
+                name = doc.Name;
+            }
+
+            Assert.NotNull(name);
+            Assert.Equal(info.Name, name);
+        }
+    }
+
+
+    private class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class Doc
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    private class RevisionsCollectionPreviewOperation : IMaintenanceOperation<RevisionsPreviewResults>
+    {
+        private readonly string _collection;
+        private readonly int _start;
+        private readonly int _pageSize;
+
+        public RevisionsCollectionPreviewOperation(int start, int pageSize)
+        {
+            _start = start;
+            _pageSize = pageSize;
+        }
+
+        public RevisionsCollectionPreviewOperation(string collection, int start, int pageSize)
+        {
+            _collection = collection;
+            _start = start;
+            _pageSize = pageSize;
+        }
+
+        public RavenCommand<RevisionsPreviewResults> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        {
+            return new RevisionsPreviewCommand(_collection, _start, _pageSize);
+        }
+
+        private sealed class RevisionsPreviewCommand : RavenCommand<RevisionsPreviewResults>
+        {
+            private readonly string _collection;
+            private readonly int _start;
+            private readonly int _pageSize;
+
+
+            public RevisionsPreviewCommand(string collection, int start, int pageSize)
+            {
+                _collection = collection;
+                _start = start;
+                _pageSize = pageSize;
+            }
+
+            public override bool IsReadRequest => true;
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/studio/revisions/preview?{Web.RequestHandler.StartParameter}={_start}&{Web.RequestHandler.PageSizeParameter}={_pageSize}";
+
+                if (string.IsNullOrEmpty(_collection) == false)
+                    url += $"&collection={Uri.EscapeDataString(_collection)}";
+
+                return new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get,
+                };
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    throw new InvalidOperationException();
+                if (fromCache)
+                {
+                    // we have to clone the response here because  otherwise the cached item might be freed while
+                    // we are still looking at this result, so we clone it to the side
+                    response = response.Clone(context);
+                }
+
+                Result = GetRevisionsPreviewResults(response);
+            }
+
+            private static readonly Func<BlittableJsonReaderObject, RevisionsPreviewResults> GetRevisionsPreviewResults = JsonDeserializationBase.GenerateJsonDeserializationRoutine<RevisionsPreviewResults>();
+
+        }
+
+    }
+
+    private class RevisionInfo
+    {
+        public string Id { get; set; }
+        public int Etag { get; set; }
+        public DateTime LastModified { get; set; }
+        public string ChangeVector { get; set; }
+        public DocumentFlags Flags { get; set; }
+        public int? ShardNumber { get; set; }
+    }
+
+    private class RevisionsPreviewResults
+    {
+        public int TotalResults { get; set; }
+        public List<RevisionInfo> Results { get; set; }
+        public string ContinuationToken { get; set; }
+
+    }
+}
+


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14963/All-revisions-view

### Additional description
related to this PR:
https://github.com/ravendb/ravendb/pull/18504#discussion_r1604417150
which is merged by mistake and reverted..
Already approved

Created from this (v6.1):
https://github.com/ravendb/ravendb/pull/18622

Json Format:


Single:
```
{
  "TotalResults": 8,
  "Results": [
    {
      "Id": "Users/1",
      "Etag": 16,
      "LastModified": "2024-05-12T11:53:41.8128727Z",
      "ChangeVector": "A:15-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Companies/1",
      "Etag": 14,
      "LastModified": "2024-05-12T11:53:35.7369914Z",
      "ChangeVector": "A:13-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Companies/1",
      "Etag": 12,
      "LastModified": "2024-05-12T11:53:33.9179408Z",
      "ChangeVector": "A:11-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Docs/1",
      "Etag": 10,
      "LastModified": "2024-05-12T11:53:23.5946301Z",
      "ChangeVector": "A:9-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Docs/1",
      "Etag": 8,
      "LastModified": "2024-05-12T11:53:21.7090247Z",
      "ChangeVector": "A:7-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Users/1",
      "Etag": 6,
      "LastModified": "2024-05-12T11:53:13.4545503Z",
      "ChangeVector": "A:5-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Users/1",
      "Etag": 4,
      "LastModified": "2024-05-09T08:34:28.8081143Z",
      "ChangeVector": "A:3-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    },
    {
      "Id": "Users/1",
      "Etag": 2,
      "LastModified": "2024-05-09T08:34:25.7935544Z",
      "ChangeVector": "A:1-UkgaAlPii063JyiBPFBdYQ",
      "Flags": "HasRevisions, Revision"
    }
  ]
}
```
Sharded:
```
{
  "TotalResults": 12,
  "Results": [
    {
      "Id": "Users/2",
      "Etag": 17,
      "LastModified": "2024-05-08T09:56:49.0218539Z",
      "ChangeVector": "A:16-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Users/2",
      "Etag": 15,
      "LastModified": "2024-05-08T09:56:47.0754333Z",
      "ChangeVector": "A:13-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Users/2",
      "Etag": 14,
      "LastModified": "2024-05-08T09:55:18.3546928Z",
      "ChangeVector": "A:4-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, FromOldDocumentRevision, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Users/3",
      "Etag": 12,
      "LastModified": "2024-05-08T09:56:43.9053422Z",
      "ChangeVector": "A:10-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Users/3",
      "Etag": 11,
      "LastModified": "2024-05-08T09:55:25.3694998Z",
      "ChangeVector": "A:5-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, FromOldDocumentRevision, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Docs/2",
      "Etag": 9,
      "LastModified": "2024-05-08T09:56:32.9012798Z",
      "ChangeVector": "A:7-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Docs/2",
      "Etag": 8,
      "LastModified": "2024-05-08T09:55:48.9191329Z",
      "ChangeVector": "A:6-qTepzTqftUy/YawCUh7MGQ",
      "Flags": "HasRevisions, FromOldDocumentRevision, Revision",
      "ShardNumber": 0
    },
    {
      "Id": "Users/1",
      "Etag": 12,
      "LastModified": "2024-05-08T09:56:53.6674637Z",
      "ChangeVector": "A:10-0wZr2SRLP0erExEpAl9raA",
      "Flags": "HasRevisions, Revision",
      "ShardNumber": 2
    }
  ],
  "ContinuationToken": "DgACAQMDAgIDAAICAQMDAgIDAgQCAQMDAgIDAxkBURAEUQcFURACAQYDCwBRBVBhZ2VzAAEwAAVTdGFydAALU2hhcmROdW1iZXIAATEAATIACFBhZ2VTaXplABAuJyQdEA0KJltR"
}
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
