### PR TITLE
RavenDB-22801 Cluster Dashboard: Expose Avg Request time

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/TrafficNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/TrafficNotificationSender.cs
@@ -33,6 +33,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
                     return new TrafficWatchPayload
                     {
                         RequestsPerSecond = trafficWatch.RequestsPerSecond,
+                        AverageRequestDuration = trafficWatch.AverageRequestDuration,
                         TrafficPerDatabase = trafficWatch.Items
                     };
                 case ClusterDashboardPayloadType.Database:

--- a/src/Raven.Server/Dashboard/Cluster/Notifications/TrafficWatchPayload.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/TrafficWatchPayload.cs
@@ -9,6 +9,8 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
 
         public int RequestsPerSecond { get; set; }
 
+        public double AverageRequestDuration { get; set; }
+
         public int DocumentWritesPerSecond { get; set; }
 
         public int AttachmentWritesPerSecond { get; set; }
@@ -32,6 +34,8 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
             var result = new TrafficWatchPayload();
             
             result.RequestsPerSecond = RequestsPerSecond;
+            result.AverageRequestDuration = AverageRequestDuration;
+
             foreach (TrafficWatchItem item in TrafficPerDatabase)
             {
                 result.Add(item);
@@ -60,6 +64,7 @@ namespace Raven.Server.Dashboard.Cluster.Notifications
             var json = base.ToJson();
 
             json[nameof(RequestsPerSecond)] = RequestsPerSecond;
+            json[nameof(AverageRequestDuration)] = AverageRequestDuration;
             json[nameof(DocumentWritesPerSecond)] = DocumentWritesPerSecond;
             json[nameof(AttachmentWritesPerSecond)] = AttachmentWritesPerSecond;
             json[nameof(CounterWritesPerSecond)] = CounterWritesPerSecond;

--- a/src/Raven.Studio/typescript/models/resources/widgets/serverTraffic.ts
+++ b/src/Raven.Studio/typescript/models/resources/widgets/serverTraffic.ts
@@ -10,6 +10,7 @@ class serverTraffic extends historyAwareNodeStats<Raven.Server.Dashboard.Cluster
     documentsWriteBytesPerSecond = this.conditionalDataExtractor(x => generalUtils.formatBytesToSize(x.DocumentsWriteBytesPerSecond) + "/s", { customNoData: "n/a" });
     documentWritesPerSecond = this.conditionalDataExtractor(x => x.DocumentWritesPerSecond.toLocaleString() + "/s", { customNoData: "n/a" });
     requestsPerSecond = this.dataExtractor(x => x.RequestsPerSecond);
+    avgRequestTime = this.dataExtractor(x => x.AverageRequestDuration);
     timeSeriesWriteBytesPerSecond = this.conditionalDataExtractor(x => generalUtils.formatBytesToSize(x.TimeSeriesWriteBytesPerSecond) + "/s", { customNoData: "n/a" });
     timeSeriesWritesPerSecond = this.conditionalDataExtractor(x => x.TimeSeriesWritesPerSecond.toLocaleString() + "/s", { customNoData: "n/a" });
     
@@ -29,7 +30,8 @@ class serverTraffic extends historyAwareNodeStats<Raven.Server.Dashboard.Cluster
     totalWriteBytesPerSecondUnit = this.conditionalDataExtractor(() => generalUtils.formatBytesToSize(this.totalWriteBytesPerSecond(), 2, true)[1], { customNoData: "-" });
     
     requestsFormatted: KnockoutComputed<string>;
-
+    avgRequestTimeFormatted: KnockoutComputed<string>;
+    
     constructor(tag: string) {
         super(tag);
         
@@ -39,6 +41,14 @@ class serverTraffic extends historyAwareNodeStats<Raven.Server.Dashboard.Cluster
                 return noData;
             }
             return this.requestsPerSecond().toLocaleString();
+        });
+        
+        this.avgRequestTimeFormatted = ko.pureComputed(() => {
+            const noData = this.noDataText();
+            if (noData) {
+                return noData;
+            }
+            return Math.round(this.avgRequestTime()).toLocaleString(); 
         });
     }
 }

--- a/src/Raven.Studio/typescript/viewmodels/resources/widgets/trafficWidget.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/widgets/trafficWidget.ts
@@ -16,6 +16,7 @@ class trafficWidget extends abstractChartsWebsocketWidget<Raven.Server.Dashboard
     showDataWrittenDetails = ko.observable<boolean>(false);
     
     requestsChart: lineChart;
+    avgRequestTimeChart: lineChart;
     writesChart: lineChart;
     dataWrittenChart: lineChart;
     
@@ -54,6 +55,14 @@ class trafficWidget extends abstractChartsWebsocketWidget<Raven.Server.Dashboard
             tooltipProvider: date => trafficWidget.tooltipContent(date),
             onMouseMove: date => this.onMouseMove(date)
         });
+
+        const avgRequestTimeContainer = this.container.querySelector(".avg-request-time-chart");
+        this.avgRequestTimeChart = new lineChart(avgRequestTimeContainer, {
+            grid: true,
+            fillData: true,
+            tooltipProvider: date => trafficWidget.tooltipContent(date),
+            onMouseMove: date => this.onMouseMove(date)
+        });
         
         const writesChartContainer = this.container.querySelector(".writes-chart");
         this.writesChart = new lineChart(writesChartContainer, {
@@ -71,12 +80,14 @@ class trafficWidget extends abstractChartsWebsocketWidget<Raven.Server.Dashboard
             onMouseMove: date => this.onMouseMove(date)
         });
         
-        return [this.requestsChart, this.writesChart, this.dataWrittenChart];
+        return [this.requestsChart, this.avgRequestTimeChart, this.writesChart, this.dataWrittenChart];
     }
 
     protected extractDataForChart(chart: lineChart, data: Raven.Server.Dashboard.Cluster.Notifications.TrafficWatchPayload): number {
         if (chart === this.requestsChart) {
             return data.RequestsPerSecond;
+        } else if (chart === this.avgRequestTimeChart) {
+            return data.AverageRequestDuration;
         } else if (chart === this.writesChart) {
             return data.DocumentWritesPerSecond + data.AttachmentWritesPerSecond + data.CounterWritesPerSecond + data.TimeSeriesWritesPerSecond;
         } else if (chart === this.dataWrittenChart) {

--- a/src/Raven.Studio/wwwroot/App/views/resources/widgets/trafficWidget.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/widgets/trafficWidget.html
@@ -29,6 +29,26 @@
             </div>
         </div>
     </div>
+    <div class="property-container">
+        <h4>Avg Request Time</h4>
+        <div class="property">
+            <div class="flex-horizontal">
+                <div class="nodes-container" data-bind="foreach: nodeStats">
+                    <div data-bind="attr: { class: 'nodes-item node-' + tag }, css: { 'no-data': !currentItem(), 'spinner': spinner }">
+                        <div class="nodes-item-header">
+                            <div class="node-label" data-bind="text: tag"></div>
+                            <div class="node-value">
+                                <span data-bind="text: avgRequestTimeFormatted"></span>
+                                <span class="supplementary-info">ms</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="graph-container avg-request-time-chart">
+            </div>
+        </div>
+    </div>
     <div class="property-container" data-bind="css: { 'property-collapse': !showWritesDetails() }">
         <h4>Writes/s</h4>
         <div class="property">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22801 

### Additional description

Exposed extra statistics on traffic widget on cluster dashboard

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
