### PR TITLE
RavenDB-22948 Using Load document in query projection does not hydrat…

### DIFF
--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/NewtonsoftJsonBlittableEntitySerializer.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/NewtonsoftJsonBlittableEntitySerializer.cs
@@ -36,10 +36,6 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                 {
                     if (json.TryGetValue(Constants.Documents.Metadata.Id, out id))
                     {
-                        if (_generateEntityIdOnTheClient.TryGetIdFromInstance(o, out var existing) &&
-                            existing != null)
-                            return;
-
                         var isProjection = json.TryGetValue(Constants.Documents.Metadata.Projection, out var projection)
                                          && projection.Type == JTokenType.Boolean
                                          && projection.Value<bool>();

--- a/test/SlowTests/Issues/RavenDB-22948.cs
+++ b/test/SlowTests/Issues/RavenDB-22948.cs
@@ -1,0 +1,118 @@
+﻿using System.Linq;
+using FastTests.Server.Replication;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22948 : ReplicationTestBase
+    {
+        public RavenDB_22948(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void RavenDB_22948_Fail()
+        {
+            // Arrange
+            var testDocumentStore = GetDocumentStore();
+
+            using (var rs = testDocumentStore.OpenSession())
+            {
+                // Act
+                var customer = new Customer() { Name = "My Customer" };
+                rs.Store(customer);
+
+                var order = new Order() { CustomerId = customer.Id, TotalPrice = 100.00 };
+                rs.Store(order);
+                rs.SaveChanges();
+
+                var customerWithPetName = rs
+                    .Query<Order>()
+                    .Select(x => new CustomerWithPet()
+                    {
+                        Customer = rs.Load<Customer>(x.CustomerId),
+                        Pet = "My Pet"
+                    })
+                    .SingleOrDefault();
+
+                // Assert
+                Assert.Equal(customer.Id, customerWithPetName.Customer.Id);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void RavenDB_22948_Pass()
+        {
+            var testDocumentStore = GetDocumentStore();
+
+            using (var rs = testDocumentStore.OpenSession())
+            {
+                // Act
+                var customer = new Customer() { Name = "My Customer" };
+                rs.Store(customer);
+
+                var order = new Order() { CustomerId = customer.Id, TotalPrice = 100.00 };
+                rs.Store(order);
+                rs.SaveChanges();
+
+                var qryorder = rs
+                    .Query<Order>()
+                    .Include(o => o.CustomerId)
+                    .Where(x => x.Id == order.Id)
+                    .SingleOrDefault();
+
+                Customer customerret = rs
+                    .Load<Customer>(qryorder.CustomerId);
+
+                var custwithpet = new CustomerWithPet()
+                {
+                    Customer = customerret,
+                    Pet = "My Pet"
+                };
+
+                // Assert
+                Assert.Equal(customer.Id, custwithpet.Customer.Id);
+            }
+        }
+
+        public class CustomerWithPet
+        {
+            public Customer Customer { get; set; }
+
+            public string Pet { get; set; }
+        }
+
+        public class Order : EntityWithId
+        {
+            public string CustomerId { get; set; }
+
+            public double TotalPrice { get; set; }
+        }
+
+        public class Customer : EntityWithId
+        {
+
+            public string Name { get; set; }
+        }
+
+        public static int i;
+        public abstract class EntityWithId
+        {
+            public EntityWithId()
+            {
+                Id = GenerateId();
+            }
+            public string Id { get; set; }
+
+            public virtual string GenerateId()
+            {
+                i++;
+                return GetType().Name + "-" + i;
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-22948.cs
+++ b/test/SlowTests/Issues/RavenDB-22948.cs
@@ -102,6 +102,7 @@ namespace SlowTests.Issues
         }
 
         private static int IdCounter;
+
         private abstract class EntityWithId
         {
             public EntityWithId()
@@ -115,6 +116,200 @@ namespace SlowTests.Issues
                 IdCounter++;
                 return GetType().Name + "-" + IdCounter;
             }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void Test_TwoClients_DifferentIdHandling()
+        {
+            using (var defaultStore = new DocumentStore
+            {
+                Urls = new []{Server.WebUrl},
+                Database = "Test"
+            }.Initialize())
+            {
+                var doc1Id = "users/1";
+                var doc2Id = "users/2";
+
+                using (var customStore = GetDocumentStore(new Options
+                       {
+                           ModifyDatabaseName = x =>"Test",
+                           ModifyDocumentStore = s =>
+                           {
+                               s.Conventions.FindIdentityPropertyNameFromCollectionName = (typeName) => "TestId";
+                               s.Conventions.FindIdentityProperty = prop => prop.Name == "TestId";
+                           }
+                       }))
+                {
+                    //Id is identity property
+                    using (var session1 = defaultStore.OpenSession())
+                    {
+                        var defaultUser = new User
+                        {
+                            Id = doc1Id,
+                            TestId = "users/1-T",
+                            Name = "Default Store User"
+                        };
+                        session1.Store(defaultUser);
+                        session1.SaveChanges();
+                    }
+
+                    //TestId is identity property
+                    using (var session2 = customStore.OpenSession())
+                    {
+                        var customUser = new User
+                        {
+                            Id = "users/2-T",
+                            TestId = doc2Id,
+                            Name = "Custom Store User"
+                        };
+                        session2.Store(customUser);
+                        session2.SaveChanges();
+
+                        var user1 = session2.Load<User>(doc1Id);
+                        user1.Id = "users/3";
+                        session2.Store(user1);
+                        session2.SaveChanges();
+                    }
+
+                    //Id is identity property
+                    using (var session1 = defaultStore.OpenSession())
+                    {
+                        var query = session1.Query<User>().Select(x => new { Id = x.Id, TestId = x.TestId });
+                        var results = query.ToList();
+
+                        Assert.Null(results[0].TestId);
+                        Assert.Equal(doc2Id, results[0].Id);
+
+                        Assert.Null(results[1].TestId);
+                        Assert.Equal(doc1Id, results[1].Id);
+                    }
+
+                    //TestId is identity property
+                    using (var session2 = customStore.OpenSession())
+                    {
+                        var query = session2.Query<User>().Select(x => new { Id = x.Id, TestId = x.TestId });
+                        var results = query.ToList();
+
+                        Assert.Equal("users/2-T", results[0].Id);
+                        Assert.Equal(doc2Id, results[0].TestId);
+
+                        Assert.Equal("users/3", results[1].Id);
+                        Assert.Equal(doc1Id, results[1].TestId);
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void Test_TwoClients_DifferentIdHandlingWithLoad()
+        {
+            using (var defaultStore = new DocumentStore
+            {
+                Urls = new[] { Server.WebUrl },
+                Database = "Test"
+            }.Initialize())
+            {
+                var doc1Id = "users/1";
+                var doc2Id = "users/2";
+
+                using (var customStore = GetDocumentStore(new Options
+                {
+                    ModifyDatabaseName = x => "Test",
+                    ModifyDocumentStore = s =>
+                    {
+                        s.Conventions.FindIdentityPropertyNameFromCollectionName = (typeName) => "TestId";
+                        s.Conventions.FindIdentityProperty = prop => prop.Name == "TestId";
+                    }
+                }))
+                {
+                    //Id is identity property
+                    using (var session1 = defaultStore.OpenSession())
+                    {
+                        var defaultUser = new User
+                        {
+                            Id = doc1Id,
+                            TestId = "users/1-T",
+                            Name = "Default Store User"
+                        };
+                        session1.Store(defaultUser); //Document Id is users/1
+                        session1.SaveChanges();
+                    }
+
+                    //TestId is identity property
+                    using (var session2 = customStore.OpenSession())
+                    {
+                        var customUser = new User
+                        {
+                            Id = "users/2-T",
+                            TestId = doc2Id,
+                            Name = "Custom Store User"
+                        };
+                        session2.Store(customUser); //Document Id is users/2
+                        session2.SaveChanges();
+
+                        var user1 = session2.Load<User>(doc1Id);
+                        user1.Id = "users/3";
+                        session2.Store(user1); // changing Id property users/1 document to users/3
+                        session2.SaveChanges();
+                    }
+
+                    //Id is identity property
+                    using (var session1 = defaultStore.OpenSession())
+                    {
+                        var results = session1
+                            .Query<User>()
+                            .Select(x => new UserWithPet()
+                            {
+                                User = session1.Load<User>(x.Id),
+                                Pet = "My Pet"
+                            })
+                            .ToList();
+
+                        //*****************Not expected****************************
+                        Assert.Equal("users/2-T", results[0].User.Id); //need to be users/2
+                        Assert.Null(results[0].User.TestId);
+
+                        Assert.Equal("users/3", results[1].User.Id); // need to be users/1
+                        Assert.Null(results[1].User.TestId);
+                        //**********************************************************
+                    }
+
+                    //TestId is identity property
+                    using (var session2 = customStore.OpenSession())
+                    {
+                        var results = session2
+                            .Query<User>()
+                            .Select(x => new UserWithPet()
+                            {
+                                User = session2.Load<User>(x.TestId),
+                                Pet = "My Pet"
+                            })
+                            .ToList();
+
+                        Assert.Equal("users/2-T", results[0].User.Id);
+                        Assert.Equal(doc2Id, results[0].User.TestId);
+
+                        Assert.Equal("users/3", results[1].User.Id);
+                        Assert.Equal(doc1Id, results[1].User.TestId);
+                    }
+                }
+            }
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+
+            public string TestId { get; set; }
+        }
+
+        private class UserWithPet
+        {
+            public User User { get; set; }
+
+            public string Pet { get; set; }
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-22948.cs
+++ b/test/SlowTests/Issues/RavenDB-22948.cs
@@ -265,13 +265,11 @@ namespace SlowTests.Issues
                             })
                             .ToList();
 
-                        //*****************Not expected****************************
-                        Assert.Equal("users/2-T", results[0].User.Id); //need to be users/2
+                        Assert.Equal("users/2-T", results[0].User.Id);
                         Assert.Null(results[0].User.TestId);
 
-                        Assert.Equal("users/3", results[1].User.Id); // need to be users/1
+                        Assert.Equal("users/3", results[1].User.Id);
                         Assert.Null(results[1].User.TestId);
-                        //**********************************************************
                     }
 
                     //TestId is identity property


### PR DESCRIPTION
…e the document "Id" when "Id" is generated in the default constructor.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22948

### Additional description

The problem was that the entity's ID was being overwritten by the deserialization process. Instead of using the ID from the loaded document, the deserialization allowed a new ID to be generated. The solution was to ensure that the entity’s ID is correctly set from the metadata during deserialization to avoid regenerating the ID.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
