### PR TITLE
RavenDB-22984 Fix colors of HTTP and TCP buttons in Traffic Watch view

### DIFF
--- a/src/Raven.Studio/package-lock.json
+++ b/src/Raven.Studio/package-lock.json
@@ -23,7 +23,7 @@
                 "boostrap5": "npm:bootstrap@^5.3.2",
                 "bootstrap": "^3.4.1",
                 "bootstrap-duration-picker": "^2.1.3",
-                "bootstrap-multiselect": "^1.1.0",
+                "bootstrap-multiselect": "^0.9.15",
                 "bootstrap-select": "^1.13.18",
                 "classnames": "^2.5.1",
                 "cronstrue": "^2.50.0",
@@ -8131,12 +8131,17 @@
             "license": "MIT"
         },
         "node_modules/bootstrap-multiselect": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/bootstrap-multiselect/-/bootstrap-multiselect-1.1.0.tgz",
-            "integrity": "sha512-d6njSMqLi488eo0rYx8QCN47zTZVsNm3s3dEd1xvd+NMalShYDpvIQ1m8JfUS8h9eroxSgPwkDWq8CX5x2udsQ==",
+            "version": "0.9.15",
+            "resolved": "https://registry.npmjs.org/bootstrap-multiselect/-/bootstrap-multiselect-0.9.15.tgz",
+            "integrity": "sha512-UwF32a0QR82xkEEGpuNrn57Bu0b/7DfCuoiOaziSHfQKFj5arR6c7+MYLs5RiIf3zl4XZ+YnY7ZBi6/EN3vEZA==",
             "dependencies": {
-                "jquery": ">= 2.2.4"
+                "jquery": "~2.1.3"
             }
+        },
+        "node_modules/bootstrap-multiselect/node_modules/jquery": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
+            "integrity": "sha512-wWR+eCq/T/Qt0NcFyM+QVho0ZVzWxFYANijmSMImXiM5mjr1aOaf4SF0eOEPc92bbK2L2vDpxw3lIszus7eO8Q=="
         },
         "node_modules/bootstrap-select": {
             "version": "1.13.18",

--- a/src/Raven.Studio/package.json
+++ b/src/Raven.Studio/package.json
@@ -119,7 +119,7 @@
         "boostrap5": "npm:bootstrap@^5.3.2",
         "bootstrap": "^3.4.1",
         "bootstrap-duration-picker": "^2.1.3",
-        "bootstrap-multiselect": "^1.1.0",
+        "bootstrap-multiselect": "^0.9.15",
         "bootstrap-select": "^1.13.18",
         "classnames": "^2.5.1",
         "cronstrue": "^2.50.0",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22984/Fix-colors-of-HTTP-and-TCP-buttons-in-Traffic-Watch-view

### Additional description

Revert bootstrap-multiselect version

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
