### PR TITLE
RavenDB-21634 Added option to not ignore expiration run exception in the test

### DIFF
--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -124,17 +124,17 @@ namespace Raven.Server.Documents.Expiration
             }
         }
 
-        internal Task CleanupExpiredDocs(int? batchSize = null)
+        internal Task CleanupExpiredDocs(int? batchSize = null, bool throwOnError = false)
         {
-            return CleanupDocs(batchSize ?? BatchSize, ExpirationConfiguration.MaxItemsToProcess ?? DefaultMaxItemsToProcessInSingleRun, forExpiration: true);
+            return CleanupDocs(batchSize ?? BatchSize, ExpirationConfiguration.MaxItemsToProcess ?? DefaultMaxItemsToProcessInSingleRun, forExpiration: true, throwOnError: throwOnError);
         }
 
-        internal Task RefreshDocs(int? batchSize = null)
+        internal Task RefreshDocs(int? batchSize = null, bool throwOnError = false)
         {
-            return CleanupDocs(batchSize ?? BatchSize, RefreshConfiguration.MaxItemsToProcess ?? DefaultMaxItemsToProcessInSingleRun, forExpiration: false);
+            return CleanupDocs(batchSize ?? BatchSize, RefreshConfiguration.MaxItemsToProcess ?? DefaultMaxItemsToProcessInSingleRun, forExpiration: false, throwOnError: throwOnError);
         }
         
-        private async Task CleanupDocs(int batchSize, long maxItemsToProcess, bool forExpiration)
+        private async Task CleanupDocs(int batchSize, long maxItemsToProcess, bool forExpiration, bool throwOnError)
         {
             var currentTime = _database.Time.GetUtcNow();
             
@@ -195,6 +195,9 @@ namespace Raven.Server.Documents.Expiration
             {
                 if (Logger.IsOperationsEnabled)
                     Logger.Operations($"Failed to {(forExpiration ? "delete" : "refresh")} documents on {_database.Name} which are older than {currentTime}", e);
+
+                if (throwOnError)
+                    throw;
             }
         }
 

--- a/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
+++ b/test/SlowTests/Server/Documents/Expiration/ExpirationTests.cs
@@ -117,7 +117,7 @@ namespace SlowTests.Server.Documents.Expiration
                     var database = await Databases.GetDocumentDatabaseInstanceFor(store);
                     database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
                     var expiredDocumentsCleaner = database.ExpiredDocumentsCleaner;
-                    await expiredDocumentsCleaner.CleanupExpiredDocs();
+                    await expiredDocumentsCleaner.CleanupExpiredDocs(throwOnError: true);
 
                     using (var session = store.OpenAsyncSession())
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21634/SlowTests.Server.Documents.Expiration.ExpirationTests.CanAddEntityWithExpiryThenReadItBeforeItExpiresButWillNotBeAbleToReadItAft

### Additional description

It looks that an exception must be thrown under the covers and we don't cleanup the expired document

### Type of change

- [x] Test investigation
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
