### PR TITLE
RavenDB-23038 allow to run Nightly tests from 16:00 UTC

### DIFF
--- a/test/Tests.Infrastructure/NightlyBuildTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/NightlyBuildTheoryAttribute.cs
@@ -10,15 +10,27 @@ namespace Tests.Infrastructure
 
         internal static bool IsNightlyBuild = Force;
 
-        internal static string SkipMessage =
-            "Nightly build tests are only working between 21:00 and 6:00 UTC and when 'RAVEN_ENABLE_NIGHTLY_BUILD_TESTS' is set to 'true'. "
-            + "They also can be enforced by setting 'RAVEN_FORCE_NIGHTLY_BUILD_TESTS' to 'true'.";
+        internal static readonly string SkipMessage;
 
         static NightlyBuildTheoryAttribute()
         {
+            int startHourUtc = 16;
+            int endHourUtc = 6;
+
+            var startHourUtcAsString = Environment.GetEnvironmentVariable("RAVEN_NIGHTLY_BUILD_TESTS_START_HOUR");
+            var endHourUtcAsString = Environment.GetEnvironmentVariable("RAVEN_NIGHTLY_BUILD_TESTS_END_HOUR");
+
+            if (startHourUtcAsString != null && int.TryParse(startHourUtcAsString, out var newStartHourUtc))
+                startHourUtc = newStartHourUtc;
+
+            if (endHourUtcAsString != null && int.TryParse(endHourUtcAsString, out var newEndHourUtc))
+                endHourUtc = newEndHourUtc;
+
+            SkipMessage = $"Nightly build tests are only working between {startHourUtc}:00 and {endHourUtc}:00 UTC and when 'RAVEN_ENABLE_NIGHTLY_BUILD_TESTS' is set to 'true'. They also can be enforced by setting 'RAVEN_FORCE_NIGHTLY_BUILD_TESTS' to 'true'.";
+
             if (IsNightlyBuild)
                 return;
-            
+
             var forceVariable = Environment.GetEnvironmentVariable("RAVEN_FORCE_NIGHTLY_BUILD_TESTS");
             if (forceVariable != null && bool.TryParse(forceVariable, out var forceNightlyBuildTests) && forceNightlyBuildTests)
             {
@@ -37,7 +49,7 @@ namespace Tests.Infrastructure
                 return;
 
             var now = SystemTime.UtcNow;
-            IsNightlyBuild = now.Hour >= 18 || now.Hour <= 6;
+            IsNightlyBuild = now.Hour >= startHourUtc || now.Hour <= endHourUtc;
         }
 
         public override string Skip


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23038

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
