### PR TITLE
RavenDB-23106 added Polly to LetsEncryptClient to handle Retry-After header properly

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncryptClient.cs
+++ b/src/Raven.Server/Commercial/LetsEncryptClient.cs
@@ -10,6 +10,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Polly;
+using Polly.Retry;
 using Raven.Client;
 using Raven.Server.Utils;
 using Sparrow.Platform;
@@ -18,6 +20,8 @@ namespace Raven.Server.Commercial
 {
     public class LetsEncryptClient
     {
+        private static readonly AsyncRetryPolicy<HttpResponseMessage> RetryPolicy;
+
         private static readonly JsonSerializerSettings jsonSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore,
@@ -53,6 +57,30 @@ namespace Raven.Server.Commercial
             }
         }
 
+        static LetsEncryptClient()
+        {
+            var maxRetryAfterDelta = TimeSpan.FromMinutes(1);
+
+            RetryPolicy = Policy
+                .HandleResult<HttpResponseMessage>(message => message.IsSuccessStatusCode == false && message.Headers.RetryAfter != null)
+                .WaitAndRetryAsync(
+                    retryCount: 5,
+                    sleepDurationProvider: (retry, result, _) =>
+                    {
+                        if (result.Result.Headers.RetryAfter.Delta.HasValue)
+                        {
+                            var retryAfter = result.Result.Headers.RetryAfter.Delta.Value;
+                            if (retryAfter > maxRetryAfterDelta)
+                                return maxRetryAfterDelta;
+
+                            return retryAfter;
+                        }
+
+                        return TimeSpan.FromSeconds(retry);
+                    },
+                    onRetryAsync: (_, _, _, _) => Task.CompletedTask);
+        }
+
         /// <summary>
         ///     In our scenario, we assume a single single wizard progressing
         ///     and the locking is basic to the wizard progress. Adding explicit
@@ -78,7 +106,7 @@ namespace Raven.Server.Commercial
         {
             _url = url ?? throw new ArgumentNullException(nameof(url));
             _directoryPath = new Uri(_url).LocalPath.TrimStart('/');
-            if(string.IsNullOrEmpty(_directoryPath))
+            if (string.IsNullOrEmpty(_directoryPath))
                 throw new ArgumentNullException(nameof(_directoryPath), "Url does not contain directory path");
 
             _path = GetCachePath(_url);
@@ -210,7 +238,7 @@ namespace Raven.Server.Commercial
                 HttpResponseMessage response;
                 try
                 {
-                    response = await _client.SendAsync(request, token).ConfigureAwait(false);
+                    response = await RetryPolicy.ExecuteAsync(t => _client.SendAsync(request, t), token, continueOnCapturedContext: false).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -362,7 +390,7 @@ namespace Raven.Server.Commercial
             {
                 await WaitForStatusAsync(authorization, new List<string> { "valid" }, token);
             }
-            
+
             await WaitForStatusAsync(_currentOrder.Location, new List<string> { "ready" }, token);
 
             try
@@ -500,7 +528,7 @@ namespace Raven.Server.Commercial
                 _cache.CachedCerts.Remove(host);
             }
         }
-        
+
         internal static string GetCachePath(string acmeUrl)
         {
             var home = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23106

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
