### PR TITLE
RavenDB-22624 - Add RavenQuery.Id method to allow explicit identity projection

### DIFF
--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -578,6 +578,11 @@ namespace Raven.Client.Documents.Linq
                    || mce.Object?.Type == typeof(ISessionDocumentCounters) && mce.Method.Name == nameof(ISessionDocumentCounters.Get);
         }
 
+        public static bool IsIdCall(MethodCallExpression mce)
+        {
+            return mce.Method.DeclaringType == typeof(RavenQuery) && mce.Method.Name == nameof(RavenQuery.Id);
+        }
+
         public static bool IsCompareExchangeCall(MethodCallExpression mce)
         {
             return mce.Method.DeclaringType == typeof(RavenQuery) && mce.Method.Name == nameof(RavenQuery.CmpXchg);

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -167,9 +167,9 @@ namespace Raven.Client.Documents.Linq
         /// <param name="expression">The expression.</param>
         private void VisitExpression(Expression expression)
         {
-            if (expression is BinaryExpression)
+            if (expression is BinaryExpression be)
             {
-                VisitBinaryExpression((BinaryExpression)expression);
+                VisitBinaryExpression(be);
             }
             else
             {
@@ -2728,6 +2728,12 @@ The recommended method is to use full text search (mark the field as Analyzed an
                         HandleSelectTimeSeries(mce, GetSelectPath(field.Member));
                         continue;
                     }
+
+                    if (LinqPathProvider.IsIdCall(mce))
+                    {
+                        HandleSelectId(GetSelectPath(field.Member));
+                        continue;
+                    }
                 }
 
                 //lambda 2 js
@@ -2804,6 +2810,12 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     if (LinqPathProvider.IsTimeSeriesCall(mce))
                     {
                         HandleSelectTimeSeries(mce, GetSelectPath(newExpression.Members[index]));
+                        continue;
+                    }
+
+                    if (LinqPathProvider.IsIdCall(mce))
+                    {
+                        HandleSelectId( GetSelectPath(newExpression.Members[index]));
                         continue;
                     }
                 }
@@ -2892,6 +2904,13 @@ The recommended method is to use full text search (mark the field as Analyzed an
             var tsQueryText = visitor.Visit(callExpression);
             string path = $"{Constants.TimeSeries.SelectFieldName}({tsQueryText})";
             alias ??= Constants.TimeSeries.QueryFunction + FieldsToFetch.Count;
+
+            AddToFieldsToFetch(path, alias);
+        }
+
+        private void HandleSelectId( string alias = null)
+        {
+            string path = $"{Constants.Documents.Indexing.Fields.DocumentIdFieldName}";
 
             AddToFieldsToFetch(path, alias);
         }

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2815,7 +2815,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
                     if (LinqPathProvider.IsIdCall(mce))
                     {
-                        HandleSelectId( GetSelectPath(newExpression.Members[index]));
+                        HandleSelectId(GetSelectPath(newExpression.Members[index]));
                         continue;
                     }
                 }
@@ -2908,9 +2908,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
             AddToFieldsToFetch(path, alias);
         }
 
-        private void HandleSelectId( string alias = null)
+        private void HandleSelectId(string alias = null)
         {
-            string path = $"{Constants.Documents.Indexing.Fields.DocumentIdFieldName}";
+            string path = Constants.Documents.Indexing.Fields.DocumentIdFieldName;
 
             AddToFieldsToFetch(path, alias);
         }

--- a/src/Raven.Client/Documents/Queries/RavenQuery.cs
+++ b/src/Raven.Client/Documents/Queries/RavenQuery.cs
@@ -11,6 +11,11 @@ namespace Raven.Client.Documents.Queries
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
+        
+        public static string Id(object documentInstance)
+        {
+            throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
+        }
 
         public static IEnumerable<T> Load<T>(IEnumerable<string> ids)
         {

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -13,7 +13,6 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Session;
-using Raven.Client.Exceptions;
 using Raven.Client.Extensions;
 using Sparrow;
 using Sparrow.Extensions;
@@ -2569,7 +2568,7 @@ namespace Raven.Client.Util
                 if (expression is MethodCallExpression { Method.Name: nameof(RavenQuery.Id) } mce && mce.Method.DeclaringType == typeof(RavenQuery) )
                 {
                     if (mce.Arguments.Count != 1)
-                        throw new InvalidQueryException($"{nameof(RavenQuery.Id)} can only get one argument");
+                        throw new InvalidOperationException($"{nameof(RavenQuery.Id)} can only get one argument");
                     innerExpression = mce.Arguments[0];
                     return true;
                 }

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -2572,7 +2572,6 @@ namespace Raven.Client.Util
                     innerExpression = mce.Arguments[0];
                     return true;
                 }
-
                 if (expression is not MemberExpression member ||
                     conventions.GetIdentityProperty(member.Member.DeclaringType) != member.Member)
                     return false;
@@ -2601,13 +2600,20 @@ namespace Raven.Client.Util
                 if (member.Expression is not MemberExpression innerMember)
                     return false;
 
+                var p = GetParameter(innerMember)?.Name;
+                if (p != null && (p.StartsWith(TransparentIdentifier) || p == parameterName))
+                {
+                    // Handling the projection case where there is a chaining select to access the ID property, ensuring proper extraction of the inner member for projection.
+                    innerExpression = innerMember;
+                    return true;
+                }
+
                 innerExpression = innerMember;
 
                 if (originalQueryType != null && innerExpression?.Type.IsEquivalentTo(originalQueryType) == false && hasTypeInLoadType == false)
                     return false;
                 
-                var p = GetParameter(innerMember)?.Name;
-                return p != null && (p.StartsWith(TransparentIdentifier) || p == parameterName);
+                return false;
             }
         }
 

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -2600,20 +2600,13 @@ namespace Raven.Client.Util
                 if (member.Expression is not MemberExpression innerMember)
                     return false;
 
-                var p = GetParameter(innerMember)?.Name;
-                if (p != null && (p.StartsWith(TransparentIdentifier) || p == parameterName))
-                {
-                    // Handling the projection case where there is a chaining select to access the ID property, ensuring proper extraction of the inner member for projection.
-                    innerExpression = innerMember;
-                    return true;
-                }
-
                 innerExpression = innerMember;
 
                 if (originalQueryType != null && innerExpression?.Type.IsEquivalentTo(originalQueryType) == false && hasTypeInLoadType == false)
                     return false;
                 
-                return false;
+                var p = GetParameter(innerMember)?.Name;
+                return p != null && (p.StartsWith(TransparentIdentifier) || p == parameterName);
             }
         }
 

--- a/test/FastTests/Client/RavenQueryTests.cs
+++ b/test/FastTests/Client/RavenQueryTests.cs
@@ -1,0 +1,166 @@
+﻿using System.Linq;
+using Raven.Client.Documents.Indexes;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Client
+{
+    public class RavenQueryTests : RavenTestBase
+    {
+        public RavenQueryTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void CheckIfDocumentExists(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                new Employees_ByFirstName().Execute(store);
+
+                var employee1 = new NewEmployee { FirstName = "Golan", LastName = "Nahum", Address = new AddressInfo { Street = "123 Main St", } };
+                var employee2 = new NewEmployee { FirstName = "Grisha", LastName = "Kotler", Address = new AddressInfo { Street = "456 Main St" } };
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(employee1);
+                        session.Store(employee2);
+
+                        session.Advanced.WaitForIndexesAfterSaveChanges();
+                        session.SaveChanges();
+
+
+                        //Test 1:
+                        var queryUnnamedClass = session.Query<Employees_ByFirstName.IndexEntry, Employees_ByFirstName>()
+                            .Select(a => new { FirstName = a.FirstName, LastName = a.LastName, EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a) });
+
+                        var queryUnnamedClassString = queryUnnamedClass.ToString();
+                        var returnedEmployees1 = queryUnnamedClass.ToList();
+                        var returnedEmployee11 = returnedEmployees1.First();
+                        var returnedEmployee12 = returnedEmployees1.Last();
+
+                        Assert.Equal(
+                            "from index 'Employees/ByFirstName' select FirstName, LastName, id() as EmployeeId",
+                            queryUnnamedClassString);
+                        Assert.Equal(2, returnedEmployees1.Count);
+
+                        Assert.Equal(employee1.Id, returnedEmployee11.EmployeeId);
+                        Assert.Equal(employee1.FirstName, returnedEmployee11.FirstName);
+                        Assert.Equal(employee1.LastName, returnedEmployee11.LastName);
+                        Assert.Equal(employee2.Id, returnedEmployee12.EmployeeId);
+
+
+                        //Test 2:
+                        var queryUnnamedClass2 = session.Query<Employees_ByFirstName.IndexEntry, Employees_ByFirstName>()
+                            .Select(a => new { FullName = a.FirstName + " " + a.LastName, EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a) });
+
+                        var queryUnnamedClass2String = queryUnnamedClass2.ToString();
+                        var returnedEmployees2 = queryUnnamedClass2.ToList();
+                        var returnedEmployee21 = returnedEmployees2.First();
+                        var returnedEmployee22 = returnedEmployees2.Last();
+
+                        Assert.Equal(
+                            "from index 'Employees/ByFirstName' as a select { FullName " +
+                            ": a.FirstName+\" \"+a.LastName, EmployeeId : id(a) }",
+                            queryUnnamedClass2String);
+                        Assert.Equal(2, returnedEmployees2.Count);
+
+                        Assert.Equal(employee1.FirstName + " " + employee1.LastName, returnedEmployee21.FullName);
+                        Assert.Equal(employee1.Id, returnedEmployee21.EmployeeId);
+                        Assert.Equal(employee2.FirstName + " " + employee2.LastName, returnedEmployee22.FullName);
+                        Assert.Equal(employee2.Id, returnedEmployee22.EmployeeId);
+
+
+                        //Test 3:
+                        var queryNamedClass = session.Query<Employees_ByFirstName.IndexEntry, Employees_ByFirstName>()
+                            .Select(a => new EmployeeProjection
+                            {
+                                FullName = a.FirstName + " " + a.LastName, EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a)
+                            });
+
+                        var queryNamedClassString = queryNamedClass.ToString();
+                        var returnedEmployees3 = queryNamedClass.ToList();
+                        var returnedEmployee31 = returnedEmployees3.First();
+                        var returnedEmployee32 = returnedEmployees3.Last();
+
+                        Assert.Equal(
+                            "from index 'Employees/ByFirstName' as a select { FullName : " +
+                            "a.FirstName+\" \"+a.LastName, EmployeeId : id(a) }",
+                            queryNamedClassString);
+                        Assert.Equal(2, returnedEmployees3.Count);
+
+                        Assert.Equal(employee1.Id, returnedEmployee31.EmployeeId);
+                        Assert.Equal(employee1.FirstName + " " + employee1.LastName, returnedEmployee31.FullName);
+                        Assert.Equal(employee2.Id, returnedEmployee32.EmployeeId);
+                        Assert.Equal(employee2.FirstName + " " + employee2.LastName, returnedEmployee32.FullName);
+
+
+                        //Test 4:
+                        var queryNamedClassWithNestedClass = session.Query<NewEmployee>()
+                            .Select(a => new EmployeeProjection
+                            {
+                                EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a),
+                                FullName = a.FirstName + " " + a.LastName,
+                                Address = new AddressInfo { AddressId = Raven.Client.Documents.Queries.RavenQuery.Id(a), }
+                            });
+
+                        var queryNamedClassWithNestedClassString = queryNamedClassWithNestedClass.ToString();
+                        var returnedEmployees4 = queryNamedClassWithNestedClass.ToList();
+                        var returnedEmployee41 = returnedEmployees4.First();
+                        var returnedEmployee42 = returnedEmployees4.Last();
+
+                        Assert.Equal(
+                            "from 'NewEmployees' as a select { EmployeeId : id(a), FullName : " +
+                            "a.FirstName+\" \"+a.LastName, Address : { AddressId : id(a) } }",
+                            queryNamedClassWithNestedClassString);
+                        Assert.Equal(2, returnedEmployees4.Count);
+
+                        Assert.Equal(employee1.Id, returnedEmployee41.EmployeeId);
+                        Assert.Equal(employee1.FirstName + " " + employee1.LastName, returnedEmployee41.FullName);
+                        Assert.Equal(employee1.Id, returnedEmployee41.Address.AddressId);
+                        Assert.Equal(employee2.Id, returnedEmployee42.EmployeeId);
+                        Assert.Equal(employee2.FirstName + " " + employee2.LastName, returnedEmployee42.FullName);
+                        Assert.Equal(employee2.Id, returnedEmployee42.Address.AddressId);
+                    }
+                }
+            }
+        }
+
+        private class Employees_ByFirstName : AbstractIndexCreationTask<NewEmployee>
+        {
+            public Employees_ByFirstName()
+            {
+                Map = employees => from employee in employees
+                    select new { employee.FirstName };
+            }
+
+            public class IndexEntry
+            {
+                public string Id { get; set; }
+                public string FirstName { get; set; }
+                public string LastName { get; set; }
+            }
+        }
+
+        private class EmployeeProjection
+        {
+            public string EmployeeId { get; set; }
+            public string FullName { get; set; }
+            public AddressInfo Address { get; set; }
+        }
+
+        private class NewEmployee : Employee
+        {
+            public AddressInfo Address { get; set; }
+        }
+
+        private class AddressInfo
+        {
+            public string Street { get; set; }
+            public string AddressId { get; set; }
+        }
+    }
+}

--- a/test/FastTests/Client/RavenQueryTests.cs
+++ b/test/FastTests/Client/RavenQueryTests.cs
@@ -1,5 +1,8 @@
 ﻿using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -13,120 +16,174 @@ namespace FastTests.Client
         {
         }
 
-        [RavenTheory(RavenTestCategory.ClientApi)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void CheckIfDocumentExists(Options options)
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void CheckIfDocumentExists()
         {
-            using (var store = GetDocumentStore(options))
+            using (var store = GetDocumentStore())
             {
                 new Employees_ByFirstName().Execute(store);
+                new DistributedAll().Execute(store);
+
 
                 var employee1 = new NewEmployee { FirstName = "Golan", LastName = "Nahum", Address = new AddressInfo { Street = "123 Main St", } };
                 var employee2 = new NewEmployee { FirstName = "Grisha", LastName = "Kotler", Address = new AddressInfo { Street = "456 Main St" } };
+                using (var session = store.OpenSession())
                 {
-                    using (var session = store.OpenSession())
-                    {
-                        session.Store(employee1);
-                        session.Store(employee2);
+                    session.Store(employee1);
+                    session.Store(employee2);
+                    session.Store(new ArticleSort { Id = "ArticleSorts/1" });
+                    session.Store(new DistributedPurchase { Id = "DistributedPurchases/1", ArticleSortId = "ArticleSorts/1" });
 
-                        session.Advanced.WaitForIndexesAfterSaveChanges();
-                        session.SaveChanges();
-
-
-                        //Test 1:
-                        var queryUnnamedClass = session.Query<Employees_ByFirstName.IndexEntry, Employees_ByFirstName>()
-                            .Select(a => new { FirstName = a.FirstName, LastName = a.LastName, EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a) });
-
-                        var queryUnnamedClassString = queryUnnamedClass.ToString();
-                        var returnedEmployees1 = queryUnnamedClass.ToList();
-                        var returnedEmployee11 = returnedEmployees1.First();
-                        var returnedEmployee12 = returnedEmployees1.Last();
-
-                        Assert.Equal(
-                            "from index 'Employees/ByFirstName' select FirstName, LastName, id() as EmployeeId",
-                            queryUnnamedClassString);
-                        Assert.Equal(2, returnedEmployees1.Count);
-
-                        Assert.Equal(employee1.Id, returnedEmployee11.EmployeeId);
-                        Assert.Equal(employee1.FirstName, returnedEmployee11.FirstName);
-                        Assert.Equal(employee1.LastName, returnedEmployee11.LastName);
-                        Assert.Equal(employee2.Id, returnedEmployee12.EmployeeId);
+                    session.Advanced.WaitForIndexesAfterSaveChanges();
+                    session.SaveChanges();
 
 
-                        //Test 2:
-                        var queryUnnamedClass2 = session.Query<Employees_ByFirstName.IndexEntry, Employees_ByFirstName>()
-                            .Select(a => new { FullName = a.FirstName + " " + a.LastName, EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a) });
+                    //Original case:
+                    var distributed2 =
+                        from a in session.Query<DistributedAll.Mapping, DistributedAll>().As<DistributedPurchase>()
+                        let articleSort = Raven.Client.Documents.Queries.RavenQuery.Load<ArticleSort>(a.ArticleSortId)
+                        select new { DistributedId = a.Id };
 
-                        var queryUnnamedClass2String = queryUnnamedClass2.ToString();
-                        var returnedEmployees2 = queryUnnamedClass2.ToList();
-                        var returnedEmployee21 = returnedEmployees2.First();
-                        var returnedEmployee22 = returnedEmployees2.Last();
+                    var results = distributed2.ToList();
 
-                        Assert.Equal(
-                            "from index 'Employees/ByFirstName' as a select { FullName " +
-                            ": a.FirstName+\" \"+a.LastName, EmployeeId : id(a) }",
-                            queryUnnamedClass2String);
-                        Assert.Equal(2, returnedEmployees2.Count);
-
-                        Assert.Equal(employee1.FirstName + " " + employee1.LastName, returnedEmployee21.FullName);
-                        Assert.Equal(employee1.Id, returnedEmployee21.EmployeeId);
-                        Assert.Equal(employee2.FirstName + " " + employee2.LastName, returnedEmployee22.FullName);
-                        Assert.Equal(employee2.Id, returnedEmployee22.EmployeeId);
+                    Assert.Equal("DistributedPurchases/1", results[0].DistributedId);
 
 
-                        //Test 3:
-                        var queryNamedClass = session.Query<Employees_ByFirstName.IndexEntry, Employees_ByFirstName>()
-                            .Select(a => new EmployeeProjection
-                            {
-                                FullName = a.FirstName + " " + a.LastName, EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a)
-                            });
+                    //Test 1:
+                    var queryUnnamedClass = session.Query<Employees_ByFirstName.IndexEntry, Employees_ByFirstName>()
+                        .Select(a => new { FirstName = a.FirstName, LastName = a.LastName, EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a) });
 
-                        var queryNamedClassString = queryNamedClass.ToString();
-                        var returnedEmployees3 = queryNamedClass.ToList();
-                        var returnedEmployee31 = returnedEmployees3.First();
-                        var returnedEmployee32 = returnedEmployees3.Last();
+                    var queryUnnamedClassString = queryUnnamedClass.ToString();
+                    var returnedEmployees1 = queryUnnamedClass.ToList();
+                    var returnedEmployee11 = returnedEmployees1.First();
+                    var returnedEmployee12 = returnedEmployees1.Last();
 
-                        Assert.Equal(
-                            "from index 'Employees/ByFirstName' as a select { FullName : " +
-                            "a.FirstName+\" \"+a.LastName, EmployeeId : id(a) }",
-                            queryNamedClassString);
-                        Assert.Equal(2, returnedEmployees3.Count);
+                    Assert.Equal(
+                        "from index 'Employees/ByFirstName' select FirstName, LastName, id() as EmployeeId",
+                        queryUnnamedClassString);
+                    Assert.Equal(2, returnedEmployees1.Count);
 
-                        Assert.Equal(employee1.Id, returnedEmployee31.EmployeeId);
-                        Assert.Equal(employee1.FirstName + " " + employee1.LastName, returnedEmployee31.FullName);
-                        Assert.Equal(employee2.Id, returnedEmployee32.EmployeeId);
-                        Assert.Equal(employee2.FirstName + " " + employee2.LastName, returnedEmployee32.FullName);
+                    Assert.Equal(employee1.Id, returnedEmployee11.EmployeeId);
+                    Assert.Equal(employee1.FirstName, returnedEmployee11.FirstName);
+                    Assert.Equal(employee1.LastName, returnedEmployee11.LastName);
+                    Assert.Equal(employee2.Id, returnedEmployee12.EmployeeId);
+                    Assert.Equal(employee2.FirstName, returnedEmployee12.FirstName);
+                    Assert.Equal(employee2.LastName, returnedEmployee12.LastName);
 
 
-                        //Test 4:
-                        var queryNamedClassWithNestedClass = session.Query<NewEmployee>()
-                            .Select(a => new EmployeeProjection
-                            {
-                                EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a),
-                                FullName = a.FirstName + " " + a.LastName,
-                                Address = new AddressInfo { AddressId = Raven.Client.Documents.Queries.RavenQuery.Id(a), }
-                            });
+                    //Test 2:
+                    var queryUnnamedClass2 = session.Query<Employees_ByFirstName.IndexEntry, Employees_ByFirstName>()
+                        .Select(a => new { FullName = a.FirstName + " " + a.LastName, EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a) });
 
-                        var queryNamedClassWithNestedClassString = queryNamedClassWithNestedClass.ToString();
-                        var returnedEmployees4 = queryNamedClassWithNestedClass.ToList();
-                        var returnedEmployee41 = returnedEmployees4.First();
-                        var returnedEmployee42 = returnedEmployees4.Last();
+                    var queryUnnamedClass2String = queryUnnamedClass2.ToString();
+                    var returnedEmployees2 = queryUnnamedClass2.ToList();
+                    var returnedEmployee21 = returnedEmployees2.First();
+                    var returnedEmployee22 = returnedEmployees2.Last();
 
-                        Assert.Equal(
-                            "from 'NewEmployees' as a select { EmployeeId : id(a), FullName : " +
-                            "a.FirstName+\" \"+a.LastName, Address : { AddressId : id(a) } }",
-                            queryNamedClassWithNestedClassString);
-                        Assert.Equal(2, returnedEmployees4.Count);
+                    Assert.Equal(
+                        "from index 'Employees/ByFirstName' as a select { FullName : a.FirstName+\" \"+a.LastName, EmployeeId : id(a) }",
+                        queryUnnamedClass2String);
+                    Assert.Equal(2, returnedEmployees2.Count);
 
-                        Assert.Equal(employee1.Id, returnedEmployee41.EmployeeId);
-                        Assert.Equal(employee1.FirstName + " " + employee1.LastName, returnedEmployee41.FullName);
-                        Assert.Equal(employee1.Id, returnedEmployee41.Address.AddressId);
-                        Assert.Equal(employee2.Id, returnedEmployee42.EmployeeId);
-                        Assert.Equal(employee2.FirstName + " " + employee2.LastName, returnedEmployee42.FullName);
-                        Assert.Equal(employee2.Id, returnedEmployee42.Address.AddressId);
-                    }
+                    Assert.Equal(employee1.FirstName + " " + employee1.LastName, returnedEmployee21.FullName);
+                    Assert.Equal(employee1.Id, returnedEmployee21.EmployeeId);
+                    Assert.Equal(employee2.FirstName + " " + employee2.LastName, returnedEmployee22.FullName);
+                    Assert.Equal(employee2.Id, returnedEmployee22.EmployeeId);
+
+
+                    //Test 3:
+                    var queryNamedClass = session.Query<Employees_ByFirstName.IndexEntry, Employees_ByFirstName>()
+                        .Select(a => new EmployeeProjection { FullName = a.FirstName + " " + a.LastName, EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a) });
+
+                    var queryNamedClassString = queryNamedClass.ToString();
+                    var returnedEmployees3 = queryNamedClass.ToList();
+                    var returnedEmployee31 = returnedEmployees3.First();
+                    var returnedEmployee32 = returnedEmployees3.Last();
+
+                    Assert.Equal(
+                        "from index 'Employees/ByFirstName' as a select { FullName : a.FirstName+\" \"+a.LastName, EmployeeId : id(a) }",
+                        queryNamedClassString);
+                    Assert.Equal(2, returnedEmployees3.Count);
+
+                    Assert.Equal(employee1.Id, returnedEmployee31.EmployeeId);
+                    Assert.Equal(employee1.FirstName + " " + employee1.LastName, returnedEmployee31.FullName);
+                    Assert.Equal(employee2.Id, returnedEmployee32.EmployeeId);
+                    Assert.Equal(employee2.FirstName + " " + employee2.LastName, returnedEmployee32.FullName);
+
+
+                    //Test 4:
+                    var queryNamedClassWithNestedClass = session.Query<NewEmployee>()
+                        .Select(a => new EmployeeProjection
+                        {
+                            EmployeeId = Raven.Client.Documents.Queries.RavenQuery.Id(a),
+                            FullName = a.FirstName + " " + a.LastName,
+                            Address = new AddressInfo { AddressId = Raven.Client.Documents.Queries.RavenQuery.Id(a), }
+                        });
+
+                    var queryNamedClassWithNestedClassString = queryNamedClassWithNestedClass.ToString();
+                    var returnedEmployees4 = queryNamedClassWithNestedClass.ToList();
+                    var returnedEmployee41 = returnedEmployees4.First();
+                    var returnedEmployee42 = returnedEmployees4.Last();
+
+                    Assert.Equal(
+                        "from 'NewEmployees' as a select { EmployeeId : id(a), FullName : a.FirstName+\" \"+a.LastName, Address : { AddressId : id(a) } }",
+                        queryNamedClassWithNestedClassString);
+                    Assert.Equal(2, returnedEmployees4.Count);
+
+                    Assert.Equal(employee1.Id, returnedEmployee41.EmployeeId);
+                    Assert.Equal(employee1.FirstName + " " + employee1.LastName, returnedEmployee41.FullName);
+                    Assert.Equal(employee1.Id, returnedEmployee41.Address.AddressId);
+                    Assert.Equal(employee2.Id, returnedEmployee42.EmployeeId);
+                    Assert.Equal(employee2.FirstName + " " + employee2.LastName, returnedEmployee42.FullName);
+                    Assert.Equal(employee2.Id, returnedEmployee42.Address.AddressId);
+
+
+                    // Test 5:
+                    var query = session.Query<Employees_ByFirstName.IndexEntry, Employees_ByFirstName>().As<NewEmployee>()
+                        .Select(e => new { Employee = e })
+                        .Select(employee => new EmployeeProjection() { EmployeeId = employee.Employee.Id });
+
+                    var returnedEmployees5 = query.ToList();
+                    var queryString = query.ToString();
+                    var returnedEmployee51 = returnedEmployees5.First();
+                    var returnedEmployee52 = returnedEmployees5.Last();
+
+                    Assert.Equal(employee1.Id, returnedEmployee51.EmployeeId);
+                    Assert.Equal(employee2.Id, returnedEmployee52.EmployeeId);
                 }
             }
+        }
+
+
+        private class DistributedAll : AbstractMultiMapIndexCreationTask<DistributedAll.Mapping>
+        {
+            public class Mapping
+            {
+                public string Id { get; set; }
+            }
+
+            public DistributedAll()
+            {
+                AddMap<DistributedPurchase>(results => from result in results
+                    select new Mapping { Id = result.Id });
+            }
+        }
+
+        private class DistributedPurchase
+        {
+            public string Id { get; set; }
+
+            public string ArticleSortId { get; set; }
+        }
+
+        private class Distributed
+        {
+            public string Id { get; set; }
+        }
+
+        private class ArticleSort
+        {
+            public string Id { get; set; }
         }
 
         private class Employees_ByFirstName : AbstractIndexCreationTask<NewEmployee>
@@ -161,6 +218,7 @@ namespace FastTests.Client
         {
             public string Street { get; set; }
             public string AddressId { get; set; }
+            public AddressInfo[] Details { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22624/Add-RavenQuery.Id-method-to-allow-explicit-identity-projection

### Additional description

Add `RavenQuery.Id` method to allow explicit identity projection.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
