### PR TITLE
RavenDB-21833 change heartbeatCheckInterval

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -190,7 +190,7 @@ namespace Raven.Client.Documents.BulkInsert
         private readonly WeakReferencingTimer _timer;
         private DateTime _lastWriteToStream;
         private readonly SemaphoreSlim _streamLock;
-        private readonly TimeSpan _heartbeatCheckInterval = TimeSpan.FromSeconds(StreamWithTimeout.DefaultReadTimeout.TotalSeconds / 3);
+        private readonly TimeSpan _heartbeatCheckInterval = TimeSpan.FromSeconds(StreamWithTimeout.DefaultReadTimeout.TotalSeconds / 4);
 
         public BulkInsertOperation(string database, IDocumentStore store, BulkInsertOptions options, CancellationToken token = default)
         {
@@ -293,7 +293,7 @@ namespace Raven.Client.Documents.BulkInsert
             _lastWriteToStream = DateTime.UtcNow;
 
             if (_options.ForTestingPurposes?.OverrideHeartbeatCheckInterval > 0)
-                _heartbeatCheckInterval = TimeSpan.FromMilliseconds(_options.ForTestingPurposes.OverrideHeartbeatCheckInterval / 3);
+                _heartbeatCheckInterval = TimeSpan.FromMilliseconds(_options.ForTestingPurposes.OverrideHeartbeatCheckInterval / 4);
 
             _timer = new WeakReferencingTimer(HandleHeartbeat,
                 this,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21833

### Additional description

The issue occurred because the heartbeat check and the 5-second read timeout were both using the read timeout divided by 3, causing failures when even a 1 ms delay occurred. Specifically:

Timer starts.
After 1666 ms (read timeout/3), we check for read timeout, but no action is taken.
At 1665 ms (just before read timeout/3), we check for a heartbeat but don’t send it yet.
At 3333 ms, the heartbeat is sent, but by then the timer has already hit 5001 ms, causing the 5-second read timeout.
To fix this, we adjusted the heartbeat interval to read timeout divided by 4, preventing these timing collisions.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
