### PR TITLE
RavenDB-23074 Index Cleanup view: fix the subset (or equal to) character

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/IndexCleanup.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/IndexCleanup.spec.tsx
@@ -32,7 +32,7 @@ describe("IndexCleanup", function () {
         expect(screen.getByRole("heading", { level: 2, name: /Merge indexes/ })).toBeInTheDocument();
         expect(screen.getByRole("heading", { level: 2, name: /Remove sub-indexes/ })).toBeInTheDocument();
         expect(screen.getByRole("heading", { level: 2, name: /Remove unused indexes/ })).toBeInTheDocument();
-        expect(screen.getByRole("heading", { level: 2, name: /Unmergable indexes/ })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { level: 2, name: /Unmergeable indexes/ })).toBeInTheDocument();
         expect(screen.getByRole("heading", { level: 2, name: /Merge suggestions errors/ })).toBeInTheDocument();
     });
 });

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/IndexCleanupAboutView.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/IndexCleanupAboutView.tsx
@@ -36,7 +36,8 @@ export default function IndexCleanupAboutView() {
                 </p>
                 <p className="mb-0">
                     To counter these performance issues, RavenDB recommends a set of actions to optimize the number of
-                    indexes. Note that you need to update the index reference in your application.
+                    indexes. Note that you need to update the index reference in your application when merging or
+                    removing indexes.
                 </p>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper isUnlimited={hasIndexCleanup} data={featureAvailability} />

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/IndexCleanupAboutView.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/IndexCleanupAboutView.tsx
@@ -36,8 +36,8 @@ export default function IndexCleanupAboutView() {
                 </p>
                 <p className="mb-0">
                     To counter these performance issues, RavenDB recommends a set of actions to optimize the number of
-                    indexes. Note that you need to update the index reference in your application when merging or
-                    removing indexes.
+                    indexes. Note that when merging or removing indexes, you need to update the index reference in your
+                    application.
                 </p>
             </AccordionItemWrapper>
             <FeatureAvailabilitySummaryWrapper isUnlimited={hasIndexCleanup} data={featureAvailability} />

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/RemoveSubindexesCard.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/RemoveSubindexesCard.tsx
@@ -105,7 +105,7 @@ function MainPanel({ surpassing }: RemoveSubindexesCardProps) {
                                         </div>
                                     </td>
                                     <td>
-                                        <div>⊇</div>
+                                        <div>⊆</div>
                                     </td>
                                     <td>
                                         <div>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/UnmergableIndexesCard.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/carouselCards/UnmergableIndexesCard.tsx
@@ -17,13 +17,13 @@ export default function UnmergableIndexesCard({ unmergable }: UnmergableIndexesC
         <Card>
             <Card className="bg-faded-primary m-1 p-4">
                 <div className="text-limit-width">
-                    <h2>Unmergable indexes</h2>
+                    <h2>Unmergeable indexes</h2>
                     The following indexes cannot be merged. See the specific reason explanation provided for each index.
                 </div>
             </Card>
 
             {unmergable.data.length === 0 ? (
-                <EmptySet>No unmergable indexes</EmptySet>
+                <EmptySet>No unmergeable indexes</EmptySet>
             ) : (
                 <MainPanel unmergable={unmergable} />
             )}
@@ -46,7 +46,7 @@ function MainPanel({ unmergable }: UnmergableIndexesCardProps) {
                                 </td>
 
                                 <td>
-                                    <div className="small-label">Unmergable reason</div>
+                                    <div className="small-label">Unmergeable reason</div>
                                 </td>
                             </tr>
                         </thead>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/navItems/MergeSuggestionsErrorsNavItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/navItems/MergeSuggestionsErrorsNavItem.tsx
@@ -28,9 +28,9 @@ export default function MergeSuggestionsErrorsNavItem({ carousel, errors }: Merg
                     {hasIndexCleanup ? errors.data.length : "?"}
                 </Badge>
                 <h4 className="text-center">
-                    Merge Suggestions
+                    Merge suggestions
                     <br />
-                    Errors
+                    errors
                 </h4>
             </Card>
         </NavItem>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/navItems/UnmergableIndexesNavItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/cleanup/navItems/UnmergableIndexesNavItem.tsx
@@ -21,12 +21,12 @@ export default function UnmergableIndexesNavItem({ carousel, unmergable }: Unmer
                 className={classNames("p-3", "card-tab", { active: carousel.activeTab === 3 })}
                 onClick={() => carousel.setActiveTab(3)}
             >
-                <img src={unmergableIndexesImg} alt="Unmergable indexes" />
+                <img src={unmergableIndexesImg} alt="Unmergeable indexes" />
                 <Badge className="rounded-pill fs-5" color={unmergable.data.length !== 0 ? "primary" : "secondary"}>
                     {hasIndexCleanup ? unmergable.data.length : "?"}
                 </Badge>
                 <h4 className="text-center">
-                    Unmergable
+                    Unmergeable
                     <br />
                     indexes
                 </h4>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23074/Index-Cleanup-view-fix-the-subset-or-equal-to-character

### Additional description
1. Fix the direction of the subset charcter...
2. Apply a small fix to the about text
3. Fix "unmergable" => "unmergeable" in UI labels only

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed - documentation is handled in https://issues.hibernatingrhinos.com/issue/RDoc-2297/Index-Cleanup

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
