### PR TITLE
RavenDB-22972 / RavenDB-22995 Managed memory utilization and GC related fixes

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -205,9 +205,9 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             _converter?.Clean();
             if (mode.HasFlag(IndexCleanup.Readers))
             {
-                foreach (LowLevelTransaction llt in _index._indexStorage.Environment().ActiveTransactions.Enumerate())
+                using (var tx = _index._indexStorage.Environment().ReadTransaction())
                 {
-                    if (llt.TryGetClientState(out IndexStateRecord stateRecord))
+                    if (tx.LowLevelTransaction.TryGetClientState(out IndexStateRecord stateRecord))
                     {
                         stateRecord.LuceneIndexState.Recreate(CreateIndexSearcher);
                     }

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -806,6 +806,8 @@ namespace Voron.Impl
                 
                 PagerTransactionState.InvokeDispose(_env, ref DataPagerState, ref PagerTransactionState);
                 OnDispose?.Invoke(this);
+
+                _envRecord = null;
             }
         }
 

--- a/test/SlowTests/Voron/Issues/RavenDB_22972.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22972.cs
@@ -1,0 +1,30 @@
+﻿using FastTests.Voron;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_22972 : StorageTest
+{
+    public RavenDB_22972(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void EnvironmentRecordIsNullAfterDisposingTransaction()
+    {
+        var tx = Env.ReadTransaction();
+        var llt = tx.LowLevelTransaction;
+        try
+        {
+            Assert.NotNull(llt.CurrentStateRecord);
+        }
+        finally
+        {
+            tx.Dispose();
+        }
+
+        Assert.Null(llt.CurrentStateRecord);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22972/Rising-managed-memory-usage-and-GC-impact-on-7.0-cluster
https://issues.hibernatingrhinos.com/issue/RavenDB-22995/Missing-disposal-of-IndexSearcher-instance-after-LuceneIndexState.Recreate



### Additional description

1. Increasing memory / GC issues - the actual fix is `_envRecord = null;` on LLT dispose

- before:

![image](https://github.com/user-attachments/assets/4f326d46-2dc7-4f36-94cb-9535b51b85e5)

- after:

![image](https://github.com/user-attachments/assets/e89112d0-f3f0-4431-bd6d-e35d62d49820)


2. Another issue that was spot was missing disposal of `IndexSearcher` - it got fixed with the usage of https://www.ayende.com/blog/199169-A/externalfinalizer-adding-a-finalizer-to-3rd-party-objects


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
