### PR TITLE
RavenDB-19234 add critical error & connection exceptions to cluster view EP

### DIFF
--- a/src/Raven.Server/NotificationCenter/NotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationCenter.cs
@@ -10,6 +10,8 @@ using Raven.Server.Documents;
 using Raven.Server.NotificationCenter.BackgroundWork;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.Server.Collections;
@@ -180,6 +182,16 @@ namespace Raven.Server.NotificationCenter
                     return message;
                 }
             }
+        }
+
+        public BlittableJsonReaderObject GetStoredMessageByPrefix(TransactionOperationContext<RavenTransaction> context, string prefix)
+        {
+            foreach (var notification in _notificationsStorage.GetByPrefix(context, prefix))
+            {
+                return notification.Json;
+            }
+
+            return null;
         }
 
         public long GetAlertCount()

--- a/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
@@ -233,6 +233,19 @@ namespace Raven.Server.NotificationCenter
             }
         }
 
+        public IEnumerable<NotificationTableValue> GetByPrefix(TransactionOperationContext<RavenTransaction> context, string prefix)
+        {
+            var table = context.Transaction.InnerTransaction.OpenTable(_actionsSchema, NotificationsSchema.NotificationsTree);
+
+            using (Slice.From(context.Transaction.InnerTransaction.Allocator, prefix, out Slice prefixSlice))
+            {
+                foreach (var notification in table.SeekByPrimaryKeyPrefix(prefixSlice, prefixSlice, skip: 0))
+                {
+                    yield return Read(context, ref notification.Value.Reader);
+                }
+            }
+        }
+
         public bool Delete(string id, RavenTransaction existingTransaction = null)
         {
             bool deleteResult;

--- a/src/Raven.Server/Rachis/LogSummary.cs
+++ b/src/Raven.Server/Rachis/LogSummary.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using static Raven.Server.Rachis.RachisConsensus;
 
 namespace Raven.Server.Rachis
 {
@@ -14,7 +15,8 @@ namespace Raven.Server.Rachis
         public long LastTruncatedTerm { get; set; }
         public long FirstEntryIndex { get; set; }
         public long LastLogEntryIndex { get; set; }
-        public IEnumerable<RachisConsensus.RachisDebugLogEntry> Logs { get; set; }
+        public UnrecoverableClusterError CriticalError { get; set; }
+        public IEnumerable<RachisDebugLogEntry> Logs { get; set; }
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
@@ -26,6 +28,7 @@ namespace Raven.Server.Rachis
                 [nameof(LastTruncatedTerm)] = LastTruncatedTerm,
                 [nameof(FirstEntryIndex)] = FirstEntryIndex,
                 [nameof(LastLogEntryIndex)] = LastLogEntryIndex,
+                [nameof(CriticalError)] = CriticalError,
                 [nameof(Logs)] = new DynamicJsonArray(Logs)
             };
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19234

### Additional description

Add critical error & connection exceptions to cluster view EP

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
