### PR TITLE
RavenDB-7070 Test fix: DistinctCountShouldWork - WaitForNonStaleResults

### DIFF
--- a/test/SlowTests/Issues/RavenDB_10611.cs
+++ b/test/SlowTests/Issues/RavenDB_10611.cs
@@ -52,6 +52,7 @@ namespace SlowTests.Issues
                 {
                     var countries = session
                         .Query<Order>()
+                        .Customize(x => x.WaitForNonStaleResults())
                         .OrderBy(x => x.ShipTo.Country)
                         .Select(x => x.ShipTo.Country)
                         .Distinct()
@@ -59,6 +60,7 @@ namespace SlowTests.Issues
 
                     var count = session
                         .Query<Order>()
+                        .Customize(x => x.WaitForNonStaleResults())
                         .OrderBy(x => x.ShipTo.Country)
                         .Select(x => x.ShipTo.Country)
                         .Distinct()


### PR DESCRIPTION
### Additional description

Perform assertions on results that are not stale.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
