### PR TITLE
RavenDB-22972 Dequeued EnvirnmentStateRecord elements should be explictly nulled because they might hold references of objects which have finalizers (ClientState)

### DIFF
--- a/src/Voron/EnvironmentStateRecord.cs
+++ b/src/Voron/EnvironmentStateRecord.cs
@@ -18,3 +18,8 @@ public record EnvironmentStateRecord(
     (JournalFile Current, long Last4KWritePosition) Journal,
     object ClientState,
     List<long> SparsePageRanges);
+
+internal sealed class EnvironmentStateRecordHolder
+{
+    public EnvironmentStateRecord EnvStateRecord;
+}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22972/Rising-managed-memory-usage-and-GC-impact-on-7.0-cluster

### Additional description

See details in the following comment: https://issues.hibernatingrhinos.com/issue/RavenDB-22972/Rising-managed-memory-usage-and-GC-impact-on-7.0-cluster#focus=Comments-67-1056937.0-0

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
