### PR TITLE
RavenDB-23101 fixed issue with zstd in EmbeddedTests

### DIFF
--- a/src/Sparrow/Utils/ZstdLib.cs
+++ b/src/Sparrow/Utils/ZstdLib.cs
@@ -12,7 +12,7 @@ namespace Sparrow.Utils
     [SuppressUnmanagedCodeSecurity]
     internal static unsafe class ZstdLib
     {
-        private const string LIBZSTD = @"libzstd";
+        internal const string LIBZSTD = "libzstd";
 
         internal static Func<string, Exception> CreateDictionaryException;
 

--- a/test/EmbeddedTests/DynamicNativeLibraryResolver.cs
+++ b/test/EmbeddedTests/DynamicNativeLibraryResolver.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace EmbeddedTests
+{
+#if NETCOREAPP3_1_OR_GREATER
+    internal static class DynamicNativeLibraryResolver
+    {
+        public static void Register(Assembly asm, string lib)
+        {
+            NativeLibrary.SetDllImportResolver(asm, Resolver);
+        }
+
+        private static IntPtr Resolver(string libraryName, Assembly assembly, DllImportSearchPath? dllImportSearchPath)
+        {
+            return NativeLibrary.Load($"runtimes\\{RuntimeInformation.RuntimeIdentifier}\\native\\{libraryName}", assembly, dllImportSearchPath);
+        }
+    }
+#endif
+}

--- a/test/EmbeddedTests/EmbeddedTestBase.cs
+++ b/test/EmbeddedTests/EmbeddedTestBase.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using EmbeddedTests.Platform;
 using Raven.Embedded;
 using Sparrow.Collections;
+using Sparrow.Utils;
 
 namespace EmbeddedTests
 {
@@ -13,6 +14,13 @@ namespace EmbeddedTests
         private static int _pathCount;
 
         private readonly ConcurrentSet<string> _localPathsToDelete = new ConcurrentSet<string>(StringComparer.OrdinalIgnoreCase);
+
+#if NETCOREAPP3_1_OR_GREATER
+        static EmbeddedTestBase()
+        {
+            DynamicNativeLibraryResolver.Register(typeof(ZstdLib).Assembly, ZstdLib.LIBZSTD);
+        }
+#endif
 
         protected string NewDataPath([CallerMemberName] string caller = null)
         {
@@ -82,7 +90,7 @@ namespace EmbeddedTests
             var (severDirectory, dataDirectory) = CopyServer();
             return new ServerOptions { ServerDirectory = severDirectory, DataDirectory = dataDirectory, LogsPath = Path.Combine(severDirectory, "Logs") };
         }
-        
+
         public virtual void Dispose()
         {
             foreach (var path in _localPathsToDelete)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23101

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
