### PR TITLE
RavenDB-22637 : XML documentation of IOperation

### DIFF
--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
@@ -7,6 +7,9 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Counters
 {
+    /// <summary>
+    /// Represents a batch of counter operations on multiple documents, supporting retrieval of counter values across nodes.
+    /// </summary>
     public sealed class CounterBatch
     {
         public bool ReplyWithAllNodesValues;
@@ -14,6 +17,9 @@ namespace Raven.Client.Documents.Operations.Counters
         public bool FromEtl;
     }
 
+    /// <summary>
+    /// Represents counter operations for a specific document, such as increment or set operations on named counters.
+    /// </summary>
     public sealed class DocumentCountersOperation
     {
         public List<CounterOperation> Operations;
@@ -82,6 +88,9 @@ namespace Raven.Client.Documents.Operations.Counters
         GetAll
     }
 
+    /// <summary>
+    /// Represents a single counter operation, which defines actions such as incrementing a counter value, deleting a counter or retrieving a counter value for a specific document and counter name.
+    /// </summary>
     public sealed class CounterOperation
     {
         public CounterOperationType Type;

--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
@@ -12,8 +12,22 @@ namespace Raven.Client.Documents.Operations.Counters
     /// </summary>
     public sealed class CounterBatch
     {
-        public bool ReplyWithAllNodesValues;
+        /// <summary>
+        /// Gets or sets a value indicating whether the response should include counter values from all nodes.
+        /// When set to <c>true</c>, the response includes the values of each counter from all nodes in the cluster.
+        /// </summary>
+        public bool ReplyWithAllNodesValues { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of counter operations to be performed on the specified documents.
+        /// Each <see cref="DocumentCountersOperation"/> represents a set of counter operations for a single document.
+        /// </summary>
         public List<DocumentCountersOperation> Documents = new List<DocumentCountersOperation>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the batch originated from an ETL process.
+        /// This is used internally to identify and manage counter operations triggered by ETL pipelines.
+        /// </summary>
         public bool FromEtl;
     }
 
@@ -22,8 +36,24 @@ namespace Raven.Client.Documents.Operations.Counters
     /// </summary>
     public sealed class DocumentCountersOperation
     {
-        public List<CounterOperation> Operations;
-        public string DocumentId;
+        /// <summary>
+        /// Gets or sets the list of counter operations to be performed on the specified document.
+        /// Each operation in the list specifies an action, such as incrementing or deleting a counter.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Operations"/> property is mandatory and must be populated before the batch operation is executed.
+        /// If it is not set or is empty, an exception will be thrown during parsing or execution.
+        /// </remarks>
+        public List<CounterOperation> Operations { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the document on which the counter operations are to be performed.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="DocumentId"/> property is mandatory and identifies the target document for the counter operations.
+        /// If it is not set, an exception will be thrown during parsing or execution.
+        /// </remarks>
+        public string DocumentId { get; set; }
         
         public static DocumentCountersOperation Parse(BlittableJsonReaderObject input)
         {
@@ -78,13 +108,39 @@ namespace Raven.Client.Documents.Operations.Counters
         }
     }
 
+    /// <summary>
+    /// Represents the types of operations that can be performed on counters in RavenDB.
+    /// </summary>
     public enum CounterOperationType
     {
+        /// <summary>
+        /// No operation. Represents the absence of any counter operation.
+        /// </summary>
         None,
+
+        /// <summary>
+        /// Increases the value of the counter by a specified amount. If the counter does not exist, it will be created with the specified value.
+        /// </summary>
         Increment,
+
+        /// <summary>
+        /// Deletes the counter, removing it from the database.
+        /// </summary>
         Delete,
+
+        /// <summary>
+        /// Retrieves the value of a specific counter.
+        /// </summary>
         Get,
+
+        /// <summary>
+        /// Used internally for sending counters by ETL
+        /// </summary>
         Put,
+
+        /// <summary>
+        /// Retrieves all counters associated with a document. When using this type, 'CounterName' should not be specified.
+        /// </summary>
         GetAll
     }
 
@@ -93,9 +149,38 @@ namespace Raven.Client.Documents.Operations.Counters
     /// </summary>
     public sealed class CounterOperation
     {
-        public CounterOperationType Type;
-        public string CounterName;
-        public long Delta;
+        /// <summary>
+        /// Gets or sets the type of the counter operation to be performed.
+        /// Specifies the action, such as incrementing, deleting, or retrieving a counter value.
+        /// </summary>
+        /// <remarks>
+        /// Valid types are defined in the <see cref="CounterOperationType"/> enumeration, including:
+        /// - <see cref="CounterOperationType.Increment"/>: Increments the counter by a specified value.
+        /// - <see cref="CounterOperationType.Delete"/>: Deletes the counter.
+        /// - <see cref="CounterOperationType.Get"/>: Retrieves the value of the counter.
+        /// - <see cref="CounterOperationType.GetAll"/>: Retrieves all counters for a document.
+        /// </remarks>
+        public CounterOperationType Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the counter to be operated on.
+        /// </summary>
+        /// <remarks>
+        /// - The <see cref="CounterName"/> property is mandatory for operations of type <see cref="CounterOperationType.Increment"/>, <see cref="CounterOperationType.Delete"/>, and <see cref="CounterOperationType.Get"/>.
+        /// - For <see cref="CounterOperationType.GetAll"/>, the <see cref="CounterName"/> property is not used and can be <c>null</c>.
+        /// - If <see cref="CounterName"/> is required but not set, an exception will be thrown during parsing or execution.
+        /// </remarks>
+        public string CounterName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value by which the counter should be incremented or decremented.
+        /// </summary>
+        /// <remarks>
+        /// - Used only for operations of type <see cref="CounterOperationType.Increment"/>.
+        /// - For <see cref="CounterOperationType.Put"/>, this specifies the exact value to set for the counter but is used internally and not intended for external use.
+        /// - For other operation types, this property is ignored.
+        /// </remarks>
+        public long Delta { get; set; }
 
         internal string ChangeVector;
         internal string DocumentId;

--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatchOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatchOperation.cs
@@ -12,6 +12,10 @@ namespace Raven.Client.Documents.Operations.Counters
     {
         private readonly CounterBatch _counterBatch;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CounterBatchOperation"/> class with the specified counter batch.
+        /// </summary>
+        /// <param name="counterBatch">The batch of counter operations to be processed.</param>
         public CounterBatchOperation(CounterBatch counterBatch)
         {
             _counterBatch = counterBatch;

--- a/src/Raven.Client/Documents/Operations/Counters/CountersDetail.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CountersDetail.cs
@@ -7,8 +7,22 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Counters
 {
+    /// <summary>
+    /// Represents the result of executing a <see cref="GetCountersOperation"/> or <see cref="CounterBatchOperation"/>, 
+    /// containing details of counters associated with a document.
+    /// </summary>
     public sealed class CountersDetail
     {
+        /// <summary>
+        /// Gets or sets the list of counter details retrieved by the operation.
+        /// Each <see cref="CounterDetail"/> in the list provides information about a specific counter, 
+        /// including its name and value.
+        /// </summary>
+        /// <remarks>
+        /// This property contains the results of either:
+        /// - A <see cref="GetCountersOperation"/>: Retrieves details of counters for a document.
+        /// - A <see cref="CounterBatchOperation"/>: Returns details of counters affected by a batch operation.
+        /// </remarks>
         public List<CounterDetail> Counters { get; set; }
 
         public CountersDetail()
@@ -25,14 +39,54 @@ namespace Raven.Client.Documents.Operations.Counters
         }
     }
 
+    /// <summary>
+    /// Represents detailed information about a counter associated with a document in RavenDB.
+    /// </summary>
     public sealed class CounterDetail
     {
+        /// <summary>
+        /// Gets or sets the ID of the document to which the counter belongs.
+        /// </summary>
         public string DocumentId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the counter.
+        /// </summary>
+        /// <remarks>
+        /// This identifies the specific counter within the document.
+        /// </remarks>
         public string CounterName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total value of the counter across all nodes.
+        /// </summary>
+        /// <remarks>
+        /// This value is the aggregate of all per-node counter values stored in <see cref="CounterValues"/>.
+        /// </remarks>
         public long TotalValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ETag associated with the counter.
+        /// </summary>
+        /// <remarks>
+        /// The ETag is a unique identifier used to track changes to the counter.
+        /// </remarks>
         public long Etag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dictionary of counter values for each node in the cluster.
+        /// </summary>
+        /// <remarks>
+        /// The key is the node identifier, and the value is the counter value for that node.
+        /// </remarks>
         public Dictionary<string, long> CounterValues { get; set; }
 
+        /// <summary>
+        /// Gets or sets the change vector for the counter.
+        /// </summary>
+        /// <remarks>
+        /// The change vector represents the version history of the counter and is used for concurrency control.
+        /// </remarks>
         public string ChangeVector { get; set; }
 
         internal LazyStringValue CounterKey { get; set; }
@@ -49,14 +103,38 @@ namespace Raven.Client.Documents.Operations.Counters
         }
     }
 
+    /// <summary>
+    /// Represents detailed information about a group of counters associated with a document in RavenDB.
+    /// </summary>
     public sealed class CounterGroupDetail : IDisposable
     {
+        /// <summary>
+        /// Gets or sets the ID of the document to which the counter group belongs.
+        /// </summary>
+        /// <remarks>
+        /// This property identifies the document that holds the counters in this group.
+        /// </remarks>
         public LazyStringValue DocumentId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the change vector for the counter group.
+        /// </summary>
+        /// <remarks>
+        /// The change vector represents the version history of the counter group and is used for concurrency control.
+        /// </remarks>
         public LazyStringValue ChangeVector { get; set; }
 
+        /// <summary>
+        /// Gets or sets the raw Blittable JSON object containing the counter values in the group.
+        /// </summary>
         public BlittableJsonReaderObject Values { get; set; }
 
+        /// <summary>
+        /// Gets or sets the ETag for the counter group.
+        /// </summary>
+        /// <remarks>
+        /// The ETag is a unique identifier used to track changes to the counter group.
+        /// </remarks>
         public long Etag { get; set; }
 
         public DynamicJsonValue ToJson()

--- a/src/Raven.Client/Documents/Operations/Counters/GetCountersOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/GetCountersOperation.cs
@@ -16,6 +16,13 @@ namespace Raven.Client.Documents.Operations.Counters
         private readonly string[] _counters;
         private readonly bool _returnFullResults;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetCountersOperation"/> class with a specific document ID, 
+        /// an array of counter names, and a flag indicating whether to include counter values from each node in the result.
+        /// </summary>
+        /// <param name="docId">The ID of the document for which to retrieve counters.</param>
+        /// <param name="counters">An array of counter names to retrieve.</param>
+        /// <param name="returnFullResults">A value indicating whether the result should include counter values from each node.</param>
         public GetCountersOperation(string docId, string[] counters, bool returnFullResults = false)
         {
             _docId = docId;
@@ -23,6 +30,12 @@ namespace Raven.Client.Documents.Operations.Counters
             _returnFullResults = returnFullResults;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetCountersOperation"/> class with a specific document ID 
+        /// and a single counter name, along with a flag indicating whether to include counter values from each node in the result.
+        /// </summary>
+        /// <inheritdoc cref="GetCountersOperation(string, string[], bool)"/>
+        /// <param name="counter">The name of the counter to retrieve.</param>
         public GetCountersOperation(string docId, string counter, bool returnFullResults = false)
         {
             _docId = docId;
@@ -30,6 +43,12 @@ namespace Raven.Client.Documents.Operations.Counters
             _returnFullResults = returnFullResults;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetCountersOperation"/> class with a specific document ID 
+        /// and a flag indicating whether to include counter values from each node in the result.
+        /// This operation retrieves all counters associated with the given document.
+        /// </summary>
+        /// <inheritdoc cref="GetCountersOperation(string, string[], bool)"/>
         public GetCountersOperation(string docId, bool returnFullResults = false)
         {
             _docId = docId;

--- a/src/Raven.Client/Documents/Operations/TimeSeries/GetMultipleTimeSeriesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/GetMultipleTimeSeriesOperation.cs
@@ -21,6 +21,18 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         private readonly Action<ITimeSeriesIncludeBuilder> _includes;
         private readonly bool _returnFullResults;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetMultipleTimeSeriesOperation"/> class, 
+        /// retrieving entries from multiple time series associated with a document across specified ranges.
+        /// </summary>
+        /// <param name="docId">The ID of the document for which time series entries are requested.</param>
+        /// <param name="ranges">
+        /// A collection of <see cref="TimeSeriesRange"/> objects, each specifying a time series name 
+        /// and a date range (<c>from</c> and <c>to</c>) to retrieve entries from.
+        /// </param>
+        /// <param name="start">The start index for pagination of results.</param>
+        /// <param name="pageSize">The number of entries to retrieve. Defaults to <c>int.MaxValue</c> for all entries.</param>
+        /// <param name="returnFullResults">Whether to include detailed information for each entry. If <c>false</c>, retrieves only basic information.</param>
         public GetMultipleTimeSeriesOperation(string docId, IEnumerable<TimeSeriesRange> ranges, int start = 0, int pageSize = int.MaxValue, bool returnFullResults = false)
             : this(docId, ranges, start, pageSize, includes: null, returnFullResults)
         {

--- a/src/Raven.Client/Documents/Operations/TimeSeries/GetTimeSeriesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/GetTimeSeriesOperation.cs
@@ -14,10 +14,16 @@ namespace Raven.Client.Documents.Operations.TimeSeries
 {
     public sealed class GetTimeSeriesOperation : GetTimeSeriesOperation<TimeSeriesEntry>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetTimeSeriesOperation"/> class, 
+        /// retrieving multiple entries from a time series associated with a document within a specified date range.
+        /// </summary>
+        /// <inheritdoc select="param" />
         public GetTimeSeriesOperation(string docId, string timeseries, DateTime? @from = null, DateTime? to = null, int start = 0, int pageSize = int.MaxValue, bool returnFullResults = false) : base(docId, timeseries, @from, to, start, pageSize, returnFullResults)
         {
         }
     }
+
 
     public class GetTimeSeriesOperation<TValues> : IOperation<TimeSeriesRangeResult<TValues>> where TValues : TimeSeriesEntry
     {
@@ -27,6 +33,21 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         private readonly Action<ITimeSeriesIncludeBuilder> _includes;
         private readonly bool _returnFullResults;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetTimeSeriesOperation{TValues}"/> class, 
+        /// retrieving multiple entries from a time series associated with a document within a specified date range.
+        /// </summary>
+        /// <typeparam name="TValues">
+        /// The type to which each time series entry should be projected. 
+        /// Must be a subtype of <see cref="TimeSeriesEntry"/>.
+        /// </typeparam>
+        /// <param name="docId">The ID of the document that holds the time series.</param>
+        /// <param name="timeseries">The name of the time series to retrieve.</param>
+        /// <param name="from">The start date of the range from which entries should be retrieved. If <c>null</c>, retrieval begins from the earliest entry.</param>
+        /// <param name="to">The end date of the range up to which entries should be retrieved. If <c>null</c>, retrieval continues to the latest entry.</param>
+        /// <param name="start">The start index for pagination of results.</param>
+        /// <param name="pageSize">The number of entries to retrieve. Defaults to <c>int.MaxValue</c> for retrieving all entries within the specified range.</param>
+        /// <param name="returnFullResults">Whether to include detailed information for each entry. If <c>false</c>, retrieves only basic information.</param>
         public GetTimeSeriesOperation(string docId, string timeseries, DateTime? from = null, DateTime? to = null, int start = 0, int pageSize = int.MaxValue, bool returnFullResults = false) 
             : this(docId, timeseries, from, to, start, pageSize, includes: null, returnFullResults)
         { }

--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesBatchOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesBatchOperation.cs
@@ -12,6 +12,12 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         private readonly string _documentId;
         private readonly TimeSeriesOperation _operation;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSeriesBatchOperation"/> class, 
+        /// performing batch operations on a time series, including appending or deleting entries.
+        /// </summary>
+        /// <param name="documentId">The ID of the document that holds the time series.</param>
+        /// <param name="operation">The batch of time series operations to be applied.</param>
         public TimeSeriesBatchOperation(string documentId, TimeSeriesOperation operation)
         {
             _documentId = documentId ?? throw new ArgumentNullException(nameof(documentId));

--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesDetails.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesDetails.cs
@@ -2,9 +2,29 @@
 
 namespace Raven.Client.Documents.Operations.TimeSeries
 {
+    /// <summary>
+    /// Represents the result of executing a <see cref="GetMultipleTimeSeriesOperation"/>, 
+    /// providing details of time series data associated with a document in RavenDB.
+    /// </summary>
+
     public sealed class TimeSeriesDetails
     {
+        /// <summary>
+        /// Gets or sets the ID of the document to which the time series data belongs.
+        /// </summary>
+        /// <remarks>
+        /// This property identifies the document that holds the time series data retrieved by the operation.
+        /// </remarks>
         public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets a dictionary containing the time series data.
+        /// </summary>
+        /// <remarks>
+        /// The dictionary maps the name of each time series to a list of <see cref="TimeSeriesRangeResult"/> objects, 
+        /// where each range result represents a segment of the time series data.
+        /// The data is retrieved as part of the <see cref="GetMultipleTimeSeriesOperation"/>.
+        /// </remarks>
         public Dictionary<string, List<TimeSeriesRangeResult>> Values { get; set; }
     }
 }

--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesOperation.cs
@@ -8,6 +8,10 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.TimeSeries
 {
+    /// <summary>
+    /// Represents a batch operation for time series data, including appends, increments, and deletions, 
+    /// to be performed on a single document’s time series.
+    /// </summary>
     public sealed class TimeSeriesOperation
     {
         private SortedList<long, AppendOperation> _appends;
@@ -291,6 +295,9 @@ namespace Raven.Client.Documents.Operations.TimeSeries
             };
         }
 
+        /// <summary>
+        /// Represents an append operation in a time series, allowing new data points to be added at specific timestamps.
+        /// </summary>
         public sealed class AppendOperation
         {
             public DateTime Timestamp;
@@ -338,6 +345,9 @@ namespace Raven.Client.Documents.Operations.TimeSeries
             }
         }
 
+        /// <summary>
+        /// Represents a delete operation in a time series, allowing data points within a specific range to be removed.
+        /// </summary>
         public sealed class DeleteOperation
         {
             public DateTime? From, To;
@@ -364,6 +374,9 @@ namespace Raven.Client.Documents.Operations.TimeSeries
             }
         }
 
+        /// <summary>
+        /// Represents an increment operation in a time series, allowing values at a specific timestamp to be incremented.
+        /// </summary>
         public sealed class IncrementOperation
         {
             public DateTime Timestamp;

--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesRange.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesRange.cs
@@ -3,9 +3,24 @@ using Sparrow;
 
 namespace Raven.Client.Documents.Operations.TimeSeries
 {
+    /// <summary>
+    /// Represents a range of time series data based on specific start and end times.
+    /// </summary>
     public sealed class TimeSeriesRange : AbstractTimeSeriesRange
     {
-        public DateTime? From, To;
+        /// <summary>
+        /// Gets or sets the start time of the range.
+        /// Data points from this timestamp (inclusive) will be included in the range.
+        /// If <c>null</c>, the range starts from the beginning of the time series.
+        /// </summary>
+        public DateTime? From { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end time of the range.
+        /// Data points up to this timestamp (inclusive) will be included in the range.
+        /// If <c>null</c>, the range extends to the end of the time series.
+        /// </summary>
+        public DateTime? To { get; set; }
     }
 
     internal sealed class TimeSeriesTimeRange : AbstractTimeSeriesRange
@@ -20,14 +35,33 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         public TimeSeriesRangeType Type;
     }
 
+    /// <summary>
+    /// Represents a base class for defining time series ranges.
+    /// </summary>
     public abstract class AbstractTimeSeriesRange
     {
-        public string Name;
+        /// <summary>
+        /// Gets or sets the name of the time series.
+        /// </summary>
+        /// <remarks>
+        /// This property identifies the time series on which the range operations will be performed.
+        /// </remarks>
+        public string Name { get; set; }
     }
 
+    /// <summary>
+    /// Specifies the type of time series range operation.
+    /// </summary>
     public enum TimeSeriesRangeType
     {
+        /// <summary>
+        /// No range type specified.
+        /// </summary>
         None,
+
+        /// <summary>
+        /// Specifies a range that retrieves the last set of data points from the time series.
+        /// </summary>
         Last
     }
 }

--- a/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
@@ -115,10 +115,36 @@ namespace Raven.Client.Documents.Session.Loaders
         TBuilder IncludeAllTimeSeries(TimeSeriesRangeType type, int count);
     }
 
+    /// <summary>
+    /// The server is instructed to include revisions of the specified documents when retrieving them.<br/>
+    /// Once loaded into the session, revisions can be accessed without additional server requests, ensuring efficient 
+    /// retrieval of document history.
+    /// </summary>
     public interface IRevisionIncludeBuilder<T, out TBuilder> 
     {
+        /// <summary>
+        /// Include a single revision by specifying the path to the document property that contains the revision's change vector.
+        /// Each time a document is modified, its change vector is updated. By storing the change vector in a dedicated 
+        /// property, you can easily include revisions when the document is loaded.
+        /// </summary>
+        /// <param name="path">An expression indicating the property path containing the revision change vector.</param>
         TBuilder IncludeRevisions(Expression<Func<T, string>> path);
+
+        /// <summary>
+        /// Include multiple revisions by specifying the path to the document property that contains an array of change vectors.
+        /// When modifications are made to the document, the updated change vectors can be stored, allowing you to easily
+        /// include multiple revisions when the document is loaded.
+        /// </summary>
+        /// <param name="path">An expression indicating the property path containing the revision change vectors.</param>
         TBuilder IncludeRevisions(Expression<Func<T, IEnumerable<string>>> path);
+
+        /// <summary>
+        /// Include a single revision by specifying its creation time. 
+        /// The specified time can be in local time or UTC; the server will convert it to UTC.
+        /// If an exact match for the creation time is found, that revision will be included. 
+        /// Otherwise, the first revision preceding the specified time will be returned.
+        /// </summary>
+        /// <param name="before">The creation time of the revision to include.</param>
         TBuilder IncludeRevisions(DateTime before);
 
     }
@@ -137,16 +163,46 @@ namespace Raven.Client.Documents.Session.Loaders
     {
     }
 
+    /// <summary>
+    /// The server is instructed to include Compare Exchange values when retrieving documents.<br/>
+    /// Compare Exchange items can be included both when loading entities and during query execution. 
+    /// The session automatically tracks the included Compare Exchange items, allowing their values 
+    /// to be accessed without making additional calls to the server.
+    /// </summary>
     public interface ICompareExchangeValueIncludeBuilder<T, out TBuilder>
     {
+        /// <summary>
+        /// Include a single Compare Exchange value by specifying its key.
+        /// The key should correspond to the Compare Exchange item you wish to include.
+        /// </summary>
+        /// <param name="path">The key of the Compare Exchange value to include.</param>
         TBuilder IncludeCompareExchangeValue(string path);
 
+        /// <summary>
+        /// Include a single Compare Exchange value by specifying a path to the key.
+        /// This allows for dynamic resolution of the Compare Exchange key based on 
+        /// the document's properties.
+        /// </summary>
+        /// <param name="path">An expression indicating the property path that resolves to the Compare Exchange key.</param>
         TBuilder IncludeCompareExchangeValue(Expression<Func<T, string>> path);
 
+        /// <summary>
+        /// Include multiple Compare Exchange values by specifying a path to a collection of keys.
+        /// This allows for the inclusion of multiple Compare Exchange items in a single call.
+        /// </summary>
+        /// <param name="path">An expression indicating the property path that resolves to an array of Compare Exchange keys.</param>
         TBuilder IncludeCompareExchangeValue(Expression<Func<T, IEnumerable<string>>> path);
         
     }
 
+    /// <summary>
+    /// The server is instructed to include various types of related items when retrieving documents.<br/>
+    /// The items are added to the session unit of work, and subsequent requests to load them are served directly from the session cache,
+    /// without requiring any additional queries to the server.
+    /// This interface combines functionalities for including documents, counters, time series, compare exchange values, and revisions.
+    /// </summary>
+    /// <typeparam name="T">The type of the document being built.</typeparam>
+    /// <typeparam name="TBuilder">The type of the builder being used.</typeparam>
     public interface IIncludeBuilder<T, out TBuilder> : IDocumentIncludeBuilder<T, TBuilder>, ICounterIncludeBuilder<T, TBuilder>, ITimeSeriesIncludeBuilder<T, TBuilder>, ICompareExchangeValueIncludeBuilder<T, TBuilder>, IRevisionIncludeBuilder<T, TBuilder>
     {
     }

--- a/src/Raven.Client/Documents/Session/TimeSeries/TimeSeriesEntry.cs
+++ b/src/Raven.Client/Documents/Session/TimeSeries/TimeSeriesEntry.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="TimeSeriesValue.cs" company="Hibernating Rhinos LTD">
+// <copyright file="TimeSeriesEntry.cs" company="Hibernating Rhinos LTD">
 //     Copyright (c) Hibernating Rhinos LTD. All rights reserved.
 // </copyright>
 //-----------------------------------------------------------------------
@@ -28,12 +28,42 @@ namespace Raven.Client.Documents.Session.TimeSeries
     /// </remarks>
     public class TimeSeriesEntry : ITimeSeriesQueryStreamEntry
     {
+        /// <summary>
+        /// Gets or sets the timestamp of the time series entry.
+        /// This represents the point in time at which the values were recorded.
+        /// </summary>
         public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the values associated with the time series entry.
+        /// These values represent the numeric data points recorded at the specified <see cref="Timestamp"/>.
+        /// </summary>
         public double[] Values { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tag for the time series entry.
+        /// This optional metadata provides additional context about the entry, such as the source or a descriptive label.
+        /// </summary>
         public string Tag { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the entry is part of a rollup time series.
+        /// A rollup aggregates data over a specific time range, as opposed to individual data points.
+        /// </summary>
         public bool IsRollup { get; set; }
+
+        /// <summary>
+        /// Gets or sets a dictionary of node-specific values for the time series entry.
+        /// The key represents the node identifier, and the value is an array of numeric data points associated with that node.
+        /// </summary>
         public Dictionary<string, double[]> NodeValues { get; set; }
 
+        /// <summary>
+        /// Gets or sets the value of the time series entry if it contains a single value.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the entry contains more than one value.
+        /// </exception>
         [JsonDeserializationIgnore]
         public double Value
         {
@@ -56,6 +86,10 @@ namespace Raven.Client.Documents.Session.TimeSeries
             }
         }
 
+        /// <summary>
+        /// Returns a string representation of the time series entry, including the timestamp, values, and tag.
+        /// </summary>
+        /// <returns>A string in the format "[Timestamp] Values Tag".</returns>
         public override string ToString()
         {
             return $"[{Timestamp}] {string.Join(", ", Values)} {Tag}";

--- a/src/Raven.Client/Documents/Session/TimeSeries/TimeSeriesEntry.cs
+++ b/src/Raven.Client/Documents/Session/TimeSeries/TimeSeriesEntry.cs
@@ -18,6 +18,14 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Session.TimeSeries
 {
+    /// <summary>
+    /// Represents an individual entry in a time series, storing a timestamp, associated values, and metadata.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TimeSeriesEntry"/> is used as a base type for time series data projections 
+    /// in operations such as <see cref="GetTimeSeriesOperation{TValues}"/>.
+    /// It contains a timestamp and associated values for a single entry within a time series.
+    /// </remarks>
     public class TimeSeriesEntry : ITimeSeriesQueryStreamEntry
     {
         public DateTime Timestamp { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22637/XML-documentation-of-IOperation

### Additional description

- `Raven.Client.Documents.Operations.TimeSeries.GetMultipleTimeSeriesOperation`
- `Raven.Client.Documents.Operations.TimeSeries.GetTimeSeriesOperation`
- `Raven.Client.Documents.Operations.TimeSeries.GetTimeSeriesOperation`1`
- `Raven.Client.Documents.Operations.TimeSeries.GetTimeSeriesStatisticsOperation`
- `Raven.Client.Documents.Operations.TimeSeries.TimeSeriesBatchOperation`
- `Raven.Client.Documents.Operations.Counters.CounterBatchOperation`
- `Raven.Client.Documents.Operations.Counters.GetCountersOperation`
- `IRevisionIncludeBuilder<T, out TBuilder>`
- `ICompareExchangeValueIncludeBuilder<T, out TBuilder>`
- `IIncludeBuilder<T, out TBuilder>`
