### PR TITLE
RavenDB-22953 Fixing sorting edge case in Corax where all matches have been found already so there is no need to fallback to normal sorting (which expected to get non empty batch of results)

### DIFF
--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
@@ -437,10 +437,14 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
                 // direct SortResult, but first we need to remove all the items that we already matched
                 int notMatchedYet = FilterAlreadyFoundMatches(allMatches);
 
-                // if we scanned through the index more than twice the amount of records of the query, but still
-                // didn't find enough to fill the page size, we'll fall back to normal sorting, instead of using the
-                // index method. That would prevent degenerate cases.
-                SortResults<TEntryComparer>(ref match, allMatches[..notMatchedYet]);
+                if (notMatchedYet > 0)
+                {
+                    // if we scanned through the index more than twice the amount of records of the query, but still
+                    // didn't find enough to fill the page size, we'll fall back to normal sorting, instead of using the
+                    // index method. That would prevent degenerate cases.
+                    SortResults<TEntryComparer>(ref match, allMatches[..notMatchedYet]);
+                }
+
                 return;
             }
 

--- a/test/SlowTests/Corax/RavenDB_22953.cs
+++ b/test/SlowTests/Corax/RavenDB_22953.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_22953 : RavenTestBase
+{
+    public RavenDB_22953(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void StreamingQueryMustNotThrowIndexOutOfRangeException(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var timestamps = new[]
+            {
+                new DateTimeOffset(new DateTime(2024, 9, 2), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 3), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 5), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 12), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 13), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 15), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 17), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 20), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 21), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 22), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 22), TimeSpan.Zero),
+                new DateTimeOffset(new DateTime(2024, 9, 27), TimeSpan.Zero),
+            };
+
+            using (var bulk = store.BulkInsert())
+            {
+                for (int i = 0; i < 10000; i++)
+                {
+                    bulk.Store(new Entry
+                    {
+                        Timestamp = timestamps[i % timestamps.Length],
+                        Schema = "foo",
+                        Name = "bar"
+                    });
+                }
+            }
+
+            using (var bulk = store.BulkInsert())
+            {
+                for (int i = 0; i < 11000; i++)
+                {
+                    bulk.Store(new Entry
+                    {
+                        Timestamp = timestamps[i % timestamps.Length],
+                        Schema = "zzz",
+                        Name = "bar"
+                    });
+                }
+            }
+
+            new Entries_ByTimestampAndQualifiedName().Execute(store);
+
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var count = 0;
+
+                var q = session.Advanced.DocumentQuery<Entries_ByTimestampAndQualifiedName.IndexEntry, Entries_ByTimestampAndQualifiedName>()
+                    .WhereGreaterThanOrEqual(x => x.Timestamp, new DateTimeOffset(new DateTime(2024, 9, 2), TimeSpan.Zero))
+                    .WhereLessThanOrEqual(x => x.Timestamp, new DateTimeOffset(new DateTime(2024, 9, 27), TimeSpan.Zero))
+                    .WhereIn(x => x.QualifiedName, new[] { "foo:bar" })
+                    .OrderBy(x => x.Timestamp);
+
+                var s = session.Advanced.Stream(q);
+
+                while (s.MoveNext())
+                {
+                    count++;
+                }
+
+                Assert.Equal(10000, count);
+            }
+        }
+    }
+
+    private class Entry
+    {
+        public DateTimeOffset? Timestamp { get; set; }
+
+        public string Name { get; set; }
+
+        public string Schema { get; set; }
+    }
+
+    private class Entries_ByTimestampAndQualifiedName : AbstractIndexCreationTask<Entry>
+    {
+        public class IndexEntry
+        {
+            public DateTimeOffset Timestamp { get; set; }
+
+            public string QualifiedName { get; set; }
+        }
+
+        public Entries_ByTimestampAndQualifiedName()
+        {
+            Map = entries => from entry in entries
+                select new IndexEntry
+                {
+                    Timestamp = entry.Timestamp ??
+                                default(DateTimeOffset),
+                    QualifiedName = string.Format("{0}:{1}", entry.Schema, entry.Name),
+                };
+        }
+    }
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22953/Corax-IndexOutOfRangeException-in-Lookup.GetFor

### Additional description

The problem was that we passed empty batch of results (`notMatchedYet` was `0`) while we try to access first element hence getting `IndexOutOfRangeException `

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
