### PR TITLE
RavenDB-22906 - SlowTests.Issues.RavenDB_17702.InsertOldSegmentAfterDeletionProblem1(options: DatabaseMode = Single , SearchEngineMode = Lucene)

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17702.cs
+++ b/test/SlowTests/Issues/RavenDB-17702.cs
@@ -44,11 +44,13 @@ namespace SlowTests.Issues
                     }
                     using (var session = store.OpenSession())
                     {
+                        session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
+
                         session.TimeSeriesFor("users/1", "Heartrate")
                             .Delete(now.AddDays(i), now.AddDays(i).AddSeconds(1));
                         session.SaveChanges();
                     }
-                    foreach (var server in Servers)
+                    foreach (var server in cluster.Nodes)
                     {
                         var database = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                         var tss = database.DocumentsStorage.TimeSeriesStorage;


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22906/SlowTests.Issues.RavenDB17702.InsertOldSegmentAfterDeletionProblem1options-DatabaseMode-Single-SearchEngineMode-Lucene

### Additional description

- Added a check to ensure that, before appending a new segment from replication, we verify if a more recent deletion of the entire time series exists (https://github.com/ravendb/ravendb/pull/18928).
- Made minor fixes to the test to ensure it waits for replication completion after deletion.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
