### PR TITLE
RavenDB-22445 - handle idle database with sink hub replication tasks

### DIFF
--- a/src/Raven.Client/Documents/Commands/GetRemoteTaskTopologyCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetRemoteTaskTopologyCommand.cs
@@ -10,12 +10,14 @@ namespace Raven.Client.Documents.Commands
         private readonly string _remoteDatabase;
         private readonly string _databaseGroupId;
         private readonly string _remoteTask;
+        private readonly string _tag;
 
-        public GetRemoteTaskTopologyCommand(string remoteDatabase, string databaseGroupId, string remoteTask)
+        public GetRemoteTaskTopologyCommand(string remoteDatabase, string databaseGroupId, string remoteTask, string tag)
         {
             _remoteDatabase = remoteDatabase ?? throw new ArgumentNullException(nameof(remoteDatabase));
             _databaseGroupId = databaseGroupId ?? throw new ArgumentNullException(nameof(databaseGroupId));
             _remoteTask = remoteTask ?? throw new ArgumentNullException(nameof(remoteTask));
+            _tag = tag;
             Timeout = TimeSpan.FromSeconds(15);
         }
 
@@ -24,7 +26,8 @@ namespace Raven.Client.Documents.Commands
             url = $"{node.Url}/info/remote-task/topology?" +
                   $"database={Uri.EscapeDataString(_remoteDatabase)}" +
                   $"&remote-task={Uri.EscapeDataString(_remoteTask)}" +
-                  $"&groupId={Uri.EscapeDataString(_databaseGroupId)}";
+                  $"&groupId={Uri.EscapeDataString(_databaseGroupId)}" +
+                  $"&tag={Uri.EscapeDataString(_tag)}";
 
             RequestedNode = node;
             var request = new HttpRequestMessage

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1600,7 +1600,7 @@ namespace Raven.Server.Documents.Replication
                 using (var requestExecutor = RequestExecutor.CreateForShortTermUse(pullReplicationAsSink.ConnectionString.TopologyDiscoveryUrls, pullReplicationAsSink.ConnectionString.Database,
                     certificate, DocumentConventions.DefaultForServer))
                 {
-                    var cmd = new GetRemoteTaskTopologyCommand(database, Database.DatabaseGroupId, remoteTask);
+                    var cmd = new GetRemoteTaskTopologyCommand(database, Database.DatabaseGroupId, remoteTask, PullReplicationAsSinkTag);
 
                     try
                     {
@@ -1628,7 +1628,7 @@ namespace Raven.Server.Documents.Replication
                 using (var requestExecutor = RequestExecutor.CreateForShortTermUse(remoteDatabaseUrls,
                     pullReplicationAsSink.ConnectionString.Database, certificate, DocumentConventions.DefaultForServer))
                 {
-                    var cmd = new GetTcpInfoForRemoteTaskCommand(ExternalReplicationTag, database, remoteTask);
+                    var cmd = new GetTcpInfoForRemoteTaskCommand(PullReplicationAsSinkTag, database, remoteTask);
 
                     try
                     {
@@ -1646,6 +1646,7 @@ namespace Raven.Server.Documents.Replication
         }
 
         private static readonly string ExternalReplicationTag = "external-replication";
+        public static readonly string PullReplicationAsSinkTag = "pull-replication-as-sink";
 
         private TcpConnectionInfo GetExternalReplicationTcpInfo(ExternalReplication exNode, X509Certificate2 certificate, string database)
         {
@@ -2151,6 +2152,37 @@ namespace Raven.Server.Documents.Replication
             public Action<Exception> OnIncomingReplicationHandlerFailure;
             public Action OnIncomingReplicationHandlerStart;
             public Action BeforeDisposingIncomingReplicationHandlers;
+        }
+
+        public int HasActivePullReplicationAsSinkConnections()
+        {
+            var c = 0;
+            foreach (var dest in _externalDestinations)
+            {
+                if (dest.Disabled)
+                    continue;
+                if (dest is not PullReplicationAsSink sink)
+                    continue;
+                if (sink.Mode == PullReplicationMode.HubToSink)
+                    c++;
+            }
+
+            foreach (var node in _outgoing)
+            {
+                var dest = node.Destination;
+
+                if (dest.Disabled)
+                    continue;
+                if (dest is not PullReplicationAsHub hub)
+                {
+                    continue;
+                }
+
+                if (hub.Mode == (PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub))
+                    c++;
+            }
+
+            return c;
         }
     }
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2721,6 +2721,18 @@ namespace Raven.Server.ServerWide
                 statistics.Explanations.Add($"Cannot unload database because number of Subscriptions connections ({numberOfSubscriptionConnections}) is greater than 0");
             }
 
+            var numberOfActivePullReplicationAsSinkConnections = database.ReplicationLoader.HasActivePullReplicationAsSinkConnections();
+            if (statistics != null)
+                statistics.NumberOfActivePullReplicationAsSinkConnections = numberOfActivePullReplicationAsSinkConnections;
+
+            if (numberOfActivePullReplicationAsSinkConnections > 0)
+            {
+                if (statistics == null)
+                    return false;
+
+                statistics.Explanations.Add($"Cannot unload database because number of active PullReplication as Sink Connections ({numberOfActivePullReplicationAsSinkConnections}) is greater than 0");
+            }
+
             var hasActiveOperations = database.Operations.HasActive;
             if (statistics != null)
                 statistics.HasActiveOperations = hasActiveOperations;

--- a/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
@@ -77,6 +77,8 @@ namespace Raven.Server.Web.System
 
             public int NumberOfSubscriptionConnections { get; set; }
 
+            public int NumberOfActivePullReplicationAsSinkConnections { get; set; }
+
             public bool HasActiveOperations { get; set; }
 
             public List<string> Explanations { get; set; }
@@ -94,6 +96,8 @@ namespace Raven.Server.Web.System
                     [nameof(RunInMemory)] = RunInMemory,
                     [nameof(CanUnload)] = CanUnload,
                     [nameof(NumberOfChangesApiConnections)] = NumberOfChangesApiConnections,
+                    [nameof(NumberOfSubscriptionConnections)] = NumberOfSubscriptionConnections,
+                    [nameof(NumberOfActivePullReplicationAsSinkConnections)] = NumberOfActivePullReplicationAsSinkConnections,
                     [nameof(HasActiveOperations)] = HasActiveOperations,
                     [nameof(Explanations)] = Explanations,
                 };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22445/Outgoing-sink-replication-should-prevent-the-database-from-going-idle

### Additional description

1. Fix sink database from going idle, and loosing the connection with the hub, current state will be 
   * Sink cannot go idle
   * Hub with `HubToSink` sink connectioncan go idle 
   * Hub with `SinkToHub` sink connection cannot go idle
2. On replication heartbeat in case of `SinkToHub` use `ReplaceUnknownEntriesWithSinkTag`, to prevent calling `MergedUpdateDatabaseChangeVectorCommand` command on each heartbeat

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
