### PR TITLE
RavenDB-22957 Save server certificate with RW group permissions

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
@@ -20,6 +20,7 @@ using Sparrow.Platform;
 using Sparrow.Server.Platform.Posix;
 using Sparrow.Threading;
 using Sparrow.Utils;
+using Voron.Platform.Posix;
 using StudioConfiguration = Raven.Client.Documents.Operations.Configuration.StudioConfiguration;
 
 namespace Raven.Server.Commercial.LetsEncrypt;
@@ -134,6 +135,11 @@ public static class SettingsZipFileHelper
                     {
                         await certFile.WriteAsync(parameters.CompleteClusterConfigurationResult.ServerCertBytes, parameters.Token);
                     } // we'll be flushing the directory when we'll write the settings.json
+
+                    if (PlatformDetails.RunningOnPosix)
+                    {
+                        PosixHelper.EnsureRWPermissionsForOwnerAndGroup(certPath);
+                    }
                 }
 
                 settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certPath ?? certificateFileName;

--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -29,8 +29,10 @@ using Raven.Server.Utils.Features;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
+using Sparrow.Platform;
 using Sparrow.Server.Json.Sync;
 using Sparrow.Utils;
+using Voron.Platform.Posix;
 using StudioConfiguration = Raven.Client.Documents.Operations.Configuration.StudioConfiguration;
 
 namespace Raven.Server.Commercial
@@ -878,6 +880,11 @@ namespace Raven.Server.Commercial
                     var certBytes = serverCertBytes;
                     await certFile.WriteAsync(certBytes, 0, certBytes.Length);
                     await certFile.FlushAsync();
+                }
+
+                if (PlatformDetails.RunningOnPosix)
+                {
+                    PosixHelper.EnsureRWPermissionsForOwnerAndGroup(certPath);
                 }
             }
             catch (Exception e)

--- a/src/Sparrow/Platform/PlatformDetails.cs
+++ b/src/Sparrow/Platform/PlatformDetails.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Sparrow.Platform
 {
@@ -12,13 +13,26 @@ namespace Sparrow.Platform
 
         public static readonly bool Is32Bits = IntPtr.Size == sizeof(int);
 
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatformGuard("linux")]
+        [SupportedOSPlatformGuard("osx")]
+#endif
         public static readonly bool RunningOnPosix = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
                                                      RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatformGuard("osx")]
+#endif
         public static readonly bool RunningOnMacOsx = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatformGuard("linux")]
+#endif
         public static readonly bool RunningOnLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-        
+
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatformGuard("windows")]
+#endif
         public static readonly bool RunningOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         public static readonly bool CanPrefetch;

--- a/src/Voron/Platform/Posix/PosixHelper.cs
+++ b/src/Voron/Platform/Posix/PosixHelper.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Sparrow;
 using Sparrow.Server.Exceptions;
 using Sparrow.Server.Platform;
@@ -130,6 +131,7 @@ namespace Voron.Platform.Posix
             dirsToCreate.ForEach(x => Directory.CreateDirectory(x));
         }
 
+        [UnsupportedOSPlatform("windows")]
         public static void EnsureRWPermissionsForOwnerAndGroup(string filePath)
         {
             var fileMode = File.GetUnixFileMode(filePath);

--- a/src/Voron/Platform/Posix/PosixHelper.cs
+++ b/src/Voron/Platform/Posix/PosixHelper.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using Mono.Unix;
 using Sparrow;
 using Sparrow.Server.Exceptions;
 using Sparrow.Server.Platform;
@@ -128,6 +129,12 @@ namespace Voron.Platform.Posix
                     break;
             }
             dirsToCreate.ForEach(x => Directory.CreateDirectory(x));
+        }
+
+        public static void EnsureRWPermissionsForOwnerAndGroup(string filePath)
+        {
+            var fileInfo = new UnixFileInfo(filePath);
+            fileInfo.FileAccessPermissions = fileInfo.FileAccessPermissions | FileAccessPermissions.UserRead | FileAccessPermissions.UserWrite | FileAccessPermissions.GroupRead | FileAccessPermissions.GroupWrite;
         }
     }
 }

--- a/src/Voron/Platform/Posix/PosixHelper.cs
+++ b/src/Voron/Platform/Posix/PosixHelper.cs
@@ -7,7 +7,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
-using Mono.Unix;
 using Sparrow;
 using Sparrow.Server.Exceptions;
 using Sparrow.Server.Platform;
@@ -133,8 +132,8 @@ namespace Voron.Platform.Posix
 
         public static void EnsureRWPermissionsForOwnerAndGroup(string filePath)
         {
-            var fileInfo = new UnixFileInfo(filePath);
-            fileInfo.FileAccessPermissions = fileInfo.FileAccessPermissions | FileAccessPermissions.UserRead | FileAccessPermissions.UserWrite | FileAccessPermissions.GroupRead | FileAccessPermissions.GroupWrite;
+            var fileMode = File.GetUnixFileMode(filePath);
+            File.SetUnixFileMode(filePath, fileMode | UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.GroupWrite);
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22957

### Additional description

Set RW group permissions for server certificate when using Wizard Setup on Posix System.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
    - Posix systems
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
