### PR TITLE
RavenDB-23039 Fix method GenerateNextIdForAsync

### DIFF
--- a/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
+++ b/src/Raven.Client/Documents/Identity/AsyncMultiTypeHiLoIdGenerator.cs
@@ -101,6 +101,8 @@ namespace Raven.Client.Documents.Identity
 
         public async Task<long> GenerateNextIdForAsync(string collectionName)
         {
+            collectionName = Conventions.TransformTypeCollectionNameToDocumentIdPrefix(collectionName);
+            
             if (_idGeneratorsByTag.TryGetValue(collectionName, out var value))
             {
                 return (await value.GetNextIdAsync().ConfigureAwait(false)).Id;

--- a/test/FastTests/Client/HiLo.cs
+++ b/test/FastTests/Client/HiLo.cs
@@ -151,6 +151,40 @@ namespace FastTests.Client
                 Assert.Equal(count * 4, productsIds.Count);
             }
         }
+        
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task GenerateNextIdAndGenerateDocumentIdUseTheSameHiLoRange()
+        {
+            using (var store = GetDocumentStore())
+            {
+                    // Call GenerateNextIdForAsync methods:
+                    var id1 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, new User());
+                    Assert.Equal(1, id1);
+                    
+                    var id2 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, typeof(User)); 
+                    Assert.Equal(2, id2);
+
+                    var id3 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, "Users"); 
+                    Assert.Equal(3, id3);
+                    
+                    // Call GenerateDocumentIdAsync:
+                    var fullDocumentId = await store.HiLoIdGenerator.GenerateDocumentIdAsync(null, new User());
+                    Assert.Equal("users/4-A", fullDocumentId);
+
+                    using (var session = store.OpenSession())
+                    {
+                        var user = new User();
+                        session.Store(user);
+                        var userId = session.Advanced.GetDocumentId(user); 
+                        Assert.Equal("users/5-A", userId);
+                    }
+
+                    var id4 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, new User());
+                    var id5 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, typeof(User)); 
+                    var id6 = await store.HiLoIdGenerator.GenerateNextIdForAsync(null, "Users"); 
+                    Assert.Equal(8, id6);
+            }
+        }
 
         [Fact]
         public async Task Capacity_Should_Double()

--- a/test/SlowTests/Issues/RavenDB-21879.cs
+++ b/test/SlowTests/Issues/RavenDB-21879.cs
@@ -79,7 +79,7 @@ public class RavenDB_21879 : RavenTestBase
 
             var fullIdForDto = await customHiloIdGenerator.GenerateDocumentIdAsync(null, dto);
             
-            Assert.Equal("dtos/33", fullIdForDto);
+            Assert.Equal("dtos/2", fullIdForDto);
         }
     }
 


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23039/Fix-method-GenerateNextIdForAsync

### Additional description
Method `GenerateNextIdForAsync` should call the `TransformTypeCollectionNameToDocumentIdPrefix` convention
before getting the next ID for the collection, (similar to the implementation in `GenerateDocumentIdAsync`).

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
