### PR TITLE
RavenDB-21535 add option to validate trusted issuers certificate's SANs

### DIFF
--- a/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
@@ -150,6 +150,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Security.WellKnownIssuers.Admin", ConfigurationEntryScope.ServerWideOnly)]
         public string[] WellKnownIssuers { get; set; }
 
+        [Description("Will determine whether to validate well known issuer certificate subject alternative names against server domain.")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Security.WellKnownIssuers.Admin.ValidateCertificateNames", ConfigurationEntryScope.ServerWideOnly)]
+        public bool ValidateSanForCertificateWithWellKnownIssuer { get; set; }
+
 
         [Description("OBSOLETE: This is no longer supported or used, use 'Security.WellKnownIssuers.Admin' instead.")]
         [DefaultValue(null)]

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -3002,7 +3002,7 @@ namespace Raven.Server
                         continue;
                     }
 
-                    if (serverDomain.EndsWith(array[1]) &&
+                    if (serverDomain.EndsWith(array[1], StringComparison.OrdinalIgnoreCase) &&
                         serverDomain.Length > array[1].Length &&
                         serverDomain[..(serverDomain.Length - array[1].Length - 1)].Contains('.') == false)
                     {

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2987,7 +2987,6 @@ namespace Raven.Server
                 return false;
             }
 
-            Regex regex;
             foreach (var san in sans)
             {
                 if (san.StartsWith("*."))
@@ -3003,15 +3002,18 @@ namespace Raven.Server
                         continue;
                     }
 
-                    regex = new Regex(@"^[^.]+\." + Regex.Escape(array[1]) + "$", RegexOptions.IgnoreCase);
+                    if (serverDomain.EndsWith(array[1]) &&
+                        serverDomain.Length > array[1].Length &&
+                        serverDomain[..(serverDomain.Length - array[1].Length - 1)].Contains('.') == false)
+                    {
+                        return true;
+                    }
                 }
                 else
                 {
-                    regex = new Regex($"^{Regex.Escape(san)}$", RegexOptions.IgnoreCase);
+                    if (string.Compare(serverDomain, san, StringComparison.OrdinalIgnoreCase) == 0)
+                        return true;
                 }
-
-                if (regex.IsMatch(serverDomain))
-                    return true;
             }
 
             return false;

--- a/test/SlowTests/Issues/RavenDB-21535.cs
+++ b/test/SlowTests/Issues/RavenDB-21535.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using Raven.Server;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21535 : ClusterTestBase
+    {
+        public RavenDB_21535(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [RavenFact(RavenTestCategory.Certificates)]
+        public void KnownIssuerCert_CanNotAccess_WithoutSAN()
+        {
+            var caKeyPair = CertificateGenerator.GenerateRSAKeyPair();
+            var ca = CertificateGenerator.GenerateRootCACertificate("ca", 2, caKeyPair);
+            var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
+
+            var clientKeyPair = CertificateGenerator.GenerateRSAKeyPair();
+            var client = CertificateGenerator.GenerateSignedClientCertificate(ca, caKeyPair, LocalDomainName, 1, clientKeyPair, []);
+
+            var server = GetNewServer(new ServerCreationOptions
+                {
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        ["Security.WellKnownIssuers.Admin"] = caBase64,
+                        ["Security.WellKnownIssuers.Admin.ValidateCertificateNames"] = true.ToString(),
+                        ["PublicServerUrl"] = $"http://{LocalDomainName}",
+                    }
+                }
+            );
+
+            var result = server.AuthenticateConnectionCertificate(client, null);
+            Assert.Equal(RavenServer.AuthenticationStatus.UnfamiliarCertificate, result.Status);
+        }
+        
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData($"a.{LocalDomainName}", $"*.{LocalDomainName}")]
+        [InlineData($"c.{LocalDomainName}", $"*.{LocalDomainName}")]
+        [InlineData($"test.{LocalDomainName}", $"*.{LocalDomainName}")]
+        [InlineData($"longdomainname.{LocalDomainName}", $"*.{LocalDomainName}")]
+        [InlineData($"{LocalDomainName}", $"{LocalDomainName}")]
+        public void KnownIssuerCert_CanAccess_WithValidSAN(string publicDomain, string san)
+        {
+            var caKeyPair = CertificateGenerator.GenerateRSAKeyPair();
+            var ca = CertificateGenerator.GenerateRootCACertificate("ca", 2, caKeyPair);
+            var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
+
+            var clientKeyPair = CertificateGenerator.GenerateRSAKeyPair();
+            var client = CertificateGenerator.GenerateSignedClientCertificate(ca, caKeyPair, "admin", 1, clientKeyPair, [san]);
+
+            var server = GetNewServer(new ServerCreationOptions
+                {
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        ["Security.WellKnownIssuers.Admin"] = caBase64,
+                        ["Security.WellKnownIssuers.Admin.ValidateCertificateNames"] = true.ToString(),
+                        ["PublicServerUrl"] = $"http://{publicDomain}",
+                    }
+                }
+            );
+
+            var result = server.AuthenticateConnectionCertificate(client, null);
+            Assert.Equal(RavenServer.AuthenticationStatus.ClusterAdmin, result.Status);
+        }
+        
+        [RavenTheory(RavenTestCategory.Certificates)]
+        [InlineData($"a.b.{LocalDomainName}", $"*.{LocalDomainName}")]
+        [InlineData($"a.{LocalDomainName}", $"*.a.{LocalDomainName}")]
+        [InlineData($"aaa.{LocalDomainName}", $"bbb.{LocalDomainName}")]
+        [InlineData($"aaa.{LocalDomainName}.bbb", $"aaa.{LocalDomainName}")]
+        [InlineData($"aaa.{LocalDomainName}", $"aaa.{LocalDomainName}.bbb")]
+        public void KnownIssuerCert_CanNotAccess_WithInvalidSAN(string publicDomain, string san)
+        {
+            var caKeyPair = CertificateGenerator.GenerateRSAKeyPair();
+            var ca = CertificateGenerator.GenerateRootCACertificate("ca", 2, caKeyPair);
+            var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
+
+            var clientKeyPair = CertificateGenerator.GenerateRSAKeyPair();
+            var client = CertificateGenerator.GenerateSignedClientCertificate(ca, caKeyPair, "admin", 1, clientKeyPair, [san]);
+
+            var server = GetNewServer(new ServerCreationOptions
+                {
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        ["Security.WellKnownIssuers.Admin"] = caBase64,
+                        ["Security.WellKnownIssuers.Admin.ValidateCertificateNames"] = true.ToString(),
+                        ["PublicServerUrl"] = $"http://{publicDomain}",
+                    }
+                }
+            );
+
+            var result = server.AuthenticateConnectionCertificate(client, null);
+            Assert.Equal(RavenServer.AuthenticationStatus.UnfamiliarCertificate, result.Status);
+        }
+
+        [RavenFact(RavenTestCategory.Certificates)]
+        public void KnownIssuerCert_CanAccess_WhenSANValidation_IsDisabled_AndNotMatchingServerDomainName()
+        {
+            var caKeyPair = CertificateGenerator.GenerateRSAKeyPair();
+            var ca = CertificateGenerator.GenerateRootCACertificate("ca", 2, caKeyPair);
+            var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
+
+
+            var clientKeyPair = CertificateGenerator.GenerateRSAKeyPair();
+            var client = CertificateGenerator.GenerateSignedClientCertificate(ca, caKeyPair, "admin", 1, clientKeyPair, [LocalDomainName]);
+
+            var server = GetNewServer(new ServerCreationOptions
+                {
+                    CustomSettings = new Dictionary<string, string>
+                    {
+                        ["Security.WellKnownIssuers.Admin"] = caBase64,
+                        ["PublicServerUrl"] = $"http://a.{LocalDomainName}",
+                    }
+                }
+            );
+
+            var result = server.AuthenticateConnectionCertificate(client, null);
+            Assert.Equal(RavenServer.AuthenticationStatus.ClusterAdmin, result.Status);
+        }
+
+        private const string LocalDomainName = "localhost";
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-21535.cs
+++ b/test/SlowTests/Issues/RavenDB-21535.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Raven.Server;
+using Raven.Server.Config;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Utils;
 using Xunit;
@@ -14,7 +15,7 @@ namespace SlowTests.Issues
         public RavenDB_21535(ITestOutputHelper output) : base(output)
         {
         }
-        
+
         [RavenFact(RavenTestCategory.Certificates)]
         public void KnownIssuerCert_CanNotAccess_WithoutSAN()
         {
@@ -29,9 +30,9 @@ namespace SlowTests.Issues
                 {
                     CustomSettings = new Dictionary<string, string>
                     {
-                        ["Security.WellKnownIssuers.Admin"] = caBase64,
-                        ["Security.WellKnownIssuers.Admin.ValidateCertificateNames"] = true.ToString(),
-                        ["PublicServerUrl"] = $"http://{LocalDomainName}",
+                        [RavenConfiguration.GetKey(x => x.Security.WellKnownIssuers)] = caBase64,
+                        [RavenConfiguration.GetKey(x => x.Security.ValidateSanForCertificateWithWellKnownIssuer)] = true.ToString(),
+                        [RavenConfiguration.GetKey(x => x.Core.PublicServerUrl)] = $"http://{LocalDomainName}",
                     }
                 }
             );
@@ -39,7 +40,7 @@ namespace SlowTests.Issues
             var result = server.AuthenticateConnectionCertificate(client, null);
             Assert.Equal(RavenServer.AuthenticationStatus.UnfamiliarCertificate, result.Status);
         }
-        
+
         [RavenTheory(RavenTestCategory.Certificates)]
         [InlineData($"a.{LocalDomainName}", $"*.{LocalDomainName}")]
         [InlineData($"c.{LocalDomainName}", $"c.{LocalDomainName}")]
@@ -59,9 +60,9 @@ namespace SlowTests.Issues
                 {
                     CustomSettings = new Dictionary<string, string>
                     {
-                        ["Security.WellKnownIssuers.Admin"] = caBase64,
-                        ["Security.WellKnownIssuers.Admin.ValidateCertificateNames"] = true.ToString(),
-                        ["PublicServerUrl"] = $"http://{publicDomain}",
+                        [RavenConfiguration.GetKey(x => x.Security.WellKnownIssuers)] = caBase64,
+                        [RavenConfiguration.GetKey(x => x.Security.ValidateSanForCertificateWithWellKnownIssuer)] = true.ToString(),
+                        [RavenConfiguration.GetKey(x => x.Core.PublicServerUrl)] = $"http://{publicDomain}",
                     }
                 }
             );
@@ -69,7 +70,7 @@ namespace SlowTests.Issues
             var result = server.AuthenticateConnectionCertificate(client, null);
             Assert.Equal(RavenServer.AuthenticationStatus.ClusterAdmin, result.Status);
         }
-        
+
         [RavenTheory(RavenTestCategory.Certificates)]
         [InlineData($"a.b.{LocalDomainName}", $"*.{LocalDomainName}")]
         [InlineData($"a.{LocalDomainName}", $"*.a.{LocalDomainName}")]
@@ -89,9 +90,9 @@ namespace SlowTests.Issues
                 {
                     CustomSettings = new Dictionary<string, string>
                     {
-                        ["Security.WellKnownIssuers.Admin"] = caBase64,
-                        ["Security.WellKnownIssuers.Admin.ValidateCertificateNames"] = true.ToString(),
-                        ["PublicServerUrl"] = $"http://{publicDomain}",
+                        [RavenConfiguration.GetKey(x => x.Security.WellKnownIssuers)] = caBase64,
+                        [RavenConfiguration.GetKey(x => x.Security.ValidateSanForCertificateWithWellKnownIssuer)] = true.ToString(),
+                        [RavenConfiguration.GetKey(x => x.Core.PublicServerUrl)] = $"http://{publicDomain}",
                     }
                 }
             );
@@ -107,7 +108,6 @@ namespace SlowTests.Issues
             var ca = CertificateGenerator.GenerateRootCACertificate("ca", 2, caKeyPair);
             var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
 
-
             var clientKeyPair = CertificateGenerator.GenerateRSAKeyPair();
             var client = CertificateGenerator.GenerateSignedClientCertificate(ca, caKeyPair, "admin", 1, clientKeyPair, [LocalDomainName]);
 
@@ -115,8 +115,8 @@ namespace SlowTests.Issues
                 {
                     CustomSettings = new Dictionary<string, string>
                     {
-                        ["Security.WellKnownIssuers.Admin"] = caBase64,
-                        ["PublicServerUrl"] = $"http://a.{LocalDomainName}",
+                        [RavenConfiguration.GetKey(x => x.Security.WellKnownIssuers)] = caBase64,
+                        [RavenConfiguration.GetKey(x => x.Core.PublicServerUrl)] = $"http://a.{LocalDomainName}",
                     }
                 }
             );

--- a/test/SlowTests/Issues/RavenDB-21535.cs
+++ b/test/SlowTests/Issues/RavenDB-21535.cs
@@ -42,7 +42,7 @@ namespace SlowTests.Issues
         
         [RavenTheory(RavenTestCategory.Certificates)]
         [InlineData($"a.{LocalDomainName}", $"*.{LocalDomainName}")]
-        [InlineData($"c.{LocalDomainName}", $"*.{LocalDomainName}")]
+        [InlineData($"c.{LocalDomainName}", $"c.{LocalDomainName}")]
         [InlineData($"test.{LocalDomainName}", $"*.{LocalDomainName}")]
         [InlineData($"longdomainname.{LocalDomainName}", $"*.{LocalDomainName}")]
         [InlineData($"{LocalDomainName}", $"{LocalDomainName}")]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21535

### Additional description

Added option to validate SAN for certificates with trusted issuer.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
