### PR TITLE
RavenDB-22840 - RemoveRevertFlagAfterNewInfo2 Fails

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2115,6 +2115,8 @@ namespace Raven.Server.Documents.Revisions
 
         private bool PrepareRevertedRevisions(DocumentsOperationContext writeCtx, Parameters parameters, RevertResult result, List<Document> list, string collection, OperationCancelToken token)
         {
+            var endEtag = parameters.LastScannedEtag - 1;
+
             using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext readCtx))
             using (readCtx.OpenReadTransaction())
             {
@@ -2141,12 +2143,12 @@ namespace Raven.Server.Documents.Revisions
                         return false;
                     }
 
-                    tvrs = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], parameters.LastScannedEtag);
+                    tvrs = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice], endEtag);
                 }
                 else
                 {
                     var revisions = new Table(RevisionsSchema, readCtx.Transaction.InnerTransaction);
-                    tvrs = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], parameters.LastScannedEtag);
+                    tvrs = revisions.SeekBackwardFrom(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice], endEtag);
                 }
 
                 foreach (var tvr in tvrs)

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -2026,6 +2026,9 @@ namespace Voron.Data.Tables
                 var result = new TableValueHolder();
                 do
                 {
+                    if (it.CurrentKey > key)
+                        continue;
+
                     GetTableValueReader(it, out result.Reader);
                     yield return result;
                 } while (it.MovePrev());

--- a/test/SlowTests/Issues/RavenDB-22840.cs
+++ b/test/SlowTests/Issues/RavenDB-22840.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide;
+using Sparrow;
+using Sparrow.Global;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+public class RavenDB_22840 : ReplicationTestBase
+{
+    public RavenDB_22840(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Revisions)]
+    public async Task RevertRevision_Should_Return_Right_ScannedRevisions_When_Reaches_To_SizeLimitInBytes()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    // MinimumRevisionsToKeep = 100
+                }
+            };
+            await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
+
+            DateTime last = default;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var person = new Person
+                {
+                    Name = "Name1"
+                };
+                await session.StoreAsync(person, "foo/bar");
+                await session.SaveChangesAsync();
+                last = DateTime.UtcNow;
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var person = new Person
+                {
+                    Name = "Name2"
+                };
+                await session.StoreAsync(person, "foo/bar");
+                await session.SaveChangesAsync();
+            }
+
+            // for (int i = 0; i < 160; i++)
+            // {
+            //     using (var session = store.OpenAsyncSession())
+            //     {
+            //         var person = new Person
+            //         {
+            //             Name = $"Name{i}"
+            //         };
+            //         await session.StoreAsync(person, "foo/bar");
+            //         await session.SaveChangesAsync();
+            //     }
+            // }
+
+            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
+            db.DocumentsStorage.RevisionsStorage.SizeLimitInBytes = 0;
+
+            RevertResult result;
+            using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
+            {
+                result = (RevertResult)await db.DocumentsStorage.RevisionsStorage.RevertRevisions(last, TimeSpan.FromMinutes(60), onProgress: null, token: token);
+            }
+
+            // WaitForUserToContinueTheTest(store, false);
+
+
+            Assert.Equal(2, result.ScannedRevisions);
+        }
+    }
+
+    private class Person
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string AddressId { get; set; }
+    }
+
+}
+


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22840/SlowTests.Issues.RavenDB17082.RemoveRevertFlagAfterNewInfo2options-DatabaseMode-Single-SearchEngineMode-Lucene

### Additional description

We were passing on the last revision again -> in the second call of `PrepareRevertedRevisions` in case of reaching to the `SizeLimitInBytes`. so we were incrementing `result.ScannedRevisions` twice on the same revision.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
