### PR TITLE
RavenDB-22986 - Free space searching improvements

### DIFF
--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -216,30 +216,12 @@ namespace Voron.Impl.FreeSpace
             StreamBitArray current, long currentSectionId, out long? page)
         {
             page = -1;
-            var start = -1;
-            var count = 0;
-            for (int i = 0; i < NumberOfPagesInSection; i++)
-            {
-                if (current.Get(i))
-                {
-                    if (start == -1)
-                        start = i;
-                    count++;
-                    if (count == num)
-                    {
-                        page = currentSectionId * NumberOfPagesInSection + start;
-                        break;
-                    }
-                }
-                else
-                {
-                    start = -1;
-                    count = 0;
-                }
-            }
 
-            if (count != num)
+            var start = current.GetContinuousRangeStart(num);
+            if (start == null)
                 return false;
+
+            page = currentSectionId * NumberOfPagesInSection + start;
 
             if (current.SetCount == num)
             {
@@ -249,7 +231,7 @@ namespace Voron.Impl.FreeSpace
             {
                 for (int i = 0; i < num; i++)
                 {
-                    current.Set(i + start, false);
+                    current.Set(i + start.Value, false);
                 }
 
                 Slice val;

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -287,32 +287,6 @@ namespace Voron.Impl.FreeSpace
             }
         }
 
-        public int? GetContinuousRangeStartLegacy(int num)
-        {
-            var start = -1;
-            var count = 0;
-
-            for (int i = 0; i < TotalBits; i++)
-            {
-                if (Get(i))
-                {
-                    if (start == -1)
-                        start = i;
-                    count++;
-
-                    if (count == num)
-                        return start;
-                }
-                else
-                {
-                    start = -1;
-                    count = 0;
-                }
-            }
-
-            return null;
-        }
-
         public void Set(int index, bool value)
         {
             if (value)

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -41,6 +41,8 @@ using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 
 namespace Voron.Impl.FreeSpace
 {
@@ -119,6 +121,24 @@ namespace Voron.Impl.FreeSpace
 
         private int? FirstSetBit()
         {
+            if (Avx2.IsSupported)
+            {
+                for (int i = 0; i < _inner.Length; i += Vector256<uint>.Count)
+                {
+                    var a = Vector256.LoadUnsafe(ref _inner[i]).AsUInt32();
+                    var gt = Vector256.GreaterThan(a, Vector256<uint>.Zero);
+                    if (gt == Vector256<uint>.Zero)
+                        continue;
+
+                    var mask = gt.ExtractMostSignificantBits();
+                    var idx = BitOperations.TrailingZeroCount(mask) + i;
+                    var item = _inner[idx];
+                    return idx * BitsInWord + BitOperations.TrailingZeroCount(item);
+                }
+
+                return null;
+            }
+
             // finding a single set bit
             for (var i = 0; i < _inner.Length; i++)
             {

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -135,7 +135,7 @@ namespace Voron.Impl.FreeSpace
 
                     return null;
 
-                case <= 32:
+                case < 32:
                     // finding sequences up to 32 bits
                     for (var i = 0; i < _inner.Length; i++)
                     {
@@ -146,24 +146,21 @@ namespace Voron.Impl.FreeSpace
                         if (current == -1)
                             return i * 32;
 
-                        if (num < 32)
+                        int firstSetBitPos = BitOperations.TrailingZeroCount((uint)current);
+
+                        // Only proceed if there is a set bit and it's within range
+                        int mask = (1 << num) - 1; // Create a mask of num 1s
+
+                        if (firstSetBitPos <= 32 - num)
                         {
-                            int firstSetBitPos = BitOperations.TrailingZeroCount((uint)current);
-
-                            // Only proceed if there is a set bit and it's within range
-                            int mask = (1 << num) - 1; // Create a mask of num 1s
-
-                            if (firstSetBitPos <= 32 - num)
+                            for (int bitPos = firstSetBitPos; bitPos <= 32 - num; bitPos++)
                             {
-                                for (int bitPos = firstSetBitPos; bitPos <= 32 - num; bitPos++)
-                                {
-                                    var temp = mask << bitPos; // Shift the mask to the current position
+                                var temp = mask << bitPos; // Shift the mask to the current position
 
-                                    // Check if the current block has the sequence of 1s
-                                    if ((current & temp) == temp)
-                                    {
-                                        return i * 32 + bitPos; // Found the sequence, return the position
-                                    }
+                                // Check if the current block has the sequence of 1s
+                                if ((current & temp) == temp)
+                                {
+                                    return i * 32 + bitPos; // Found the sequence, return the position
                                 }
                             }
                         }

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -146,42 +146,21 @@ namespace Voron.Impl.FreeSpace
                 if (current == -1)
                     return i * BitsInWord;
 
-                int position = 0;
                 var currentCopy = current;
-                while (currentCopy != 0)
+                int numCopy = num - 1;
+
+                // find consecutive range: https://stackoverflow.com/a/37903049/6366
+                // perform AND operations with shifted versions of the number
+                // this will leave 1s only where there were n consecutive 1s
+                while (currentCopy != 0 && numCopy-- > 0)
                 {
-                    int firstSetBitPos = BitOperations.TrailingZeroCount((uint)currentCopy);
-                    position += firstSetBitPos;
+                    currentCopy &= (currentCopy << 1);
+                }
 
-                    currentCopy >>= firstSetBitPos;
-                    if (currentCopy == -1)
-                    {
-                        // all bits after the shift are ones
-                        if (BitsInWord - position >= num)
-                            return i * BitsInWord + position;
-
-                        break;
-                    }
-
-                    int onesCount = BitOperations.TrailingZeroCount((uint)~currentCopy);
-                    if (onesCount >= num)
-                        return i * BitsInWord + position;
-
-                    position += onesCount;
-
-                    if (BitsInWord - position < num)
-                    {
-                        // impossible to satisfy the continuous bit requirement
-                        break;
-                    }
-
-                    currentCopy >>= onesCount;
-                    if (currentCopy != 0)
-                    {
-                        int zerosCount = BitOperations.TrailingZeroCount((uint)currentCopy);
-                        position += zerosCount;
-                        currentCopy >>= zerosCount; // prepare for the next iteration
-                    }
+                if (currentCopy != 0)
+                {
+                    int position = BitOperations.TrailingZeroCount(currentCopy);
+                    return i * BitsInWord + position - (num - 1);
                 }
 
                 if (i == _inner.Length - 1)

--- a/test/FastTests/Voron/StreamBitArrayTests.cs
+++ b/test/FastTests/Voron/StreamBitArrayTests.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using FastTests;
-using SlowTests.Utils;
+using FastTests.Voron.FixedSize;
+using Tests.Infrastructure;
+using Voron.Impl.FreeSpace;
 using Xunit;
 using Xunit.Abstractions;
-using Voron.Impl.FreeSpace;
-using Tests.Infrastructure;
 
-namespace SlowTests.Voron
+namespace FastTests.Voron
 {
     public class StreamBitArrayTests : NoDisposalNeeded
     {
@@ -102,36 +101,6 @@ namespace SlowTests.Voron
             }
 
             const int num = 451;
-            var result1 = GetContinuousRangeSlow(sba, num);
-            var result2 = sba.GetContinuousRangeStart(num);
-            Assert.Equal(result1, result2);
-        }
-
-        [RavenFact(RavenTestCategory.Voron)]
-        public void VerifySingleLargeResult()
-        {
-            int[] arr =
-            [
-                0, 0, 0, 0, 0, 0, -256, -1, -1, -1, -1, -1, 65535, 0, 0, 0, 0, 0, -16777216, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, -256, -1, -1, -1, -1, -1, 65535, 0,
-                0, 0, 0, 0, -16777216, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, -256, -1, -1, -1, -1, -1, 65535, 0
-            ];
-
-            var sba = new StreamBitArray();
-
-            for (var wordIndex = 0; wordIndex < arr.Length; wordIndex++)
-            {
-                var word = arr[wordIndex];
-                for (int i = 0; i < 32; i++)
-                {
-                    if ((word & (1 << i)) == 0)
-                        continue;
-
-                    int globalIndex = wordIndex * 32 + i;
-                    sba.Set(globalIndex, true);
-                }
-            }
-
-            const int num = 100;
             var result1 = GetContinuousRangeSlow(sba, num);
             var result2 = sba.GetContinuousRangeStart(num);
             Assert.Equal(result1, result2);

--- a/test/SlowTests/Voron/StreamBitArrayTests.cs
+++ b/test/SlowTests/Voron/StreamBitArrayTests.cs
@@ -1,0 +1,66 @@
+﻿using FastTests;
+using Xunit;
+using Xunit.Abstractions;
+using Voron.Impl.FreeSpace;
+using Tests.Infrastructure;
+using Random = System.Random;
+
+namespace SlowTests.Voron
+{
+    public class StreamBitArrayTests : NoDisposalNeeded
+    {
+        public StreamBitArrayTests(ITestOutputHelper output) : base(output)
+        {
+        }
+   
+        [RavenFact(RavenTestCategory.Voron)]
+        public void VerifyResultWithRandomInput()
+        {
+            var random = new Random();
+            var sba = new StreamBitArray();
+
+            for (int j = 0; j < 2048; j += 1)
+            {
+                sba.Set(j, random.Next(2) == 1);
+            }
+
+            for (int j = 1; j <= 2048; j += 1)
+            {
+                var result1 = sba.GetContinuousRangeStart(j);
+                var result2 = sba.GetContinuousRangeStartLegacy(j);
+                Assert.Equal(result1, result2);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(1, 2)]
+        [InlineData(2, 32)]
+        [InlineData(32, 300)]
+        [InlineData(500, 600)]
+        public void VerifyResultWithRandomMinMaxInput(int minContinuous, int maxContinuous)
+        {
+            var random = new Random();
+            var sba = new StreamBitArray();
+
+            int i = 0;
+            while (i < 2048)
+            {
+                int blockSize = random.Next(minContinuous, maxContinuous + 1);
+
+                bool value = random.Next(2) == 1;
+
+                for (int k = 0; k < blockSize && i < 2048; k++, i++)
+                {
+                    sba.Set(i, value);
+                }
+            }
+
+            for (int j = 1; j <= 2048; j += 1)
+            {
+                var result1 = sba.GetContinuousRangeStart(j);
+                var result2 = sba.GetContinuousRangeStartLegacy(j);
+                Assert.Equal(result1, result2);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Voron/StreamBitArrayTests.cs
+++ b/test/SlowTests/Voron/StreamBitArrayTests.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Voron
             for (int j = 1; j <= 2048; j += 1)
             {
                 var result1 = sba.GetContinuousRangeStart(j);
-                var result2 = sba.GetContinuousRangeStartLegacy(j);
+                var result2 = GetContinuousRangeSlow(sba, j);
                 Assert.Equal(result1, result2);
             }
         }
@@ -58,9 +58,35 @@ namespace SlowTests.Voron
             for (int j = 1; j <= 2048; j += 1)
             {
                 var result1 = sba.GetContinuousRangeStart(j);
-                var result2 = sba.GetContinuousRangeStartLegacy(j);
+                var result2 = GetContinuousRangeSlow(sba, j);
                 Assert.Equal(result1, result2);
             }
+        }
+
+        public static int? GetContinuousRangeSlow(StreamBitArray current, int num)
+        {
+            var start = -1;
+            var count = 0;
+
+            for (int i = 0; i < 2048; i++)
+            {
+                if (current.Get(i))
+                {
+                    if (start == -1)
+                        start = i;
+                    count++;
+
+                    if (count == num)
+                        return start;
+                }
+                else
+                {
+                    start = -1;
+                    count = 0;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/test/SlowTests/Voron/StreamBitArrayTests.cs
+++ b/test/SlowTests/Voron/StreamBitArrayTests.cs
@@ -42,8 +42,68 @@ namespace SlowTests.Voron
             }
 
             const int num = 19;
-            var result1 = sba.GetContinuousRangeStart(num);
-            var result2 = GetContinuousRangeSlow(sba, num);
+            var result1 = GetContinuousRangeSlow(sba, num);
+            var result2 = sba.GetContinuousRangeStart(num);
+            Assert.Equal(result1, result2);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void VerifySingleLargeResultSearching100()
+        {
+            int[] arr =
+            [
+                0, 0, 0, 0, 0, 0, -256, -1, -1, -1, -1, -1, 65535, 0, 0, 0, 0, 0, -16777216, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, -256, -1, -1, -1, -1, -1, 65535, 0,
+                0, 0, 0, 0, -16777216, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, -256, -1, -1, -1, -1, -1, 65535, 0
+            ];
+
+            var sba = new StreamBitArray();
+
+            for (var wordIndex = 0; wordIndex < arr.Length; wordIndex++)
+            {
+                var word = arr[wordIndex];
+                for (int i = 0; i < 32; i++)
+                {
+                    if ((word & (1 << i)) == 0)
+                        continue;
+
+                    int globalIndex = wordIndex * 32 + i;
+                    sba.Set(globalIndex, true);
+                }
+            }
+
+            const int num = 100;
+            var result1 = GetContinuousRangeSlow(sba, num);
+            var result2 = sba.GetContinuousRangeStart(num);
+            Assert.Equal(result1, result2);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void VerifySingleLargeResultSearching451()
+        {
+            int[] arr =
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -8, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 8388607, 0, -1, -1, -1, -1, -1,
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+            ];
+
+            var sba = new StreamBitArray();
+
+            for (var wordIndex = 0; wordIndex < arr.Length; wordIndex++)
+            {
+                var word = arr[wordIndex];
+                for (int i = 0; i < 32; i++)
+                {
+                    if ((word & (1 << i)) == 0)
+                        continue;
+
+                    int globalIndex = wordIndex * 32 + i;
+                    sba.Set(globalIndex, true);
+                }
+            }
+
+            const int num = 451;
+            var result1 = GetContinuousRangeSlow(sba, num);
+            var result2 = sba.GetContinuousRangeStart(num);
             Assert.Equal(result1, result2);
         }
 
@@ -72,8 +132,8 @@ namespace SlowTests.Voron
             }
 
             const int num = 100;
-            var result1 = sba.GetContinuousRangeStart(num);
-            var result2 = GetContinuousRangeSlow(sba, num);
+            var result1 = GetContinuousRangeSlow(sba, num);
+            var result2 = sba.GetContinuousRangeStart(num);
             Assert.Equal(result1, result2);
         }
 
@@ -91,8 +151,8 @@ namespace SlowTests.Voron
 
             for (int j = 1; j <= 2048; j += 1)
             {
-                var result1 = sba.GetContinuousRangeStart(j);
-                var result2 = GetContinuousRangeSlow(sba, j);
+                var result1 = GetContinuousRangeSlow(sba, j);
+                var result2 = sba.GetContinuousRangeStart(j);
                 Assert.Equal(result1, result2);
             }
         }
@@ -123,8 +183,8 @@ namespace SlowTests.Voron
 
             for (int j = 1; j <= 2048; j += 1)
             {
-                var result1 = sba.GetContinuousRangeStart(j);
-                var result2 = GetContinuousRangeSlow(sba, j);
+                var result1 = GetContinuousRangeSlow(sba, j);
+                var result2 = sba.GetContinuousRangeStart(j);
                 Assert.Equal(result1, result2);
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22986/Free-space-fragmentation

### Additional description

The objective was to enhance performance in searching for continuous sets of bits, particularly when the number of bits in the sequence exceeds 512.

- **Single set bit (num == 1)** - The first set bit in each block is efficiently located using `TrailingZeroCount`, returning its position immediately upon discovery.
- **Finding sequences up to 32 bits** - Used the approach is described here: https://stackoverflow.com/a/37903049/6366. If a sequence is not found, trailing bits of the current block and leading bits of the next block are analyzed to check across block boundaries.
- **Finding sequences larger than 32 bits** - Since sequences longer than 32 bits must span across blocks, the approach efficiently tracks these sequences by checking `LeadingZeroCount` and `TrailingZeroCount` in each block. Once the required number of set bits is accumulated, the starting position is returned.

The tests simulate a single batch of patch operations with a batch size of 1024, targeting sizes that are not available in any of the 5000 sections.

**Results for random set of bits**
Requested size: 1
legacy: 38ms
new: 9ms

Requested size: 2-31
legacy: 13484ms
new: 1343ms

Requested size: 32-2048
legacy: 20091ms
new: 462ms

Requested size: 1-2048
legacy: 20518ms
new: 473ms

**Results for random sequnces of set bits ranging from 2-128**
Requested size: 1
legacy: 154ms
new: 10ms

Requested size: 2-31
legacy: 267ms
new: 228ms

Requested size: 32-2048
legacy: 6515ms
new: 525ms

Requested size: 1-2048
legacy: 6431ms
new: 520ms

**Results for real life highly fragmented sections**
Requested size: 1
legacy: 774ms
new: 34ms

Requested size: 2-31
legacy: 8246ms
new: 745ms

Requested size: 32-2048
legacy: 8232ms
new: 533ms

Requested size: 1-2048
legacy: 8396ms
new: 521ms

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
