### PR TITLE
RavenDB-22986 - Allow to get free space snapshot to investigate related performance issue

### DIFF
--- a/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Sparrow.Json.Parsing;
 
 namespace Voron.Impl.FreeSpace
 {
@@ -6,6 +7,7 @@ namespace Voron.Impl.FreeSpace
     {
         long? TryAllocateFromFreeSpace(LowLevelTransaction tx, int num);
         List<long> AllPages(LowLevelTransaction tx);
+        List<DynamicJsonValue> FreeSpaceSnapshot(LowLevelTransaction tx, bool hex);
         void FreePage(LowLevelTransaction tx, long pageNumber);
         long GetFreePagesOverhead(LowLevelTransaction tx);
         IEnumerable<long> GetFreePagesOverheadPages(LowLevelTransaction tx);

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -33,8 +33,11 @@
 
 using Sparrow;
 using System;
+using System.Collections;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 
 namespace Voron.Impl.FreeSpace
@@ -189,6 +192,19 @@ namespace Voron.Impl.FreeSpace
             var scope = context.From(buffer, 0, buffer.Length, type, out byteString);
             str = new Slice(byteString);
             return scope;
+        }
+
+        public DynamicJsonValue ToJson(long key, bool hex)
+        {
+            IEnumerable collection = hex
+                ? _inner.Select(x => x.ToString("X"))
+                : _inner;
+
+            return new DynamicJsonValue { 
+                ["Key"] = key,
+                [nameof(SetCount)] = SetCount, 
+                ["Data"] = new DynamicJsonArray(collection) 
+            };
         }
     }
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22986

### Additional description
We have added the option to retrieve the free space state of an environment for debugging purposes.

This is not included in the debug package, as it can be very large depending on the size of the data file.
While it's probably needed only for document environments, the option has been added for all environments.

The free space state can be retrieved in either integer or hexadecimal format.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
