### PR TITLE
RavenDB-22412 Striped background for partially online databases

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasePanel.tsx
@@ -74,6 +74,8 @@ function getStatusColor(db: DatabaseSharedInfo, localInfo: locationAwareLoadable
             return "secondary";
         case "Disabled":
             return "warning";
+        case "Partially Online":
+            return "striped-success";
         default:
             return "success";
     }

--- a/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
@@ -571,12 +571,13 @@ select {
     display: inline !important;
 }
 
-//Classes for different panel colors
+// Classes for different panel colors
 $panels: (
     1: --panel-bg-1,
     2: --panel-bg-2,
     3: --panel-bg-3,
 );
+
 @each $key, $color in $panels {
     .panel-bg-#{$key} {
         background-color: var(#{$color});
@@ -622,5 +623,21 @@ $filtering-input-bg: $toggle-bg !default;
         pointer-events: unset;
         background-color: $panel-bg-1-var;
         color: $text-muted-var;
+    }
+}
+
+// Classes for bg-striped-*
+@each $key, $value in $theme-colors {
+    $striped-bg: repeating-linear-gradient(
+        45deg,
+        $value,
+        $value $gutter-xs,
+        shade-color($value, 10%) $gutter-xs,
+        shade-color($value, 10%) $gutter-sm
+    );
+
+    .bg-striped-#{$key} {
+        @extend .bg-#{$key};
+        background: #{$striped-bg};
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22412

### Additional description

Added `bg-striped-*` classes function for partially online databases

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
