### PR TITLE
RavenDB-22502 fix conflict status detection for a cluster-wide vs non-cluster-wide doc

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2461,7 +2461,12 @@ namespace Raven.Server.Documents
         }
 
 
-        public ConflictStatus GetConflictStatus(string remote, string local)
+        public ConflictStatus GetConflictStatusForOrder(string remote, string local)
+        {
+            return ChangeVectorUtils.GetConflictStatus(remote, local);
+        }
+
+        public ConflictStatus GetConflictStatusForVersion(string remote, string local)
         {
             return GetConflictStatus(remote, local, out _);
         }
@@ -2508,11 +2513,7 @@ namespace Raven.Server.Documents
 
                 TryRemoveUnusedIds(ref remote);
                 skipValidation = TryRemoveUnusedIds(ref local);
-                var after = ChangeVectorUtils.GetConflictStatus(remote, local);
-
-                if (after == ConflictStatus.AlreadyMerged)
-                    return ConflictStatus.Conflict;
-                return after;
+                return ChangeVectorUtils.GetConflictStatus(remote, local);
             }
 
             return originalStatus;

--- a/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/IncomingReplicationHandler.cs
@@ -1349,9 +1349,8 @@ namespace Raven.Server.Documents.Replication
                                     continue;
                                 }
 
-                                var hasRemoteClusterTx = doc.Flags.Contain(DocumentFlags.FromClusterTransaction);
-                                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, doc.Id, doc.ChangeVector, out var hasLocalClusterTx);
                                 var flags = doc.Flags;
+                                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, doc.Id, doc.ChangeVector, flags);
                                 var resolvedDocument = document;
 
                                 switch (conflictStatus)
@@ -1404,25 +1403,9 @@ namespace Raven.Server.Documents.Replication
                                             _replicationInfo.Logger.Info(
                                                 $"Conflict check resolved to Conflict operation, resolving conflict for doc = {doc.Id}, with change vector = {doc.ChangeVector}");
 
-                                        if (hasLocalClusterTx == hasRemoteClusterTx)
-                                        {
-                                            // when hasLocalClusterTx and hasRemoteClusterTx both 'true'
-                                            // it is a case of a conflict between documents which were modified in a cluster transaction
-                                            // in two _different clusters_, so we will treat it as a "normal" conflict
-
-                                            IsIncomingInternalReplication = false;
-                                            _replicationInfo.ConflictManager.HandleConflictForDocument(context, doc.Id, doc.Collection, doc.LastModifiedTicks,
-                                                document, rcvdChangeVector, doc.Flags);
-                                            continue;
-                                        }
-
-                                        // cluster tx has precedence over regular tx
-
-                                        if (hasLocalClusterTx)
-                                            goto case ConflictStatus.AlreadyMerged;
-
-                                        if (hasRemoteClusterTx)
-                                            goto case ConflictStatus.Update;
+                                        IsIncomingInternalReplication = false;
+                                        _replicationInfo.ConflictManager.HandleConflictForDocument(context, doc.Id, doc.Collection, doc.LastModifiedTicks,
+                                            document, rcvdChangeVector, doc.Flags);
 
                                         break;
 

--- a/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationDocumentSender.cs
@@ -818,7 +818,7 @@ namespace Raven.Server.Documents.Replication
             }
 
             // destination already has it
-            if (_parent._database.DocumentsStorage.GetConflictStatus(item.ChangeVector, _parent.LastAcceptedChangeVector) == ConflictStatus.AlreadyMerged)
+            if (_parent._database.DocumentsStorage.GetConflictStatusForOrder(item.ChangeVector, _parent.LastAcceptedChangeVector) == ConflictStatus.AlreadyMerged)
             {
                 stats.RecordChangeVectorSkip();
                 skippedReplicationItemsInfo.Update(item);

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -2104,7 +2104,7 @@ namespace Raven.Server.Documents.Replication
                 if (internalUrls.Contains(destination.Destination.Url) == false)
                     continue;
 
-                var conflictStatus = Database.DocumentsStorage.GetConflictStatus(changeVector, destination.LastAcceptedChangeVector);
+                var conflictStatus = Database.DocumentsStorage.GetConflictStatusForOrder(changeVector, destination.LastAcceptedChangeVector);
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                     count++;
             }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -578,7 +578,7 @@ namespace Raven.Server.Documents.Revisions
 
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out var lowerId, out _))
             {
-                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, id, changeVector, out _);
+                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, id, changeVector, flags);
                 if (conflictStatus != ConflictStatus.Update)
                     return; // Do not modify the document.
 

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DocumentsSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionProcessor/DocumentsSubscriptionProcessor.cs
@@ -205,12 +205,12 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
                 return false;
             }
 
-            var status = Database.DocumentsStorage.GetConflictStatus(item.Document.ChangeVector, currentChangeVector);
+            var status = Database.DocumentsStorage.GetConflictStatusForOrder(item.Document.ChangeVector, currentChangeVector);
             switch (status)
             {
                 case ConflictStatus.Update:
                     // If document was updated, but the subscription went too far.
-                    var resendStatus = Database.DocumentsStorage.GetConflictStatus(item.Document.ChangeVector, SubscriptionConnectionsState.LastChangeVectorSent);
+                    var resendStatus = Database.DocumentsStorage.GetConflictStatusForOrder(item.Document.ChangeVector, SubscriptionConnectionsState.LastChangeVectorSent);
                     if (resendStatus == ConflictStatus.Update)
                     {
                         // we can clear it from resend list, and it will processed as regular document
@@ -236,7 +236,7 @@ namespace Raven.Server.Documents.Subscriptions.SubscriptionProcessor
         {
             if (item.Document != null)
             {
-                var status = Database.DocumentsStorage.GetConflictStatus(item.Document.ChangeVector, currentChangeVector);
+                var status = Database.DocumentsStorage.GetConflictStatusForVersion(item.Document.ChangeVector, currentChangeVector);
                 switch (status)
                 {
                     case ConflictStatus.Update:

--- a/test/SlowTests/Cluster/RavenDB_22502.cs
+++ b/test/SlowTests/Cluster/RavenDB_22502.cs
@@ -7,7 +7,9 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -209,6 +211,113 @@ namespace SlowTests.Cluster
             }
         }
         
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionConflictStatusMatrix()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                var raftId = database.DatabaseGroupId;
+                var clusterId = database.ClusterTransactionId;
+                var databaseId = database.DbBase64Id;
+                var unusedId = Guid.NewGuid().ToBase64Unpadded();
+
+                // our local change vector is           RAFT:2, TRXN:10
+                // case 1: incoming change vector A:10, RAFT:3          -> update    (although it is a conflict) 
+                // case 2: incoming change vector A:10, RAFT:2          -> update    (although it is a conflict)
+                // case 3: incoming change vector A:10, RAFT:1          -> already merged
+
+                var remote = $"A:10-{databaseId}, RAFT:10-{raftId}";
+                var local = $"RAFT:10-{raftId}, TRXN:10-{clusterId}";
+                var status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                Assert.Equal(ConflictStatus.Update, status);
+
+                status = database.DocumentsStorage.GetConflictStatusForVersion(local, remote);
+                Assert.Equal(ConflictStatus.AlreadyMerged, status);
+
+                local = $"A:10-{databaseId}, RAFT:11-{raftId}";
+                remote = $"RAFT:10-{raftId}, TRXN:10-{clusterId}";
+                status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                Assert.Equal(ConflictStatus.AlreadyMerged, status);
+
+                status = database.DocumentsStorage.GetConflictStatusForVersion(local, remote);
+                Assert.Equal(ConflictStatus.Update, status);
+
+                remote = $"A:10-{databaseId}";
+                local = $"RAFT:10-{raftId}, TRXN:10-{clusterId}";
+                status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                // this is conflict between cluster and non-cluster, we have a special treatment for this case higher in the stack
+                Assert.Equal(ConflictStatus.Conflict, status);
+
+                local = $"A:10-{unusedId}";
+                remote = $"RAFT:10-{raftId}, TRXN:10-{clusterId}";
+                status = database.DocumentsStorage.GetConflictStatusForVersion(local, remote);
+                Assert.Equal(ConflictStatus.Conflict, status);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task ConflictStatusMatrix()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                var databaseId = database.DbBase64Id;
+                var otherNode = Guid.NewGuid().ToBase64Unpadded();
+                var unusedId = Guid.NewGuid().ToBase64Unpadded();
+
+                database.DocumentsStorage.UnusedDatabaseIds = [unusedId];
+
+                // our local change vector is     A:10, B:10, C:10
+                // case 1: incoming change vector A:10, B:10, C:11  -> update           (original: update, after: already merged)
+                // case 2: incoming change vector A:11, B:10, C:10  -> update           (original: update, after: update)
+                // case 3: incoming change vector A:11, B:10        -> update           (original: conflict, after: update)
+                // case 4: incoming change vector A:10, B:10        -> already merged   (original: already merged, after: already merged)
+
+                // our local change vector is     A:11, B:10
+                // case 1: incoming change vector A:10, B:10, C:10 -> conflict              (original: conflict, after: already merged)        
+                // case 2: incoming change vector A:10, B:11, C:10 -> conflict              (original: conflict, after: conflict)
+                // case 3: incoming change vector A:11, B:10, C:10 -> update                (original: update, after: already merged)
+                // case 4: incoming change vector A:11, B:12, C:10 -> update 
+
+                var local = $"A:10-{databaseId}, B:10-{otherNode}, C:10-{unusedId}";
+                var remote = $"A:10-{databaseId}, B:10-{otherNode}, C:11-{unusedId}"; 
+                var status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                Assert.Equal(ConflictStatus.Update, status);
+
+                remote = $"A:11-{databaseId}, B:10-{otherNode}, C:10-{unusedId}"; 
+                status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                Assert.Equal(ConflictStatus.Update, status);
+
+                remote = $"A:11-{databaseId}, B:10-{otherNode}"; 
+                status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                Assert.Equal(ConflictStatus.Update, status);
+
+                remote = $"A:10-{databaseId}, B:10-{otherNode}"; 
+                status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                Assert.Equal(ConflictStatus.AlreadyMerged, status);
+
+
+                local = $"A:11-{databaseId}, B:10-{otherNode}";
+                remote = $"A:10-{databaseId}, B:10-{otherNode}, C:10-{unusedId}"; 
+                status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                Assert.Equal(ConflictStatus.AlreadyMerged, status);
+
+                remote = $"A:10-{databaseId}, B:11-{otherNode}, C:10-{unusedId}"; 
+                status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                Assert.Equal(ConflictStatus.Conflict, status);
+
+                remote = $"A:11-{databaseId}, B:10-{otherNode}, C:10-{unusedId}"; 
+                status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                Assert.Equal(ConflictStatus.Update, status);
+
+                remote = $"A:11-{databaseId}, B:12-{otherNode}, C:10-{unusedId}"; 
+                status = database.DocumentsStorage.GetConflictStatusForVersion(remote, local);
+                Assert.Equal(ConflictStatus.Update, status);
+            }
+        }
+
         private static void ModifyTopology(Options original, Options @new)
         {
             if (original.DatabaseMode == RavenDatabaseMode.Single)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22502

### Additional description

We have a special and a delicate mechanism to handle conflict status between cluster-wide and non-cluster-wide tx, which also takes into account the `UnusedDatabaseIds`.

There was a special case that handled a conflict status between a document that has only unused database ID in his change vector and cluster-wide document.
The handle of this case was very specific and had a collision with recently added changes https://github.com/ravendb/ravendb/pull/19305/commits/6403fd5f80b5565165e81fbb6628216be8c55c02 to handle a conflict between updated document and his previous version that was created by cluster-wide tx.

The fix is to have a separation between checking the partial order of the document and its version.

### Type of change

- [x] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
