### PR TITLE
RavenDB-22973 Free scratch page immediately if it was allocated in current transaction. The issue was that we put a deletion marker for a scratch page instead and the scratch page has been never feed if it was allocated in the same transaction again. Exposing more debug info.

### DIFF
--- a/src/Voron/Debugging/InMemoryStorageState.cs
+++ b/src/Voron/Debugging/InMemoryStorageState.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using Voron.Impl.Journal;
+using Voron.Impl.Scratch;
 
 namespace Voron.Debugging
 {
@@ -9,12 +12,17 @@ namespace Voron.Debugging
 
         public long PossibleOldestReadTransaction { get; set; }
 
+        public EnvironmentStateRecordDetails EnvironmentStateRecord { get; set; }
+
         public List<ActiveTransaction> ActiveTransactions { get; set; }
+
+        public List<EnvironmentStateRecordDetails> TransactionsToFlush { get; set; }
 
         public FlushStateDetails FlushState { get; set; }
 
         public SyncStateDetails SyncState { get; set; }
 
+        public DateTime CurrentTime { get; set; } = DateTime.UtcNow;
 
         public sealed class FlushStateDetails
         {
@@ -27,6 +35,8 @@ namespace Voron.Debugging
             public bool ShouldFlush { get; set; }
 
             public List<long> JournalsToDelete { get; set; }
+
+            public int TotalCommittedSinceLastFlushPages { get; set; }
         }
 
         public sealed class SyncStateDetails
@@ -37,6 +47,32 @@ namespace Voron.Debugging
 
             public bool ShouldSync { get; set; }
 
+        }
+
+        public sealed class EnvironmentStateRecordDetails
+        {
+            public long TransactionId { get; set; }
+          
+            public ScratchTableDetails ScratchPagesTable { get; set; }
+            
+            public long WrittenToJournalNumber { get; set; }
+            
+            public long NextPageNumber { get; set; }
+
+            public string ClientStateType { get; set; }
+        }
+
+        public sealed class ScratchTableDetails
+        {
+            public int NumberOfPages { get; set; }
+
+            public long MinAllocatedInTransaction { get; set; }
+
+            public long MaxAllocatedInTransaction { get; set; }
+
+            public int MinScratchNumber { get; set; }
+
+            public int MaxScratchNumber { get; set; }
         }
     }
 

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1306,11 +1306,15 @@ namespace Voron.Impl.Journal
                         {
                             for (int i = 0; i < pages.Length; i++)
                             {
-                                Debug.Assert(pages[i].PageNumber + pages[i].GetNumberOfPages() <= dataPagerState.NumberOfAllocatedPages,
+                                int numberOfPages = pages[i].GetNumberOfPages();
+
+                                Debug.Assert(pages[i].PageNumber + numberOfPages <= dataPagerState.NumberOfAllocatedPages,
                                     "pages[i].PageNumber + pages[i].GetNumberOfPagesUpdateStateOnCommit() <= dataPagerState.NumberOfAllocatedPages");
 
-                                var span = new Span<byte>(pages[i].Pointer, pages[i].GetNumberOfPages() * Constants.Storage.PageSize);
+                                var span = new Span<byte>(pages[i].Pointer, numberOfPages * Constants.Storage.PageSize);
                                 RandomAccess.Write(fileHandle, span, pages[i].PageNumber * Constants.Storage.PageSize);
+
+                                written += numberOfPages * Constants.Storage.PageSize;
                             }
                         }
                     }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -628,6 +628,9 @@ namespace Voron.Impl.Journal
 
                     if (_failedToUpdateJournalState)
                     {
+                        // we have failed to update the journal state during the last flush, the environment is considered to be in faulty state (hence it's going to be restarted)
+                        // we need to refrain from executing more flushes since we cannot relay neither on in-memory nor data date of the environment
+
                         if (_waj._logger.IsWarnEnabled)
                         {
                             _waj._logger.Warn("Ignoring the flush due to failure in updating the journal state. This is a catastrophic failure so the environment is going to be restarted.");

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1331,11 +1331,7 @@ namespace Voron.Impl.Journal
                         continue; // We already wrote those pages to disk in a previous flush... 
 
                     Debug.Assert(pageValue.AllocatedInTransaction <= record.TransactionId, "pageValue.AllocatedInTransaction <= record.TransactionId");
-                    if (pageValue.IsDeleted)
-                    {
-                        //dataPager.ZeroPage() - hole punching
-                        continue;
-                    }
+                    
                     pageNumsBuffer[index] = pageNum;
                     var page = PreparePage(ref txState, pageValue);
                     pagesBuffer[index] = page;

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -843,7 +843,8 @@ namespace Voron.Impl
                 && scratchPage.AllocatedInTransaction == Id)
             {
                 _transactionPages.Remove(scratchPage);
-                scratchPagesInUse[pageNumber] = scratchPage with { IsDeleted = true };
+
+                _env.ScratchBufferPool.Free(this, scratchPage.File.Number, scratchPage.PositionInScratchBuffer);
 
                 if (_env.Options.Encryption.IsEnabled)
                 {

--- a/src/Voron/Impl/Scratch/PageFromScratchBuffer.cs
+++ b/src/Voron/Impl/Scratch/PageFromScratchBuffer.cs
@@ -36,8 +36,7 @@ namespace Voron.Impl.Scratch
         long PositionInScratchBuffer,
         long PageNumberInDataFile,
         Page PreviousVersion,
-        int NumberOfPages,
-        bool IsDeleted = false
+        int NumberOfPages
     )
     {
         public unsafe Page ReadPage(LowLevelTransaction tx)
@@ -47,12 +46,8 @@ namespace Voron.Impl.Scratch
         
         public unsafe byte* Read(ref Pager.PagerTransactionState txState)
         {
-            if (IsDeleted == false)
-            {
-                File.VerifyMatch(PageNumberInDataFile, PositionInScratchBuffer, NumberOfPages);
-                return File.Pager.AcquirePagePointerWithOverflowHandling(State, ref txState, PositionInScratchBuffer);
-            }
-            throw new InvalidOperationException($"Attempt to read page {PageNumberInDataFile} that was deleted");
+            File.VerifyMatch(PageNumberInDataFile, PositionInScratchBuffer, NumberOfPages);
+            return File.Pager.AcquirePagePointerWithOverflowHandling(State, ref txState, PositionInScratchBuffer);
         }
 
         public unsafe Page ReadNewPage(LowLevelTransaction tx)
@@ -69,12 +64,8 @@ namespace Voron.Impl.Scratch
         
         public unsafe byte* ReadRaw(ref Pager.PagerTransactionState txState)
         {
-            if (IsDeleted == false)
-            {
-                File.VerifyMatch(PageNumberInDataFile, PositionInScratchBuffer, NumberOfPages);
-                return File.Pager.AcquireRawPagePointerWithOverflowHandling(State, ref txState, PositionInScratchBuffer);
-            }
-            throw new InvalidOperationException($"Attempt to read page {PageNumberInDataFile} that was deleted");
+            File.VerifyMatch(PageNumberInDataFile, PositionInScratchBuffer, NumberOfPages);
+            return File.Pager.AcquireRawPagePointerWithOverflowHandling(State, ref txState, PositionInScratchBuffer);
         }
 
         public unsafe Page ReadWritable(LowLevelTransaction tx)

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -4,7 +4,6 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-using Sparrow;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -328,6 +327,26 @@ namespace Voron.Impl.Scratch
                     $"Failed to verify page {pageNumberInDataFile} when reading scratch page {positionInScratchBuffer}, values different!" +
                     $"Page: {pageNumberInDataFile} vs. {allocated.PageNumberInDataFile} ({numberOfPages} vs {allocated.NumberOfPages})!");
 
+        }
+
+        [Conditional("DEBUG")]
+        public void AssertNoPagesAllocatedInTransactionOlderThan(long txId)
+        {
+            foreach (PageFromScratchBuffer p in _allocatedPages.Values)
+            {
+                if (p.AllocatedInTransaction < txId)
+                {
+                    var message =
+                        $"Found page #{p.PageNumberInDataFile} allocated in tx {p.AllocatedInTransaction} (scratch {p.File.Number}, pos in scratch: {p.PositionInScratchBuffer}) while we freed up to tx {txId}";
+
+                    Console.Error.WriteLine(message);
+
+                    Console.WriteLine(message);
+
+                    throw new InvalidOperationException(message);
+
+                }
+            }
         }
     }
 }

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -339,12 +339,7 @@ namespace Voron.Impl.Scratch
                     var message =
                         $"Found page #{p.PageNumberInDataFile} allocated in tx {p.AllocatedInTransaction} (scratch {p.File.Number}, pos in scratch: {p.PositionInScratchBuffer}) while we freed up to tx {txId}";
 
-                    Console.Error.WriteLine(message);
-
-                    Console.WriteLine(message);
-
                     throw new InvalidOperationException(message);
-
                 }
             }
         }

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -578,7 +578,8 @@ namespace Voron.Impl.Scratch
                     scratchFileUsage.MostAvailableFreePages.Add(new MostAvailableFreePagesBySize
                     {
                         Size = freePage.Key,
-                        ValidAfterTransactionId = freePage.Value
+                        ValidAfterTransactionId = freePage.Value.ValidAfterTransactionId,
+                        AllocatedInTransaction = freePage.Value.AllocatedInTransaction
                     });
                 }
 
@@ -589,6 +590,7 @@ namespace Voron.Impl.Scratch
                         NumberOfPages = allocatedPage.NumberOfPages,
                         PositionInScratchBuffer = allocatedPage.PositionInScratchBuffer,
                         ScratchFileNumber = allocatedPage.File.Number,
+                        AllocatedInTransaction = allocatedPage.AllocatedInTransaction,
                     });
                 }
 

--- a/src/Voron/Impl/Scratch/ScratchBufferPoolInfo.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPoolInfo.cs
@@ -29,6 +29,8 @@ namespace Voron.Impl.Scratch
     {
         public long Size { get; set; }
         public long ValidAfterTransactionId { get; set; }
+
+        public long AllocatedInTransaction { get; set; }
     }
 
     public sealed class AllocatedPageInScratchBuffer
@@ -36,6 +38,7 @@ namespace Voron.Impl.Scratch
         public int ScratchFileNumber { get; set; }
         public long PositionInScratchBuffer { get; set; }
         public int NumberOfPages { get; set; }
+        public long AllocatedInTransaction { get; set; }
     }
 
     public sealed class ScratchFileUsage

--- a/test/SlowTests/Voron/Issues/RavenDB_22973.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22973.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_22973 : StorageTest
+{
+    public RavenDB_22973(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        base.Configure(options);
+
+        options.ManualFlushing = true;
+        options.ManualSyncing = true;
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void ScratchBufferMustNotContainDeletedLeftoversAfterFlushing_AllocateFreeAllocateInSameTx()
+    {
+        using (var txw = Env.WriteTransaction())
+        {
+            var llt = txw.LowLevelTransaction;
+
+            var p1 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+
+            llt.ModifyPage(p1);
+
+            llt.FreePage(p1);
+
+            var p11 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+
+            Assert.Equal(p1, p11); // the same page number was returned by free space handling
+
+            llt.ModifyPage(p11);
+
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        var scratchBufferFile = Env.ScratchBufferPool.GetScratchBufferFile(0);
+
+        Assert.Equal(0, scratchBufferFile.AllocatedPagesCount);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void ScratchBufferMustNotContainDeletedLeftoversAfterFlushing_AllocateInOneTx_FreeAndAllocateInNextTx()
+    {
+        long p1;
+
+        using (var txw = Env.WriteTransaction())
+        {
+            var llt = txw.LowLevelTransaction;
+
+            p1 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+
+            llt.ModifyPage(p1);
+
+            txw.Commit();
+        }
+
+        using (var txw = Env.WriteTransaction())
+        {
+            var llt = txw.LowLevelTransaction;
+            llt.FreePage(p1);
+
+            var p11 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+
+            Assert.Equal(p1, p11); // the same page number was returned by free space handling
+
+            llt.ModifyPage(p11);
+
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        var scratchBufferFile = Env.ScratchBufferPool.GetScratchBufferFile(0);
+
+        Assert.Equal(0, scratchBufferFile.AllocatedPagesCount);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void ScratchBufferMustNotContainDeletedLeftoversAfterFlushing_AllocateInOneTx_FreeAndAllocateInNextTxWrappedByReadTx()
+    {
+        long p1;
+
+        using (var txw = Env.WriteTransaction())
+        {
+            var llt = txw.LowLevelTransaction;
+
+            p1 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+
+            llt.ModifyPage(p1);
+
+            txw.Commit();
+        }
+
+        using (var readTx = Env.ReadTransaction())
+        {
+            var readPage = readTx.LowLevelTransaction.GetPage(p1);
+
+            using (var txw = Env.WriteTransaction())
+            {
+                var llt = txw.LowLevelTransaction;
+                llt.FreePage(p1);
+
+                var p11 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+
+                Assert.Equal(p1, p11); // the same page number was returned by free space handling
+                    
+                llt.ModifyPage(p11);
+
+                txw.Commit();
+            }
+
+            Env.FlushLogToDataFile();
+
+            var scratchBufferFile = Env.ScratchBufferPool.GetScratchBufferFile(0);
+
+            Assert.Equal(readTx.LowLevelTransaction.CurrentStateRecord.ScratchPagesTable.Count, scratchBufferFile.AllocatedPagesCount);
+        }
+    }
+}

--- a/test/SlowTests/Voron/Issues/RavenDB_22973.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22973.cs
@@ -128,4 +128,69 @@ public class RavenDB_22973 : StorageTest
             Assert.Equal(readTx.LowLevelTransaction.CurrentStateRecord.ScratchPagesTable.Count, scratchBufferFile.AllocatedPagesCount);
         }
     }
+
+    [Fact]
+    public void FailureOnUpdatingJournalStateMustIgnoreFurtherFlushes()
+    {
+        long p1;
+
+        using (var txw = Env.WriteTransaction())
+        {
+            var llt = txw.LowLevelTransaction;
+
+            p1 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+
+            llt.ModifyPage(p1);
+
+            txw.Commit();
+        }
+
+        using (var txw = Env.WriteTransaction())
+        {
+            var llt = txw.LowLevelTransaction;
+            llt.FreePage(p1);
+
+            var p11 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+
+            Assert.Equal(p1, p11); // the same page number was returned by free space handling
+
+            llt.ModifyPage(p11);
+
+            txw.Commit();
+        }
+
+        var throwOnUpdatingJournalState = true;
+
+        Env.Journal.Applicator.ForTestingPurposesOnly().OnUpdateJournalStateUnderWriteTransactionLock += () =>
+        {
+            if (throwOnUpdatingJournalState == false)
+                return;
+
+            throwOnUpdatingJournalState = false; // do it just once
+
+            throw new InvalidOperationException("For testing purposes");
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => Env.FlushLogToDataFile());
+
+        Assert.Equal("For testing purposes", ex.Message);
+
+        var flushWasCalled = false;
+
+        Env.Journal.Applicator.ForTestingPurposesOnly().OnApplyLogsToDataFileUnderFlushingLock += () =>
+        {
+            flushWasCalled = true;
+        };
+
+        Env.FlushLogToDataFile();
+
+        // originally I thought that the below assertion must be valid after second FlushLogToDataFile() call
+        // although the first exception thrown there makes that the whole environment isn't in valid state so we'll prevent from
+        // making more attempts to flush logs what is verified next in the test
+        //
+        //var scratchBufferFile = Env.ScratchBufferPool.GetScratchBufferFile(0);
+        //Assert.Equal(0, scratchBufferFile.AllocatedPagesCount);
+
+        Assert.False(flushWasCalled);
+    }
 }

--- a/test/SlowTests/Voron/Issues/RavenDB_22973.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22973.cs
@@ -193,4 +193,27 @@ public class RavenDB_22973 : StorageTest
 
         Assert.False(flushWasCalled);
     }
+
+
+    [Fact]
+    public void FlushingMustIncrementTotalWrittenButUnsyncedBytes()
+    {
+        long p1;
+
+        using (var txw = Env.WriteTransaction())
+        {
+            var llt = txw.LowLevelTransaction;
+
+            p1 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+
+            llt.ModifyPage(p1);
+
+            txw.Commit();
+        }
+
+
+        Env.FlushLogToDataFile();
+
+        Assert.True(Env.Journal.Applicator.TotalWrittenButUnsyncedBytes > 0);
+    }
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22973/Temporary-files-take-much-more-space-on-7.0

### Additional description

The problem was missing release of scratch buffer pages. The scenario was: allocate page, free page, allocate page - this created leftovers in scratch file allocations.

The solution is to free a scratch buffer page immediately if it was allocated in a current transaction. Also we remove the concept of scratch file deletion marker (IsDeleted = true) since we don't actually need it.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
