### PR TITLE
RavenDB-22854 added total number of indexing errors for all loaded databases to SNMP

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/5.1.7/TotalNumberOfIndexingErrors.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/5.1.7/TotalNumberOfIndexingErrors.cs
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------
+//  <copyright file="TotalNumberOfIndexingErrors.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Lextm.SharpSnmpLib;
+using Raven.Server.ServerWide;
+
+namespace Raven.Server.Monitoring.Snmp.Objects.Database
+{
+    public class TotalNumberOfIndexingErrors : DatabaseBase<Integer32>
+    {
+        public TotalNumberOfIndexingErrors(ServerStore serverStore)
+            : base(serverStore, SnmpOids.Databases.General.TotalNumberOfIndexingErrors)
+        {
+        }
+
+        protected override Integer32 GetData()
+        {
+            var count = 0;
+            foreach (var database in GetLoadedDatabases())
+                count += GetCountSafely(database, DatabaseIndexingErrors.GetCount);
+
+            return new Integer32(count);
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/1/DatabaseIndexingErrors.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/1/DatabaseIndexingErrors.cs
@@ -13,13 +13,17 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
 
         protected override Integer32 GetData(DocumentDatabase database)
         {
-            var indexes = database.IndexStore.GetIndexes().ToList();
+            return new Integer32(GetCount(database));
+        }
 
+        internal static int GetCount(DocumentDatabase database)
+        {
+            var indexes = database.IndexStore.GetIndexes().ToList();
             var count = 0L;
             foreach (var index in indexes)
                 count += index.GetErrorCount();
 
-            return new Integer32((int)count);
+            return (int)count;
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpOids.cs
@@ -628,6 +628,9 @@ namespace Raven.Server.Monitoring.Snmp
                 [Description("Number of faulty indexes in all loaded databases")]
                 public const string TotalNumberOfFaultyIndexes = "5.1.7.4";
 
+                [Description("Number of indexing errors in all loaded databases")]
+                public const string TotalNumberOfIndexingErrors = "5.1.7.5";
+
                 [Description("Number of indexed documents per second for map indexes (one minute rate) in all loaded databases")]
                 public const string TotalMapIndexIndexesPerSecond = "5.1.8.1";
 

--- a/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
+++ b/src/Raven.Server/Monitoring/Snmp/SnmpWatcher.cs
@@ -431,6 +431,7 @@ namespace Raven.Server.Monitoring.Snmp
             store.Add(new TotalDatabaseCountOfStaleIndexes(server.ServerStore));
             store.Add(new TotalDatabaseNumberOfErrorIndexes(server.ServerStore));
             store.Add(new TotalDatabaseNumberOfFaultyIndexes(server.ServerStore));
+            store.Add(new TotalNumberOfIndexingErrors(server.ServerStore));
 
             store.Add(new TotalNumberOfActiveBackupTasks(server.ServerStore));
             store.Add(new TotalNumberOfActiveElasticSearchEtlTasks(server.ServerStore));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22854

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
