### PR TITLE
RavenDB-22983 -  clone compressed document item in ForgetAboutDocument

### DIFF
--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -180,6 +180,13 @@ namespace Raven.Server.Documents
             InnerTransaction.ForgetAbout(doc.StorageId);
         }
 
+        public bool CanForgetAbout(Document doc)
+        {
+            if (doc == null)
+                return false;
+            return InnerTransaction.CanForgetAbout(doc.StorageId);
+        }
+
         internal void CheckIfShouldDeleteAttachmentStream(Slice hash)
         {
             var clone = hash.Clone(InnerTransaction.Allocator);

--- a/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutAbstractEnumerator.cs
+++ b/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutAbstractEnumerator.cs
@@ -16,16 +16,27 @@ public abstract class TransactionForgetAboutAbstractEnumerator<T> : IEnumerator<
         DocsContext = docsContext;
     }
 
-    protected abstract void ForgetAbout(T item);
+    protected abstract void ForgetAbout(ForgetAboutItem item);
+    protected abstract ForgetAboutItem CloneCurrent(T item);
+
+    protected struct ForgetAboutItem
+    {
+        public T Item;
+        public T CompressedItem;
+        public bool IsCloned;
+    }
 
     public bool MoveNext()
     {
-        ForgetAbout(Current);
+        ForgetAbout(_current);
 
         if (_innerEnumerator.MoveNext() == false)
             return false;
 
-        Current = _innerEnumerator.Current;
+        // the clone is needed because we are going to forget about the _current document
+        // Current should be disposed by the caller
+        _current = CloneCurrent(_innerEnumerator.Current);
+        Current = _current.Item;
 
         return true;
     }
@@ -35,6 +46,7 @@ public abstract class TransactionForgetAboutAbstractEnumerator<T> : IEnumerator<
         throw new System.NotImplementedException();
     }
 
+    private ForgetAboutItem _current = new ForgetAboutItem();
     public T Current { get; private set; }
 
     object IEnumerator.Current => Current;

--- a/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutCurrentPreviousRevisionEnumerator.cs
+++ b/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutCurrentPreviousRevisionEnumerator.cs
@@ -11,9 +11,35 @@ public class TransactionForgetAboutCurrentPreviousRevisionEnumerator : Transacti
     {
     }
 
-    protected override void ForgetAbout((Document Previous, Document Current) item)
+    protected override void ForgetAbout(ForgetAboutItem item)
     {
-        DocsContext.Transaction.ForgetAbout(item.Current);
-        DocsContext.Transaction.ForgetAbout(item.Previous);
+        if (item.IsCloned)
+        {
+            using (item.CompressedItem.Current)
+            using (item.CompressedItem.Previous)
+            {
+                DocsContext.Transaction.ForgetAbout(item.CompressedItem.Current);
+                DocsContext.Transaction.ForgetAbout(item.CompressedItem.Previous);
+            }
+        }
+    }
+
+    protected override ForgetAboutItem CloneCurrent((Document Previous, Document Current) item)
+    {
+        if (DocsContext.Transaction.CanForgetAbout(item.Previous) && DocsContext.Transaction.CanForgetAbout(item.Current))
+        {
+            // this is revision so both items should be compressed
+            return new ForgetAboutItem()
+            {
+                Item = (item.Previous.Clone(DocsContext), item.Current.Clone(DocsContext)),
+                CompressedItem = item,
+                IsCloned = true
+            };
+        }
+
+        return new ForgetAboutItem()
+        {
+            Item = item
+        };
     }
 }

--- a/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutDocumentEnumerator.cs
+++ b/src/Raven.Server/Utils/Enumerators/TransactionForgetAboutDocumentEnumerator.cs
@@ -11,8 +11,32 @@ public class TransactionForgetAboutDocumentEnumerator : TransactionForgetAboutAb
     {
     }
 
-    protected override void ForgetAbout(Document item)
+    protected override void ForgetAbout(ForgetAboutItem item)
     {
-        DocsContext.Transaction.ForgetAbout(Current);
+        if (item.IsCloned)
+        {
+            using (item.CompressedItem)
+            {
+                DocsContext.Transaction.ForgetAbout(item.CompressedItem);
+            }
+        }
+    }
+
+    protected override ForgetAboutItem CloneCurrent(Document item)
+    {
+        if (DocsContext.Transaction.CanForgetAbout(item))
+        {
+            return new ForgetAboutItem()
+            {
+                Item = item.Clone(DocsContext),
+                CompressedItem = item,
+                IsCloned = true
+            };
+        }
+
+        return new ForgetAboutItem()
+        {
+            Item = item
+        };
     }
 }

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -710,6 +710,14 @@ namespace Voron.Impl
             }
         }
 
+        public bool CanForgetAbout(in long storageId)
+        {
+            if (_cachedDecompressedBuffersByStorageId == null)
+                return false;
+
+            return _cachedDecompressedBuffersByStorageId.ContainsKey(storageId);
+        }
+
         public void Forget(Slice name)
         {
             LowLevelTransaction.RootObjects.Forget(name);

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -222,6 +222,15 @@ namespace FastTests
                         }
                     };
 
+                    if (RavenTestHelper.RunTestsWithDocsCompression)
+                    {
+                        doc.DocumentsCompression = new DocumentsCompressionConfiguration
+                        {
+                            CompressAllCollections = true, 
+                            CompressRevisions = true
+                        };
+                    }
+
                     if (options.Encrypted)
                         doc.Encrypted = true;
 

--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -28,6 +28,7 @@ namespace Tests.Infrastructure
     {
         public static readonly bool IsRunningOnCI;
         public static readonly bool SkipIntegrationTests;
+        public static bool RunTestsWithDocsCompression;
 
         public const string SkipIntegrationMessage = "Skipping integration tests.";
 
@@ -40,6 +41,7 @@ namespace Tests.Infrastructure
         {
             bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_IS_RUNNING_ON_CI"), out IsRunningOnCI);
             bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_SKIP_INTEGRATION_TESTS"), out SkipIntegrationTests);
+            bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_DOCS_COMPRESSION_TESTS"), out RunTestsWithDocsCompression);
         }
 
         private static int _pathCount;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22983/AVE-in-SubscriptionConnectionBase-Document.EnsureMetadata-in-5.4.203

### Additional description

This pull request introduces several changes to improve document compression handling and refactor the transaction forget functionality. Key changes include adding methods to check if documents can be forgotten, refactoring enumerators to handle compressed documents, and adding test configurations for document compression.

### Document Compression Handling:

* Added `CanForgetAbout` method in `DocumentsTransaction` to check if a document can be forgotten. (`src/Raven.Server/Documents/DocumentsTransaction.cs`)
* Added `CanForgetAbout` method in `Transaction` to check if a storage ID can be forgotten. (`src/Voron/Impl/Transaction.cs`)

### Enumerator Refactoring:

* Refactored `TransactionForgetAboutAbstractEnumerator` to use a new `ForgetAboutItem` struct and added `CloneCurrent` method for handling document compression. (`src/Raven.Server/Utils/Enumerators/TransactionForgetAboutAbstractEnumerator.cs`) [[1]](diffhunk://#diff-7b107a721804b168880a1890a5e7b437f60a6f3a5c4957910a0336cf25492654L19-R39) [[2]](diffhunk://#diff-7b107a721804b168880a1890a5e7b437f60a6f3a5c4957910a0336cf25492654R49)
* Updated `TransactionForgetAboutCurrentPreviousRevisionEnumerator` to use the new `ForgetAboutItem` struct and handle compressed documents. (`src/Raven.Server/Utils/Enumerators/TransactionForgetAboutCurrentPreviousRevisionEnumerator.cs`)
* Updated `TransactionForgetAboutDocumentEnumerator` to use the new `ForgetAboutItem` struct and handle compressed documents. (`src/Raven.Server/Utils/Enumerators/TransactionForgetAboutDocumentEnumerator.cs`)

### Testing Enhancements:

* Added configuration to enable document compression in tests. (`test/Tests.Infrastructure/RavenTestBase.cs`, `test/Tests.Infrastructure/RavenTestHelper.cs`) [[1]](diffhunk://#diff-4994ec880471b40f3f576dd5ed5465be478303af863cdf9f4d945447b445486bR225-R233) [[2]](diffhunk://#diff-69f5b87066461a50381299baf4c9b3d45b251a6cd5c3d68f4204c7bb214caccaR31) [[3]](diffhunk://#diff-69f5b87066461a50381299baf4c9b3d45b251a6cd5c3d68f4204c7bb214caccaR44)




### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
