### PR TITLE
RavenDB-22979 moved to RecyclableMemoryStream

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -265,6 +265,8 @@ namespace Raven.Client.Documents.BulkInsert
                 _writer.Write("{\"Type\":\"HeartBeat\"}");
 
                 await FlushIfNeeded(force: true).ConfigureAwait(false);
+
+                _options.ForTestingPurposes?.OnSendHeartBeat_AfterFlush?.Invoke();
             }
             catch (Exception)
             {

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOptions.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOptions.cs
@@ -25,6 +25,7 @@ namespace Raven.Client.Documents.BulkInsert
         internal class TestingStuff
         {
             internal Action OnSendHeartBeat_DoBulkStore;
+            internal Action OnSendHeartBeat_AfterFlush;
             internal int OverrideHeartbeatCheckInterval;
         }
     }

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -36,8 +36,8 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
         _token = token;
         StreamExposer = new BulkInsertOperation.BulkInsertStreamExposerContent();
 
-        _currentWriteStream = RecyclableMemoryStreamFactory.GetMemoryStream();
-        _backgroundWriteStream = RecyclableMemoryStreamFactory.GetMemoryStream();
+        _currentWriteStream = RecyclableMemoryStreamFactory.GetRecyclableStream();
+        _backgroundWriteStream = RecyclableMemoryStreamFactory.GetRecyclableStream();
         _asyncWrite = Task.CompletedTask;
 
         var returnMemoryBuffer = ctx.GetMemoryBuffer(out _memoryBuffer);
@@ -71,12 +71,11 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
             finally
             {
                 using (StreamExposer)
-                using (returnMemoryBuffer)
-                using (returnBackgroundMemoryBuffer)
                 using (_currentWriteStream)
                 using (_backgroundWriteStream)
+                using (returnMemoryBuffer)
+                using (returnBackgroundMemoryBuffer)
                 {
-
                 }
             }
         });

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -3,7 +3,9 @@ using System.IO;
 using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IO;
 using Raven.Client.Http;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Threading;
 using Sparrow.Utils;
@@ -34,8 +36,8 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
         _token = token;
         StreamExposer = new BulkInsertOperation.BulkInsertStreamExposerContent();
 
-        _currentWriteStream = new MemoryStream();
-        _backgroundWriteStream = new MemoryStream();
+        _currentWriteStream = RecyclableMemoryStreamFactory.GetMemoryStream();
+        _backgroundWriteStream = RecyclableMemoryStreamFactory.GetMemoryStream();
         _asyncWrite = Task.CompletedTask;
 
         var returnMemoryBuffer = ctx.GetMemoryBuffer(out _memoryBuffer);
@@ -71,6 +73,8 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
                 using (StreamExposer)
                 using (returnMemoryBuffer)
                 using (returnBackgroundMemoryBuffer)
+                using (_currentWriteStream)
+                using (_backgroundWriteStream)
                 {
 
                 }

--- a/src/Raven.Client/Documents/Changes/AbstractDatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/AbstractDatabaseChanges.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IO;
 using Raven.Client.Exceptions.Changes;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;
@@ -22,7 +23,7 @@ internal abstract class AbstractDatabaseChanges<TDatabaseConnectionState> : IDis
 {
     private int _commandId;
     private readonly SemaphoreSlim _semaphore = new(1, 1);
-    private readonly MemoryStream _ms = new();
+    private readonly MemoryStream _ms = RecyclableMemoryStreamFactory.GetMemoryStream();
 
     protected readonly RequestExecutor RequestExecutor;
     private readonly string _database;
@@ -192,6 +193,8 @@ internal abstract class AbstractDatabaseChanges<TDatabaseConnectionState> : IDis
         }
 
         ConnectionStatusChanged -= OnConnectionStatusChanged;
+
+        _ms?.Dispose();
 
         _onDispose?.Invoke();
     }

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -10,6 +10,7 @@ using Raven.Client.Exceptions.Documents.Compilation;
 using Raven.Client.Http;
 using Raven.Client.Http.Behaviors;
 using Raven.Client.Json.Serialization;
+using Sparrow;
 using Sparrow.Json;
 
 namespace Raven.Client.Exceptions
@@ -228,29 +229,26 @@ namespace Raven.Client.Exceptions
 
         private static async Task<BlittableJsonReaderObject> GetJson(JsonOperationContext context, HttpResponseMessage response, Stream stream)
         {
-            var ms = context.CheckoutMemoryStream();
-
             BlittableJsonReaderObject json;
 
-            try
+            using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
-                // copying the error stream so we can read it as string if we fail to parse it
-                await stream.CopyToAsync(ms).ConfigureAwait(false);
-                ms.Position = 0;
-                json = await context.ReadForMemoryAsync(ms, "error/response").ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                string content = "Content: ";
-                ms.Position = 0;
-                using (var reader = new StreamReader(ms, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true))
-                    content += await reader.ReadToEndAsync().ConfigureAwait(false);
+                try
+                {
+                    // copying the error stream so we can read it as string if we fail to parse it
+                    await stream.CopyToAsync(ms).ConfigureAwait(false);
+                    ms.Position = 0;
+                    json = await context.ReadForMemoryAsync(ms, "error/response").ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    string content = "Content: ";
+                    ms.Position = 0;
+                    using (var reader = new StreamReader(ms, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true))
+                        content += await reader.ReadToEndAsync().ConfigureAwait(false);
 
-                throw new InvalidOperationException($"Cannot parse the '{response.StatusCode}' response. {content}", e);
-            }
-            finally
-            {
-                context.ReturnMemoryStream(ms);
+                    throw new InvalidOperationException($"Cannot parse the '{response.StatusCode}' response. {content}", e);
+                }
             }
 
             return json;

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -2016,7 +2016,7 @@ namespace Raven.Client.Http
             if (response != null)
             {
                 using (var stream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false))
-                using (var ms = new MemoryStream()) // todo: have a pool of those
+                using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 {
                     await stream.CopyToAsync(ms).ConfigureAwait(false);
                     try

--- a/src/Raven.Client/Json/BlittableOperation.cs
+++ b/src/Raven.Client/Json/BlittableOperation.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Raven.Client.Documents.Session;
+using Sparrow;
 using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Sync;
@@ -186,7 +187,7 @@ namespace Raven.Client.Json
                 if (numOfEscapePositions == 0)
                     return false;
 
-                using (var memoryStream = new MemoryStream())
+                using (var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 {
                     using (var textWriter = new BlittableJsonTextWriter(context, memoryStream))
                     {

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SessionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/SessionBlittableJsonConverter.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Newtonsoft.Json.Serialization;
 using Raven.Client.Documents.Session;
 using Raven.Client.Util;
+using Sparrow;
 using Sparrow.Json;
 
 namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
@@ -80,7 +81,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
             {
                 var jsString = string.Empty;
 
-                using (var memoryStream = new MemoryStream())
+                using (var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 {
                     try
                     {

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -138,7 +138,6 @@
   <ItemGroup>
     <PackageReference Include="Lambda2Js.Signed" Version="3.1.4" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.8" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -138,6 +138,8 @@
   <ItemGroup>
     <PackageReference Include="Lambda2Js.Signed" Version="3.1.4" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.8" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageReference Include="Raven.CodeAnalysis" Version="1.0.11" PrivateAssets="All" />

--- a/src/Raven.Client/Util/StreamWithTimeout.cs
+++ b/src/Raven.Client/Util/StreamWithTimeout.cs
@@ -172,8 +172,8 @@ namespace Raven.Client.Util
         {
             if (_readCts == null)
             {
-            _readCts = cancellationToken == default ? new CancellationTokenSource() : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _readCts.CancelAfter(_readTimeout);
+                _readCts = cancellationToken == default ? new CancellationTokenSource() : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                _readCts.CancelAfter(_readTimeout);
                 _readSw = Stopwatch.StartNew();
 
 #if DEBUG
@@ -230,8 +230,8 @@ namespace Raven.Client.Util
         {
             if (_writeCts == null)
             {
-            _writeCts = cancellationToken == default ? new CancellationTokenSource() : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _writeCts.CancelAfter(_writeTimeout);
+                _writeCts = cancellationToken == default ? new CancellationTokenSource() : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                _writeCts.CancelAfter(_writeTimeout);
                 _writeSw = Stopwatch.StartNew();
 
 #if DEBUG

--- a/src/Raven.Server/Commercial/LicenseValidator.cs
+++ b/src/Raven.Server/Commercial/LicenseValidator.cs
@@ -8,6 +8,7 @@ using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Security;
+using Sparrow;
 
 namespace Raven.Server.Commercial
 {

--- a/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
+++ b/src/Raven.Server/Documents/Changes/AbstractChangesClientConnection.cs
@@ -152,7 +152,7 @@ public abstract class AbstractChangesClientConnection<TOperationContext> : ILowM
     {
         using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
         {
-            await using (var ms = new MemoryStream())
+            await using (var ms = RecyclableMemoryStreamFactory.GetMemoryStream())
             {
                 var sp = Stopwatch.StartNew();
                 var sendTaskSp = Stopwatch.StartNew();

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingsFailureInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingsFailureInfoCommand.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents.Commands.Replication
         public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
             await using var stream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
-            using var memoryStream = new MemoryStream();
+            using var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream();
             await stream.CopyToAsync(memoryStream);
 
             memoryStream.Position = 0;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2164,7 +2164,8 @@ namespace Raven.Server.Documents
             internal ManualResetEvent DatabaseRecordLoadHold;
             internal ManualResetEvent HealthCheckHold;
 
-            internal int BulkInsertStreamReadTimeout;
+            internal int BulkInsert_StreamReadTimeout;
+            internal Action BulkInsert_OnHeartBeat;
         }
     }
 

--- a/src/Raven.Server/Documents/ETL/Handlers/Processors/EtlHandlerProcessorForPerformanceLive.cs
+++ b/src/Raven.Server/Documents/ETL/Handlers/Processors/EtlHandlerProcessorForPerformanceLive.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Sparrow;
 
 namespace Raven.Server.Documents.ETL.Handlers.Processors;
 
@@ -26,7 +27,7 @@ internal sealed class EtlHandlerProcessorForPerformanceLive : AbstractEtlHandler
             var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
             var receive = webSocket.ReceiveAsync(receiveBuffer, token.Token);
 
-            await using (var ms = new MemoryStream())
+            await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             using (var collector = new LiveEtlPerformanceCollector(RequestHandler.Database, etls))
             {
                 // 1. Send data to webSocket without making UI wait upon opening webSocket

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/BlittableJsonEventBinaryFormatter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/BlittableJsonEventBinaryFormatter.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Documents.ETL.Providers.Queue
                 return Array.Empty<byte>();
             }
 
-            var ms = new MemoryStream();
+            var ms = RecyclableMemoryStreamFactory.GetRecyclableStream();
 
             _streams.Add(ms);
 

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/BlittableJsonEventBinaryFormatter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/BlittableJsonEventBinaryFormatter.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Net.Mime;
 using CloudNative.CloudEvents;
 using CloudNative.CloudEvents.Core;
+using Microsoft.IO;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Sync;
 
@@ -28,7 +30,7 @@ namespace Raven.Server.Documents.ETL.Providers.Queue
                 return Array.Empty<byte>();
             }
 
-            MemoryStream ms = _ctx.CheckoutMemoryStream();
+            var ms = new MemoryStream();
 
             _streams.Add(ms);
 
@@ -74,7 +76,7 @@ namespace Raven.Server.Documents.ETL.Providers.Queue
         {
             foreach (MemoryStream ms in _streams)
             {
-                _ctx.ReturnMemoryStream(ms);
+                ms.Dispose();
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/BulkInsert/BulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/BulkInsert/BulkInsertHandler.cs
@@ -23,8 +23,14 @@ namespace Raven.Server.Documents.Handlers.BulkInsert
                 {
                     using (var bulkInsertProcessor = new BulkInsertHandlerProcessor(this, Database, progress, skipOverwriteIfUnchanged, operationCancelToken.Token))
                     {
-                        if (Database.ForTestingPurposes?.BulkInsertStreamReadTimeout > 0)
-                            bulkInsertProcessor.ForTestingPurposesOnly().BulkInsertStreamReadTimeout = Database.ForTestingPurposes.BulkInsertStreamReadTimeout;
+                        if (Database.ForTestingPurposes != null)
+                        {
+                            if (Database.ForTestingPurposes.BulkInsert_StreamReadTimeout > 0)
+                                bulkInsertProcessor.ForTestingPurposesOnly().BulkInsert_StreamReadTimeout = Database.ForTestingPurposes.BulkInsert_StreamReadTimeout;
+
+                            if (Database.ForTestingPurposes.BulkInsert_OnHeartBeat != null)
+                                bulkInsertProcessor.ForTestingPurposesOnly().BulkInsert_OnHeartBeat = Database.ForTestingPurposes.BulkInsert_OnHeartBeat;
+                        }
 
                         await bulkInsertProcessor.ExecuteAsync();
 

--- a/src/Raven.Server/Documents/Handlers/Debugging/DatabaseDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DatabaseDebugInfoPackageHandler.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
+using Sparrow;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Debugging
@@ -20,7 +21,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             HttpContext.Response.Headers[Constants.Headers.ContentDisposition] = contentDisposition;
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
             {
-                await using (var ms = new MemoryStream())
+                await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 {
                     using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
                     {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideDebugInfoPackageHandler.cs
@@ -20,6 +20,7 @@ using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Web;
+using Sparrow;
 using Sparrow.Exceptions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -74,7 +75,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext jsonOperationContext))
             using (transactionOperationContext.OpenReadTransaction())
             {
-                await using (var ms = new MemoryStream())
+                await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 {
                     using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
                     {
@@ -126,7 +127,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 async _ =>
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext jsonOperationContext))
-                await using (var ms = new MemoryStream())
+                await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 {
                     using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
                     {
@@ -193,7 +194,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 async _ =>
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-                await using (var ms = new MemoryStream())
+                await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 {
                     using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
                     {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ServerWideQueriesDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ServerWideQueriesDebugHandler.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Routing;
 using Raven.Server.Web;
+using Sparrow;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
@@ -30,7 +31,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
                 var receive = webSocket.ReceiveAsync(receiveBuffer, ServerStore.ServerShutdown);
 
-                await using (var ms = new MemoryStream())
+                await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 using (var collector = new LiveRunningQueriesCollector(ServerStore, dbNames))
                 {
                     // 1. Send data to webSocket without making UI wait upon opening webSocket

--- a/src/Raven.Server/Documents/Handlers/Processors/AbstractHandlerWebSocketProxyProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/AbstractHandlerWebSocketProxyProcessor.cs
@@ -7,6 +7,7 @@ using Raven.Client.Http;
 using Raven.Server.NotificationCenter.Handlers;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Json.Sync;
@@ -109,7 +110,7 @@ internal abstract class AbstractHandlerWebSocketProxyProcessor<TRequestHandler, 
         try
         {
             using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-            using (var ms = new MemoryStream())
+            using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
                 using (var writer = new BlittableJsonTextWriter(context, ms))
                 {

--- a/src/Raven.Server/Documents/Handlers/Processors/BulkInsert/AbstractBulkInsertHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/BulkInsert/AbstractBulkInsertHandlerProcessor.cs
@@ -63,7 +63,7 @@ internal abstract class AbstractBulkInsertHandlerProcessor<TCommandData, TReques
         }
 
         attachmentStream.Hash = await CopyAttachmentStreamAsync(stream, attachmentStream.Stream, token);
-        
+
         await attachmentStream.Stream.FlushAsync(token);
 
         return attachmentStream;
@@ -91,10 +91,10 @@ internal abstract class AbstractBulkInsertHandlerProcessor<TCommandData, TReques
                     currentCtxReset = ContextPool.AllocateOperationContext(out JsonOperationContext docsCtx);
                     var requestBodyStream = RequestHandler.RequestBodyStream();
 
-                    if (ForTestingPurposes?.BulkInsertStreamReadTimeout > 0)
+                    if (ForTestingPurposes?.BulkInsert_StreamReadTimeout > 0)
                     {
                         var streamWithTimeout = (StreamWithTimeout)requestBodyStream;
-                        streamWithTimeout.ReadTimeout = ForTestingPurposes.BulkInsertStreamReadTimeout;
+                        streamWithTimeout.ReadTimeout = ForTestingPurposes.BulkInsert_StreamReadTimeout;
                     }
                     using (var reader = GetCommandsReader(context, requestBodyStream, buffer, CancellationToken))
                     {
@@ -144,7 +144,10 @@ internal abstract class AbstractBulkInsertHandlerProcessor<TCommandData, TReques
                                     break;
 
                                 if (commandData.Type == CommandType.HeartBeat)
+                                {
+                                    ForTestingPurposes?.BulkInsert_OnHeartBeat?.Invoke();
                                     continue;
+                                }
 
                                 if (commandData.Type == CommandType.AttachmentPUT)
                                 {
@@ -299,6 +302,7 @@ internal abstract class AbstractBulkInsertHandlerProcessor<TCommandData, TReques
 
     internal sealed class TestingStuff
     {
-        internal int BulkInsertStreamReadTimeout;
+        internal int BulkInsert_StreamReadTimeout;
+        internal Action BulkInsert_OnHeartBeat;
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Changes/AbstractChangesHandlerProcessorForGetChanges.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Changes/AbstractChangesHandlerProcessorForGetChanges.cs
@@ -7,6 +7,7 @@ using Raven.Client.Extensions;
 using Raven.Server.Documents.Changes;
 using Raven.Server.Extensions;
 using Raven.Server.ServerWide;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -61,7 +62,7 @@ internal abstract class AbstractChangesHandlerProcessorForGetChanges<TRequestHan
                         if (webSocket.State != WebSocketState.Open)
                             return;
 
-                        await using (var ms = new MemoryStream())
+                        await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                         {
                             await using (var writer = new AsyncBlittableJsonTextWriter(context, ms))
                             {

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForPerformanceLive.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForPerformanceLive.cs
@@ -9,6 +9,7 @@ using Raven.Client;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Sparrow;
 using Index = Raven.Server.Documents.Indexes.Index;
 
 namespace Raven.Server.Documents.Handlers.Processors.Indexes;
@@ -43,7 +44,7 @@ internal sealed class IndexHandlerProcessorForPerformanceLive : AbstractIndexHan
         var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
         var receive = webSocket.ReceiveAsync(receiveBuffer, token.Token);
 
-        await using (var ms = new MemoryStream())
+        await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
         using (var collector = new LiveIndexingPerformanceCollector(RequestHandler.Database, indexNames))
         {
             // 1. Send data to webSocket without making UI wait upon opening webSocket

--- a/src/Raven.Server/Documents/Handlers/Processors/IoMetrics/IoMetricsHandlerProcessorForLive.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/IoMetrics/IoMetricsHandlerProcessorForLive.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils.IoMetrics;
+using Sparrow;
 
 namespace Raven.Server.Documents.Handlers.Processors.IoMetrics;
 
@@ -23,7 +24,7 @@ internal sealed class IoMetricsHandlerProcessorForLive : AbstractIoMetricsHandle
         var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
         var receive = webSocket.ReceiveAsync(receiveBuffer, token.Token);
 
-        await using (var ms = new MemoryStream())
+        await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
         using (var collector = new DatabaseLiveIoStatsCollector(RequestHandler.Database))
         {
             // 1. Send data to webSocket without making UI wait upon opening webSocket

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetPerformanceLive.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetPerformanceLive.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Sparrow;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
 {
@@ -22,7 +23,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
             var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
             var receive = webSocket.ReceiveAsync(receiveBuffer, RequestHandler.Database.DatabaseShutdown);
 
-            await using (var ms = new MemoryStream())
+            await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             using (var collector = new LiveReplicationPerformanceCollector(RequestHandler.Database))
             {
                 // 1. Send data to webSocket without making UI wait upon opening webSocket

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetPulsesLive.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetPulsesLive.cs
@@ -7,6 +7,7 @@ using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers.Processors.Replication
@@ -24,7 +25,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
             var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
             var receive = webSocket.ReceiveAsync(receiveBuffer, RequestHandler.Database.DatabaseShutdown);
 
-            await using (var ms = new MemoryStream())
+            await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             using (var collector = new LiveReplicationPulsesCollector(RequestHandler.Database))
             {
                 // 1. Send data to webSocket without making UI wait upon opening webSocket

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportDir.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportDir.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Smuggler;
 using Raven.Server.Smuggler.Documents.Data;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Utils;
 
@@ -83,10 +84,10 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportDir<TRequestHan
         {
             ((IOperationResult)importResult).MergeWith(finalResult);
         }
-        
+
         using (ContextPool.AllocateOperationContext(out JsonOperationContext finalContext))
+        using (var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream())
         {
-            var memoryStream = new MemoryStream();
             await WriteSmugglerResultAsync(finalContext, finalResult, memoryStream);
             memoryStream.Position = 0;
             try

--- a/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/SubscriptionsHandlerProcessorForPerformanceLive.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Subscriptions/SubscriptionsHandlerProcessorForPerformanceLive.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Sparrow;
 
 namespace Raven.Server.Documents.Handlers.Processors.Subscriptions;
 
@@ -22,7 +23,7 @@ internal sealed class SubscriptionsHandlerProcessorForPerformanceLive : Abstract
         var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
         var receive = webSocket.ReceiveAsync(receiveBuffer, token.Token);
 
-        using (var ms = new MemoryStream())
+        using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
         using (var collector = new LiveSubscriptionPerformanceCollector(RequestHandler.Database))
         {
             // 1. Send data to webSocket without making UI wait upon opening webSocket

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/Fields/BlittableObjectReader.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Documents/Fields/BlittableObjectReader.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IO;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
@@ -12,7 +13,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents.Fields
     public sealed class BlittableObjectReader : IDisposable
     {
         private readonly NonDisposableStreamReader _reader;
-        private readonly MemoryStream _ms;
+        private readonly RecyclableMemoryStream _ms;
 
         private StringBuilder _sb;
         private char[] _readBuffer;
@@ -30,7 +31,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Documents.Fields
 
         public BlittableObjectReader()
         {
-            _ms = new MemoryStream();
+            _ms = RecyclableMemoryStreamFactory.GetRecyclableStream();
             _reader = new NonDisposableStreamReader(new StreamReader(_ms, Encodings.Utf8, true, 1024, leaveOpen: true));
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -23,6 +23,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server.Json.Sync;
@@ -321,7 +322,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                 throw new InvalidOperationException($"Unable to get backup configuration by executing {command} {arguments}. Failed to start process.", e);
             }
 
-            using (var ms = new MemoryStream())
+            using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
                 var readErrors = process.StandardError.ReadToEndAsync();
                 var readStdOut = process.StandardOutput.BaseStream.CopyToAsync(ms);

--- a/src/Raven.Server/Documents/QueueSink/Handlers/QueueSinkHandler.cs
+++ b/src/Raven.Server/Documents/QueueSink/Handlers/QueueSinkHandler.cs
@@ -8,6 +8,7 @@ using Sparrow.Json;
 using System.Collections.Generic;
 using System.Linq;
 using Raven.Server.Documents.QueueSink.Stats.Performance;
+using Sparrow;
 
 namespace Raven.Server.Documents.QueueSink.Handlers;
 
@@ -40,7 +41,7 @@ public class QueueSinkHandler : DatabaseRequestHandler
             var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
             var receive = webSocket.ReceiveAsync(receiveBuffer, Database.DatabaseShutdown);
 
-            await using (var ms = new MemoryStream())
+            await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             using (var collector = new LiveQueueSinkPerformanceCollector(Database, sinks))
             {
                 // 1. Send data to webSocket without making UI wait upon opening webSocket

--- a/src/Raven.Server/Documents/Sharding/Handlers/BulkInsert/ShardedBatchCommandData.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/BulkInsert/ShardedBatchCommandData.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.IO;
+using Microsoft.IO;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Server.Documents.Handlers.Batches;
 using Raven.Server.Documents.Handlers.Batches.Commands;
+using Sparrow;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Handlers.BulkInsert;
@@ -14,7 +16,7 @@ public sealed class ShardedBatchCommandData : IDisposable, IBatchCommandData
     public ShardedBatchCommandData(JsonOperationContext ctx)
     {
         _ctx = ctx;
-        Stream = ctx.CheckoutMemoryStream();
+        Stream = RecyclableMemoryStreamFactory.GetMemoryStream();
     }
 
     public MemoryStream Stream { get; }
@@ -31,6 +33,6 @@ public sealed class ShardedBatchCommandData : IDisposable, IBatchCommandData
 
     public void Dispose()
     {
-        _ctx.ReturnMemoryStream(Stream);
+        Stream.Dispose();
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/BulkInsert/ShardedBulkInsertHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/BulkInsert/ShardedBulkInsertHandler.cs
@@ -16,7 +16,7 @@ public sealed class ShardedBulkInsertHandler : ShardedDatabaseRequestHandler
         await using (var processor = new ShardedBulkInsertHandlerProcessor(this, DatabaseContext, id, skipOverwriteIfUnchanged, operationCancelToken.Token))
         {
             if (DatabaseContext.ForTestingPurposes?.BulkInsertStreamWriteTimeout > 0)
-                processor.ForTestingPurposesOnly().BulkInsertStreamReadTimeout = DatabaseContext.ForTestingPurposes.BulkInsertStreamWriteTimeout;
+                processor.ForTestingPurposesOnly().BulkInsert_StreamReadTimeout = DatabaseContext.ForTestingPurposes.BulkInsertStreamWriteTimeout;
 
             await processor.ExecuteAsync();
         }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IO;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Commercial;
@@ -74,7 +75,7 @@ namespace Raven.Server.Documents.Subscriptions
         public readonly SubscriptionStatsCollector Stats;
 
         public Task SubscriptionConnectionTask { get; set; }
-        private readonly MemoryStream _buffer = new();
+        private readonly MemoryStream _buffer = RecyclableMemoryStreamFactory.GetMemoryStream();
 
         private readonly DisposeOnce<SingleAttempt> _disposeOnce;
 

--- a/src/Raven.Server/Indexing/VoronIndexOutput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexOutput.cs
@@ -5,6 +5,7 @@ using Raven.Server.Utils;
 using Sparrow.Logging;
 using Voron.Impl;
 using Voron;
+using Microsoft.IO;
 
 namespace Raven.Server.Indexing
 {
@@ -17,7 +18,7 @@ namespace Raven.Server.Indexing
         private readonly string _tree;
         private readonly Transaction _tx;
         private Stream _file;
-        private MemoryStream _ms;
+        private RecyclableMemoryStream _ms;
         private readonly IndexOutputFilesSummary _indexOutputFilesSummary;
 
         private Stream StreamToUse => _ms ?? _file;

--- a/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardHandler.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ClusterDashboardHandler.cs
@@ -15,6 +15,7 @@ using Raven.Server.Dashboard.Cluster;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Json.Sync;
@@ -152,7 +153,7 @@ namespace Raven.Server.NotificationCenter.Handlers
             try
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
-                using (var ms = new MemoryStream())
+                using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 {
                     using (var writer = new BlittableJsonTextWriter(context, ms))
                     {

--- a/src/Raven.Server/NotificationCenter/NotificationCenterWebsocketWriter.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationCenterWebsocketWriter.cs
@@ -4,8 +4,10 @@ using System.IO;
 using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IO;
 using Raven.Server.Dashboard;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Collections;
@@ -24,7 +26,7 @@ namespace Raven.Server.NotificationCenter
         private readonly JsonOperationContext _context;
         protected readonly CancellationToken _resourceShutdown;
 
-        private readonly MemoryStream _ms = new MemoryStream();
+        private readonly MemoryStream _ms = RecyclableMemoryStreamFactory.GetMemoryStream();
         public Action AfterTrackActionsRegistration;
         private readonly IDisposable _returnContext;
 

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -906,7 +906,7 @@ namespace Raven.Server
                 throw new InvalidOperationException($"Unable to get cpu credits by executing {command} {arguments}. Failed to start process.", e);
             }
 
-            using (var ms = new MemoryStream())
+            using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
                 var readErrors = process.StandardError.ReadToEndAsync();
                 var readStdOut = process.StandardOutput.BaseStream.CopyToAsync(ms);

--- a/src/Raven.Server/ServerWide/ServerStatistics.cs
+++ b/src/Raven.Server/ServerWide/ServerStatistics.cs
@@ -6,6 +6,7 @@ using Raven.Client.Util;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Sync;
 using Sparrow.Logging;
@@ -159,7 +160,7 @@ namespace Raven.Server.ServerWide
                     using (contextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var tx = context.OpenWriteTransaction())
                     {
-                        using (var ms = new MemoryStream())
+                        using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                         using (var writer = new BlittableJsonTextWriter(context, ms))
                         {
                             WriteTo(writer);

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -14,6 +14,7 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.IO;
 using Microsoft.Net.Http.Headers;
 using Raven.Client;
 using Raven.Client.Documents.Conventions;
@@ -31,6 +32,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents.Data;
 using Raven.Server.Smuggler.Migration;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Platform;
@@ -93,7 +95,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
         [RavenAction("/databases/*/admin/smuggler/import-dir", "GET", AuthorizationStatus.DatabaseAdmin, DisableOnCpuCreditsExhaustion = true)]
         public async Task PostImportDirectory()
         {
-            using (var processor = new SmugglerHandlerProcessorForImportDir(this)) 
+            using (var processor = new SmugglerHandlerProcessorForImportDir(this))
                 await processor.ExecuteAsync();
         }
 
@@ -145,8 +147,8 @@ namespace Raven.Server.Smuggler.Documents.Handlers
             }
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext finalContext))
+            using (var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
-                var memoryStream = new MemoryStream();
                 await SmugglerHandlerProcessorForImport.WriteSmugglerResultAsync(finalContext, finalResult, memoryStream);
                 memoryStream.Position = 0;
                 try

--- a/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
+++ b/src/Raven.Server/TrafficWatch/TrafficWatchHandler.cs
@@ -49,7 +49,7 @@ namespace Raven.Server.TrafficWatch
 
                         try
                         {
-                            await using (var ms = new MemoryStream())
+                            await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                             {
                                 await using (var writer = new AsyncBlittableJsonTextWriter(context, ms))
                                 {

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -1039,46 +1039,48 @@ namespace Raven.Server.Utils.Cli
 
         public static string ConvertResultToString(ScriptRunnerResult result)
         {
-            var ms = new MemoryStream();
-            using (var ctx = JsonOperationContext.ShortTermSingleUse())
-            using (var writer = new BlittableJsonTextWriter(ctx, ms))
+            using (var ms = new MemoryStream())
             {
-                writer.WriteStartObject();
+                using (var ctx = JsonOperationContext.ShortTermSingleUse())
+                using (var writer = new BlittableJsonTextWriter(ctx, ms))
+                {
+                    writer.WriteStartObject();
 
-                writer.WritePropertyName("Result");
+                    writer.WritePropertyName("Result");
 
-                if (result.IsNull)
-                {
-                    writer.WriteNull();
-                }
-                else if (result.RawJsValue.IsBoolean())
-                {
-                    writer.WriteBool(result.RawJsValue.AsBoolean());
-                }
-                else if (result.RawJsValue.IsString())
-                {
-                    writer.WriteString(result.RawJsValue.AsString());
-                }
-                else if (result.RawJsValue.IsDate())
-                {
-                    var date = result.RawJsValue.AsDate();
-                    writer.WriteString(date.ToDateTime().ToString(DefaultFormat.DateTimeOffsetFormatsToWrite));
-                }
-                else if (result.RawJsValue.IsNumber())
-                {
-                    writer.WriteDouble(result.RawJsValue.AsNumber());
-                }
-                else
-                {
-                    writer.WriteObject(result.TranslateToObject(ctx));
+                    if (result.IsNull)
+                    {
+                        writer.WriteNull();
+                    }
+                    else if (result.RawJsValue.IsBoolean())
+                    {
+                        writer.WriteBool(result.RawJsValue.AsBoolean());
+                    }
+                    else if (result.RawJsValue.IsString())
+                    {
+                        writer.WriteString(result.RawJsValue.AsString());
+                    }
+                    else if (result.RawJsValue.IsDate())
+                    {
+                        var date = result.RawJsValue.AsDate();
+                        writer.WriteString(date.ToDateTime().ToString(DefaultFormat.DateTimeOffsetFormatsToWrite));
+                    }
+                    else if (result.RawJsValue.IsNumber())
+                    {
+                        writer.WriteDouble(result.RawJsValue.AsNumber());
+                    }
+                    else
+                    {
+                        writer.WriteObject(result.TranslateToObject(ctx));
+                    }
+
+                    writer.WriteEndObject();
+                    writer.Flush();
                 }
 
-                writer.WriteEndObject();
-                writer.Flush();
+                var str = Encoding.UTF8.GetString(ms.ToArray());
+                return str;
             }
-
-            var str = Encoding.UTF8.GetString(ms.ToArray());
-            return str;
         }
 
         private static bool CommandLowMem(List<string> args, RavenCli cli)

--- a/src/Raven.Server/Web/System/AdminIoMetricsHandler.cs
+++ b/src/Raven.Server/Web/System/AdminIoMetricsHandler.cs
@@ -7,6 +7,7 @@ using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Server.Utils.IoMetrics;
+using Sparrow;
 using Sparrow.Json;
 using Voron;
 
@@ -33,7 +34,7 @@ namespace Raven.Server.Web.System
                 var receiveBuffer = new ArraySegment<byte>(new byte[1024]);
                 var receive = webSocket.ReceiveAsync(receiveBuffer, ServerStore.ServerShutdown);
 
-                await using (var ms = new MemoryStream())
+                await using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 using (var collector = new ServerStoreLiveIoStatsCollector(ServerStore))
                 {
                     // 1. Send data to webSocket without making UI wait upon opening webSocket

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -89,7 +89,7 @@ namespace Raven.Server.Web.System
         {
             var serverMetrics = provider.CollectServerMetrics();
 
-            using (var ms = new MemoryStream())
+            using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
                 await using (var writer = PrometheusWriter(ms))
                 {
@@ -206,7 +206,7 @@ namespace Raven.Server.Web.System
 
             var cachedTags = metrics.Select(x => SerializeTags(new Dictionary<string, string> {{"database_name", x.DatabaseName}})).ToList();
 
-            using (var ms = new MemoryStream())
+            using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
                 await using (var writer = PrometheusWriter(ms))
                 {
@@ -304,7 +304,7 @@ namespace Raven.Server.Web.System
                 }
             }
 
-            using (var ms = new MemoryStream())
+            using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
                 await using (var writer = PrometheusWriter(ms))
                 {
@@ -353,7 +353,7 @@ namespace Raven.Server.Web.System
                 }
             }
 
-            using (var ms = new MemoryStream())
+            using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
                 await using (var writer = PrometheusWriter(ms))
                 {

--- a/src/Sparrow/Json/BlittableJsonReaderArray.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderArray.cs
@@ -47,7 +47,7 @@ namespace Sparrow.Json
 
             AssertContextNotDisposed();
 
-            using (var memoryStream = new MemoryStream())
+            using (var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
                 var tw = new AsyncBlittableJsonTextWriter(_context, memoryStream);
                 try

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -42,7 +42,7 @@ namespace Sparrow.Json
 
             AssertContextNotDisposed();
 
-            using (var memoryStream = new MemoryStream())
+            using (var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream())
             {
                 WriteJsonToAsync(memoryStream).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
                 memoryStream.Position = 0;

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -1158,40 +1158,6 @@ namespace Sparrow.Json
             return _arenaAllocator.GrowAllocation(allocation, sizeIncrease);
         }
 
-        public MemoryStream CheckoutMemoryStream()
-        {
-            EnsureNotDisposed();
-            if (_cachedMemoryStreams.Count == 0)
-            {
-                return new MemoryStream();
-            }
-
-            var stream = _cachedMemoryStreams.Pop();
-            _sizeOfMemoryStreamCache -= stream.Capacity;
-
-            return stream;
-        }
-
-        private const long MemoryStreamCacheThreshold = Constants.Size.Megabyte;
-        private const int MemoryStreamCacheMaxCapacityInBytes = 64 * Constants.Size.Megabyte;
-
-        private long _sizeOfMemoryStreamCache;
-
-        public void ReturnMemoryStream(MemoryStream stream)
-        {
-            //We don't want to hold big streams in the cache or have too big of a cache
-            if (stream.Capacity > MemoryStreamCacheThreshold || _sizeOfMemoryStreamCache >= MemoryStreamCacheMaxCapacityInBytes)
-            {
-                return;
-            }
-
-            EnsureNotDisposed();
-
-            stream.SetLength(0);
-            _cachedMemoryStreams.Push(stream);
-            _sizeOfMemoryStreamCache += stream.Capacity;
-        }
-
         public void ReturnMemory(AllocatedMemoryData allocation)
         {
             EnsureNotDisposed();

--- a/src/Sparrow/RecyclableMemoryStreamFactory.cs
+++ b/src/Sparrow/RecyclableMemoryStreamFactory.cs
@@ -6,8 +6,6 @@ namespace Sparrow;
 
 internal class RecyclableMemoryStreamFactory
 {
-    public static RecyclableMemoryStreamFactory Instance = new();
-
     private static readonly RecyclableMemoryStreamManager Manager = new()
     {
         Settings =

--- a/src/Sparrow/RecyclableMemoryStreamFactory.cs
+++ b/src/Sparrow/RecyclableMemoryStreamFactory.cs
@@ -1,0 +1,37 @@
+﻿using System.IO;
+using Microsoft.IO;
+using Sparrow.Global;
+
+namespace Sparrow;
+
+internal class RecyclableMemoryStreamFactory
+{
+    public static RecyclableMemoryStreamFactory Instance = new();
+
+    private static readonly RecyclableMemoryStreamManager Manager = new()
+    {
+        Settings =
+        {
+            AggressiveBufferReturn = true,
+            MaximumBufferSize = Constants.Size.Megabyte,
+            MaximumSmallPoolFreeBytes = 256 * Constants.Size.Megabyte,
+            MaximumLargePoolFreeBytes = 128 * Constants.Size.Megabyte,
+            ThrowExceptionOnToArray = true
+        }
+    };
+
+    public static RecyclableMemoryStream GetRecyclableStream()
+    {
+        return Manager.GetStream();
+    }
+
+    public static RecyclableMemoryStream GetRecyclableStream(long requiredSize)
+    {
+        return Manager.GetStream(null, requiredSize);
+    }
+
+    public static MemoryStream GetMemoryStream()
+    {
+        return new MemoryStream();
+    }
+}

--- a/src/Sparrow/Sparrow.csproj
+++ b/src/Sparrow/Sparrow.csproj
@@ -27,6 +27,7 @@
     <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageReference Include="Raven.CodeAnalysis" Version="1.0.11" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -152,19 +152,6 @@ namespace Voron.Impl.FreeSpace
             return c == max;
         }
 
-        public Stream ToStream()
-        {
-            var ms = new MemoryStream(260);
-
-            var tmpBuffer = ToBuffer();
-
-            Debug.Assert(BitConverter.ToInt32(tmpBuffer,0) == SetCount); 
-
-            ms.Write(tmpBuffer, 0, tmpBuffer.Length);
-            ms.Position = 0;
-            return ms;
-        }
-
         private unsafe byte[] ToBuffer()
         {
             var tmpBuffer = new byte[(_inner.Length + 1)*sizeof (int)];


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22979

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
