### PR TITLE
RavenDB-22966 Exclude missing compare exchange if atomic guard

### DIFF
--- a/src/Raven.Server/Documents/Includes/IncludeCompareExchangeValuesCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeCompareExchangeValuesCommand.cs
@@ -110,12 +110,12 @@ namespace Raven.Server.Documents.Includes
                 if (string.IsNullOrEmpty(includedKey))
                     continue;
 
-                var toAdd = TryGetCompareExchange(includedKey, maxAllowedAtomicGuardIndex, out var index, out var value)
-                    ? (index, value)
-                    : (-1, null);
-
+                if (TryGetCompareExchange(includedKey, maxAllowedAtomicGuardIndex, out var index, out var value) == false
+                    && ClusterWideTransactionHelper.IsAtomicGuardKey(includedKey))
+                    continue;  
+                
                 Results ??= new Dictionary<string, CompareExchangeValue<BlittableJsonReaderObject>>(StringComparer.OrdinalIgnoreCase);
-                Results.Add(includedKey, new CompareExchangeValue<BlittableJsonReaderObject>(includedKey, toAdd.index,  toAdd.value));
+                Results.Add(includedKey, new CompareExchangeValue<BlittableJsonReaderObject>(includedKey, index,  value));
             }
         }
 

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -2081,5 +2081,32 @@ select incl(c)"
             
         }
         
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ClusterWideTrx_WhenLoadingDeletedDoc_ShouldNotIncludingMissingAtomicGard(Options options)
+        {
+            using (var store = GetDocumentStore())
+            {
+                string id;
+
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    var user = new User() { Name = "Test" };
+
+                    await session.StoreAsync(user);
+                    await session.SaveChangesAsync();
+
+                    session.Delete(user);
+                    await session.SaveChangesAsync();
+
+                    id = user.Id;
+                }
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    _ = await session.LoadAsync<User>(id);
+                    Assert.Equal(0, ((ClusterTransactionOperationsBase)session.Advanced.ClusterTransaction).NumberOfTrackedCompareExchangeValues);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22966

### Additional description
We include an atomic guard in case the document does not exist to solve a situation where the document has been deleted in a regular session.
This allows us to verify the document's version and allows creating the document again if it no longer exists.

Additionally, we include a "not existing" compare exchange when the client explicitly tries to include it to avoid an extra HTTP request.
However, there's no need to include the compare exchange if it's an atomic guard.
We have a check to prevent explicitly including a compare exchange for the atomic guard, and this was the issue with backward compatibility.

Excluding the missing atomic guard resolves the problem.
This is also how the implementation works in v6.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
