### PR TITLE
RavenDB-22964 Fix BackwardIterator

### DIFF
--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
@@ -66,13 +66,12 @@ namespace Corax.Querying.Matches.TermProviders
             TVal startKey = _iterator.IsForward ? _low : _high;
             TVal finalKey = _iterator.IsForward ? _high : _low;
 
-            // Seek for startKey in the iterator
             _iterator.Seek(startKey);
             
-            // We get either
-            // currentKey equal to startKey
-            // currentKey equal to element succeeding startKey
-            // MoveNext returns false
+            // The iterator may be positioned at:
+            // - Element equal to startKey
+            // - Element succeeding the startKey
+            // - End of the collection if no elements match
             if (_iterator.MoveNext(out TVal currentKey, out _, out _) == false)
             {
                 // When MoveNext returns false it means we jumped over all values stored inside a lookup tree
@@ -104,13 +103,12 @@ namespace Corax.Querying.Matches.TermProviders
             if (_skipRangeCheck)
                 return;
             
-            // Seek for finalKey in the iterator
             _iterator.Seek(finalKey);
             
-            // We get either
-            // currentKey equal to finalKey
-            // currentKey equal to element succeeding finalKey
-            // MoveNext returns false
+            // The iterator may be positioned at:
+            // - Element equal to finalKey
+            // - Element succeeding the finalKey
+            // - End of the collection if no elements match
             if (_iterator.MoveNext(out currentKey, out _lastTermId, out _) == false)
             {
                 // We jumped over all data stored in the tree. Other side of the range is unbound
@@ -120,9 +118,11 @@ namespace Corax.Querying.Matches.TermProviders
             
             _includeLastTerm = true;
             
-            // 1 - finalKey > currentKey
-            // 0 - finalKey == currentKey
-            // -1 - finalKey < currentKey (not possible)
+            // Compare the range boundary (finalKey) with the current element (currentKey)
+            // Result:
+            //   1  - Range boundary is greater than the current element
+            //   0  - Range boundary is equal to the current element
+            //  -1  - Range boundary is less than the current element (not expected)
             var cmp = finalKey.CompareTo(currentKey);
             
             if (_iterator.IsForward)

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
@@ -32,7 +32,7 @@ namespace Corax.Querying.Matches.TermProviders
         private readonly FieldMetadata _field;
         private TVal _low, _high;
         private TLookupIterator _iterator;
-        private readonly bool _skipRangeCheck;
+        private bool _skipRangeCheck;
         private long _lastTermId = -1;
         private bool _includeLastTerm = true;
         private bool _isEmpty;
@@ -59,56 +59,74 @@ namespace Corax.Querying.Matches.TermProviders
             PrepareKeys();
             Reset();
         }
-
+        
         private void PrepareKeys()
         {
+            // We want to rewrite the range, so it starts and ends with elements that are presented in our data source
             TVal startKey = _iterator.IsForward ? _low : _high;
             TVal finalKey = _iterator.IsForward ? _high : _low;
 
+            // Seek for startKey in the iterator
             _iterator.Seek(startKey);
-            if (_iterator.MoveNext(out TVal key, out _, out _) == false)
+            
+            // We get either
+            // currentKey equal to startKey
+            // currentKey equal to element succeeding startKey
+            // MoveNext returns false
+            if (_iterator.MoveNext(out TVal currentKey, out _, out _) == false)
             {
+                // When MoveNext returns false it means we jumped over all values stored inside a lookup tree
                 _isEmpty = true;
                 return;
             }
 
-            var skipFirst = _iterator.IsForward switch
-            {
-                true when typeof(TLow) == typeof(Range.Exclusive) && key.IsEqual(_low) => true,
-                false when typeof(THigh) == typeof(Range.Exclusive) && _high.CompareTo(key) <= 0 => true,
-                false when typeof(THigh) == typeof(Range.Inclusive) && _high.CompareTo(key) < 0 => true,
-                _ => false
-            };
-
+            // The first element may be equal to the startKey. For exclusive range start we want to skip it
+            var skipFirst = (_iterator.IsForward ? typeof(TLow) : typeof(THigh)) == typeof(Range.Exclusive) 
+                            && startKey.IsEqual(currentKey);
+            
+            // If we're supposed to skip first element, we rewrite the range to start from element succeeding startKey
             if (skipFirst)
             {
-                if (_iterator.MoveNext(out key, out _, out _) == false)
+                if (_iterator.MoveNext(out currentKey, out _, out _) == false)
                 {
+                    // We moved past queried range, nothing matches the query
                     _isEmpty = true;
                     return;
                 }
-                
-                if (_iterator.IsForward)
-                    _low = key;
-                else
-                    _high = key;
             }
+            
+            // Update the range accordingly to the iterator option
+            if (_iterator.IsForward)
+                _low = currentKey;
+            else
+                _high = currentKey;
             
             if (_skipRangeCheck)
-                return; // to the end
+                return;
             
-            //Now seek to the last key
+            // Seek for finalKey in the iterator
             _iterator.Seek(finalKey);
-            if (_iterator.MoveNext(out key, out _lastTermId, out var hasPreviousValue) == false)
+            
+            // We get either
+            // currentKey equal to finalKey
+            // currentKey equal to element succeeding finalKey
+            // MoveNext returns false
+            if (_iterator.MoveNext(out currentKey, out _lastTermId, out _) == false)
             {
-                _includeLastTerm = false;
+                // We jumped over all data stored in the tree. Other side of the range is unbound
+                _skipRangeCheck = true;
                 return;
             }
-
+            
             _includeLastTerm = true;
+            
+            // 1 - finalKey > currentKey
+            // 0 - finalKey == currentKey
+            // -1 - finalKey < currentKey (not possible)
+            var cmp = finalKey.CompareTo(currentKey);
+            
             if (_iterator.IsForward)
             {
-                var cmp = _high.CompareTo(key);
                 if (typeof(THigh) == typeof(Range.Exclusive) && cmp <= 0 ||
                     typeof(THigh) == typeof(Range.Inclusive) && cmp < 0)
                 {
@@ -117,7 +135,6 @@ namespace Corax.Querying.Matches.TermProviders
             }
             else
             {
-                var cmp = _low.CompareTo(key);
                 if (typeof(TLow) == typeof(Range.Exclusive) && cmp >= 0 ||
                     typeof(TLow) == typeof(Range.Inclusive) && cmp > 0)
                     _includeLastTerm = false;

--- a/src/Voron/Data/Lookups/Lookup.Iterator.cs
+++ b/src/Voron/Data/Lookups/Lookup.Iterator.cs
@@ -14,15 +14,15 @@ namespace Voron.Data.Lookups
         bool MoveNext<TLookupKey>(out TLookupKey key, out long value, out bool hasPreviousValue);
         
         /// <summary>
-        /// Moves iterator to the element equal to key parameter
+        /// If an element equal to the key exists, the iterator is positioned at that element.
         /// 
-        /// If equal element doesn't exist, moves iterator to element that succeeds it:
-        /// Forward - the smallest element that's bigger than key parameter
-        /// Backward - the biggest element that's smaller than key parameter
+        /// If an equal element doesn't exist:
+        /// - ForwardIterator - positions at the smallest element greater than the key.
+        /// - BackwardIterator - positions at the biggest element smaller than the key.
         /// 
-        /// If succeeding element doesn't exist, moves iterator (LastSearchPosition) to:
-        /// ForwardIterator - position n, where n is the number of elements (effectively moving one position after actual data)
-        /// BackwardIterator - position -1
+        /// If succeeding element doesn't exist, positions iterator (LastSearchPosition) at:
+        /// - ForwardIterator - position n, where n is the number of elements (effectively moving one position after actual data)
+        /// - BackwardIterator - position n - 1
         /// </summary>
         /// <param name="key">Lookup key</param>
         /// <typeparam name="TLookupKey">Type of lookup key used for seek.</typeparam>

--- a/src/Voron/Data/Lookups/Lookup.Iterator.cs
+++ b/src/Voron/Data/Lookups/Lookup.Iterator.cs
@@ -12,6 +12,20 @@ namespace Voron.Data.Lookups
         bool Skip(long count);
         bool MoveNext(out long value);
         bool MoveNext<TLookupKey>(out TLookupKey key, out long value, out bool hasPreviousValue);
+        
+        /// <summary>
+        /// Moves iterator to the element equal to key parameter
+        /// 
+        /// If equal element doesn't exist, moves iterator to element that succeeds it:
+        /// Forward - the smallest element that's bigger than key parameter
+        /// Backward - the biggest element that's smaller than key parameter
+        /// 
+        /// If succeeding element doesn't exist, moves iterator (LastSearchPosition) to:
+        /// ForwardIterator - position n, where n is the number of elements (effectively moving one position after actual data)
+        /// BackwardIterator - position -1
+        /// </summary>
+        /// <param name="key">Lookup key</param>
+        /// <typeparam name="TLookupKey">Type of lookup key used for seek.</typeparam>
         void Seek<TLookupKey>(TLookupKey key);
     }
 
@@ -161,6 +175,11 @@ namespace Voron.Data.Lookups
                 }
             }
             
+            /// <summary>
+            /// Returns currently pointed value and moves to the next element in the tree.
+            /// </summary>
+            /// <param name="value">Current (before MoveNext) value.</param>
+            /// <returns>Indicates if current exists.</returns>
             public bool MoveNext(out long value)
             {
                 if (_cursor._pos < 0)
@@ -276,8 +295,11 @@ namespace Voron.Data.Lookups
                 _tree.FindPageFor(ref lookupKey, ref _cursor);
 
                 ref var state = ref _cursor._stk[_cursor._pos];
-                if (state.LastSearchPosition < 0)
-                    state.LastSearchPosition = Math.Min(~state.LastSearchPosition, state.Header->NumberOfEntries - 1);
+                
+                if (state.LastSearchPosition >= 0)
+                    return;
+
+                state.LastSearchPosition = ~state.LastSearchPosition - 1;
             }
             
             
@@ -343,7 +365,7 @@ namespace Voron.Data.Lookups
                     if (state.LastSearchPosition >= 0)
                     {
                         int read = 0;
-                        while(read < results.Length && state.LastSearchPosition >= 0)
+                        while (read < results.Length && state.LastSearchPosition >= 0)
                         {
                             int curPos = state.LastSearchPosition--;
                             results[read++] = GetValue(ref state, curPos);
@@ -373,7 +395,9 @@ namespace Voron.Data.Lookups
                     value = default;
                     return false;
                 }
+                
                 ref var state = ref _cursor._stk[_cursor._pos];
+                
                 while (true)
                 {
                     Debug.Assert(state.Header->PageFlags.HasFlag(LookupPageFlags.Leaf));
@@ -407,6 +431,7 @@ namespace Voron.Data.Lookups
                     return false;
                 }
                 ref var state = ref _cursor._stk[_cursor._pos];
+                
                 while (true)
                 {
                     Debug.Assert(state.Header->PageFlags.HasFlag(LookupPageFlags.Leaf));

--- a/src/Voron/Data/Lookups/Lookup.cs
+++ b/src/Voron/Data/Lookups/Lookup.cs
@@ -190,7 +190,15 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
     public struct CursorState
     {
         public Page Page;
+        
+        /// <summary>
+        /// Values:
+        /// 0: searched value was found
+        /// 1: searched value was bigger than last compared value in the page
+        /// -1: searched value was smaller than last compared value in the page
+        /// </summary>
         public int LastMatch;
+        
         public int LastSearchPosition;
 
         public LookupPageHeader* Header => (LookupPageHeader*)Page.Pointer;
@@ -1304,6 +1312,9 @@ public sealed unsafe partial class Lookup<TLookupKey> : IPrepareForCommit
 
         NotFound:
         state.LastMatch = match > 0 ? 1 : -1;
+        // Negation gives information we didn't find the key in the page
+        // In this case, if last compared value is smaller than seeked key, we may suspect it will be the next element of the tree.
+        // It points to the smallest element that is bigger than seeked key. 
         state.LastSearchPosition = ~(bot + (match > 0).ToInt32());
     }
 

--- a/test/FastTests/Corax/CompactTreeTests.cs
+++ b/test/FastTests/Corax/CompactTreeTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FastTests.Voron;
+using Tests.Infrastructure;
 using Voron.Data.CompactTrees;
 using Voron.Data.Lookups;
 using Xunit;
@@ -122,7 +123,7 @@ public class CompactTreeTests : StorageTest
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Corax)]
     public void TestSeekForBackwardIterator()
     {
         using (var wtx = Env.WriteTransaction())
@@ -170,7 +171,7 @@ public class CompactTreeTests : StorageTest
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Corax)]
     public void TestSeekForBackwardIteratorUsingMultiplePages()
     {
         using (var wtx = Env.WriteTransaction())

--- a/test/SlowTests/Issues/RavenDB-22964.cs
+++ b/test/SlowTests/Issues/RavenDB-22964.cs
@@ -164,8 +164,161 @@ public class RavenDB_22964 : RavenTestBase
         }
     }
     
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void TestOrderByDescendingForStrings(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var t1 = new TestObject() { StringValue = "3" };
+                var t2 = new TestObject() { StringValue = "5" };
+                var t3 = new TestObject() { StringValue = "6" };
+                var t4 = new TestObject() { StringValue = "7" };
+                
+                session.Store(t1);
+                session.Store(t2);
+                session.Store(t3);
+                session.Store(t4);
+                session.SaveChanges();
+                
+                string min = "4";
+                string max = "6";
+                
+                var r0 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue >= $p0 and StringValue < $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+
+                Assert.Equal(1, r0.Count);
+                Assert.Equal("5", r0[0].StringValue);
+                
+                var r1 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue > $p0 and StringValue < $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+
+                Assert.Equal(1, r1.Count);
+                Assert.Equal("5", r1[0].StringValue);
+                
+                var r2 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue > $p0 and StringValue <= $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+                
+                Assert.Equal(2, r2.Count);
+                Assert.Equal("6", r2[0].StringValue);
+                Assert.Equal("5", r2[1].StringValue);
+                
+                var r3 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue >= $p0 and StringValue <= $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+                
+                Assert.Equal(2, r3.Count);
+                Assert.Equal("6", r3[0].StringValue);
+                Assert.Equal("5", r3[1].StringValue);
+
+                min = "2";
+                
+                var r4 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue > $p0 and StringValue < $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+                
+                Assert.Equal(2, r4.Count);
+                Assert.Equal("5", r4[0].StringValue);
+                Assert.Equal("3", r4[1].StringValue);
+
+                max = "9";
+                
+                var r5 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue > $p0 and StringValue < $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+                
+                Assert.Equal(4, r5.Count);
+                Assert.Equal("7", r5[0].StringValue);
+                Assert.Equal("6", r5[1].StringValue);
+                Assert.Equal("5", r5[2].StringValue);
+                Assert.Equal("3", r5[3].StringValue);
+                
+                min = "9";
+                max = "90";
+                
+                var r6 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue > $p0 and StringValue < $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+                
+                Assert.Equal(0, r6.Count);
+                
+                min = "0";
+                max = "2";
+                
+                var r7 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue > $p0 and StringValue < $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+                
+                Assert.Equal(0, r7.Count);
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void TestRangeBetweenValuesForStrings(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var t1 = new TestObject() { StringValue = "2" };
+                var t2 = new TestObject() { StringValue = "8" };
+
+                session.Store(t1);
+                session.Store(t2);
+                session.SaveChanges();
+
+                const string min = "4";
+                const string max = "6";
+                
+                var r1 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue > $p0 and StringValue < $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+
+                Assert.Equal(0, r1.Count);
+                
+                var r2 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue >= $p0 and StringValue < $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+                
+                Assert.Equal(0, r2.Count);
+                
+                var r3 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue > $p0 and StringValue <= $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+                
+                Assert.Equal(0, r3.Count);
+                
+                var r4 = session.Advanced.RawQuery<TestObject>("from 'TestObjects' where StringValue >= $p0 and StringValue <= $p1 order by StringValue desc")
+                    .AddParameter("$p0", min)
+                    .AddParameter("$p1", max)
+                    .ToList();
+                
+                Assert.Equal(0, r4.Count);
+            }
+        }
+    }
+    
     private class TestObject
     {
-        public required long Value { get; set; }
+        public long Value { get; set; }
+        public string StringValue { get; set; }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-22964.cs
+++ b/test/SlowTests/Issues/RavenDB-22964.cs
@@ -1,0 +1,171 @@
+using System.Linq;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_22964 : RavenTestBase
+{
+    public RavenDB_22964(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void TestOrderByDescending(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var t1 = new TestObject() { Value = 1 };
+                var t2 = new TestObject() { Value = 3 };
+                var t3 = new TestObject() { Value = 4 };
+                var t4 = new TestObject() { Value = 5 };
+                
+                session.Store(t1);
+                session.Store(t2);
+                session.Store(t3);
+                session.Store(t4);
+                session.SaveChanges();
+                
+                long min = 2;
+                long max = 4;
+                
+                var r0 = session.Query<TestObject>()
+                    .Where(x => x.Value >= min && x.Value < max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+
+                Assert.Equal(1, r0.Count);
+                Assert.Equal(3, r0[0].Value);
+                
+                var r1 = session.Query<TestObject>()
+                    .Where(x => x.Value > min && x.Value < max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+
+                Assert.Equal(1, r1.Count);
+                Assert.Equal(3, r1[0].Value);
+                
+                var r2 = session.Query<TestObject>()
+                    .Where(x => x.Value > min && x.Value <= max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+                
+                Assert.Equal(2, r2.Count);
+                Assert.Equal(4, r2[0].Value);
+                Assert.Equal(3, r2[1].Value);
+                
+                var r3 = session.Query<TestObject>()
+                    .Where(x => x.Value >= min && x.Value <= max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+                
+                Assert.Equal(2, r3.Count);
+                Assert.Equal(4, r3[0].Value);
+                Assert.Equal(3, r3[1].Value);
+
+                min = 0;
+                
+                var r4 = session.Query<TestObject>()
+                    .Where(x => x.Value > min && x.Value < max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+                
+                Assert.Equal(2, r4.Count);
+                Assert.Equal(3, r4[0].Value);
+                Assert.Equal(1, r4[1].Value);
+
+                max = 7;
+                
+                var r5 = session.Query<TestObject>()
+                    .Where(x => x.Value > min && x.Value < max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+                
+                Assert.Equal(4, r5.Count);
+                Assert.Equal(5, r5[0].Value);
+                Assert.Equal(4, r5[1].Value);
+                Assert.Equal(3, r5[2].Value);
+                Assert.Equal(1, r5[3].Value);
+                
+                min = 10;
+                max = 15;
+                
+                var r6 = session.Query<TestObject>()
+                    .Where(x => x.Value > min && x.Value < max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+                
+                Assert.Equal(0, r6.Count);
+                
+                min = -5;
+                max = -2;
+                
+                var r7 = session.Query<TestObject>()
+                    .Where(x => x.Value > min && x.Value < max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+                
+                Assert.Equal(0, r7.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void TestRangeBetweenValues(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var t1 = new TestObject() { Value = 2 };
+                var t2 = new TestObject() { Value = 24 };
+
+                session.Store(t1);
+                session.Store(t2);
+                session.SaveChanges();
+
+                const long min = 6;
+                const long max = 12;
+
+                var r1 = session.Query<TestObject>()
+                    .Where(x => x.Value > min && x.Value < max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+
+                Assert.Equal(0, r1.Count);
+                
+                var r2 = session.Query<TestObject>()
+                    .Where(x => x.Value >= min && x.Value < max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+                
+                Assert.Equal(0, r2.Count);
+                
+                var r3 = session.Query<TestObject>()
+                    .Where(x => x.Value > min && x.Value <= max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+                
+                Assert.Equal(0, r3.Count);
+                
+                var r4 = session.Query<TestObject>()
+                    .Where(x => x.Value >= min && x.Value <= max)
+                    .OrderByDescending(x => x.Value)
+                    .ToList();
+                
+                Assert.Equal(0, r4.Count);
+            }
+        }
+    }
+    
+    private class TestObject
+    {
+        public required long Value { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22964/Order-by-long-returns-incorrect-results-on-Corax

### Additional description

This PR consists of two changes:
1. `Seek` method of `Lookup.Iterator` - for `ForwardIterator`, if seeked key doesn't exist, we point to the smallest key that's bigger than seeked key. Previously `BackwardIterator` behaved the same, which is incorrect. It should point to the biggest key that's smaller than seeked key.
2. `PrepareKeys` method of `TermProvider.NumericRange` - changed to match iterator changes

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
