### PR TITLE
RavenDB-22767 Adding caller name to a low-level transaction so we'll be able to find area causing a hanging read trasanaction more easily if it happens

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/TransactionDebugHandler.cs
@@ -85,6 +85,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(TxInfoResult.TransactionId)] = lowLevelTransaction.Id,
                 [nameof(TxInfoResult.ThreadId)] = lowLevelTransaction.CurrentTransactionHolder?.ManagedThreadId,
                 [nameof(TxInfoResult.ThreadName)] = lowLevelTransaction.CurrentTransactionHolder?.Name,
+                [nameof(TxInfoResult.CallerName)] = lowLevelTransaction.CallerName,
                 [nameof(TxInfoResult.StartTime)] = lowLevelTransaction.TxStartTime.GetDefaultRavenFormat(isUtc: true),
                 [nameof(TxInfoResult.TotalTime)] = $"{(DateTime.UtcNow - lowLevelTransaction.TxStartTime).TotalMilliseconds} mSecs",
                 [nameof(TxInfoResult.FlushInProgressLockTaken)] = lowLevelTransaction.FlushInProgressLockTaken,
@@ -103,6 +104,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         public int TransactionId;
         public int ThreadId;
         public string ThreadName;
+        public string CallerName;
         public int StartTime;
         public int TotalTime;
         public bool FlushInProgressLockTaken;

--- a/src/Raven.Server/Documents/Indexes/QueryOperationContext.cs
+++ b/src/Raven.Server/Documents/Indexes/QueryOperationContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Raven.Server.Documents.Queries;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -55,12 +56,12 @@ namespace Raven.Server.Documents.Indexes
                 _releaseServer = _database.ServerStore.ContextPool.AllocateOperationContext(out Server);
         }
 
-        public IDisposable OpenReadTransaction()
+        public IDisposable OpenReadTransaction([CallerMemberName] string caller = null)
         {
-            var documentsTx = Documents.OpenReadTransaction();
+            var documentsTx = Documents.OpenReadTransaction(caller);
             RavenTransaction serverTx = null;
             if (Server != null)
-                serverTx = Server.OpenReadTransaction();
+                serverTx = Server.OpenReadTransaction(caller);
 
             return new DisposeTransactions(documentsTx, serverTx);
         }

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Sparrow.Json;
 using Sparrow.Server;
 using Sparrow.Threading;
@@ -55,12 +56,15 @@ namespace Raven.Server.ServerWide.Context
             Allocator = new ByteStringContext(lowMemoryFlag);
         }
 
-        public TTransaction OpenReadTransaction()
+        public TTransaction OpenReadTransaction([CallerMemberName] string caller = null)
         {
             if (Transaction != null && Transaction.Disposed == false)
                 ThrowTransactionAlreadyOpened();
 
             Transaction = CreateReadTransaction();
+
+            if (caller != null)
+                Transaction.InnerTransaction.LowLevelTransaction.CallerName = caller;
 
             return Transaction;
         }
@@ -118,7 +122,7 @@ namespace Raven.Server.ServerWide.Context
 
         protected abstract TTransaction CreateWriteTransaction(TimeSpan? timeout = null);
 
-        public TTransaction OpenWriteTransaction(TimeSpan? timeout = null)
+        public TTransaction OpenWriteTransaction(TimeSpan? timeout = null, [CallerMemberName] string caller = null)
         {
             if (Transaction != null && Transaction.Disposed == false)
             {
@@ -126,6 +130,9 @@ namespace Raven.Server.ServerWide.Context
             }
 
             Transaction = CreateWriteTransaction(timeout);
+
+            if (caller != null)
+                Transaction.InnerTransaction.LowLevelTransaction.CallerName = caller;
 
             return Transaction;
         }

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -930,6 +930,8 @@ namespace Voron.Impl
 
         public NativeMemory.ThreadStats CurrentTransactionHolder { get; set; }
 
+        public string CallerName { get; set; }
+
         public void Dispose()
         {
             if (_txState.HasFlag(TxState.Disposed))


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22767

### Additional description

We're getting occasional requests about space problems which after investigation appear to be scratch.buffers. They are kept because of long running read transaction which apparently no longer exist. The change made here will provide us with additional info - the caller of the read transaction - so hopefully we'll be able to narrow down the area which potentially leaks a transaction,

### Type of change

- [x] Debugging improvement
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
