### PR TITLE
RavenDB-22973 Fixing the issue that scratch space was not reused anymore after page shrinking

### DIFF
--- a/src/Voron/Impl/Scratch/PageFromScratchBuffer.cs
+++ b/src/Voron/Impl/Scratch/PageFromScratchBuffer.cs
@@ -16,14 +16,14 @@ namespace Voron.Impl.Scratch
             if (x == y) return true;
             if (x == null || y == null) return false;            
 
-            return x.PositionInScratchBuffer == y.PositionInScratchBuffer && x.NumberOfPages == y.NumberOfPages && x.File == y.File;
+            return x.PositionInScratchBuffer == y.PositionInScratchBuffer && x.Size == y.Size && x.NumberOfPages == y.NumberOfPages && x.File.Number == y.File.Number;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(PageFromScratchBuffer obj)
         {
             int v = Hashing.Combine(obj.NumberOfPages, obj.File.Number);
-            int w = Hashing.Combine(obj.PositionInScratchBuffer.GetHashCode(), obj.PageNumberInDataFile.GetHashCode());
+            int w = Hashing.Combine(obj.Size.GetHashCode(), obj.PositionInScratchBuffer.GetHashCode());
             return Hashing.Combine(v, w);
         }
     }
@@ -36,6 +36,7 @@ namespace Voron.Impl.Scratch
         long PositionInScratchBuffer,
         long PageNumberInDataFile,
         Page PreviousVersion,
+        long Size,
         int NumberOfPages
     )
     {

--- a/src/Voron/Impl/Scratch/ScratchBufferFile.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferFile.cs
@@ -113,7 +113,7 @@ namespace Voron.Impl.Scratch
         {
             _scratchPager.EnsureContinuous(ref _scratchPagerState, _lastUsedPage, sizeToAllocate);
             
-            var result = new PageFromScratchBuffer(this,_scratchPagerState, tx.Id, _lastUsedPage, pageNumber, previousVersion, numberOfPages);
+            var result = new PageFromScratchBuffer(this,_scratchPagerState, tx.Id, _lastUsedPage, pageNumber, previousVersion, sizeToAllocate, numberOfPages);
 
             _allocatedPagesCount += numberOfPages;
             _allocatedPages.Add(_lastUsedPage, result);
@@ -144,7 +144,7 @@ namespace Voron.Impl.Scratch
             _scratchPager.UnprotectPageRange(freePageBySizePointer, freePageBySizeSize, true);
 #endif
 
-            result = new PageFromScratchBuffer(this, _scratchPagerState, tx.Id,val.Page, pageNumber, previousVersion, numberOfPages);
+            result = new PageFromScratchBuffer(this, _scratchPagerState, tx.Id,val.Page, pageNumber, previousVersion, size, numberOfPages);
 
             _allocatedPagesCount += numberOfPages;
             _allocatedPages.Add(val.Page, result);
@@ -199,13 +199,10 @@ namespace Voron.Impl.Scratch
 
             Debug.Assert(value.NumberOfPages > 0);
 
-        
-            // We are freeing with the pages being 'visible' to any party (for ex. commits)
-            var size = Bits.PowerOf2(value.NumberOfPages);
-            if (_freePagesBySize.TryGetValue(size, out LinkedList<PendingPage> list) == false)
+            if (_freePagesBySize.TryGetValue(value.Size, out LinkedList<PendingPage> list) == false)
             {
                 list = new LinkedList<PendingPage>();
-                _freePagesBySize[size] = list;
+                _freePagesBySize[value.Size] = list;
             }
 
             list.AddFirst(new PendingPage


### PR DESCRIPTION
This caused scratch files to grow to much while there was free space inside. We need to retain the original Size of allocation for free space handling purposes as we had in 5.x / 6.x.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22973/Temporary-files-take-much-more-space-on-7.0

### Additional description

We must not relay on `var size = Bits.PowerOf2(value.NumberOfPages);` because after page shrinking we decrease `NumberOfPages`. In result we returned a page to `_freePagesBySize` into invalid size slot. 

Example:

- we requested 5 pages - actual allocation size was 8 (power of 2)
- we shrinked to 3 pages
- we free the page - this resulted in `_freePagesBySize(4, page)` while we should call `_freePagesBySize(8, page)`
- next time we needed 5 pages, we made a new allocation of 8 pages in size instead of reusing the allocation from `_freePagesBySize`

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
