### PR TITLE
RavenDB-22894 - Delete Time Series Directly Should Update Index Entries - Corax

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -632,14 +632,16 @@ namespace Corax.Indexing
 
         public void DeleteByPrefix(string term)
         {
+            using var __ = Slice.From(_transaction.Allocator, term, ByteStringType.Immutable, out var termSlice);
+
             var fieldsTree = _fieldsTree.CompactTreeFor(_fieldsMapping.GetByFieldId(Constants.IndexWriter.PrimaryKeyFieldId).FieldName);
 
             var iterator = fieldsTree.Iterate();
-            iterator.Seek(term);
+            iterator.Seek(termSlice);
 
             while (iterator.MoveNext(out var key, out var id, out _))
             {
-                if (key.ToString().StartsWith(term) == false)
+                if (key.Decoded().StartsWith(termSlice) == false)
                     continue;
 
                 RecordDeletion(id, out _, out _);

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -629,7 +629,23 @@ namespace Corax.Indexing
             FlushBatch();
             return TryDeleteEntry(termSlice, out entryId);
         }
-        
+
+        public void DeleteByPrefix(string term)
+        {
+            var fieldsTree = _fieldsTree.CompactTreeFor(_fieldsMapping.GetByFieldId(Constants.IndexWriter.PrimaryKeyFieldId).FieldName);
+
+            var iterator = fieldsTree.Iterate();
+            iterator.Seek(term);
+
+            while (iterator.MoveNext(out var key, out var id, out _))
+            {
+                if (key.ToString().StartsWith(term) == false)
+                    continue;
+
+                RecordDeletion(id, out _, out _);
+            }
+        }
+
         private void FlushBatch()
         {
             // We cannot actually handles modifications to the same entry in the same batch, so we cheat

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceLuceneIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceLuceneIndexWriteOperation.cs
@@ -46,10 +46,10 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
                 _outputScope.Delete(key, stats);
         }
 
-        public override void DeleteTimeSeries(LazyStringValue docId, LazyStringValue key, IndexingStatsScope stats)
+        public override void DeleteByPrefix(LazyStringValue key, IndexingStatsScope stats)
         {
             if (_outputScope.IsActive)
-                base.DeleteTimeSeries(docId, key, stats);
+                base.DeleteByPrefix(key, stats);
             else
                 _outputScope.Delete(key, stats);
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -171,9 +171,12 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 _indexWriter.TryDeleteEntry(key.AsReadOnlySpan());
         }
 
-        public override void DeleteTimeSeries(LazyStringValue docId, LazyStringValue key, IndexingStatsScope stats)
+        public override void DeleteByPrefix(LazyStringValue key, IndexingStatsScope stats)
         {
-            // Lucene method
+            EnsureValidStats(stats);
+
+            using (Stats.DeleteStats.Start())
+                _indexWriter.DeleteByPrefix(key.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -176,7 +176,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             EnsureValidStats(stats);
 
             using (Stats.DeleteStats.Start())
-                _indexWriter.DeleteByPrefix(key.ToString(CultureInfo.InvariantCulture));
+                _indexWriter.DeleteByPrefix(key.AsReadOnlySpan());
         }
 
         /// <summary>

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/OutputReduceCoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/OutputReduceCoraxIndexWriteOperation.cs
@@ -42,9 +42,12 @@ public sealed class OutputReduceCoraxIndexWriteOperation : CoraxIndexWriteOperat
             _outputScope.Delete(key, stats);
     }
     
-    public override void DeleteTimeSeries(LazyStringValue docId, LazyStringValue key, IndexingStatsScope stats)
+    public override void DeleteByPrefix(LazyStringValue key, IndexingStatsScope stats)
     {
-        // Lucene method
+         if (_outputScope.IsActive)
+             base.DeleteByPrefix(key, stats);
+         else
+             _outputScope.Delete(key, stats);
     }
 
     public override void UpdateDocument(LazyStringValue key, LazyStringValue sourceDocumentId, object document, IndexingStatsScope stats, JsonOperationContext indexContext)

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexWriteOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexWriteOperationBase.cs
@@ -29,7 +29,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
 
         public abstract void Delete(LazyStringValue key, IndexingStatsScope stats);
 
-        public abstract void DeleteTimeSeries(LazyStringValue docId, LazyStringValue key, IndexingStatsScope stats);
+        public abstract void DeleteByPrefix(LazyStringValue key, IndexingStatsScope stats);
 
         public abstract void DeleteBySourceDocument(LazyStringValue sourceDocumentId, IndexingStatsScope stats);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
@@ -203,7 +203,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 _writer.DeleteDocuments(_documentId.CreateTerm(key), _state);
         }
 
-        public override void DeleteTimeSeries(LazyStringValue docId, LazyStringValue key, IndexingStatsScope stats)
+        public override void DeleteByPrefix(LazyStringValue key, IndexingStatsScope stats)
         {
             EnsureValidStats(stats);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriteOperation.cs
@@ -210,7 +210,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             using (Stats.DeleteStats.Start())
             {
                 var term = _documentId.CreateTerm(key);
-                _writer.DeleteTimeSeries(term, _state);
+                _writer.DeleteByPrefix(term, _state);
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriter.cs
@@ -64,7 +64,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             _indexWriter.DeleteDocuments(term, state);
         }
 
-        public void DeleteTimeSeries(Term term, IState state)
+        public void DeleteByPrefix(Term term, IState state)
         {
             using var reader = _indexWriter.GetReader(state);
             using var termsEnumerator = reader.Terms(term, state);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexWriter.cs
@@ -71,7 +71,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             
             while (termsEnumerator.Term != null)
             {
-                if (termsEnumerator.Term.Text.Contains(term.Text, StringComparison.OrdinalIgnoreCase) == false)
+                if (termsEnumerator.Term.Text.StartsWith(term.Text) == false)
                     return;
 
                 // found by prefix

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
@@ -176,7 +176,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
         internal void HandleTimeSeriesDelete(TombstoneIndexItem tombstone, TransactionOperationContext indexContext)
         {
             var toDelete = new List<Slice>();
-            using (Slice.External(indexContext.Allocator, tombstone.LuceneKey, out var prefixKey))
+            using (Slice.External(indexContext.Allocator, tombstone.PrefixKey, out var prefixKey))
             {
                 using (var it = MapReduceWorkContext.MapPhaseTree.Iterate(prefetch: true))
                 {

--- a/src/Raven.Server/Documents/Indexes/Test/TestIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Test/TestIndexWriteOperation.cs
@@ -73,9 +73,9 @@ public sealed class TestIndexWriteOperation : IndexWriteOperationBase
         _inner.Delete(key, stats);
     }
 
-    public override void DeleteTimeSeries(LazyStringValue docId, LazyStringValue key, IndexingStatsScope stats)
+    public override void DeleteByPrefix(LazyStringValue key, IndexingStatsScope stats)
     {
-        _inner.DeleteTimeSeries(docId, key, stats);
+        _inner.DeleteByPrefix(key, stats);
     }
 
     public override void DeleteBySourceDocument(LazyStringValue sourceDocumentId, IndexingStatsScope stats)

--- a/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupTimeSeries.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupTimeSeries.cs
@@ -51,12 +51,12 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
         protected override void HandleDelete(TombstoneIndexItem tombstone, string collection, Lazy<IndexWriteOperationBase> writer,
             QueryOperationContext queryContext, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
-            if (_timeSeriesStats.TryGetValue(tombstone.LuceneKey, out var result) == false)
+            if (_timeSeriesStats.TryGetValue(tombstone.PrefixKey, out var result) == false)
             {
                 var tsStats = _tsStorage.Stats.GetStats(queryContext.Documents, tombstone.LowerId, tombstone.Name);
                 result.Item1 = tsStats;
                 result.Deleted = false;
-                _timeSeriesStats.Add(tombstone.LuceneKey, result);
+                _timeSeriesStats.Add(tombstone.PrefixKey, result);
             }
             
             // if the time series is not completely deleted, we can skip further processing
@@ -69,13 +69,13 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
             HandleTimeSeriesDelete(tombstone, collection, writer, queryContext, indexContext, stats);
 
             result.Deleted = true;
-            _timeSeriesStats[tombstone.LuceneKey] = result;
+            _timeSeriesStats[tombstone.PrefixKey] = result;
         }
 
         protected virtual void HandleTimeSeriesDelete(TombstoneIndexItem tombstone, string collection, Lazy<IndexWriteOperationBase> writer,
             QueryOperationContext queryContext, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
-            writer.Value.DeleteByPrefix(tombstone.LuceneKey, stats);
+            writer.Value.DeleteByPrefix(tombstone.PrefixKey, stats);
         }
 
         protected override void ClearStatsIfNeeded()

--- a/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupTimeSeries.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupTimeSeries.cs
@@ -75,7 +75,7 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
         protected virtual void HandleTimeSeriesDelete(TombstoneIndexItem tombstone, string collection, Lazy<IndexWriteOperationBase> writer,
             QueryOperationContext queryContext, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
-            writer.Value.DeleteTimeSeries(tombstone.LowerId, tombstone.LuceneKey, stats);
+            writer.Value.DeleteByPrefix(tombstone.LuceneKey, stats);
         }
 
         protected override void ClearStatsIfNeeded()

--- a/src/Raven.Server/Documents/Indexes/Workers/Cleanup/TombstoneIndexItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Cleanup/TombstoneIndexItem.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
     {
         public IndexItemType Type;
         public LazyStringValue LowerId;
-        public LazyStringValue LuceneKey;
+        public LazyStringValue PrefixKey;
         public LazyStringValue Name;
         public long Etag;
         public DateTime From;
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
             return new DynamicJsonValue
             {
                 [nameof(LowerId)] = LowerId?.ToString(),
-                [nameof(LuceneKey)] = LuceneKey?.ToString(),
+                [nameof(PrefixKey)] = PrefixKey?.ToString(),
                 [nameof(Name)] = Name?.ToString(),
                 [nameof(Etag)] = Etag,
                 [nameof(Type)] = Type.GetDescription(),
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
         public void Dispose()
         {
             LowerId?.Dispose();
-            LuceneKey?.Dispose();
+            PrefixKey?.Dispose();
             Name?.Dispose();
         }
     }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesDeletedRangeEntry.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesDeletedRangeEntry.cs
@@ -7,8 +7,6 @@ namespace Raven.Server.Documents.TimeSeries
     {
         public LazyStringValue Key;
 
-        public LazyStringValue LuceneKey;
-
         public LazyStringValue DocId;
 
         public LazyStringValue Name;
@@ -19,9 +17,6 @@ namespace Raven.Server.Documents.TimeSeries
         {
             if (Key != null && Key.IsDisposed == false)
                 Key.Dispose();
-
-            if (LuceneKey != null && LuceneKey.IsDisposed == false)
-                LuceneKey.Dispose();
 
             if (DocId != null && DocId.IsDisposed == false)
                 DocId.Dispose();

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -2465,7 +2465,6 @@ namespace Raven.Server.Documents.TimeSeries
                 return new TimeSeriesDeletedRangeEntry
                 {
                     Key = new LazyStringValue(null, keyPtr, keySize, context),
-                    LuceneKey = GetTimeSeriesDeletedRangeLuceneKey(context, docId, name),
                     DocId = docId,
                     Name = name,
                     Etag = Bits.SwapBytes(etag)
@@ -2522,7 +2521,7 @@ namespace Raven.Server.Documents.TimeSeries
 
             return new TombstoneIndexItem
             {
-                LuceneKey = GetTimeSeriesDeletedRangeLuceneKey(context, docId, name),
+                PrefixKey = GetTimeSeriesDeletedRangePrefixKey(context, docId, name),
                 LowerId = docId,
                 Name = name,
                 Etag = Bits.SwapBytes(etag),
@@ -2699,7 +2698,7 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        private static LazyStringValue GetTimeSeriesDeletedRangeLuceneKey(DocumentsOperationContext context, LazyStringValue documentId, LazyStringValue name)
+        private static LazyStringValue GetTimeSeriesDeletedRangePrefixKey(DocumentsOperationContext context, LazyStringValue documentId, LazyStringValue name)
         {
             var size = documentId.Size
                        + 1 // Lucene separator

--- a/test/FastTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes.cs
+++ b/test/FastTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes.cs
@@ -811,8 +811,7 @@ namespace FastTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void MapIndexWithCaseInsensitiveTimeSeriesNames(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -1085,8 +1084,7 @@ namespace FastTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanMapAllTimeSeriesFromCollection(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -1262,8 +1260,7 @@ namespace FastTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanMapAllTimeSeries(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_JavaScript.cs
+++ b/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_JavaScript.cs
@@ -854,8 +854,7 @@ return ({
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanMapAllTimeSeriesFromCollection(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -1002,8 +1001,7 @@ return ({
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, DatabaseMode = RavenDatabaseMode.All)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
         public void CanMapAllTimeSeries(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_MethodSyntax.cs
+++ b/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_MethodSyntax.cs
@@ -751,8 +751,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanMapAllTimeSeriesFromCollection(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -908,8 +907,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanMapAllTimeSeries(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_StrongSyntax.cs
+++ b/test/SlowTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes_StrongSyntax.cs
@@ -966,8 +966,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanMapAllTimeSeriesFromCollection(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -1114,8 +1113,7 @@ namespace SlowTests.Client.Indexing.TimeSeries
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanMapAllTimeSeries(Options options)
         {
             using (var store = GetDocumentStore(options))

--- a/test/SlowTests/Issues/RavenDB_21681.cs
+++ b/test/SlowTests/Issues/RavenDB_21681.cs
@@ -25,8 +25,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Cluster | RavenTestCategory.Replication | RavenTestCategory.TimeSeries | RavenTestCategory.ExpirationRefresh)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task DeleteExpiredDocumentWithBigTimeSeriesShouldNotCauseReplicationToBreak(Options options)
         {
             var (nodes, leader) = await CreateRaftCluster(2, watcherCluster: true);
@@ -87,8 +86,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task ShouldUpdateMapIndexEntriesAfterDeletingEntireTimeSeries(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -129,8 +127,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task ShouldUpdateMapIndexEntriesAfterDeletingEntireTimeSeries_multipleDocuments(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -178,8 +175,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task ShouldUpdateMapIndexEntriesAfterDeletingEntireTimeSeries_multipleDocuments2(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -230,8 +226,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task ShouldUpdateMapIndexEntriesAfterDeletingEntireTimeSeries_multipleDocuments3(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -285,8 +280,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task ShouldUpdateMapIndexEntriesAfterDeletingEntireTimeSeries_multipleSegments(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -334,8 +328,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task ShouldUpdateMapIndexEntriesAfterDeletingEntireTimeSeries_multipleSegments2(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -414,8 +407,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Skip = "https://issues.hibernatingrhinos.com/issue/RavenDB-22894")]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task ShouldUpdateMapIndexEntriesAfterDeletingEntireTimeSeriesAfterRetention(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22894/Delete-Time-Series-Directly-Should-Update-Index-Entries-Corax


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
