### PR TITLE
RavenDB-22074 Add an option to specify max items to process in single…

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.spec.tsx
@@ -4,7 +4,7 @@ import { rtlRender } from "test/rtlTestUtils";
 import * as stories from "./DocumentExpiration.stories";
 import { DatabasesStubs } from "test/stubs/DatabasesStubs";
 
-const { DefaultDocumentExpiration, LicenseRestricted } = composeStories(stories);
+const { DefaultDocumentExpiration, LicenseRestricted, InitialDocumentExpiration } = composeStories(stories);
 
 describe("DocumentExpiration", () => {
     it("can render", async () => {
@@ -25,6 +25,21 @@ describe("DocumentExpiration", () => {
         const deleteFrequencyAfter = screen.getByName("deleteFrequency");
         expect(deleteFrequencyAfter).toBeDisabled();
         expect(deleteFrequencyAfter).toHaveValue(null);
+    });
+
+    it("can set default batch size", async () => {
+        const { screen, fireClick } = rtlRender(<InitialDocumentExpiration />);
+        const enableButton = await screen.findByRole("checkbox", { name: "Enable Document Expiration" });
+
+        expect(enableButton).not.toBeChecked();
+
+        await fireClick(enableButton);
+
+        const setMaxNumberOfDocumentToProcessCheckbox = await screen.findByLabelText(
+            "Set max number of documents to process in a single run"
+        );
+        expect(setMaxNumberOfDocumentToProcessCheckbox).toBeChecked();
+        expect(await screen.findByName("maxItemsToProcess")).toHaveValue(65536);
     });
 
     it("is license restricted", async () => {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.stories.tsx
@@ -11,18 +11,33 @@ export default {
     decorators: [withStorybookContexts, withBootstrap5],
 } satisfies Meta<typeof DocumentExpiration>;
 
-function commonInit() {
+function commonInit(hasConfiguration: boolean) {
     const { databasesService } = mockServices;
     const { databases } = mockStore;
 
-    databasesService.withExpirationConfiguration();
+    if (hasConfiguration) {
+        databasesService.withExpirationConfiguration();
+    } else {
+        databasesService.withoutExpirationConfiguration();
+    }
     databases.withActiveDatabase_NonSharded_SingleNode();
 }
 
 export const DefaultDocumentExpiration: StoryObj<typeof DocumentExpiration> = {
     name: "Document Expiration",
     render: () => {
-        commonInit();
+        commonInit(true);
+
+        const { license } = mockStore;
+        license.with_License();
+
+        return <DocumentExpiration />;
+    },
+};
+
+export const InitialDocumentExpiration: StoryObj<typeof DocumentExpiration> = {
+    render: () => {
+        commonInit(false);
 
         const { license } = mockStore;
         license.with_License();
@@ -33,7 +48,7 @@ export const DefaultDocumentExpiration: StoryObj<typeof DocumentExpiration> = {
 
 export const LicenseRestricted: StoryObj<typeof DocumentExpiration> = {
     render: () => {
-        commonInit();
+        commonInit(true);
 
         const { license } = mockStore;
         license.with_LicenseLimited();

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpiration.tsx
@@ -28,6 +28,8 @@ import { databaseSelectors } from "components/common/shell/databaseSliceSelector
 import activeDatabaseTracker = require("common/shell/activeDatabaseTracker");
 import RichAlert from "components/common/RichAlert";
 
+const defaultItemsToProcess = 65536;
+
 export default function DocumentExpiration() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const { databasesService } = useServices();
@@ -36,7 +38,7 @@ export default function DocumentExpiration() {
         mapToFormData(await databasesService.getExpirationConfiguration(databaseName))
     );
 
-    const { handleSubmit, control, formState, reset, setValue } = useForm<DocumentExpirationFormData>({
+    const { handleSubmit, control, formState, reset, setValue, watch } = useForm<DocumentExpirationFormData>({
         resolver: documentExpirationYupResolver,
         mode: "all",
         defaultValues: asyncGetExpirationConfiguration.execute,
@@ -68,18 +70,35 @@ export default function DocumentExpiration() {
         deleteFrequencyInHours < minPeriodForExpirationInHours;
 
     useEffect(() => {
-        if (!formValues.isDeleteFrequencyEnabled && formValues.deleteFrequency !== null) {
-            setValue("deleteFrequency", null, { shouldValidate: true });
-        }
-        if (!formValues.isDocumentExpirationEnabled && formValues.isDeleteFrequencyEnabled) {
-            setValue("isDeleteFrequencyEnabled", false, { shouldValidate: true });
-        }
-    }, [
-        formValues.isDocumentExpirationEnabled,
-        formValues.isDeleteFrequencyEnabled,
-        formValues.deleteFrequency,
-        setValue,
-    ]);
+        const { unsubscribe } = watch((values, { name }) => {
+            switch (name) {
+                case "isDocumentExpirationEnabled": {
+                    if (values.isDocumentExpirationEnabled) {
+                        setValue("isLimitMaxItemsToProcessEnabled", true, { shouldValidate: true });
+                    } else {
+                        setValue("isLimitMaxItemsToProcessEnabled", false, { shouldValidate: true });
+                        setValue("isDeleteFrequencyEnabled", false, { shouldValidate: true });
+                    }
+                    break;
+                }
+                case "isLimitMaxItemsToProcessEnabled": {
+                    if (values.isLimitMaxItemsToProcessEnabled) {
+                        setValue("maxItemsToProcess", defaultItemsToProcess, { shouldValidate: true });
+                    } else {
+                        setValue("maxItemsToProcess", null, { shouldValidate: true });
+                    }
+                    break;
+                }
+                case "isDeleteFrequencyEnabled": {
+                    if (!values.isDeleteFrequencyEnabled) {
+                        setValue("deleteFrequency", null, { shouldValidate: true });
+                    }
+                    break;
+                }
+            }
+        });
+        return () => unsubscribe();
+    }, [setValue, watch]);
 
     const onSave: SubmitHandler<DocumentExpirationFormData> = async (formData) => {
         return tryHandleSubmit(async () => {
@@ -88,6 +107,7 @@ export default function DocumentExpiration() {
             await databasesService.saveExpirationConfiguration(databaseName, {
                 Disabled: !formData.isDocumentExpirationEnabled,
                 DeleteFrequencyInSec: formData.isDeleteFrequencyEnabled ? formData.deleteFrequency : null,
+                MaxItemsToProcess: formData.isLimitMaxItemsToProcessEnabled ? formData.maxItemsToProcess : null,
             });
 
             messagePublisher.reportSuccess("Expiration configuration saved successfully");
@@ -173,6 +193,29 @@ export default function DocumentExpiration() {
                                                     </RichAlert>
                                                 )}
                                             </div>
+                                            <div>
+                                                <FormSwitch
+                                                    name="isLimitMaxItemsToProcessEnabled"
+                                                    control={control}
+                                                    className="mb-3"
+                                                    disabled={
+                                                        formState.isSubmitting ||
+                                                        !formValues.isDocumentExpirationEnabled
+                                                    }
+                                                >
+                                                    Set max number of documents to process in a single run
+                                                </FormSwitch>
+                                                <FormInput
+                                                    name="maxItemsToProcess"
+                                                    control={control}
+                                                    type="number"
+                                                    disabled={
+                                                        formState.isSubmitting ||
+                                                        !formValues.isLimitMaxItemsToProcessEnabled
+                                                    }
+                                                    addon="items"
+                                                />
+                                            </div>
                                         </div>
                                     </CardBody>
                                 </Card>
@@ -228,6 +271,8 @@ function mapToFormData(dto: ServerExpirationConfiguration): DocumentExpirationFo
             isDocumentExpirationEnabled: false,
             isDeleteFrequencyEnabled: false,
             deleteFrequency: null,
+            isLimitMaxItemsToProcessEnabled: false,
+            maxItemsToProcess: null,
         };
     }
 
@@ -235,6 +280,8 @@ function mapToFormData(dto: ServerExpirationConfiguration): DocumentExpirationFo
         isDocumentExpirationEnabled: !dto.Disabled,
         isDeleteFrequencyEnabled: dto.DeleteFrequencyInSec != null,
         deleteFrequency: dto.DeleteFrequencyInSec,
+        isLimitMaxItemsToProcessEnabled: dto.MaxItemsToProcess != null,
+        maxItemsToProcess: dto.MaxItemsToProcess,
     };
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpirationValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentExpiration/DocumentExpirationValidation.ts
@@ -14,6 +14,16 @@ const schema = yup
                 is: true,
                 then: (schema) => schema.required(),
             }),
+        isLimitMaxItemsToProcessEnabled: yup.boolean(),
+        maxItemsToProcess: yup
+            .number()
+            .nullable()
+            .positive()
+            .integer()
+            .when("isLimitMaxItemsToProcessEnabled", {
+                is: true,
+                then: (schema) => schema.required(),
+            }),
     })
     .required();
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRefresh/DocumentRefresh.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRefresh/DocumentRefresh.spec.tsx
@@ -4,7 +4,7 @@ import { rtlRender } from "test/rtlTestUtils";
 import * as stories from "./DocumentRefresh.stories";
 import { DatabasesStubs } from "test/stubs/DatabasesStubs";
 
-const { DefaultDocumentRefresh, LicenseRestricted } = composeStories(stories);
+const { DefaultDocumentRefresh, LicenseRestricted, InitialDocumentRefresh } = composeStories(stories);
 
 describe("DocumentRefresh", () => {
     it("can render", async () => {
@@ -25,6 +25,21 @@ describe("DocumentRefresh", () => {
         const refreshFrequencyAfter = screen.getByName("refreshFrequency");
         expect(refreshFrequencyAfter).toBeDisabled();
         expect(refreshFrequencyAfter).toHaveValue(null);
+    });
+
+    it("can set default batch size", async () => {
+        const { screen, fireClick } = rtlRender(<InitialDocumentRefresh />);
+        const enableButton = await screen.findByRole("checkbox", { name: "Enable Document Refresh" });
+
+        expect(enableButton).not.toBeChecked();
+
+        await fireClick(enableButton);
+
+        const setMaxNumberOfDocumentToProcessCheckbox = await screen.findByLabelText(
+            "Set max number of documents to process in a single run"
+        );
+        expect(setMaxNumberOfDocumentToProcessCheckbox).toBeChecked();
+        expect(await screen.findByName("maxItemsToProcess")).toHaveValue(65536);
     });
 
     it("is license restricted", async () => {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRefresh/DocumentRefresh.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRefresh/DocumentRefresh.stories.tsx
@@ -11,17 +11,33 @@ export default {
     decorators: [withStorybookContexts, withBootstrap5],
 } satisfies Meta<typeof DocumentRefresh>;
 
-function commonInit() {
+function commonInit(hasConfiguration: boolean) {
     const { databasesService } = mockServices;
     const { databases } = mockStore;
-    databasesService.withRefreshConfiguration();
+    if (hasConfiguration) {
+        databasesService.withRefreshConfiguration();
+    } else {
+        databasesService.withoutRefreshConfiguration();
+    }
+
     databases.withActiveDatabase_NonSharded_SingleNode();
 }
 
 export const DefaultDocumentRefresh: StoryObj<typeof DocumentRefresh> = {
     name: "Document Refresh",
     render: () => {
-        commonInit();
+        commonInit(true);
+
+        const { license } = mockStore;
+        license.with_License();
+
+        return <DocumentRefresh />;
+    },
+};
+
+export const InitialDocumentRefresh: StoryObj<typeof DocumentRefresh> = {
+    render: () => {
+        commonInit(false);
 
         const { license } = mockStore;
         license.with_License();
@@ -32,7 +48,7 @@ export const DefaultDocumentRefresh: StoryObj<typeof DocumentRefresh> = {
 
 export const LicenseRestricted: StoryObj<typeof DocumentRefresh> = {
     render: () => {
-        commonInit();
+        commonInit(true);
 
         const { license } = mockStore;
         license.with_LicenseLimited();

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRefresh/DocumentRefreshValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRefresh/DocumentRefreshValidation.ts
@@ -14,6 +14,16 @@ const schema = yup
                 is: true,
                 then: (schema) => schema.required(),
             }),
+        isLimitMaxItemsToProcessEnabled: yup.boolean(),
+        maxItemsToProcess: yup
+            .number()
+            .nullable()
+            .positive()
+            .integer()
+            .when("isLimitMaxItemsToProcessEnabled", {
+                is: true,
+                then: (schema) => schema.required(),
+            }),
     })
     .required();
 

--- a/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
+++ b/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
@@ -65,12 +65,20 @@ export default class MockDatabasesService extends AutoMockService<DatabasesServi
         return this.mockResolvedValue(this.mocks.getRefreshConfiguration, dto, DatabasesStubs.refreshConfiguration());
     }
 
+    withoutRefreshConfiguration() {
+        return this.mockResolvedValue(this.mocks.getRefreshConfiguration, () => null, undefined);
+    }
+
     withExpirationConfiguration(dto?: RefreshConfiguration) {
         return this.mockResolvedValue(
             this.mocks.getExpirationConfiguration,
             dto,
             DatabasesStubs.expirationConfiguration()
         );
+    }
+
+    withoutExpirationConfiguration() {
+        return this.mockResolvedValue(this.mocks.getExpirationConfiguration, () => null, undefined);
     }
 
     withTombstonesState(dto?: TombstonesStateOnWire) {


### PR DESCRIPTION
… expiration and refresh run

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22074 

### Additional description

Add an option to specify max items to process in single expiration and refresh run

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
