### PR TITLE
RavenDB-22986 - Improve the performance of getting the free pages count

### DIFF
--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -349,6 +349,31 @@ namespace Voron.Impl.FreeSpace
             }
         }
 
+        public int GetFreePagesCount(LowLevelTransaction tx)
+        {
+            var freeSpaceTree = GetFreeSpaceTree(tx);
+            if (freeSpaceTree.NumberOfEntries == 0)
+                return 0;
+
+            using (var it = freeSpaceTree.Iterate())
+            {
+                if (it.Seek(0) == false)
+                    return 0;
+
+                var count = 0;
+
+                do
+                {
+                    var stream = it.CreateReaderForCurrent();
+                    var current = new StreamBitArray(stream);
+                    count += current.GetNumberOfSetBits();
+
+                } while (it.MoveNext());
+
+                return count;
+            }
+        }
+
         public void FreePage(LowLevelTransaction tx, long pageNumber)
         {
             if (_guard.IsProcessingFixedSizeTree)

--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -366,7 +366,7 @@ namespace Voron.Impl.FreeSpace
                 {
                     var stream = it.CreateReaderForCurrent();
                     var current = new StreamBitArray(stream);
-                    count += current.GetNumberOfSetBits();
+                    count += current.SetCount;
 
                 } while (it.MoveNext());
 

--- a/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
@@ -6,6 +6,7 @@ namespace Voron.Impl.FreeSpace
     {
         long? TryAllocateFromFreeSpace(LowLevelTransaction tx, int num);
         List<long> AllPages(LowLevelTransaction tx);
+        int GetFreePagesCount(LowLevelTransaction txLowLevelTransaction);
         void FreePage(LowLevelTransaction tx, long pageNumber);
         long GetFreePagesOverhead(LowLevelTransaction tx);
         IEnumerable<long> GetFreePagesOverheadPages(LowLevelTransaction tx);

--- a/src/Voron/Impl/FreeSpace/NoFreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/NoFreeSpaceHandling.cs
@@ -14,6 +14,11 @@ namespace Voron.Impl.FreeSpace
             return new List<long>();
         }
 
+        public int GetFreePagesCount(LowLevelTransaction txLowLevelTransaction)
+        {
+            return 0;
+        }
+
         public void FreePage(LowLevelTransaction tx, long pageNumber)
         {
             

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -35,7 +35,6 @@ using Sparrow;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Numerics;
 using Sparrow.Server;
 
 namespace Voron.Impl.FreeSpace
@@ -109,18 +108,6 @@ namespace Voron.Impl.FreeSpace
         public bool Get(int index)
         {
             return (_inner[index >> 5] & (1 << (index & 31))) != 0;
-        }
-
-        public int GetNumberOfSetBits()
-        {
-            var count = 0;
-
-            for (int i = 0; i < _inner.Length; i++)
-            {
-                count += BitOperations.PopCount((uint)_inner[i]);
-            }
-
-            return count;
         }
 
         public void Set(int index, bool value)

--- a/src/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/src/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -35,6 +35,7 @@ using Sparrow;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Numerics;
 using Sparrow.Server;
 
 namespace Voron.Impl.FreeSpace
@@ -108,6 +109,18 @@ namespace Voron.Impl.FreeSpace
         public bool Get(int index)
         {
             return (_inner[index >> 5] & (1 << (index & 31))) != 0;
+        }
+
+        public int GetNumberOfSetBits()
+        {
+            var count = 0;
+
+            for (int i = 0; i < _inner.Length; i++)
+            {
+                count += BitOperations.PopCount((uint)_inner[i]);
+            }
+
+            return count;
         }
 
         public void Set(int index, bool value)

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1032,7 +1032,7 @@ namespace Voron
         public StorageReport GenerateReport(Transaction tx)
         {
             var numberOfAllocatedPages = GetNumberOfAllocatedPages();
-            var numberOfFreePages = _freeSpaceHandling.AllPages(tx.LowLevelTransaction).Count;
+            var numberOfFreePages = _freeSpaceHandling.GetFreePagesCount(tx.LowLevelTransaction);
 
             var countOfTrees = 0;
             var countOfTables = 0;
@@ -1106,7 +1106,7 @@ namespace Voron
         public unsafe DetailedReportInput CreateDetailedReportInput(Transaction tx, bool includeDetails)
         {
             var numberOfAllocatedPages = Math.Max(_dataPager.NumberOfAllocatedPages, NextPageNumber - 1); // async apply to data file task
-            var numberOfFreePages = _freeSpaceHandling.AllPages(tx.LowLevelTransaction).Count;
+            var numberOfFreePages = _freeSpaceHandling.GetFreePagesCount(tx.LowLevelTransaction);
 
             var totalCryptoBufferSize = GetTotalCryptoBufferSize();
 

--- a/test/FastTests/Voron/Trees/FreeSpaceTest.cs
+++ b/test/FastTests/Voron/Trees/FreeSpaceTest.cs
@@ -239,6 +239,8 @@ namespace FastTests.Voron.Trees
             using (var tx = Env.WriteTransaction())
             {
                 var retrievedFreePages = Env.FreeSpaceHandling.AllPages(tx.LowLevelTransaction);
+                var freePagesCount = Env.FreeSpaceHandling.GetFreePagesCount(tx.LowLevelTransaction);
+                Assert.Equal(freePagesCount, retrievedFreePages.Count);
 
                 freedPages.ExceptWith(Env.FreeSpaceHandling.GetFreePagesOverheadPages(tx.LowLevelTransaction)); // need to take into account that some of free pages might be used for free space handling
                 var sorted = freedPages.OrderBy(x => x).ToList();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22986/Free-space-fragmentation

### Additional description

This is used when generating the storage report.
Instead of calling `AllPages`, which is expensive as it iterates over the entire StreamBitArray for all sections (reference: [AllPages](https://github.com/grisha-kotler/ravendb/blob/35351eaff1ae7145058dcd05bbb7d36642198527/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs#L321)), we can efficiently count the set bits using `BitOperations.PopCount`.

This will reduce overhead and improve performance by avoiding the full iteration.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
