### PR TITLE
RavenDB-22628 If you make a mistake with 2FA code, it will only work in a new window

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1630,19 +1630,12 @@ namespace Raven.Server
 
             public void WaitingForTwoFactorAuthentication()
             {
-                _statusAfterTwoFactorAuth = _status;
                 _status = AuthenticationStatus.TwoFactorAuthNotProvided;
             }
 
             public void SuccessfulTwoFactorAuthentication()
             {
-                // _statusAfterTwoFactorAuth is nullable
-                // when we override existing configuration we skip WaitingForTwoFactorAuthentication stage
-
-                if (_statusAfterTwoFactorAuth.HasValue)
-                    _status = _statusAfterTwoFactorAuth.Value;
-
-                _statusAfterTwoFactorAuth = null;
+                _status = _statusAfterTwoFactorAuth.Value;
             }
 
             public AuthenticationStatus Status
@@ -1717,6 +1710,8 @@ namespace Raven.Server
                         AuthorizedDatabases.Add(kvp.Key, kvp.Value);
                     }
                 }
+
+                _statusAfterTwoFactorAuth = Status;
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22628/If-you-make-a-mistake-with-2FA-code-it-will-only-work-in-a-new-window

### Additional description

`_statusAfterTwoFactorAuth` was sometimes set to `TwoFactorAuthNotProvided` or null. To avoid this, I moved setting to `SetBasedOnCertificateDefinition()`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
