### PR TITLE
RavenDB-22074 Add an option to specify max items to process in single…

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/settings/expiration.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/expiration.html
@@ -15,26 +15,49 @@
                                 Enable document expiration
                             </label>
                         </div>
-                        <div class="flex-horizontal">
-                            <div class="flex-start" >
-                                <div class="checkbox">
-                                    <input id="specifyDeleteFrequency" class="styled" type="checkbox"
-                                           data-bind="checked: specifyDeleteFrequency, enable: enabled, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }">
-                                    <label for="specifyDeleteFrequency">
-                                        Set delete frequency
-                                    </label>
+                        <div class="margin-left margin-left-lg">
+                            <div class="flex-horizontal margin-bottom margin-bottom-sm">
+                                <div class="flex-start" >
+                                    <div class="checkbox">
+                                        <input id="specifyDeleteFrequency" class="styled" type="checkbox"
+                                               data-bind="checked: specifyDeleteFrequency, enable: enabled, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }">
+                                        <label for="specifyDeleteFrequency">
+                                            Set delete frequency
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="flex-grow" data-bind="validationElement: deleteFrequencyInSec">
+                                    <div class="input-group">
+                                        <input class="form-control" type="number" min="0" placeholder="Default (60)"
+                                               data-bind="numericInput: deleteFrequencyInSec, enable: specifyDeleteFrequency, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }" />
+                                        <div class="input-group-addon">
+                                            seconds
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="flex-grow" data-bind="validationElement: deleteFrequencyInSec">
-                                <div class="input-group">
-                                    <input class="form-control" type="number" min="0" placeholder="Default (60)"
-                                           data-bind="numericInput: deleteFrequencyInSec, enable: specifyDeleteFrequency, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }" />
-                                    <div class="input-group-addon">
-                                        seconds
+                            <div class="flex-horizontal">
+                                <div class="flex-start" >
+                                    <div class="checkbox">
+                                        <input id="toggleLimitMaxItemsToProcess" class="styled" type="checkbox"
+                                               data-bind="checked: limitMaxItemsToProcess, enable: enabled, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }">
+                                        <label for="toggleLimitMaxItemsToProcess">
+                                            Set max number of documents to process in a single run
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="flex-grow" data-bind="validationElement: maxItemsToProcess">
+                                    <div class="input-group">
+                                        <input class="form-control" type="number" min="0" 
+                                               data-bind="numericInput: maxItemsToProcess, enable: limitMaxItemsToProcess, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }" />
+                                        <div class="input-group-addon">
+                                            items
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
+                        
                     </div>
                 </div>
                 <div class="col-sm-5">

--- a/src/Raven.Studio/wwwroot/App/views/database/settings/refresh.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/settings/refresh.html
@@ -15,22 +15,44 @@
                                 Enable document refresh
                             </label>
                         </div>
-                        <div class="flex-horizontal">
-                            <div class="flex-start" >
-                                <div class="checkbox">
-                                    <input id="specifyRefreshFrequency" class="styled" type="checkbox"
-                                           data-bind="checked: specifyRefreshFrequency, enable: enabled, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }">
-                                    <label for="specifyRefreshFrequency">
-                                        Set refresh frequency
-                                    </label>
+                        <div class="margin-left margin-left-lg">
+                            <div class="flex-horizontal margin-bottom margin-bottom-sm">
+                                <div class="flex-start" >
+                                    <div class="checkbox">
+                                        <input id="specifyRefreshFrequency" class="styled" type="checkbox"
+                                               data-bind="checked: specifyRefreshFrequency, enable: enabled, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }">
+                                        <label for="specifyRefreshFrequency">
+                                            Set refresh frequency
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="flex-grow" data-bind="validationElement: refreshFrequencyInSec">
+                                    <div class="input-group">
+                                        <input class="form-control" type="number" min="0" placeholder="Default (60)"
+                                               data-bind="numericInput: refreshFrequencyInSec, enable: specifyRefreshFrequency, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }" />
+                                        <div class="input-group-addon">
+                                            seconds
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="flex-grow" data-bind="validationElement: refreshFrequencyInSec">
-                                <div class="input-group">
-                                    <input class="form-control" type="number" min="0" placeholder="Default (60)"
-                                           data-bind="numericInput: refreshFrequencyInSec, enable: specifyRefreshFrequency, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }" />
-                                    <div class="input-group-addon">
-                                        seconds
+                            <div class="flex-horizontal">
+                                <div class="flex-start" >
+                                    <div class="checkbox">
+                                        <input id="toggleLimitMaxItemsToProcess" class="styled" type="checkbox"
+                                               data-bind="checked: limitMaxItemsToProcess, enable: enabled, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }">
+                                        <label for="toggleLimitMaxItemsToProcess">
+                                            Set max number of documents to process in a single run
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="flex-grow" data-bind="validationElement: maxItemsToProcess">
+                                    <div class="input-group">
+                                        <input class="form-control" type="number" min="0"
+                                               data-bind="numericInput: maxItemsToProcess, enable: limitMaxItemsToProcess, requiredAccess: 'DatabaseAdmin', requiredAccessOptions: { strategy: 'disable' }" />
+                                        <div class="input-group-addon">
+                                            items
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
… expiration and refresh run

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22074 

### Additional description

Add an option to specify max items to process in single expiration and refresh run

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
