### PR TITLE
RavenDB-7070 fixed invalid condition in AllTestsShouldUseRavenFactOrRavenTheoryAttributes

### DIFF
--- a/test/FastTests/Server/DebugMemoryTests.cs
+++ b/test/FastTests/Server/DebugMemoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Raven.Server.EventListener;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,7 +12,7 @@ public class DebugMemoryTests : NoDisposalNeeded
     {
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Core)]
     public void Debug_Events()
     {
         Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCStart == "GCStart_V2",

--- a/test/FastTests/Voron/RawData/SmallDataSection.cs
+++ b/test/FastTests/Voron/RawData/SmallDataSection.cs
@@ -167,7 +167,7 @@ namespace FastTests.Voron.RawData
             Env.FlushLogToDataFile();
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public async Task CanReadAndWriteFromSection_AfterFlush_MixedFlushDuringTransaction()
         {
             Options.ManualFlushing = true;

--- a/test/FastTests/Voron/Trees/Updates.cs
+++ b/test/FastTests/Voron/Trees/Updates.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Xunit;
 using Voron.Global;
 using Xunit.Abstractions;
+using Tests.Infrastructure;
 
 namespace FastTests.Voron.Trees
 {
@@ -11,8 +12,8 @@ namespace FastTests.Voron.Trees
         public Updates(ITestOutputHelper output) : base(output)
         {
         }
-        
-        [Fact]
+
+        [RavenFact(RavenTestCategory.Voron)]
         public void HandleReadingValuesWhenWeGrowTheFileSize()
         {
             Options.ManualFlushing = true;

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -43,13 +43,13 @@ namespace SlowTests.Authentication
         public AuthenticationLetsEncryptTests(ITestOutputHelper output) : base(output)
         {
         }
-        
+
         [RavenIntegrationRetryFact(delayBetweenRetriesMs: 1000)]
         public async Task CanGetPebbleCertificate()
         {
             var acmeUrl = Environment.GetEnvironmentVariable("RAVEN_PEBBLE_URL") ?? string.Empty;
             Assert.NotEmpty(acmeUrl);
-            
+
             RemoveAcmeCache(acmeUrl);
 
             SetupLocalServer();
@@ -64,7 +64,7 @@ namespace SlowTests.Authentication
         public async Task CanGetLetsEncryptCertificateAndRenewIt()
         {
             var acmeUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
-            
+
             SetupLocalServer();
             SetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
 
@@ -82,7 +82,7 @@ namespace SlowTests.Authentication
 
                 var cluster = Server.ServerStore.Cluster.GetCertificateThumbprintsFromCluster(context).ToList();
                 Assert.Equal(0, cluster.Count);
-        }
+            }
         }
 
         [RavenIntegrationRetryFact(delayBetweenRetriesMs: 1000)]
@@ -94,18 +94,18 @@ namespace SlowTests.Authentication
             await CanGetLetsEncryptCertificateAndRenewAfterFailure(acmeUrl);
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RavenRetryFact(RavenTestCategory.Certificates, delayBetweenRetriesMs: 1000)]
         public async Task CanGetLetsEncryptCertificateAndRenewAfterFailure()
         {
             var acmeUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
             await CanGetLetsEncryptCertificateAndRenewAfterFailure(acmeUrl);
         }
 
-        [RetryFact(delayBetweenRetriesMs: 1000)]
+        [RavenRetryFact(RavenTestCategory.Certificates, delayBetweenRetriesMs: 1000)]
         public async Task ReplaceCertificateWithPrivateKey()
         {
             var acmeUrl = "https://acme-staging-v02.api.letsencrypt.org/directory";
-            
+
             SetupLocalServer();
             SetupInfo setupInfo = await SetupClusterInfo(acmeUrl);
 
@@ -414,7 +414,7 @@ namespace SlowTests.Authentication
             File.Copy(defaultSettingsPath, settingPath, true);
 
             UseNewLocalServer(customConfigPath: settingPath);
-            
+
             Server.Configuration.Core.AcmeUrl = acmeStagingUrl;
             Server.ServerStore.Configuration.Core.SetupMode = SetupMode.Initial;
 

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -94,11 +94,10 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-
-            if (array.Length > 0)
+            if (array.Length == 0)
                 return;
 
-            var userMessage = $"We have detected '{array.Length}' test(s) that do not have {nameof(RavenFactAttribute)} or {nameof(RavenTheoryAttribute)} attribute. Please check if tests that you have added have those attributes. List of test files:{Environment.NewLine}{string.Join(Environment.NewLine, array.Select(x => GetTestName(x)))}";
+            var userMessage = $"We have detected '{array.Length}' test(s) that do not have {nameof(RavenFactAttribute)} or {nameof(RavenTheoryAttribute)} attribute. Please check if tests that you have added have those attributes. List of test files:{Environment.NewLine}{string.Join(Environment.NewLine, array.Select(GetTestName))}";
             throw new Exception(userMessage);
 
             static string GetTestName(MethodInfo method)

--- a/test/SlowTests/Voron/Issues/RavenDB_22973.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22973.cs
@@ -129,7 +129,7 @@ public class RavenDB_22973 : StorageTest
         }
     }
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Voron)]
     public void FailureOnUpdatingJournalStateMustIgnoreFurtherFlushes()
     {
         long p1;
@@ -195,7 +195,7 @@ public class RavenDB_22973 : StorageTest
     }
 
 
-    [Fact]
+    [RavenFact(RavenTestCategory.Voron)]
     public void FlushingMustIncrementTotalWrittenButUnsyncedBytes()
     {
         long p1;

--- a/test/SlowTests/Voron/Storage/FreeScratchPages.cs
+++ b/test/SlowTests/Voron/Storage/FreeScratchPages.cs
@@ -5,9 +5,9 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Tests.Infrastructure;
 using Voron.Impl.Scratch;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,7 +20,7 @@ namespace SlowTests.Voron.Storage
         {
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Voron)]
         public void UncommittedTransactionShouldFreeScratchPagesThatWillBeReusedFutureTransactions()
         {
             var random = new Random();
@@ -50,13 +50,13 @@ namespace SlowTests.Voron.Storage
             }
 
             Env.FlushLogToDataFile();
-            
+
             using (var tx = Env.WriteTransaction())
             {
                 tx.LowLevelTransaction.AllocatePage(1);
                 tx.Commit();
             }
-            
+
             PageFromScratchBuffer[] scratchPagesOfCommittedTransaction;
 
             using (var tx = Env.WriteTransaction())


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
