### PR TITLE
RavenDB-22952 introduced SmapsRollupReader

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -225,6 +225,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     var procStatus = MemoryInformation.GetMemoryUsageFromProcStatus();
                     var djv = new DynamicJsonValue
                     {
+                        ["Type"] = SmapsFactory.DefaultSmapsReaderType,
                         ["Totals"] = new DynamicJsonValue
                         {
                             ["WorkingSet"] = result.Rss,

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -215,12 +215,12 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var buffers = new[]
                 {
-                    ArrayPool<byte>.Shared.Rent(SmapsReader.BufferSize),
-                    ArrayPool<byte>.Shared.Rent(SmapsReader.BufferSize)
+                    ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize),
+                    ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize)
                 };
                 try
                 {
-                    var result = new SmapsReader(buffers).CalculateMemUsageFromSmaps<SmapsReaderJsonResults>();
+                    var result = AbstractSmapsReader.CreateSmapsReader(buffers).CalculateMemUsageFromSmaps<SmapsReaderJsonResults>();
                     var procStatus = MemoryInformation.GetMemoryUsageFromProcStatus();
                     var djv = new DynamicJsonValue
                     {

--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -14,6 +14,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Platform.Posix;
+using Sparrow.Server.Platform.Posix;
 using Sparrow.Server.Platform.Win32;
 using Sparrow.Utils;
 using Voron.Impl;
@@ -215,12 +216,12 @@ namespace Raven.Server.Documents.Handlers.Debugging
             {
                 var buffers = new[]
                 {
-                    ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize),
-                    ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize)
+                    ArrayPool<byte>.Shared.Rent(SmapsFactory.BufferSize),
+                    ArrayPool<byte>.Shared.Rent(SmapsFactory.BufferSize)
                 };
                 try
                 {
-                    var result = AbstractSmapsReader.CreateSmapsReader(buffers).CalculateMemUsageFromSmaps<SmapsReaderJsonResults>();
+                    var result = SmapsFactory.CreateSmapsReader(buffers).CalculateMemUsageFromSmaps<SmapsReaderJsonResults>();
                     var procStatus = MemoryInformation.GetMemoryUsageFromProcStatus();
                     var djv = new DynamicJsonValue
                     {

--- a/src/Raven.Server/ServerWide/ServerMetricCacher.cs
+++ b/src/Raven.Server/ServerWide/ServerMetricCacher.cs
@@ -5,13 +5,14 @@ using Raven.Server.Utils;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Platform.Posix;
+using Sparrow.Server.Platform.Posix;
 using Sparrow.Server.Utils;
 
 namespace Raven.Server.ServerWide
 {
     public class ServerMetricCacher : MetricCacher
     {
-        private readonly AbstractSmapsReader _smapsReader;
+        private readonly ISmapsReader _smapsReader;
         private readonly RavenServer _server;
 
         public const int DefaultCpuRefreshRateInMs = 1000;
@@ -21,7 +22,7 @@ namespace Raven.Server.ServerWide
             _server = server;
 
             if (PlatformDetails.RunningOnLinux)
-                _smapsReader = AbstractSmapsReader.CreateSmapsReader([new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize]]);
+                _smapsReader = SmapsFactory.CreateSmapsReader([new byte[SmapsFactory.BufferSize], new byte[SmapsFactory.BufferSize]]);
         }
 
         public void Initialize()

--- a/src/Sparrow.Server/LowMemory/LowMemoryMonitor.cs
+++ b/src/Sparrow.Server/LowMemory/LowMemoryMonitor.cs
@@ -7,7 +7,7 @@ namespace Sparrow.Server.LowMemory
 {
     public class LowMemoryMonitor : AbstractLowMemoryMonitor
     {
-        private readonly SmapsReader _smapsReader;
+        private readonly AbstractSmapsReader _smapsReader;
 
         private byte[][] _buffers;
 
@@ -15,10 +15,10 @@ namespace Sparrow.Server.LowMemory
         {
             if (PlatformDetails.RunningOnLinux)
             {
-                var buffer1 = ArrayPool<byte>.Shared.Rent(SmapsReader.BufferSize);
-                var buffer2 = ArrayPool<byte>.Shared.Rent(SmapsReader.BufferSize);
+                var buffer1 = ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize);
+                var buffer2 = ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize);
                 _buffers = new[] { buffer1, buffer2 };
-                _smapsReader = new SmapsReader(_buffers);
+                _smapsReader = AbstractSmapsReader.CreateSmapsReader(_buffers);
             }
         }
 

--- a/src/Sparrow.Server/LowMemory/LowMemoryMonitor.cs
+++ b/src/Sparrow.Server/LowMemory/LowMemoryMonitor.cs
@@ -2,12 +2,13 @@
 using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Platform.Posix;
+using Sparrow.Server.Platform.Posix;
 
 namespace Sparrow.Server.LowMemory
 {
     public class LowMemoryMonitor : AbstractLowMemoryMonitor
     {
-        private readonly AbstractSmapsReader _smapsReader;
+        private readonly ISmapsReader _smapsReader;
 
         private byte[][] _buffers;
 
@@ -15,10 +16,10 @@ namespace Sparrow.Server.LowMemory
         {
             if (PlatformDetails.RunningOnLinux)
             {
-                var buffer1 = ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize);
-                var buffer2 = ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize);
+                var buffer1 = ArrayPool<byte>.Shared.Rent(SmapsFactory.BufferSize);
+                var buffer2 = ArrayPool<byte>.Shared.Rent(SmapsFactory.BufferSize);
                 _buffers = new[] { buffer1, buffer2 };
-                _smapsReader = AbstractSmapsReader.CreateSmapsReader(_buffers);
+                _smapsReader = SmapsFactory.CreateSmapsReader(_buffers);
             }
         }
 

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -299,7 +299,7 @@ namespace Sparrow.LowMemory
 
         public static MemoryInfoResult GetMemoryInformationUsingOneTimeSmapsReader()
         {
-            SmapsReader smapsReader = null;
+            AbstractSmapsReader smapsReader = null;
             byte[][] buffers = null;
             try
             {
@@ -308,7 +308,7 @@ namespace Sparrow.LowMemory
                     var buffer1 = ArrayPool<byte>.Shared.Rent(SmapsReader.BufferSize);
                     var buffer2 = ArrayPool<byte>.Shared.Rent(SmapsReader.BufferSize);
                     buffers = new[] { buffer1, buffer2 };
-                    smapsReader = new SmapsReader(new[] { buffer1, buffer2 });
+                    smapsReader = AbstractSmapsReader.CreateSmapsReader(new[] { buffer1, buffer2 });
                 }
 
                 return GetMemoryInfo(smapsReader, extended: true);

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -299,16 +299,16 @@ namespace Sparrow.LowMemory
 
         public static MemoryInfoResult GetMemoryInformationUsingOneTimeSmapsReader()
         {
-            AbstractSmapsReader smapsReader = null;
+            ISmapsReader smapsReader = null;
             byte[][] buffers = null;
             try
             {
                 if (PlatformDetails.RunningOnLinux)
                 {
-                    var buffer1 = ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize);
-                    var buffer2 = ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize);
+                    var buffer1 = ArrayPool<byte>.Shared.Rent(SmapsFactory.BufferSize);
+                    var buffer2 = ArrayPool<byte>.Shared.Rent(SmapsFactory.BufferSize);
                     buffers = new[] { buffer1, buffer2 };
-                    smapsReader = AbstractSmapsReader.CreateSmapsReader(new[] { buffer1, buffer2 });
+                    smapsReader = SmapsFactory.CreateSmapsReader(new[] { buffer1, buffer2 });
                 }
 
                 return GetMemoryInfo(smapsReader, extended: true);
@@ -323,7 +323,7 @@ namespace Sparrow.LowMemory
             }
         }
 
-        private static bool GetFromProcMemInfo(AbstractSmapsReader smapsReader, ref ProcMemInfoResults procMemInfoResults)
+        private static bool GetFromProcMemInfo(ISmapsReader smapsReader, ref ProcMemInfoResults procMemInfoResults)
         {
             const string path = "/proc/meminfo";
 
@@ -387,7 +387,7 @@ namespace Sparrow.LowMemory
             return true;
         }
 
-        internal static MemoryInfoResult GetMemoryInfo(AbstractSmapsReader smapsReader = null, bool extended = false)
+        internal static MemoryInfoResult GetMemoryInfo(ISmapsReader smapsReader = null, bool extended = false)
         {
             if (_failedToGetAvailablePhysicalMemory)
             {
@@ -434,7 +434,7 @@ namespace Sparrow.LowMemory
             return totalScratchAllocated;
         }
 
-        private static MemoryInfoResult GetMemoryInfoLinux(AbstractSmapsReader smapsReader, bool extended)
+        private static MemoryInfoResult GetMemoryInfoLinux(ISmapsReader smapsReader, bool extended)
         {
             var fromProcMemInfo = new ProcMemInfoResults();
             GetFromProcMemInfo(smapsReader, ref fromProcMemInfo);

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -305,8 +305,8 @@ namespace Sparrow.LowMemory
             {
                 if (PlatformDetails.RunningOnLinux)
                 {
-                    var buffer1 = ArrayPool<byte>.Shared.Rent(SmapsReader.BufferSize);
-                    var buffer2 = ArrayPool<byte>.Shared.Rent(SmapsReader.BufferSize);
+                    var buffer1 = ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize);
+                    var buffer2 = ArrayPool<byte>.Shared.Rent(AbstractSmapsReader.BufferSize);
                     buffers = new[] { buffer1, buffer2 };
                     smapsReader = AbstractSmapsReader.CreateSmapsReader(new[] { buffer1, buffer2 });
                 }

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -323,7 +323,7 @@ namespace Sparrow.LowMemory
             }
         }
 
-        private static bool GetFromProcMemInfo(SmapsReader smapsReader, ref ProcMemInfoResults procMemInfoResults)
+        private static bool GetFromProcMemInfo(AbstractSmapsReader smapsReader, ref ProcMemInfoResults procMemInfoResults)
         {
             const string path = "/proc/meminfo";
 
@@ -387,7 +387,7 @@ namespace Sparrow.LowMemory
             return true;
         }
 
-        internal static MemoryInfoResult GetMemoryInfo(SmapsReader smapsReader = null, bool extended = false)
+        internal static MemoryInfoResult GetMemoryInfo(AbstractSmapsReader smapsReader = null, bool extended = false)
         {
             if (_failedToGetAvailablePhysicalMemory)
             {
@@ -434,7 +434,7 @@ namespace Sparrow.LowMemory
             return totalScratchAllocated;
         }
 
-        private static MemoryInfoResult GetMemoryInfoLinux(SmapsReader smapsReader, bool extended)
+        private static MemoryInfoResult GetMemoryInfoLinux(AbstractSmapsReader smapsReader, bool extended)
         {
             var fromProcMemInfo = new ProcMemInfoResults();
             GetFromProcMemInfo(smapsReader, ref fromProcMemInfo);

--- a/src/Sparrow.Server/Platform/Posix/ISmapsReader.cs
+++ b/src/Sparrow.Server/Platform/Posix/ISmapsReader.cs
@@ -1,0 +1,10 @@
+﻿using System.IO;
+
+namespace Sparrow.Platform.Posix;
+
+internal interface ISmapsReader
+{
+    SmapsReadResult<T> CalculateMemUsageFromSmaps<T>() where T : struct, ISmapsReaderResultAction;
+
+    SmapsReadResult<T> CalculateMemUsageFromSmaps<T>(Stream fileStream, int pid) where T : struct, ISmapsReaderResultAction;
+}

--- a/src/Sparrow.Server/Platform/Posix/ISmapsReaderResultAction.cs
+++ b/src/Sparrow.Server/Platform/Posix/ISmapsReaderResultAction.cs
@@ -1,0 +1,6 @@
+﻿namespace Sparrow.Platform.Posix;
+
+internal interface ISmapsReaderResultAction
+{
+    void Add(SmapsReaderResults results);
+}

--- a/src/Sparrow.Server/Platform/Posix/SmapsFactory.cs
+++ b/src/Sparrow.Server/Platform/Posix/SmapsFactory.cs
@@ -1,0 +1,52 @@
+﻿using Sparrow.Platform.Posix;
+using System.Diagnostics;
+using System;
+using System.IO;
+using Sparrow.Platform;
+
+namespace Sparrow.Server.Platform.Posix;
+
+internal static class SmapsFactory
+{
+    public const int BufferSize = 4096;
+
+    public static SmapsReaderType DefaultSmapsReaderType = SmapsReaderType.Smaps;
+
+    static SmapsFactory()
+    {
+        var envSmapsReaderType = Environment.GetEnvironmentVariable("RAVEN_SMAPS_READER_TYPE");
+
+        if (PlatformDetails.RunningOnPosix == false)
+            return;
+
+        if (string.IsNullOrWhiteSpace(envSmapsReaderType) == false && Enum.TryParse<SmapsReaderType>(envSmapsReaderType, ignoreCase: true, out var smapsReaderType))
+        {
+            DefaultSmapsReaderType = smapsReaderType;
+            return;
+        }
+
+        using (var process = Process.GetCurrentProcess())
+        {
+            if (File.Exists(SmapsRollupReader.GetSmapsPath(process.Id)))
+                DefaultSmapsReaderType = SmapsReaderType.SmapsRollup;
+        }
+    }
+
+    public static ISmapsReader CreateSmapsReader(byte[][] smapsBuffer)
+    {
+        return CreateSmapsReader(DefaultSmapsReaderType, smapsBuffer);
+    }
+
+    public static ISmapsReader CreateSmapsReader(SmapsReaderType type, byte[][] smapsBuffer)
+    {
+        switch (type)
+        {
+            case SmapsReaderType.Smaps:
+                return new SmapsReader(smapsBuffer);
+            case SmapsReaderType.SmapsRollup:
+                return new SmapsRollupReader(smapsBuffer);
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+}

--- a/src/Sparrow.Server/Platform/Posix/SmapsReadResult.cs
+++ b/src/Sparrow.Server/Platform/Posix/SmapsReadResult.cs
@@ -1,0 +1,11 @@
+﻿namespace Sparrow.Platform.Posix;
+
+internal struct SmapsReadResult<T> where T : struct, ISmapsReaderResultAction
+{
+    public long Rss;
+    public long SharedClean;
+    public long PrivateClean;
+    public long TotalDirty;
+    public long Swap;
+    public T SmapsResults;
+}

--- a/src/Sparrow.Server/Platform/Posix/SmapsReaderJsonResults.cs
+++ b/src/Sparrow.Server/Platform/Posix/SmapsReaderJsonResults.cs
@@ -1,0 +1,37 @@
+﻿using Sparrow.Json.Parsing;
+using Sparrow.Utils;
+
+namespace Sparrow.Platform.Posix;
+
+internal struct SmapsReaderJsonResults : ISmapsReaderResultAction
+{
+    private DynamicJsonArray _dja;
+
+    public void Add(SmapsReaderResults results)
+    {
+        var djv = new DynamicJsonValue
+        {
+            ["File"] = results.ResultString,
+            ["Size"] = Sizes.Humane(results.Size),
+            ["Rss"] = Sizes.Humane(results.Rss),
+            ["SharedClean"] = Sizes.Humane(results.SharedClean),
+            ["SharedDirty"] = Sizes.Humane(results.SharedDirty),
+            ["PrivateClean"] = Sizes.Humane(results.PrivateClean),
+            ["PrivateDirty"] = Sizes.Humane(results.PrivateDirty),
+            ["TotalClean"] = results.SharedClean + results.PrivateClean,
+            ["TotalCleanHumanly"] = Sizes.Humane(results.SharedClean + results.PrivateClean),
+            ["TotalDirty"] = results.SharedDirty + results.PrivateDirty,
+            ["TotalDirtyHumanly"] = Sizes.Humane(results.SharedDirty + results.PrivateDirty),
+            ["TotalSwap"] = results.Swap,
+            ["TotalSwapHumanly"] = Sizes.Humane(results.Swap)
+        };
+        if (_dja == null)
+            _dja = new DynamicJsonArray();
+        _dja.Add(djv);
+    }
+
+    public DynamicJsonArray ReturnResults()
+    {
+        return _dja;
+    }
+}

--- a/src/Sparrow.Server/Platform/Posix/SmapsReaderNoAllocResults.cs
+++ b/src/Sparrow.Server/Platform/Posix/SmapsReaderNoAllocResults.cs
@@ -1,0 +1,9 @@
+﻿namespace Sparrow.Platform.Posix;
+
+internal struct SmapsReaderNoAllocResults : ISmapsReaderResultAction
+{
+    public void Add(SmapsReaderResults results)
+    {
+        // currently we do not use these results with SmapsReaderNoAllocResults so we do not store them
+    }
+}

--- a/src/Sparrow.Server/Platform/Posix/SmapsReaderResults.cs
+++ b/src/Sparrow.Server/Platform/Posix/SmapsReaderResults.cs
@@ -1,0 +1,13 @@
+﻿namespace Sparrow.Platform.Posix;
+
+internal class SmapsReaderResults
+{
+    public string ResultString;
+    public long Size;
+    public long Rss;
+    public long SharedClean;
+    public long SharedDirty;
+    public long PrivateClean;
+    public long PrivateDirty;
+    public long Swap;
+}

--- a/src/Sparrow.Server/Platform/Posix/SmapsReaderType.cs
+++ b/src/Sparrow.Server/Platform/Posix/SmapsReaderType.cs
@@ -1,0 +1,7 @@
+﻿namespace Sparrow.Server.Platform.Posix;
+
+internal enum SmapsReaderType
+{
+    Smaps,
+    SmapsRollup
+}

--- a/test/SlowTests/Utils/SmapsReaderTests.cs
+++ b/test/SlowTests/Utils/SmapsReaderTests.cs
@@ -16,18 +16,57 @@ namespace SlowTests.Utils
         {
         }
 
+        private const string SmapsRollup = @"605f1bf67000-7fff4b6e2000 ---p 00000000 00:00 0                          [rollup]
+Rss:              843564 kB
+Pss:              809811 kB
+Pss_Dirty:        543903 kB
+Pss_Anon:         422104 kB
+Pss_File:         265771 kB
+Pss_Shmem:        121935 kB
+Shared_Clean:      61696 kB
+Shared_Dirty:         32 kB
+Private_Clean:    237944 kB
+Private_Dirty:    543892 kB
+Referenced:       713176 kB
+Anonymous:        422104 kB
+LazyFree:              0 kB
+AnonHugePages:         0 kB
+ShmemPmdMapped:        0 kB
+FilePmdMapped:         0 kB
+Shared_Hugetlb:        0 kB
+Private_Hugetlb:       0 kB
+Swap:                  0 kB
+SwapPss:               0 kB
+Locked:                0 kB
+";
+
+
+        [Fact]
+        public void ParsesSmapsProperlyFromRollup()
+        {
+            var smapsReader = new SmapsRollupReader(new[] { new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize] });
+            AbstractSmapsReader.SmapsReadResult<SmapsTestResult> result;
+            using (var smapsStream = new FakeProcSmapsEntriesStream(new MemoryStream(Encoding.UTF8.GetBytes(SmapsRollup))))
+            {
+                result = smapsReader
+                    .CalculateMemUsageFromSmaps<SmapsTestResult>(smapsStream, pid: 1234);
+            }
+
+            Assert.Single(result.SmapsResults.Entries);
+        }
+
         [Fact]
         public void ParsesSmapsProperly()
         {
             var assembly = typeof(SmapsReaderTests).Assembly;
             var smapsReader = new SmapsReader(new[]
             {
-                new byte[SmapsReader.BufferSize], new byte[SmapsReader.BufferSize]
+                new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize]
             });
 
-            SmapsReader.SmapsReadResult<SmapsTestResult> result;
-            
-            using (var fs = 
+            AbstractSmapsReader.SmapsReadResult<SmapsTestResult> result;
+
+            using (var fs =
                 assembly.GetManifestResourceStream("SlowTests.Data.RavenDB_15159.12119.smaps.gz"))
             using (var deflated = new GZipStream(fs, CompressionMode.Decompress))
             using (var smapsStream = new FakeProcSmapsEntriesStream(deflated))
@@ -35,14 +74,14 @@ namespace SlowTests.Utils
                 result = smapsReader
                     .CalculateMemUsageFromSmaps<SmapsTestResult>(smapsStream, pid: 1234);
             }
-            
+
             // 385 .buffers
             // 181 .voron
-            Assert.Equal(385 + 181, result.SmapsResults.Entries.Count); 
-            
+            Assert.Equal(385 + 181, result.SmapsResults.Entries.Count);
+
             // cat 12119.smaps | grep -e "rw-s" -A 3 | awk '$1 ~ /Rss/ {sum += $2} END {print sum}'
             Assert.Equal(722136L * 1024, result.Rss);
-            
+
             // cat 12119.smaps | grep -e "rw-s" -A 16 | awk '$1 ~ /Swap/ {sum += $2} END {print sum}'
             Assert.Equal(1348L * 1024, result.Swap);
         }
@@ -54,12 +93,12 @@ namespace SlowTests.Utils
             {
                 if (Entries == null)
                     Entries = new List<SmapsReaderResults>();
-                
+
                 Entries.Add(results);
             }
         }
 
-        private class FakeProcSmapsEntriesStream : Stream 
+        private class FakeProcSmapsEntriesStream : Stream
         {
             private readonly Stream _smapsSnapshotStream;
 
@@ -73,24 +112,26 @@ namespace SlowTests.Utils
 
             private IEnumerable<string> ReadEntry()
             {
-                using (StreamReader reader = new StreamReader(_smapsSnapshotStream))
+                using (StreamReader reader = new(_smapsSnapshotStream))
                 {
                     var currentEntry = new StringBuilder();
                     string line;
-                    
+
                     while ((line = reader.ReadLine()) != null)
                     {
                         currentEntry.Append(line + '\n');
-                        
+
                         if (line.StartsWith("VmFlags"))
                         {
                             yield return currentEntry.ToString();
                             currentEntry = new StringBuilder();
                         }
                     }
+
+                    yield return currentEntry.ToString();
                 }
             }
-            
+
             public override void Flush()
             {
                 throw new System.NotImplementedException();
@@ -100,7 +141,7 @@ namespace SlowTests.Utils
             {
                 if (_entriesEnumerator.MoveNext() == false)
                     return 0;
-                
+
                 var currentEntryString = _entriesEnumerator.Current;
                 var entryBytes = Encoding.UTF8.GetBytes(currentEntryString);
                 entryBytes.CopyTo(new Memory<byte>(buffer));
@@ -128,6 +169,6 @@ namespace SlowTests.Utils
             public override long Length => 0;
             public override long Position { get; set; }
         }
-    
+
     }
 }

--- a/test/SlowTests/Utils/SmapsReaderTests.cs
+++ b/test/SlowTests/Utils/SmapsReaderTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using FastTests;
 using Sparrow;
 using Sparrow.Platform.Posix;
+using Sparrow.Server.Platform.Posix;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -46,8 +47,8 @@ Locked:                0 kB
         [RavenFact(RavenTestCategory.Linux | RavenTestCategory.Memory)]
         public void ParsesSmapsProperlyFromRollup()
         {
-            var smapsReader = SmapsRollupReader.CreateNew([new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize]]);
-            AbstractSmapsReader.SmapsReadResult<SmapsTestResult> result;
+            var smapsReader = new SmapsRollupReader([new byte[SmapsFactory.BufferSize], new byte[SmapsFactory.BufferSize]]);
+            SmapsReadResult<SmapsTestResult> result;
             using (var smapsStream = new FakeProcSmapsEntriesStream(new MemoryStream(Encoding.UTF8.GetBytes(SmapsRollup))))
             {
                 result = smapsReader
@@ -71,9 +72,9 @@ Locked:                0 kB
         public void ParsesSmapsProperly()
         {
             var assembly = typeof(SmapsReaderTests).Assembly;
-            var smapsReader = SmapsReader.CreateNew([new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize]]);
+            var smapsReader = new SmapsReader([new byte[SmapsFactory.BufferSize], new byte[SmapsFactory.BufferSize]]);
 
-            AbstractSmapsReader.SmapsReadResult<SmapsTestResult> result;
+            SmapsReadResult<SmapsTestResult> result;
 
             using (var fs =
                 assembly.GetManifestResourceStream("SlowTests.Data.RavenDB_15159.12119.smaps.gz"))

--- a/test/SlowTests/Utils/SmapsReaderTests.cs
+++ b/test/SlowTests/Utils/SmapsReaderTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Text;
 using FastTests;
+using Sparrow;
 using Sparrow.Platform.Posix;
 using Xunit;
 using Xunit.Abstractions;
@@ -53,6 +54,16 @@ Locked:                0 kB
             }
 
             Assert.Single(result.SmapsResults.Entries);
+
+            var totalDirty = new Size(0, SizeUnit.Bytes);
+            totalDirty.Add(543892, SizeUnit.Kilobytes);
+            totalDirty.Add(32, SizeUnit.Kilobytes);
+
+            Assert.Equal(new Size(843564, SizeUnit.Kilobytes).GetValue(SizeUnit.Bytes), result.Rss);
+            Assert.Equal(new Size(61696, SizeUnit.Kilobytes).GetValue(SizeUnit.Bytes), result.SharedClean);
+            Assert.Equal(new Size(237944, SizeUnit.Kilobytes).GetValue(SizeUnit.Bytes), result.PrivateClean);
+            Assert.Equal(new Size(0, SizeUnit.Kilobytes).GetValue(SizeUnit.Bytes), result.Swap);
+            Assert.Equal(totalDirty.GetValue(SizeUnit.Bytes), result.TotalDirty);
         }
 
         [Fact]

--- a/test/SlowTests/Utils/SmapsReaderTests.cs
+++ b/test/SlowTests/Utils/SmapsReaderTests.cs
@@ -44,7 +44,7 @@ Locked:                0 kB
         [Fact]
         public void ParsesSmapsProperlyFromRollup()
         {
-            var smapsReader = new SmapsRollupReader(new[] { new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize] });
+            var smapsReader = SmapsRollupReader.CreateNew([new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize]]);
             AbstractSmapsReader.SmapsReadResult<SmapsTestResult> result;
             using (var smapsStream = new FakeProcSmapsEntriesStream(new MemoryStream(Encoding.UTF8.GetBytes(SmapsRollup))))
             {
@@ -59,10 +59,7 @@ Locked:                0 kB
         public void ParsesSmapsProperly()
         {
             var assembly = typeof(SmapsReaderTests).Assembly;
-            var smapsReader = new SmapsReader(new[]
-            {
-                new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize]
-            });
+            var smapsReader = SmapsReader.CreateNew([new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize]]);
 
             AbstractSmapsReader.SmapsReadResult<SmapsTestResult> result;
 

--- a/test/SlowTests/Utils/SmapsReaderTests.cs
+++ b/test/SlowTests/Utils/SmapsReaderTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using FastTests;
 using Sparrow;
 using Sparrow.Platform.Posix;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -42,7 +43,7 @@ Locked:                0 kB
 ";
 
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Linux | RavenTestCategory.Memory)]
         public void ParsesSmapsProperlyFromRollup()
         {
             var smapsReader = SmapsRollupReader.CreateNew([new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize]]);

--- a/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
+++ b/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
@@ -9,13 +9,13 @@ namespace Tests.Infrastructure.TestMetrics
 {
     public class TestResourcesAnalyzerMetricCacher : MetricCacher
     {
-        private readonly SmapsReader _smapsReader;
+        private readonly AbstractSmapsReader _smapsReader;
         private readonly TimeSpan _cacheRefreshRate = TimeSpan.FromMilliseconds(25);
 
         public TestResourcesAnalyzerMetricCacher(ICpuUsageCalculator cpuUsageCalculator)
         {
             if (PlatformDetails.RunningOnLinux)
-                _smapsReader = new SmapsReader(new[] { new byte[SmapsReader.BufferSize], new byte[SmapsReader.BufferSize] });
+                _smapsReader = AbstractSmapsReader.CreateSmapsReader([new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize]]);
 
             Register(Keys.Server.CpuUsage, _cacheRefreshRate, cpuUsageCalculator.Calculate);
             Register(Keys.Server.MemoryInfo, _cacheRefreshRate, CalculateMemoryInfo);

--- a/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
+++ b/test/Tests.Infrastructure/TestMetrics/TestResourcesAnalyzerMetricCacher.cs
@@ -4,18 +4,19 @@ using Raven.Server.Utils.Cpu;
 using Sparrow.LowMemory;
 using Sparrow.Platform;
 using Sparrow.Platform.Posix;
+using Sparrow.Server.Platform.Posix;
 
 namespace Tests.Infrastructure.TestMetrics
 {
     public class TestResourcesAnalyzerMetricCacher : MetricCacher
     {
-        private readonly AbstractSmapsReader _smapsReader;
+        private readonly ISmapsReader _smapsReader;
         private readonly TimeSpan _cacheRefreshRate = TimeSpan.FromMilliseconds(25);
 
         public TestResourcesAnalyzerMetricCacher(ICpuUsageCalculator cpuUsageCalculator)
         {
             if (PlatformDetails.RunningOnLinux)
-                _smapsReader = AbstractSmapsReader.CreateSmapsReader([new byte[AbstractSmapsReader.BufferSize], new byte[AbstractSmapsReader.BufferSize]]);
+                _smapsReader = SmapsFactory.CreateSmapsReader([new byte[SmapsFactory.BufferSize], new byte[SmapsFactory.BufferSize]]);
 
             Register(Keys.Server.CpuUsage, _cacheRefreshRate, cpuUsageCalculator.Calculate);
             Register(Keys.Server.MemoryInfo, _cacheRefreshRate, CalculateMemoryInfo);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22952

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Linux
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
