### PR TITLE
RavenDB-22445 - handle idle database with sink hub replication tasks

### DIFF
--- a/src/Raven.Client/Documents/Commands/GetRemoteTaskTopologyCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetRemoteTaskTopologyCommand.cs
@@ -10,12 +10,14 @@ namespace Raven.Client.Documents.Commands
         private readonly string _remoteDatabase;
         private readonly string _databaseGroupId;
         private readonly string _remoteTask;
+        private readonly string _tag;
 
-        public GetRemoteTaskTopologyCommand(string remoteDatabase, string databaseGroupId, string remoteTask)
+        public GetRemoteTaskTopologyCommand(string remoteDatabase, string databaseGroupId, string remoteTask, string tag)
         {
             _remoteDatabase = remoteDatabase ?? throw new ArgumentNullException(nameof(remoteDatabase));
             _databaseGroupId = databaseGroupId ?? throw new ArgumentNullException(nameof(databaseGroupId));
             _remoteTask = remoteTask ?? throw new ArgumentNullException(nameof(remoteTask));
+            _tag = tag;
             Timeout = TimeSpan.FromSeconds(15);
         }
 
@@ -24,7 +26,8 @@ namespace Raven.Client.Documents.Commands
             url = $"{node.Url}/info/remote-task/topology?" +
                   $"database={Uri.EscapeDataString(_remoteDatabase)}" +
                   $"&remote-task={Uri.EscapeDataString(_remoteTask)}" +
-                  $"&groupId={Uri.EscapeDataString(_databaseGroupId)}";
+                  $"&groupId={Uri.EscapeDataString(_databaseGroupId)}" +
+                  $"&tag={Uri.EscapeDataString(_tag)}";
 
             RequestedNode = node;
             var request = new HttpRequestMessage

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -104,6 +104,11 @@ namespace Raven.Server.Documents.Replication.Incoming
             return new MergedUpdateDatabaseChangeVectorCommand(changeVector, lastDocumentEtag, connectionInfo, trigger);
         }
 
+        protected virtual string ReplaceUnknownEntriesWithSinkIfNeeded(DocumentsOperationContext context, string changeVector)
+        {
+           return changeVector;
+        }
+
         protected virtual DocumentMergedTransactionCommand GetMergeDocumentsCommand(DocumentsOperationContext context,
             DataForReplicationCommand data, long lastDocumentEtag)
         {
@@ -212,6 +217,8 @@ namespace Raven.Server.Documents.Replication.Incoming
                     lastEtag = DocumentsStorage.GetLastReplicatedEtagFrom(documentsContext, ConnectionInfo.SourceDatabaseId);
                     lastChangeVector = DocumentsStorage.GetDatabaseChangeVector(documentsContext);
                 }
+
+                changeVector = ReplaceUnknownEntriesWithSinkIfNeeded(documentsContext, changeVector);
 
                 var status = ChangeVectorUtils.GetConflictStatus(changeVector, lastChangeVector);
                 if (status == ConflictStatus.Update || _lastDocumentEtag > lastEtag)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2902,6 +2902,18 @@ namespace Raven.Server.ServerWide
                 statistics.Explanations.Add($"Cannot unload database because number of Subscriptions connections ({numberOfSubscriptionConnections}) is greater than 0");
             }
 
+            var numberOfActivePullReplicationAsSinkConnections = database.ReplicationLoader.HasActivePullReplicationAsSinkConnections();
+            if (statistics != null)
+                statistics.NumberOfActivePullReplicationAsSinkConnections = numberOfActivePullReplicationAsSinkConnections;
+
+            if (numberOfActivePullReplicationAsSinkConnections > 0)
+            {
+                if (statistics == null)
+                    return false;
+
+                statistics.Explanations.Add($"Cannot unload database because number of active PullReplication as Sink Connections ({numberOfActivePullReplicationAsSinkConnections}) is greater than 0");
+            }
+
             var hasActiveOperations = database.Operations.HasActive;
             if (statistics != null)
                 statistics.HasActiveOperations = hasActiveOperations;

--- a/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
@@ -77,6 +77,8 @@ namespace Raven.Server.Web.System
 
             public int NumberOfSubscriptionConnections { get; set; }
 
+            public int NumberOfActivePullReplicationAsSinkConnections { get; set; }
+
             public bool HasActiveOperations { get; set; }
 
             public List<string> Explanations { get; set; }
@@ -94,6 +96,8 @@ namespace Raven.Server.Web.System
                     [nameof(RunInMemory)] = RunInMemory,
                     [nameof(CanUnload)] = CanUnload,
                     [nameof(NumberOfChangesApiConnections)] = NumberOfChangesApiConnections,
+                    [nameof(NumberOfSubscriptionConnections)] = NumberOfSubscriptionConnections,
+                    [nameof(NumberOfActivePullReplicationAsSinkConnections)] = NumberOfActivePullReplicationAsSinkConnections,
                     [nameof(HasActiveOperations)] = HasActiveOperations,
                     [nameof(Explanations)] = Explanations,
                 };

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -4,12 +4,17 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Database;
+using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -17,6 +22,7 @@ using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+using static Raven.Server.Web.System.DatabasesDebugHandler;
 
 namespace SlowTests.Server.Replication
 {
@@ -716,6 +722,245 @@ namespace SlowTests.Server.Replication
                     30_000);
 
                 Assert.Equal("Karmel2", user.Name);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task PullReplicationAsSinkToHubWithIdleShouldWork()
+        {
+            var name = $"pull-replication {GetDatabaseName()}";
+            using (var hubServer = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "10",
+                    [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "3",
+                    [RavenConfiguration.GetKey(x => x.Replication.RetryMaxTimeout)] = "1",
+                    [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
+                }
+            }))
+            using (var sinkServer = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = new Dictionary<string, string>
+                {
+                    [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "10",
+                    [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "3",
+                    [RavenConfiguration.GetKey(x => x.Replication.RetryMaxTimeout)] = "1",
+                    [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
+                }
+            }))
+            using (var sink = GetDocumentStore(new Options
+            {
+                Server = sinkServer,
+                ModifyDatabaseName = s => $"Sink_{s}",
+                RunInMemory = false,
+
+            }))
+            using (var hub = GetDocumentStore(new Options
+            {
+                Server = hubServer,
+                ModifyDatabaseName = s => $"Hub_{s}",
+                RunInMemory = false,
+
+            }))
+            {
+                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(name));
+                using (var s2 = hub.OpenSession())
+                {
+                    s2.Store(new User(), "foo/bar");
+                    s2.SaveChanges();
+                }
+
+                await SetupPullReplicationAsync(name, sink, hub);
+                var timeout = 3000;
+                Assert.True(WaitForDocument(sink, "foo/bar", timeout), sink.Identifier);
+
+                var now = DateTime.Now;
+                var nextNow = now + TimeSpan.FromSeconds(60);
+                while (now < nextNow && hubServer.ServerStore.IdleDatabases.Count < 1)
+                {
+                    await Task.Delay(1000);
+                    now = DateTime.Now;
+                }
+
+                Assert.Equal(1, hubServer.ServerStore.IdleDatabases.Count);
+                Assert.Equal(0, sinkServer.ServerStore.IdleDatabases.Count);
+
+                var sinkDb = await GetDatabase(sinkServer, sink.Database);
+
+                await WaitAndAssertForValueAsync(() =>
+                {
+                    if (sinkDb.ReplicationLoader.OutgoingFailureInfo.Count == 0)
+                        return false;
+
+                    var outgoingFailureInfos = sinkDb.ReplicationLoader.OutgoingFailureInfo.Values.ToList();
+
+                    if (outgoingFailureInfos.Any(x => x.Errors.Count > 0) == false)
+                        return false;
+
+                    foreach (var failureInfo in outgoingFailureInfos)
+                    {
+                        foreach (var error in failureInfo.Errors)
+                        {
+                            if (error is not DatabaseIdleException idleException)
+                                continue;
+
+                            if (idleException.Message.Contains($"Raven.Client.Exceptions.Database.DatabaseIdleException: Cannot GetRemoteTaskTopology for PullReplicationAsSink connection because database '{hub.Database}' currently is idle."))
+                                return true;
+                        }
+                    }
+
+                    return false;
+                }, true, 30_000, 322);
+
+                using (var s2 = hub.OpenSession())
+                {
+                    s2.Store(new User() { Name = "EGOR" }, "foo/bar/322");
+                    s2.SaveChanges();
+                }
+
+                Assert.Equal(0, WaitForValue(() => sinkServer.ServerStore.IdleDatabases.Count, 0, 60_000, 333));
+                Assert.True(WaitForDocument(sink, "foo/bar/322", timeout * 5), sink.Identifier);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task PullReplicationAsHubToSinkWithIdleShouldWork()
+        {
+            var name = $"pull-replication {GetDatabaseName()}";
+
+            var hubSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "10",
+                [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "3",
+                [RavenConfiguration.GetKey(x => x.Replication.RetryMaxTimeout)] = "1",
+                [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
+            };
+            var certificates = Certificates.SetupServerAuthentication(customSettings: hubSettings);
+            using (var server = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = hubSettings
+            }))
+            using (var sink = GetDocumentStore(new Options
+            {
+                Server = server,
+                ModifyDatabaseName = s => $"Sink_{s}",
+                RunInMemory = false,
+                ClientCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificate.Value
+            }))
+            using (var hub = GetDocumentStore(new Options
+            {
+                Server = server,
+                ModifyDatabaseName = s => $"Hub_{s}",
+                RunInMemory = false,
+                ClientCertificate = certificates.ServerCertificate.Value,
+                AdminCertificate = certificates.ServerCertificate.Value
+            }))
+            {
+                await hub.Maintenance.ForDatabase(hub.Database).SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(name)
+                {
+                    Name = name,
+                    Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink
+                }));
+
+                await hub.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation(name,
+                    new ReplicationHubAccess
+                    {
+                        Name = name,
+                        CertificateBase64 = Convert.ToBase64String(certificates.ClientCertificate1.Value.Export(X509ContentType.Cert)),
+                    }));
+
+                var conStrName = "PullReplicationAsSink";
+                await sink.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Database = hub.Database,
+                    Name = conStrName,
+                    TopologyDiscoveryUrls = hub.Urls
+                }));
+                await sink.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+                {
+                    ConnectionStringName = conStrName,
+                    CertificateWithPrivateKey = Convert.ToBase64String(certificates.ClientCertificate1.Value.Export(X509ContentType.Pfx)),
+                    HubName = name,
+                    Mode = PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub
+                }));
+
+                using (var s2 = hub.OpenSession())
+                {
+                    s2.Store(new User(), "foo/bar");
+                    s2.SaveChanges();
+                }
+
+                var timeout = 3000;
+                Assert.True(WaitForDocument(sink, "foo/bar", timeout * 5), sink.Identifier);
+
+                using (var s2 = sink.OpenSession())
+                {
+                    s2.Store(new User(), "foo/bar/228");
+                    s2.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument(hub, "foo/bar/228", timeout * 5), hub.Identifier);
+
+                var dic = new Dictionary<IdleDatabaseStatistics, int>();
+                Assert.True(WaitForValue( () =>
+                {
+                    dic = new Dictionary<IdleDatabaseStatistics, int>();
+                    foreach (var databaseKvp in server.ServerStore.DatabasesLandlord.LastRecentlyUsed.ForceEnumerateInThreadSafeManner())
+                    {
+                        var statistics = new IdleDatabaseStatistics
+                        {
+                            Name = databaseKvp.Key.ToString()
+                        };
+
+                        server.ServerStore.CanUnloadDatabase(databaseKvp.Key, databaseKvp.Value, statistics, out _);
+
+                        if (statistics.CanUnload == false)
+                            continue;
+
+                        if (statistics.Explanations.Count > 1)
+                        {
+                            continue;
+                        }
+
+                        if (statistics.NumberOfActivePullReplicationAsSinkConnections == 0)
+                            continue;
+
+                        dic.Add(statistics, statistics.NumberOfActivePullReplicationAsSinkConnections);
+                    }
+
+                    if (dic.Count != 2)
+                        return false;
+
+                    return dic.All(x => x.Value == 1);
+                }, true, 75_000, 1000), string.Join(Environment.NewLine, dic.Keys.Select(x =>
+                {
+                    using (var context = JsonOperationContext.ShortTermSingleUse())
+                    {
+                        return context.ReadObject(x.ToJson(), "json").ToString();
+                    }
+                })));
+
+                // the hub & sink should be online  
+                Assert.Equal(0, server.ServerStore.IdleDatabases.Count);
+                Assert.All(dic.Keys, x => Assert.Contains($"Cannot unload database because number of active PullReplication as Sink Connections (1) is greater than 0", x.Explanations));
+
+                using (var s2 = hub.OpenSession())
+                {
+                    s2.Store(new User(), "foo/bar/123");
+                    s2.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument(sink, "foo/bar/123", timeout * 5), sink.Identifier);
+
+                using (var s2 = sink.OpenSession())
+                {
+                    s2.Store(new User(), "foo/bar/322");
+                    s2.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument(hub, "foo/bar/322", timeout * 5), hub.Identifier);
             }
         }
 


### PR DESCRIPTION
### Issue link
https://github.com/ravendb/ravendb/pull/19520

https://issues.hibernatingrhinos.com/issue/RavenDB-22445/Outgoing-sink-replication-should-prevent-the-database-from-going-idle

### Additional description

1. Fix sink database from going idle, and loosing the connection with the hub, current state will be 
   * Sink cannot go idle
   * Hub with `HubToSink` sink connectioncan go idle 
   * Hub with `SinkToHub` sink connection cannot go idle
2. On replication heartbeat in case of `SinkToHub` use `ReplaceUnknownEntriesWithSinkTag`, to prevent calling `MergedUpdateDatabaseChangeVectorCommand` command on each heartbeat

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
