### PR TITLE
RavenDB-23082 use AuthenticationStatus and AuthorizationStatus to generate the message on the auth-error page

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -2914,17 +2914,17 @@ namespace Raven.Server
 
         public enum AuthenticationStatus
         {
-            None,
-            NoCertificateProvided,
-            UnfamiliarCertificate,
-            UnfamiliarIssuer,
-            Allowed,
-            Operator,
-            ClusterAdmin,
-            Expired,
-            NotYetValid,
-            TwoFactorAuthNotProvided,
-            TwoFactorAuthFromInvalidLimit
+            None = 0,
+            NoCertificateProvided = 1,
+            UnfamiliarCertificate = 2,
+            UnfamiliarIssuer = 3,
+            Allowed = 4,
+            Operator = 5,
+            ClusterAdmin = 6,
+            Expired = 7,
+            NotYetValid = 8,
+            TwoFactorAuthNotProvided = 9,
+            TwoFactorAuthFromInvalidLimit = 10
         }
 
         internal TestingStuff ForTestingPurposesOnly()

--- a/src/Raven.Server/Routing/RavenActionAttribute.cs
+++ b/src/Raven.Server/Routing/RavenActionAttribute.cs
@@ -81,11 +81,11 @@ namespace Raven.Server.Routing
 
     public enum AuthorizationStatus
     {
-        ClusterAdmin,
-        Operator,
-        DatabaseAdmin,
-        ValidUser,
-        UnauthenticatedClients,
-        RestrictedAccess
+        ClusterAdmin = 0,
+        Operator = 1,
+        DatabaseAdmin = 2,
+        ValidUser = 3,
+        UnauthenticatedClients = 4,
+        RestrictedAccess = 5
     }
 }

--- a/src/Raven.Server/Web/System/StudioHandler.cs
+++ b/src/Raven.Server/Web/System/StudioHandler.cs
@@ -23,6 +23,7 @@ using Raven.Client;
 using Raven.Client.Extensions;
 using Raven.Server.Commercial;
 using Raven.Server.Routing;
+using Raven.Server.ServerWide;
 using Sparrow.Collections;
 using Sparrow.Threading;
 using Sparrow.Utils;
@@ -179,12 +180,16 @@ namespace Raven.Server.Web.System
 
             var aeAsString = GetStringQueryString("ae", required: false);
             var aoAsString = GetStringQueryString("ao", required: false);
+            var rtAsString = GetStringQueryString("rt", required: false);
 
-            Enum.TryParse<RavenServer.AuthenticationStatus>(aeAsString, ignoreCase: true, out var authenticationStatus);
+            if (Enum.TryParse<RavenServer.AuthenticationStatus>(aeAsString, ignoreCase: true, out var authenticationStatus) == false)
+                authenticationStatus = RavenServer.AuthenticationStatus.None;
             if (Enum.TryParse<AuthorizationStatus>(aoAsString, ignoreCase: true, out var authorizationStatus) == false)
                 authorizationStatus = AuthorizationStatus.UnauthenticatedClients;
+            if (Enum.TryParse<ResourceType>(aeAsString, ignoreCase: true, out var resourceType) == false)
+                resourceType = ResourceType.Server;
 
-            var message = RequestRouter.GetFailedAuthorizationMessage(HttpContext, database: null, feature?.Certificate, authenticationStatus, authorizationStatus, out _);
+            var message = RequestRouter.GetFailedAuthorizationMessage(HttpContext, resourceType, database: null, feature?.Certificate, authenticationStatus, authorizationStatus, out _);
 
             HttpContext.Response.Headers["Content-Type"] = "text/html; charset=utf-8";
             SetupSecurityHeaders();

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -347,7 +347,7 @@ namespace SlowTests.Issues
                 requestExecutor.TryRemoveHttpClient(force: true); // reset to forget the previous connection
 
                 var ex = await Assert.ThrowsAsync<AuthorizationException>(async () => await TrySavingDocument((DocumentStore)store));
-                Assert.Contains($"Could not authorize access to {databaseName} using provided client certificate", ex.Message);
+                Assert.Contains($"Could not authorize access to database '{databaseName}' using provided client certificate", ex.Message);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23082

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
