### PR TITLE
RavenDB-22960 Corax Facets: empty strings have to be projected as `EMPTY_STRING` instead of `\u0003`

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -18,6 +18,7 @@ namespace Corax
         
         public const string EmptyString = "\u0003";
         public static readonly ReadOnlyMemory<char> EmptyStringCharSpan = new(Constants.EmptyString.ToCharArray());
+        public static ReadOnlySpan<byte> EmptyStringByteSpan => "\u0003"u8;
 
         private const string NonExistingValue = "\u0001";
         
@@ -28,15 +29,17 @@ namespace Corax
         public const string IndexTimeFields = "@index_time_fields";
         public const string DocumentBoost = "@document_boost";
         public const string ProjectionNullValue = "NULL_VALUE";
+        public const string ProjectionEmptyString = "EMPTY_STRING";
         public const string JsonValue = "JSON_VALUE";
 
-        public static readonly Slice NullValueSlice, ProjectionNullValueSlice, EmptyStringSlice, IndexMetadataSlice, DocumentBoostSlice, IndexTimeFieldsSlice, NonExistingValueSlice;
+        public static readonly Slice NullValueSlice, ProjectionNullValueSlice, EmptyStringSlice, IndexMetadataSlice, DocumentBoostSlice, IndexTimeFieldsSlice, NonExistingValueSlice, ProjectionEmptyStringSlice;
 
         static Constants()
         {
             using (StorageEnvironment.GetStaticContext(out var ctx))
             {
                 Slice.From(ctx, ProjectionNullValue, ByteStringType.Immutable, out ProjectionNullValueSlice);
+                Slice.From(ctx, ProjectionEmptyString, ByteStringType.Immutable, out ProjectionEmptyStringSlice);
                 Slice.From(ctx, NullValue, ByteStringType.Immutable, out NullValueSlice);
                 Slice.From(ctx, EmptyString, ByteStringType.Immutable, out EmptyStringSlice);
                 Slice.From(ctx, IndexMetadata, ByteStringType.Immutable, out IndexMetadataSlice);

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
@@ -167,16 +167,19 @@ namespace Corax.Querying.Matches.TermProviders
             while (_iterator.MoveNext(_compactKey, out long postingListId, out _))
             {
                 var key = _compactKey.Decoded();
+                
                 int termSize = key.Length;
                 if (key.Length > 1)
                 {
                     if (key[^1] == 0)
                         termSize--;
                 }
+
+                var term = key.SequenceEqual(Constants.EmptyStringByteSpan) 
+                    ? Constants.ProjectionEmptyString 
+                    : Encodings.Utf8.GetString(key.Slice(0, termSize));
                 
-                var term = Encodings.Utf8.GetString(key.Slice(0, termSize));
                 terms.Add(term);
-                
                 termCount[termIdx++] = postingListId;
             }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -354,10 +354,14 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
             if (reader.IsNonExisting)
                 continue;
             
+            
             var key = reader.IsNull
                 ? Constants.ProjectionNullValueSlice
                 : reader.Current.Decoded();
 
+            if (key.SequenceEqual(Constants.EmptyStringByteSpan))
+                key = Constants.ProjectionEmptyStringSlice;
+            
             InsertTerm(key, ref cloned, facetValues, result, legacy, needToApplyAggregation, token);
         }
     }

--- a/test/SlowTests/Issues/RavenDB-22960.cs
+++ b/test/SlowTests/Issues/RavenDB-22960.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22960(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Facets)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void NullAndEmptyWillBeReturnedExactlyTheSameForAllEngines(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Store(new Dto(Name: "test", NumericalValue: 1));
+        session.Store(new Dto(Name: string.Empty, NumericalValue: 1));
+        session.Store(new Dto(Name: null, NumericalValue: 1));
+        
+        session.SaveChanges();
+        new Index().Execute(store);
+        Indexes.WaitForIndexing(store);
+        
+        //Testing Aggregate via Index (Corax)
+        var viaIndex = session.Query<Dto, Index>().AggregateBy(x => x.ByField(x => x.Name)).Execute();
+        Assert.Equal(3, viaIndex["Name"].Values.Count);
+        var ranges = viaIndex["Name"].Values.Select(x => x.Range).ToArray();
+        Assert.Contains("test", ranges);
+        Assert.Contains("EMPTY_STRING", ranges);
+        Assert.Contains("NULL_VALUE", ranges);
+        
+        //aggregation On is not supported by index aggregation
+        var viaScan = session.Query<Dto, Index>().AggregateBy(x => x.ByField(x => x.Name).SumOn(x => x.NumericalValue)).Execute();
+        Assert.Equal(3, viaScan["Name"].Values.Count);
+        ranges = viaScan["Name"].Values.Select(x => x.Range).ToArray();
+        Assert.Equal(1, viaScan["Name"].Values.Select(x => x.Sum).Distinct().First());
+        Assert.Contains("test", ranges);
+        Assert.Contains("EMPTY_STRING", ranges);
+        Assert.Contains("NULL_VALUE", ranges);
+    }
+
+    private record Dto(string Name, long NumericalValue, string Id = null);
+
+    private class Index : AbstractIndexCreationTask<Dto>
+    {
+        public Index()
+        {
+            Map = docs => docs.Select(doc => new {doc.Name, doc.NumericalValue, Id = doc.Id});
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22960

### Additional description
Corax uses its internal value for empty strings  (`\u0003`); however, during aggregation, it should return `EMPTY_STRING`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
