### PR TITLE
RavenDB-19234 cluster log debug EPs adjustments

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.Debug.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.Debug.cs
@@ -116,7 +116,7 @@ public abstract partial class RachisConsensus
         }
     }
 
-    public LogSummary GetLogDetails(ClusterOperationContext context, int start, int take, bool detailed)
+    public LogSummary GetLogDetails(ClusterOperationContext context, long? fromIndex, int take, bool detailed)
     {
         GetLastTruncated(context, out var index, out var term);
         var range = GetLogEntriesRange(context);
@@ -129,21 +129,21 @@ public abstract partial class RachisConsensus
             LastLogEntryIndex = range.Max,
             LastAppendedTime = LastAppended,
             LastCommitedTime = LastCommitted,
-            Logs = GetLogEntries(context, range.Min, start, take, detailed)
+            Logs = GetLogEntries(context, fromIndex ?? range.Min, take, detailed)
         };
     }
 
-    public IEnumerable<RachisDebugLogEntry> GetLogEntries(ClusterOperationContext context, long first, int start, int take, bool detailed)
+    public IEnumerable<RachisDebugLogEntry> GetLogEntries(ClusterOperationContext context, long fromIndex, int take, bool detailed)
     {
-        var reveredNextIndex = Bits.SwapBytes(first);
+        var reveredNextIndex = Bits.SwapBytes(fromIndex);
         Span<byte> span = stackalloc byte[sizeof(long)];
         if (BitConverter.TryWriteBytes(span, reveredNextIndex) == false)
-            throw new InvalidOperationException($"Couldn't convert {first} to span<byte>");
+            throw new InvalidOperationException($"Couldn't convert {fromIndex} to span<byte>");
 
         var table = context.Transaction.InnerTransaction.OpenTable(LogsTable, EntriesSlice);
         using (Slice.From(context.Allocator, span, out Slice key))
         {
-            foreach (var value in table.SeekByPrimaryKey(key, start))
+            foreach (var value in table.SeekByPrimaryKey(key, 0))
             {
                 if (take-- <= 0)
                     yield break;
@@ -233,9 +233,9 @@ public abstract class RaftDebugView : IDynamicJsonValueConvertible
         Since = engine.LastStateChangeTime;
     }
 
-    public void PopulateLogs(ClusterOperationContext context, int start, int take, bool detailed)
+    public void PopulateLogs(ClusterOperationContext context, long? fromIndex, int take, bool detailed)
     {
-        Log = _engine.GetLogDetails(context, start, take, detailed);
+        Log = _engine.GetLogDetails(context, fromIndex, take, detailed);
     }
 
     public class PeerConnection(string destination) : IDynamicJsonValueConvertible

--- a/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Cluster.cs
@@ -217,7 +217,7 @@ public partial class RavenTestBase
             return
                 $"{Environment.NewLine}Log for server '{server.ServerStore.NodeTag}':" +
                 $"{Environment.NewLine}Last notified Index '{server.ServerStore.Cluster.LastNotifiedIndex}':" +
-                $"{Environment.NewLine}{context.ReadObject(server.ServerStore.Engine.GetLogDetails(context, start: 0, take: int.MaxValue, detailed: true).ToJson(), "LogSummary/" + server.ServerStore.NodeTag)}" +
+                $"{Environment.NewLine}{context.ReadObject(server.ServerStore.Engine.GetLogDetails(context, fromIndex: 0, take: int.MaxValue, detailed: true).ToJson(), "LogSummary/" + server.ServerStore.NodeTag)}" +
                 $"{Environment.NewLine}{server.ServerStore.Engine.LogHistory.GetHistoryLogsAsString(context)}";
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19234

### Additional description

- Add EP to get a single detailed raft log by index (`/admin/cluster/log-by-index`)
- Instead of paging for the raft logs, we should specify the start raft index with the query paramter `from`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
