### PR TITLE
RavenDB-22870 Ensure that we replace a server certificate that has a private key

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1290,7 +1290,7 @@ namespace Raven.Server
 
             try
             {
-                SecretProtection.ValidatePrivateKey(newCertificate, password);
+                SecretProtection.ValidateCertificateBeforeReplacement(newCertificate, password, ServerStore.GetLicenseType(), ServerStore.Configuration.Security.CertificateValidationKeyUsages);
 
                 if (Certificate.Certificate.Thumbprint == newCertificate.Thumbprint)
                 {

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -774,6 +774,8 @@ namespace Raven.Server.ServerWide
             }
         }
 
+        internal static void ValidatePrivateKey(X509Certificate2 certificate, string password) => ValidatePrivateKey("ValidatePrivateKey", password, certificate.Export(X509ContentType.Pkcs12), out _);
+
         internal static void ValidatePrivateKey(string source, string certificatePassword, byte[] rawData, out AsymmetricKeyEntry pk, SetupProgressAndResult progress = null)
         {
             pk = null;

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -774,7 +774,14 @@ namespace Raven.Server.ServerWide
             }
         }
 
-        internal static void ValidatePrivateKey(X509Certificate2 certificate, string password) => ValidatePrivateKey("ValidatePrivateKey", password, certificate.Export(X509ContentType.Pkcs12), out _);
+        public static void ValidateCertificateBeforeReplacement(X509Certificate2 certificate, string password, LicenseType licenseType, bool certificateValidationKeyUsages)
+        {
+            ValidateExpiration("ValidateCertificateBeforeReplacement", certificate, licenseType, throwOnExpired: true);
+
+            ValidatePrivateKey("ValidateCertificateBeforeReplacement", password, certificate.Export(X509ContentType.Pkcs12), out _);
+            
+            ValidateKeyUsages("ValidateCertificateBeforeReplacement", certificate, certificateValidationKeyUsages);
+        }
 
         internal static void ValidatePrivateKey(string source, string certificatePassword, byte[] rawData, out AsymmetricKeyEntry pk, SetupProgressAndResult progress = null)
         {

--- a/src/Raven.Server/Utils/Cli/RavenCli.cs
+++ b/src/Raven.Server/Utils/Cli/RavenCli.cs
@@ -929,7 +929,7 @@ namespace Raven.Server.Utils.Cli
             {
                 var timeoutTask = TimeoutManager.WaitFor(TimeSpan.FromSeconds(60), cli._server.ServerStore.ServerShutdown);
 
-                var replicationTask = cli._server.ServerStore.Server.StartCertificateReplicationAsync(loadedCert, replaceImmediately, RaftIdGenerator.NewId());
+                var replicationTask = cli._server.ServerStore.Server.StartCertificateReplicationAsync(loadedCert, password, replaceImmediately, RaftIdGenerator.NewId());
 
                 Task.WhenAny(replicationTask, timeoutTask).Wait();
                 if (replicationTask.IsCompleted == false)
@@ -937,6 +937,8 @@ namespace Raven.Server.Utils.Cli
                     WriteError("Timeout when trying to replace the server certificate.", cli);
                     return false;
                 }
+
+                replicationTask.GetAwaiter().GetResult(); // already completed, need to propagate any exception
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -1083,11 +1083,13 @@ namespace Raven.Server.Web.Authentication
                         {
                             Logger.Operations("Initiating the replacement of the certificate upon explicit request - '/admin/certificates/replace-cluster-cert'.");
                         }
-                        var replicationTask = Server.StartCertificateReplicationAsync(newCertificate, replaceImmediately, GetRaftRequestIdFromQuery());
+                        var replicationTask = Server.StartCertificateReplicationAsync(newCertificate, certificate.Password, replaceImmediately, GetRaftRequestIdFromQuery());
 
                         await Task.WhenAny(replicationTask, timeoutTask);
                         if (replicationTask.IsCompleted == false)
                             throw new TimeoutException("Timeout when trying to replace the server certificate.");
+
+                        await replicationTask;
                     }
                     catch (Exception e)
                     {

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -23,7 +23,9 @@ using Xunit;
 using Xunit.Abstractions;
 using Sparrow.Server;
 using System.Linq;
+using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server.ServerWide.Context;
+using Raven.Client.Exceptions;
 
 namespace SlowTests.Authentication
 {
@@ -88,6 +90,40 @@ namespace SlowTests.Authentication
         {
             var acmeUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
             await CanGetLetsEncryptCertificateAndRenewAfterFailure(acmeUrl);
+        }
+
+        [RetryFact(delayBetweenRetriesMs: 1000)]
+        public async Task ReplaceCertificateWithPrivateKey()
+        {
+            var acmeUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
+            
+            SetupLocalServer();
+            SetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
+
+            var serverCert = await GetCertificateFromLetsEncrypt(setupInfo, acmeUrl);
+            Server.Dispose();
+            UseNewLocalServer();
+
+            var mre = new AsyncManualResetEvent();
+            Server.ServerCertificateChanged += (sender, args) => mre.Set();
+
+            var ct = Certificates.GenerateAndSaveSelfSignedCertificate();
+            var first = Server.Certificate.Certificate.Thumbprint;
+
+            using (var store = GetDocumentStore(new Options { AdminCertificate = serverCert, ClientCertificate = serverCert }))
+            {
+                var bytesWithoutPrivateKey = ct.ServerCertificate.Value.RawData;
+                var op = new ReplaceClusterCertificateOperation(bytesWithoutPrivateKey, replaceImmediately: true);
+                var ex = await Assert.ThrowsAsync<RavenException>(() => store.Maintenance.Server.SendAsync(op));
+                Assert.Contains("Unable to find the private key in the provided certificate", ex.ToString());
+
+                var bytesWithPrivateKey = ct.ServerCertificate.Value.Export(X509ContentType.Pkcs12);
+                var op2 = new ReplaceClusterCertificateOperation(bytesWithPrivateKey, replaceImmediately: true);
+                await store.Maintenance.Server.SendAsync(op2);
+            }
+
+            await mre.WaitAsync(TimeSpan.FromSeconds(15));
+            Assert.NotEqual(first, Server.Certificate.Certificate.Thumbprint);
         }
 
         private async Task CanGetLetsEncryptCertificateAndRenewAfterFailure(string acmeUrl)

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6415;
+            const int numberToTolerate = 6416;
             if (array.Length == numberToTolerate)
                 return;
 

--- a/test/Tests.Infrastructure/TestCertificatesHolder.cs
+++ b/test/Tests.Infrastructure/TestCertificatesHolder.cs
@@ -160,7 +160,7 @@ namespace FastTests
             {
                 try
                 {
-                    return new TrackingX509Certificate2(ServerCertificatePath, (string)null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable);
+                    return new TrackingX509Certificate2(ServerCertificatePath, (string)null, X509KeyStorageFlags.MachineKeySet | CertificateLoaderUtil.FlagsForExport);
                 }
                 catch (CryptographicException e)
                 {
@@ -211,7 +211,7 @@ namespace FastTests
             {
                 try
                 {
-                    return new TrackingX509Certificate2(ServerCertificatePath, (string)null, X509KeyStorageFlags.MachineKeySet| X509KeyStorageFlags.Exportable);
+                    return new TrackingX509Certificate2(ServerCertificatePath, (string)null, X509KeyStorageFlags.MachineKeySet | CertificateLoaderUtil.FlagsForExport);
                 }
                 catch (CryptographicException e)
                 {
@@ -230,7 +230,7 @@ namespace FastTests
             {
                 try
                 {
-                    return new TrackingX509Certificate2(path(), (string)null, X509KeyStorageFlags.MachineKeySet);
+                    return new TrackingX509Certificate2(path(), (string)null, X509KeyStorageFlags.MachineKeySet | CertificateLoaderUtil.FlagsForExport);
                 }
                 catch (CryptographicException e)
                 {

--- a/test/Tests.Infrastructure/TestCertificatesHolder.cs
+++ b/test/Tests.Infrastructure/TestCertificatesHolder.cs
@@ -160,7 +160,7 @@ namespace FastTests
             {
                 try
                 {
-                    return new TrackingX509Certificate2(ServerCertificatePath, (string)null, X509KeyStorageFlags.MachineKeySet);
+                    return new TrackingX509Certificate2(ServerCertificatePath, (string)null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.Exportable);
                 }
                 catch (CryptographicException e)
                 {
@@ -211,7 +211,7 @@ namespace FastTests
             {
                 try
                 {
-                    return new TrackingX509Certificate2(ServerCertificatePath, (string)null, X509KeyStorageFlags.MachineKeySet);
+                    return new TrackingX509Certificate2(ServerCertificatePath, (string)null, X509KeyStorageFlags.MachineKeySet| X509KeyStorageFlags.Exportable);
                 }
                 catch (CryptographicException e)
                 {
@@ -230,7 +230,7 @@ namespace FastTests
             {
                 try
                 {
-                    return new TrackingX509Certificate2(path(), (string)null, X509KeyStorageFlags.MachineKeySet | CertificateLoaderUtil.FlagsForExport);
+                    return new TrackingX509Certificate2(path(), (string)null, X509KeyStorageFlags.MachineKeySet);
                 }
                 catch (CryptographicException e)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22870

### Additional description

Ensure that when we replace the server certificate it has the private key.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
