### PR TITLE
RavenDB-23056 Exposed additional memory metrics for Prometheus

### DIFF
--- a/src/Raven.Server/Monitoring/MetricsProvider.cs
+++ b/src/Raven.Server/Monitoring/MetricsProvider.cs
@@ -156,6 +156,11 @@ public class MetricsProvider
 
         result.TotalDirtyInMb = MemoryInformation.GetDirtyMemoryState().TotalDirty.GetValue(SizeUnit.Megabytes);
 
+        result.AvailableMemoryForProcessingInMb = memoryInfoResult.AvailableMemoryForProcessing.GetValue(SizeUnit.Megabytes);
+        
+        result.ManagedMemoryInBytes = AbstractLowMemoryMonitor.GetManagedMemoryInBytes();
+        result.UnmanagedMemoryInBytes = AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes();
+
         return result;
     }
 

--- a/src/Raven.Server/Utils/Monitoring/ServerMetrics.cs
+++ b/src/Raven.Server/Utils/Monitoring/ServerMetrics.cs
@@ -121,6 +121,9 @@ namespace Raven.Server.Utils.Monitoring
         public long TotalSwapUsageInMb { get; set; }
         public long WorkingSetSwapUsageInMb { get; set; }
         public long TotalDirtyInMb { get; set; }
+        public long AvailableMemoryForProcessingInMb { get; set; }
+        public long ManagedMemoryInBytes { get; set; }
+        public long UnmanagedMemoryInBytes { get; set; }
 
         public DynamicJsonValue ToJson()
         {
@@ -133,7 +136,10 @@ namespace Raven.Server.Utils.Monitoring
                 [nameof(TotalSwapSizeInMb)] = TotalSwapSizeInMb,
                 [nameof(TotalSwapUsageInMb)] = TotalSwapUsageInMb,
                 [nameof(WorkingSetSwapUsageInMb)] = WorkingSetSwapUsageInMb,
-                [nameof(TotalDirtyInMb)] = TotalDirtyInMb
+                [nameof(TotalDirtyInMb)] = TotalDirtyInMb,
+                [nameof(AvailableMemoryForProcessingInMb)] = AvailableMemoryForProcessingInMb,
+                [nameof(ManagedMemoryInBytes)] = ManagedMemoryInBytes,
+                [nameof(UnmanagedMemoryInBytes)] = UnmanagedMemoryInBytes
             };
         }
     }

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -138,7 +138,7 @@ namespace Raven.Server.Web.System
                         new Size(serverMetrics.Memory.TotalSwapUsageInMb, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes));
                     WriteGaugeWithHelp(writer, "Server working set swap usage", "memory_working_set_swap_usage_bytes",
                         new Size(serverMetrics.Memory.WorkingSetSwapUsageInMb, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes));
-                    WriteGaugeWithHelp(writer, "Available memory for processing", "available_memory_for_processing", 
+                    WriteGaugeWithHelp(writer, "Available memory for processing", "available_memory_for_processing_bytes", 
                         new Size(serverMetrics.Memory.AvailableMemoryForProcessingInMb, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes));
                     WriteGaugeWithHelp(writer, "Managed memory", "managed_memory_bytes",
                         new Size(serverMetrics.Memory.ManagedMemoryInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Bytes));

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -138,6 +138,12 @@ namespace Raven.Server.Web.System
                         new Size(serverMetrics.Memory.TotalSwapUsageInMb, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes));
                     WriteGaugeWithHelp(writer, "Server working set swap usage", "memory_working_set_swap_usage_bytes",
                         new Size(serverMetrics.Memory.WorkingSetSwapUsageInMb, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes));
+                    WriteGaugeWithHelp(writer, "Available memory for processing", "available_memory_for_processing", 
+                        new Size(serverMetrics.Memory.AvailableMemoryForProcessingInMb, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes));
+                    WriteGaugeWithHelp(writer, "Managed memory", "managed_memory_bytes",
+                        new Size(serverMetrics.Memory.ManagedMemoryInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Bytes));
+                    WriteGaugeWithHelp(writer, "Unmanaged memory", "unmanaged_memory_bytes",
+                        new Size(serverMetrics.Memory.UnmanagedMemoryInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Bytes));
 
                     // network
                     WriteGaugeWithHelp(writer, "Number of active TCP connections", "network_tcp_active_connections", serverMetrics.Network.TcpActiveConnections);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23056/Expose-detailed-memory-metrics-in-prometheus-interface

### Additional description

Exposed additional memory metrics for Prometheus

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
