### PR TITLE
RavenDB-23017 

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -62,6 +62,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         ValueTask DeleteDocumentAsync(string id);
         IEnumerable<DocumentItem> GetDocumentsWithDuplicateCollection();
+        ValueTask FlushAsync();
     }
 
     public interface INewCompareExchangeActions
@@ -116,7 +117,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface ICompareExchangeActions : INewCompareExchangeActions, IAsyncDisposable
     {
-        ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument);
+        ValueTask<bool> WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument);
 
         ValueTask WriteTombstoneKeyAsync(string key);
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseSmuggler.cs
@@ -790,7 +790,9 @@ namespace Raven.Server.Smuggler.Documents
                     if (compareExchangeActions != null && item.Document.ChangeVector != null && item.Document.ChangeVector.Contains(ChangeVectorParser.TrxnTag))
                     {
                         var key = ClusterWideTransactionHelper.GetAtomicGuardKey(item.Document.Id);
-                        await compareExchangeActions.WriteKeyValueAsync(key, null, item.Document);
+                        if (await compareExchangeActions.WriteKeyValueAsync(key, null, item.Document))
+                            await documentActions.FlushAsync();
+
                         continue;
                     }
 

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1412,6 +1412,11 @@ namespace Raven.Server.Smuggler.Documents
                 yield break;
             }
 
+            public ValueTask FlushAsync()
+            {
+                return ValueTask.CompletedTask;
+            }
+
             public Stream GetTempStream()
             {
                 throw new NotSupportedException();
@@ -1538,7 +1543,7 @@ namespace Raven.Server.Smuggler.Documents
             {
             }
 
-            public async ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument)
+            public async ValueTask<bool> WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument)
             {
                 using (value)
                 {
@@ -1556,6 +1561,8 @@ namespace Raven.Server.Smuggler.Documents
 
                     await Writer.MaybeFlushAsync();
                 }
+
+                return false;
             }
 
             public async ValueTask WriteTombstoneKeyAsync(string key)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23017 

### Additional description

we need to force flushing in the document actions after we flush anything in the compare exchange, by doing that we will recreate a context and builder, which will avoid us from retaining one context for a long time and keeping a lot of unmanaged memory allocations

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
