### PR TITLE
RavenDB-22849 - Have a separate backup status for each node

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/BackupStatus.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/BackupStatus.cs
@@ -7,6 +7,8 @@ namespace Raven.Client.Documents.Operations.Backups
 {
     public abstract class BackupStatus
     {
+        public string DbBase64Id { get; set; }
+
         public DateTime? LastFullBackup { get; set; }
 
         public DateTime? LastIncrementalBackup { get; set; }

--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
@@ -6,6 +6,8 @@ namespace Raven.Client.Documents.Operations.Backups
 {
     public class PeriodicBackupStatus : IDatabaseTaskStatus
     {
+        public string DbId { get; set; }
+
         public long TaskId { get; set; }
 
         public BackupType BackupType { get; set; }
@@ -93,13 +95,6 @@ namespace Raven.Client.Documents.Operations.Backups
             json[nameof(LastOperationId)] = LastOperationId;
             json[nameof(LastDatabaseChangeVector)] = LastDatabaseChangeVector;
             json[nameof(IsEncrypted)] = IsEncrypted;
-        }
-
-        public static string Prefix => "periodic-backups/";
-
-        public static string GenerateItemName(string databaseName, long taskId)
-        {
-            return $"values/{databaseName}/{Prefix}{taskId}";
         }
     }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -275,7 +275,7 @@ namespace Raven.Server.Documents.PeriodicBackup
                         // save the backup status
                         // create a local copy of ref `runningBackupStatus` so that it can be used in the anonymous method.
                         var status = runningBackupStatus;
-                        BackupUtils.SaveBackupStatus(status, Database.Name, Database.ServerStore, _logger, BackupResult, _onProgress, TaskCancelToken);
+                        BackupUtils.SaveBackupStatusForLocalNode(status, Database.Name, Database.ServerStore, _logger, BackupResult, _onProgress, TaskCancelToken);
                     }
                 }
             }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseOldestBackup.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.1/DatabaseOldestBackup.cs
@@ -78,7 +78,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
 
                 foreach (var periodicBackupTaskId in periodicBackupTaskIds)
                 {
-                    var status = BackupUtils.GetBackupStatusFromCluster(serverStore, context, databaseName, periodicBackupTaskId);
+                    var status = BackupUtils.GetBackupStatusOfResponsibleNode(serverStore, context, databaseName, periodicBackupTaskId);
                     if (status == null)
                         continue; // we have a backup task but no backup was ever done
 

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
@@ -1,12 +1,16 @@
 ﻿using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.ServerWide;
+using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Voron;
+using Voron.Data.Tables;
+using static Raven.Server.Utils.BackupUtils;
 
 namespace Raven.Server.ServerWide.Commands.PeriodicBackup
 {
     public class UpdatePeriodicBackupStatusCommand : UpdateValueForDatabaseCommand
     {
+        public string Base64DbId;
         public PeriodicBackupStatus PeriodicBackupStatus;
 
         // ReSharper disable once UnusedMember.Local
@@ -15,13 +19,17 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
             // for deserialization
         }
 
-        public UpdatePeriodicBackupStatusCommand(string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
+        public UpdatePeriodicBackupStatusCommand(string base64DbId, string databaseName, string uniqueRequestId) : base(databaseName, uniqueRequestId)
         {
+            Base64DbId = base64DbId;
         }
-
+        
         public override string GetItemId()
         {
-            return PeriodicBackupStatus.GenerateItemName(DatabaseName, PeriodicBackupStatus.TaskId);
+            if (ClusterCommandsVersionManager.CurrentClusterMinimalVersion >= SeparateBackupStatusVersion)
+                return BackupStatusKeys.GenerateItemNameForBackupStatusPerDbId(DatabaseName, PeriodicBackupStatus.TaskId, Base64DbId);
+
+            return BackupStatusKeys.GenerateItemNameLegacy(DatabaseName, PeriodicBackupStatus.TaskId);
         }
 
         protected override UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue)
@@ -31,6 +39,7 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
 
         public override void FillJson(DynamicJsonValue json)
         {
+            json[nameof(Base64DbId)] = Base64DbId;
             json[nameof(PeriodicBackupStatus)] = PeriodicBackupStatus.ToJson();
         }
     }

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
@@ -18,6 +18,10 @@ namespace Raven.Server.ServerWide.Commands
 
         protected abstract UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, JsonOperationContext context, BlittableJsonReaderObject existingValue);
 
+        protected virtual void AfterExecuteCommand(ClusterOperationContext context, long index, Table items)
+        {
+        }
+
         public virtual unsafe void Execute(ClusterOperationContext context, Table items, long index, RawDatabaseRecord record, RachisState state, out object result)
         {
             result = null;
@@ -57,6 +61,8 @@ namespace Raven.Server.ServerWide.Commands
             {
                 ClusterStateMachine.UpdateValue(index, items, valueNameLowered, valueName, updatedValue.Value);
             }
+
+            AfterExecuteCommand(context, index, items);
         }
 
         public virtual object GetState()

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.Backup.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.Backup.cs
@@ -156,7 +156,7 @@ internal partial class ClusterObserver
     {
         var lastResponsibleNode = currentResponsibleNode ??
                                   // backward compatibility - will continue running the backup on the last node that ran the backup
-                                  BackupUtils.GetBackupStatusFromCluster(_server, context, databaseName, configuration.TaskId)?.NodeTag;
+                                  BackupUtils.GetBackupStatusFromClusterLegacy(_server, context, databaseName, configuration.TaskId)?.NodeTag;
 
         var mentorNode = configuration.GetMentorNode();
         if (mentorNode != null)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -581,9 +581,14 @@ namespace Raven.Server.ServerWide.Maintenance
             {
                 foreach (var taskId in periodicBackupTaskIds)
                 {
-                    var singleBackupStatus = _server.Cluster.Read(context, PeriodicBackupStatus.GenerateItemName(databaseName, taskId));
+                    //TODO stav: what if responsible node is deleted and so there is no backup status for it anymore? so we have no backup, but we will delete the files
+
+                    var singleBackupStatus = BackupUtils.GetBackupStatusOfResponsibleNodeBlittable(_server, context, databaseName, taskId);
                     if (singleBackupStatus == null)
+                    {
+                        Console.WriteLine($"Observer: GetMaxCompareExchangeTombstonesEtagToDelete: No backup status exists");
                         continue;
+                    }
 
                     if (singleBackupStatus.TryGet(nameof(PeriodicBackupStatus.LastFullBackupInternal), out DateTime? lastFullBackupInternal) == false ||
                         lastFullBackupInternal == null)

--- a/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
+++ b/src/Raven.Server/Storage/Schema/SchemaUpgrader.cs
@@ -104,7 +104,7 @@ namespace Raven.Server.Storage.Schema
                     var msg = $"Started schema upgrade from version #{updater.From} to version #{updater.To}";
                     _documentsStorage.DocumentDatabase.AddToInitLog?.Invoke(LogMode.Information, msg);
                 }
-
+                
                 bool result =  updater.Update(new UpdateStep(transactions)
                 {
                     ConfigurationStorage = _configurationStorage,

--- a/src/Raven.Server/Storage/Schema/Updates/Server/42015/From42014.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/42015/From42014.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.ServerWide;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Voron;
@@ -95,7 +96,7 @@ namespace Raven.Server.Storage.Schema.Updates.Server
 
                     foreach (var pb in databaseRecord.PeriodicBackups)
                     {
-                        var pbItemName = PeriodicBackupStatus.GenerateItemName(db, pb.TaskId);
+                        var pbItemName = BackupUtils.BackupStatusKeys.GenerateItemNameLegacy(db, pb.TaskId);
                         using (Slice.From(step.WriteTx.Allocator, pbItemName, out Slice pbsSlice))
                         using (Slice.From(step.WriteTx.Allocator, pbItemName.ToLowerInvariant(), out Slice pbsSliceLower))
                         {

--- a/src/Raven.Server/Web/System/DatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesHandler.cs
@@ -517,7 +517,7 @@ namespace Raven.Server.Web.System
                             periodicBackups.Add(new PeriodicBackup
                             {
                                 Configuration = periodicBackupConfiguration,
-                                BackupStatus = BackupUtils.GetBackupStatusFromCluster(ServerStore, context, databaseName, periodicBackupConfiguration.TaskId)
+                                BackupStatus = BackupUtils.GetBackupStatusOfResponsibleNode(ServerStore, context, databaseName, periodicBackupConfiguration.TaskId)
                             });
                         }
 
@@ -529,7 +529,7 @@ namespace Raven.Server.Web.System
                             [nameof(DatabaseInfo.NodesTopology)] = nodesTopology.ToJson(),
                             [nameof(DatabaseInfo.DeletionInProgress)] = DynamicJsonValue.Convert(dbRecord.DeletionInProgress),
                             [nameof(DatabaseInfo.Environment)] = studioEnvironment,
-                            [nameof(DatabaseInfo.BackupInfo)] = BackupUtils.GetBackupInfo(
+                            [nameof(DatabaseInfo.BackupInfo)] = BackupUtils.GetBackupsInfoForDatabase(
                                 new BackupUtils.BackupInfoParameters()
                                 {
                                     ServerStore = ServerStore,

--- a/src/Raven.Server/Web/System/OngoingTasksHandler.cs
+++ b/src/Raven.Server/Web/System/OngoingTasksHandler.cs
@@ -519,7 +519,7 @@ namespace Raven.Server.Web.System
                                     {
                                         var runningBackupStatus = new PeriodicBackupStatus { TaskId = 0, BackupType = backupConfiguration.BackupType };
                                         var backupResult = backupTask.RunPeriodicBackup(onProgress, ref runningBackupStatus);
-                                        BackupUtils.SaveBackupStatus(runningBackupStatus, Database.Name, Database.ServerStore, Logger, backupResult, operationCancelToken: cancelToken);
+                                        BackupUtils.SaveBackupStatusForLocalNode(runningBackupStatus, Database.Name, Database.ServerStore, Logger, backupResult, operationCancelToken: cancelToken);
                                         tcs.SetResult(backupResult);
                                     }
                                 }
@@ -594,7 +594,7 @@ namespace Raven.Server.Web.System
 
         private OngoingTaskBackup GetOngoingTaskBackup(long taskId, PeriodicBackupConfiguration backupConfiguration, ClusterTopology clusterTopology)
         {
-            var backupStatus = Database.PeriodicBackupRunner.GetBackupStatus(taskId);
+            var backupStatus = Database.PeriodicBackupRunner.GetBackupStatusForLocalNode(taskId);
             var nextBackup = Database.PeriodicBackupRunner.GetNextBackupDetails(backupConfiguration, backupStatus, out var responsibleNodeTag);
             var onGoingBackup = Database.PeriodicBackupRunner.OnGoingBackup(taskId);
             var backupDestinations = backupConfiguration.GetFullBackupDestinations();

--- a/test/SlowTests/Issues/RavenDB-13553.cs
+++ b/test/SlowTests/Issues/RavenDB-13553.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Issues
                 }
 
                 var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var status = documentDatabase.PeriodicBackupRunner.GetBackupStatus(config.TaskId);
+                var status = documentDatabase.PeriodicBackupRunner.GetBackupStatusForLocalNode(config.TaskId);
                 var nextBackupDetails = documentDatabase.PeriodicBackupRunner.GetNextBackupDetails(record.PeriodicBackups.First(), status, out var responsibleNode);
                 
                 Assert.True(nextBackupDetails.IsFull);

--- a/test/SlowTests/Issues/RavenDB-19922.cs
+++ b/test/SlowTests/Issues/RavenDB-19922.cs
@@ -353,7 +353,7 @@ namespace SlowTests.Issues
                     var responsibleNodeInfo = Raven.Server.Utils.BackupUtils.GetResponsibleNodeInfoFromCluster(Server.ServerStore, context, store.Database, backupTaskId);
                     Assert.Null(responsibleNodeInfo);
 
-                    var backupStatus = Raven.Server.Utils.BackupUtils.GetBackupStatusFromCluster(Server.ServerStore, context, store.Database, backupTaskId);
+                    var backupStatus = Raven.Server.Utils.BackupUtils.GetBackupStatusFromClusterPerDbId(Server.ServerStore, context, store.Database, backupTaskId, Server.ServerStore._env.Base64Id);
                     Assert.Null(backupStatus);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-22573.cs
+++ b/test/SlowTests/Issues/RavenDB-22573.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Issues
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 1 * * *", backupType: BackupType.Backup, disabled: false);
                 var id = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
                 var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store);
-                var status = documentDatabase.PeriodicBackupRunner.GetBackupStatus(id);
+                var status = documentDatabase.PeriodicBackupRunner.GetBackupStatusForLocalNode(id);
                 config.TaskId = id;
                 var nextBackupDetails = periodicBackupRunner.GetNextBackupDetails(config, status, out string _);
                 var nextBackup = nextBackupDetails.DateTime.ToLocalTime();

--- a/test/SlowTests/Issues/RavenDB_20150.cs
+++ b/test/SlowTests/Issues/RavenDB_20150.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Documents.Session;
 using Raven.Server.Config;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Tests.Infrastructure;
@@ -82,7 +83,7 @@ public class RavenDB_20150 : ClusterTestBase
                     using (dbServer.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (context.OpenReadTransaction())
                     {
-                        var itemName = PeriodicBackupStatus.GenerateItemName(database, result.TaskId);
+                        var itemName = BackupUtils.BackupStatusKeys.GenerateItemNameLegacy(database, result.TaskId);
                         var status = dbServer.ServerStore.Cluster.Read(context, itemName);
                         if (status == null)
                             return false;

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.ServerWide.Commands.Cluster;
+using Raven.Client.Util;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Commands.PeriodicBackup;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.PeriodicBackup
+{
+    public class ClusterBackupTests : ClusterTestBase
+    {
+        public ClusterBackupTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster)]
+        public async Task DontRunFullBackupAgainIfComingBackFromAnotherNode()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0);
+
+            using (var store = GetDocumentStore(new Options
+            {
+                ReplicationFactor = 3,
+                Server = leader
+            }))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Stav" }, "users/1");
+                    await session.SaveChangesAsync();
+                    var exists = await WaitForDocumentInClusterAsync<User>(nodes, store.Database, "users/1", x => x.Name == "Stav", TimeSpan.FromSeconds(10));
+                    Assert.True(exists);
+                }
+
+                // A runs backup
+                var originalNode = nodes[0].ServerStore.NodeTag;
+                var config = Backup.CreateBackupConfiguration(backupPath, mentorNode: originalNode);
+                var taskId = await Backup.UpdateConfigAndRunBackupAsync(leader, config, store, isFullBackup: false);
+
+                // assert number of directories
+                var dirs = Directory.GetDirectories(backupPath);
+                Console.WriteLine($"dirs first backup:\n {string.Join("\n", dirs)}");
+                Assert.Equal(1, dirs.Length);
+
+                // change responsible node
+                var command = new UpdateResponsibleNodeForTasksCommand(
+                    new UpdateResponsibleNodeForTasksCommand.Parameters
+                    {
+                        ResponsibleNodePerDatabase = new Dictionary<string, List<ResponsibleNodeInfo>>()
+                        {
+                            { store.Database, new List<ResponsibleNodeInfo>() { new () { TaskId = taskId, ResponsibleNode = nodes[1].ServerStore.NodeTag } } }
+                        }
+                    }, RaftIdGenerator.NewId());
+                await leader.ServerStore.Engine.SendToLeaderAsync(command);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, originalNode);
+
+                // wait for backup to finish on that node
+                var op = await store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: false, taskId));
+                await op.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
+
+                // assert number of directories grew
+                var newDirs = Directory.GetDirectories(backupPath).Except(dirs).ToList();
+                Console.WriteLine($"dirs after second backup:\n {string.Join("\n", newDirs)}");
+                Assert.Equal(1, newDirs.Count);
+
+                //change responsible node back to original node
+                command = new UpdateResponsibleNodeForTasksCommand(
+                    new UpdateResponsibleNodeForTasksCommand.Parameters
+                    {
+                        ResponsibleNodePerDatabase = new Dictionary<string, List<ResponsibleNodeInfo>>()
+                        {
+                            { store.Database, new List<ResponsibleNodeInfo>() { new () { TaskId = taskId, ResponsibleNode = originalNode } } }
+                        }
+                    }, RaftIdGenerator.NewId());
+                await leader.ServerStore.Engine.SendToLeaderAsync(command);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, nodes[1].ServerStore.NodeTag);
+
+                // wait for backup to finish on that node
+                op = await store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup: false, taskId));
+                await op.WaitForCompletionAsync(TimeSpan.FromSeconds(10));
+
+                // assert no new dirs for full backup
+                var dirsAfterSwitchBack = Directory.GetDirectories(backupPath);
+                Console.WriteLine($"DirsAfterSwitchBack:\n {string.Join("\n", dirsAfterSwitchBack)}");
+                Assert.Equal(2, dirsAfterSwitchBack.Length);
+            }
+        }
+        //TODO stav: test for deleting node A, then creating it again -> backup status should be deleted and start from scratch
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster)]
+        public async Task BackupWillNotRunAgainIfNodeTagReplaced()
+        {
+            // If we have a backup status for node A and then we replace node A
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0);
+
+            using (var store = GetDocumentStore(new Options
+            {
+                ReplicationFactor = 3,
+                Server = leader
+            }))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Stav" }, "users/1");
+                    await session.SaveChangesAsync();
+                    var exists = await WaitForDocumentInClusterAsync<User>(nodes, store.Database, "users/1", x => x.Name == "Stav", TimeSpan.FromSeconds(10));
+                    Assert.True(exists);
+                }
+
+                // A runs backup
+                var originalNode = nodes[0].ServerStore.NodeTag;
+                var config = Backup.CreateBackupConfiguration(backupPath, mentorNode: originalNode);
+                var taskId = await Backup.UpdateConfigAndRunBackupAsync(leader, config, store, isFullBackup: false);
+
+                
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster)]
+        public async Task DontDeleteCompareExchangeBelongingToBackupIfResponsibleNodeRemoved()
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var settings = new Dictionary<string, string>
+            {
+                { RavenConfiguration.GetKey(x => x.Cluster.CompareExchangeTombstonesCleanupInterval), "10" },
+            };
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, customSettings: settings);
+
+            using (var store = GetDocumentStore(new Options
+            {
+                ReplicationFactor = 3,
+                Server = leader
+            }))
+            {
+                // Create compare exchange
+                var res = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/1", new User(){ Name = "Jane" }, 0));
+                
+                // Delete it to create a tombstone
+                res = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/1", res.Index));
+                Assert.True(res.Successful);
+                await Cluster.WaitForRaftIndexToBeAppliedOnClusterNodesAsync(res.Index, nodes, TimeSpan.FromSeconds(15));
+                var stats = store.Maintenance.ForDatabase(store.Database).Send(new GetDetailedStatisticsOperation());
+                Assert.Equal(0, stats.CountOfCompareExchange);
+                Assert.Equal(1, stats.CountOfCompareExchangeTombstones);
+
+                // Run full backup
+                var responsibleNode = nodes[2].ServerStore.NodeTag;
+                var config = Backup.CreateBackupConfiguration(backupPath, mentorNode: responsibleNode);
+                var taskId = await Backup.UpdateConfigAndRunBackupAsync(nodes[2], config, store, isFullBackup: false);
+
+                // assert number of directories
+                var dirs = Directory.GetDirectories(backupPath);
+                Assert.Equal(1, dirs.Length);
+
+                // Make sure there is backup status for this node
+                GetPeriodicBackupStatusOperationResult backupStatus = null;
+                var noStatus = await WaitForValueAsync(async () =>
+                {
+                    backupStatus = await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId)); // this will fetch by responsible node
+                    return backupStatus?.Status != null;
+                }, true);
+                Assert.True(noStatus);
+                
+                Assert.NotNull(backupStatus?.Status);
+                Assert.Equal(responsibleNode, backupStatus.Status.NodeTag);
+
+                // remove the backup's responsible node from the cluster
+                await store.Operations.SendAsync(new RemoveClusterNodeOperation(responsibleNode));
+
+                // Make sure there is no backup status for this node anymore
+                var statusExists = await WaitForValueAsync(async () =>
+                {
+                    backupStatus = await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId)); // this will fetch by responsible node
+                    return backupStatus?.Status == null;
+                }, true);
+                Assert.True(statusExists);
+
+                var timeBeforeCxDeletion = DateTime.UtcNow;
+
+                // execute the compare exchange cleanup
+                leader.ServerStore.Observer._lastTombstonesCleanupTimeInTicks = 0;
+
+                // wait for tombstone cleaner to finish
+                await WaitAndAssertForValueAsync(() => leader.ServerStore.Observer._lastTombstonesCleanupTimeInTicks > timeBeforeCxDeletion.Ticks, true);
+
+
+                // make sure the compare exchange tombstone hasn't been deleted
+                await AssertWaitForValueAsync(async () =>
+                {
+                    var stats = await store.Maintenance.ForDatabase(store.Database).SendAsync(new GetDetailedStatisticsOperation());
+                    return stats.CountOfCompareExchange == 0 && stats.CountOfCompareExchangeTombstones != 0;
+                }, true);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3396,7 +3396,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                             PeriodicBackupStatus inMemoryStatus = null;
                             WaitForValue(() =>
                             {
-                                inMemoryStatus = documentDatabase.PeriodicBackupRunner.GetBackupStatus(taskId);
+                                inMemoryStatus = documentDatabase.PeriodicBackupRunner.GetBackupStatusForLocalNode(taskId);
                                 return inMemoryStatus != null;
                             }, true);
 

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -60,7 +60,11 @@ namespace FastTests
                 BackupResult result = default;
                 var actual = await WaitForValueAsync(async () =>
                 {
-                    var state = await store.Maintenance.SendAsync(new GetOperationStateOperation(op));
+                    //TODO stav: this NREs if the responsible node is not the first in topology of the store (this ep has no redirecting)
+                    //var state = await store.Maintenance.SendAsync(new GetOperationStateOperation(op));
+
+                    var state = documentDatabase.Operations.GetOperation(op).State;
+
                     result = state.Result as BackupResult;
                     return state.Status;
                 }, opStatus, timeout: timeout ?? _reasonableTimeout);
@@ -257,11 +261,11 @@ namespace FastTests
                 return backupTaskId;
             }
 
-            public void WaitForResponsibleNodeUpdateInCluster(DocumentStore store, List<RavenServer> nodes, long backupTaskId)
+            public void WaitForResponsibleNodeUpdateInCluster(DocumentStore store, List<RavenServer> nodes, long backupTaskId, string differentThan = null)
             {
                 foreach (var server in nodes)
                 {
-                    WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, backupTaskId);
+                    WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, backupTaskId, differentThan);
                 }
             }
 

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -10,6 +10,7 @@ using SlowTests.Issues;
 using SlowTests.MailingList;
 using SlowTests.Rolling;
 using SlowTests.Server.Documents.ETL.Raven;
+using SlowTests.Server.Documents.PeriodicBackup;
 using Tests.Infrastructure;
 
 namespace Tryouts
@@ -30,9 +31,9 @@ namespace Tryouts
                 try
                 {
                     using (var testOutputHelper = new ConsoleTestOutputHelper())
-                    using (var test = new RavenDB_21173(testOutputHelper))
+                    using (var test = new ClusterBackupTests(testOutputHelper))
                     {
-                        await test.ClusterTransaction_Failover_Shouldnt_Throw_ConcurrencyException();
+                        await test.DontDeleteCompareExchangeBelongingToBackupIfResponsibleNodeRemoved();
                     }
                 }
                 catch (Exception e)
@@ -40,6 +41,7 @@ namespace Tryouts
                     Console.ForegroundColor = ConsoleColor.Red;
                     Console.WriteLine(e);
                     Console.ForegroundColor = ConsoleColor.White;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22849

### Additional description

Backup will now have a backup status for each node, to avoid overriding the backup status each time the responsible node changes. This causes full backups to happen twice on a "rechosen" node, since it thinks it never had a backup before.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
