### PR TITLE
RavenDB-22986 - Free space searching improvements using in-memory state

### DIFF
--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -14,6 +14,8 @@ namespace Voron.Impl.FreeSpace
 
         private readonly FreeSpaceRecursiveCallGuard _guard;
 
+        private readonly Dictionary<long, int> _maxConsecutiveRangePerSection = new();
+
         static FreeSpaceHandling()
         {
             using (StorageEnvironment.GetStaticContext(out var ctx))
@@ -192,19 +194,31 @@ namespace Voron.Impl.FreeSpace
             {
                 var current = new StreamBitArray(it.CreateReaderForCurrent());
 
+                long currentSectionId = it.CurrentKey;
                 long? page;
-                if (current.SetCount < num)
+                if (_maxConsecutiveRangePerSection.TryGetValue(currentSectionId, out var knownMax) && knownMax <= num)
                 {
-                    if (TryFindSmallValueMergingTwoSections(tx, freeSpaceTree, it.CurrentKey, num, current, out page))
+                    // current section's maximum continuous range is insufficient for the requested size.
+                    // while we can skip searching within this section alone, we still need to check
+                    // if merging with the following section could provide enough space
+                    if (TryFindSmallValueMergingTwoSections(tx, freeSpaceTree, currentSectionId, num, current, out page))
                         return page;
+                    
                     continue;
                 }
 
-                if (TryFindContinuousRange(tx, freeSpaceTree, it, num, current, it.CurrentKey, out page))
+                if (current.SetCount >= num
+                    && TryFindContinuousRange(tx, freeSpaceTree, it, num, current, currentSectionId, out page))
                     return page;
 
-                //could not find a continuous so trying to merge
-                if (TryFindSmallValueMergingTwoSections(tx, freeSpaceTree, it.CurrentKey, num, current, out page))
+                if (knownMax == 0 || num < knownMax)
+                {
+                    // here we _know_ it can't fit anything larger, so we mark it for the next time
+                    _maxConsecutiveRangePerSection[currentSectionId] = num;
+                }
+
+                // could not find a continuous so trying to merge two consecutive sections
+                if (TryFindSmallValueMergingTwoSections(tx, freeSpaceTree, currentSectionId, num, current, out page))
                     return page;
             }
             while (it.MoveNext());
@@ -392,8 +406,10 @@ namespace Voron.Impl.FreeSpace
                 var freeSpaceTree = GetFreeSpaceTree(tx);
                 StreamBitArray sba;
                 var section = pageNumber / NumberOfPagesInSection;
-                Slice result;
-                using (freeSpaceTree.Read(section, out result))
+
+                _maxConsecutiveRangePerSection.Remove(section);
+
+                using (freeSpaceTree.Read(section, out Slice result))
                 {
                     sba = !result.HasValue ? new StreamBitArray() : new StreamBitArray(result.CreateReader());
                 }
@@ -422,6 +438,16 @@ namespace Voron.Impl.FreeSpace
                 yield return page;
             }
         }
+
+        public Dictionary<long, int> GetMaxConsecutiveRangePerSection(LowLevelTransaction tx)
+        {
+            if (tx.Transaction.IsWriteTransaction == false)
+                throw new InvalidOperationException($"{nameof(GetMaxConsecutiveRangePerSection)} must be called with an open write transaction");
+
+            return new Dictionary<long, int>(_maxConsecutiveRangePerSection);
+        }
+
+        public void OnRollback() => _maxConsecutiveRangePerSection.Clear();
 
         public FreeSpaceHandlingDisabler Disable()
         {

--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -24,7 +24,7 @@ namespace Voron.Impl.FreeSpace
             public ushort StartBits = NumberOfPagesInSection;
             public ushort EndBits = NumberOfPagesInSection;
 
-            private ushort Padding = 0;
+            private ushort Reserved = 0;
         }
 
         static FreeSpaceHandling()

--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -17,12 +17,14 @@ namespace Voron.Impl.FreeSpace
 
         private readonly Dictionary<long, SectionMetadata> _maxConsecutiveRangePerSection = new();
 
-        [StructLayout(LayoutKind.Sequential, Size = 6)]
+        [StructLayout(LayoutKind.Sequential, Size = 8)]
         public struct SectionMetadata()
         {
             public ushort Max = NumberOfPagesInSection;
             public ushort StartBits = NumberOfPagesInSection;
             public ushort EndBits = NumberOfPagesInSection;
+
+            private ushort Padding = 0;
         }
 
         static FreeSpaceHandling()

--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron.Data.Fixed;
@@ -14,7 +15,15 @@ namespace Voron.Impl.FreeSpace
 
         private readonly FreeSpaceRecursiveCallGuard _guard;
 
-        private readonly Dictionary<long, int> _maxConsecutiveRangePerSection = new();
+        private readonly Dictionary<long, SectionMetadata> _maxConsecutiveRangePerSection = new();
+
+        [StructLayout(LayoutKind.Sequential, Size = 6)]
+        public struct SectionMetadata()
+        {
+            public ushort Max = NumberOfPagesInSection;
+            public ushort StartBits = NumberOfPagesInSection;
+            public ushort EndBits = NumberOfPagesInSection;
+        }
 
         static FreeSpaceHandling()
         {
@@ -187,34 +196,44 @@ namespace Voron.Impl.FreeSpace
             }
         }
 
-
         private long? TryFindSmallValue(LowLevelTransaction tx, FixedSizeTree freeSpaceTree, FixedSizeTree.IFixedSizeIterator it, int num)
         {
             do
             {
-                var current = new StreamBitArray(it.CreateReaderForCurrent());
-
                 long currentSectionId = it.CurrentKey;
                 long? page;
-                if (_maxConsecutiveRangePerSection.TryGetValue(currentSectionId, out var knownMax) && knownMax <= num)
+
+                if (_maxConsecutiveRangePerSection.TryGetValue(currentSectionId, out var known) && known.Max <= num)
                 {
+                    if (_maxConsecutiveRangePerSection.TryGetValue(currentSectionId + 1, out var knownNext))
+                    {
+                        if (known.EndBits + knownNext.StartBits < num)
+                            continue;
+                    }
+
                     // current section's maximum continuous range is insufficient for the requested size.
                     // while we can skip searching within this section alone, we still need to check
                     // if merging with the following section could provide enough space
-                    if (TryFindSmallValueMergingTwoSections(tx, freeSpaceTree, currentSectionId, num, current, out page))
+                    var currentBitArray = new StreamBitArray(it.CreateReaderForCurrent());
+                    if (TryFindSmallValueMergingTwoSections(tx, freeSpaceTree, currentSectionId, num, currentBitArray, out page))
                         return page;
-                    
+
                     continue;
                 }
 
+                var current = new StreamBitArray(it.CreateReaderForCurrent());
                 if (current.SetCount >= num
-                    && TryFindContinuousRange(tx, freeSpaceTree, it, num, current, currentSectionId, out page))
+                    && TryFindContinuousRange(tx, freeSpaceTree, num, current, currentSectionId, out page))
                     return page;
 
-                if (knownMax == 0 || num < knownMax)
+                ref var metadata = ref CollectionsMarshal.GetValueRefOrAddDefault(_maxConsecutiveRangePerSection, currentSectionId, out var exists);
+                if (exists == false)
+                    metadata = new SectionMetadata();
+
+                if (num < metadata.Max)
                 {
                     // here we _know_ it can't fit anything larger, so we mark it for the next time
-                    _maxConsecutiveRangePerSection[currentSectionId] = num;
+                    metadata.Max = (ushort)Math.Min(num, current.SetCount);
                 }
 
                 // could not find a continuous so trying to merge two consecutive sections
@@ -226,8 +245,8 @@ namespace Voron.Impl.FreeSpace
             return null;
         }
 
-        private bool TryFindContinuousRange(LowLevelTransaction tx, FixedSizeTree freeSpaceTree, FixedSizeTree.IFixedSizeIterator it, int num,
-            StreamBitArray current, long currentSectionId, out long? page)
+        private bool TryFindContinuousRange(LowLevelTransaction tx, FixedSizeTree freeSpaceTree, 
+            int num, StreamBitArray current, long currentSectionId, out long? page)
         {
             page = -1;
 
@@ -239,7 +258,7 @@ namespace Voron.Impl.FreeSpace
 
             if (current.SetCount == num)
             {
-                freeSpaceTree.Delete(it.CurrentKey);
+                freeSpaceTree.Delete(currentSectionId);
             }
             else
             {
@@ -250,39 +269,61 @@ namespace Voron.Impl.FreeSpace
 
                 Slice val;
                 using (current.ToSlice(tx.Allocator, out val))
-                    freeSpaceTree.Add(it.CurrentKey, val);
+                    freeSpaceTree.Add(currentSectionId, val);
             }
 
             return true;
         }
 
-        private static bool TryFindSmallValueMergingTwoSections(LowLevelTransaction tx, FixedSizeTree freeSpacetree, long currentSectionId, int num,
-            StreamBitArray current, out long? result)
+        private bool TryFindSmallValueMergingTwoSections(LowLevelTransaction tx, FixedSizeTree freeSpaceTree,
+            long currentSectionId, int num, StreamBitArray current, out long? result)
         {
             result = -1;
             var currentEndRange = current.GetEndRangeCount();
-            if (currentEndRange == 0)
-                return false;
 
             var nextSectionId = currentSectionId + 1;
-
-            StreamBitArray next;
-            Slice read;
-            using (freeSpacetree.Read(nextSectionId, out read))
+            StreamBitArray next = null;
+            int nextRangeStart = 0;
+            using (freeSpaceTree.Read(nextSectionId, out Slice read))
             {
-                if (!read.HasValue)
-                    return false;
+                if (read.HasValue)
+                {
+                    next = new StreamBitArray(read.CreateReader());
+                    nextRangeStart = next.GetStartRangeCount();
+                }
+            }
 
-                next = new StreamBitArray(read.CreateReader());
+            if (currentEndRange == 0 || next == null || currentEndRange + nextRangeStart < num)
+            {
+                // we update the cache in any of the following cases:
+                // - the current section has no more available space at its end
+                // - the next section does not exist
+                // - even when combining the current and next sections, the total space is insufficient
+
+                ref var metadata = ref CollectionsMarshal.GetValueRefOrAddDefault(
+                    _maxConsecutiveRangePerSection, currentSectionId, out var exists);
+
+                if (exists == false)
+                    metadata = new SectionMetadata();
+
+                metadata.EndBits = (ushort)currentEndRange;
+
+                ref var nextMetadata = ref CollectionsMarshal.GetValueRefOrAddDefault(
+                    _maxConsecutiveRangePerSection, nextSectionId, out exists);
+
+                if (exists == false)
+                    nextMetadata = new SectionMetadata();
+
+                nextMetadata.StartBits = (ushort)nextRangeStart;
+
+                return false;
             }
 
             var nextRange = num - currentEndRange;
-            if (next.HasStartRangeCount(nextRange) == false)
-                return false;
 
             if (next.SetCount == nextRange)
             {
-                freeSpacetree.Delete(nextSectionId);
+                freeSpaceTree.Delete(nextSectionId);
             }
             else
             {
@@ -292,12 +333,12 @@ namespace Voron.Impl.FreeSpace
                 }
                 Slice val;
                 using (next.ToSlice(tx.Allocator, out val))
-                    freeSpacetree.Add(nextSectionId, val);
+                    freeSpaceTree.Add(nextSectionId, val);
             }
 
             if (current.SetCount == currentEndRange)
             {
-                freeSpacetree.Delete(currentSectionId);
+                freeSpaceTree.Delete(currentSectionId);
             }
             else
             {
@@ -307,7 +348,7 @@ namespace Voron.Impl.FreeSpace
                 }
                 Slice val;
                 using (current.ToSlice(tx.Allocator, out val))
-                    freeSpacetree.Add(currentSectionId, val);
+                    freeSpaceTree.Add(currentSectionId, val);
             }
 
 
@@ -338,13 +379,14 @@ namespace Voron.Impl.FreeSpace
                     for (var i = 0; i < NumberOfPagesInSection; i++)
                     {
                         if (current.Get(i))
-                            freePages.Add(currentSectionId*NumberOfPagesInSection + i);
+                            freePages.Add(currentSectionId * NumberOfPagesInSection + i);
                     }
                 } while (it.MoveNext());
 
                 return freePages;
             }
-        } 
+        }
+
         public List<DynamicJsonValue> FreeSpaceSnapshot(LowLevelTransaction tx, bool hex)
         {
             var freeSpaceTree = GetFreeSpaceTree(tx);
@@ -367,7 +409,7 @@ namespace Voron.Impl.FreeSpace
 
                 return freeSpace;
             }
-        } 
+        }
 
         public int GetFreePagesCount(LowLevelTransaction tx)
         {
@@ -439,12 +481,12 @@ namespace Voron.Impl.FreeSpace
             }
         }
 
-        public Dictionary<long, int> GetMaxConsecutiveRangePerSection(LowLevelTransaction tx)
+        public Dictionary<long, SectionMetadata> GetMaxConsecutiveRangePerSection(LowLevelTransaction tx)
         {
             if (tx.Transaction.IsWriteTransaction == false)
                 throw new InvalidOperationException($"{nameof(GetMaxConsecutiveRangePerSection)} must be called with an open write transaction");
 
-            return new Dictionary<long, int>(_maxConsecutiveRangePerSection);
+            return new Dictionary<long, SectionMetadata>(_maxConsecutiveRangePerSection);
         }
 
         public void OnRollback() => _maxConsecutiveRangePerSection.Clear();

--- a/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
@@ -12,6 +12,8 @@ namespace Voron.Impl.FreeSpace
         void FreePage(LowLevelTransaction tx, long pageNumber);
         long GetFreePagesOverhead(LowLevelTransaction tx);
         IEnumerable<long> GetFreePagesOverheadPages(LowLevelTransaction tx);
+        Dictionary<long, int> GetMaxConsecutiveRangePerSection(LowLevelTransaction tx);
+        void OnRollback();
         FreeSpaceHandlingDisabler Disable();
     }
 }

--- a/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
@@ -12,7 +12,7 @@ namespace Voron.Impl.FreeSpace
         void FreePage(LowLevelTransaction tx, long pageNumber);
         long GetFreePagesOverhead(LowLevelTransaction tx);
         IEnumerable<long> GetFreePagesOverheadPages(LowLevelTransaction tx);
-        Dictionary<long, int> GetMaxConsecutiveRangePerSection(LowLevelTransaction tx);
+        Dictionary<long, FreeSpaceHandling.SectionMetadata> GetMaxConsecutiveRangePerSection(LowLevelTransaction tx);
         void OnRollback();
         FreeSpaceHandlingDisabler Disable();
     }

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -42,7 +42,6 @@ using Sparrow.Server;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
 
 namespace Voron.Impl.FreeSpace
 {
@@ -295,27 +294,84 @@ namespace Voron.Impl.FreeSpace
 
         public int GetEndRangeCount()
         {
-            int c = 0;
-            for (int i = _inner.Length * 32 -1; i >= 0; i--)
+            var count = 0;
+            var span = MemoryMarshal.Cast<int, long>(_inner);
+
+            for (var i = span.Length - 1; i >= 0 ; i--)
             {
-                if (Get(i) == false)
+                var current = span[i];
+                if (current == 0)
                     break;
-                c++;
+
+                if (current == -1)
+                {
+                    count += BitsInWord * 2;
+                    continue;
+                }
+
+                int numberOfSetBits = BitOperations.LeadingZeroCount(~(ulong)current);
+                count += numberOfSetBits;
+
+                // we won't find any more continuous bits after this.
+                break;
             }
-            return c;
+
+            return count;
+        }
+
+        public int GetStartRangeCount()
+        {
+            var count = 0;
+            var span = MemoryMarshal.Cast<int, long>(_inner);
+
+            foreach (var current in span)
+            {
+                if (current == 0)
+                    break;
+
+                if (current == -1)
+                {
+                    count += BitsInWord * 2;
+                    continue;
+                }
+
+                int numberOfSetBits = BitOperations.TrailingZeroCount(~current);
+                count += numberOfSetBits;
+
+                // we won't find any more continuous bits after this.
+                return count;
+            }
+
+            return count;
         }
 
         public bool HasStartRangeCount(int max)
         {
-            int c = 0;
-            var len = _inner.Length*32;
-            for (int i = 0; i < len && c < max; i++)
+            var count = 0;
+            var span = MemoryMarshal.Cast<int, long>(_inner);
+
+            foreach (var current in span)
             {
-                if (Get(i) == false)
+                if (current == 0)
                     break;
-                c++;
+
+                if (current == -1)
+                {
+                    count += BitsInWord * 2;
+                    if (count >= max)
+                        return true;
+
+                    continue;
+                }
+
+                int numberOfSetBits = BitOperations.TrailingZeroCount(~current);
+                count += numberOfSetBits;
+
+                // we won't find any more continuous bits after this.
+                return count >= max;
             }
-            return c == max;
+
+            return false;
         }
 
         public Stream ToStream()

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -1377,11 +1377,12 @@ namespace Voron.Impl
             if (_txState.HasFlag(TxState.Disposed))
                 ThrowObjectDisposed();
 
-
             if (Committed || RolledBack || Flags != (TransactionFlags.ReadWrite))
                 return;
 
             OnRollBack?.Invoke(this);
+
+            _freeSpaceHandling.OnRollback();
 
             ValidateReadOnlyPages();
 

--- a/test/FastTests/Voron/StreamBitArrayTests.cs
+++ b/test/FastTests/Voron/StreamBitArrayTests.cs
@@ -158,6 +158,94 @@ namespace FastTests.Voron
             }
         }
 
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed(0, 2)]
+        [InlineDataWithRandomSeed(2, 32)]
+        [InlineDataWithRandomSeed(32, 64)]
+        [InlineDataWithRandomSeed(64, 2048)]
+        [InlineDataWithRandomSeed(0, 2048)]
+        public void VerifyEndRangeCountWithRandomMinMaxInput(int minContinuous, int maxContinuous, int seed)
+        {
+            var random = new Random(seed);
+            var sba = new StreamBitArray();
+
+            int i = 2047;
+
+            while (i >= 0)
+            {
+                int blockSize = random.Next(minContinuous, maxContinuous + 1);
+                bool value = random.Next(2) == 1;
+
+                for (int k = 0; k < blockSize && i >= 0; k++, i--)
+                {
+                    sba.Set(i, value);
+                }
+            }
+
+            var result1 = GetEndRangeCountSlow(sba);
+            var result2 = sba.GetEndRangeCount();
+            Assert.Equal(result1, result2);
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed(0, 2)]
+        [InlineDataWithRandomSeed(2, 32)]
+        [InlineDataWithRandomSeed(32, 64)]
+        [InlineDataWithRandomSeed(64, 2048)]
+        [InlineDataWithRandomSeed(0, 2048)]
+        public void VerifyStartRangeCountWithRandomMinMaxInput(int minContinuous, int maxContinuous, int seed)
+        {
+            var random = new Random(seed);
+            var sba = new StreamBitArray();
+
+            int i = 0;
+            while (i < 2048)
+            {
+                int blockSize = random.Next(minContinuous, maxContinuous + 1);
+                bool value = random.Next(2) == 1;
+
+                for (int k = 0; k < blockSize && i < 2048; k++, i++)
+                {
+                    sba.Set(i, value);
+                }
+            }
+
+            var result1 = GetStartRangeCount(sba);
+            var result2 = sba.GetStartRangeCount();
+            Assert.Equal(result1, result2);
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed(0, 2)]
+        [InlineDataWithRandomSeed(2, 32)]
+        [InlineDataWithRandomSeed(32, 64)]
+        [InlineDataWithRandomSeed(64, 2048)]
+        [InlineDataWithRandomSeed(0, 2048)]
+        public void VerifyHasStartRangeCountWithRandomMinMaxInput(int minContinuous, int maxContinuous, int seed)
+        {
+            var random = new Random(seed);
+            var sba = new StreamBitArray();
+
+            int i = 0;
+            while (i < 2048)
+            {
+                int blockSize = random.Next(minContinuous, maxContinuous + 1);
+                bool value = random.Next(2) == 1;
+
+                for (int k = 0; k < blockSize && i < 2048; k++, i++)
+                {
+                    sba.Set(i, value);
+                }
+            }
+
+            for (int j = 1; j <= 2048; j += 1)
+            {
+                var result1 = HasStartRangeCount(sba, j);
+                var result2 = sba.HasStartRangeCount(j);
+                Assert.Equal(result1, result2);
+            }
+        }
+
         private static int? GetContinuousRangeSlow(StreamBitArray current, int num)
         {
             var start = -1;
@@ -182,6 +270,48 @@ namespace FastTests.Voron
             }
 
             return null;
+        }
+
+        public int GetEndRangeCountSlow(StreamBitArray current)
+        {
+            int c = 0;
+
+            for (int i = 2048 - 1; i >= 0; i--)
+            {
+                if (current.Get(i) == false)
+                    break;
+                c++;
+            }
+
+            return c;
+        }
+
+        public int GetStartRangeCount(StreamBitArray current)
+        {
+            int c = 0;
+
+            for (int i = 0; i < 2048; i++)
+            {
+                if (current.Get(i) == false)
+                    break;
+                c++;
+            }
+
+            return c;
+        }
+
+        public bool HasStartRangeCount(StreamBitArray current, int max)
+        {
+            int c = 0;
+
+            for (int i = 0; i < 2048 && c < max; i++)
+            {
+                if (current.Get(i) == false)
+                    break;
+                c++;
+            }
+
+            return c == max;
         }
     }
 }

--- a/test/FastTests/Voron/Trees/FreeSpaceTest.cs
+++ b/test/FastTests/Voron/Trees/FreeSpaceTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FastTests.Voron.FixedSize;
+using Tests.Infrastructure;
 using Xunit;
 using Voron.Impl.FreeSpace;
 using Xunit.Abstractions;
@@ -246,6 +247,110 @@ namespace FastTests.Voron.Trees
                 var sorted = freedPages.OrderBy(x => x).ToList();
 
                 Assert.Equal(sorted, retrievedFreePages);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void CanUpdateMaxConsecutiveRanges()
+        {
+            const int totalSections = 4;
+            const int totalPages = 2048 * totalSections;
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                Assert.Empty(max);
+
+                for (int i = 0; i < totalPages; i++)
+                {
+                    tx.LowLevelTransaction.AllocatePage(1);
+                }
+
+                tx.Commit();
+
+                max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                Assert.Empty(max);
+            }
+
+            const int lastPageInAllSections = totalPages - 1;
+            using (var tx = Env.WriteTransaction())
+            {
+                for (int i = 0; i < totalPages; i += 2048)
+                {
+                    Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, i);
+                }
+
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, lastPageInAllSections);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.LowLevelTransaction.AllocatePage(3);
+
+                // releasing 2 pages in section 4 to make 3 consecutive pages between two sections
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, totalPages);
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, totalPages + 1);
+                tx.Commit();
+
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+
+                for (var i = 0; i < totalSections; i++)
+                {
+                    Assert.Equal(max[i], 3);
+                }
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var page = tx.LowLevelTransaction.AllocatePage(3);
+                Assert.Equal(lastPageInAllSections, page.PageNumber);
+                tx.Commit();
+
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+
+                for (var i = 0; i < totalSections; i++)
+                {
+                    Assert.Equal(max[i], 3);
+                }
+
+                // shouldn't find anything and update the max consecutive
+                tx.LowLevelTransaction.AllocatePage(2);
+
+                max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+
+                for (var i = 0; i < totalSections; i++)
+                {
+                    Assert.Equal(max[i], 2);
+                }
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                // releasing from sections 0 and 2 - this should clear the in memory state for those sections
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, 3);
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, 2048 * 2 + 15);
+
+                tx.Commit();
+
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+
+                Assert.Equal(max[1], 2);
+                Assert.Equal(max[3], 2);
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, 4);
+
+                // not commiting on purpose, this should simulate a rollback and clear the in memory state
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                Assert.Empty(max);
             }
         }
     }

--- a/test/FastTests/Voron/Trees/FreeSpaceTest.cs
+++ b/test/FastTests/Voron/Trees/FreeSpaceTest.cs
@@ -254,7 +254,7 @@ namespace FastTests.Voron.Trees
         public void CanUpdateMaxConsecutiveRanges()
         {
             const int totalSections = 4;
-            const int totalPages = 2048 * totalSections;
+            const int totalPages = FreeSpaceHandling.NumberOfPagesInSection * totalSections;
 
             using (var tx = Env.WriteTransaction())
             {
@@ -275,7 +275,7 @@ namespace FastTests.Voron.Trees
             const int lastPageInAllSections = totalPages - 1;
             using (var tx = Env.WriteTransaction())
             {
-                for (int i = 0; i < totalPages; i += 2048)
+                for (int i = 0; i < totalPages; i += FreeSpaceHandling.NumberOfPagesInSection)
                 {
                     Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, i);
                 }
@@ -333,7 +333,7 @@ namespace FastTests.Voron.Trees
 
             using (var tx = Env.WriteTransaction())
             {
-                for (int i = 0; i < totalPages; i += 2048)
+                for (int i = 0; i < totalPages; i += FreeSpaceHandling.NumberOfPagesInSection)
                 {
                     Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, i + 2);
                     Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, i + 4);
@@ -381,7 +381,7 @@ namespace FastTests.Voron.Trees
             {
                 // releasing from sections 0 and 2 - this should clear the in memory state for those sections
                 Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, 3);
-                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, 2048 * 2 + 15);
+                Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, FreeSpaceHandling.NumberOfPagesInSection * 2 + 15);
 
                 tx.Commit();
 

--- a/test/FastTests/Voron/Trees/FreeSpaceTest.cs
+++ b/test/FastTests/Voron/Trees/FreeSpaceTest.cs
@@ -289,40 +289,78 @@ namespace FastTests.Voron.Trees
             {
                 tx.LowLevelTransaction.AllocatePage(3);
 
+                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                Assert.Equal(5, max.Count);
+
+                for (var i = 0; i < totalSections - 1; i++)
+                {
+                    Assert.Equal(1, max[i].Max);
+                    Assert.Equal(0, max[i].EndBits);
+                }
+
+                Assert.Equal(2, max[3].Max);
+                Assert.Equal(1, max[3].StartBits);
+                Assert.Equal(1, max[3].EndBits);
+
+                Assert.Equal(0, max[4].StartBits);
+
                 // releasing 2 pages in section 4 to make 3 consecutive pages between two sections
                 Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, totalPages);
                 Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, totalPages + 1);
                 tx.Commit();
 
-                var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
+                Assert.Equal(4, max.Count);
 
-                for (var i = 0; i < totalSections; i++)
+                for (var i = 0; i < totalSections - 1; i++)
                 {
-                    Assert.Equal(max[i], 3);
+                    Assert.Equal(1, max[i].Max);
                 }
+
+                Assert.Equal(2, max[3].Max);
+                Assert.Equal(1, max[3].StartBits);
+                Assert.Equal(1, max[3].EndBits);
             }
 
             using (var tx = Env.WriteTransaction())
             {
-                var page = tx.LowLevelTransaction.AllocatePage(3);
-                Assert.Equal(lastPageInAllSections, page.PageNumber);
-                tx.Commit();
+                for (int i = 0; i < totalPages; i += 2048)
+                {
+                    Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, i + 2);
+                    Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, i + 4);
+                }
+
+                tx.LowLevelTransaction.AllocatePage(4);
 
                 var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
 
-                for (var i = 0; i < totalSections; i++)
+                for (var i = 0; i < totalSections - 1; i++)
                 {
-                    Assert.Equal(max[i], 3);
+                    Assert.Equal(3, max[i].Max);
+                    Assert.Equal(0, max[i].EndBits);
                 }
+
+                Assert.Equal(4, max[3].Max);
+                Assert.Equal(1, max[3].StartBits);
+                Assert.Equal(1, max[3].EndBits);
+
+                Assert.Equal(2, max[4].Max);
+                Assert.Equal(2, max[4].StartBits);
+
+                Assert.Equal(0, max[5].StartBits);
+
+                var page = tx.LowLevelTransaction.AllocatePage(3);
+                Assert.Equal(lastPageInAllSections, page.PageNumber);
+                tx.Commit();
 
                 // shouldn't find anything and update the max consecutive
                 tx.LowLevelTransaction.AllocatePage(2);
 
                 max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
 
-                for (var i = 0; i < totalSections; i++)
+                for (var i = 0; i < totalSections + 1; i++)
                 {
-                    Assert.Equal(max[i], 2);
+                    Assert.Equal(2, max[i].Max);
                 }
             }
 
@@ -336,8 +374,9 @@ namespace FastTests.Voron.Trees
 
                 var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
 
-                Assert.Equal(max[1], 2);
-                Assert.Equal(max[3], 2);
+                Assert.Equal(2, max[1].Max);
+                Assert.Equal(2, max[3].Max);
+                Assert.Equal(2, max[4].Max);
             }
 
             using (var tx = Env.WriteTransaction())

--- a/test/FastTests/Voron/Trees/FreeSpaceTest.cs
+++ b/test/FastTests/Voron/Trees/FreeSpaceTest.cs
@@ -292,9 +292,14 @@ namespace FastTests.Voron.Trees
                 var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
                 Assert.Equal(5, max.Count);
 
-                for (var i = 0; i < totalSections - 1; i++)
+                Assert.Equal(1, max[0].Max);
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[0].StartBits);
+                Assert.Equal(0, max[0].EndBits);
+                
+                for (var i = 1; i < totalSections - 1; i++)
                 {
                     Assert.Equal(1, max[i].Max);
+                    Assert.Equal(1, max[i].StartBits);
                     Assert.Equal(0, max[i].EndBits);
                 }
 
@@ -302,7 +307,9 @@ namespace FastTests.Voron.Trees
                 Assert.Equal(1, max[3].StartBits);
                 Assert.Equal(1, max[3].EndBits);
 
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[4].Max);
                 Assert.Equal(0, max[4].StartBits);
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[4].EndBits);
 
                 // releasing 2 pages in section 4 to make 3 consecutive pages between two sections
                 Env.FreeSpaceHandling.FreePage(tx.LowLevelTransaction, totalPages);
@@ -311,6 +318,8 @@ namespace FastTests.Voron.Trees
 
                 max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
                 Assert.Equal(4, max.Count);
+
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[0].StartBits);
 
                 for (var i = 0; i < totalSections - 1; i++)
                 {
@@ -334,6 +343,8 @@ namespace FastTests.Voron.Trees
 
                 var max = Env.FreeSpaceHandling.GetMaxConsecutiveRangePerSection(tx.LowLevelTransaction);
 
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[0].StartBits);
+
                 for (var i = 0; i < totalSections - 1; i++)
                 {
                     Assert.Equal(3, max[i].Max);
@@ -348,6 +359,8 @@ namespace FastTests.Voron.Trees
                 Assert.Equal(2, max[4].StartBits);
 
                 Assert.Equal(0, max[5].StartBits);
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[5].EndBits);
+                Assert.Equal(FreeSpaceHandling.NumberOfPagesInSection, max[5].Max);
 
                 var page = tx.LowLevelTransaction.AllocatePage(3);
                 Assert.Equal(lastPageInAllSections, page.PageNumber);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22986/Free-space-fragmentation

### Additional description

This is based on the optimization that was done here: https://github.com/ravendb/ravendb/pull/19392/commits/267600dae179ccfb00f3a8c72bab82de82ed71f9#diff-d2dbb8e40687614174e0654344ec0c25a05c45ec41bbe0df0c9b42df8d7c35f2R193

- Remember the maximum number of pages that we **couldn't** allocate from a segment, and skip checking it if it's known **not** to have the required consecutive range.
- On FreePage, we simply delete the information for that segment (this requires a re-check, and we'll remember it again if needed). The re-check was optimized here: https://github.com/ravendb/ravendb/pull/19386.
- On RollBack, we clear all information and require a re-check (this could be turned into a proper state on the environment record, but hasn't been done so far to make it easier to merge into previous versions).
- This approach keeps the state minimal and is essentially self-healing if necessary.

**Results for real life highly fragmented sections**
The tests simulate a single batch of patch operations with a batch size of 1024, targeting sizes that are not available in any of the 5000 sections (Except a size of 1 which **does** exist).

The reason for the different numbers in [this test](https://github.com/ravendb/ravendb/pull/19386) is that it was conducted at the storage level, whereas the previous test was performed directly on the `StreamBitArray`.

Requested size: 1
original: 2ms
current: 1ms
new: 1ms

Requested size: 2-31
original: 20,754ms
current: 2,199ms
new: 109ms

Requested size: 32-63
original: 18,927ms
current: 2,230ms
new: 102ms

Requested size: 32-2048
original: 2,097ms
current: 816ms
new: 102ms

Requested size: 1-2048
original: 2,353ms
current: 849ms
new: 113ms

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
