### PR TITLE
RavenDB-22990 fix NRE at WhoAmI when cert is unknown

### DIFF
--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -679,6 +679,11 @@ namespace Raven.Server.Web.Authentication
                         };
                         certificate = ctx.ReadObject(wellKnownCertDef.ToJson(), "WellKnown/Certificate/Definition");
                     }
+                    else
+                    {
+                        NoContentStatus();
+                        return;
+                    }
                 }
 
                 await using (var writer = new AsyncBlittableJsonTextWriter(ctx, ResponseBodyStream()))

--- a/test/SlowTests/Issues/RavenDB-19951.cs
+++ b/test/SlowTests/Issues/RavenDB-19951.cs
@@ -269,6 +269,23 @@ public class RavenDB_19951 : RavenTestBase
         }
     }
 
+    [RavenFact(RavenTestCategory.Security)]
+    public async Task CanAccessWhoAmIWithBadCertificate()
+    {
+        var certificates = Certificates.SetupServerAuthentication();
+        var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificate.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+        var userCert = certificates.ClientCertificate2.Value;
+
+        using (var store = GetDocumentStore(new Options
+               {
+                   AdminCertificate = adminCert, 
+                   ClientCertificate = userCert
+               }))
+        {
+            var client = new TwoFactorClient(store, userCert);
+            await client.WhoAmIRequest();
+        }
+    }
 
     class TwoFactorClient : IDisposable
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22990 

### Additional description

`WhoAmI` EP is `UnauthenticatedClients`.
When certificate is not provided we return `NoContent`
Did the same behavior when an unknown certificate is provided

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
