### PR TITLE
RavenDB-23025 - add missing configurations in TestBase

### DIFF
--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -22,9 +22,11 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes.Static.NuGet;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.PeriodicBackup.Restore;
+using Raven.Server.EventListener;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.TrafficWatch;
 using Raven.Server.Utils;
 using Raven.Server.Utils.Features;
 using Sparrow.Collections;
@@ -150,6 +152,16 @@ namespace FastTests
             }
 
             RequestExecutor.RemoteCertificateValidationCallback += (sender, cert, chain, errors) => true;
+
+            TrafficWatchToLog.Instance.UpdateConfiguration(RavenConfiguration.Default.TrafficWatch);
+            EventListenerToLog.Instance.UpdateConfiguration(new EventListenerToLog.EventListenerConfiguration
+            {
+                EventListenerMode = RavenConfiguration.Default.DebugConfiguration.EventListenerMode,
+                EventTypes = RavenConfiguration.Default.DebugConfiguration.EventTypes,
+                MinimumDurationInMs = RavenConfiguration.Default.DebugConfiguration.MinimumDuration.GetValue(TimeUnit.Milliseconds),
+                AllocationsLoggingIntervalInMs = RavenConfiguration.Default.DebugConfiguration.AllocationsLoggingInterval.GetValue(TimeUnit.Milliseconds),
+                AllocationsLoggingCount = RavenConfiguration.Default.DebugConfiguration.AllocationsLoggingCount
+            });
         }
 
         protected TestBase(ITestOutputHelper output) : base(output)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23025

### Additional description

We are missing init of new configurations in RavenDB server created in TestBase

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
