### PR TITLE
RavenDB-22973 Fixing the omit of journal state update after the flush

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -523,7 +523,6 @@ namespace Voron.Impl.Journal
             private LastFlushState _lastFlushed = new LastFlushState(0, 0, null, null);
             private long _totalWrittenButUnsyncedBytes;
             private bool _ignoreLockAlreadyTaken;
-            private long _transactionThatUpdatedFlush;
             private Action<LowLevelTransaction> _updateJournalStateAfterFlush;
             private DateTime _lastFlushTime;
             private DateTime _lastSyncTime;
@@ -552,7 +551,7 @@ namespace Voron.Impl.Journal
             {
                 // we are getting the transaction here just to verify that the write lock is held
                 Debug.Assert(tx.Flags is TransactionFlags.ReadWrite);
-                if (tx.Committed && _transactionThatUpdatedFlush == tx.Id)
+                if (tx.Committed && tx.AppliedJournalStateAfterFlush)
                 {
                     _updateJournalStateAfterFlush = null;
                 }
@@ -744,7 +743,7 @@ namespace Voron.Impl.Journal
                     {
                         try
                         {
-                            _transactionThatUpdatedFlush = txw.Id;
+                            txw.AppliedJournalStateAfterFlush = true;
                             txw.UpdateDataPagerState(dataPagerState);
                             UpdateJournalStateUnderWriteTransactionLock(txw, bufferOfPageFromScratchBuffersToFree, record);
 

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -772,7 +772,12 @@ namespace Voron.Impl.Journal
             private void WaitForJournalStateToBeUpdated(CancellationToken token, TransactionPersistentContext transactionPersistentContext,
                 Action<LowLevelTransaction> currentAction, ByteStringContext byteStringContext)
             {
+                _forTestingPurposes?.OnWaitForJournalStateToBeUpdated_BeforeAssigning_updateJournalStateAfterFlush?.Invoke();
+
                 Interlocked.Exchange(ref _updateJournalStateAfterFlush, currentAction);
+
+                _forTestingPurposes?.OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush?.Invoke();
+
                 do
                 {
                     LowLevelTransaction txw = null;
@@ -972,6 +977,9 @@ namespace Voron.Impl.Journal
 
                 internal Action OnApplyLogsToDataFileUnderFlushingLock;
 
+                internal Action OnWaitForJournalStateToBeUpdated_BeforeAssigning_updateJournalStateAfterFlush;
+
+                internal Action OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush;
             }
 
             // This can take a LONG time, and it needs to run concurrently with the

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -781,6 +781,8 @@ namespace Voron.Impl
 
         public string CallerName { get; set; }
 
+        internal bool AppliedJournalStateAfterFlush { get; set; }
+
         public void Dispose()
         {
             if (IsDisposed)

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -874,7 +874,9 @@ namespace Voron
                 GlobalFlushingBehavior.GlobalFlusher.Value.MaybeFlushEnvironment(this);
             }
 
-                
+#if DEBUG
+            _forTestingPurposes?.OnWriteTransactionCompleted?.Invoke(tx);
+#endif
             // this must occur when we are holding the transaction lock
             Journal.Applicator.OnTransactionCompleted(tx);
 
@@ -1625,6 +1627,7 @@ namespace Voron
         internal sealed class TestingStuff
         {
             internal Action ActionToCallDuringFullBackupRighAfterCopyHeaders;
+            public Action<LowLevelTransaction> OnWriteTransactionCompleted { get; set; }
         }
 
 

--- a/test/SlowTests/Voron/Issues/RavenDB_22973.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22973.cs
@@ -359,11 +359,13 @@ public class RavenDB_22973 : StorageTest
             mre.Set();
         };
 
+        Thread t = null;
+
         Env.ForTestingPurposesOnly().OnWriteTransactionCompleted += tx =>
         {
             if (tx == txw.LowLevelTransaction)
             {
-                var t = new Thread(() =>
+                t = new Thread(() =>
                 {
                     Env.FlushLogToDataFile();
                 });
@@ -377,6 +379,8 @@ public class RavenDB_22973 : StorageTest
 
         Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
         Env.ForTestingPurposesOnly().OnWriteTransactionCompleted = null;
+
+        t.Join();
 
         using (var txw2 = Env.WriteTransaction())
         {

--- a/test/SlowTests/Voron/Issues/RavenDB_22973.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22973.cs
@@ -380,7 +380,11 @@ public class RavenDB_22973 : StorageTest
         Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
         Env.ForTestingPurposesOnly().OnWriteTransactionCompleted = null;
 
-        t.Join();
+        if (t != null)
+        {
+            // OnWriteTransactionCompleted is executed only in DEBUG so t might be null in Release
+            t.Join();
+        }
 
         using (var txw2 = Env.WriteTransaction())
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22973/Temporary-files-take-much-more-space-on-7.0

### Additional description

This fixes the issue with not released scratch pages after the flush of committed data to the data file. The problem started to be detected by the debug assertion added in  https://github.com/ravendb/ravendb/pull/19462 - `AssertNoPagesAllocatedInTransactionOlderThan()`. It was reproduced on a live system with constant 24/7 load (the assertion was forced to be checked in Release mode as well).

```
System.InvalidOperationException: Found page #532 allocated in tx 103506 (scratch 0, pos in scratch: 8) while we freed up to tx 103511
   at Voron.Impl.Scratch.ScratchBufferFile.AssertNoPagesAllocatedInTransactionOlderThan(Int64 maxTx) in D:\workspace\ravendb-7.0\src\Voron\Impl\Scratch\ScratchBufferFile.cs:line 348
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.UpdateJournalStateUnderWriteTransactionLock(LowLevelTransaction txw, List`1 bufferOfPageFromScratchBuffersToFree, EnvironmentStateRecord flushedRecord) in D:\workspace\ravendb-7.0\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 879
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.<>c__DisplayClass44_0.<ApplyJournalStateAfterFlush>b__0(LowLevelTransaction txw) in D:\workspace\ravendb-7.0\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 727
   at Voron.Impl.LowLevelTransaction.CommitStage1_CompleteTransaction() in D:\workspace\ravendb-7.0\src\Voron\Impl\LowLevelTransaction.cs:line 1135
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.WaitForJournalStateToBeUpdated(CancellationToken token, TransactionPersistentContext transactionPersistentContext, Action`1 currentAction, ByteStringContext byteStringContext) in D:\workspace\ravendb-7.0\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 806
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.ApplyJournalStateAfterFlush(CancellationToken token, List`1 bufferOfPageFromScratchBuffersToFree, EnvironmentStateRecord record, State dataPagerState, ByteStringContext byteStringContext) in D:\workspace\ravendb-7.0\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 721
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.ApplyLogsToDataFile(CancellationToken token, TimeSpan timeToWait) in D:\workspace\ravendb-7.0\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 680
   at Voron.StorageEnvironment.BackgroundFlushWritesToDataFile() in D:\workspace\ravendb-7.0\src\Voron\StorageEnvironment.cs:line 1384
  
  ```
  
The problem was that for the detection of a transaction which did the update of the journal state after the flush we used the transaction Id. Under specific circumstances / races it resulted in setting `_updateJournalStateAfterFlush = null;` here:

https://github.com/ravendb/ravendb/blob/b5aa7d7fc945020db47df92c24fc1e39f2ce8e99/src/Voron/Impl/Journal/WriteAheadJournal.cs#L555-L558

while ` tx` wasn't actually a transaction which did `UpdateJournalStateUnderWriteTransactionLock()`.

This was a regression issue introduced in https://github.com/ravendb/ravendb/commit/b41e7c045a3c5d889128fec16b86841b34b14984 (part of https://github.com/ravendb/ravendb/pull/18908 PR)

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing  - It has been tested by running it on the system which reproduced the issue for more than 2 days

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
