### PR TITLE
RavenDB-23023 Run the most memory-intensive PostingList tests only on x64 architecture

### DIFF
--- a/test/StressTests/Corax/Bugs/PostingListTestsExtended.cs
+++ b/test/StressTests/Corax/Bugs/PostingListTestsExtended.cs
@@ -27,17 +27,18 @@ public class PostingListTestsExtended : NoDisposalNoOutputNeeded
     [InlineData(511767612, 4172)]
     [InlineData(439188321, 502627)]
     [InlineData(506431817, 2)]
+    public void CanDeleteAndInsertInRandomOrder(int seed, int size) => CanDeleteAndInsertInRandomOrderBase(seed, size);
+
+    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Voron, RavenArchitecture.X64)]
     [InlineData(1477187726, 1828658)]
     [MemberData("Configuration")]
-    public void CanDeleteAndInsertInRandomOrder(int seed, int size)
-    {
-        using var testClass = new FastTests.Voron.PostingLists.PostingListTests(Output);
-        testClass.CanDeleteAndInsertInRandomOrder(seed, size, 10);
-    }
-
-    [RavenMultiplatformTheory(RavenTestCategory.Voron | RavenTestCategory.Corax, RavenPlatform.Windows)]
+    public void CanDeleteAndInsertInRandomOrderX64Only(int seed, int size) => CanDeleteAndInsertInRandomOrderBase(seed, size);
+    
+    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Voron, RavenPlatform.Windows, RavenArchitecture.X64)]
     [InlineData(391060845, 31707323)]
-    public void CanDeleteAndInsertInRandomOrderWindows(int seed, int size)
+    public void CanDeleteAndInsertInRandomOrderWindows(int seed, int size) => CanDeleteAndInsertInRandomOrderBase(seed, size);
+
+    private void CanDeleteAndInsertInRandomOrderBase(int seed, int size)
     {
         using var testClass = new FastTests.Voron.PostingLists.PostingListTests(Output);
         testClass.CanDeleteAndInsertInRandomOrder(seed, size, 10);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23023

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
