### PR TITLE
RavenDB-23017 

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -65,6 +65,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         ValueTask DeleteDocumentAsync(string id);
         IEnumerable<DocumentItem> GetDocumentsWithDuplicateCollection();
+        ValueTask FlushAsync();
     }
 
     public interface INewCompareExchangeActions
@@ -118,7 +119,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
     public interface ICompareExchangeActions : INewCompareExchangeActions, IAsyncDisposable
     {
-        ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument);
+        ValueTask<bool> WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument);
 
         ValueTask WriteTombstoneKeyAsync(string key);
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -268,7 +268,7 @@ namespace Raven.Server.Smuggler.Documents
                 }
 
                 _command.Add(item);
-                return HandleBatchOfDocumentsIfNecessaryAsync(beforeFlushing);
+                return HandleBatchOfDocumentsIfNecessaryAsync(beforeFlushing, force: false);
             }
 
             public async ValueTask WriteTombstoneAsync(Tombstone tombstone, SmugglerProgressBase.CountsWithLastEtag progress)
@@ -277,7 +277,7 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     Tombstone = tombstone
                 });
-                await HandleBatchOfDocumentsIfNecessaryAsync(null);
+                await HandleBatchOfDocumentsIfNecessaryAsync(null, force: false);
             }
 
             public async ValueTask WriteConflictAsync(DocumentConflict conflict, SmugglerProgressBase.CountsWithLastEtag progress)
@@ -286,7 +286,7 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     Conflict = conflict
                 });
-                await HandleBatchOfDocumentsIfNecessaryAsync(null);
+                await HandleBatchOfDocumentsIfNecessaryAsync(null, force: false);
             }
 
             public async ValueTask DeleteDocumentAsync(string id)
@@ -308,6 +308,11 @@ namespace Raven.Server.Smuggler.Documents
                 }
 
                 _duplicateDocsHandler._markForDispose = true;
+            }
+
+            public async ValueTask FlushAsync()
+            {
+                await HandleBatchOfDocumentsIfNecessaryAsync(null, force: true);
             }
 
             public Task<Stream> GetTempStreamAsync()
@@ -481,13 +486,13 @@ namespace Raven.Server.Smuggler.Documents
                 _revisionDeleteCommand = null;
             }
 
-            private ValueTask HandleBatchOfDocumentsIfNecessaryAsync(Func<ValueTask> beforeFlush)
+            private ValueTask HandleBatchOfDocumentsIfNecessaryAsync(Func<ValueTask> beforeFlush, bool force)
             {
                 var commandSize = _command.GetCommandAllocationSize();
                 var prevDoneAndHasEnough = commandSize > Constants.Size.Megabyte && _prevCommandTask.IsCompleted;
                 var currentReachedLimit = commandSize > _enqueueThreshold.GetValue(SizeUnit.Bytes);
 
-                if (currentReachedLimit == false && prevDoneAndHasEnough == false)
+                if (currentReachedLimit == false && prevDoneAndHasEnough == false && force == false)
                 {
                     return ValueTask.CompletedTask;
                 }

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -511,7 +511,9 @@ namespace Raven.Server.Smuggler.Documents
                     if (compareExchangeActions != null && item.Document.ChangeVector != null && item.Document.ChangeVector.Contains(ChangeVectorParser.TrxnTag))
                     {
                         var key = ClusterWideTransactionHelper.GetAtomicGuardKey(item.Document.Id);
-                        await compareExchangeActions.WriteKeyValueAsync(key, null, item.Document);
+                        if (await compareExchangeActions.WriteKeyValueAsync(key, null, item.Document))
+                            await documentActions.FlushAsync();
+
                         continue;
                     }
 

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1530,6 +1530,11 @@ namespace Raven.Server.Smuggler.Documents
                 yield break;
             }
 
+            public ValueTask FlushAsync()
+            {
+                return ValueTask.CompletedTask;
+            }
+
             public async Task<Stream> GetTempStreamAsync() => _attachmentStreamsTempFile ??= await StreamDestination.GetTempStreamAsync(_options);
 
             private async ValueTask WriteUniqueAttachmentStreamsAsync(Document document, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress)
@@ -1668,7 +1673,7 @@ namespace Raven.Server.Smuggler.Documents
                 _context = context;
             }
 
-            public async ValueTask WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument)
+            public async ValueTask<bool> WriteKeyValueAsync(string key, BlittableJsonReaderObject value, Document existingDocument)
             {
                 using (value)
                 {
@@ -1686,6 +1691,8 @@ namespace Raven.Server.Smuggler.Documents
 
                     await Writer.MaybeFlushAsync();
                 }
+
+                return false;
             }
 
             public async ValueTask WriteTombstoneKeyAsync(string key)


### PR DESCRIPTION
5.4 PR: https://github.com/ravendb/ravendb/pull/19465

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23017

### Additional description

we need to force flushing in the document actions after we flush anything in the compare exchange, by doing that we will recreate a context and builder, which will avoid us from retaining one context for a long time and keeping a lot of unmanaged memory allocations

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
