### PR TITLE
RavenDB-22943 Database name comparison needs to be case insensitive

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/formBackup/createDatabaseFromBackupValidation.ts
@@ -1,18 +1,12 @@
 import {
     encryptionStepSchema,
     dataDirectoryStepSchema,
+    databaseNameSchema,
 } from "components/pages/resources/databases/partials/create/shared/createDatabaseSharedValidation";
 import * as yup from "yup";
 
 const basicInfoStepSchema = yup.object({
-    databaseName: yup
-        .string()
-        .trim()
-        .strict()
-        .required()
-        .when("$usedDatabaseNames", ([usedDatabaseNames], schema) =>
-            schema.notOneOf(usedDatabaseNames, "Database already exists")
-        ),
+    databaseName: databaseNameSchema,
     isSharded: yup.boolean(),
 });
 

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/createDatabaseRegularValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/createDatabaseRegularValidation.ts
@@ -1,15 +1,12 @@
-import { encryptionStepSchema, dataDirectoryStepSchema } from "../shared/createDatabaseSharedValidation";
+import {
+    encryptionStepSchema,
+    dataDirectoryStepSchema,
+    databaseNameSchema,
+} from "../shared/createDatabaseSharedValidation";
 import * as yup from "yup";
 
 const basicInfoStepSchema = yup.object({
-    databaseName: yup
-        .string()
-        .trim()
-        .strict()
-        .required()
-        .when("$usedDatabaseNames", ([usedDatabaseNames], schema) =>
-            schema.notOneOf(usedDatabaseNames, "Database already exists")
-        ),
+    databaseName: databaseNameSchema,
     isEncrypted: yup.boolean(),
 });
 

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/shared/createDatabaseSharedValidation.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/shared/createDatabaseSharedValidation.tsx
@@ -51,3 +51,14 @@ export const encryptionStepSchema = yup.object({
 });
 
 export type Encryption = yup.InferType<typeof encryptionStepSchema>;
+
+export const databaseNameSchema = yup
+    .string()
+    .trim()
+    .strict()
+    .required()
+    .test("db-exists", "Database already exists", (value, ctx) => {
+        return !ctx.options.context.usedDatabaseNames.some(
+            (name: string) => name.toLowerCase() === value.toLowerCase()
+        );
+    });


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22943/Database-name-comparison-needs-to-be-case-insensitive

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
