### PR TITLE
RavenDB-12945 Change the global http timeout to 4 minutes [WIP]

### DIFF
--- a/src/Raven.Client/Documents/Changes/AbstractDatabaseChanges.cs
+++ b/src/Raven.Client/Documents/Changes/AbstractDatabaseChanges.cs
@@ -109,7 +109,7 @@ internal abstract class AbstractDatabaseChanges<TDatabaseConnectionState> : IDis
         }
 #endif
 #endif
-
+        clientWebSocket.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);
         return clientWebSocket;
     }
 

--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -96,9 +96,9 @@ namespace Raven.Client.Documents.Commands.Batches
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
-                Content = new BlittableJsonContent(async stream =>
+                Content = new BlittableJsonContent(async (stream, token) =>
                 {
-                    await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
+                    await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream, token))
                     {
                         writer.WriteStartObject();
                         writer.WriteArray("Commands", _commandsAsJson);

--- a/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
@@ -56,9 +56,9 @@ namespace Raven.Client.Documents.Commands.MultiGet
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
-                Content = new BlittableJsonContent(async stream =>
+                Content = new BlittableJsonContent(async (stream, token) =>
                 {
-                    await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
+                    await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream, token))
                     {
                         writer.WriteStartObject();
 

--- a/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
@@ -28,9 +28,9 @@ namespace Raven.Client.Documents.Commands
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Post,
-                Content = new BlittableJsonContent(async stream =>
+                Content = new BlittableJsonContent(async (stream, token) =>
                 {
-                    await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
+                    await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream, token))
                     {
                         writer.WriteIndexQuery(_conventions, ctx, _indexQuery);
                     }
@@ -43,14 +43,8 @@ namespace Raven.Client.Documents.Commands
 
         public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
-            var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
-
-            Result = new StreamResult
-            {
-                Response = response,
-                Stream = new StreamWithTimeout(responseStream)
-            };
-
+            var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false);
+            Result = new StreamResult(responseStream, response);
             return ResponseDisposeHandling.Manually;
         }
 

--- a/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
+++ b/src/Raven.Client/Documents/Commands/QueryStreamCommand.cs
@@ -1,17 +1,17 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
 using Raven.Client.Json;
-using Raven.Client.Util;
 using Sparrow.Json;
 
 namespace Raven.Client.Documents.Commands
 {
-    public sealed class QueryStreamCommand : RavenCommand<StreamResult>
+    public sealed class QueryStreamCommand : LongRunningRavenCommand<StreamResult>
     {
         private readonly DocumentConventions _conventions;
         private readonly IndexQuery _indexQuery;

--- a/src/Raven.Client/Documents/Commands/StreamCommand.cs
+++ b/src/Raven.Client/Documents/Commands/StreamCommand.cs
@@ -29,19 +29,8 @@ namespace Raven.Client.Documents.Commands
 
         public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
-            var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
-
-            var timeout = (int)(Timeout ?? StreamWithTimeout.DefaultReadTimeout).TotalMilliseconds;
-            Result = new StreamResult
-            {
-                Response = response,
-                Stream = new StreamWithTimeout(responseStream)
-                {
-                    ReadTimeout = timeout,
-                    WriteTimeout = timeout
-                }
-            };
-
+            var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false);
+            Result = new StreamResult(responseStream, response);
             return ResponseDisposeHandling.Manually;
         }
 

--- a/src/Raven.Client/Documents/Commands/StreamCommand.cs
+++ b/src/Raven.Client/Documents/Commands/StreamCommand.cs
@@ -2,12 +2,11 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Raven.Client.Http;
-using Raven.Client.Util;
 using Sparrow.Json;
 
 namespace Raven.Client.Documents.Commands
 {
-    internal sealed class StreamCommand : RavenCommand<StreamResult>
+    internal sealed class StreamCommand : LongRunningRavenCommand<StreamResult>
     {
         private readonly string _url;
 

--- a/src/Raven.Client/Documents/Commands/StreamResult.cs
+++ b/src/Raven.Client/Documents/Commands/StreamResult.cs
@@ -1,13 +1,50 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Session;
+using Raven.Client.Util;
 
 namespace Raven.Client.Documents.Commands
 {
-    public sealed class StreamResult
+    public class StreamResult : IDisposable, IAsyncDisposable
     {
-        public HttpResponseMessage Response { get; set; }
-        public Stream Stream { get; set; }
+        public StreamResult(Stream stream, HttpResponseMessage response)
+        {
+            Response = response;
+            Stream = new StreamWithTimeout(stream);
+        }
+        public HttpResponseMessage Response { get; }
+        public Stream Stream { get; }
+
+        public void Dispose()
+        {
+            using (Response)
+            using (Stream)
+            {
+            }
+        }
+
+#if NETSTANDARD2_0
+        public ValueTask DisposeAsync()
+        {
+            using (this)
+            {
+
+            }
+
+            return default;
+        }
+#else
+        public async ValueTask DisposeAsync()
+        {
+            using (Response)
+            {
+                await Stream.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+#endif
+
     }
 
     public sealed class StreamResult<TType> : AbstractStreamResult

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -47,7 +47,11 @@ namespace Raven.Client.Documents.Conventions
         internal static TimeSpan? DefaultHttpPooledConnectionIdleTimeout;
 #endif
 
+#if NETCOREAPP3_1_OR_GREATER
+        internal static HttpCompressionAlgorithm DefaultHttpCompressionAlgorithm = HttpCompressionAlgorithm.Zstd;
+#else
         internal static HttpCompressionAlgorithm DefaultHttpCompressionAlgorithm = HttpCompressionAlgorithm.Gzip;
+#endif
 
         internal static readonly DocumentConventions Default = new();
 

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -313,7 +313,7 @@ namespace Raven.Client.Documents.Conventions
             _firstBroadcastAttemptTimeout = TimeSpan.FromSeconds(5);
             _secondBroadcastAttemptTimeout = TimeSpan.FromSeconds(30);
 
-            _globalHttpClientTimeout = TimeSpan.FromHours(12);
+            _globalHttpClientTimeout = TimeSpan.FromMinutes(4);
 
             _waitForIndexesAfterSaveChangesTimeout = TimeSpan.FromSeconds(15);
             _waitForReplicationAfterSaveChangesTimeout = TimeSpan.FromSeconds(15);

--- a/src/Raven.Client/Documents/Operations/Attachments/AttachmentResult.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/AttachmentResult.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
+using System.Net.Http;
+using Raven.Client.Documents.Commands;
 
 namespace Raven.Client.Documents.Operations.Attachments
 {
@@ -9,22 +10,16 @@ namespace Raven.Client.Documents.Operations.Attachments
     /// <remarks>
     /// This class provides access to the binary content of the attachment and its associated metadata.
     /// </remarks>
-    public sealed class AttachmentResult : IDisposable
+    public sealed class AttachmentResult : StreamResult
     {
-        /// <summary>
-        /// The stream containing the binary content of the attachment.
-        /// </summary>
-        public Stream Stream;
-
         /// <summary>
         /// The details of the attachment, including its metadata.
         /// </summary>
         public AttachmentDetails Details;
 
-        public void Dispose()
+        public AttachmentResult(Stream stream, HttpResponseMessage response) : base(stream, response)
         {
-            Stream?.Dispose();
-            Stream = null;
+
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Conventions;
@@ -74,7 +75,7 @@ namespace Raven.Client.Documents.Operations.Attachments
             return new GetAttachmentCommand(conventions, context, _documentId, _name, _type, _changeVector, _from, _to);
         }
 
-        internal sealed class GetAttachmentCommand : RavenCommand<AttachmentResult>
+        internal sealed class GetAttachmentCommand : LongRunningRavenCommand<AttachmentResult>
         {
             private readonly DocumentConventions _conventions;
             private readonly JsonOperationContext _context;

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentOperation.cs
@@ -124,9 +124,9 @@ namespace Raven.Client.Documents.Operations.Attachments
                 {
                     request.Method = HttpMethod.Post;
 
-                    request.Content = new BlittableJsonContent(async stream =>
+                    request.Content = new BlittableJsonContent(async (stream, token) =>
                     {
-                        await using (var writer = new AsyncBlittableJsonTextWriter(_context, stream))
+                        await using (var writer = new AsyncBlittableJsonTextWriter(_context, stream, token))
                         {
                             writer.WriteStartObject();
 
@@ -164,14 +164,12 @@ namespace Raven.Client.Documents.Operations.Attachments
                     DocumentId = _documentId
                 };
 
-                var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
-                var streamReader = new StreamWithTimeout(responseStream);
-                var stream = new AttachmentStream(response, streamReader);
+                var streamResponse = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false);
+                var stream = new AttachmentStream(response, streamResponse);
 
-                Result = new AttachmentResult
+                Result = new AttachmentResult(stream, response)
                 {
-                    Stream = stream,
-                    Details = attachmentDetails
+                    Details = attachmentDetails,
                 };
 
                 return ResponseDisposeHandling.Manually;

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentsOperation.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Conventions;
@@ -45,7 +46,7 @@ namespace Raven.Client.Documents.Operations.Attachments
             return new GetAttachmentsCommand(conventions, context, _attachments, _type);
         }
 
-        internal sealed class GetAttachmentsCommand : RavenCommand<IEnumerator<AttachmentEnumeratorResult>>
+        internal sealed class GetAttachmentsCommand : LongRunningRavenCommand<IEnumerator<AttachmentEnumeratorResult>>
         {
             private readonly DocumentConventions _conventions;
             private readonly JsonOperationContext _context;

--- a/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/GetAttachmentsOperation.cs
@@ -69,9 +69,9 @@ namespace Raven.Client.Documents.Operations.Attachments
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethods.Post,
-                    Content = new BlittableJsonContent(async stream =>
+                    Content = new BlittableJsonContent(async (stream, token) =>
                     {
-                        await using (var writer = new AsyncBlittableJsonTextWriter(_context, stream))
+                        await using (var writer = new AsyncBlittableJsonTextWriter(_context, stream, token))
                         {
                             writer.WriteStartObject();
 
@@ -110,7 +110,7 @@ namespace Raven.Client.Documents.Operations.Attachments
             public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
             {
                 var state = new JsonParserState();
-                Stream stream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
+                Stream stream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false);
 
                 using (context.GetMemoryBuffer(out var buffer))
                 using (var parser = new UnmanagedJsonParser(context, state, "attachments/receive"))

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.Stream.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.Stream.cs
@@ -166,8 +166,7 @@ namespace Raven.Client.Documents.Session
 
                 streamOperation.EnsureIsAcceptable(query.IndexName, command.Result);
 
-                using (command.Result.Response)
-                using (command.Result.Stream)
+                await using (command.Result)
                 {
                     await command.Result.Stream.CopyToAsync(output, 16 * 1024, token).ConfigureAwait(false);
                 }

--- a/src/Raven.Client/Documents/Session/DocumentSession.Stream.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.Stream.cs
@@ -103,8 +103,7 @@ namespace Raven.Client.Documents.Session
             RequestExecutor.Execute(command, Context, sessionInfo: _sessionInfo);
             streamOperation.EnsureIsAcceptable(query.IndexName, command.Result);
 
-            using (command.Result.Response)
-            using (command.Result.Stream)
+            using (command.Result)
             {
                 command.Result.Stream.CopyTo(output);
             }

--- a/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
@@ -373,22 +373,19 @@ namespace Raven.Client.Documents.Session.Operations
                 Dispose();
                 return default;
 #else
-                await _response.Stream.DisposeAsync().ConfigureAwait(false);
-
+                await _response.DisposeAsync().ConfigureAwait(false);
                 DisposeInternal();
 #endif
             }
 
             public void Dispose()
             {
-                _response.Stream.Dispose();
-
+                _response.Dispose();
                 DisposeInternal();
             }
 
             private void DisposeInternal()
             {
-                _response.Response.Dispose();
                 _parser.Dispose();
                 _returnBuffer.Dispose();
                 _peepingTomStream.Dispose();

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -353,9 +353,9 @@ namespace Raven.Client.Documents.Smuggler
                 return new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream =>
+                    Content = new BlittableJsonContent(async (stream, token) =>
                     {
-                        await ctx.WriteAsync(stream, _options).ConfigureAwait(false);
+                        await ctx.WriteAsync(stream, _options, token).ConfigureAwait(false);
                         _tcs.TrySetResult(null);
                     }, _conventions)
                 };
@@ -363,7 +363,7 @@ namespace Raven.Client.Documents.Smuggler
 
             public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
             {
-                using (var stream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false))
+                using (var stream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false))
                 {
                     await _handleStreamResponse(stream).ConfigureAwait(false);
                 }
@@ -409,7 +409,7 @@ namespace Raven.Client.Documents.Smuggler
 
                 var form = new MultipartFormDataContent
                 {
-                    {new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, _options).ConfigureAwait(false), _conventions), Constants.Smuggler.ImportOptions},
+                    {new BlittableJsonContent(async (stream, token) => await ctx.WriteAsync(stream, _options, token).ConfigureAwait(false), _conventions), Constants.Smuggler.ImportOptions},
                     {new StreamContentWithConfirmation(_stream, _tcs, _parent), "file", "name"}
                 };
 
@@ -435,17 +435,24 @@ namespace Raven.Client.Documents.Smuggler
                 _tcs = tcs ?? throw new ArgumentNullException(nameof(tcs));
                 _parent = parent;
             }
+#if NET6_0_OR_GREATER
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken) => SerializeToStreamAsyncCore(stream, context, cancellationToken);
+#endif
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) => SerializeToStreamAsyncCore(stream, context, CancellationToken.None);
 
-            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            private async Task SerializeToStreamAsyncCore(Stream stream, TransportContext context, CancellationToken token)
             {
                 _parent?.ForTestingPurposes?.BeforeSerializeToStreamAsync?.Invoke();
 
                 // Immediately flush request stream to send headers
                 // https://github.com/dotnet/corefx/issues/39586#issuecomment-516210081
                 // https://github.com/dotnet/runtime/issues/96223#issuecomment-1865009861
-                await stream.FlushAsync().ConfigureAwait(false);
-
+                await stream.FlushAsync(token).ConfigureAwait(false);
+#if NET6_0_OR_GREATER
+                await base.SerializeToStreamAsync(stream, context, token).ConfigureAwait(false);
+#else
                 await base.SerializeToStreamAsync(stream, context).ConfigureAwait(false);
+#endif
                 _tcs.TrySetResult(null);
             }
         }

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -319,7 +319,7 @@ namespace Raven.Client.Documents.Smuggler
             }
         }
 
-        private sealed class ExportCommand : RavenCommand
+        private sealed class ExportCommand : LongRunningRavenCommand
         {
             private readonly BlittableJsonReaderObject _options;
             private readonly DocumentConventions _conventions;
@@ -372,7 +372,7 @@ namespace Raven.Client.Documents.Smuggler
             }
         }
 
-        private sealed class ImportCommand : RavenCommand
+        private sealed class ImportCommand : LongRunningRavenCommand
         {
             private readonly BlittableJsonReaderObject _options;
             private readonly DocumentConventions _conventions;

--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmuggler.cs
@@ -437,9 +437,9 @@ namespace Raven.Client.Documents.Smuggler
             }
 #if NET6_0_OR_GREATER
             protected override Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken) => SerializeToStreamAsyncCore(stream, context, cancellationToken);
-#endif
+#else
             protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) => SerializeToStreamAsyncCore(stream, context, CancellationToken.None);
-
+#endif
             private async Task SerializeToStreamAsyncCore(Stream stream, TransportContext context, CancellationToken token)
             {
                 _parent?.ForTestingPurposes?.BeforeSerializeToStreamAsync?.Invoke();

--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -246,7 +246,7 @@ namespace Raven.Client.Documents.Subscriptions
                 ).ConfigureAwait(false);
 
                 _tcpClient = result.TcpClient;
-                _stream = new StreamWithTimeout(result.Stream);
+                _stream = result.Stream;
                 _supportedFeatures = result.SupportedFeatures;
 
                 _tcpClient.NoDelay = true;

--- a/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
+++ b/src/Raven.Client/Http/HttpCompressionAlgorithm.cs
@@ -65,13 +65,11 @@ internal static class HttpCompressionAlgorithmExtensions
 #endif
     }
 
+    internal static async Task<Stream> ReadAsStreamWithZstdSupportAsync(this HttpContent httpContent, CancellationToken token)
+    {
 #if NET6_0_OR_GREATER
-    internal static async Task<Stream> ReadAsStreamWithZstdSupportAsync(this HttpContent httpContent, CancellationToken cancellationToken = default)
-    {
-        var contentStream = await httpContent.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var contentStream = await httpContent.ReadAsStreamAsync(token).ConfigureAwait(false);
 #else
-    internal static async Task<Stream> ReadAsStreamWithZstdSupportAsync(this HttpContent httpContent)
-    {
         var contentStream = await httpContent.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
         var contentStreamType = contentStream.GetType();

--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -47,6 +47,16 @@ namespace Raven.Client.Http
         string RaftUniqueRequestId { get; }
     }
 
+    public abstract class LongRunningRavenCommand : RavenCommand
+    {
+        public override TimeSpan? Timeout { get; protected internal set; } = TimeSpan.FromHours(12);
+    }
+
+    public abstract class LongRunningRavenCommand<TResult> : RavenCommand<TResult>
+    {
+        public override TimeSpan? Timeout { get; protected internal set; } = TimeSpan.FromHours(12);
+    }
+
     public abstract class RavenCommand<TResult>
     {
         public CancellationToken CancellationToken = CancellationToken.None;

--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -157,9 +157,9 @@ namespace Raven.Client.Http
                 return ResponseDisposeHandling.Automatic;
 
 #if NETSTANDARD2_0
-            using (var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false))
+            using (var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false))
 #else
-            await using (var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false))
+            await using (var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false))
 #endif
             {
                 if (ResponseType == RavenCommandResponseType.Object)

--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -170,16 +170,14 @@ namespace Raven.Client.Http
 
                     // we intentionally don't dispose the reader here, we'll be using it
                     // in the command, any associated memory will be released on context reset
-                    await using (var stream = new StreamWithTimeout(responseStream))
+                    
+                    var json = await context.ReadForMemoryAsync(responseStream, "response/object").ConfigureAwait(false);
+                    if (cache != null) //precaution
                     {
-                        var json = await context.ReadForMemoryAsync(stream, "response/object").ConfigureAwait(false);
-                        if (cache != null) //precaution
-                        {
-                            CacheResponse(cache, url, response, json);
-                        }
-                        SetResponse(context, json, fromCache: false);
-                        return ResponseDisposeHandling.Automatic;
+                        CacheResponse(cache, url, response, json);
                     }
+                    SetResponse(context, json, fromCache: false);
+                    return ResponseDisposeHandling.Automatic;
                 }
 
                 // We do not cache the stream response.
@@ -188,8 +186,7 @@ namespace Raven.Client.Http
 #else
                 await using (var uncompressedStream = await RequestExecutor.ReadAsStreamUncompressedAsync(response).ConfigureAwait(false))
 #endif
-                await using (var stream = new StreamWithTimeout(uncompressedStream))
-                    SetResponseRaw(response, stream, context);
+                    SetResponseRaw(response, uncompressedStream, context);
             }
             return ResponseDisposeHandling.Automatic;
         }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -107,8 +107,6 @@ namespace Raven.Client.Http
 
         protected internal NodeSelector _nodeSelector;
 
-        private TimeSpan? _defaultTimeout;
-
         public long NumberOfServerRequests;
 
         protected readonly string TopologyHash;
@@ -145,45 +143,11 @@ namespace Raven.Client.Http
 
         private AbstractCommandResponseBehavior.CommandUnsuccessfulResponseBehavior _commandUnsuccessfulResponseBehavior = AbstractCommandResponseBehavior.CommandUnsuccessfulResponseBehavior.WrapException;
 
-        public TimeSpan? DefaultTimeout
-        {
-            get => _defaultTimeout;
-            set
-            {
-                if (value.HasValue && value.Value > GlobalHttpClientTimeout && GlobalHttpClientTimeout != Timeout.InfiniteTimeSpan)
-                    ThrowTimeoutTooLarge(value);
+        public TimeSpan? DefaultTimeout { get; set; }
 
-                _defaultTimeout = value;
-            }
-        }
+        public TimeSpan SecondBroadcastAttemptTimeout { get; set; }
 
-        private TimeSpan _secondBroadcastAttemptTimeout;
-
-        public TimeSpan SecondBroadcastAttemptTimeout
-        {
-            get => _secondBroadcastAttemptTimeout;
-            set
-            {
-                if (value > GlobalHttpClientTimeout && GlobalHttpClientTimeout != Timeout.InfiniteTimeSpan)
-                    ThrowTimeoutTooLarge(value);
-
-                _secondBroadcastAttemptTimeout = value;
-            }
-        }
-
-        private TimeSpan _firstBroadcastAttemptTimeout;
-
-        public TimeSpan FirstBroadcastAttemptTimeout
-        {
-            get => _firstBroadcastAttemptTimeout;
-            set
-            {
-                if (value > GlobalHttpClientTimeout && GlobalHttpClientTimeout != Timeout.InfiniteTimeSpan)
-                    ThrowTimeoutTooLarge(value);
-
-                _firstBroadcastAttemptTimeout = value;
-            }
-        }
+        public TimeSpan FirstBroadcastAttemptTimeout { get; set; }
 
         public event EventHandler<(long RaftCommandIndex, ClientConfiguration Configuration)> ClientConfigurationChanged;
 
@@ -1097,13 +1061,10 @@ namespace Raven.Client.Http
                 }
 
                 Interlocked.Increment(ref NumberOfServerRequests);
-                var timeout = command.Timeout ?? _defaultTimeout;
+                var timeout = command.Timeout ?? DefaultTimeout;
                 if (timeout.HasValue)
                 {
-                    if (timeout > GlobalHttpClientTimeout && GlobalHttpClientTimeout != Timeout.InfiniteTimeSpan)
-                        ThrowTimeoutTooLarge(timeout);
-
-                    using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token, CancellationToken.None))
+                    using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
                     {
                         cts.CancelAfter(timeout.Value);
                         try
@@ -1458,11 +1419,6 @@ namespace Raven.Client.Http
             // of the nodes, in which case we have nothing to do
         }
 
-        private void ThrowTimeoutTooLarge(TimeSpan? timeout)
-        {
-            throw new InvalidOperationException($"Maximum request timeout is set to '{GlobalHttpClientTimeout}' but was '{timeout}'.");
-        }
-
         private HttpCache.ReleaseCacheItem GetFromCache<TResult>(JsonOperationContext context, RavenCommand<TResult> command, bool useCache, string url, out string cachedChangeVector, out BlittableJsonReaderObject cachedValue)
         {
             if (useCache && command.CanCache && command.CanReadFromCache && command.IsReadRequest && command.ResponseType == RavenCommandResponseType.Object)
@@ -1512,7 +1468,7 @@ namespace Raven.Client.Http
 
             if (ShouldBroadcast(command))
             {
-                command.SetTimeout(command.Timeout ?? _firstBroadcastAttemptTimeout);
+                command.SetTimeout(command.Timeout ?? FirstBroadcastAttemptTimeout);
             }
 
             if (Conventions.HttpVersion != null)
@@ -1832,7 +1788,7 @@ namespace Raven.Client.Http
                     Command = (RavenCommand<TResult>)command.PrepareToBroadcast(ctx, Conventions)
                 };
 
-                state.Command.SetTimeout(_secondBroadcastAttemptTimeout);
+                state.Command.SetTimeout(SecondBroadcastAttemptTimeout);
 
                 var task = ExecuteAsync(state.Node, null, ctx, state.Command, shouldRetry: false, sessionInfo, token);
                 tasks.Add(task, state);

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -1996,7 +1996,7 @@ namespace Raven.Client.Http
         {
             if (response != null)
             {
-                using (var stream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false))
+                using (var stream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken.None).ConfigureAwait(false))
                 using (var ms = RecyclableMemoryStreamFactory.GetRecyclableStream())
                 {
                     await stream.CopyToAsync(ms).ConfigureAwait(false);

--- a/src/Raven.Client/Json/BlittableJsonContent.cs
+++ b/src/Raven.Client/Json/BlittableJsonContent.cs
@@ -17,10 +17,16 @@ namespace Raven.Client.Json
 
         private TaskCompletionSource<object> _tcs;
 
-        private readonly Func<Stream, Task> _asyncTaskWriter;
+        private readonly Func<Stream, CancellationToken, Task> _asyncTaskWriter;
         private readonly DocumentConventions _conventions;
 
-        public BlittableJsonContent(Func<Stream, Task> writer, DocumentConventions conventions)
+        [Obsolete("Use the ctor with the token")]
+        public BlittableJsonContent(Func<Stream, Task> writer, DocumentConventions conventions) : this((stream, _) => writer(stream), conventions)
+        {
+
+        }
+
+        public BlittableJsonContent(Func<Stream, CancellationToken, Task> writer, DocumentConventions conventions)
         {
             _asyncTaskWriter = writer ?? throw new ArgumentNullException(nameof(writer));
             _conventions = conventions;
@@ -37,7 +43,12 @@ namespace Raven.Client.Json
                 ? Task.CompletedTask // SerializeToStreamAsync was never called
                 : _tcs!.Task;
 
-        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+#if NET6_0_OR_GREATER
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken token) => SerializeToStreamAsyncCore(stream, context, CancellationToken.None);
+#endif
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) => SerializeToStreamAsyncCore(stream, context, CancellationToken.None);
+
+        private async Task SerializeToStreamAsyncCore(Stream stream, TransportContext context, CancellationToken token)
         {
             if (Interlocked.CompareExchange(ref _tcs, new(TaskCreationOptions.RunContinuationsAsynchronously), null) is not null)
                 throw new InvalidOperationException($"Already called previously, or called after {nameof(EnsureCompletedAsync)}");
@@ -47,11 +58,11 @@ namespace Raven.Client.Json
                 // Immediately flush request stream to send headers
                 // https://github.com/dotnet/corefx/issues/39586#issuecomment-516210081
                 // https://github.com/dotnet/runtime/issues/96223#issuecomment-1865009861
-                await stream.FlushAsync().ConfigureAwait(false);
+                await stream.FlushAsync(token).ConfigureAwait(false);
 
                 if (_conventions.UseHttpCompression == false)
                 {
-                    await _asyncTaskWriter(stream).ConfigureAwait(false);
+                    await _asyncTaskWriter(stream, token).ConfigureAwait(false);
                     return;
                 }
 
@@ -64,7 +75,7 @@ namespace Raven.Client.Json
                         await using (var gzipStream = new GZipStream(stream, CompressionLevel.Fastest, leaveOpen: true))
 #endif
                         {
-                            await _asyncTaskWriter(gzipStream).ConfigureAwait(false);
+                            await _asyncTaskWriter(gzipStream, token).ConfigureAwait(false);
                         }
 
                         break;
@@ -72,7 +83,7 @@ namespace Raven.Client.Json
                 case HttpCompressionAlgorithm.Brotli:
                     await using (var brotliStream = new BrotliStream(stream, CompressionLevel.Optimal, leaveOpen: true))
                     {
-                        await _asyncTaskWriter(brotliStream).ConfigureAwait(false);
+                        await _asyncTaskWriter(brotliStream, token).ConfigureAwait(false);
                     }
                     break;
 #endif
@@ -80,7 +91,7 @@ namespace Raven.Client.Json
                     case HttpCompressionAlgorithm.Zstd:
                         await using (var zstdStream = ZstdStream.Compress(stream, CompressionLevel.Fastest, leaveOpen: true))
                         {
-                            await _asyncTaskWriter(zstdStream).ConfigureAwait(false);
+                            await _asyncTaskWriter(zstdStream, token).ConfigureAwait(false);
                         }
 
                         break;

--- a/src/Raven.Client/ServerWide/Commands/GetRawStreamResultCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetRawStreamResultCommand.cs
@@ -6,7 +6,7 @@ using Sparrow.Json;
 
 namespace Raven.Client.ServerWide.Commands
 {
-    public sealed class GetRawStreamResultCommand : RavenCommand<Stream>, IDisposable
+    public sealed class GetRawStreamResultCommand : LongRunningRavenCommand<Stream>, IDisposable
     {
         private readonly string _commandUrl;
         private readonly HttpMethod _method;

--- a/src/Raven.Client/ServerWide/Operations/Certificates/CreateClientCertificateOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/Certificates/CreateClientCertificateOperation.cs
@@ -58,9 +58,9 @@ namespace Raven.Client.ServerWide.Operations.Certificates
                     Method = HttpMethod.Post
                 };
 
-                request.Content = new BlittableJsonContent(async stream =>
+                request.Content = new BlittableJsonContent(async (stream, token) =>
                 {
-                    await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream))
+                    await using (var writer = new AsyncBlittableJsonTextWriter(ctx, stream, token))
                     {
                         writer.WriteStartObject();
 

--- a/src/Raven.Client/Util/TcpUtils.cs
+++ b/src/Raven.Client/Util/TcpUtils.cs
@@ -172,27 +172,18 @@ namespace Raven.Client.Util
             return tcpClient;
         }
 
-        internal static async Task<Stream> WrapStreamWithSslAsync(
+        private static async Task<Stream> WrapStreamWithSslAsync(
             TcpClient tcpClient,
             TcpConnectionInfo info,
-            X509Certificate2 storeCertificate,
-#if !NETSTANDARD
-            CipherSuitesPolicy cipherSuitesPolicy,
-#endif
-            TimeSpan? timeout
+            X509Certificate2 storeCertificate
 #if !NETSTANDARD
             ,
+            CipherSuitesPolicy cipherSuitesPolicy,
             CancellationToken token = default
 #endif
             )
         {
             var networkStream = tcpClient.GetStream();
-            if (timeout != null)
-            {
-                networkStream.ReadTimeout =
-                    networkStream.WriteTimeout = (int)timeout.Value.TotalMilliseconds;
-            }
-
             if (info.Certificate == null)
                 return networkStream;
 
@@ -321,13 +312,10 @@ namespace Raven.Client.Util
                     stream = await WrapStreamWithSslAsync(
                         tcpClient,
                         info,
-                        cert,
-#if !NETSTANDARD
-                        cipherSuitesPolicy,
-#endif
-                        timeout
+                        cert
 #if !NETSTANDARD
                         ,
+                        cipherSuitesPolicy,
                         token: token
 #endif
                     ).ConfigureAwait(false);

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -1904,7 +1904,7 @@ namespace Raven.Server.Commercial
                         return GetDefaultLicenseSupportInfo();
                     }
 
-                    var licenseSupportStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
+                    var licenseSupportStream = await response.Content.ReadAsStreamWithZstdSupportAsync(cts.Token).ConfigureAwait(false);
                     using (var context = JsonOperationContext.ShortTermSingleUse())
                     {
                         var json = await context.ReadForMemoryAsync(licenseSupportStream, "license support info");

--- a/src/Raven.Server/Config/Categories/HttpConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/HttpConfiguration.cs
@@ -17,13 +17,13 @@ namespace Raven.Server.Config.Categories
         }
 
         [Description("Set Kestrel's minimum required data rate in bytes per second. This option must be configured together with 'Http.MinDataRateGracePeriod'.")]
-        [DefaultValue(null)]
+        [DefaultValue(5)]
         [SizeUnit(SizeUnit.Bytes)]
         [ConfigurationEntry("Http.MinDataRateBytesPerSec", ConfigurationEntryScope.ServerWideOnly)]
         public Size? MinDataRatePerSecond { get; set; }
 
         [Description("Set Kestrel's allowed request and response grace in seconds. This option must be configured together with 'Http.MinDataRateBytesPerSec'.")]
-        [DefaultValue(null)]
+        [DefaultValue(240)]
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("Http.MinDataRateGracePeriodInSec", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting? MinDataRateGracePeriod { get; set; }

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingsFailureInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingsFailureInfoCommand.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.Commands.Replication
 
         public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
-            await using var stream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
+            await using var stream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false);
             await using var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream();
             await stream.CopyToAsync(memoryStream);
 

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingsFailureInfoCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationOutgoingsFailureInfoCommand.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents.Commands.Replication
         public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
             await using var stream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
-            using var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream();
+            await using var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream();
             await stream.CopyToAsync(memoryStream);
 
             memoryStream.Position = 0;

--- a/src/Raven.Server/Documents/Commands/Streaming/PostQueryStreamCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Streaming/PostQueryStreamCommand.cs
@@ -55,7 +55,7 @@ namespace Raven.Server.Documents.Commands.Streaming
 
         public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
-            var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
+            var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false);
             Result = new StreamResult(responseStream, response);
             return ResponseDisposeHandling.Manually;
         }

--- a/src/Raven.Server/Documents/Commands/Streaming/PostQueryStreamCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Streaming/PostQueryStreamCommand.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents.Commands.Streaming
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Post, 
-                Content = new BlittableJsonContent(async (stream) => await ctx.WriteAsync(stream, queryToWrite), _conventions)
+                Content = new BlittableJsonContent(async (stream, token) => await ctx.WriteAsync(stream, queryToWrite, token), _conventions)
             };
 
             var sb = new StringBuilder($"{node.Url}/databases/{node.Database}/streams/queries?");
@@ -58,15 +58,7 @@ namespace Raven.Server.Documents.Commands.Streaming
         public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
         {
             var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
-
-            Result = new StreamResult
-            {
-                Response = response,
-                Stream = new StreamWithTimeout(responseStream)
-            };
-
-            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal, "Handle possible stream timeout when not reading from stream for a while");
-
+            Result = new StreamResult(responseStream, response);
             return ResponseDisposeHandling.Manually;
         }
     }

--- a/src/Raven.Server/Documents/Commands/Streaming/PostQueryStreamCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Streaming/PostQueryStreamCommand.cs
@@ -6,13 +6,11 @@ using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.Json;
-using Raven.Client.Util;
 using Sparrow.Json;
-using Sparrow.Utils;
 
 namespace Raven.Server.Documents.Commands.Streaming
 {
-    public sealed class PostQueryStreamCommand : RavenCommand<StreamResult>
+    public sealed class PostQueryStreamCommand : LongRunningRavenCommand<StreamResult>
     {
         private readonly DocumentConventions _conventions;
         private readonly BlittableJsonReaderObject _query;

--- a/src/Raven.Server/Documents/Handlers/Processors/BulkInsert/AbstractBulkInsertHandlerProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/BulkInsert/AbstractBulkInsertHandlerProcessor.cs
@@ -90,11 +90,9 @@ internal abstract class AbstractBulkInsertHandlerProcessor<TCommandData, TReques
                 {
                     currentCtxReset = ContextPool.AllocateOperationContext(out JsonOperationContext docsCtx);
                     var requestBodyStream = RequestHandler.RequestBodyStream();
-
                     if (ForTestingPurposes?.BulkInsert_StreamReadTimeout > 0)
                     {
-                        var streamWithTimeout = (StreamWithTimeout)requestBodyStream;
-                        streamWithTimeout.ReadTimeout = ForTestingPurposes.BulkInsert_StreamReadTimeout;
+                        requestBodyStream.ReadTimeout = ForTestingPurposes.BulkInsert_StreamReadTimeout;
                     }
                     using (var reader = GetCommandsReader(context, requestBodyStream, buffer, CancellationToken))
                     {

--- a/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Smuggler/AbstractSmugglerHandlerProcessorForImportGet.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Exceptions.Security;
@@ -35,16 +36,16 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportGet<TRequestHan
         operationId ??= GetOperationId();
 
         var options = DatabaseSmugglerOptionsServerSide.Create(HttpContext, RequestHandler.GetAuthorizationStatusForSmuggler(RequestHandler.DatabaseName));
-        await using (var file = await GetImportStream())
-        await using (var stream = await BackupUtils.GetDecompressionStreamAsync(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte)))
         using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
+        await using (var file = await GetImportStream(token.Token))
+        await using (var stream = await BackupUtils.GetDecompressionStreamAsync(new BufferedStream(file, 128 * Voron.Global.Constants.Size.Kilobyte)))
         {
             var result = await DoImport(context, stream, options, result: null, onProgress: null, operationId.Value, token);
             await WriteSmugglerResultAsync(context, result, RequestHandler.ResponseBodyStream());
         }
     }
 
-    private async Task<Stream> GetImportStream()
+    private async Task<Stream> GetImportStream(CancellationToken token)
     {
         var file = RequestHandler.GetStringQueryString("file", required: false);
         if (string.IsNullOrEmpty(file) == false)
@@ -66,11 +67,11 @@ internal abstract class AbstractSmugglerHandlerProcessorForImportGet<TRequestHan
                     new StreamContent(HttpContext.Request.Body)
                     {
                         Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(HttpContext.Request.ContentType) }
-                    });
-                return await msg.Content.ReadAsStreamWithZstdSupportAsync();
+                    }, token);
+                return await msg.Content.ReadAsStreamWithZstdSupportAsync(token);
             }
 
-            return await SmugglerHandler.HttpClient.GetStreamAsync(url);
+            return await SmugglerHandler.HttpClient.GetStreamAsync(url, token);
         }
 
         return HttpContext.Request.Body;

--- a/src/Raven.Server/Documents/Sharding/Streaming/ReadContinuationState.cs
+++ b/src/Raven.Server/Documents/Sharding/Streaming/ReadContinuationState.cs
@@ -101,8 +101,7 @@ public sealed class ReadContinuationState : IDisposable
 
     public void Dispose()
     {
-        _response.Response.Dispose();
-        _response.Stream.Dispose();
+        _response.Dispose();
         _parser.Dispose();
         _returnBuffer.Dispose();
         _peepingTomStream.Dispose();

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -329,7 +329,6 @@ namespace Raven.Server
                 ((string, TrafficWatchChangeType)?)contextItem ?? ("N/A", TrafficWatchChangeType.None);
 
             var timings = context.Items[nameof(QueryTimings)];
-
             var twn = new TrafficWatchHttpChange
             {
                 TimeStamp = DateTime.UtcNow,
@@ -345,8 +344,8 @@ namespace Raven.Server
                 Type = twTuple.Type,
                 ClientIP = context.Connection.RemoteIpAddress?.ToString(),
                 CertificateThumbprint = context.Connection.ClientCertificate?.Thumbprint,
-                RequestSizeInBytes = ((StreamWithTimeout)context.Items["RequestStream"])?.TotalRead ?? 0,
-                ResponseSizeInBytes = ((StreamWithTimeout)context.Items["ResponseStream"])?.TotalWritten ?? 0,
+                RequestSizeInBytes = context.Request.ContentLength ?? 0,
+                ResponseSizeInBytes = context.Response.ContentLength ?? 0,
             };
 
             TrafficWatchManager.DispatchMessage(twn);

--- a/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
+++ b/src/Raven.Server/Smuggler/Documents/Handlers/SmugglerHandler.cs
@@ -76,6 +76,7 @@ namespace Raven.Server.Smuggler.Documents.Handlers
             var dirTextXml = await result.Content.ReadAsStringWithZstdSupportAsync();
             var filesListing = XElement.Parse(dirTextXml);
             var ns = XNamespace.Get("http://s3.amazonaws.com/doc/2006-03-01/");
+            using var cts = CreateHttpRequestBoundOperationToken();
             var urls = from content in filesListing.Elements(ns + "Contents")
                        let requestUri = url.TrimEnd('/') + "/" + content.Element(ns + "Key").Value
                        select (Func<Task<Stream>>)(async () =>
@@ -83,8 +84,8 @@ namespace Raven.Server.Smuggler.Documents.Handlers
                           var response = await HttpClient.GetAsync(requestUri);
                           if (response.IsSuccessStatusCode == false)
                               throw new InvalidOperationException("Request failed on " + requestUri + " with " +
-                                                                  await response.Content.ReadAsStreamWithZstdSupportAsync());
-                          return await response.Content.ReadAsStreamWithZstdSupportAsync();
+                                                                  await response.Content.ReadAsStreamWithZstdSupportAsync(cts.Token));
+                          return await response.Content.ReadAsStreamWithZstdSupportAsync(cts.Token);
                       });
 
             var files = new BlockingCollection<Func<Task<Stream>>>(new ConcurrentQueue<Func<Task<Stream>>>(urls));

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -116,13 +116,8 @@ namespace Raven.Server.Web
         {
             if (_requestBodyStream != null)
                 return _requestBodyStream;
-            _requestBodyStream = new StreamWithTimeout(GetDecompressedStream(HttpContext.Request.Body, HttpContext.Request.Headers));
 
-            if (TrafficWatchManager.HasRegisteredClients)
-            {
-                HttpContext.Items["RequestStream"] = _requestBodyStream;
-            }
-
+            _requestBodyStream = GetDecompressedStream(HttpContext.Request.Body, HttpContext.Request.Headers);
             _context.HttpContext.Response.RegisterForDispose(_requestBodyStream);
 
             return _requestBodyStream;
@@ -131,7 +126,7 @@ namespace Raven.Server.Web
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Stream GetBodyStream(MultipartSection section)
         {
-            Stream stream = new StreamWithTimeout(GetDecompressedStream(section.Body, section.Headers));
+            Stream stream = GetDecompressedStream(section.Body, section.Headers);
             _context.HttpContext.Response.RegisterForDispose(stream);
             return stream;
         }
@@ -239,7 +234,7 @@ namespace Raven.Server.Web
             if (_responseStream != null)
                 return _responseStream;
 
-            _responseStream = new StreamWithTimeout(HttpContext.Response.Body);
+            _responseStream = HttpContext.Response.Body;
 
             _context.HttpContext.Response.RegisterForDispose(_responseStream);
 

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -204,7 +204,7 @@ public sealed class ShardedStudioCollectionsHandlerProcessorForPreviewCollection
 
             public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
             {
-                var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
+                var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false);
 
                 Result = new StreamResult(responseStream, response);
 

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using NuGet.Packaging;
@@ -171,7 +172,7 @@ public sealed class ShardedStudioCollectionsHandlerProcessorForPreviewCollection
             return new ShardedCollectionPreviewCommand(_collection, _token.Pages[shardNumber].Start, _token.PageSize);
         }
 
-        private sealed class ShardedCollectionPreviewCommand : RavenCommand<StreamResult>
+        private sealed class ShardedCollectionPreviewCommand : LongRunningRavenCommand<StreamResult>
         {
             private readonly string _collection;
             private readonly int _start;

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -205,11 +205,7 @@ public sealed class ShardedStudioCollectionsHandlerProcessorForPreviewCollection
             {
                 var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
 
-                Result = new StreamResult
-                {
-                    Response = response,
-                    Stream = new StreamWithTimeout(responseStream)
-                };
+                Result = new StreamResult(responseStream, response);
 
                 return ResponseDisposeHandling.Manually;
             }

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -176,7 +176,7 @@ internal sealed class ShardedStudioCollectionsHandlerProcessorForPreviewRevision
             return new ShardedRevisionsPreviewCommand(_collection, _continuationToken.Pages[shardNumber].Start, _continuationToken.PageSize);
         }
 
-        private sealed class ShardedRevisionsPreviewCommand : RavenCommand<StreamResult>
+        private sealed class ShardedRevisionsPreviewCommand : LongRunningRavenCommand<StreamResult>
         {
             private readonly string _collection;
             private readonly int _start;

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -208,7 +208,7 @@ internal sealed class ShardedStudioCollectionsHandlerProcessorForPreviewRevision
 
             public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
             {
-                var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
+                var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync(CancellationToken).ConfigureAwait(false);
                 Result = new StreamResult(responseStream, response);
                 return ResponseDisposeHandling.Manually;
             }

--- a/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
+++ b/src/Raven.Server/Web/Studio/Sharding/Processors/ShardedStudioCollectionsHandlerProcessorForPreviewRevisions.cs
@@ -209,13 +209,7 @@ internal sealed class ShardedStudioCollectionsHandlerProcessorForPreviewRevision
             public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
             {
                 var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false);
-
-                Result = new StreamResult
-                {
-                    Response = response,
-                    Stream = new StreamWithTimeout(responseStream)
-                };
-
+                Result = new StreamResult(responseStream, response);
                 return ResponseDisposeHandling.Manually;
             }
         }

--- a/test/SlowTests/Issues/RavenDB-19852.cs
+++ b/test/SlowTests/Issues/RavenDB-19852.cs
@@ -72,9 +72,7 @@ public class RavenDB_19852 : RavenTestBase
 
         public override void SetResponseRaw(HttpResponseMessage response, Stream stream, JsonOperationContext context)
         {
-            var streamWithTimeout = (StreamWithTimeout)stream;
-            var innerStream = streamWithTimeout._stream;
-            var contentTypeName = innerStream.GetType().Name;
+            var contentTypeName = stream.GetType().Name;
 
             switch (_compressionAlgorithm)
             {

--- a/test/SlowTests/SparrowTests/DownloadLogsCommand.cs
+++ b/test/SlowTests/SparrowTests/DownloadLogsCommand.cs
@@ -8,7 +8,7 @@ using Sparrow.Json;
 
 namespace SlowTests.SparrowTests;
 
-public class DownloadLogsCommand : RavenCommand<byte[]>
+public class DownloadLogsCommand : LongRunningRavenCommand<byte[]>
 {
     private readonly DateTime? _startDate;
     private readonly DateTime? _endDate;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-12945

### Additional description

TBD

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
