### PR TITLE
RavenDB-21326 - Automatic revision bin cleaning (RevisionsBinCleaner)

### DIFF
--- a/src/Raven.Client/Documents/Operations/Revisions/ConfigureRevisionsBinCleanerOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/ConfigureRevisionsBinCleanerOperation.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
+using Raven.Client.Util;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.Revisions
+{
+    public sealed class ConfigureRevisionsBinCleanerOperation : IMaintenanceOperation<ConfigureRevisionsBinCleanerOperationResult>
+    {
+        private readonly RevisionsBinConfiguration _configuration;
+
+        /// <summary>
+        /// Configure the revisions-bin cleaner which cleans the revisions bin automatically when enabled.
+        /// </summary>
+        /// <param name="configuration">The configuration for the revisions bin cleaner. This parameter cannot be null.</param>
+        /// <exception cref="ArgumentNullException">Thrown if the <paramref name="configuration"/> is null.</exception>
+        public ConfigureRevisionsBinCleanerOperation(RevisionsBinConfiguration configuration)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+
+        public RavenCommand<ConfigureRevisionsBinCleanerOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+        {
+            return new ConfigureRevisionsBinCleanerCommand(conventions, _configuration);
+        }
+
+        private sealed class ConfigureRevisionsBinCleanerCommand : RavenCommand<ConfigureRevisionsBinCleanerOperationResult>, IRaftCommand
+        {
+            private readonly DocumentConventions _conventions;
+            private readonly RevisionsBinConfiguration _configuration;
+
+            public ConfigureRevisionsBinCleanerCommand(DocumentConventions conventions, RevisionsBinConfiguration configuration)
+            {
+                _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
+                _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            }
+
+            public override bool IsReadRequest => false;
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/admin/revisions/bin-cleaner/config";
+
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Post,
+                    Content =
+                        new BlittableJsonContent(
+                            async stream => await ctx.WriteAsync(stream, DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(_configuration, ctx))
+                                .ConfigureAwait(false), _conventions)
+                };
+
+                return request;
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    ThrowInvalidResponse();
+
+                Result = JsonDeserializationClient.ConfigureRevisionsBinCleanerOperationResult(response);
+            }
+
+            public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/Revisions/ConfigureRevisionsBinCleanerOperationResult.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/ConfigureRevisionsBinCleanerOperationResult.cs
@@ -1,0 +1,7 @@
+﻿namespace Raven.Client.Documents.Operations.Revisions
+{
+    public sealed class ConfigureRevisionsBinCleanerOperationResult
+    {
+        public long? RaftCommandIndex { get; set; }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/Revisions/RevisionsBinConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/RevisionsBinConfiguration.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Raven.Client.Documents.Conventions;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Documents.Operations.Revisions
+{
+    public sealed class RevisionsBinConfiguration : IDynamicJson
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the revisions bin cleaner is disabled.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if the cleaner is disabled; otherwise, <c>false</c>.
+        /// </value>
+        public bool Disabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum age of revisions-bin entries (deleted docs with revisions) to keep in the database.
+        /// The revisions-bin cleaner deletes the entries that are older than that.
+        /// </summary>
+        /// <value>
+        /// The minimum <see cref="int"/> that revisions-bin entries (deleted docs with revisions) must be kept before being eligible for deletion.
+        /// A null value means no age restriction is applied.
+        /// </value>
+        public int? MinimumEntriesAgeToKeepInMin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the frequency (in seconds) at which the revisions bin cleaner executes cleaning.
+        /// </summary>
+        /// <value>
+        /// The <see cref="long"/> defining how often the cleaner will check for and process old entries (deleted docs with revisions).
+        /// The default value is 5 minutes.
+        /// </value>
+        public long RefreshFrequencyInSec { get; set; } = 5 * 60;
+
+        private bool Equals(RevisionsBinConfiguration other)
+        {
+            return Disabled == other.Disabled &&
+                   MinimumEntriesAgeToKeepInMin == other.MinimumEntriesAgeToKeepInMin &&
+                   RefreshFrequencyInSec == other.RefreshFrequencyInSec;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != GetType())
+                return false;
+            return Equals((RevisionsBinConfiguration)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Disabled.GetHashCode();
+                hashCode = (hashCode * 397) ^ (MinimumEntriesAgeToKeepInMin?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ RefreshFrequencyInSec.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Disabled)] = Disabled,
+                [nameof(MinimumEntriesAgeToKeepInMin)] = MinimumEntriesAgeToKeepInMin,
+                [nameof(RefreshFrequencyInSec)] = RefreshFrequencyInSec
+            };
+        }
+
+        public DynamicJsonValue ToAuditJson()
+        {
+            return ToJson();
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -188,6 +188,8 @@ namespace Raven.Client.Json.Serialization
         internal static readonly Func<BlittableJsonReaderObject, DeleteDatabaseResult> DeleteDatabaseResult = GenerateJsonDeserializationRoutine<DeleteDatabaseResult>();
 
         internal static readonly Func<BlittableJsonReaderObject, ConfigureExpirationOperationResult> ConfigureExpirationOperationResult = GenerateJsonDeserializationRoutine<ConfigureExpirationOperationResult>();
+
+        internal static readonly Func<BlittableJsonReaderObject, ConfigureRevisionsBinCleanerOperationResult> ConfigureRevisionsBinCleanerOperationResult = GenerateJsonDeserializationRoutine<ConfigureRevisionsBinCleanerOperationResult>();
         
         internal static readonly Func<BlittableJsonReaderObject, ConfigureDataArchivalOperationResult> ConfigureDataArchivalOperationResult = GenerateJsonDeserializationRoutine<ConfigureDataArchivalOperationResult>();
 

--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -89,6 +89,8 @@ namespace Raven.Client.ServerWide
 
         public RevisionsConfiguration Revisions;
 
+        public RevisionsBinConfiguration RevisionsBin;
+
         public TimeSeriesConfiguration TimeSeries;
 
         public RevisionsCollectionConfiguration RevisionsForConflicts;

--- a/src/Raven.Client/ServerWide/Operations/DatabaseRecordBuilder.cs
+++ b/src/Raven.Client/ServerWide/Operations/DatabaseRecordBuilder.cs
@@ -347,6 +347,12 @@ public sealed class DatabaseRecordBuilder :
         _databaseRecord.Revisions = configuration ?? throw new ArgumentNullException(nameof(configuration));
         return this;
     }
+    
+    IDatabaseRecordBuilderBase IDatabaseRecordBuilderBase.ConfigureRevisionsBin(RevisionsBinConfiguration configuration)
+    {
+        _databaseRecord.RevisionsBin = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        return this;
+    }
 
     IDatabaseRecordBuilderBase IDatabaseRecordBuilderBase.WithEtls(Action<IEtlConfigurationBuilder> builder)
     {
@@ -586,6 +592,8 @@ public interface IDatabaseRecordBuilderBase
     IDatabaseRecordBuilderBase WithSettings(Action<Dictionary<string, string>> builder);
 
     IDatabaseRecordBuilderBase ConfigureRevisions(RevisionsConfiguration configuration);
+
+    IDatabaseRecordBuilderBase ConfigureRevisionsBin(RevisionsBinConfiguration configuration);
 
     IDatabaseRecordBuilderBase WithEtls(Action<IEtlConfigurationBuilder> builder);
 

--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -152,7 +152,7 @@ public abstract unsafe class AbstractBackgroundWorkStorage
 
     protected abstract void HandleDocumentConflict(BackgroundWorkParameters options, Slice ticksAsSlice, Slice clonedId, Queue<DocumentExpirationInfo> expiredDocs, ref int totalCount);
 
-    protected static bool ShouldHandleWorkOnCurrentNode(DatabaseTopology topology, string nodeTag)
+    public static bool ShouldHandleWorkOnCurrentNode(DatabaseTopology topology, string nodeTag)
     {
         var isFirstInTopology = string.Equals(topology.AllNodes.FirstOrDefault(), nodeTag, StringComparison.OrdinalIgnoreCase);
         if (isFirstInTopology == false)

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -302,6 +302,8 @@ namespace Raven.Server.Documents
 
         public TombstoneCleaner TombstoneCleaner { get; private set; }
 
+        public RevisionsBinCleaner RevisionsBinCleaner { get; set; }
+
         public DocumentsChanges Changes { get; }
 
         public IoChangesNotifications IoChanges { get; }
@@ -1214,6 +1216,11 @@ namespace Raven.Server.Documents
             {
                 TombstoneCleaner?.Dispose();
             });
+            ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposing RevisionsBinCleaner");
+            exceptionAggregator.Execute(() =>
+            {
+                RevisionsBinCleaner?.Dispose();
+            });
             ForTestingPurposes?.DisposeLog?.Invoke(Name, "Disposed TombstoneCleaner");
         }
 
@@ -1807,6 +1814,7 @@ namespace Raven.Server.Documents
             InitializeCompressionFromDatabaseRecord(record);
             DocumentsStorage.RevisionsStorage.InitializeFromDatabaseRecord(record);
             ExpiredDocumentsCleaner = ExpiredDocumentsCleaner.LoadConfigurations(this, record, ExpiredDocumentsCleaner);
+            RevisionsBinCleaner = RevisionsBinCleaner.LoadConfigurations(this, record, RevisionsBinCleaner, ServerStore.NodeTag);
             DataArchivist = DataArchivist.LoadConfiguration(this, record, DataArchivist);
             TimeSeriesPolicyRunner = TimeSeriesPolicyRunner.LoadConfigurations(this, record, TimeSeriesPolicyRunner);
             UpdateCompressionConfigurationFromDatabaseRecord(record);

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2755,8 +2755,11 @@ namespace Raven.Server.Documents
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ByteStringContext.InternalScope GetEtagAsSlice(DocumentsOperationContext context, long etag, out Slice slice)
         {
-            Span<long> swapped = [Bits.SwapBytes(etag)];
-            return Slice.From(context.Allocator, MemoryMarshal.AsBytes(swapped), out slice);
+            var scope = context.Allocator.Allocate(sizeof(long), out var keyMem);
+            var swapped = Bits.SwapBytes(etag);
+            Memory.Copy(keyMem.Ptr, (byte*)&swapped, sizeof(long));
+            slice = new Slice(SliceOptions.Key, keyMem);
+            return scope;
         }
 
         [DoesNotReturn]

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForPostRevisionsConflictsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AbstractAdminRevisionsHandlerProcessorForPostRevisionsConflictsConfiguration.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Revisions
 
         protected override ValueTask OnAfterUpdateConfiguration(TransactionOperationContext context, BlittableJsonReaderObject configuration, string raftRequestId)
         {
-            RequestHandler.LogTaskToAudit(RevisionsHandler.ConflictedRevisionsConfigTag, Index, configuration);
+            RequestHandler.LogTaskToAudit(Web.RequestHandler.ConflictedRevisionsConfigTag, Index, configuration);
             return ValueTask.CompletedTask;
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -63,7 +63,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
             nameof(DatabaseRecord.TimeSeries),
             nameof(DatabaseRecord.SupportedFeatures),
 
-            nameof(DatabaseRecord.Sharding)
+            nameof(DatabaseRecord.Sharding),
+            nameof(DatabaseRecord.RevisionsBin)
         };
 
         private readonly Logger _logger = LoggingSource.Instance.GetLogger<ServerWideDebugInfoPackageHandler>("Server");

--- a/src/Raven.Server/Documents/Handlers/Processors/Databases/AbstractDatabaseHandlerProcessorForGetConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Databases/AbstractDatabaseHandlerProcessorForGetConfiguration.cs
@@ -1,25 +1,26 @@
 ﻿using System.Net;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Raven.Client.Documents.Operations.Expiration;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
-namespace Raven.Server.Documents.Handlers.Processors.Expiration
+namespace Raven.Server.Documents.Handlers.Processors.Databases
 {
-    internal abstract class AbstractExpirationHandlerProcessorForGet<TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
-        where TOperationContext : JsonOperationContext 
+    internal abstract class AbstractDatabaseHandlerProcessorForGetConfiguration<TRequestHandler, TOperationContext, TConfiguration> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
         where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+        where TConfiguration : IDynamicJson
     {
-        protected AbstractExpirationHandlerProcessorForGet([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+        protected AbstractDatabaseHandlerProcessorForGetConfiguration([NotNull] TRequestHandler requestHandler) : base(requestHandler)
         {
         }
 
-        protected abstract ExpirationConfiguration GetExpirationConfiguration();
+        protected abstract TConfiguration GetConfiguration();
 
         public override async ValueTask ExecuteAsync()
         {
-            var expirationConfig = GetExpirationConfiguration();
+            var expirationConfig = GetConfiguration();
 
             using (RequestHandler.Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             {

--- a/src/Raven.Server/Documents/Handlers/Processors/Expiration/ExpirationHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Expiration/ExpirationHandlerProcessorForGet.cs
@@ -1,16 +1,17 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Raven.Client.Documents.Operations.Expiration;
+using Raven.Server.Documents.Handlers.Processors.Databases;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Handlers.Processors.Expiration
 {
-    internal sealed class ExpirationHandlerProcessorForGet : AbstractExpirationHandlerProcessorForGet<DatabaseRequestHandler, DocumentsOperationContext>
+    internal sealed class ExpirationHandlerProcessorForGet : AbstractDatabaseHandlerProcessorForGetConfiguration<DatabaseRequestHandler, DocumentsOperationContext, ExpirationConfiguration>
     {
         public ExpirationHandlerProcessorForGet([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
         {
         }
 
-        protected override ExpirationConfiguration GetExpirationConfiguration()
+        protected override ExpirationConfiguration GetConfiguration()
         {
             using (RequestHandler.Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsBinCleanerHandlerProcessorForPostConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsBinCleanerHandlerProcessorForPostConfiguration.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents.Handlers.Processors.Databases;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Revisions
+{
+    internal abstract class AbstractRevisionsBinCleanerHandlerProcessorForPostConfiguration<TRequestHandler, TOperationContext> : AbstractHandlerProcessorForUpdateDatabaseConfiguration<BlittableJsonReaderObject, TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
+        where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    {
+        protected AbstractRevisionsBinCleanerHandlerProcessorForPostConfiguration([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override Task<(long Index, object Result)> OnUpdateConfiguration(TransactionOperationContext context, BlittableJsonReaderObject configurationJson,
+            string raftRequestId)
+        {
+            var database = RequestHandler.DatabaseName;
+
+            var config = JsonDeserializationCluster.RevisionsBinConfiguration(configurationJson);
+
+            var cmd = new RevisionsBinConfigurationCommand(config, database, raftRequestId);
+            return ServerStore.SendToLeaderAsync(cmd);
+        }
+
+        protected override ValueTask OnAfterUpdateConfiguration(TransactionOperationContext context, BlittableJsonReaderObject configuration, string raftRequestId)
+        {
+            RequestHandler.LogTaskToAudit(Web.RequestHandler.RevisionsBinConfigTag, Index, configuration);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForPostRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/AbstractRevisionsHandlerProcessorForPostRevisionsConfiguration.cs
@@ -47,7 +47,7 @@ internal abstract class AbstractRevisionsHandlerProcessorForPostRevisionsConfigu
 
     protected override ValueTask OnAfterUpdateConfiguration(TransactionOperationContext context, BlittableJsonReaderObject configuration, string raftRequestId)
     {
-        RequestHandler.LogTaskToAudit(RevisionsHandler.ReadRevisionsConfigTag, Index, configuration);
+        RequestHandler.LogTaskToAudit(Web.RequestHandler.ReadRevisionsConfigTag, Index, configuration);
         return ValueTask.CompletedTask;
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsBinCleanerHandlerProcessorForGetConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsBinCleanerHandlerProcessorForGetConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents.Handlers.Processors.Databases;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Handlers.Processors.Revisions
+{
+    internal class RevisionsBinCleanerHandlerProcessorForGetConfiguration : AbstractDatabaseHandlerProcessorForGetConfiguration<DatabaseRequestHandler, DocumentsOperationContext, RevisionsBinConfiguration>
+    {
+        public RevisionsBinCleanerHandlerProcessorForGetConfiguration([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override RevisionsBinConfiguration GetConfiguration()
+        {
+            using (RequestHandler.Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                using (var rawRecord = RequestHandler.Server.ServerStore.Cluster.ReadRawDatabaseRecord(context, RequestHandler.Database.Name))
+                {
+                    return rawRecord?.RevisionsBin;
+                }
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsBinCleanerHandlerProcessorForPostConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Revisions/RevisionsBinCleanerHandlerProcessorForPostConfiguration.cs
@@ -1,0 +1,11 @@
+﻿using JetBrains.Annotations;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Handlers.Processors.Revisions;
+
+internal sealed class RevisionsBinCleanerHandlerProcessorForPostConfiguration : AbstractRevisionsBinCleanerHandlerProcessorForPostConfiguration<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    public RevisionsBinCleanerHandlerProcessorForPostConfiguration([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/RevisionsBinCleanerHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsBinCleanerHandler.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Handlers.Processors.Revisions;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Handlers;
+public class RevisionsBinCleanerHandler : DatabaseRequestHandler
+{
+    [RavenAction("/databases/*/revisions/bin-cleaner/config", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+    public async Task GetRevisionsBinConfig()
+    {
+        using (var processor = new RevisionsBinCleanerHandlerProcessorForGetConfiguration(this))
+            await processor.ExecuteAsync();
+    }
+
+    [RavenAction("/databases/*/admin/revisions/bin-cleaner/config", "POST", AuthorizationStatus.DatabaseAdmin)]
+    public async Task ConfigRevisionsBinCleaner()
+    {
+        using (var processor = new RevisionsBinCleanerHandlerProcessorForPostConfiguration(this))
+            await processor.ExecuteAsync();
+    }
+}
+

--- a/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/RevisionsHandler.cs
@@ -20,9 +20,6 @@ namespace Raven.Server.Documents.Handlers
 {
     public sealed class RevisionsHandler : DatabaseRequestHandler
     {
-        public const string ReadRevisionsConfigTag = "read-revisions-config";
-        public const string ConflictedRevisionsConfigTag = "conflicted-revisions-config";
-
         [RavenAction("/databases/*/revisions/config", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetRevisionsConfiguration()
         {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.RevisionsBinCleanMergedCommand.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.RevisionsBinCleanMergedCommand.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Voron;
+
+namespace Raven.Server.Documents.Revisions;
+
+public partial class RevisionsStorage
+{
+    internal sealed class RevisionsBinCleanMergedCommand : DocumentMergedTransactionCommand
+    {
+        private List<(string Id, long Etag)> _idsAndEtags;
+        private readonly long _lastEtag;
+        private readonly bool _isFirst;
+
+        private const int MaxDeletesUponUpdate = 1024;
+
+        public (int DeletedEntries, int NextStartIndex) Result { get; private set; }
+
+        public RevisionsBinCleanMergedCommand(List<(string Id, long Etag)> idsAndEtags, long lastEtag, bool isFirst)
+        {
+            _idsAndEtags = idsAndEtags;
+            _lastEtag = lastEtag;
+            _isFirst = isFirst;
+        }
+
+        protected override long ExecuteCmd(DocumentsOperationContext context)
+        {
+            Result = DeleteRevisions(context);
+            var etag = Result.NextStartIndex == _idsAndEtags.Count ? _lastEtag : _idsAndEtags[Result.NextStartIndex].Etag;
+            SetLastRevisionsBinCleanerLastEtag(context, etag);
+            return 1;
+        }
+
+        private (int DeletedEntries, int NextStartIndex) DeleteRevisions(DocumentsOperationContext context)
+        {
+            var revisionsStorage = context.DocumentDatabase.DocumentsStorage.RevisionsStorage;
+
+            var index = 0;
+            var deletedEntities = 0;
+
+            foreach (var (id, etag) in _idsAndEtags)
+            {
+                using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+                using (revisionsStorage.GetKeyPrefix(context, lowerId, out Slice prefixSlice))
+                {
+                    var collectionName = revisionsStorage.GetCollectionFor(context, prefixSlice);
+                    if (collectionName == null)
+                    {
+                        if (_isFirst && revisionsStorage._logger.IsInfoEnabled)
+                            revisionsStorage._logger.Info($"Tried to delete revisions for '{id}' but no revisions found.");
+                    }
+                    else
+                    {
+                        using var document = context.DocumentDatabase.DocumentsStorage.Get(context, lowerId, fields: DocumentFields.Default, throwOnConflict: false);
+                        if (document == null) // document is delete, so we can remove all its revisions
+                        {
+                            if (_isFirst == false)
+                                return (deletedEntities, index);
+
+                            (bool moreWork, long _) =
+                                revisionsStorage.ForceDeleteAllRevisionsFor(context, lowerId, prefixSlice, collectionName, MaxDeletesUponUpdate, etagBarrier: etag);
+                            if (moreWork)
+                                return (deletedEntities, index);
+
+                            deletedEntities++;
+                        }
+                    }
+                }
+
+                index++;
+            }
+
+            return (deletedEntities, index);
+        }
+
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>>
+            ToDto(DocumentsOperationContext context)
+        {
+            return new RevisionsBinCleanMergedCommandDto(_idsAndEtags, _lastEtag, _isFirst);
+        }
+
+        public sealed class RevisionsBinCleanMergedCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, RevisionsBinCleanMergedCommand>
+        {
+            private List<(string Id, long Etag)> _idsAndEtags;
+            private readonly long _lastEtag;
+            private readonly bool _isFirst;
+
+            public RevisionsBinCleanMergedCommandDto(List<(string Id, long Etag)> idsAndEtags, long lastEtag, bool isFirst)
+            {
+                _idsAndEtags = idsAndEtags;
+                _lastEtag = lastEtag;
+                _isFirst = isFirst;
+            }
+
+            public RevisionsBinCleanMergedCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+            {
+                return new RevisionsBinCleanMergedCommand(_idsAndEtags, _lastEtag, _isFirst);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/RevisionsBinCleaner.cs
+++ b/src/Raven.Server/Documents/RevisionsBinCleaner.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.ServerWide;
+using Raven.Server.Background;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Logging;
+
+namespace Raven.Server.Documents
+{
+    public class RevisionsBinCleaner : BackgroundWorkBase
+    {
+        private readonly DocumentDatabase _documentDatabase;
+        private readonly RevisionsBinConfiguration _configuration;
+        private readonly long _batchSize;
+
+        public RevisionsBinCleaner(DocumentDatabase documentDatabase, RevisionsBinConfiguration configuration) : base(documentDatabase.Name, documentDatabase.DatabaseShutdown)
+        {
+            _documentDatabase = documentDatabase;
+            _configuration = configuration;
+            _batchSize = _documentDatabase.Is32Bits ? 1024 : 10 * 1024;
+        }
+
+        protected override async Task DoWork()
+        {
+            await WaitOrThrowOperationCanceled(TimeSpan.FromSeconds(_configuration.RefreshFrequencyInSec));
+
+            await ExecuteCleanup(_configuration);
+        }
+
+        public static RevisionsBinCleaner LoadConfigurations(DocumentDatabase database, DatabaseRecord record, RevisionsBinCleaner oldCleaner, string nodeTag)
+        {
+            try
+            {
+                var config = record.RevisionsBin;
+
+                if (config == null || config.Disabled)
+                {
+                    oldCleaner?.Dispose();
+                    return null;
+                }
+
+                if (oldCleaner != null && config.Equals(oldCleaner._configuration))
+                    return oldCleaner;
+
+                oldCleaner?.Dispose();
+
+                var cleaner = new RevisionsBinCleaner(database, config);
+                cleaner.Start();
+
+                if (cleaner.Logger.IsInfoEnabled)
+                    cleaner.Logger.Info($"Executed revisions-bin cleanup on {database.Name} started");
+
+                return cleaner;
+            }
+            catch (Exception e)
+            {
+                const string msg = "Cannot enable revisions-bin cleaner as the configuration record is not valid.";
+                database.NotificationCenter.Add(AlertRaised.Create(
+                    database.Name,
+                    $"Revisions-bin cleaner error in {database.Name}", msg,
+                    AlertType.RevisionsConfigurationNotValid, NotificationSeverity.Error, database.Name));
+
+                var logger = LoggingSource.Instance.GetLogger<RevisionsBinCleaner>(database.Name);
+                if (logger.IsOperationsEnabled)
+                    logger.Operations(msg, e);
+
+                return null;
+            }
+        }
+
+        internal bool IsFirst => AbstractBackgroundWorkStorage.ShouldHandleWorkOnCurrentNode(_documentDatabase.ReadDatabaseRecord().Topology, _documentDatabase.ServerStore.NodeTag);
+
+        internal async Task<long> ExecuteCleanup(RevisionsBinConfiguration config = null)
+        {
+            var totalDeletedEntries = 0L;
+
+            config ??= _configuration;
+
+            if (config == null ||
+                config.MinimumEntriesAgeToKeepInMin == null ||
+                config.MinimumEntriesAgeToKeepInMin.Value == int.MaxValue ||
+                CancellationToken.IsCancellationRequested)
+            {
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Executed revisions-bin cleanup on {_documentDatabase.Name}, 0 revisions were deleted, finished on etag 0");
+                return totalDeletedEntries;
+            }
+
+            try
+            {
+                var before = _documentDatabase.Time.GetUtcNow() - TimeSpan.FromMinutes(config.MinimumEntriesAgeToKeepInMin.Value < 0 ? 0 : config.MinimumEntriesAgeToKeepInMin.Value);
+
+                while (CancellationToken.IsCancellationRequested == false)
+                {
+                    List<(string Id, long Etag)> idsAndEtags;
+                    long readLastEtag;
+                    
+                    using (_documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                    using (ctx.OpenReadTransaction())
+                    {
+                        readLastEtag = RevisionsStorage.ReadLastRevisionsBinCleanerLastEtag(ctx.Transaction.InnerTransaction);
+                        idsAndEtags = _documentDatabase.DocumentsStorage.RevisionsStorage
+                            .GetDeletedRevisionsIds(ctx, before, _batchSize, ref readLastEtag, Cts.Token);
+                    }
+
+                    int idsAndEtagsOriginalCount = idsAndEtags.Count;
+
+                    var isFirst = IsFirst;
+
+                    while (CancellationToken.IsCancellationRequested == false)
+                    {
+                        var command = new RevisionsStorage.RevisionsBinCleanMergedCommand(idsAndEtags, readLastEtag, isFirst);
+                        await _documentDatabase.TxMerger.Enqueue(command);
+
+                        var res = command.Result;
+                        totalDeletedEntries += res.DeletedEntries;
+
+                        if (Logger.IsInfoEnabled)
+                            Logger.Info(GetLogMsg(res.DeletedEntries, idsAndEtags, res.NextStartIndex, isFirst));
+                        
+
+                        if (res.NextStartIndex >= idsAndEtags.Count)
+                            break;
+
+                        // we can't actually remove revisions and we skipped whatever we could
+                        if (isFirst == false)
+                            return 0;
+
+                        idsAndEtags = idsAndEtags.Slice(res.NextStartIndex, idsAndEtags.Count - res.NextStartIndex);
+                    }
+
+                    if (idsAndEtagsOriginalCount < _batchSize)
+                        return totalDeletedEntries;
+                }
+            }
+            catch (Exception e)
+            {
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Failed to execute revisions bin cleanup on {_documentDatabase.Name}", e);
+            }
+
+            return totalDeletedEntries;
+        }
+
+        private string GetLogMsg(int deletedEntries, List<(string Id, long Etag)> idsAndEtags, int startIndex, bool isFirst)
+        {
+            var sb = new StringBuilder();
+            sb.Append("Revisions-Bin Cleanup was executed: ");
+            if (isFirst)
+            {
+                sb.Append("Node is first of database \"");
+                sb.Append(_documentDatabase.Name);
+                sb.Append("\" topology, ");
+                sb.Append(deletedEntries);
+                sb.Append(" entries were deleted");
+            }
+            else
+            {
+                sb.Append(" database \"");
+                sb.Append(_documentDatabase.Name);
+                if (deletedEntries > 0)
+                {
+                    sb.Append(", ");
+                    sb.Append(deletedEntries);
+                    sb.Append(" entries were deleted");
+                }
+            }
+
+            if (idsAndEtags.Count != 0)
+            {
+                sb.Append(", finished on etag ");
+                sb.Append(idsAndEtags[startIndex == 0 ? 0 : startIndex - 1]);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Expiration/ShardedExpirationHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Expiration/ShardedExpirationHandlerProcessorForGet.cs
@@ -1,17 +1,17 @@
 ﻿using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.Expiration;
-using Raven.Server.Documents.Handlers.Processors.Expiration;
+using Raven.Server.Documents.Handlers.Processors.Databases;
 using Raven.Server.ServerWide.Context;
 
 namespace Raven.Server.Documents.Sharding.Handlers.Processors.Expiration
 {
-    internal sealed class ShardedExpirationHandlerProcessorForGet : AbstractExpirationHandlerProcessorForGet<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    internal sealed class ShardedExpirationHandlerProcessorForGet : AbstractDatabaseHandlerProcessorForGetConfiguration<ShardedDatabaseRequestHandler, TransactionOperationContext, ExpirationConfiguration>
     {
         public ShardedExpirationHandlerProcessorForGet([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
         {
         }
 
-        protected override ExpirationConfiguration GetExpirationConfiguration()
+        protected override ExpirationConfiguration GetConfiguration()
         {
             return RequestHandler.DatabaseContext.DatabaseRecord.Expiration;
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsBinCleanerHandlerProcessorForGetConfiguration.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsBinCleanerHandlerProcessorForGetConfiguration.cs
@@ -1,0 +1,20 @@
+﻿using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents.Handlers.Processors.Databases;
+using Raven.Server.ServerWide.Context;
+
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions
+{
+    internal sealed class ShardedRevisionsBinCleanerHandlerProcessorForGetConfiguration : AbstractDatabaseHandlerProcessorForGetConfiguration<ShardedDatabaseRequestHandler, TransactionOperationContext, RevisionsBinConfiguration>
+    {
+        public ShardedRevisionsBinCleanerHandlerProcessorForGetConfiguration([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override RevisionsBinConfiguration GetConfiguration()
+        {
+            return RequestHandler.DatabaseContext.DatabaseRecord.RevisionsBin;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsBinCleanerHandlerProcessorForPostConfiguration.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Revisions/ShardedRevisionsBinCleanerHandlerProcessorForPostConfiguration.cs
@@ -1,0 +1,12 @@
+﻿using JetBrains.Annotations;
+using Raven.Server.Documents.Handlers.Processors.Revisions;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Revisions;
+
+internal sealed class ShardedRevisionsBinCleanerHandlerProcessorForPostConfiguration : AbstractRevisionsBinCleanerHandlerProcessorForPostConfiguration<ShardedDatabaseRequestHandler, TransactionOperationContext>
+{
+    public ShardedRevisionsBinCleanerHandlerProcessorForPostConfiguration([NotNull] ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedRevisionsBinCleanerHandler .cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedRevisionsBinCleanerHandler .cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors.Revisions;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers
+{
+    public sealed class ShardedRevisionsBinCleanerHandler : ShardedDatabaseRequestHandler
+    {
+        [RavenShardedAction("/databases/*/revisions/bin-cleaner/config", "GET")]
+        public async Task GetRevisionsBinConfig()
+        {
+            using (var processor = new ShardedRevisionsBinCleanerHandlerProcessorForGetConfiguration(this))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/admin/revisions/bin-cleaner/config", "POST")]
+        public async Task ConfigRevisionsBinCleaner()
+        {
+            using (var processor = new ShardedRevisionsBinCleanerHandlerProcessorForPostConfiguration(this))
+                await processor.ExecuteAsync();
+        }
+    }
+}
+

--- a/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
+++ b/src/Raven.Server/ServerWide/ClusterCommandsVersionManager.cs
@@ -187,7 +187,8 @@ namespace Raven.Server.ServerWide
             [nameof(UpdateResponsibleNodeForTasksCommand)] = UpdateResponsibleNodeForTasksCommand.CommandVersion,
             [nameof(AddPrefixedShardingSettingCommand)] = 62_000,
             [nameof(DeletePrefixedShardingSettingCommand)] = 62_000,
-            [nameof(UpdatePrefixedShardingSettingCommand)] = 62_000
+            [nameof(UpdatePrefixedShardingSettingCommand)] = 62_000,
+            [nameof(RevisionsBinConfigurationCommand)] = 62_001
 
         };
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -487,6 +487,7 @@ namespace Raven.Server.ServerWide
                     case nameof(AddPrefixedShardingSettingCommand):
                     case nameof(DeletePrefixedShardingSettingCommand):
                     case nameof(UpdatePrefixedShardingSettingCommand):
+                    case nameof(RevisionsBinConfigurationCommand):
                         UpdateDatabase(context, type, cmd, index, serverStore);
                         break;
 

--- a/src/Raven.Server/ServerWide/Commands/RevisionsBinConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RevisionsBinConfigurationCommand.cs
@@ -1,0 +1,35 @@
+﻿using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.ServerWide;
+using Raven.Server.Utils;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.ServerWide.Commands
+{
+    public sealed class RevisionsBinConfigurationCommand : UpdateDatabaseCommand
+    {
+        public RevisionsBinConfiguration Configuration;
+        public void UpdateDatabaseRecord(DatabaseRecord databaseRecord)
+        {
+            databaseRecord.RevisionsBin = Configuration;
+        }
+
+        public RevisionsBinConfigurationCommand()
+        {
+        }
+
+        public RevisionsBinConfigurationCommand(RevisionsBinConfiguration configuration, string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+        {
+            Configuration = configuration;
+        }
+
+        public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
+        {
+            record.RevisionsBin = Configuration;
+        }
+
+        public override void FillJson(DynamicJsonValue json)
+        {
+            json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
+++ b/src/Raven.Server/ServerWide/JsonDeserializationCluster.cs
@@ -67,6 +67,8 @@ namespace Raven.Server.ServerWide
 
         public static readonly Func<BlittableJsonReaderObject, ExpirationConfiguration> ExpirationConfiguration = GenerateJsonDeserializationRoutine<ExpirationConfiguration>();
 
+        public static readonly Func<BlittableJsonReaderObject, RevisionsBinConfiguration> RevisionsBinConfiguration = GenerateJsonDeserializationRoutine<RevisionsBinConfiguration>();
+
         public static readonly Func<BlittableJsonReaderObject, RefreshConfiguration> RefreshConfiguration = GenerateJsonDeserializationRoutine<RefreshConfiguration>();
         
         public static readonly Func<BlittableJsonReaderObject, DataArchivalConfiguration> DataArchivalConfiguration = GenerateJsonDeserializationRoutine<DataArchivalConfiguration>();
@@ -289,7 +291,8 @@ namespace Raven.Server.ServerWide
             [nameof(UpdateResponsibleNodeForTasksCommand)] = GenerateJsonDeserializationRoutine<UpdateResponsibleNodeForTasksCommand>(),
             [nameof(AddPrefixedShardingSettingCommand)] = GenerateJsonDeserializationRoutine<AddPrefixedShardingSettingCommand>(),
             [nameof(DeletePrefixedShardingSettingCommand)] = GenerateJsonDeserializationRoutine<DeletePrefixedShardingSettingCommand>(),
-            [nameof(UpdatePrefixedShardingSettingCommand)] = GenerateJsonDeserializationRoutine<UpdatePrefixedShardingSettingCommand>()
+            [nameof(UpdatePrefixedShardingSettingCommand)] = GenerateJsonDeserializationRoutine<UpdatePrefixedShardingSettingCommand>(),
+            [nameof(RevisionsBinConfigurationCommand)] = GenerateJsonDeserializationRoutine<RevisionsBinConfigurationCommand>()
         };
     }
 }

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -465,6 +465,22 @@ namespace Raven.Server.ServerWide
             }
         }
 
+        private RevisionsBinConfiguration _revisionsBin;
+
+        public RevisionsBinConfiguration RevisionsBin
+        {
+            get
+            {
+                if (_materializedRecord != null)
+                    return _materializedRecord.RevisionsBin;
+
+                if (_revisionsBin == null && _record.TryGet(nameof(DatabaseRecord.RevisionsBin), out BlittableJsonReaderObject config) && config != null)
+                    _revisionsBin = JsonDeserializationCluster.RevisionsBinConfiguration(config);
+
+                return _revisionsBin;
+            }
+        }
+
         private DocumentsCompressionConfiguration _documentsCompressionConfiguration;
 
         public DocumentsCompressionConfiguration DocumentsCompressionConfiguration

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -813,15 +813,21 @@ namespace Raven.Server.Web
         public const string AddEtlDebugTag = "etl-add";
         public const string AddQueueSinkDebugTag = "queue-sink-add";
         public const string UpdateExternalReplicationDebugTag = "update_external_replication";
+        public const string ReadRevisionsConfigTag = "read-revisions-config";
+        public const string ConflictedRevisionsConfigTag = "conflicted-revisions-config";
+        public const string RevisionsBinConfigTag = "revisions-bin-config";
 
         private DynamicJsonValue GetCustomConfigurationAuditJson(string name, BlittableJsonReaderObject configuration)
         {
             switch (name)
             {
-                case RevisionsHandler.ReadRevisionsConfigTag:
+                case RevisionsBinConfigTag:
+                    return JsonDeserializationCluster.RevisionsBinConfiguration(configuration).ToAuditJson();
+                
+                case ReadRevisionsConfigTag:
                     return JsonDeserializationServer.RevisionsConfiguration(configuration).ToAuditJson();
                 
-                case RevisionsHandler.ConflictedRevisionsConfigTag:
+                case ConflictedRevisionsConfigTag:
                     return JsonDeserializationServer.RevisionsCollectionConfiguration(configuration).ToAuditJson();
 
                 case BackupDatabaseOnceTag:

--- a/src/Raven.Studio/typescript/commands/database/settings/getRevisionsBinCleanerConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/settings/getRevisionsBinCleanerConfigurationCommand.ts
@@ -1,0 +1,31 @@
+import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+import endpoints = require("endpoints");
+import RevisionsBinConfiguration = Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration;
+
+class getRevisionsBinCleanerConfigurationCommand extends commandBase {
+  
+  constructor(private db: database | string) {
+    super();
+  }
+  
+  execute(): JQueryPromise<RevisionsBinConfiguration> {
+    const url = endpoints.databases.revisionsBinCleaner.revisionsBinCleanerConfig;
+    
+    const deferred = $.Deferred<RevisionsBinConfiguration>();
+    this.query<RevisionsBinConfiguration>(url, null, this.db)
+      .done((revisionBinCleanerConfig: RevisionsBinConfiguration) => deferred.resolve(revisionBinCleanerConfig))
+      .fail((response: JQueryXHR) => {
+        if (response.status === 404) {
+          deferred.resolve(null);
+        } else {
+          deferred.reject(response);
+          this.reportError("Failed to get Revisions bin cleaner configuration", response.responseText, response.statusText);
+        }
+      });
+    
+    return deferred;
+  }
+}
+
+export = getRevisionsBinCleanerConfigurationCommand;

--- a/src/Raven.Studio/typescript/commands/database/settings/saveRevisionsBinCleanerConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/settings/saveRevisionsBinCleanerConfigurationCommand.ts
@@ -13,7 +13,7 @@ class saveRevisionsBinCleanerConfigurationCommand extends commandBase {
     const url = endpoints.databases.revisionsBinCleaner.adminRevisionsBinCleanerConfig;
     
     return this.post<void>(url, JSON.stringify(this.revisionsBinCleanerDto), this.db)
-      .fail((response: JQueryXHR) => this.reportError("Failed to get Revisions bin cleaner", response.responseText, response.statusText))
+      .fail((response: JQueryXHR) => this.reportError("Failed to save Revisions bin cleaner configuration", response.responseText, response.statusText))
       .done(() => this.reportSuccess(`Revisions bin cleaner configuration saved successfully`))
   }
 }

--- a/src/Raven.Studio/typescript/commands/database/settings/saveRevisionsBinCleanerConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/settings/saveRevisionsBinCleanerConfigurationCommand.ts
@@ -1,0 +1,21 @@
+import commandBase = require("commands/commandBase");
+import database = require("models/resources/database");
+import endpoints = require("endpoints");
+import RevisionsBinConfiguration = Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration;
+
+class saveRevisionsBinCleanerConfigurationCommand extends commandBase {
+  
+  constructor(private db: database | string, private revisionsBinCleanerDto: RevisionsBinConfiguration) {
+    super();
+  }
+  
+  execute(): JQueryPromise<void> {
+    const url = endpoints.databases.revisionsBinCleaner.adminRevisionsBinCleanerConfig;
+    
+    return this.post<void>(url, JSON.stringify(this.revisionsBinCleanerDto), this.db)
+      .fail((response: JQueryXHR) => this.reportError("Failed to get Revisions bin cleaner", response.responseText, response.statusText))
+      .done(() => this.reportSuccess(`Revisions bin cleaner configuration saved successfully`))
+  }
+}
+
+export = saveRevisionsBinCleanerConfigurationCommand;

--- a/src/Raven.Studio/typescript/common/appUrl.ts
+++ b/src/Raven.Studio/typescript/common/appUrl.ts
@@ -110,6 +110,7 @@ class appUrl {
         integrations: ko.pureComputed(() => appUrl.forIntegrations(appUrl.currentDatabase())),
         connectionStrings: ko.pureComputed(() => appUrl.forConnectionStrings(appUrl.currentDatabase())),
         conflictResolution: ko.pureComputed(() => appUrl.forConflictResolution(appUrl.currentDatabase())),
+        revisionsBinCleaner: ko.pureComputed(() => appUrl.forRevisionsBinCleaner(appUrl.currentDatabase())),
 
         statusStorageReport: ko.pureComputed(() => appUrl.forStatusStorageReport(appUrl.currentDatabase())),
         statusBucketsReport: ko.pureComputed(() => appUrl.forStatusBucketsReport(appUrl.currentDatabase())),
@@ -414,6 +415,10 @@ class appUrl {
 
     static forIntegrations(db: database): string {
         return "#databases/settings/integrations?" + appUrl.getEncodedDbPart(db);
+    }
+    
+    static forRevisionsBinCleaner(db: database): string {
+        return "#databases/settings/revisionsBinCleaner?" + appUrl.getEncodedDbPart(db);
     }
 
     static forConnectionStrings(db: database | string, type?: StudioEtlType, name?: string): string {

--- a/src/Raven.Studio/typescript/common/appUrl.ts
+++ b/src/Raven.Studio/typescript/common/appUrl.ts
@@ -417,7 +417,7 @@ class appUrl {
         return "#databases/settings/integrations?" + appUrl.getEncodedDbPart(db);
     }
     
-    static forRevisionsBinCleaner(db: database): string {
+    static forRevisionsBinCleaner(db: database | string): string {
         return "#databases/settings/revisionsBinCleaner?" + appUrl.getEncodedDbPart(db);
     }
 

--- a/src/Raven.Studio/typescript/common/constants/timeInSeconds.ts
+++ b/src/Raven.Studio/typescript/common/constants/timeInSeconds.ts
@@ -1,4 +1,4 @@
-export const TimeTypes = {
+export const TimeInSeconds = {
   Minute: 60,
   Hour: 60 * 60,
   Day: 60 * 60 * 24,

--- a/src/Raven.Studio/typescript/common/constants/timeTypes.ts
+++ b/src/Raven.Studio/typescript/common/constants/timeTypes.ts
@@ -1,0 +1,6 @@
+export const TimeTypes = {
+  Minute: 60,
+  Hour: 60 * 60,
+  Day: 60 * 60 * 24,
+  Week: 60 * 60 * 24 * 7,
+};

--- a/src/Raven.Studio/typescript/common/shell/menu/items/settings.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/settings.ts
@@ -19,6 +19,7 @@ import DatabaseRecord = require("components/pages/database/settings/databaseReco
 import ConflictResolution = require("components/pages/database/settings/conflictResolution/ConflictResolution");
 import Integrations = require("components/pages/database/settings/integrations/Integrations");
 import UnusedDatabaseIds = require("components/pages/database/settings/unusedDatabaseIds/UnusedDatabaseIds");
+import RevisionsBinCleaner = require("components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner");
 
 export = getSettingsMenuItem;
 
@@ -182,6 +183,22 @@ function getSettingsMenuItem(appUrls: computedAppUrls) {
             search: {
                 innerActions: [
                     { name: "Compress revisions for all collections" },
+                ],
+            },
+        }),
+        new leafMenuItem({
+            route: 'databases/settings/revisionsBinCleaner',
+            moduleId: reactUtils.bridgeToReact(RevisionsBinCleaner.default, "nonShardedView"),
+            shardingMode: "allShards",
+            title: 'Revisions Bin Cleaner',
+            nav: true,
+            css: 'icon-revisions-bin',
+            dynamicHash: appUrls.revisionsBinCleaner,
+            search: {
+                innerActions: [
+                    { name: "Set automatic revision bin configuration" },
+                    { name: "Configure retention policies" },
+                    { name: "View current revisions bin configuration" },
                 ],
             },
         }),

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.spec.tsx
@@ -3,7 +3,6 @@ import { composeStories } from "@storybook/react";
 import { rtlRender, rtlRender_WithWaitForLoad } from "test/rtlTestUtils";
 import * as stories from "./RevisionsBinCleaner.stories";
 import { DatabasesStubs } from "test/stubs/DatabasesStubs";
-import { TimeTypes } from "common/constants/timeTypes";
 import userEvent from "@testing-library/user-event";
 
 const { DefaultRevisionsBinCleaner } = composeStories(stories);
@@ -32,7 +31,7 @@ describe("RevisionsBinCleaner", () => {
         await user.click(screen.getByRole("checkbox", { name: "Enable Revisions Bin Cleaner" }));
 
         const minimumEntriesAgeToKeepAfter = await screen.findByName("minimumEntriesAgeToKeepInMin");
-        
+
         expect(minimumEntriesAgeToKeepAfter).toBeDisabled();
         expect(minimumEntriesAgeToKeepAfter).toHaveValue(null);
     });
@@ -44,14 +43,14 @@ describe("RevisionsBinCleaner", () => {
         const refreshFrequencyBefore = await screen.findByName("refreshFrequencyInSec");
 
         await user.click(screen.getByRole("checkbox", { name: "Set custom refresh frequency" }));
-        
+
         expect(refreshFrequencyBefore).toBeEnabled();
         expect(refreshFrequencyBefore).toHaveValue(DatabasesStubs.revisionsBinCleaner().RefreshFrequencyInSec);
 
         await user.click(screen.getByRole("checkbox", { name: "Enable Revisions Bin Cleaner" }));
 
         const refreshFrequencyAfter = await screen.findByName("refreshFrequencyInSec");
-        
+
         expect(refreshFrequencyAfter).toBeDisabled();
         expect(refreshFrequencyAfter).toHaveValue(null);
     });

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.spec.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { composeStories } from "@storybook/react";
+import { rtlRender, rtlRender_WithWaitForLoad } from "test/rtlTestUtils";
+import * as stories from "./RevisionsBinCleaner.stories";
+import { DatabasesStubs } from "test/stubs/DatabasesStubs";
+import { TimeTypes } from "common/constants/timeTypes";
+import userEvent from "@testing-library/user-event";
+
+const { DefaultRevisionsBinCleaner } = composeStories(stories);
+
+describe("RevisionsBinCleaner", () => {
+    it("can render", async () => {
+        const { screen } = rtlRender(<DefaultRevisionsBinCleaner />);
+
+        const revisionBinCleanerHeading = await screen.findByRole("heading", {
+            name: "Revisions Bin Cleaner",
+        });
+        expect(revisionBinCleanerHeading).toBeInTheDocument();
+    });
+
+    it("can disable 'set minimum entries age to keep' after disabling 'enable revisions bin cleaner'", async () => {
+        const user = userEvent.setup();
+        const { screen } = await rtlRender_WithWaitForLoad(<DefaultRevisionsBinCleaner />);
+
+        const minimumEntriesAgeToKeepBefore = await screen.findByName("minimumEntriesAgeToKeepInMin");
+
+        expect(minimumEntriesAgeToKeepBefore).toBeEnabled();
+        expect(minimumEntriesAgeToKeepBefore).toHaveValue(
+            DatabasesStubs.revisionsBinCleaner().MinimumEntriesAgeToKeepInMin
+        );
+
+        await user.click(screen.getByRole("checkbox", { name: "Enable Revisions Bin Cleaner" }));
+
+        const minimumEntriesAgeToKeepAfter = await screen.findByName("minimumEntriesAgeToKeepInMin");
+        
+        expect(minimumEntriesAgeToKeepAfter).toBeDisabled();
+        expect(minimumEntriesAgeToKeepAfter).toHaveValue(null);
+    });
+
+    it("can disable 'set custom refresh frequency' after disabling 'enable revisions bin cleaner'", async () => {
+        const user = userEvent.setup();
+        const { screen } = await rtlRender_WithWaitForLoad(<DefaultRevisionsBinCleaner />);
+
+        const refreshFrequencyBefore = await screen.findByName("refreshFrequencyInSec");
+
+        await user.click(screen.getByRole("checkbox", { name: "Set custom refresh frequency" }));
+        
+        expect(refreshFrequencyBefore).toBeEnabled();
+        expect(refreshFrequencyBefore).toHaveValue(DatabasesStubs.revisionsBinCleaner().RefreshFrequencyInSec);
+
+        await user.click(screen.getByRole("checkbox", { name: "Enable Revisions Bin Cleaner" }));
+
+        const refreshFrequencyAfter = await screen.findByName("refreshFrequencyInSec");
+        
+        expect(refreshFrequencyAfter).toBeDisabled();
+        expect(refreshFrequencyAfter).toHaveValue(null);
+    });
+
+    it("can hide 'Save' button when has access below database admin", async () => {
+        const { screen } = await rtlRender_WithWaitForLoad(
+            <DefaultRevisionsBinCleaner databaseAccess="DatabaseReadWrite" />
+        );
+
+        expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+    });
+
+    it("can show 'Save' button when has database admin access", async () => {
+        const { screen } = await rtlRender_WithWaitForLoad(
+            <DefaultRevisionsBinCleaner databaseAccess="DatabaseAdmin" />
+        );
+
+        expect(await screen.findByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+
+    it("can't click any switch when has access below database admin", async () => {
+        const { screen } = await rtlRender_WithWaitForLoad(
+            <DefaultRevisionsBinCleaner databaseAccess="DatabaseReadWrite" />
+        );
+
+        const isRevisionBinCleanerEnabledSwitch = await screen.findByRole("checkbox", {
+            name: "Enable Revisions Bin Cleaner",
+        });
+        const minimumEntriesAgeToKeepSwitch = await screen.findByRole("checkbox", {
+            name: "Set minimum entries age to keep",
+        });
+        const refreshFrequencySwitch = await screen.findByRole("checkbox", { name: "Set custom refresh frequency" });
+
+        expect(isRevisionBinCleanerEnabledSwitch).toBeDisabled();
+        expect(minimumEntriesAgeToKeepSwitch).toBeDisabled();
+        expect(refreshFrequencySwitch).toBeDisabled();
+    });
+
+    it("can remove value from 'refresh frequency' when disabling checkbox", async () => {
+        const user = userEvent.setup();
+        const { screen } = await rtlRender_WithWaitForLoad(
+            <DefaultRevisionsBinCleaner
+                revisionsBinCleanerDto={{
+                    Disabled: false,
+                    MinimumEntriesAgeToKeepInMin: null,
+                    RefreshFrequencyInSec: 500,
+                }}
+            />
+        );
+
+        const refreshFrequencySwitchBefore = (await screen.findByRole("checkbox", {
+            name: "Set custom refresh frequency",
+        })) as HTMLInputElement;
+        const refreshFrequencyBefore = await screen.findByName("refreshFrequencyInSec");
+
+        expect(refreshFrequencyBefore).toHaveValue(500);
+        expect(refreshFrequencySwitchBefore.checked).toBe(true);
+        await user.click(refreshFrequencySwitchBefore);
+
+        const refreshFrequencySwitchAfter = (await screen.findByRole("checkbox", {
+            name: "Set custom refresh frequency",
+        })) as HTMLInputElement;
+        const refreshFrequencyAfter = await screen.findByName("refreshFrequencyInSec");
+
+        expect(refreshFrequencyAfter).toHaveValue(null);
+        expect(refreshFrequencyAfter).toBeDisabled();
+        expect(refreshFrequencySwitchAfter.checked).toBe(false);
+    });
+
+    it("can remove value from 'set minimum entries age to keep' when disabling checkbox", async () => {
+        const minimumEntriesAge = 3;
+
+        const user = userEvent.setup();
+
+        const { screen } = await rtlRender_WithWaitForLoad(
+            <DefaultRevisionsBinCleaner
+                revisionsBinCleanerDto={{
+                    Disabled: false,
+                    MinimumEntriesAgeToKeepInMin: minimumEntriesAge,
+                    RefreshFrequencyInSec: 500,
+                }}
+            />
+        );
+
+        const setMinimumEntriesAgeToKeepSwitchBefore = (await screen.findByRole("checkbox", {
+            name: "Set minimum entries age to keep",
+        })) as HTMLInputElement;
+        const setMinimumEntriesAgeToKeepBefore = await screen.findByName("minimumEntriesAgeToKeepInMin");
+
+        expect(setMinimumEntriesAgeToKeepBefore).toHaveValue(minimumEntriesAge);
+        expect(setMinimumEntriesAgeToKeepSwitchBefore.checked).toBe(true);
+
+        await user.click(setMinimumEntriesAgeToKeepSwitchBefore);
+
+        const setMinimumEntriesAgeToKeepSwitchAfter = (await screen.findByRole("checkbox", {
+            name: "Set minimum entries age to keep",
+        })) as HTMLInputElement;
+        const setMinimumEntriesAgeToKeepAfter = await screen.findByName("minimumEntriesAgeToKeepInMin");
+
+        expect(setMinimumEntriesAgeToKeepAfter).toHaveValue(null);
+        expect(setMinimumEntriesAgeToKeepAfter).toBeDisabled();
+        expect(setMinimumEntriesAgeToKeepSwitchAfter.checked).toBe(false);
+    });
+});

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.spec.tsx
@@ -45,7 +45,6 @@ describe("RevisionsBinCleaner", () => {
         await user.click(screen.getByRole("checkbox", { name: "Set custom refresh frequency" }));
 
         expect(refreshFrequencyBefore).toBeEnabled();
-        expect(refreshFrequencyBefore).toHaveValue(DatabasesStubs.revisionsBinCleaner().RefreshFrequencyInSec);
 
         await user.click(screen.getByRole("checkbox", { name: "Enable Revisions Bin Cleaner" }));
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.stories.tsx
@@ -1,0 +1,37 @@
+import DocumentExpiration from "components/pages/database/settings/documentExpiration/DocumentExpiration";
+import { withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
+import { Meta, StoryObj } from "@storybook/react";
+import RevisionsBinCleaner from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner";
+import { mockServices } from "test/mocks/services/MockServices";
+import { mockStore } from "test/mocks/store/MockStore";
+import React from "react";
+
+export default {
+    title: "Pages/Database/Settings/Revisions Bin Cleaner",
+    component: DocumentExpiration,
+    decorators: [withStorybookContexts, withBootstrap5],
+} satisfies Meta<typeof RevisionsBinCleaner>;
+
+function commonInit(hasConfiguration: boolean) {
+    const { databasesService } = mockServices;
+    const { databases } = mockStore;
+
+    if (hasConfiguration) {
+        databasesService.withExpirationConfiguration();
+    } else {
+        databasesService.withoutExpirationConfiguration();
+    }
+    databases.withActiveDatabase_NonSharded_SingleNode();
+}
+
+export const DefaultRevisionsBinCleaner: StoryObj<typeof RevisionsBinCleaner> = {
+    name: "Revisions Bin Cleaner",
+    render: () => {
+        commonInit(true);
+
+        const { license } = mockStore;
+        license.with_License();
+
+        return <RevisionsBinCleaner />;
+    },
+};

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.stories.tsx
@@ -1,37 +1,47 @@
-import DocumentExpiration from "components/pages/database/settings/documentExpiration/DocumentExpiration";
-import { withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
+import { databaseAccessArgType, withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
 import { Meta, StoryObj } from "@storybook/react";
 import RevisionsBinCleaner from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner";
 import { mockServices } from "test/mocks/services/MockServices";
 import { mockStore } from "test/mocks/store/MockStore";
 import React from "react";
+import { DatabasesStubs } from "test/stubs/DatabasesStubs";
 
 export default {
     title: "Pages/Database/Settings/Revisions Bin Cleaner",
-    component: DocumentExpiration,
+    component: RevisionsBinCleaner,
     decorators: [withStorybookContexts, withBootstrap5],
 } satisfies Meta<typeof RevisionsBinCleaner>;
 
-function commonInit(hasConfiguration: boolean) {
-    const { databasesService } = mockServices;
-    const { databases } = mockStore;
-
-    if (hasConfiguration) {
-        databasesService.withExpirationConfiguration();
-    } else {
-        databasesService.withoutExpirationConfiguration();
-    }
-    databases.withActiveDatabase_NonSharded_SingleNode();
+interface RevisionsBinCleanerStoryArgs {
+    databaseAccess: databaseAccessLevel;
+    revisionsBinCleanerDto: Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration;
 }
 
-export const DefaultRevisionsBinCleaner: StoryObj<typeof RevisionsBinCleaner> = {
-    name: "Revisions Bin Cleaner",
-    render: () => {
-        commonInit(true);
+function commonInit(dto: Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration) {
+    const { databasesService } = mockServices;
 
-        const { license } = mockStore;
-        license.with_License();
+    databasesService.withRevisionsBinCleanerConfiguration(dto);
+}
+
+export const DefaultRevisionsBinCleaner: StoryObj<RevisionsBinCleanerStoryArgs> = {
+    name: "Revisions Bin Cleaner",
+    render: (args) => {
+        const { accessManager, databases } = mockStore;
+
+        commonInit(args.revisionsBinCleanerDto);
+        const db = databases.withActiveDatabase_NonSharded_SingleNode();
+
+        accessManager.with_databaseAccess({
+            [db.name]: args.databaseAccess,
+        });
 
         return <RevisionsBinCleaner />;
+    },
+    argTypes: {
+        databaseAccess: databaseAccessArgType,
+    },
+    args: {
+        databaseAccess: "DatabaseAdmin",
+        revisionsBinCleanerDto: DatabasesStubs.revisionsBinCleaner(),
     },
 };

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.stories.tsx
@@ -8,28 +8,22 @@ import { DatabasesStubs } from "test/stubs/DatabasesStubs";
 
 export default {
     title: "Pages/Database/Settings/Revisions Bin Cleaner",
-    component: RevisionsBinCleaner,
     decorators: [withStorybookContexts, withBootstrap5],
-} satisfies Meta<typeof RevisionsBinCleaner>;
+} satisfies Meta;
 
 interface RevisionsBinCleanerStoryArgs {
     databaseAccess: databaseAccessLevel;
     revisionsBinCleanerDto: Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration;
 }
 
-function commonInit(dto: Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration) {
-    const { databasesService } = mockServices;
-
-    databasesService.withRevisionsBinCleanerConfiguration(dto);
-}
-
 export const DefaultRevisionsBinCleaner: StoryObj<RevisionsBinCleanerStoryArgs> = {
     name: "Revisions Bin Cleaner",
     render: (args) => {
         const { accessManager, databases } = mockStore;
-
-        commonInit(args.revisionsBinCleanerDto);
+        const { databasesService } = mockServices;
         const db = databases.withActiveDatabase_NonSharded_SingleNode();
+
+        databasesService.withRevisionsBinCleanerConfiguration(args.revisionsBinCleanerDto);
 
         accessManager.with_databaseAccess({
             [db.name]: args.databaseAccess,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.tsx
@@ -12,7 +12,6 @@ import { useAsyncCallback } from "react-async-hook";
 import { useDirtyFlag } from "hooks/useDirtyFlag";
 import { useEventsCollector } from "hooks/useEventsCollector";
 import { tryHandleSubmit } from "components/utils/common";
-import activeDatabaseTracker from "common/shell/activeDatabaseTracker";
 import { AboutViewHeading } from "components/common/AboutView";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { FormInput, FormSwitch } from "components/common/Form";
@@ -174,7 +173,7 @@ export default function RevisionsBinCleaner() {
                         </Form>
                     </Col>
                     <Col sm={12} lg={4}>
-                        <RevisionsBinCleanerInfoHub />
+                        {false && <RevisionsBinCleanerInfoHub />}
                     </Col>
                 </Row>
             </Col>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.tsx
@@ -1,90 +1,61 @@
-import React, { useState } from "react";
+import React from "react";
 import { useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useServices } from "hooks/useServices";
-import { Card, CardBody, Col, Form, Row } from "reactstrap";
+import { Card, CardBody, Col, Collapse, Form, Row } from "reactstrap";
 import { SubmitHandler, useForm, useWatch } from "react-hook-form";
 import {
     RevisionsBinCleanerFormData,
     revisionsBinCleanerYupResolver,
 } from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerValidation";
 import { useAsyncCallback } from "react-async-hook";
-import RevisionsBinConfiguration = Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration;
 import { useDirtyFlag } from "hooks/useDirtyFlag";
 import { useEventsCollector } from "hooks/useEventsCollector";
 import { tryHandleSubmit } from "components/utils/common";
-import messagePublisher from "common/messagePublisher";
 import activeDatabaseTracker from "common/shell/activeDatabaseTracker";
-import { LoadingView } from "components/common/LoadingView";
-import { LoadError } from "components/common/LoadError";
 import { AboutViewHeading } from "components/common/AboutView";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { FormInput, FormSwitch } from "components/common/Form";
 import { RevisionsBinCleanerInfoHub } from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerInfoHub";
+import { LoadingView } from "components/common/LoadingView";
+import {
+    mapToDto,
+    mapToFormData,
+} from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerUtils";
+import { LoadError } from "components/common/LoadError";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
+import useRevisionsBinCleanerFormSideEffects from "components/pages/database/settings/revisionsBinCleaner/useRevisionsBinCleanerFormSideEffects";
 
 export default function RevisionsBinCleaner() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const { databasesService } = useServices();
+    const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
 
     const asyncGetRevisionsBinCleanerConfiguration = useAsyncCallback<RevisionsBinCleanerFormData>(async () =>
-        // mapToFormData(await databasesService.getRevisionsBinCleanerConfiguration(databaseName))
-        mapToFormData(null)
+        mapToFormData(await databasesService.getRevisionsBinCleanerConfiguration(databaseName))
     );
 
-    const { handleSubmit, control, formState, reset, setValue, watch } = useForm<RevisionsBinCleanerFormData>({
+    const { handleSubmit, control, formState, reset, setValue, watch } = useForm<Partial<RevisionsBinCleanerFormData>>({
         resolver: revisionsBinCleanerYupResolver,
         mode: "all",
         defaultValues: asyncGetRevisionsBinCleanerConfiguration.execute,
     });
 
     useDirtyFlag(formState.isDirty);
-    const formValues = useWatch({ control: control });
+    const formValues = useWatch({ control });
 
     const { reportEvent } = useEventsCollector();
 
-    // useEffect(() => {
-    //     const { unsubscribe } = watch((values, { name }) => {
-    //         switch (name) {
-    //             case "isRevisionsBinCleanerEnabled": {
-    //                 if (values.isRevisionsBinCleanerEnabled) {
-    //                     setValue("isRefreshFrequencyEnabled", true, { shouldValidate: true});
-    //                 } else {
-    //                     setValue("isRefreshFrequencyEnabled", false, { shouldValidate: true});
-    //                     setValue("isMinimumEntriesAgeToKeepEnabled", false, { shouldValidate: true});
-    //                 }
-    //                 break;
-    //             }
-    //             case "isMinimumEntriesAgeToKeepEnabled": {
-    //                 if (values.isMinimumEntriesAgeToKeepEnabled) {
-    //                     setValue("minimumEntriesAgeToKeepInMin",)
-    //                 }
-    //             }
-    //             }
-    //         }
-    //     }
-    // })
+    useRevisionsBinCleanerFormSideEffects(watch, setValue);
 
     const onSave: SubmitHandler<RevisionsBinCleanerFormData> = async (formData) => {
         return tryHandleSubmit(async () => {
             reportEvent("revisions-bin-configuration", "save");
-
-            await databasesService.saveRevisionsBinCleanerConfiguration(databaseName, {
-                Disabled: !formData.isRevisionsBinCleanerEnabled,
-                MinimumEntriesAgeToKeepInMin: formData.isMinimumEntriesAgeToKeepEnabled
-                    ? formData.minimumEntriesAgeToKeepInMin
-                    : null,
-                RefreshFrequencyInSec: formData.isRefreshFrequencyEnabled ? formData.refreshFrequencyInSec : null,
-            });
-
-            messagePublisher.reportSuccess("Revisions bin cleaner configuration saved successfully");
-            activeDatabaseTracker.default.database().hasRevisionsConfiguration(formData.isRevisionsBinCleanerEnabled);
+            await databasesService.saveRevisionsBinCleanerConfiguration(databaseName, mapToDto(formData));
 
             reset(formData);
         });
     };
-
-    const [isMinimumEntriesAgeToKeepOpen, setIsMinimumEntriesToKeepOpen] = useState(false);
-    const toggleMinimumEntriesAgeToKeep = () => setIsMinimumEntriesToKeepOpen(!isMinimumEntriesAgeToKeepOpen);
 
     if (
         asyncGetRevisionsBinCleanerConfiguration.status === "not-requested" ||
@@ -92,6 +63,7 @@ export default function RevisionsBinCleaner() {
     ) {
         return <LoadingView />;
     }
+
     if (asyncGetRevisionsBinCleanerConfiguration.status === "error") {
         return (
             <LoadError
@@ -108,52 +80,74 @@ export default function RevisionsBinCleaner() {
                     <Col>
                         <Form onSubmit={handleSubmit(onSave)} autoComplete="off">
                             <AboutViewHeading title="Revisions Bin Cleaner" icon="revisions-bin" />
-                            <ButtonWithSpinner
-                                type="submit"
-                                color="primary"
-                                className="mb-3"
-                                icon="save"
-                                disabled={!formState.isDirty}
-                                isSpinning={formState.isSubmitting}
-                            >
-                                Save
-                            </ButtonWithSpinner>
+                            {hasDatabaseAdminAccess && (
+                                <ButtonWithSpinner
+                                    type="submit"
+                                    color="primary"
+                                    className="mb-3"
+                                    icon="save"
+                                    disabled={!formState.isDirty}
+                                    isSpinning={formState.isSubmitting}
+                                >
+                                    Save
+                                </ButtonWithSpinner>
+                            )}
                             <Col>
                                 <Card>
                                     <CardBody>
                                         <div className="vstack gap-2">
-                                            <FormSwitch name="isRevisionsBinCleanerEnabled" control={control}>
+                                            <FormSwitch
+                                                name="isRevisionsBinCleanerEnabled"
+                                                disabled={!hasDatabaseAdminAccess}
+                                                control={control}
+                                            >
                                                 Enable Revisions Bin Cleaner
                                             </FormSwitch>
                                             <div>
                                                 <FormSwitch
-                                                    id="toggleMinEntriesAgeToKeep"
                                                     name="isMinimumEntriesAgeToKeepEnabled"
                                                     control={control}
-                                                    className={formValues.isMinimumEntriesAgeToKeepEnabled && "mb-3"}
+                                                    color="primary"
+                                                    className={
+                                                        formValues.isMinimumEntriesAgeToKeepEnabled &&
+                                                        formValues.isRevisionsBinCleanerEnabled &&
+                                                        "mb-3"
+                                                    }
                                                     disabled={
+                                                        !hasDatabaseAdminAccess ||
                                                         formState.isSubmitting ||
                                                         !formValues.isRevisionsBinCleanerEnabled
                                                     }
                                                 >
                                                     Set minimum entries age to keep
                                                 </FormSwitch>
-                                                {formValues.isMinimumEntriesAgeToKeepEnabled && (
+                                                <Collapse
+                                                    isOpen={
+                                                        formValues.isMinimumEntriesAgeToKeepEnabled &&
+                                                        formValues.isRevisionsBinCleanerEnabled
+                                                    }
+                                                >
                                                     <FormInput
                                                         name="minimumEntriesAgeToKeepInMin"
                                                         control={control}
                                                         type="number"
-                                                        disabled={formState.isSubmitting}
+                                                        disabled={
+                                                            !hasDatabaseAdminAccess ||
+                                                            formState.isSubmitting ||
+                                                            !formValues.isMinimumEntriesAgeToKeepEnabled
+                                                        }
                                                         addon="minutes"
                                                     />
-                                                )}
+                                                </Collapse>
                                             </div>
                                             <div>
                                                 <FormSwitch
                                                     name="isRefreshFrequencyEnabled"
                                                     control={control}
+                                                    color="primary"
                                                     className="mb-3"
                                                     disabled={
+                                                        !hasDatabaseAdminAccess ||
                                                         formState.isSubmitting ||
                                                         !formValues.isRevisionsBinCleanerEnabled
                                                     }
@@ -165,7 +159,9 @@ export default function RevisionsBinCleaner() {
                                                     control={control}
                                                     type="number"
                                                     disabled={
-                                                        formState.isSubmitting || !formValues.isRefreshFrequencyEnabled
+                                                        !hasDatabaseAdminAccess ||
+                                                        formState.isSubmitting ||
+                                                        !formValues.isRefreshFrequencyEnabled
                                                     }
                                                     placeholder="Default (300)"
                                                     addon="seconds"
@@ -184,24 +180,4 @@ export default function RevisionsBinCleaner() {
             </Col>
         </div>
     );
-}
-
-function mapToFormData(dto: RevisionsBinConfiguration): RevisionsBinCleanerFormData {
-    if (!dto) {
-        return {
-            isRevisionsBinCleanerEnabled: false,
-            isMinimumEntriesAgeToKeepEnabled: false,
-            minimumEntriesAgeToKeepInMin: null,
-            isRefreshFrequencyEnabled: false,
-            refreshFrequencyInSec: null,
-        };
-    }
-
-    return {
-        isRevisionsBinCleanerEnabled: !dto.Disabled,
-        isMinimumEntriesAgeToKeepEnabled: dto.MinimumEntriesAgeToKeepInMin != null,
-        minimumEntriesAgeToKeepInMin: dto.MinimumEntriesAgeToKeepInMin,
-        isRefreshFrequencyEnabled: dto.RefreshFrequencyInSec != null,
-        refreshFrequencyInSec: dto.RefreshFrequencyInSec,
-    };
 }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleaner.tsx
@@ -1,0 +1,207 @@
+import React, { useState } from "react";
+import { useAppSelector } from "components/store";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import { useServices } from "hooks/useServices";
+import { Card, CardBody, Col, Form, Row } from "reactstrap";
+import { SubmitHandler, useForm, useWatch } from "react-hook-form";
+import {
+    RevisionsBinCleanerFormData,
+    revisionsBinCleanerYupResolver,
+} from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerValidation";
+import { useAsyncCallback } from "react-async-hook";
+import RevisionsBinConfiguration = Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration;
+import { useDirtyFlag } from "hooks/useDirtyFlag";
+import { useEventsCollector } from "hooks/useEventsCollector";
+import { tryHandleSubmit } from "components/utils/common";
+import messagePublisher from "common/messagePublisher";
+import activeDatabaseTracker from "common/shell/activeDatabaseTracker";
+import { LoadingView } from "components/common/LoadingView";
+import { LoadError } from "components/common/LoadError";
+import { AboutViewHeading } from "components/common/AboutView";
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import { FormInput, FormSwitch } from "components/common/Form";
+import { RevisionsBinCleanerInfoHub } from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerInfoHub";
+
+export default function RevisionsBinCleaner() {
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const { databasesService } = useServices();
+
+    const asyncGetRevisionsBinCleanerConfiguration = useAsyncCallback<RevisionsBinCleanerFormData>(async () =>
+        // mapToFormData(await databasesService.getRevisionsBinCleanerConfiguration(databaseName))
+        mapToFormData(null)
+    );
+
+    const { handleSubmit, control, formState, reset, setValue, watch } = useForm<RevisionsBinCleanerFormData>({
+        resolver: revisionsBinCleanerYupResolver,
+        mode: "all",
+        defaultValues: asyncGetRevisionsBinCleanerConfiguration.execute,
+    });
+
+    useDirtyFlag(formState.isDirty);
+    const formValues = useWatch({ control: control });
+
+    const { reportEvent } = useEventsCollector();
+
+    // useEffect(() => {
+    //     const { unsubscribe } = watch((values, { name }) => {
+    //         switch (name) {
+    //             case "isRevisionsBinCleanerEnabled": {
+    //                 if (values.isRevisionsBinCleanerEnabled) {
+    //                     setValue("isRefreshFrequencyEnabled", true, { shouldValidate: true});
+    //                 } else {
+    //                     setValue("isRefreshFrequencyEnabled", false, { shouldValidate: true});
+    //                     setValue("isMinimumEntriesAgeToKeepEnabled", false, { shouldValidate: true});
+    //                 }
+    //                 break;
+    //             }
+    //             case "isMinimumEntriesAgeToKeepEnabled": {
+    //                 if (values.isMinimumEntriesAgeToKeepEnabled) {
+    //                     setValue("minimumEntriesAgeToKeepInMin",)
+    //                 }
+    //             }
+    //             }
+    //         }
+    //     }
+    // })
+
+    const onSave: SubmitHandler<RevisionsBinCleanerFormData> = async (formData) => {
+        return tryHandleSubmit(async () => {
+            reportEvent("revisions-bin-configuration", "save");
+
+            await databasesService.saveRevisionsBinCleanerConfiguration(databaseName, {
+                Disabled: !formData.isRevisionsBinCleanerEnabled,
+                MinimumEntriesAgeToKeepInMin: formData.isMinimumEntriesAgeToKeepEnabled
+                    ? formData.minimumEntriesAgeToKeepInMin
+                    : null,
+                RefreshFrequencyInSec: formData.isRefreshFrequencyEnabled ? formData.refreshFrequencyInSec : null,
+            });
+
+            messagePublisher.reportSuccess("Revisions bin cleaner configuration saved successfully");
+            activeDatabaseTracker.default.database().hasRevisionsConfiguration(formData.isRevisionsBinCleanerEnabled);
+
+            reset(formData);
+        });
+    };
+
+    const [isMinimumEntriesAgeToKeepOpen, setIsMinimumEntriesToKeepOpen] = useState(false);
+    const toggleMinimumEntriesAgeToKeep = () => setIsMinimumEntriesToKeepOpen(!isMinimumEntriesAgeToKeepOpen);
+
+    if (
+        asyncGetRevisionsBinCleanerConfiguration.status === "not-requested" ||
+        asyncGetRevisionsBinCleanerConfiguration.status === "loading"
+    ) {
+        return <LoadingView />;
+    }
+    if (asyncGetRevisionsBinCleanerConfiguration.status === "error") {
+        return (
+            <LoadError
+                error="Unable to load revisions bin cleaner"
+                refresh={asyncGetRevisionsBinCleanerConfiguration.execute}
+            />
+        );
+    }
+
+    return (
+        <div className="content-margin">
+            <Col xxl={12}>
+                <Row className="gy-sm">
+                    <Col>
+                        <Form onSubmit={handleSubmit(onSave)} autoComplete="off">
+                            <AboutViewHeading title="Revisions Bin Cleaner" icon="revisions-bin" />
+                            <ButtonWithSpinner
+                                type="submit"
+                                color="primary"
+                                className="mb-3"
+                                icon="save"
+                                disabled={!formState.isDirty}
+                                isSpinning={formState.isSubmitting}
+                            >
+                                Save
+                            </ButtonWithSpinner>
+                            <Col>
+                                <Card>
+                                    <CardBody>
+                                        <div className="vstack gap-2">
+                                            <FormSwitch name="isRevisionsBinCleanerEnabled" control={control}>
+                                                Enable Revisions Bin Cleaner
+                                            </FormSwitch>
+                                            <div>
+                                                <FormSwitch
+                                                    id="toggleMinEntriesAgeToKeep"
+                                                    name="isMinimumEntriesAgeToKeepEnabled"
+                                                    control={control}
+                                                    className={formValues.isMinimumEntriesAgeToKeepEnabled && "mb-3"}
+                                                    disabled={
+                                                        formState.isSubmitting ||
+                                                        !formValues.isRevisionsBinCleanerEnabled
+                                                    }
+                                                >
+                                                    Set minimum entries age to keep
+                                                </FormSwitch>
+                                                {formValues.isMinimumEntriesAgeToKeepEnabled && (
+                                                    <FormInput
+                                                        name="minimumEntriesAgeToKeepInMin"
+                                                        control={control}
+                                                        type="number"
+                                                        disabled={formState.isSubmitting}
+                                                        addon="minutes"
+                                                    />
+                                                )}
+                                            </div>
+                                            <div>
+                                                <FormSwitch
+                                                    name="isRefreshFrequencyEnabled"
+                                                    control={control}
+                                                    className="mb-3"
+                                                    disabled={
+                                                        formState.isSubmitting ||
+                                                        !formValues.isRevisionsBinCleanerEnabled
+                                                    }
+                                                >
+                                                    Set custom refresh frequency
+                                                </FormSwitch>
+                                                <FormInput
+                                                    name="refreshFrequencyInSec"
+                                                    control={control}
+                                                    type="number"
+                                                    disabled={
+                                                        formState.isSubmitting || !formValues.isRefreshFrequencyEnabled
+                                                    }
+                                                    placeholder="Default (300)"
+                                                    addon="seconds"
+                                                />
+                                            </div>
+                                        </div>
+                                    </CardBody>
+                                </Card>
+                            </Col>
+                        </Form>
+                    </Col>
+                    <Col sm={12} lg={4}>
+                        <RevisionsBinCleanerInfoHub />
+                    </Col>
+                </Row>
+            </Col>
+        </div>
+    );
+}
+
+function mapToFormData(dto: RevisionsBinConfiguration): RevisionsBinCleanerFormData {
+    if (!dto) {
+        return {
+            isRevisionsBinCleanerEnabled: false,
+            isMinimumEntriesAgeToKeepEnabled: false,
+            minimumEntriesAgeToKeepInMin: null,
+            isRefreshFrequencyEnabled: false,
+            refreshFrequencyInSec: null,
+        };
+    }
+
+    return {
+        isRevisionsBinCleanerEnabled: !dto.Disabled,
+        isMinimumEntriesAgeToKeepEnabled: dto.MinimumEntriesAgeToKeepInMin != null,
+        minimumEntriesAgeToKeepInMin: dto.MinimumEntriesAgeToKeepInMin,
+        isRefreshFrequencyEnabled: dto.RefreshFrequencyInSec != null,
+        refreshFrequencyInSec: dto.RefreshFrequencyInSec,
+    };
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerInfoHub.tsx
@@ -1,0 +1,18 @@
+import { AboutViewAnchored, AccordionItemWrapper } from "components/common/AboutView";
+import React from "react";
+
+export function RevisionsBinCleanerInfoHub() {
+    return (
+        <AboutViewAnchored>
+            <AccordionItemWrapper
+                targetId="about"
+                icon="about"
+                color="info"
+                heading="About this view"
+                description="Get additional info on this feature"
+            >
+                Content
+            </AccordionItemWrapper>
+        </AboutViewAnchored>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerUtils.ts
@@ -1,7 +1,7 @@
 import { RevisionsBinCleanerFormData } from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerValidation";
 import RevisionsBinConfiguration = Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration;
 
-export function mapToDto(dto: RevisionsBinCleanerFormData): RevisionsBinConfiguration {
+function mapToDto(dto: RevisionsBinCleanerFormData): RevisionsBinConfiguration {
     return {
         Disabled: !dto.isRevisionsBinCleanerEnabled,
         MinimumEntriesAgeToKeepInMin: dto.isMinimumEntriesAgeToKeepEnabled ? dto.minimumEntriesAgeToKeepInMin : null,
@@ -9,7 +9,7 @@ export function mapToDto(dto: RevisionsBinCleanerFormData): RevisionsBinConfigur
     };
 }
 
-export function mapToFormData(dto: RevisionsBinConfiguration): RevisionsBinCleanerFormData {
+function mapToFormData(dto: RevisionsBinConfiguration): RevisionsBinCleanerFormData {
     if (!dto) {
         return {
             isRevisionsBinCleanerEnabled: false,
@@ -25,6 +25,11 @@ export function mapToFormData(dto: RevisionsBinConfiguration): RevisionsBinClean
         isMinimumEntriesAgeToKeepEnabled: dto.MinimumEntriesAgeToKeepInMin != null,
         minimumEntriesAgeToKeepInMin: dto.MinimumEntriesAgeToKeepInMin,
         isRefreshFrequencyEnabled: dto.RefreshFrequencyInSec !== 300,
-        refreshFrequencyInSec: dto.RefreshFrequencyInSec,
+        refreshFrequencyInSec: dto.RefreshFrequencyInSec !== 300 ? dto.RefreshFrequencyInSec : null,
     };
 }
+
+export const revisionsBinCleanerUtils = {
+    mapToDto,
+    mapToFormData,
+};

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerUtils.ts
@@ -4,9 +4,7 @@ import RevisionsBinConfiguration = Raven.Client.Documents.Operations.Revisions.R
 export function mapToDto(dto: RevisionsBinCleanerFormData): RevisionsBinConfiguration {
     return {
         Disabled: !dto.isRevisionsBinCleanerEnabled,
-        MinimumEntriesAgeToKeepInMin: dto.isMinimumEntriesAgeToKeepEnabled
-            ? dto.minimumEntriesAgeToKeepInMin
-            : null,
+        MinimumEntriesAgeToKeepInMin: dto.isMinimumEntriesAgeToKeepEnabled ? dto.minimumEntriesAgeToKeepInMin : null,
         RefreshFrequencyInSec: dto.isRefreshFrequencyEnabled ? dto.refreshFrequencyInSec : 300,
     };
 }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerUtils.ts
@@ -1,0 +1,32 @@
+import { RevisionsBinCleanerFormData } from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerValidation";
+import RevisionsBinConfiguration = Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration;
+
+export function mapToDto(dto: RevisionsBinCleanerFormData): RevisionsBinConfiguration {
+    return {
+        Disabled: !dto.isRevisionsBinCleanerEnabled,
+        MinimumEntriesAgeToKeepInMin: dto.isMinimumEntriesAgeToKeepEnabled
+            ? dto.minimumEntriesAgeToKeepInMin
+            : null,
+        RefreshFrequencyInSec: dto.isRefreshFrequencyEnabled ? dto.refreshFrequencyInSec : 300,
+    };
+}
+
+export function mapToFormData(dto: RevisionsBinConfiguration): RevisionsBinCleanerFormData {
+    if (!dto) {
+        return {
+            isRevisionsBinCleanerEnabled: false,
+            isMinimumEntriesAgeToKeepEnabled: false,
+            minimumEntriesAgeToKeepInMin: null,
+            isRefreshFrequencyEnabled: false,
+            refreshFrequencyInSec: null,
+        };
+    }
+
+    return {
+        isRevisionsBinCleanerEnabled: !dto.Disabled,
+        isMinimumEntriesAgeToKeepEnabled: dto.MinimumEntriesAgeToKeepInMin != null,
+        minimumEntriesAgeToKeepInMin: dto.MinimumEntriesAgeToKeepInMin,
+        isRefreshFrequencyEnabled: dto.RefreshFrequencyInSec !== 300,
+        refreshFrequencyInSec: dto.RefreshFrequencyInSec,
+    };
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerValidation.ts
@@ -1,0 +1,29 @@
+import * as yup from "yup";
+import { yupResolver } from "@hookform/resolvers/yup";
+
+const schema = yup.object({
+    isRevisionsBinCleanerEnabled: yup.boolean(),
+    isMinimumEntriesAgeToKeepEnabled: yup.boolean(),
+    minimumEntriesAgeToKeepInMin: yup
+        .number()
+        .nullable()
+        .positive()
+        .integer()
+        .when("isMinimumEntriesAgeToKeepEnabled", {
+            is: true,
+            then: (schema) => schema.required(),
+        }),
+    isRefreshFrequencyEnabled: yup.boolean(),
+    refreshFrequencyInSec: yup
+        .number()
+        .nullable()
+        .positive()
+        .integer()
+        .when("isRefreshFrequencyEnabled", {
+            is: true,
+            then: (schema) => schema.required(),
+        }),
+});
+
+export const revisionsBinCleanerYupResolver = yupResolver(schema);
+export type RevisionsBinCleanerFormData = yup.InferType<typeof schema>;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/useRevisionsBinCleanerFormSideEffects.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/useRevisionsBinCleanerFormSideEffects.tsx
@@ -1,0 +1,39 @@
+import { UseFormSetValue, UseFormWatch } from "react-hook-form";
+import { RevisionsBinCleanerFormData } from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerValidation";
+import { useEffect } from "react";
+import { TimeTypes } from "common/constants/timeTypes";
+
+const defaultRefreshFrequency = 5 * TimeTypes.Minute;
+
+export default function useRevisionsBinCleanerFormSideEffects(
+    watch: UseFormWatch<RevisionsBinCleanerFormData>,
+    setValue: UseFormSetValue<RevisionsBinCleanerFormData>
+) {
+    useEffect(() => {
+        const { unsubscribe } = watch((values, { name }) => {
+            switch (name) {
+                case "isRevisionsBinCleanerEnabled": {
+                    if (!values.isRevisionsBinCleanerEnabled) {
+                        setValue("isMinimumEntriesAgeToKeepEnabled", false, { shouldValidate: true });
+                        setValue("isRefreshFrequencyEnabled", false, { shouldValidate: true });
+                    }
+                    break;
+                }
+                case "isMinimumEntriesAgeToKeepEnabled": {
+                    if (!values.isMinimumEntriesAgeToKeepEnabled) {
+                        setValue("minimumEntriesAgeToKeepInMin", null, { shouldValidate: true });
+                    }
+                    break;
+                }
+                case "isRefreshFrequencyEnabled": {
+                    if (values.isRefreshFrequencyEnabled) {
+                        setValue("refreshFrequencyInSec", defaultRefreshFrequency, { shouldValidate: true });
+                    } else {
+                        setValue("refreshFrequencyInSec", null, { shouldValidate: true });
+                    }
+                }
+            }
+        });
+        return () => unsubscribe();
+    }, [setValue, watch]);
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/useRevisionsBinCleanerFormSideEffects.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/revisionsBinCleaner/useRevisionsBinCleanerFormSideEffects.tsx
@@ -1,9 +1,6 @@
 import { UseFormSetValue, UseFormWatch } from "react-hook-form";
 import { RevisionsBinCleanerFormData } from "components/pages/database/settings/revisionsBinCleaner/RevisionsBinCleanerValidation";
 import { useEffect } from "react";
-import { TimeTypes } from "common/constants/timeTypes";
-
-const defaultRefreshFrequency = 5 * TimeTypes.Minute;
 
 export default function useRevisionsBinCleanerFormSideEffects(
     watch: UseFormWatch<RevisionsBinCleanerFormData>,
@@ -26,9 +23,7 @@ export default function useRevisionsBinCleanerFormSideEffects(
                     break;
                 }
                 case "isRefreshFrequencyEnabled": {
-                    if (values.isRefreshFrequencyEnabled) {
-                        setValue("refreshFrequencyInSec", defaultRefreshFrequency, { shouldValidate: true });
-                    } else {
+                    if (!values.isRefreshFrequencyEnabled) {
                         setValue("refreshFrequencyInSec", null, { shouldValidate: true });
                     }
                 }

--- a/src/Raven.Studio/typescript/components/services/DatabasesService.ts
+++ b/src/Raven.Studio/typescript/components/services/DatabasesService.ts
@@ -65,7 +65,8 @@ import getDocumentsPreviewCommand = require("commands/database/documents/getDocu
 import getDocumentsMetadataByIDPrefixCommand = require("commands/database/documents/getDocumentsMetadataByIDPrefixCommand");
 import getIdentitiesCommand from "commands/database/identities/getIdentitiesCommand";
 import seedIdentityCommand from "commands/database/identities/seedIdentityCommand";
-import RevisionsBinConfiguration = Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration;
+import getRevisionsBinCleanerConfigurationCommand from "commands/database/settings/getRevisionsBinCleanerConfigurationCommand";
+import saveRevisionsBinCleanerConfigurationCommand from "commands/database/settings/saveRevisionsBinCleanerConfigurationCommand";
 
 export default class DatabasesService {
     async setLockMode(databaseNames: string[], newLockMode: DatabaseLockMode) {
@@ -180,12 +181,16 @@ export default class DatabasesService {
         return new saveRevisionsConfigurationCommand(databaseName, dto).execute();
     }
 
-    async getRevisionsBinCleanerConfiguration(databaseName: string) {
-        // return new getRevisionsBinCleanerConfigurationCommand(databaseName).execute();
+    async getRevisionsBinCleanerConfiguration(
+        ...args: ConstructorParameters<typeof getRevisionsBinCleanerConfigurationCommand>
+    ) {
+        return new getRevisionsBinCleanerConfigurationCommand(...args).execute();
     }
 
-    async saveRevisionsBinCleanerConfiguration(databaseName: string, dto: RevisionsBinConfiguration) {
-        // return new saveRevisionsBinCleanerConfigurationCommand(databaseName, dto).execute();
+    async saveRevisionsBinCleanerConfiguration(
+        ...args: ConstructorParameters<typeof saveRevisionsBinCleanerConfigurationCommand>
+    ) {
+        return new saveRevisionsBinCleanerConfigurationCommand(...args).execute();
     }
 
     async enforceRevisionsConfiguration(

--- a/src/Raven.Studio/typescript/components/services/DatabasesService.ts
+++ b/src/Raven.Studio/typescript/components/services/DatabasesService.ts
@@ -65,6 +65,7 @@ import getDocumentsPreviewCommand = require("commands/database/documents/getDocu
 import getDocumentsMetadataByIDPrefixCommand = require("commands/database/documents/getDocumentsMetadataByIDPrefixCommand");
 import getIdentitiesCommand from "commands/database/identities/getIdentitiesCommand";
 import seedIdentityCommand from "commands/database/identities/seedIdentityCommand";
+import RevisionsBinConfiguration = Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration;
 
 export default class DatabasesService {
     async setLockMode(databaseNames: string[], newLockMode: DatabaseLockMode) {
@@ -177,6 +178,14 @@ export default class DatabasesService {
 
     async saveRevisionsConfiguration(databaseName: string, dto: RevisionsConfiguration) {
         return new saveRevisionsConfigurationCommand(databaseName, dto).execute();
+    }
+
+    async getRevisionsBinCleanerConfiguration(databaseName: string) {
+        // return new getRevisionsBinCleanerConfigurationCommand(databaseName).execute();
+    }
+
+    async saveRevisionsBinCleanerConfiguration(databaseName: string, dto: RevisionsBinConfiguration) {
+        // return new saveRevisionsBinCleanerConfigurationCommand(databaseName, dto).execute();
     }
 
     async enforceRevisionsConfiguration(

--- a/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
+++ b/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
@@ -182,4 +182,14 @@ export default class MockDatabasesService extends AutoMockService<DatabasesServi
     withIdentities(dto?: MockedValue<Record<string, number>>) {
         return this.mockResolvedValue(this.mocks.getIdentities, dto, DatabasesStubs.getIdentities(5));
     }
+
+    withRevisionsBinCleanerConfiguration(
+        dto?: MockedValue<Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration>
+    ) {
+        return this.mockResolvedValue(
+            this.mocks.getRevisionsBinCleanerConfiguration,
+            dto,
+            DatabasesStubs.revisionsBinCleaner()
+        );
+    }
 }

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -1,5 +1,7 @@
 ﻿import nonShardedDatabase from "models/resources/nonShardedDatabase";
 import shardedDatabase from "models/resources/shardedDatabase";
+import document from "models/database/documents/document";
+import { TimeInSeconds } from "common/constants/timeInSeconds";
 import DetailedDatabaseStatistics = Raven.Client.Documents.Operations.DetailedDatabaseStatistics;
 import EssentialDatabaseStatistics = Raven.Client.Documents.Operations.EssentialDatabaseStatistics;
 import StudioDatabaseInfo = Raven.Server.Web.System.Processors.Studio.StudioDatabasesHandlerForGetDatabases.StudioDatabaseInfo;
@@ -12,8 +14,6 @@ import RevisionsConfiguration = Raven.Client.Documents.Operations.Revisions.Revi
 import RevisionsCollectionConfiguration = Raven.Client.Documents.Operations.Revisions.RevisionsCollectionConfiguration;
 import SorterDefinition = Raven.Client.Documents.Queries.Sorting.SorterDefinition;
 import AnalyzerDefinition = Raven.Client.Documents.Indexes.Analysis.AnalyzerDefinition;
-import document from "models/database/documents/document";
-import { TimeTypes } from "common/constants/timeTypes";
 
 export class DatabasesStubs {
     private static genericDatabaseInfo(name: string): StudioDatabaseInfo {
@@ -969,7 +969,7 @@ return docs[0];`,
         return {
             Disabled: false,
             MinimumEntriesAgeToKeepInMin: 1,
-            RefreshFrequencyInSec: 5 * TimeTypes.Minute,
+            RefreshFrequencyInSec: 5 * TimeInSeconds.Minute,
         };
     }
 }

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -13,6 +13,7 @@ import RevisionsCollectionConfiguration = Raven.Client.Documents.Operations.Revi
 import SorterDefinition = Raven.Client.Documents.Queries.Sorting.SorterDefinition;
 import AnalyzerDefinition = Raven.Client.Documents.Indexes.Analysis.AnalyzerDefinition;
 import document from "models/database/documents/document";
+import { TimeTypes } from "common/constants/timeTypes";
 
 export class DatabasesStubs {
     private static genericDatabaseInfo(name: string): StudioDatabaseInfo {
@@ -962,5 +963,13 @@ return docs[0];`,
             Object.assign(object, identity);
         }
         return object;
+    }
+
+    static revisionsBinCleaner(): Raven.Client.Documents.Operations.Revisions.RevisionsBinConfiguration {
+        return {
+            Disabled: false,
+            MinimumEntriesAgeToKeepInMin: 1,
+            RefreshFrequencyInSec: 5 * TimeTypes.Minute,
+        };
     }
 }

--- a/src/Raven.Studio/typings/_studio/computedAppUrls.d.ts
+++ b/src/Raven.Studio/typings/_studio/computedAppUrls.d.ts
@@ -84,6 +84,7 @@ interface computedAppUrls {
     integrations: KnockoutComputed<string>;
     connectionStrings: KnockoutComputed<string>;
     conflictResolution: KnockoutComputed<string>;
+    revisionsBinCleaner: KnockoutComputed<string>;
 
     about: KnockoutComputed<string>;
     whatsNew: KnockoutComputed<string>;

--- a/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
@@ -649,3 +649,13 @@ $filtering-input-bg: $toggle-bg !default;
         background: #{$striped-bg};
     }
 }
+
+// Lower opacity for disabled inputs and text addons
+.form-control {
+    &:disabled {
+        opacity: .5;
+        + .input-group-text {
+            opacity: .5;
+        }
+    }
+}

--- a/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
@@ -653,9 +653,9 @@ $filtering-input-bg: $toggle-bg !default;
 // Lower opacity for disabled inputs and text addons
 .form-control {
     &:disabled {
-        opacity: .5;
+        opacity: 0.5;
         + .input-group-text {
-            opacity: .5;
+            opacity: 0.5;
         }
     }
 }

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -72,7 +72,7 @@ namespace FastTests.Client
                 "AddQueueSinkCommand", "UpdateQueueSinkCommand", "ConfigureDataArchivalCommand",
                 "AdoptOrphanedRevisionsCommand",
                 "AddPrefixedShardingSettingCommand", "DeletePrefixedShardingSettingCommand", "UpdatePrefixedShardingSettingCommand", "RevertRevisionsByIdCommand",
-                "DeleteRevisionsCommand"
+                "DeleteRevisionsCommand", "ConfigureRevisionsBinCleanerCommand"
             }.OrderBy(t => t);
 
             var commandBaseType = typeof(RavenCommand<>);

--- a/test/FastTests/Issues/RavenDB_19938.cs
+++ b/test/FastTests/Issues/RavenDB_19938.cs
@@ -112,6 +112,13 @@ public class RavenDB_19938 : RavenTestBase
 
         record = CreateDatabaseRecord(builder => builder
             .Regular("DB1")
+            .ConfigureRevisionsBin(new RevisionsBinConfiguration { MinimumEntriesAgeToKeepInMin = 5})
+        );
+
+        Assert.Equal(5, record.RevisionsBin.MinimumEntriesAgeToKeepInMin);
+
+        record = CreateDatabaseRecord(builder => builder
+            .Regular("DB1")
             .ConfigureStudio(new StudioConfiguration { Environment = StudioConfiguration.StudioEnvironment.Production })
         );
 

--- a/test/SlowTests/Issues/RavenDB-21326.cs
+++ b/test/SlowTests/Issues/RavenDB-21326.cs
@@ -1,0 +1,777 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Commands;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21326 : ClusterTestBase
+    {
+        public RavenDB_21326(ITestOutputHelper output) : base(output)
+        {
+        }
+
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task TestReadAndWriteLastRevisionsBinCleanerState()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (var tx = context.OpenWriteTransaction())
+                {
+                    RevisionsStorage.SetLastRevisionsBinCleanerLastEtag(context, 1234567890123456789);
+                    tx.Commit();
+                }
+
+
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var state = RevisionsStorage.ReadLastRevisionsBinCleanerLastEtag(context.Transaction.InnerTransaction);
+
+                    Assert.Equal(1234567890123456789, state);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Revisions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task RevisionsBinCleanerTest(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            var revisionsConfig = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 100 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, store.Database, revisionsConfig);
+
+            var user1 = new User { Id = "Users/1-A", Name = "Shahar" };
+            var user2 = new User { Id = "Users/2-B", Name = "Shahar" };
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.StoreAsync(user2);
+                await session.SaveChangesAsync();
+
+                for (int i = 1; i <= 10; i++)
+                {
+                    (await session.LoadAsync<User>(user1.Id)).Name = $"Shahar{i}";
+                    (await session.LoadAsync<User>(user2.Id)).Name = $"Shahar{i}";
+                    await session.SaveChangesAsync();
+                }
+
+                session.Delete(user1.Id);
+                session.Delete(user2.Id);
+                await session.SaveChangesAsync();
+
+                await session.StoreAsync(user2); // revive user2
+                await session.SaveChangesAsync();
+
+                Assert.Equal(12, await session.Advanced.Revisions.GetCountForAsync(user1.Id));
+                Assert.Equal(13, await session.Advanced.Revisions.GetCountForAsync(user2.Id));
+            }
+
+            var config = new RevisionsBinConfiguration
+            {
+                MinimumEntriesAgeToKeepInMin = 0, 
+                RefreshFrequencyInSec = 1
+            };
+            await ConfigRevisionsBinCleaner(store, config);
+
+            await AssertWaitForValueAsync(async () =>
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    return await session.Advanced.Revisions.GetCountForAsync(user1.Id);
+                }
+            }, 0);
+
+            // End Cleanup
+            config.Disabled = true;
+            await ConfigRevisionsBinCleaner(store, config);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete(user2.Id);
+                await session.SaveChangesAsync(); // delete user2
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                Assert.Equal(14, await session.Advanced.Revisions.GetCountForAsync(user2.Id));
+            }
+
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task RevisionsBinCleaner_Shouldnt_Delete_Entities_Newest_Then_MinimumEntriesAgeToKeep()
+        {
+            var baseTime = new DateTime(year: 2024, month: 1, day: 1);
+
+            using var store = GetDocumentStore();
+
+            var revisionsConfig = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 100 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, store.Database, revisionsConfig);
+
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            db.Time.UtcDateTime = () => baseTime - TimeSpan.FromDays(30);
+
+            var user = new User() { Id = "Users/1", Name = "Shahar" };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user);
+                await session.SaveChangesAsync();
+
+                session.Delete(user.Id);
+                await session.SaveChangesAsync();
+            }
+
+            db.Time.UtcDateTime = () => baseTime;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user);
+                await session.SaveChangesAsync();
+
+                session.Delete(user.Id);
+                await session.SaveChangesAsync();
+
+                Assert.Equal(4, await session.Advanced.Revisions.GetCountForAsync(user.Id));
+            }
+
+            var config = new RevisionsBinConfiguration
+            {
+                MinimumEntriesAgeToKeepInMin = 15 * 60 * 24, // 15 days
+                RefreshFrequencyInSec = 1
+            };
+
+            var cleaner = new RevisionsBinCleaner(db, config);
+
+            var deletes = await cleaner.ExecuteCleanup();
+
+            Assert.Equal(1, deletes);
+            deletes = await cleaner.ExecuteCleanup();
+            Assert.Equal(0, deletes);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                Assert.Equal(2, await session.Advanced.Revisions.GetCountForAsync(user.Id));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task RevisionsBinCleanerAgeTest()
+        {
+            var baseTime = new DateTime(year: 2024, month: 1, day: 1);
+
+            using var store = GetDocumentStore();
+
+            var revisionsConfig = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 100 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, store.Database, revisionsConfig);
+
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            db.Time.UtcDateTime = () => baseTime - TimeSpan.FromDays(30);
+
+            var users = new List<User>();
+            for (int i = 0; i < 10; i++)
+                users.Add(new User { Id = $"Users/{i}", Name = "Shahar" });
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.MaxNumberOfRequestsPerSession = Int32.MaxValue;
+
+                for (int u = 0; u < 10; u++)
+                {
+                    var user = users[u];
+
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+                    for (int i = 1; i <= 10; i++)
+                    {
+                        (await session.LoadAsync<User>(user.Id)).Name = $"Shahar{i}";
+                        await session.SaveChangesAsync();
+                    }
+
+                    session.Delete(user.Id);
+                    await session.SaveChangesAsync();
+
+                    Assert.Equal(12, await session.Advanced.Revisions.GetCountForAsync(user.Id));
+
+                    if (u == 4)
+                        db.Time.UtcDateTime = () => baseTime;
+                }
+            }
+
+            // users 0-4 30 days ago, users 5-9 is now
+
+            var config = new RevisionsBinConfiguration
+            {
+                MinimumEntriesAgeToKeepInMin = 15 * 24 * 60, // 15 days
+                RefreshFrequencyInSec = 1
+            };
+
+            var cleaner = new RevisionsBinCleaner(db, config);
+
+            var deletes = await cleaner.ExecuteCleanup();
+            Assert.Equal(5, deletes);
+            deletes = await cleaner.ExecuteCleanup();
+            Assert.Equal(0, deletes);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int u = 0; u < 5; u++)
+                {
+                    Assert.Equal(0, await session.Advanced.Revisions.GetCountForAsync(users[u].Id));
+                }
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int u = 5; u < 10; u++)
+                {
+                    Assert.Equal(12, await session.Advanced.Revisions.GetCountForAsync(users[u].Id));
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task RevisionsBinCleanerStateTest()
+        {
+            var baseTime = new DateTime(year: 2024, month: 1, day: 1);
+
+            using var store = GetDocumentStore();
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            db.Time.UtcDateTime = () => baseTime - TimeSpan.FromDays(30);
+
+            var revisionsConfig = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 100 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, store.Database, revisionsConfig);
+
+            var users = new List<User>();
+            for (int i = 0; i < 10; i++)
+                users.Add(new User { Id = $"Users/{i}", Name = "Shahar" });
+
+            long lastEtag5;
+            long lastEtag9;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.MaxNumberOfRequestsPerSession = Int32.MaxValue;
+
+                for (int u = 0; u < 10; u++)
+                {
+                    if (u == 5)
+                        db.Time.UtcDateTime = () => baseTime;
+
+                    var user = users[u];
+
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+                    for (int i = 1; i <= 10; i++)
+                    {
+                        (await session.LoadAsync<User>(user.Id)).Name = $"Shahar{i}";
+                        await session.SaveChangesAsync();
+                    }
+
+                    session.Delete(user.Id);
+                    await session.SaveChangesAsync();
+
+                    Assert.Equal(12, await session.Advanced.Revisions.GetCountForAsync(user.Id));
+                }
+
+                var revisions5MetaData = (await session.Advanced.Revisions.GetMetadataForAsync(users[5].Id));
+                Assert.True(revisions5MetaData[0].TryGetValue(Constants.Documents.Metadata.ChangeVector, out string cv5));
+
+                lastEtag5 = ChangeVectorUtils.GetEtagById(cv5, db.DbBase64Id) + 1;
+
+                var revisions9MetaData = (await session.Advanced.Revisions.GetMetadataForAsync(users[9].Id));
+                Assert.True(revisions9MetaData[0].TryGetValue(Constants.Documents.Metadata.ChangeVector, out string cv9));
+
+                lastEtag9 = ChangeVectorUtils.GetEtagById(cv9, db.DbBase64Id) + 1;
+            }
+
+            db.Time.UtcDateTime = () => baseTime;
+
+            var config = new RevisionsBinConfiguration
+            {
+                MinimumEntriesAgeToKeepInMin = 15 * 24 * 60, // 15 days
+            };
+            var cleaner = new RevisionsBinCleaner(db, config);
+
+            var deletes = await cleaner.ExecuteCleanup();
+            Assert.Equal(5, deletes);
+
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var state = RevisionsStorage.ReadLastRevisionsBinCleanerLastEtag(context.Transaction.InnerTransaction);
+                Assert.Equal(lastEtag5, state);
+            }
+
+            db.Time.UtcDateTime = () => baseTime + TimeSpan.FromDays(30);
+            deletes = await cleaner.ExecuteCleanup();
+            Assert.Equal(5, deletes);
+
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var state = RevisionsStorage.ReadLastRevisionsBinCleanerLastEtag(context.Transaction.InnerTransaction);
+                Assert.Equal(lastEtag9, state);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task RevisionsBinCleanerStateTest2()
+        {
+            var baseTime = new DateTime(year: 2024, month: 1, day: 1);
+
+            using var store = GetDocumentStore();
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            db.Time.UtcDateTime = () => baseTime - TimeSpan.FromDays(30);
+
+            var revisionsConfig = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 100 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, store.Database, revisionsConfig);
+
+            var users = new List<User>();
+            for (int i = 0; i < 10; i++)
+                users.Add(new User { Id = $"Users/{i}", Name = "Shahar" });
+
+            long lastEtag0;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.MaxNumberOfRequestsPerSession = Int32.MaxValue;
+
+                for (int u = 0; u < 10; u++)
+                {
+                    var user = users[u];
+
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+                    for (int i = 1; i <= 10; i++)
+                    {
+                        (await session.LoadAsync<User>(user.Id)).Name = $"Shahar{i}";
+                        await session.SaveChangesAsync();
+                    }
+
+                    session.Delete(user.Id);
+                    await session.SaveChangesAsync();
+
+                    Assert.Equal(12, await session.Advanced.Revisions.GetCountForAsync(user.Id));
+                }
+
+                var revisions0MetaData = await session.Advanced.Revisions.GetMetadataForAsync(users[0].Id);
+                Assert.True(revisions0MetaData[0].TryGetValue(Constants.Documents.Metadata.ChangeVector, out string cv0));
+
+                lastEtag0 = ChangeVectorUtils.GetEtagById(cv0, db.DbBase64Id) + 1;
+            }
+
+            var config = new RevisionsBinConfiguration
+            {
+                MinimumEntriesAgeToKeepInMin = 15 * 24 * 60, // 15 days
+            };
+            var cleaner = new RevisionsBinCleaner(db, config);
+
+            var deletes = await cleaner.ExecuteCleanup();
+            Assert.Equal(0, deletes);
+
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var state = RevisionsStorage.ReadLastRevisionsBinCleanerLastEtag(context.Transaction.InnerTransaction);
+                Assert.Equal(lastEtag0, state);
+            }
+
+            db.Time.UtcDateTime = () => baseTime;
+            deletes = await cleaner.ExecuteCleanup();
+            Assert.Equal(10, deletes);
+        }
+
+        [RavenTheory(RavenTestCategory.Revisions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task RevisionsBinCleanerClusterTest(Options options)
+        {
+            var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
+
+            options.Server = leader;
+            options.ReplicationFactor = 3;
+
+            using var store = GetDocumentStore(options);
+
+            var revisionsConfig = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 100 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, store.Database, revisionsConfig);
+
+            var user1 = new User { Id = "Users/1-A", Name = "Shahar" };
+            var user2 = new User { Id = "Users/2-B", Name = "Shahar" };
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.StoreAsync(user2);
+                await session.SaveChangesAsync();
+
+                for (int i = 1; i <= 10; i++)
+                {
+                    (await session.LoadAsync<User>(user1.Id)).Name = $"Shahar{i}";
+                    (await session.LoadAsync<User>(user2.Id)).Name = $"Shahar{i}";
+                    await session.SaveChangesAsync();
+                }
+
+                session.Delete(user1.Id);
+                session.Delete(user2.Id);
+                await session.SaveChangesAsync();
+
+                await session.StoreAsync(user2); // revive user2
+                await session.SaveChangesAsync();
+
+                Assert.Equal(12, await session.Advanced.Revisions.GetCountForAsync(user1.Id));
+                Assert.Equal(13, await session.Advanced.Revisions.GetCountForAsync(user2.Id));
+            }
+
+            var config = new RevisionsBinConfiguration
+            {
+                MinimumEntriesAgeToKeepInMin = 0, 
+                RefreshFrequencyInSec = 1
+            };
+            await ConfigRevisionsBinCleaner(store, config);
+
+            using (var stores = new NodesDocumentStores(nodes, store.Database))
+            {
+                await AssertWaitForValueAsync(async () =>
+                {
+                    foreach (var node in nodes)
+                    {
+                        using (var session = stores.GetStore(node.ServerStore.NodeTag).OpenAsyncSession())
+                        {
+                            var count = await session.Advanced.Revisions.GetCountForAsync(user1.Id);
+                            if (count != 0)
+                            {
+                                var db = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+                                var topology = db.ReadDatabaseRecord().Topology;
+                                return $"node {node} has {count} revisions for 'user1.Id' instead of 0 revisions, Database Topology: {topology}";
+                            }
+                        }
+                    }
+
+                    return string.Empty;
+                }, string.Empty);
+            }
+
+            if (options.DatabaseMode == RavenDatabaseMode.Single)
+            {
+                await AssertDatabaseClusterCleaners(nodes, store.Database);
+            }
+            else if (options.DatabaseMode == RavenDatabaseMode.Sharded)
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    await AssertDatabaseClusterCleaners(nodes, store.Database + "$" + i);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task RevisionsBinCleanerClusterTest2()
+        {
+            var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
+
+            using var store = GetDocumentStore(new Options { Server = leader, ReplicationFactor = 3 });
+
+            var user0 = new User { Id = "Users/0", Name = "Shahar" }; // continue
+            var user1 = new User { Id = "Users/1", Name = "Shahar" };
+
+            await CreateDeletedRevisionsToContinue(store, user0);
+
+            var revisionsConfig = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 100 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, store.Database, revisionsConfig);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.SaveChangesAsync();
+
+                for (int i = 1; i < 9; i++)
+                {
+                    (await session.LoadAsync<User>(user1.Id)).Name = $"Shahar{i}";
+                    await session.SaveChangesAsync();
+                }
+
+                session.Delete(user1.Id);
+                await session.SaveChangesAsync();
+
+                await session.SaveChangesAsync();
+
+                Assert.Equal(10, await session.Advanced.Revisions.GetCountForAsync(user1.Id));
+            }
+
+            var config = new RevisionsBinConfiguration
+            {
+                MinimumEntriesAgeToKeepInMin = 0, 
+                RefreshFrequencyInSec = 1
+            };
+
+            var firsts = 0;
+
+            foreach (var node in nodes)
+            {
+                var db = await Databases.GetDocumentDatabaseInstanceFor(node, store);
+                var cleaner = new RevisionsBinCleaner(db, config);
+
+                var deletedCount = await cleaner.ExecuteCleanup();
+                long readLastEtag;
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    readLastEtag = RevisionsStorage.ReadLastRevisionsBinCleanerLastEtag(ctx.Transaction.InnerTransaction);
+                }
+
+                if (cleaner.IsFirst)
+                {
+                    firsts++;
+                    Assert.Equal(1, deletedCount);
+                }
+                else
+                {
+                    Assert.Equal(0, deletedCount);
+                }
+
+                Assert.True(readLastEtag > 0);
+            }
+
+
+            Assert.Equal(1, firsts);
+        }
+
+        private async Task CreateDeletedRevisionsToContinue(DocumentStore store, User user0)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user0);
+                await session.SaveChangesAsync();
+            }
+
+            var revisionsConfig = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 100 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, store.Database, revisionsConfig);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete(user0.Id);
+                await session.SaveChangesAsync();
+            }
+
+            var emptyConfig = new RevisionsConfiguration { Default = null };
+            await RevisionsHelper.SetupRevisionsAsync(store, store.Database, emptyConfig);
+
+            for (int i = 0; i < 10; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(user0);
+                    await session.SaveChangesAsync();
+
+                    session.Delete(user0.Id);
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user0);
+                await session.SaveChangesAsync();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task ExistingDocShouldntHasRevisionBinEntry()
+        {
+            using var store = GetDocumentStore();
+            var user1 = new User() { Id = "Users/1", Name = "Shahar" };
+
+            // Add revisions configuration
+            var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 100 } };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete(user1.Id);
+                await session.SaveChangesAsync();
+            }
+
+            // Delete Revisions Configuration
+            configuration = new RevisionsConfiguration { Default = null };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(user1);
+                await session.SaveChangesAsync();
+
+                Assert.NotNull(await session.LoadAsync<User>(user1.Id));
+            }
+
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+
+                var (revisionsBinEntries, continuationToken) =
+                    await store.Commands().GetRevisionsBinEntriesAndContinuationTokenAsync(context, etag: 0, pageSize: 100);
+
+                Assert.Equal(0, revisionsBinEntries.Length); // Fail - this is 1, because "Users/1" has revisions bin entries eventhough it is not a deleted doc
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task ReachToBatchSize()
+        {
+            const long maxDeletesUponUpdate = 1024;
+
+            using var store = GetDocumentStore();
+
+            // Add revisions configuration
+            var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, } };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            await CreateRevisionsAndDelete(store, "Users/1", maxDeletesUponUpdate - 1);
+            await CreateRevisionsAndDelete(store, "Users/2", 1);
+
+            await CreateRevisionsAndDelete(store, "Users/1", maxDeletesUponUpdate * 2 - 1);
+            await CreateRevisionsAndDelete(store, "Users/1", maxDeletesUponUpdate);
+
+            var config = new RevisionsBinConfiguration
+            {
+                MinimumEntriesAgeToKeepInMin = 0, 
+                RefreshFrequencyInSec = 1
+            };
+
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            var cleaner = new RevisionsBinCleaner(db, config);
+
+            await cleaner.ExecuteCleanup();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                Assert.Equal(0, await session.Advanced.Revisions.GetCountForAsync("Users/1"));
+                Assert.Equal(0, await session.Advanced.Revisions.GetCountForAsync("Users/2"));
+            }
+
+
+        }
+
+        private async Task CreateRevisionsAndDelete(DocumentStore store, string id, long revisionsNumber)
+        {
+            var user1 = new User() { Id = id, Name = "Shahar" };
+            for (int i = 0; i < revisionsNumber; i++)
+            {
+                user1.Name = "Shahar" + i;
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(user1);
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete(id);
+                await session.SaveChangesAsync();
+            }
+        }
+
+        private async Task AssertDatabaseClusterCleaners(IEnumerable<RavenServer> nodes, string database)
+        {
+            foreach (var node in nodes)
+            {
+                var db = await node.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                Assert.NotNull(db.RevisionsBinCleaner);
+            }
+        }
+
+        private class NodesDocumentStores : IDisposable
+        {
+            private Dictionary<string, IDocumentStore> _stores;
+
+            public NodesDocumentStores(IEnumerable<RavenServer> nodes, string database)
+            {
+                _stores = new Dictionary<string, IDocumentStore>();
+                foreach (var node in nodes)
+                {
+                    _stores[node.ServerStore.NodeTag] = GetStoreForServer(node, database);
+                }
+            }
+
+            public IDocumentStore GetStore(string nodeTag)
+            {
+                return _stores[nodeTag];
+            }
+
+            private IDocumentStore GetStoreForServer(RavenServer server, string database)
+            {
+                return new DocumentStore { Database = database, Urls = new[] { server.WebUrl }, Conventions = new DocumentConventions { DisableTopologyUpdates = true } }
+                    .Initialize();
+            }
+
+            public void Dispose()
+            {
+                var exceptions = new List<Exception>();
+
+                foreach (var store in _stores.Values)
+                {
+                    try
+                    {
+                        store?.Dispose();
+                    }
+                    catch (Exception e)
+                    {
+                        exceptions.Add(e);
+                    }
+                }
+
+                if (exceptions.Count == 1)
+                    throw exceptions.First();
+
+                if (exceptions.Count > 1)
+                    throw new AggregateException(exceptions);
+            }
+        }
+
+        private async Task ConfigRevisionsBinCleaner(DocumentStore store, RevisionsBinConfiguration config)
+        {
+            var result = await store.Maintenance.SendAsync(new ConfigureRevisionsBinCleanerOperation(config));
+            await store.Maintenance.SendAsync(new WaitForIndexNotificationOperation(result.RaftCommandIndex.Value));
+
+            await AssertWaitForTrueAsync(async () =>
+            {
+                var record = await GetDatabaseRecordAsync(store);
+                return config.Equals(record.RevisionsBin);
+            });
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_11909.cs
+++ b/test/SlowTests/Issues/RavenDB_11909.cs
@@ -89,7 +89,7 @@ namespace SlowTests.Issues
         [Fact]
         public void ThrowOnDatabaseRecordChanges()
         {
-            const int numberOfFields = 44;
+            const int numberOfFields = 45;
             const int numberOfProperties = 1;
 
             var tasksList = new List<string>

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Smuggler
                 .Select(field => field.Name)
                 .ToList();
 
-            Assert.Equal(45, fieldNames.Count);
+            Assert.Equal(46, fieldNames.Count);
         }
 
         [RavenFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21326/Automatic-revision-bin-cleaning

### Additional description

Revisions Bin Cleaner that starts execution (revisions bin entries deletion in batches) by adding `RevisionsBinConfiguration` to the database. `RevisionsBinConfiguration` is located on the db record.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
