### PR TITLE
RavenDB-22502 fix conflict status detection for a cluster-wide vs non-cluster-wide doc

### DIFF
--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -547,7 +547,7 @@ namespace Raven.Server.Documents
 
                         foreach (var conflict in conflicts)
                         {
-                            var conflictStatus = _documentDatabase.DocumentsStorage.GetConflictStatus(context, incomingChangeVector, conflict.ChangeVector, ChangeVectorMode.Version);
+                            var conflictStatus = _documentDatabase.DocumentsStorage.GetConflictStatusForVersion(context, incomingChangeVector, conflict.ChangeVector);
                             switch (conflictStatus)
                             {
                                 case ConflictStatus.Update:
@@ -644,10 +644,11 @@ namespace Raven.Server.Documents
             }
         }
 
-        public static ConflictStatus GetConflictStatusForDocument(DocumentsOperationContext context, string id, string changeVector, out bool hasLocalClusterTx)
+        public static ConflictStatus GetConflictStatusForDocument(DocumentsOperationContext context, string id, string changeVector, DocumentFlags flags)
         {
-            hasLocalClusterTx = false;
-
+            var hasLocalClusterTx = false;
+            var hasRemoteClusterTx = flags.Contain(DocumentFlags.FromClusterTransaction);
+            
             //tombstones also can be a conflict entry
             var conflicts = context.DocumentDatabase.DocumentsStorage.ConflictsStorage.GetConflictsFor(context, id);
             ConflictStatus status;
@@ -684,12 +685,23 @@ namespace Raven.Server.Documents
             else
                 return ConflictStatus.Update; //document with 'id' doesn't exist locally, so just do PUT
 
-            status = context.DocumentDatabase.DocumentsStorage.GetConflictStatus(context, context.GetChangeVector(changeVector), context.GetChangeVector(local), ChangeVectorMode.Version, out var skipValidation);
-            context.SkipChangeVectorValidation |= skipValidation;
+            status = context.DocumentDatabase.DocumentsStorage.GetConflictStatusForVersion(context, changeVector, local);
 
             if (status == ConflictStatus.Conflict)
             {
                 ConflictManager.AssertChangeVectorNotNull(local);
+
+                // when hasLocalClusterTx and hasRemoteClusterTx both 'true'
+                // it is a case of a conflict between documents which were modified in a cluster transaction
+                // in two _different clusters_, so we will treat it as a "normal" conflict
+                if (hasLocalClusterTx == hasRemoteClusterTx)
+                    return ConflictStatus.Conflict;
+            
+                // cluster tx has precedence over regular tx
+                if (hasLocalClusterTx)
+                    return ConflictStatus.AlreadyMerged;
+                // hasRemoteClusterTx is true
+                return ConflictStatus.Update;
             }
             return status;
         }

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -568,8 +568,8 @@ namespace Raven.Server.Documents.Replication.Incoming
                                 }
 
                                 var hasRemoteClusterTx = doc.Flags.Contain(DocumentFlags.FromClusterTransaction);
-                                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, doc.Id, doc.ChangeVector, out var hasLocalClusterTx);
                                 var flags = doc.Flags;
+                                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, doc.Id, doc.ChangeVector, flags);
                                 var resolvedDocument = document;
 
                                 switch (conflictStatus)
@@ -622,26 +622,14 @@ namespace Raven.Server.Documents.Replication.Incoming
                                             _replicationInfo.Logger.Info(
                                                 $"Conflict check resolved to Conflict operation, resolving conflict for doc = {doc.Id}, with change vector = {doc.ChangeVector}");
 
-                                        if (hasLocalClusterTx == hasRemoteClusterTx)
-                                        {
-                                            // when hasLocalClusterTx and hasRemoteClusterTx both 'true'
-                                            // it is a case of a conflict between documents which were modified in a cluster transaction
-                                            // in two _different clusters_, so we will treat it as a "normal" conflict
+                                        // when hasLocalClusterTx and hasRemoteClusterTx both 'true'
+                                        // it is a case of a conflict between documents which were modified in a cluster transaction
+                                        // in two _different clusters_, so we will treat it as a "normal" conflict
 
-                                            IsIncomingInternalReplication = false;
+                                        IsIncomingInternalReplication = false;
 
-                                            conflictManager.HandleConflictForDocument(context, doc.Id, doc.Collection, doc.LastModifiedTicks,
-                                                document, incomingChangeVector, doc.Flags);
-                                            continue;
-                                        }
-
-                                        // cluster tx has precedence over regular tx
-
-                                        if (hasLocalClusterTx)
-                                            goto case ConflictStatus.AlreadyMerged;
-
-                                        if (hasRemoteClusterTx)
-                                            goto case ConflictStatus.Update;
+                                        conflictManager.HandleConflictForDocument(context, doc.Id, doc.Collection, doc.LastModifiedTicks,
+                                            document, incomingChangeVector, doc.Flags);
 
                                         break;
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1871,7 +1871,7 @@ namespace Raven.Server.Documents.Replication
                 if (internalUrls.Contains(destination.Destination.Url) == false)
                     continue;
 
-                var conflictStatus = Database.DocumentsStorage.GetConflictStatus(context, changeVector, destination.LastAcceptedChangeVector, ChangeVectorMode.Order);
+                var conflictStatus = Database.DocumentsStorage.GetConflictStatusForOrder(context, changeVector, destination.LastAcceptedChangeVector);
                 if (conflictStatus == ConflictStatus.AlreadyMerged)
                     count++;
             }

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -586,7 +586,7 @@ namespace Raven.Server.Documents.Replication.Senders
             }
 
             // destination already has it
-            if (_parent._database.DocumentsStorage.GetConflictStatus(context, item.ChangeVector, _parent.LastAcceptedChangeVector, ChangeVectorMode.Order) == ConflictStatus.AlreadyMerged)
+            if (_parent._database.DocumentsStorage.GetConflictStatusForOrder(context ,item.ChangeVector, _parent.LastAcceptedChangeVector) == ConflictStatus.AlreadyMerged)
             {
                 stats.RecordChangeVectorSkip();
                 skippedReplicationItemsInfo.Update(item);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -484,7 +484,7 @@ namespace Raven.Server.Documents.Revisions
 
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out var lowerId, out _))
             {
-                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, id, changeVector, out _);
+                var conflictStatus = ConflictsStorage.GetConflictStatusForDocument(context, id, changeVector, flags);
                 if (conflictStatus != ConflictStatus.Update)
                     return; // Do not modify the document.
 

--- a/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Subscriptions/ShardedDocumentsDatabaseSubscriptionProcessor.cs
@@ -153,7 +153,7 @@ public sealed class ShardedDocumentsDatabaseSubscriptionProcessor : DocumentsDat
 
     protected override bool CheckIfNewerInResendList(DocumentsOperationContext context, string id, string cvInStorage, string cvInResendList)
     {
-        var resendListCvIsNewer = Database.DocumentsStorage.GetConflictStatus(context, cvInResendList, cvInStorage, ChangeVectorMode.Version);
+        var resendListCvIsNewer = Database.DocumentsStorage.GetConflictStatusForVersion(context, cvInResendList, cvInStorage);
         if (resendListCvIsNewer == ConflictStatus.Update)
         {
             return true;

--- a/src/Raven.Server/Documents/Subscriptions/Processor/DocumentsDatabaseSubscriptionProcessor.cs
+++ b/src/Raven.Server/Documents/Subscriptions/Processor/DocumentsDatabaseSubscriptionProcessor.cs
@@ -234,12 +234,12 @@ namespace Raven.Server.Documents.Subscriptions.Processor
                 return false;
             }
 
-            var status = Database.DocumentsStorage.GetConflictStatus(context, item.ChangeVector, currentChangeVector, ChangeVectorMode.Version);
+            var status = Database.DocumentsStorage.GetConflictStatusForVersion(context, item.ChangeVector, currentChangeVector);
             switch (status)
             {
                 case ConflictStatus.Update:
                     // If document was updated, but the subscription went too far.
-                    var resendStatus = Database.DocumentsStorage.GetConflictStatus(context, item.ChangeVector, SubscriptionConnectionsState.LastChangeVectorSent, ChangeVectorMode.Order);
+                    var resendStatus = Database.DocumentsStorage.GetConflictStatusForOrder(context, item.ChangeVector, SubscriptionConnectionsState.LastChangeVectorSent);
                     if (resendStatus == ConflictStatus.Update)
                     {
                         // we can clear it from resend list, and it will processed as regular document
@@ -282,7 +282,7 @@ namespace Raven.Server.Documents.Subscriptions.Processor
         {
             if (item.Document != null)
             {
-                var status = Database.DocumentsStorage.GetConflictStatus(context, item.Document.ChangeVector, currentChangeVector, ChangeVectorMode.Version);
+                var status = Database.DocumentsStorage.GetConflictStatusForVersion(context, item.Document.ChangeVector, currentChangeVector);
                 switch (status)
                 {
                     case ConflictStatus.Update:

--- a/test/SlowTests/Cluster/RavenDB_22502.cs
+++ b/test/SlowTests/Cluster/RavenDB_22502.cs
@@ -8,7 +8,10 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Sharding;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -210,6 +213,98 @@ namespace SlowTests.Cluster
             }
         }
         
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.ClusterTransactions)]
+        public async Task ClusterTransactionConflictStatusMatrix()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                var raftId = database.DatabaseGroupId;
+                var clusterId = database.ClusterTransactionId;
+                var databaseId = database.DbBase64Id;
+                var unusedId = Guid.NewGuid().ToBase64Unpadded();
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                {
+                    // our local change vector is           RAFT:2, TRXN:10
+                    // case 1: incoming change vector A:10, RAFT:3          -> update    (although it is a conflict) 
+                    // case 2: incoming change vector A:10, RAFT:2          -> update    (although it is a conflict)
+                    // case 3: incoming change vector A:10, RAFT:1          -> already merged
+                    var remote = $"A:10-{databaseId}, RAFT:10-{raftId}";
+                    var local = $"RAFT:10-{raftId}, TRXN:10-{clusterId}";
+                    var status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    Assert.Equal(ConflictStatus.Update, status);
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, local, remote);
+                    Assert.Equal(ConflictStatus.AlreadyMerged, status);
+                    local = $"A:10-{databaseId}, RAFT:11-{raftId}";
+                    remote = $"RAFT:10-{raftId}, TRXN:10-{clusterId}";
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    Assert.Equal(ConflictStatus.AlreadyMerged, status);
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, local, remote);
+                    Assert.Equal(ConflictStatus.Update, status);
+                    remote = $"A:10-{databaseId}";
+                    local = $"RAFT:10-{raftId}, TRXN:10-{clusterId}";
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    // this is conflict between cluster and non-cluster, we have a special treatment for this case higher in the stack
+                    Assert.Equal(ConflictStatus.Conflict, status);
+                    local = $"A:10-{unusedId}";
+                    remote = $"RAFT:10-{raftId}, TRXN:10-{clusterId}";
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, local, remote);
+                    Assert.Equal(ConflictStatus.Conflict, status);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task ConflictStatusMatrix()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                var databaseId = database.DbBase64Id;
+                var otherNode = Guid.NewGuid().ToBase64Unpadded();
+                var unusedId = Guid.NewGuid().ToBase64Unpadded();
+                database.DocumentsStorage.UnusedDatabaseIds = [unusedId];
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                {
+                    // our local change vector is     A:10, B:10, C:10
+                    // case 1: incoming change vector A:10, B:10, C:11  -> update           (original: update, after: already merged)
+                    // case 2: incoming change vector A:11, B:10, C:10  -> update           (original: update, after: update)
+                    // case 3: incoming change vector A:11, B:10        -> update           (original: conflict, after: update)
+                    // case 4: incoming change vector A:10, B:10        -> already merged   (original: already merged, after: already merged)
+                    // our local change vector is     A:11, B:10
+                    // case 1: incoming change vector A:10, B:10, C:10 -> conflict              (original: conflict, after: already merged)        
+                    // case 2: incoming change vector A:10, B:11, C:10 -> conflict              (original: conflict, after: conflict)
+                    // case 3: incoming change vector A:11, B:10, C:10 -> update                (original: update, after: already merged)
+                    // case 4: incoming change vector A:11, B:12, C:10 -> update 
+                    var local = $"A:10-{databaseId}, B:10-{otherNode}, C:10-{unusedId}";
+                    var remote = $"A:10-{databaseId}, B:10-{otherNode}, C:11-{unusedId}";
+                    var status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    Assert.Equal(ConflictStatus.Update, status);
+                    remote = $"A:11-{databaseId}, B:10-{otherNode}, C:10-{unusedId}";
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    Assert.Equal(ConflictStatus.Update, status);
+                    remote = $"A:11-{databaseId}, B:10-{otherNode}";
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    Assert.Equal(ConflictStatus.Update, status);
+                    remote = $"A:10-{databaseId}, B:10-{otherNode}";
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    Assert.Equal(ConflictStatus.AlreadyMerged, status);
+                    local = $"A:11-{databaseId}, B:10-{otherNode}";
+                    remote = $"A:10-{databaseId}, B:10-{otherNode}, C:10-{unusedId}";
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    Assert.Equal(ConflictStatus.AlreadyMerged, status);
+                    remote = $"A:10-{databaseId}, B:11-{otherNode}, C:10-{unusedId}";
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    Assert.Equal(ConflictStatus.Conflict, status);
+                    remote = $"A:11-{databaseId}, B:10-{otherNode}, C:10-{unusedId}";
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    Assert.Equal(ConflictStatus.Update, status);
+                    remote = $"A:11-{databaseId}, B:12-{otherNode}, C:10-{unusedId}";
+                    status = database.DocumentsStorage.GetConflictStatusForVersion(context, remote, local);
+                    Assert.Equal(ConflictStatus.Update, status);
+                }
+            }
+        }
         private static void ModifyTopology(Options original, Options @new)
         {
             if (original.DatabaseMode == RavenDatabaseMode.Single)

--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -283,8 +283,7 @@ namespace SlowTests.Server.Replication
                     session.Advanced.WaitForReplicationAfterSaveChanges(replicas: 2);
                     session.Store(new User { Name = "Karmel" }, "marker");
                     session.SaveChanges();
-
-                    await WaitForDocumentInClusterAsync<User>(cluster.Nodes, databaseName, "marker", (u) => u.Id == "marker", TimeSpan.FromSeconds(15));
+                    await Cluster.WaitForDocumentOnAllNodesAsync<User>(store, "marker", (u) => u.Id == "marker", TimeSpan.FromSeconds(15));
                 }
 
                 // wait for CV to merge after replication


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22502 

### Additional description

Apply changes from https://github.com/ravendb/ravendb/pull/19436

### Type of change

- [x] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
