### PR TITLE
RavenDB-22436 fixed possible System.ArgumentException: An item with the same key has already been added

### DIFF
--- a/src/Raven.Server/Utils/RavenServerHttpClientFactory.cs
+++ b/src/Raven.Server/Utils/RavenServerHttpClientFactory.cs
@@ -44,7 +44,7 @@ internal class RavenServerHttpClientFactory : IRavenHttpClientFactory
 
     private sealed class RavenDynamicHttpClientFactoryConfiguration : IConfigureNamedOptions<HttpClientFactoryOptions>
     {
-        private readonly object _locker = new object();
+        private readonly object _locker = new();
 
         private FrozenDictionary<string, HttpClientCacheKey> _registeredConfigurations = FrozenDictionary<string, HttpClientCacheKey>.Empty;
 
@@ -55,10 +55,13 @@ internal class RavenServerHttpClientFactory : IRavenHttpClientFactory
 
             lock (_locker)
             {
-                _registeredConfigurations = new Dictionary<string, HttpClientCacheKey>(_registeredConfigurations)
-                {
-                    { key.AsString, key }
-                }.ToFrozenDictionary(StringComparer.Ordinal);
+                if (_registeredConfigurations.ContainsKey(key.AsString))
+                    return;
+
+                var registeredConfigurations = new Dictionary<string, HttpClientCacheKey>(_registeredConfigurations);
+                registeredConfigurations.TryAdd(key.AsString, key);
+
+                _registeredConfigurations = registeredConfigurations.ToFrozenDictionary(StringComparer.Ordinal);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22436

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
