### PR TITLE
RavenDB-22835 : fix corruption in counters data

### DIFF
--- a/src/Raven.Server/Documents/CountersRepairTask.cs
+++ b/src/Raven.Server/Documents/CountersRepairTask.cs
@@ -11,7 +11,7 @@ using Voron.Data.Tables;
 
 namespace Raven.Server.Documents;
 
-public class FixCorruptedCountersTask
+public class CountersRepairTask
 {
     private readonly DocumentDatabase _database;
 
@@ -19,10 +19,10 @@ public class FixCorruptedCountersTask
 
     public static string Completed = string.Empty;
 
-    public FixCorruptedCountersTask(DocumentDatabase database)
+    public CountersRepairTask(DocumentDatabase database)
     {
         _database = database;
-        _logger = LoggingSource.Instance.GetLogger<FixCorruptedCountersTask>(_database.Name);
+        _logger = LoggingSource.Instance.GetLogger<CountersRepairTask>(_database.Name);
     }
 
     public async Task Start(string lastProcessedKey)
@@ -128,7 +128,7 @@ public class FixCorruptedCountersTask
         using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext writeCtx))
         using (var tx = writeCtx.OpenWriteTransaction())
         {
-            _database.DocumentsStorage.SetFixCountersLastKey(writeCtx, Completed);
+            _database.DocumentsStorage.SetLastFixedCounterKey(writeCtx, Completed);
             tx.Commit();
         }
     }

--- a/src/Raven.Server/Documents/CountersRepairTask.cs
+++ b/src/Raven.Server/Documents/CountersRepairTask.cs
@@ -1,27 +1,33 @@
-﻿using Raven.Server.ServerWide.Context;
-using Sparrow.Server.Utils;
+﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Binary;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Logging;
+using Sparrow.Server.Utils;
 using Voron;
 using Voron.Data.Tables;
+using static Raven.Server.Documents.CountersStorage;
+using static Raven.Server.Documents.DocumentsStorage;
 
 namespace Raven.Server.Documents;
 
 public class CountersRepairTask
 {
     private readonly DocumentDatabase _database;
-
+    private readonly CancellationToken _cancellationToken;
     private readonly Logger _logger;
 
     public static string Completed = string.Empty;
 
-    public CountersRepairTask(DocumentDatabase database)
+    public CountersRepairTask(DocumentDatabase database, CancellationToken databaseShutdown)
     {
         _database = database;
+        _cancellationToken = databaseShutdown;
         _logger = LoggingSource.Instance.GetLogger<CountersRepairTask>(_database.Name);
     }
 
@@ -41,10 +47,12 @@ public class CountersRepairTask
         {
             while (true)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
+
                 using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var table = new Table(CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
+                    var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
 
                     while (true)
                     {
@@ -52,9 +60,11 @@ public class CountersRepairTask
 
                         foreach (var (_, tvh) in table.SeekByPrimaryKeyPrefix(Slices.BeforeAllKeys, startAfter: startAfterSliceHolder?.GetStartAfterSlice(context) ?? Slices.Empty, skip: 0))
                         {
+                            _cancellationToken.ThrowIfCancellationRequested();
+
                             hasMore = true;
 
-                            using (var docId = CountersStorage.ExtractDocId(context, ref tvh.Reader))
+                            using (var docId = ExtractDocId(context, ref tvh.Reader))
                             {
                                 if (docId != lastDocId)
                                 {
@@ -66,10 +76,10 @@ public class CountersRepairTask
                                     }
                                 }
 
-                                using (var data = CountersStorage.GetCounterValuesData(context, ref tvh.Reader))
+                                using (var data = GetCounterValuesData(context, ref tvh.Reader))
                                 {
-                                    data.TryGet(CountersStorage.Values, out BlittableJsonReaderObject counterValues);
-                                    data.TryGet(CountersStorage.CounterNames, out BlittableJsonReaderObject counterNames);
+                                    data.TryGet(Values, out BlittableJsonReaderObject counterValues);
+                                    data.TryGet(CounterNames, out BlittableJsonReaderObject counterNames);
 
                                     if (counterValues.Count == counterNames.Count)
                                     {
@@ -105,7 +115,6 @@ public class CountersRepairTask
                         startAfterSliceHolder?.Dispose();
                         return;
                     }
-
                 }
             }
         }
@@ -131,6 +140,136 @@ public class CountersRepairTask
             _database.DocumentsStorage.SetLastFixedCounterKey(writeCtx, Completed);
             tx.Commit();
         }
+    }
+
+    internal int FixCountersForDocuments(DocumentsOperationContext context, List<string> docIds, bool hasMore)
+    {
+        var numOfCounterGroupsFixed = 0;
+        foreach (var docId in docIds)
+        {
+            numOfCounterGroupsFixed += FixCountersForDocument(context, docId);
+        }
+
+        var lastProcessedKey = hasMore ? docIds[^1] : Completed;
+        _database.DocumentsStorage.SetLastFixedCounterKey(context, lastProcessedKey);
+
+        return numOfCounterGroupsFixed;
+    }
+
+    internal unsafe int FixCountersForDocument(DocumentsOperationContext context, string documentId)
+    {
+        List<string> allNames = null;
+        LazyStringValue collection = default;
+
+        Table writeTable = default;
+        int numOfCounterGroupFixed = 0;
+        CollectionName collectionName = default;
+        try
+        {
+            var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
+
+            using (DocumentIdWorker.GetSliceFromId(context, documentId, out Slice key, separator: SpecialChars.RecordSeparator))
+            {
+                foreach (var result in table.SeekByPrimaryKeyPrefix(key, Slices.Empty, 0))
+                {
+                    var tvr = result.Value.Reader;
+                    BlittableJsonReaderObject data;
+
+                    using (data = GetCounterValuesData(context, ref tvr))
+                    {
+                        data = data.Clone(context);
+                    }
+
+                    data.TryGet(Values, out BlittableJsonReaderObject counterValues);
+                    data.TryGet(CounterNames, out BlittableJsonReaderObject counterNames);
+
+                    if (counterValues.Count == counterNames.Count)
+                    {
+                        var counterValuesPropertyNames = counterValues.GetSortedPropertyNames();
+                        var counterNamesPropertyNames = counterNames.GetSortedPropertyNames();
+                        if (counterValuesPropertyNames.SequenceEqual(counterNamesPropertyNames))
+                            continue;
+                    }
+
+                    if (collection == null)
+                    {
+                        collection = TableValueToId(context, (int)CountersTable.Collection, ref tvr);
+                        collectionName = _database.DocumentsStorage.ExtractCollectionName(context, collection);
+
+                        writeTable = _database.DocumentsStorage.CountersStorage.GetOrCreateTable(context.Transaction.InnerTransaction, CountersSchema, collectionName, CollectionTableType.CounterGroups);
+                    }
+
+                    BlittableJsonReaderObject.PropertyDetails prop = default;
+                    var originalNames = new DynamicJsonValue();
+
+                    for (int i = 0; i < counterValues.Count; i++)
+                    {
+                        counterValues.GetPropertyByIndex(i, ref prop);
+
+                        var lowerCasedCounterName = prop.Name;
+                        if (counterNames.TryGet(lowerCasedCounterName, out string counterNameToUse) == false)
+                        {
+                            // CounterGroup document is corrupted - missing counter name
+                            allNames ??= _database.DocumentsStorage.CountersStorage.GetCountersForDocument(context, documentId).ToList();
+                            var location = allNames.BinarySearch(lowerCasedCounterName, StringComparer.OrdinalIgnoreCase);
+
+                            // if we don't have the counter name in its original casing - we'll use the lowered-case name instead
+                            counterNameToUse = location < 0
+                                ? lowerCasedCounterName
+                                : allNames[location];
+                        }
+
+                        originalNames[lowerCasedCounterName] = counterNameToUse;
+                    }
+
+                    data.Modifications = new DynamicJsonValue(data)
+                    {
+                        [CounterNames] = originalNames
+                    };
+
+                    using (var old = data)
+                    {
+                        data = context.ReadObject(data, documentId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                    }
+
+                    // we're using the same change vector and etag here, in order to avoid replicating
+                    // the counter group to other nodes (each node should fix its counters locally)
+                    using var changeVector = TableValueToString(context, (int)CountersTable.ChangeVector, ref tvr);
+                    var groupEtag = TableValueToEtag((int)CountersTable.Etag, ref tvr);
+
+                    using (var counterGroupKey = TableValueToString(context, (int)CountersTable.CounterKey, ref tvr))
+                    using (context.Allocator.Allocate(counterGroupKey.Size, out var buffer))
+                    {
+                        counterGroupKey.CopyTo(buffer.Ptr);
+
+                        using (var clonedKey = context.AllocateStringValue(null, buffer.Ptr, buffer.Length))
+                        using (Slice.External(context.Allocator, clonedKey, out var countersGroupKey))
+                        using (Slice.From(context.Allocator, changeVector, out var cv))
+                        using (DocumentIdWorker.GetStringPreserveCase(context, collectionName.Name, out Slice collectionSlice))
+                        using (writeTable.Allocate(out TableValueBuilder tvb))
+                        {
+                            tvb.Add(countersGroupKey);
+                            tvb.Add(Bits.SwapBytes(groupEtag));
+                            tvb.Add(cv);
+                            tvb.Add(data.BasePointer, data.Size);
+                            tvb.Add(collectionSlice);
+                            tvb.Add(context.GetTransactionMarker());
+
+                            writeTable.Set(tvb);
+                        }
+                    }
+
+                    numOfCounterGroupFixed++;
+                }
+            }
+        }
+        finally
+        {
+            collection?.Dispose();
+        }
+
+        return numOfCounterGroupFixed;
+
     }
 
     private class StartAfterSliceHolder : IDisposable
@@ -167,7 +306,7 @@ public class CountersRepairTask
         }
     }
 
-    public class ExecuteFixCounterGroupsCommand : TransactionOperationsMerger.MergedTransactionCommand
+    private class ExecuteFixCounterGroupsCommand : TransactionOperationsMerger.MergedTransactionCommand
     {
         private readonly List<string> _docIds;
         private readonly bool _hasMore;
@@ -182,7 +321,7 @@ public class CountersRepairTask
 
         protected override long ExecuteCmd(DocumentsOperationContext context)
         {
-            var numOfCounterGroupFixed = _database.DocumentsStorage.CountersStorage.FixCountersForDocuments(context, _docIds, _hasMore);
+            var numOfCounterGroupFixed = _database.CountersRepairTask.FixCountersForDocuments(context, _docIds, _hasMore);
             return numOfCounterGroupFixed;
         }
 

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -1463,6 +1463,15 @@ namespace Raven.Server.Documents
                 existingCount = existingCounter.Length / SizeOfCounterValues;
             }
 
+            if (existingCount == 0 && sourceCount == 0)
+            {
+                // RavenDB-22835
+                // incoming counter has blob.Length = 0, but we still need to merge it
+                // otherwise we'll have the counter name in '@names' without having the counter value in '@values'
+
+                modified = true;
+            }
+
             if (modified)
             {
                 if (changeType == CounterChangeTypes.None)

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -1169,8 +1169,8 @@ namespace Raven.Server.Documents
                 numOfCounterGroupsFixed += FixCountersForDocument(context, docId);
             }
 
-            var lastProcessedKey = hasMore ? docIds[^1] : FixCorruptedCountersTask.Completed;
-            _documentsStorage.SetFixCountersLastKey(context, lastProcessedKey);
+            var lastProcessedKey = hasMore ? docIds[^1] : CountersRepairTask.Completed;
+            _documentsStorage.SetLastFixedCounterKey(context, lastProcessedKey);
 
             return numOfCounterGroupsFixed;
         }

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -1161,15 +1161,16 @@ namespace Raven.Server.Documents
             }
         }
 
-
-
-        public int FixCountersForDocuments(DocumentsOperationContext context, List<string> docIds)
+        public int FixCountersForDocuments(DocumentsOperationContext context, List<string> docIds, bool hasMore)
         {
             var numOfCounterGroupsFixed = 0;
             foreach (var docId in docIds)
             {
                 numOfCounterGroupsFixed += FixCountersForDocument(context, docId);
             }
+
+            var lastProcessedKey = hasMore ? docIds[^1] : FixCorruptedCountersTask.Completed;
+            _documentsStorage.SetFixCountersLastKey(context, lastProcessedKey);
 
             return numOfCounterGroupsFixed;
         }

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Exceptions.Documents.Counters;
@@ -22,6 +23,8 @@ using Voron;
 using Voron.Data.Tables;
 using Voron.Impl;
 using static Raven.Server.Documents.DocumentsStorage;
+using static Raven.Server.Documents.Handlers.CountersHandler;
+using static Raven.Server.Utils.MetricCacher.Keys;
 using Constants = Raven.Client.Constants;
 using Memory = Sparrow.Memory;
 
@@ -1178,6 +1181,8 @@ namespace Raven.Server.Documents
                 _dictionariesPool.Free(entriesToUpdate);
             }
         }
+
+
 
         public int FixCountersForDocuments(DocumentsOperationContext context, List<string> docIds)
         {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -201,7 +201,7 @@ namespace Raven.Server.Documents
                 });
                 _hasClusterTransaction = new ManualResetEventSlim(false);
                 IdentityPartsSeparator = '/';
-                CountersRepairTask = new CountersRepairTask(this);
+                CountersRepairTask = new CountersRepairTask(this, DatabaseShutdown);
             }
             catch (Exception)
             {
@@ -395,7 +395,7 @@ namespace Raven.Server.Documents
 
                     var lastCounterFixed = DocumentsStorage.ReadLastFixedCounterKey(ctx.Transaction.InnerTransaction);
                     if (lastCounterFixed != CountersRepairTask.Completed)
-                        _ = Task.Run(() => CountersRepairTask.Start(lastCounterFixed), DatabaseShutdown);
+                        _ = Task.Run(() => CountersRepairTask.Start(lastCounterFixed));
                 }
 
                 _ = Task.Run(async () =>

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -201,6 +201,7 @@ namespace Raven.Server.Documents
                 });
                 _hasClusterTransaction = new ManualResetEventSlim(false);
                 IdentityPartsSeparator = '/';
+                FixCorruptedCountersTask = new FixCorruptedCountersTask(this);
             }
             catch (Exception)
             {
@@ -285,6 +286,8 @@ namespace Raven.Server.Documents
         public ClientConfiguration ClientConfiguration { get; private set; }
 
         public StudioConfiguration StudioConfiguration { get; private set; }
+
+        public FixCorruptedCountersTask FixCorruptedCountersTask { get; private set; }
 
         public bool Is32Bits { get; }
 
@@ -390,6 +393,8 @@ namespace Raven.Server.Documents
                     var lastCompletedClusterTransactionIndex = DocumentsStorage.ReadLastCompletedClusterTransactionIndex(ctx.Transaction.InnerTransaction);
                     ClusterWideTransactionIndexWaiter.SetAndNotifyListenersIfHigher(lastCompletedClusterTransactionIndex);
                 }
+
+                FixCorruptedCountersTask.Start();
 
                 _ = Task.Run(async () =>
                 {

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -757,7 +757,7 @@ namespace Raven.Server.Documents
                 tree.Add(LastCompletedClusterTransactionIndexSlice, indexSlice);
         }
 
-        public static string ReadFixCountersLastKey(Transaction tx)
+        public static string ReadLastFixedCounterKey(Transaction tx)
         {
             if (tx == null)
                 throw new InvalidOperationException("No active transaction found in the context, and at least read transaction is needed");
@@ -768,7 +768,7 @@ namespace Raven.Server.Documents
             return Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length);
         }
 
-        public void SetFixCountersLastKey(DocumentsOperationContext context, string lastKey)
+        public void SetLastFixedCounterKey(DocumentsOperationContext context, string lastKey)
         {
             var tree = context.Transaction.InnerTransaction.ReadTree(GlobalTreeSlice);
             using (Slice.From(context.Allocator, lastKey, out var slice))

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -764,30 +764,18 @@ namespace Raven.Server.Documents
             var tree = tx.ReadTree(GlobalTreeSlice);
             var val = tree.Read(FixCountersLastKeySlice);
             if (val == null)
-            {
-                return string.Empty;
-            }
+                return null;
             return Encodings.Utf8.GetString(val.Reader.Base, val.Reader.Length);
         }
 
         public void SetFixCountersLastKey(DocumentsOperationContext context, string lastKey)
         {
-            try
+            var tree = context.Transaction.InnerTransaction.ReadTree(GlobalTreeSlice);
+            using (Slice.From(context.Allocator, lastKey, out var slice))
             {
-                var tree = context.Transaction.InnerTransaction.ReadTree(GlobalTreeSlice);
-                using (Slice.From(context.Allocator, lastKey, out var slice))
-                {
-                    tree.Add(FixCountersLastKeySlice, slice);
-                }
+                tree.Add(FixCountersLastKeySlice, slice);
             }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                throw;
-            }
-
         }
-
 
         public IEnumerable<Document> GetDocumentsStartingWith(DocumentsOperationContext context, string idPrefix, string startAfterId,
             long start, long take, string collection, Reference<long> skippedResults, DocumentFields fields = DocumentFields.All, CancellationToken token = default)

--- a/src/Raven.Server/Documents/FixCorruptedCountersTask.cs
+++ b/src/Raven.Server/Documents/FixCorruptedCountersTask.cs
@@ -1,0 +1,190 @@
+﻿using Raven.Server.ServerWide.Context;
+using Sparrow.Server.Utils;
+using static Raven.Server.Documents.Handlers.CountersHandler;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+using System.Linq;
+using Sparrow.Json;
+using Sparrow.Logging;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents;
+
+public class FixCorruptedCountersTask
+{
+    private readonly DocumentDatabase _database;
+
+    private string _lastProcessedKey;
+    private readonly Logger _logger;
+
+    private const string Completed = "Completed";
+
+    public FixCorruptedCountersTask(DocumentDatabase database)
+    {
+        _database = database;
+        _logger = LoggingSource.Instance.GetLogger<DocumentDatabase>(_database.Name);
+    }
+
+    public void Start()
+    {
+        using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
+        using (var tx = documentsContext.OpenReadTransaction())
+        {
+            _lastProcessedKey = DocumentsStorage.ReadFixCountersLastKey(tx.InnerTransaction);
+            if (_lastProcessedKey == Completed)
+                return; // completed
+        }
+
+        _ = Task.Run(ExecuteFixCountersTask);
+    }
+
+    private async Task ExecuteFixCountersTask()
+    {
+        const int maxNumberOfDocsToFixInSingleTx = 1024;
+        List<string> docIdsToFix = [];
+        StartAfterSliceHolder startAfterSliceHolder = null;
+        string lastDocId = null;
+
+        if (string.IsNullOrEmpty(_lastProcessedKey) == false)
+        {
+            startAfterSliceHolder = new StartAfterSliceHolder(_lastProcessedKey);
+        }
+
+        try
+        {
+            while (true)
+            {
+                using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var table = new Table(CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
+
+                    while (true)
+                    {
+                        bool hasMore = false;
+
+                        foreach (var (_, tvh) in table.SeekByPrimaryKeyPrefix(Slices.BeforeAllKeys,
+                                     startAfter: startAfterSliceHolder?.GetStartAfterSlice(context) ?? Slices.Empty, skip: 0))
+                        {
+                            hasMore = true;
+
+                            using (var docId = CountersStorage.ExtractDocId(context, ref tvh.Reader))
+                            {
+                                if (docId != lastDocId)
+                                {
+                                    lastDocId = docId;
+
+                                    using (var old = startAfterSliceHolder)
+                                    {
+                                        startAfterSliceHolder = new StartAfterSliceHolder(lastDocId);
+                                    }
+                                }
+
+                                using (var data = CountersStorage.GetCounterValuesData(context, ref tvh.Reader))
+                                {
+                                    data.TryGet(CountersStorage.Values, out BlittableJsonReaderObject counterValues);
+                                    data.TryGet(CountersStorage.CounterNames, out BlittableJsonReaderObject counterNames);
+
+                                    if (counterValues.Count == counterNames.Count)
+                                    {
+                                        var counterValuesPropertyNames = counterValues.GetSortedPropertyNames();
+                                        var counterNamesPropertyNames = counterNames.GetSortedPropertyNames();
+                                        if (counterValuesPropertyNames.SequenceEqual(counterNamesPropertyNames))
+                                            continue;
+                                    }
+                                }
+
+                                // Document is corrupted; add to list and break to skip remaining CounterGroups of current document
+                                docIdsToFix.Add(lastDocId);
+
+                                break;
+                            }
+                        }
+
+                        if (docIdsToFix.Count == 0)
+                        {
+                            //_database.DocumentsStorage.SetFixCountersLastKey(context, Completed);
+                            SaveLastProcessedKey(Completed);
+                            return;
+                        }
+
+                        if (docIdsToFix.Count < maxNumberOfDocsToFixInSingleTx && hasMore)
+                            continue;
+
+                        await _database.TxMerger.Enqueue(new ExecuteFixCounterGroupsCommand(_database, docIdsToFix));
+                        docIdsToFix.Clear();
+
+                        if (hasMore)
+                        {
+                            SaveLastProcessedKey(lastDocId);
+                            break; // break from inner while loop in order to open a new read tx
+                        }
+
+                        SaveLastProcessedKey(Completed);
+                        startAfterSliceHolder?.Dispose();
+                        return;
+                    }
+
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            if (_logger.IsInfoEnabled)
+            {
+                _logger.Info($"An Error occured while executing FixCorruptedCountersTask. Last DocId : '{lastDocId}'", e);
+            }
+
+        }
+        finally
+        {
+            startAfterSliceHolder?.Dispose();
+        }
+    }
+
+    private void SaveLastProcessedKey(string lastDocId)
+    {
+        using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext writeCtx))
+        using (var tx = writeCtx.OpenWriteTransaction())
+        {
+            _database.DocumentsStorage.SetFixCountersLastKey(writeCtx, lastDocId);
+            tx.Commit();
+        }
+    }
+
+    private class StartAfterSliceHolder : IDisposable
+    {
+        private readonly string _docId;
+
+        private readonly List<IDisposable> _toDispose = [];
+
+        public StartAfterSliceHolder(string docId)
+        {
+            _docId = docId;
+        }
+
+        public void Dispose()
+        {
+            foreach (var scope in _toDispose)
+            {
+                scope.Dispose();
+            }
+
+            _toDispose.Clear();
+        }
+
+        public unsafe Slice GetStartAfterSlice(DocumentsOperationContext context)
+        {
+            _toDispose.Add(DocumentIdWorker.GetSliceFromId(context, _docId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator));
+            _toDispose.Add(context.Allocator.Allocate(documentKeyPrefix.Size + sizeof(long), out var startAfterBuffer));
+            _toDispose.Add(Slice.External(context.Allocator, startAfterBuffer.Ptr, startAfterBuffer.Length, out var startAfter));
+
+            documentKeyPrefix.CopyTo(startAfterBuffer.Ptr);
+            *(long*)(startAfterBuffer.Ptr + documentKeyPrefix.Size) = long.MaxValue;
+
+            return startAfter;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/FixCorruptedCountersTask.cs
+++ b/src/Raven.Server/Documents/FixCorruptedCountersTask.cs
@@ -187,4 +187,32 @@ public class FixCorruptedCountersTask
             return startAfter;
         }
     }
+
+    public class ExecuteFixCounterGroupsCommand : TransactionOperationsMerger.MergedTransactionCommand
+    {
+        private readonly List<string> _docIds;
+        private readonly DocumentDatabase _database;
+
+
+        public ExecuteFixCounterGroupsCommand(DocumentDatabase database, string docId) : this(database, [docId])
+        {
+        }
+
+        public ExecuteFixCounterGroupsCommand(DocumentDatabase database, List<string> docIdsToFix)
+        {
+            _docIds = docIdsToFix;
+            _database = database;
+        }
+
+        protected override long ExecuteCmd(DocumentsOperationContext context)
+        {
+            var numOfCounterGroupFixed = _database.DocumentsStorage.CountersStorage.FixCountersForDocuments(context, _docIds);
+            return numOfCounterGroupFixed;
+        }
+
+        public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -400,20 +400,10 @@ namespace Raven.Server.Documents.Handlers
 
                 foreach (var cgd in _counterGroups)
                 {
-                    try
+                    using (cgd.Values)
                     {
-
-                        using (cgd.Values)
-                        {
-                            PutCounters(context, cgd);
-                        }
+                        PutCounters(context, cgd);
                     }
-                    catch (Exception e)
-                    {
-                        Console.WriteLine(e);
-                        throw;
-                    }
-
                 }
 
                 UpdateDocumentsMetadata(context);

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -7,28 +7,21 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Changes;
-using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.Exceptions.Documents.Counters;
-using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.TrafficWatch;
 using Raven.Server.Utils;
-using Voron.Data.Tables;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
-using Voron;
-using System.Linq;
-using Sparrow.Server.Utils;
 
 namespace Raven.Server.Documents.Handlers
 {
@@ -761,232 +754,6 @@ namespace Raven.Server.Documents.Handlers
         {
             throw new DocumentDoesNotExistException(docId, "Cannot operate on counters of a missing document.");
         }
-
-        public class ExecuteFixCounterGroupsCommand : TransactionOperationsMerger.MergedTransactionCommand
-        {
-            private readonly List<string> _docIds;
-            private readonly DocumentDatabase _database;
-
-
-            public ExecuteFixCounterGroupsCommand(DocumentDatabase database, string docId) : this(database, [docId])
-            {
-            }
-
-            public ExecuteFixCounterGroupsCommand(DocumentDatabase database, List<string> docIdsToFix)
-            {
-                _docIds = docIdsToFix;
-                _database = database;
-            }
-
-            protected override long ExecuteCmd(DocumentsOperationContext context)
-            {
-                var numOfCounterGroupFixed = _database.DocumentsStorage.CountersStorage.FixCountersForDocuments(context, _docIds);
-                return numOfCounterGroupFixed;
-            }
-
-            public override TransactionOperationsMerger.IReplayableCommandDto<TransactionOperationsMerger.MergedTransactionCommand> ToDto<TTransaction>(TransactionOperationContext<TTransaction> context)
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        [RavenAction("/databases/*/counters/fix-document", "PATCH", AuthorizationStatus.ValidUser, EndpointType.Write)]
-        public async Task FixCounterGroupsForDocument()
-        {
-            var docId = GetStringQueryString("id");
-            await FixCounterGroupsInternal(docId);
-        }
-
-        [RavenAction("/databases/*/counters/fix", "PATCH", AuthorizationStatus.ValidUser, EndpointType.Write)]
-        public async Task FixCounterGroupsForDatabase() => await FixCounterGroupsInternal();
-
-        private async Task FixCounterGroupsInternal(string id = null)
-        {
-            var first = GetBoolValueQueryString("first", required: false) ?? true;
-
-            Task task = id == null
-                ? FixAllCounterGroups()
-                : Database.TxMerger.Enqueue(new ExecuteFixCounterGroupsCommand(Database, id));
-
-            if (first == false)
-            {
-                await task;
-                return;
-            }
-
-            var tasks = new List<Task> { task };
-            var toDispose = new List<IDisposable>();
-            try
-            {
-                using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (context.OpenReadTransaction())
-                {
-                    foreach (var node in ServerStore.GetClusterTopology(context).AllNodes)
-                    {
-                        if (node.Value == Server.WebUrl)
-                            continue;
-
-                        var requestExecutor = ClusterRequestExecutor.CreateForShortTermUse(node.Value, Server.Certificate.Certificate, DocumentConventions.DefaultForServer);
-                        toDispose.Add(requestExecutor);
-
-                        var cmd = new FixCounterGroupsCommand(Database.Name);
-
-                        toDispose.Add(requestExecutor.ContextPool.AllocateOperationContext(out JsonOperationContext ctx));
-                        tasks.Add(requestExecutor.ExecuteAsync(cmd, ctx));
-                    }
-                }
-
-                await Task.WhenAll(tasks);
-            }
-            finally
-            {
-                foreach (var disposable in toDispose)
-                {
-                    disposable.Dispose();
-                }
-            }
-        }
-
-        private async Task FixAllCounterGroups()
-        {
-            const int maxNumberOfDocsToFixInSingleTx = 1024;
-            List<string> docIdsToFix = new();
-            StartAfterSliceHolder startAfterSliceHolder = null;
-            string lastDocId = null;
-
-            try
-            {
-                while (true)
-                {
-                    using (Database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                    using (context.OpenReadTransaction())
-                    {
-                        var table = new Table(CountersStorage.CountersSchema, context.Transaction.InnerTransaction);
-
-                        while (true)
-                        {
-                            bool hasMore = false;
-
-                            foreach (var (_, tvh) in table.SeekByPrimaryKeyPrefix(Slices.BeforeAllKeys, startAfter: startAfterSliceHolder?.GetStartAfterSlice(context) ?? Slices.Empty, skip: 0))
-                            {
-                                hasMore = true;
-
-                                using (var docId = CountersStorage.ExtractDocId(context, ref tvh.Reader))
-                                {
-                                    if (docId != lastDocId)
-                                    {
-                                        lastDocId = docId;
-
-                                        using (var old = startAfterSliceHolder)
-                                        {
-                                            startAfterSliceHolder = new StartAfterSliceHolder(lastDocId);
-                                        }
-                                    }
-
-                                    using (var data = CountersStorage.GetCounterValuesData(context, ref tvh.Reader))
-                                    {
-                                        data.TryGet(CountersStorage.Values, out BlittableJsonReaderObject counterValues);
-                                        data.TryGet(CountersStorage.CounterNames, out BlittableJsonReaderObject counterNames);
-
-                                        if (counterValues.Count == counterNames.Count)
-                                        {
-                                            var counterValuesPropertyNames = counterValues.GetSortedPropertyNames();
-                                            var counterNamesPropertyNames = counterNames.GetSortedPropertyNames();
-                                            if (counterValuesPropertyNames.SequenceEqual(counterNamesPropertyNames))
-                                                continue;
-                                        }
-                                    }
-
-                                    // Document is corrupted; add to list and break to skip remaining CounterGroups of current document
-                                    docIdsToFix.Add(lastDocId);
-
-                                    break;
-                                }
-                            }
-
-                            if (docIdsToFix.Count == 0)
-                                return;
-
-                            if (docIdsToFix.Count < maxNumberOfDocsToFixInSingleTx && hasMore)
-                                continue;
-
-                            await Database.TxMerger.Enqueue(new ExecuteFixCounterGroupsCommand(Database, docIdsToFix));
-                            docIdsToFix.Clear();
-
-                            if (hasMore)
-                                break;  // break from inner while loop in order to open a new read tx
-
-                            startAfterSliceHolder?.Dispose();
-                            return;
-                        }
-
-                    }
-                }
-            }
-            finally
-            {
-                startAfterSliceHolder?.Dispose();
-            }
-        }
-
-
-        private class StartAfterSliceHolder : IDisposable
-        {
-            private readonly string _docId;
-
-            private readonly List<IDisposable> _toDispose = [];
-
-
-            public StartAfterSliceHolder(string docId)
-            {
-                _docId = docId;
-            }
-
-            public void Dispose()
-            {
-                foreach (var scope in _toDispose)
-                {
-                    scope.Dispose();
-                }
-
-                _toDispose.Clear();
-            }
-
-            public unsafe Slice GetStartAfterSlice(DocumentsOperationContext context)
-            {
-                _toDispose.Add(DocumentIdWorker.GetSliceFromId(context, _docId, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator));
-                _toDispose.Add(context.Allocator.Allocate(documentKeyPrefix.Size + sizeof(long), out var startAfterBuffer));
-                _toDispose.Add(Slice.External(context.Allocator, startAfterBuffer.Ptr, startAfterBuffer.Length, out var startAfter));
-
-                documentKeyPrefix.CopyTo(startAfterBuffer.Ptr);
-                *(long*)(startAfterBuffer.Ptr + documentKeyPrefix.Size) = long.MaxValue;
-
-                return startAfter;
-            }
-        }
-
-        private class FixCounterGroupsCommand : RavenCommand
-        {
-            private readonly string _database;
-
-            public FixCounterGroupsCommand(string database)
-            {
-                _database = database;
-            }
-
-            public override bool IsReadRequest => false;
-
-            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-            {
-                url = $"{node.Url}/databases/{_database}/counters/fix?first=false";
-
-                return new HttpRequestMessage
-                {
-                    Method = HttpMethod.Patch
-                };
-            }
-        }
-
     }
 
     public class ExecuteCounterBatchCommandDto : TransactionOperationsMerger.IReplayableCommandDto<CountersHandler.ExecuteCounterBatchCommand>

--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -425,8 +426,11 @@ namespace Raven.Server.Documents.Handlers
 
             private static void CheckForDataCorruption(DocumentsOperationContext context, CounterGroupDetail counterGroup, Document doc)
             {
-                counterGroup.Values.TryGet(Values, out BlittableJsonReaderObject counterValues);
-                counterGroup.Values.TryGet(CounterNames, out BlittableJsonReaderObject counterNames);
+                if (counterGroup.Values.TryGet(Values, out BlittableJsonReaderObject counterValues) == false)
+                    throw new InvalidDataException($"Counter-group of document '{counterGroup.DocumentId}' is missing '{Values}' property");
+
+                if (counterGroup.Values.TryGet(CounterNames, out BlittableJsonReaderObject counterNames) == false)
+                    return; // legacy counters
 
                 if (counterValues.Count == counterNames.Count && 
                     counterValues.GetSortedPropertyNames().SequenceEqual(counterNames.GetSortedPropertyNames()))

--- a/test/SlowTests/Issues/RavenDB_22835.cs
+++ b/test/SlowTests/Issues/RavenDB_22835.cs
@@ -1,0 +1,558 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Http;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Binary;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Utils;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Tables;
+using Xunit;
+using Xunit.Abstractions;
+using static Raven.Server.Documents.CountersStorage;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22835 : ClusterTestBase
+    {
+        public RavenDB_22835(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task SplittingCountersManyTimes_ShouldNotCauseErrorsDuringImport()
+        {
+            var rand = new Random(12345);
+            const string id = "users/1";
+
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User(), id);
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var countersFor = session.CountersFor(id);
+
+                for (int j = 0; j < 100; j++)
+                {
+                    var strSize = (int)rand.NextInt64(5, 15);
+                    var s = GenRandomString(rand, strSize);
+
+                    countersFor.Increment(s, j);
+                }
+
+                session.SaveChanges();
+            }
+
+            // starting import 1
+            Console.WriteLine("starting import 1");
+
+            var temp1 = GetTempFileName();
+            var export = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), temp1);
+            await export.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+            using var store2 = GetDocumentStore();
+            var import = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), temp1);
+            await import.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+            // import 1 went well, now adding more counters to this doc
+            Console.WriteLine("import 1 went well, now adding more counters to this doc ");
+
+            AddMoreCountersForDoc(store2, rand, id);
+
+            // starting import 2
+            Console.WriteLine("starting import 2");
+
+            var temp2 = GetTempFileName();
+            export = await store2.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), temp2);
+            await export.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+            using var store3 = GetDocumentStore();
+            import = await store3.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), temp2);
+            await import.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+            // import 2 went well, now adding more counters to this doc
+            Console.WriteLine("import 2 went well, now adding more counters to this doc ");
+
+            AddMoreCountersForDoc(store3, rand, id);
+
+            // all good - no exception was thrown during imports or when adding new counters
+            Console.WriteLine("all good");
+        }
+
+        [Fact]
+        public async Task FixCorruptedCounterData()
+        {
+            var rand = new Random(12345);
+            const string id = "users/1";
+
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User(), id);
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var countersFor = session.CountersFor(id);
+
+                for (int j = 0; j < 100; j++)
+                {
+                    var strSize = (int)rand.NextInt64(5, 15);
+                    var s = GenRandomString(rand, strSize);
+
+                    countersFor.Increment(s, j);
+                }
+
+                session.SaveChanges();
+            }
+
+            var temp1 = GetTempFileName();
+            var export = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), temp1);
+            await export.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+            using var store2 = GetDocumentStore();
+            var import = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), temp1);
+            await import.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+            var db = await GetDatabase(store.Database);
+
+            // deliberately corrupt counters group data
+            CorruptCountersData(db);
+            
+            AddMoreCountersForDoc(store2, rand, id);
+
+            // verify that counters data is corrupted - we're missing a counter name
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var counterGroup = (CounterReplicationItem)db.DocumentsStorage.CountersStorage.GetCountersFrom(context, etag: 0).First();
+                Assert.True(counterGroup.Values.TryGet(Values, out BlittableJsonReaderObject counterValues));
+                Assert.True(counterGroup.Values.TryGet(CounterNames, out BlittableJsonReaderObject counterNames));
+
+                Assert.NotEqual(counterValues.Count, counterNames.Count);
+
+                BlittableJsonReaderObject.PropertyDetails p = default;
+                counterValues.GetPropertyByIndex(0, ref p);
+                var firstCounter = p.Name;
+
+                Assert.False(counterNames.TryGet(firstCounter, out string _));
+            }
+
+            // call FixCounters tool
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (var tx = context.OpenWriteTransaction())
+            {
+                var numOfFixes = db.DocumentsStorage.CountersStorage.FixCountersForDocument(context, id);
+                Assert.Equal(1, numOfFixes);
+
+                tx.Commit();
+            }
+
+            // calling FixCounters tool again should return 0 - no CounterGroup was fixed
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (var tx = context.OpenWriteTransaction())
+            {
+                var numOfFixes = db.DocumentsStorage.CountersStorage.FixCountersForDocument(context, id);
+                Assert.Equal(0, numOfFixes);
+            }
+
+            // assert that counters data is fixed
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var counterGroups = db.DocumentsStorage.CountersStorage.GetCountersFrom(context, etag: 0);
+
+                foreach (var item in counterGroups)
+                {
+                    var counterGroup = item as CounterReplicationItem;
+                    Assert.NotNull(counterGroup);
+
+                    Assert.True(counterGroup.Values.TryGet(Values, out BlittableJsonReaderObject counterValues));
+                    Assert.True(counterGroup.Values.TryGet(CounterNames, out BlittableJsonReaderObject counterNames));
+
+                    Assert.Equal(counterValues.Count, counterNames.Count);
+
+                    BlittableJsonReaderObject.PropertyDetails p1 = default, p2 = default;
+                    for (int i = 0; i < counterValues.Count; i++)
+                    {
+                        counterValues.GetPropertyByIndex(i, ref p1);
+                        counterNames.GetPropertyByIndex(i, ref p2);
+
+                        Assert.Equal(p1.Name, p2.Name);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task FixCorruptedCounterData_InCluster()
+        {
+            var rand = new Random(12345);
+            const string id = "users/1";
+
+            var cluster = await CreateRaftCluster(numberOfNodes: 3, watcherCluster: true);
+            var dbName = GetDatabaseName();
+            await CreateDatabaseInCluster(dbName, replicationFactor: 3, cluster.Leader.WebUrl);
+
+            using var leaderStore = GetDocumentStore(new Options
+            {
+                CreateDatabase = false,
+                Server = cluster.Leader,
+                ModifyDatabaseName = _ => dbName,
+                ModifyDocumentStore = s => s.Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
+            });
+
+            using (var session = leaderStore.OpenSession())
+            {
+                session.Store(new User(), id);
+                session.SaveChanges();
+            }
+
+            using (var session = leaderStore.OpenSession())
+            {
+                var countersFor = session.CountersFor(id);
+
+                for (int j = 0; j < 100; j++)
+                {
+                    var strSize = (int)rand.NextInt64(5, 15);
+                    var s = GenRandomString(rand, strSize);
+
+                    countersFor.Increment(s, j);
+                }
+
+                session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
+                session.SaveChanges();
+            }
+
+            var nodeB = cluster.Nodes.First(x => x != cluster.Leader);
+
+            using var storeB = GetDocumentStore(new Options
+            {
+                CreateDatabase = false,
+                Server = nodeB,
+                ModifyDatabaseName = _ => dbName,
+                ModifyDocumentStore = s => s.Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
+            });
+
+            AddMoreCountersForDoc(storeB, rand, id, numOfIterations: 10, replicas: 2);
+
+            var nodeC = cluster.Nodes.Single(x => x != cluster.Leader && x != nodeB);
+
+            using var storeC = GetDocumentStore(new Options
+            {
+                CreateDatabase = false,
+                Server = nodeC,
+                ModifyDatabaseName = _ => dbName,
+                ModifyDocumentStore = s => s.Conventions = new DocumentConventions
+                {
+                    DisableTopologyUpdates = true
+                }
+            });
+
+            AddMoreCountersForDoc(storeC, rand, id, numOfIterations: 10, replicas: 2);
+
+            foreach (var node in cluster.Nodes)
+            {
+                var db = await GetDatabase(node, dbName);
+
+                // deliberately corrupt counters group data on each node
+                CorruptCountersData(db);
+
+                // verify that counters data is corrupted - we're missing a counter name
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var counterGroup = (CounterReplicationItem)db.DocumentsStorage.CountersStorage.GetCountersFrom(context, etag: 0).First();
+                    Assert.True(counterGroup.Values.TryGet(Values, out BlittableJsonReaderObject counterValues));
+                    Assert.True(counterGroup.Values.TryGet(CounterNames, out BlittableJsonReaderObject counterNames));
+
+                    Assert.NotEqual(counterValues.Count, counterNames.Count);
+                    BlittableJsonReaderObject.PropertyDetails p = default;
+                    counterValues.GetPropertyByIndex(0, ref p);
+                    var firstCounter = p.Name;
+
+                    Assert.False(counterNames.TryGet(firstCounter, out string _));
+                }
+            }
+
+            // call FixCounters endpoint
+            using var requestExecutor = leaderStore.GetRequestExecutor();
+            var cmd = new FixCountersCommand();
+            using (cluster.Leader.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
+                await requestExecutor.ExecuteAsync(cmd, ctx);
+
+            // assert that counters data is fixed on all nodes
+            foreach (var node in cluster.Nodes)
+            {
+                var db = await GetDatabase(node, dbName);
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var counterGroups = db.DocumentsStorage.CountersStorage.GetCountersFrom(context, etag: 0);
+
+                    foreach (var item in counterGroups)
+                    {
+                        var counterGroup = item as CounterReplicationItem;
+                        Assert.NotNull(counterGroup);
+
+                        Assert.True(counterGroup.Values.TryGet(Values, out BlittableJsonReaderObject counterValues));
+                        Assert.True(counterGroup.Values.TryGet(CounterNames, out BlittableJsonReaderObject counterNames));
+
+                        Assert.Equal(counterValues.Count, counterNames.Count);
+
+                        BlittableJsonReaderObject.PropertyDetails p1 = default, p2 = default;
+                        for (int i = 0; i < counterValues.Count; i++)
+                        {
+                            counterValues.GetPropertyByIndex(i, ref p1);
+                            counterNames.GetPropertyByIndex(i, ref p2);
+
+                            Assert.Equal(p1.Name, p2.Name);
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task FixCorruptedCounterData_MultipleDocs()
+        {
+            var rand = new Random(12345);
+            List<string> docIdsToCorrupt = ["users/1", "users/10", "users/20", "users/100"];
+
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                for (int i = 1; i <= 100; i++)
+                {
+                    session.Store(new User(), "users/" + i);
+                }
+
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                for (int i = 1; i <= 100; i++)
+                {
+                    var countersFor = session.CountersFor("users/" + i);
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        var strSize = (int)rand.NextInt64(5, 15);
+                        var s = GenRandomString(rand, strSize);
+
+                        countersFor.Increment(s, j);
+                    }
+                }
+
+                session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
+                session.SaveChanges();
+            }
+
+            var db = await GetDatabase(store.Database);
+
+            foreach (var id in docIdsToCorrupt)
+            {
+                // deliberately corrupt counters group data
+                CorruptCountersData(db, id);
+
+                // verify that counters data is corrupted - we're missing a counter name
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var readTable = new Table(CountersSchema, context.Transaction.InnerTransaction);
+                    TableValueReader tvr;
+                    using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    {
+                        Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
+                    }
+
+                    var data = GetCounterValuesData(context, ref tvr);
+                    Assert.True(data.TryGet(Values, out BlittableJsonReaderObject counterValues));
+                    Assert.True(data.TryGet(CounterNames, out BlittableJsonReaderObject counterNames));
+
+                    Assert.NotEqual(counterValues.Count, counterNames.Count);
+                    BlittableJsonReaderObject.PropertyDetails p = default;
+                    counterValues.GetPropertyByIndex(0, ref p);
+                    var firstCounter = p.Name;
+
+                    Assert.False(counterNames.TryGet(firstCounter, out string _));
+                }
+
+                AddMoreCountersForDoc(store, rand, id, numOfIterations: 10);
+            }
+
+            // call FixCounters endpoint
+            using var requestExecutor = store.GetRequestExecutor();
+            var cmd = new FixCountersCommand();
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext ctx))
+                await requestExecutor.ExecuteAsync(cmd, ctx);
+
+            // assert that counters data was fixed in all corrupted documents
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var counterGroups = db.DocumentsStorage.CountersStorage.GetCountersFrom(context, etag: 0);
+
+                foreach (var item in counterGroups)
+                {
+                    var counterGroup = item as CounterReplicationItem;
+                    Assert.NotNull(counterGroup);
+
+                    Assert.True(counterGroup.Values.TryGet(Values, out BlittableJsonReaderObject counterValues));
+                    Assert.True(counterGroup.Values.TryGet(CounterNames, out BlittableJsonReaderObject counterNames));
+
+                    Assert.Equal(counterValues.Count, counterNames.Count);
+
+                    BlittableJsonReaderObject.PropertyDetails p1 = default, p2 = default;
+                    for (int i = 0; i < counterValues.Count; i++)
+                    {
+                        counterValues.GetPropertyByIndex(i, ref p1);
+                        counterNames.GetPropertyByIndex(i, ref p2);
+
+                        Assert.Equal(p1.Name, p2.Name);
+                    }
+                }
+            }
+        }
+
+        private unsafe void CorruptCountersData(DocumentDatabase database, string? id = null)
+        {
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var readTable = new Table(CountersSchema, context.Transaction.InnerTransaction);
+                TableValueReader tvr;
+                if (id == null)
+                {
+                    id = "users/1";
+                    tvr = readTable.ReadFirst(CountersSchema.FixedSizeIndexes[AllCountersEtagSlice]).Reader;
+                }
+                else
+                {
+                    using (DocumentIdWorker.GetSliceFromId(context, id, out Slice documentKeyPrefix, separator: SpecialChars.RecordSeparator))
+                    {
+                        Assert.True(readTable.SeekOnePrimaryKeyPrefix(documentKeyPrefix, out tvr));
+                    }
+                }
+
+                BlittableJsonReaderObject.PropertyDetails prop = default;
+                BlittableJsonReaderObject data;
+                using (data = GetCounterValuesData(context, ref tvr))
+                {
+                    data = data.Clone(context);
+                }
+
+                data.TryGet(CounterNames, out BlittableJsonReaderObject originalNames);
+
+                // remove first name from @names blittable
+                originalNames.Modifications = new DynamicJsonValue(originalNames)
+                {
+                    Removals = [0]
+                };
+
+                using (var old = data)
+                {
+                    data = context.ReadObject(data, id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                }
+
+                using var changeVector = DocumentsStorage.TableValueToString(context, (int)CountersTable.ChangeVector, ref tvr);
+                var groupEtag = DocumentsStorage.TableValueToEtag((int)CountersTable.Etag, ref tvr);
+
+                using (var counterGroupKey = DocumentsStorage.TableValueToString(context, (int)CountersTable.CounterKey, ref tvr))
+                using (context.Allocator.Allocate(counterGroupKey.Size, out var buffer))
+                {
+                    counterGroupKey.CopyTo(buffer.Ptr);
+
+                    using (var clonedKey = context.AllocateStringValue(null, buffer.Ptr, buffer.Length))
+                    using (Slice.External(context.Allocator, clonedKey, out var countersGroupKey))
+                    using (Slice.From(context.Allocator, changeVector, out var cv))
+                    using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, "Users", out _, out Slice collectionSlice))
+                    using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext writeContext))
+                    using (var tx = writeContext.OpenWriteTransaction())
+                    {
+                        var tableName = new CollectionName("Users").GetTableName(CollectionTableType.CounterGroups);
+                        var writeTable = tx.InnerTransaction.OpenTable(CountersSchema, tableName);
+                        using (writeTable.Allocate(out TableValueBuilder tvb))
+                        {
+                            tvb.Add(countersGroupKey);
+                            tvb.Add(Bits.SwapBytes(groupEtag));
+                            tvb.Add(cv);
+                            tvb.Add(data.BasePointer, data.Size);
+                            tvb.Add(collectionSlice);
+                            tvb.Add(writeContext.GetTransactionMarker());
+
+                            writeTable.Set(tvb);
+                        }
+
+                        tx.Commit();
+                    }
+                }
+            }
+        }
+
+        private static void AddMoreCountersForDoc(IDocumentStore store, Random rand, string id, int numOfIterations = 100, int replicas = 0)
+        {
+            for (int i = 0; i < numOfIterations; i++)
+            {
+                using (var session = store.OpenSession())
+                {
+                    var countersFor = session.CountersFor(id);
+
+                    for (int j = 0; j < 100; j++)
+                    {
+                        var strSize = (int)rand.NextInt64(5, 15);
+                        var counterName = GenRandomString(rand, strSize);
+
+                        countersFor.Increment(counterName, j);
+                    }
+
+                    session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(60), replicas: replicas);
+
+                    session.SaveChanges();
+                }
+            }
+        }
+
+        private class FixCountersCommand : RavenCommand
+        {
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/counters/fix";
+
+                return new HttpRequestMessage
+                {
+                    Method = HttpMethod.Patch
+                };
+            }
+
+            public override bool IsReadRequest => false;
+
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_22835.cs
+++ b/test/SlowTests/Issues/RavenDB_22835.cs
@@ -60,8 +60,6 @@ namespace SlowTests.Issues
             }
 
             // starting import 1
-            Console.WriteLine("starting import 1");
-
             var temp1 = GetTempFileName();
             var export = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), temp1);
             await export.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
@@ -71,13 +69,9 @@ namespace SlowTests.Issues
             await import.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
 
             // import 1 went well, now adding more counters to this doc
-            Console.WriteLine("import 1 went well, now adding more counters to this doc ");
-
             AddMoreCountersForDoc(store2, rand, id);
 
             // starting import 2
-            Console.WriteLine("starting import 2");
-
             var temp2 = GetTempFileName();
             export = await store2.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), temp2);
             await export.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
@@ -87,12 +81,9 @@ namespace SlowTests.Issues
             await import.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
 
             // import 2 went well, now adding more counters to this doc
-            Console.WriteLine("import 2 went well, now adding more counters to this doc ");
-
             AddMoreCountersForDoc(store3, rand, id);
 
             // all good - no exception was thrown during imports or when adding new counters
-            Console.WriteLine("all good");
         }
 
         [Fact]
@@ -168,7 +159,7 @@ namespace SlowTests.Issues
 
             // calling FixCounters tool again should return 0 - no CounterGroup was fixed
             using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            using (var tx = context.OpenWriteTransaction())
+            using (context.OpenWriteTransaction())
             {
                 var numOfFixes = db.DocumentsStorage.CountersStorage.FixCountersForDocument(context, id);
                 Assert.Equal(0, numOfFixes);
@@ -370,7 +361,6 @@ namespace SlowTests.Issues
                     }
                 }
 
-                session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
                 session.SaveChanges();
             }
 
@@ -441,7 +431,7 @@ namespace SlowTests.Issues
             }
         }
 
-        private unsafe void CorruptCountersData(DocumentDatabase database, string? id = null)
+        private unsafe void CorruptCountersData(DocumentDatabase database, string id = null)
         {
             using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenReadTransaction())

--- a/test/SlowTests/Issues/RavenDB_22835.cs
+++ b/test/SlowTests/Issues/RavenDB_22835.cs
@@ -153,7 +153,7 @@ namespace SlowTests.Issues
             using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (var tx = context.OpenWriteTransaction())
             {
-                var numOfFixes = db.DocumentsStorage.CountersStorage.FixCountersForDocument(context, id);
+                var numOfFixes = db.CountersRepairTask.FixCountersForDocument(context, id);
                 Assert.Equal(1, numOfFixes);
 
                 tx.Commit();
@@ -163,7 +163,7 @@ namespace SlowTests.Issues
             using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (context.OpenWriteTransaction())
             {
-                var numOfFixes = db.DocumentsStorage.CountersStorage.FixCountersForDocument(context, id);
+                var numOfFixes = db.CountersRepairTask.FixCountersForDocument(context, id);
                 Assert.Equal(0, numOfFixes);
             }
 
@@ -300,7 +300,7 @@ namespace SlowTests.Issues
                 using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    var numOfFixes = db.DocumentsStorage.CountersStorage.FixCountersForDocument(context, id);
+                    var numOfFixes = db.CountersRepairTask.FixCountersForDocument(context, id);
                     Assert.Equal(1, numOfFixes);
 
                     tx.Commit();
@@ -407,7 +407,7 @@ namespace SlowTests.Issues
             using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             using (var tx = context.OpenWriteTransaction())
             {
-                var numOfFixes = db.DocumentsStorage.CountersStorage.FixCountersForDocuments(context, docIdsToCorrupt, hasMore: false);
+                var numOfFixes = db.CountersRepairTask.FixCountersForDocuments(context, docIdsToCorrupt, hasMore: false);
                 Assert.Equal(4, numOfFixes);
 
                 tx.Commit();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22835/Error-during-import

### Additional description

When splitting a counter group, we try to get rid of unused db-ids (https://github.com/ravendb/ravendb/pull/11031).
By doing that, counters with value 0 can end up without any content, i.e: `RawBlob` with no partial values and size 0.
Merging such counters (from import or replication) that have an empty blob 
caused us to add the counter name to `@names` but without adding the actual counter value to `@values`.

This resulted in corrupted counters data and potential errors when adding/incrementing/merging counters,
because we rely on counter-groups having the same number of counter values and counter names, 
with a matching name for each counter.

- Added a small fix which will merge an incoming counter even if it has `blob.Length = 0`
- Introduced a tool (`FixCountersForDocument`) which tries to fix all corrupted counters data for a specific document.
- Introduced `counters/fix` endpoint which will inform all database nodes to call the `FixCountersForDocument` tool for all the documents that have counters.
- Each node is responsible to fix its own counters data, and after the fix the Etag and ChangeVector of the counter-groups remains the same - in order to avoid replicating the data to other nodes.

The FixCounters tool identifies groups that have inconsistencies between counter values and counter names.
For counter values that don't have a matching name we'll try to look for the counter name in other counter-groups of the same document. if not found, we'll use the lower-cased counter name.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
