### PR TITLE
RavenDB-23017 - Dispose the command if it's being skipped

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -382,7 +382,7 @@ namespace Raven.Server.ServerWide.Commands
 
             return null;
         }
-        
+
         public DynamicJsonArray SaveCommandsBatch(ClusterOperationContext context, RawDatabaseRecord rawRecord, long index)
         {
             var result = new DynamicJsonArray();
@@ -595,9 +595,12 @@ namespace Raven.Server.ServerWide.Commands
 
             public void Dispose()
             {
-                foreach (var command in Commands)
+                if (Commands is { Count: > 0 })
                 {
-                    command.Document?.Dispose();
+                    foreach (var command in Commands)
+                    {
+                        command.Document?.Dispose();
+                    }
                 }
             }
         }
@@ -647,7 +650,7 @@ namespace Raven.Server.ServerWide.Commands
                         // beware of reading commands of other databases.
                         result.Dispose();
                         continue;
-                    } 
+                    }
 
                     if (result.PreviousCount < fromCount)
                     {

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.ServerWide.Commands
         //We take the current ticks in advance to ensure consistent results of the command execution on all nodes
         public long CommandCreationTicks = long.MinValue;
 
-        public class ClusterTransactionDataCommand
+        public class ClusterTransactionDataCommand : IDisposable
         {
             public CommandType Type;
             public string Id;
@@ -81,6 +81,11 @@ namespace Raven.Server.ServerWide.Commands
                     djv[nameof(FromBackup)] = FromBackup.Value;
 
                 return djv;
+            }
+
+            public void Dispose()
+            {
+                Document?.Dispose();
             }
         }
 
@@ -599,7 +604,7 @@ namespace Raven.Server.ServerWide.Commands
                 {
                     foreach (var command in Commands)
                     {
-                        command.Document?.Dispose();
+                        command.Dispose();
                     }
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23017

### Additional description

After restoring the cluster transactions and restarting the database, they were previously reapplied. This was addressed in PR [#18199](https://github.com/ravendb/ravendb/pull/18199). Now, the commands are skipped, but we still need to make sure they’re properly disposed of.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
