### PR TITLE
RavenDB-22934 - Make sure that the stream is disposed only once

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AwsS3DirectUploadStream.cs
@@ -17,14 +17,9 @@ public class AwsS3DirectUploadStream : DirectUploadStream<RavenAwsS3Client>
         MinOnePartUploadSizeInBytes = Client.MinOnePartUploadSizeLimit.GetValue(SizeUnit.Bytes);
     }
 
-    protected override void Dispose(bool disposing)
+    protected override void OnCompleteUpload()
     {
-        using (Client)
-        {
-            base.Dispose(disposing);
-
-            var runner = new S3RetentionPolicyRunner(_retentionPolicyParameters, Client);
-            runner.Execute();
-        }
+        var runner = new S3RetentionPolicyRunner(_retentionPolicyParameters, Client);
+        runner.Execute();
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AzureDirectUploadStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/AzureDirectUploadStream.cs
@@ -17,14 +17,9 @@ public class AzureDirectUploadStream : DirectUploadStream<IRavenAzureClient>
         MinOnePartUploadSizeInBytes = Client.MaxSingleBlockSize.GetValue(SizeUnit.Bytes);
     }
 
-    protected override void Dispose(bool disposing)
+    protected override void OnCompleteUpload()
     {
-        using (Client)
-        {
-            base.Dispose(disposing);
-
-            var runner = new AzureRetentionPolicyRunner(_retentionPolicyParameters, Client);
-            runner.Execute();
-        }
+        var runner = new AzureRetentionPolicyRunner(_retentionPolicyParameters, Client);
+        runner.Execute();
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadBackupTask.cs
@@ -59,7 +59,7 @@ public class DirectUploadBackupTask : BackupTask
             RetentionPolicyParameters = RetentionPolicyParameters,
             CloudUploadStatus = BackupResult.S3Backup,
             OnBackupException = OnBackupException,
-            OnProgress = AddInfo,
+            OnProgress = AddInfo
         };
     }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadStream.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/DirectUploadStream.cs
@@ -111,19 +111,21 @@ public abstract class DirectUploadStream<T> : Stream where T : IDirectUploader
 
     protected override void Dispose(bool disposing)
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
         if (_abortUpload)
         {
+            using (Client)
             using (_backupStatusIDisposable)
             using (_uploadStream)
             using (_writeStream)
                 return;
         }
 
-        if (_disposed)
-            return;
-
-        _disposed = true;
-
+        using (Client)
         using (_backupStatusIDisposable)
         {
             using (_uploadStream)
@@ -150,8 +152,12 @@ public abstract class DirectUploadStream<T> : Stream where T : IDirectUploader
             _cloudUploadStatus.UploadProgress.ChangeState(UploadState.Done);
 
             _onProgress.Invoke($"Total uploaded: {new Size(_position, SizeUnit.Bytes)}");
+
+            OnCompleteUpload();
         }
     }
+
+    protected abstract void OnCompleteUpload();
 
     public override bool CanRead => false;
     public override bool CanSeek => false;

--- a/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/IDirectUploader.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DirectUpload/IDirectUploader.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Raven.Server.Documents.PeriodicBackup.DirectUpload;
 
-public interface IDirectUploader
+public interface IDirectUploader : IDisposable
 {
     public IMultiPartUploader GetUploader(string key, Dictionary<string, string> metadata);
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/Retention/RetentionPolicyRunnerBase.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Retention/RetentionPolicyRunnerBase.cs
@@ -116,8 +116,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Retention
             {
                 // failure to delete backups shouldn't result in backup failure
 
-                var message = $"Failed to run Retention Policy for {Name}";
-                _onProgress.Invoke($"{message}. Error: {e.Message}");
+                _onProgress.Invoke($"Failed to run Retention Policy for {Name}. Exception: {e}");
 
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"Failed to run Retention Policy for {Name}", e);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22934/NRE-running-backup-retention-policies

### Additional description

The disposal of the stream can be called twice, we need to make sure that we dispose the stream internally correctly.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
