### PR TITLE
RavenDB-23036 getting thread name for linux

### DIFF
--- a/src/Raven.Server/Utils/ThreadHelper.cs
+++ b/src/Raven.Server/Utils/ThreadHelper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.IO;
 using System.Threading;
 using Sparrow.Logging;
+using Sparrow.Platform;
 
 namespace Raven.Server.Utils;
 
@@ -32,6 +34,21 @@ public static class ThreadHelper
         catch
         {
             return ThreadPriority.Normal;
+        }
+    }
+
+    public static string GetThreadName(int processId, int threadId)
+    {
+        if (PlatformDetails.RunningOnLinux == false)
+            return null;
+
+        try
+        {
+            return File.ReadAllText($"/proc/{processId}/task/{threadId}/comm");
+        }
+        catch
+        {
+            return null;
         }
     }
 }

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -111,11 +111,13 @@ namespace Raven.Server.Utils
                                 }
                                 else
                                 {
-                                    threadName = threadStats.Name ?? "Thread Pool Thread";
+                                    threadName = threadStats.Name ?? ThreadHelper.GetThreadName(process.Id, thread.Id) ?? "Thread Pool Thread";
                                 }
 
                                 unmanagedAllocations = threadStats.TotalAllocated;
                             }
+
+                            threadName ??= ThreadHelper.GetThreadName(process.Id, thread.Id);
 
                             var threadState = GetThreadInfoOrDefault<ThreadState?>(() => thread.ThreadState);
                             threadsInfo.List.Add(new ThreadInfo


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23036

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Linux.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
