### PR TITLE
RavenDB-23014 fix NRE due to lack of ClusterTransactionId

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2479,7 +2479,12 @@ namespace Raven.Server.Documents
             // case 1: incoming change vector A:10, RAFT:3          -> update    (although it is a conflict) 
             // case 2: incoming change vector A:10, RAFT:2          -> update    (although it is a conflict)
             // case 3: incoming change vector A:10, RAFT:1          -> already merged
-            var partOfClusterTx = remote?.Contains(DocumentDatabase.ClusterTransactionId) == true || local?.Contains(DocumentDatabase.ClusterTransactionId) == true;
+            var partOfClusterTx = false;
+            var clusterTransactionId = DocumentDatabase.ClusterTransactionId;
+            if (string.IsNullOrEmpty(clusterTransactionId) == false)
+            {
+                partOfClusterTx = remote?.Contains(clusterTransactionId) == true || local?.Contains(clusterTransactionId) == true;
+            }
 
             if (originalStatus == ConflictStatus.Conflict && (HasUnusedDatabaseIds() || partOfClusterTx))
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23014

### Additional description

Very old databases doesn't have the `ClusterTransactionId` property set which would cause an NRE

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change (now it is not breaking)
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
