### PR TITLE
RavenDB-19049 add range support for attachments

### DIFF
--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Exceptions.Documents.Attachments;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Json;
@@ -156,6 +158,14 @@ namespace Raven.Client.Documents.Operations.Attachments
                 };
 
                 return ResponseDisposeHandling.Manually;
+            }
+
+            public override void OnResponseFailure(HttpResponseMessage response)
+            {
+                if (response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable)
+                {
+                    InvalidAttachmentRangeException.ThrowFor(_documentId, _name, _from, _to);
+                }
             }
 
             public override bool IsReadRequest => true;

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
@@ -35,6 +35,23 @@ namespace Raven.Client.Documents.Operations.Attachments
         /// <param name="name">The name of the attachment to be retrieved.</param>
         /// <param name="type">The type of the attachment.</param>
         /// <param name="changeVector">change vector for optimistic concurrency control. If no concurrency control require this should be set to null</param>
+        /// <remarks>
+        /// This constructor sets up an operation to retrieve a specific attachment.
+        /// If the <paramref name="changeVector"/> is provided, it ensures that the operation 
+        /// corresponds to the specified version of the document.
+        /// </remarks>
+        public GetAttachmentOperation(string documentId, string name, AttachmentType type, string changeVector)
+            : this(documentId, name, type, changeVector, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetAttachmentOperation"/> class.
+        /// </summary>
+        /// <param name="documentId">The ID of the document associated with the attachment.</param>
+        /// <param name="name">The name of the attachment to be retrieved.</param>
+        /// <param name="type">The type of the attachment.</param>
+        /// <param name="changeVector">change vector for optimistic concurrency control. If no concurrency control require this should be set to null</param>
         /// <param name="from">the position at which to start sending data</param>
         /// <param name="to">the position at which to stop sending data</param>
         /// <remarks>
@@ -42,7 +59,7 @@ namespace Raven.Client.Documents.Operations.Attachments
         /// If the <paramref name="changeVector"/> is provided, it ensures that the operation 
         /// corresponds to the specified version of the document.
         /// </remarks>
-        public GetAttachmentOperation(string documentId, string name, AttachmentType type, string changeVector, long? from = null, long? to = null)
+        public GetAttachmentOperation(string documentId, string name, AttachmentType type, string changeVector, long? from, long? to)
         {
             _documentId = documentId;
             _name = name;

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Conventions;
@@ -22,6 +23,8 @@ namespace Raven.Client.Documents.Operations.Attachments
         private readonly string _name;
         private readonly AttachmentType _type;
         private readonly string _changeVector;
+        private readonly long? _from;
+        private readonly long? _to;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GetAttachmentOperation"/> class.
@@ -30,22 +33,26 @@ namespace Raven.Client.Documents.Operations.Attachments
         /// <param name="name">The name of the attachment to be retrieved.</param>
         /// <param name="type">The type of the attachment.</param>
         /// <param name="changeVector">change vector for optimistic concurrency control. If no concurrency control require this should be set to null</param>
+        /// <param name="from">the position at which to start sending data</param>
+        /// <param name="to">the position at which to stop sending data</param>
         /// <remarks>
         /// This constructor sets up an operation to retrieve a specific attachment.
         /// If the <paramref name="changeVector"/> is provided, it ensures that the operation 
         /// corresponds to the specified version of the document.
         /// </remarks>
-        public GetAttachmentOperation(string documentId, string name, AttachmentType type, string changeVector)
+        public GetAttachmentOperation(string documentId, string name, AttachmentType type, string changeVector, long? from = null, long? to = null)
         {
             _documentId = documentId;
             _name = name;
             _type = type;
             _changeVector = changeVector;
+            _from = from;
+            _to = to;
         }
 
         public RavenCommand<AttachmentResult> GetCommand(IDocumentStore store, DocumentConventions conventions, JsonOperationContext context, HttpCache cache)
         {
-            return new GetAttachmentCommand(conventions, context, _documentId, _name, _type, _changeVector);
+            return new GetAttachmentCommand(conventions, context, _documentId, _name, _type, _changeVector, _from, _to);
         }
 
         internal sealed class GetAttachmentCommand : RavenCommand<AttachmentResult>
@@ -56,8 +63,10 @@ namespace Raven.Client.Documents.Operations.Attachments
             private readonly string _name;
             private readonly AttachmentType _type;
             private readonly string _changeVector;
+            private readonly long? _from;
+            private readonly long? _to;
 
-            public GetAttachmentCommand(DocumentConventions conventions, JsonOperationContext context, string documentId, string name, AttachmentType type, string changeVector)
+            public GetAttachmentCommand(DocumentConventions conventions, JsonOperationContext context, string documentId, string name, AttachmentType type, string changeVector, long? from = null, long? to = null)
             {
                 if (string.IsNullOrWhiteSpace(documentId))
                     throw new ArgumentNullException(nameof(documentId));
@@ -73,6 +82,8 @@ namespace Raven.Client.Documents.Operations.Attachments
                 _name = name;
                 _type = type;
                 _changeVector = changeVector;
+                _from = from;
+                _to = to;
 
                 ResponseType = RavenCommandResponseType.Empty;
             }
@@ -84,6 +95,11 @@ namespace Raven.Client.Documents.Operations.Attachments
                 {
                     Method = HttpMethods.Get
                 };
+
+                if (_from is not null || _to is not null)
+                {
+                    request.Headers.Range = new RangeHeaderValue(_from, _to);
+                }
 
                 if (_type != AttachmentType.Document)
                 {

--- a/src/Raven.Client/Documents/Session/DocumentSessionAttachments.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSessionAttachments.cs
@@ -48,6 +48,15 @@ namespace Raven.Client.Documents.Session
             return Session.Operations.Send(operation, SessionInfo);
         }
 
+        public AttachmentResult GetRange(object entity, string name, long? from, long? to)
+        {
+            if (Session.DocumentsByEntity.TryGetValue(entity, out DocumentInfo document) == false)
+                ThrowEntityNotInSessionOrMissingId(entity);
+
+            var operation = new GetAttachmentOperation(document.Id, name, AttachmentType.Document, null, from, to);
+            return Session.Operations.Send(operation, SessionInfo);
+        }
+
         public IEnumerator<AttachmentEnumeratorResult> Get(IEnumerable<AttachmentRequest> attachments)
         {
             var operation = new GetAttachmentsOperation(attachments, AttachmentType.Document);

--- a/src/Raven.Client/Documents/Session/DocumentSessionAttachments.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSessionAttachments.cs
@@ -42,6 +42,12 @@ namespace Raven.Client.Documents.Session
             return Session.Operations.Send(operation, SessionInfo);
         }
 
+        public AttachmentResult GetRange(string documentId, string name, long? from, long? to)
+        {
+            var operation = new GetAttachmentOperation(documentId, name, AttachmentType.Document, null, from, to);
+            return Session.Operations.Send(operation, SessionInfo);
+        }
+
         public IEnumerator<AttachmentEnumeratorResult> Get(IEnumerable<AttachmentRequest> attachments)
         {
             var operation = new GetAttachmentsOperation(attachments, AttachmentType.Document);

--- a/src/Raven.Client/Documents/Session/DocumentSessionAttachmentsAsync.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSessionAttachmentsAsync.cs
@@ -67,6 +67,19 @@ namespace Raven.Client.Documents.Session
             }
         }
 
+        public async Task<AttachmentResult> GetRangeAsync(object entity, string name, long? from, long? to, CancellationToken token = default)
+        {
+            using (Session.AsyncTaskHolder())
+            {
+                if (Session.DocumentsByEntity.TryGetValue(entity, out DocumentInfo document) == false)
+                    ThrowEntityNotInSessionOrMissingId(entity);
+
+                var operation = new GetAttachmentOperation(document.Id, name, AttachmentType.Document, null, from, to);
+                Session.IncrementRequestCount();
+                return await Session.Operations.SendAsync(operation, sessionInfo: SessionInfo, token).ConfigureAwait(false);
+            }
+        }
+
         public Task<IEnumerator<AttachmentEnumeratorResult>> GetAsync(IEnumerable<AttachmentRequest> attachments, CancellationToken token = default)
         {
             var operation = new GetAttachmentsOperation(attachments, AttachmentType.Document);

--- a/src/Raven.Client/Documents/Session/DocumentSessionAttachmentsAsync.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSessionAttachmentsAsync.cs
@@ -57,6 +57,16 @@ namespace Raven.Client.Documents.Session
             }
         }
 
+        public async Task<AttachmentResult> GetRangeAsync(string documentId, string name, long? from, long? to, CancellationToken token = default)
+        {
+            using (Session.AsyncTaskHolder())
+            {
+                var operation = new GetAttachmentOperation(documentId, name, AttachmentType.Document, null, from, to);
+                Session.IncrementRequestCount();
+                return await Session.Operations.SendAsync(operation, sessionInfo: SessionInfo, token).ConfigureAwait(false);
+            }
+        }
+
         public Task<IEnumerator<AttachmentEnumeratorResult>> GetAsync(IEnumerable<AttachmentRequest> attachments, CancellationToken token = default)
         {
             var operation = new GetAttachmentsOperation(attachments, AttachmentType.Document);

--- a/src/Raven.Client/Documents/Session/IAttachmentsSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAttachmentsSessionOperations.cs
@@ -30,6 +30,11 @@ namespace Raven.Client.Documents.Session
         AttachmentResult Get(object entity, string name);
 
         /// <summary>
+        /// Returns a range of the attachment by the document id and attachment name.
+        /// </summary>
+        AttachmentResult GetRange(string documentId, string name, long? from, long? to);
+
+        /// <summary>
         /// Returns Enumerator of KeyValuePairs of attachment name and stream.
         /// </summary>
         IEnumerator<AttachmentEnumeratorResult> Get(IEnumerable<AttachmentRequest> attachments);

--- a/src/Raven.Client/Documents/Session/IAttachmentsSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAttachmentsSessionOperations.cs
@@ -35,6 +35,11 @@ namespace Raven.Client.Documents.Session
         AttachmentResult GetRange(string documentId, string name, long? from, long? to);
 
         /// <summary>
+        /// Returns a range of the attachment by the document id and attachment name.
+        /// </summary>
+        AttachmentResult GetRange(object entity, string name, long? from, long? to);
+
+        /// <summary>
         /// Returns Enumerator of KeyValuePairs of attachment name and stream.
         /// </summary>
         IEnumerator<AttachmentEnumeratorResult> Get(IEnumerable<AttachmentRequest> attachments);

--- a/src/Raven.Client/Documents/Session/IAttachmentsSessionOperationsAsync.cs
+++ b/src/Raven.Client/Documents/Session/IAttachmentsSessionOperationsAsync.cs
@@ -32,6 +32,11 @@ namespace Raven.Client.Documents.Session
         Task<AttachmentResult> GetAsync(object entity, string name, CancellationToken token = default);
 
         /// <summary>
+        /// Returns a range of the attachment by the document id and attachment name.
+        /// </summary>
+        Task<AttachmentResult> GetRangeAsync(string documentId, string name, long? from, long? to, CancellationToken token = default);
+
+        /// <summary>
         /// Returns Enumerator of KeyValuePairs of attachment name and stream.
         /// </summary>
         Task<IEnumerator<AttachmentEnumeratorResult>> GetAsync(IEnumerable<AttachmentRequest> attachments, CancellationToken token = default);

--- a/src/Raven.Client/Documents/Session/IAttachmentsSessionOperationsAsync.cs
+++ b/src/Raven.Client/Documents/Session/IAttachmentsSessionOperationsAsync.cs
@@ -37,6 +37,11 @@ namespace Raven.Client.Documents.Session
         Task<AttachmentResult> GetRangeAsync(string documentId, string name, long? from, long? to, CancellationToken token = default);
 
         /// <summary>
+        /// Returns a range of the attachment by the document id and attachment name.
+        /// </summary>
+        Task<AttachmentResult> GetRangeAsync(object entity, string name, long? from, long? to, CancellationToken token = default);
+
+        /// <summary>
         /// Returns Enumerator of KeyValuePairs of attachment name and stream.
         /// </summary>
         Task<IEnumerator<AttachmentEnumeratorResult>> GetAsync(IEnumerable<AttachmentRequest> attachments, CancellationToken token = default);

--- a/src/Raven.Client/Exceptions/Documents/Attachments/InvalidAttachmentRangeException.cs
+++ b/src/Raven.Client/Exceptions/Documents/Attachments/InvalidAttachmentRangeException.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Raven.Client.Exceptions.Documents.Attachments;
+
+public sealed class InvalidAttachmentRangeException : RavenException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidAttachmentRangeException"/> class.
+    /// </summary>
+    public InvalidAttachmentRangeException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidAttachmentRangeException"/> class.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    public InvalidAttachmentRangeException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidAttachmentRangeException"/> class.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    /// <param name="inner">The inner.</param>
+    public InvalidAttachmentRangeException(string message, Exception inner) : base(message, inner)
+    {
+    }
+
+    public static InvalidAttachmentRangeException ThrowFor(string documentId, string attachmentName, long? rangeFrom, long? rangeTo)
+    {
+        throw new InvalidAttachmentRangeException($"There requested range '{rangeFrom}-{rangeTo}' is invalid for '{attachmentName}' in document '{documentId}'.");
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForHeadAttachment.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForHeadAttachment.cs
@@ -33,6 +33,8 @@ internal sealed class AttachmentHandlerProcessorForHeadAttachment : AbstractAtta
 
             HttpContext.Response.Headers[Constants.Headers.Etag] = $"\"{attachment.ChangeVector}\"";
 
+            RangeHelper.SetRangeHeaders(HttpContext, attachment.Size);
+
             return ValueTask.CompletedTask;
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/RangeHelper.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/RangeHelper.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+
+namespace Raven.Server.Documents.Handlers.Processors.Attachments
+{
+    internal static class RangeHelper
+    {
+        public static (bool SendBody, long Start, long? Length) SetRangeHeaders(HttpContext context, long size)
+        {
+            var responseHeaders = context.Response.GetTypedHeaders();
+            context.Response.Headers.AcceptRanges = "bytes";
+
+            long start = 0;
+            var (isRangeRequest, range) = ParseRange(context, size);
+            if (isRangeRequest)
+            {
+                if (range is null)
+                {
+                    context.Response.StatusCode = (int)HttpStatusCode.RequestedRangeNotSatisfiable;
+                    responseHeaders.ContentRange = new ContentRangeHeaderValue(size);
+                    responseHeaders.ContentLength = 0;
+                    return (false, start, null);
+                }
+
+                context.Response.StatusCode = (int)HttpStatusCode.PartialContent;
+                responseHeaders.ContentRange = ComputeContentRange(range, size, out start, out var length);
+                responseHeaders.ContentLength = length;
+                return (true, start, length);
+            }
+            else
+            {
+                responseHeaders.ContentLength = size;
+                return (true, 0, null);
+            }
+        }
+
+        private static (bool IsRangeRequest, RangeItemHeaderValue Range) ParseRange(HttpContext context, long length)
+        {
+            var rawRangeHeader = context.Request.Headers.Range;
+            if (StringValues.IsNullOrEmpty(rawRangeHeader))
+            {
+                return (false, null);
+            }
+
+            // Perf: Check for a single entry before parsing it
+            if (rawRangeHeader.Count > 1 || (rawRangeHeader[0] ?? string.Empty).Contains(','))
+            {
+                // The spec allows for multiple ranges but we choose not to support them because the client may request
+                // very strange ranges (e.g. each byte separately, overlapping ranges, etc.) that could negatively
+                // impact the server. Ignore the header and serve the response normally.
+                return (false, null);
+            }
+
+            var rangeHeader = context.Request.GetTypedHeaders().Range;
+            if (rangeHeader == null)
+            {
+                // Invalid
+                return (false, null);
+            }
+
+            // Already verified above
+            Debug.Assert(rangeHeader.Ranges.Count == 1);
+
+            var ranges = rangeHeader.Ranges;
+            if (ranges == null)
+            {
+                return (false, null);
+            }
+
+            if (ranges.Count == 0)
+            {
+                return (true, null);
+            }
+
+            if (length == 0)
+            {
+                return (true, null);
+            }
+
+            // Normalize the ranges
+            var range = NormalizeRange(ranges.Single(), length);
+
+            // Return the single range
+            return (true, range);
+        }
+
+
+        // Note: This assumes ranges have been normalized to absolute byte offsets.
+        private static ContentRangeHeaderValue ComputeContentRange(RangeItemHeaderValue range, long size, out long start, out long length)
+        {
+            start = range.From!.Value;
+            var end = range.To!.Value;
+            length = end - start + 1;
+            return new ContentRangeHeaderValue(start, end, size);
+        }
+
+        private static RangeItemHeaderValue? NormalizeRange(RangeItemHeaderValue range, long length)
+        {
+            var start = range.From;
+            var end = range.To;
+
+            // X-[Y]
+            if (start.HasValue)
+            {
+                if (start.Value >= length)
+                {
+                    // Not satisfiable, skip/discard.
+                    return null;
+                }
+                if (!end.HasValue || end.Value >= length)
+                {
+                    end = length - 1;
+                }
+            }
+            else if (end.HasValue)
+            {
+                // suffix range "-X" e.g. the last X bytes, resolve
+                if (end.Value == 0)
+                {
+                    // Not satisfiable, skip/discard.
+                    return null;
+                }
+
+                var bytes = Math.Min(end.Value, length);
+                start = length - bytes;
+                end = start + bytes - 1;
+            }
+
+            return new RangeItemHeaderValue(start, end);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/RangeHelper.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/RangeHelper.cs
@@ -99,7 +99,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
             return new ContentRangeHeaderValue(start, end, size);
         }
 
-        private static RangeItemHeaderValue? NormalizeRange(RangeItemHeaderValue range, long length)
+        private static RangeItemHeaderValue NormalizeRange(RangeItemHeaderValue range, long length)
         {
             var start = range.From;
             var end = range.To;

--- a/test/SlowTests/Issues/RavenDB_19049.cs
+++ b/test/SlowTests/Issues/RavenDB_19049.cs
@@ -5,6 +5,7 @@ using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Exceptions.Documents.Attachments;
 using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -35,7 +36,7 @@ namespace SlowTests.Issues
             return (id, name);
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Attachments)]
         public async Task ReturnsRange()
         {
             using var store = GetDocumentStore();
@@ -55,7 +56,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Attachments)]
         public async Task ThrowsForUnsupportedRange()
         {
             using var store = GetDocumentStore();

--- a/test/SlowTests/Issues/RavenDB_19049.cs
+++ b/test/SlowTests/Issues/RavenDB_19049.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Exceptions.Documents.Attachments;
+using SlowTests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_19049 : RavenTestBase
+    {
+        public RavenDB_19049(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private async Task<(string Id, string Name)> Setup(DocumentStore store)
+        {
+            var id = "users/1";
+            var name = "file.txt";
+
+            using (var session = store.OpenAsyncSession())
+            using (var fileStream = new MemoryStream([1, 2, 3, 4, 5, 6, 7, 8, 9]))
+            {
+                var user = new User { Name = "Fitzchak" };
+                await session.StoreAsync(user, id);
+
+                session.Advanced.Attachments.Store(user, name, fileStream);
+
+                await session.SaveChangesAsync();
+            }
+
+            return (id, name);
+        }
+
+        [Fact]
+        public async Task ReturnsRange()
+        {
+            using var store = GetDocumentStore();
+            var (id, name) = await Setup(store);
+
+            using (var result = new MemoryStream())
+            using (var session = store.OpenAsyncSession())
+            {
+                var attachment = await session.Advanced.Attachments.GetRangeAsync(id, name, 3, 5);
+
+                await attachment.Stream.CopyToAsync(result);
+                var bytes = result.ToArray();
+
+                Assert.Equal(attachment.Details.Size, 9);
+                Assert.Equal(bytes.Length, 3);
+                Assert.Equal(bytes, [4, 5, 6]);
+            }
+        }
+
+        [Fact]
+        public async Task ThrowsForUnsupportedRange()
+        {
+            using var store = GetDocumentStore();
+            var (id, name) = await Setup(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await Assert.ThrowsAsync<InvalidAttachmentRangeException>(
+                    () => session.Advanced.Attachments.GetRangeAsync(id, name, 999, 1000)
+                );
+
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                    () => session.Advanced.Attachments.GetRangeAsync(id, name, -5, 5)
+                );
+
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                    () => session.Advanced.Attachments.GetRangeAsync(id, name, 10, 5)
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19049

### Additional description

This change allows clients to only fetch a range of an attachment. 
I opted to implement this following the standard HTTP range requests spec https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
