### PR TITLE
RavenDB-22704 Cannot view subscription when one node is down

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksPage.tsx
@@ -210,9 +210,22 @@ export function OngoingTasksPage() {
             return task;
         });
 
-        const taskInfo = await Promise.all(loadTasks);
+        const taskInfoSettledResult = await Promise.allSettled(loadTasks);
 
-        const targetNode = taskInfo.find((x) => x.ResponsibleNode.NodeTag);
+        if (!taskInfoSettledResult.some((x) => x.status === "fulfilled")) {
+            dispatch({
+                type: "SubscriptionConnectionDetailsLoaded",
+                subscriptionId: taskId,
+                loadError: "Failed to get client connection details",
+            });
+
+            return;
+        }
+
+        const targetNode = taskInfoSettledResult
+            .filter((x) => x.status === "fulfilled")
+            .map((x) => x.value)
+            .find((x) => x.ResponsibleNode.NodeTag);
 
         try {
             // ask only responsible node for connection details


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22704/Cannot-view-subscription-when-one-node-is-down

### Additional description

When we use `Promise.all` and one of the promises throws an error, the code below will not execute. I replaced it with `Promise.allSettled`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
