### PR TITLE
RavenDB-23073 Lock out inactive Connection Strings options instead of hiding them

### DIFF
--- a/src/Raven.Studio/typescript/components/common/select/Select.tsx
+++ b/src/Raven.Studio/typescript/components/common/select/Select.tsx
@@ -50,7 +50,7 @@ export function OptionWithIcon(props: OptionProps<SelectOptionWithIcon>) {
     const { data } = props;
 
     return (
-        <div style={{ cursor: "pointer" }}>
+        <div className="cursor-pointer">
             <components.Option {...props}>
                 {data.icon && <Icon icon={data.icon} color={data.iconColor} />}
                 {data.label}

--- a/src/Raven.Studio/typescript/components/common/select/Select.tsx
+++ b/src/Raven.Studio/typescript/components/common/select/Select.tsx
@@ -50,7 +50,7 @@ export function OptionWithIcon(props: OptionProps<SelectOptionWithIcon>) {
     const { data } = props;
 
     return (
-        <div style={{ cursor: "default" }}>
+        <div style={{ cursor: "pointer" }}>
             <components.Option {...props}>
                 {data.icon && <Icon icon={data.icon} color={data.iconColor} />}
                 {data.label}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/EditConnectionStrings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/EditConnectionStrings.tsx
@@ -26,10 +26,6 @@ export interface EditConnectionStringsProps {
     initialConnection?: Connection;
 }
 
-interface ConnectionStringOption extends SelectOptionWithIcon {
-    licenseRequired: LicenseBadgeText;
-}
-
 export default function EditConnectionStrings(props: EditConnectionStringsProps) {
     const { initialConnection } = props;
 
@@ -84,7 +80,7 @@ export default function EditConnectionStrings(props: EditConnectionStringsProps)
                     <InputGroup className="gap-1 flex-wrap flex-column">
                         <Select
                             options={availableConnectionStringsOptions}
-                            value={connectionStringsOptions.find((x) => x.value === connectionStringType)}
+                            value={availableConnectionStringsOptions.find((x) => x.value === connectionStringType)}
                             onChange={(x: SelectOptionWithIcon<StudioEtlType>) => setConnectionStringType(x.value)}
                             placeholder="Select a connection string type"
                             isSearchable={false}
@@ -132,14 +128,29 @@ export default function EditConnectionStrings(props: EditConnectionStringsProps)
     );
 }
 
-const connectionStringsOptions: SelectOptionWithIcon<StudioEtlType>[] = [
-    { value: "Raven", label: "RavenDB", icon: "raven" },
-    { value: "Sql", label: "SQL", icon: "table" },
-    { value: "Olap", label: "OLAP", icon: "olap" },
-    { value: "ElasticSearch", label: "ElasticSearch", icon: "elasticsearch" },
-    { value: "Kafka", label: "Kafka", icon: "kafka" },
-    { value: "RabbitMQ", label: "RabbitMQ", icon: "rabbitmq" },
-];
+function getEditConnectionStringComponent(type: StudioEtlType): (props: EditConnectionStringFormProps) => JSX.Element {
+    switch (type) {
+        case "Raven":
+            return RavenConnectionString;
+        case "Sql":
+            return SqlConnectionString;
+        case "Olap":
+            return OlapConnectionString;
+        case "ElasticSearch":
+            return ElasticSearchConnectionString;
+        case "Kafka":
+            return KafkaConnectionString;
+        case "RabbitMQ":
+            return RabbitMqConnectionString;
+        default:
+            return null;
+    }
+}
+
+interface ConnectionStringOption extends SelectOptionWithIcon<StudioEtlType> {
+    isDisabled: boolean;
+    licenseRequired: LicenseBadgeText;
+}
 
 function getAvailableConnectionStringsOptions(features: ConnectionStringsLicenseFeatures): ConnectionStringOption[] {
     return [
@@ -188,30 +199,11 @@ function getAvailableConnectionStringsOptions(features: ConnectionStringsLicense
     ];
 }
 
-function getEditConnectionStringComponent(type: StudioEtlType): (props: EditConnectionStringFormProps) => JSX.Element {
-    switch (type) {
-        case "Raven":
-            return RavenConnectionString;
-        case "Sql":
-            return SqlConnectionString;
-        case "Olap":
-            return OlapConnectionString;
-        case "ElasticSearch":
-            return ElasticSearchConnectionString;
-        case "Kafka":
-            return KafkaConnectionString;
-        case "RabbitMQ":
-            return RabbitMqConnectionString;
-        default:
-            return null;
-    }
-}
-
-export function OptionWithIconAndBadge(props: OptionProps<ConnectionStringOption>) {
+function OptionWithIconAndBadge(props: OptionProps<ConnectionStringOption>) {
     const { data, isDisabled } = props;
 
     return (
-        <div style={{ cursor: "pointer" }}>
+        <div className="cursor-pointer">
             <components.Option {...props}>
                 {data.icon && <Icon icon={data.icon} color={data.iconColor} />}
                 <span>{data.label}</span>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23073

### Additional description

Instead of hiding inactive select item (e.g. OLAP due to inefficient licensing) we should disable the item and show a proper badge

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
