### PR TITLE
RavenDB-22942 Add export and import indexes to omni search

### DIFF
--- a/src/Raven.Studio/typescript/common/shell/menu/items/indexes.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/indexes.ts
@@ -33,8 +33,22 @@ function getIndexesMenuItem(appUrls: computedAppUrls) {
                     { name: "Delete index", alternativeNames: ["Remove index"] },
                     { name: "Edit index" },
                     { name: "Reset index (rebuild)", alternativeNames: ["Reset in place", "Reset side by side"] }, 
+                    { name: "Export indexes" }
                 ],
             },
+        }),
+        new leafMenuItem({
+            title: "List of Indexes",
+            nav: false,
+            shardingMode: "allShards",
+            route: "databases/indexes",
+            moduleId: bridgeToReact(IndexesPage, "shardedView"),
+            css: 'icon-index-import',
+            itemRouteToHighlight: 'databases/indexes',
+            dynamicHash: appUrls.indexes(null, false, true),
+            search: {
+                overrideTitle: "Import indexes",
+            }
         }),
         new leafMenuItem({
             route: 'databases/indexes/performance',


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22942/Add-Import-indexes-to-omni-search

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
