### PR TITLE
RavenDB-22773 - Fix throwing TaskCanceledException in WaitForLeaderCh…

### DIFF
--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -1157,8 +1157,8 @@ namespace Raven.Server.Rachis
 
             // if leader / candidate, this remove them from play and revert to follower mode
             _engine.SetNewState(RachisState.Follower, this, _term,
-                $"Accepted a new connection from {_connection.Source} in term {negotiation.Term}");
-            _engine.LeaderTag = _connection.Source;
+                $"Accepted a new connection from {_connection.Source} in term {negotiation.Term}",
+                beforeStateChangedEvent: () => _engine.LeaderTag = _connection.Source);
 
             _debugRecorder.Record("Follower connection accepted");
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22773/InterversionTests.MixedClusterTests.ReplicationInMixedCluster60Leaderwithtwo54

### Additional description
Apply this https://github.com/ravendb/ravendb/pull/19103 on v5.4.
Fix throwing TaskCanceledException in WaitForLeaderChange, on interversion tests.
The problem is that in Follower.AcceptConnectionAsync between `await _engine.SetNewStateAsync` and `_engine.LeaderTag = _connection.Source;` the `_stateChanged` is already changed but the 'LeaderTag' isn't, so `GetLeaderTag` returns null and on WaitForLeaderChange we wait for the new `_stateChanged` for more than 15 seconds, instead of waiting for the old `_stateChanged`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
