### PR TITLE
RavenDB-22873 - Improve the deployment of multiple indexes

### DIFF
--- a/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/AbstractIndexCreateController.cs
@@ -57,16 +57,6 @@ public abstract class AbstractIndexCreateController
 
         ServerStore.LicenseManager.AssertCanAddAdditionalAssembliesFromNuGet(definition);
 
-        var safeFileSystemIndexName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(definition.Name);
-
-        var indexWithFileSystemNameCollision = GetIndexNames().FirstOrDefault(x =>
-            x.Equals(definition.Name, StringComparison.OrdinalIgnoreCase) == false &&
-            safeFileSystemIndexName.Equals(IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(x), StringComparison.OrdinalIgnoreCase));
-
-        if (indexWithFileSystemNameCollision != null)
-            throw new IndexCreationException(
-                $"Could not create index '{definition.Name}' because it would result in directory name collision with '{indexWithFileSystemNameCollision}' index");
-
         definition.RemoveDefaultValues();
         ValidateAnalyzers(definition);
         

--- a/src/Raven.Server/Documents/Indexes/DatabaseIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/DatabaseIndexCreateController.cs
@@ -20,7 +20,7 @@ public class DatabaseIndexCreateController : AbstractIndexCreateController
 
     protected override string GetDatabaseName() => _database.Name;
 
-    protected override SystemTime GetDatabaseTime() => _database.Time;
+    public override SystemTime GetDatabaseTime() => _database.Time;
 
     public override RavenConfiguration GetDatabaseConfiguration() => _database.Configuration;
 

--- a/src/Raven.Server/Documents/Indexes/Sharding/ShardedIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/ShardedIndexCreateController.cs
@@ -25,7 +25,7 @@ public sealed class ShardedIndexCreateController : AbstractIndexCreateController
 
     protected override string GetDatabaseName() => _context.DatabaseName;
 
-    protected override SystemTime GetDatabaseTime() => _context.Time;
+    public override SystemTime GetDatabaseTime() => _context.Time;
 
     public override RavenConfiguration GetDatabaseConfiguration() => _context.Configuration;
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -2798,6 +2798,7 @@ namespace Raven.Server.ServerWide
                 case nameof(PutDatabaseStudioConfigurationCommand):
                 case nameof(PutElasticSearchConnectionStringCommand):
                 case nameof(PutIndexCommand):
+                case nameof(PutIndexesCommand):
                 case nameof(PutIndexHistoryCommand):
                 case nameof(PutOlapConnectionStringCommand):
                 case nameof(PutQueueConnectionStringCommand):

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -21,6 +21,7 @@ using Raven.Client.Documents.Queries.Sorting;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Commercial;
 using Raven.Client.Exceptions.Database;
+using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.Exceptions.Security;
 using Raven.Client.Http;
@@ -942,7 +943,8 @@ namespace Raven.Server.ServerWide
                    e is DatabaseDoesNotExistException ||
                    e is AuthorizationException ||
                    e is CompareExchangeKeyTooBigException ||
-                   e is LicenseLimitException;
+                   e is LicenseLimitException ||
+                   e is IndexCreationException;
         }
 
         private void ClusterStateCleanUp(ClusterOperationContext context, BlittableJsonReaderObject cmd, long index)

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.ServerWide;
+using Raven.Server.Documents.Indexes;
 using Raven.Server.Extensions;
 using Raven.Server.Rachis;
 using Sparrow.Json.Parsing;
@@ -38,15 +40,11 @@ namespace Raven.Server.ServerWide.Commands.Indexes
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
+            var indexValidator = new StaticIndexNameValidator(record);
+            indexValidator.Validate(Definition);
+
             try
             {
-                var indexNames = record.Indexes.Select(x => x.Value.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-                if (indexNames.Add(Definition.Name) == false && record.Indexes.TryGetValue(Definition.Name, out _) == false)
-                {
-                    throw new InvalidOperationException($"Can not add index: {Definition.Name} because an index with the same name but different casing already exist");
-                }
-
                 record.AddIndex(Definition, Source, CreatedAt, etag, RevisionsToKeep, DefaultDeploymentMode ?? IndexDeploymentMode.Parallel);
 
             }
@@ -74,6 +72,47 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             }
 
             return msg;
+        }
+
+        public class StaticIndexNameValidator
+        {
+            private readonly DatabaseRecord _record;
+            private HashSet<string> _indexNames;
+            private HashSet<string> _safeFileSystemIndexNames;
+
+            public StaticIndexNameValidator(DatabaseRecord record)
+            {
+                _record = record;
+            }
+
+            public void Validate(IndexDefinition definition)
+            {
+                if (_record.Indexes.TryGetValue(definition.Name, out _))
+                    return;
+
+                // this is not an update to an existing index. we'll check for:
+                // - directory name collisions
+                // - index name case sensitivity
+
+                _indexNames ??= _record.Indexes.Select(x => x.Value.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+                _safeFileSystemIndexNames ??= _record.Indexes.Select(x => IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(x.Value.Name)).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                if (_indexNames.Add(definition.Name) == false)
+                {
+                    throw new RachisApplyException($"Can not add index: {definition.Name} because an index with the same name but different casing already exist");
+                }
+
+                var safeFileSystemIndexName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(definition.Name);
+                if (_safeFileSystemIndexNames.Add(safeFileSystemIndexName) == false)
+                {
+                    var existingIndexName = _indexNames.FirstOrDefault(x =>
+                        x.Equals(definition.Name, StringComparison.OrdinalIgnoreCase) == false &&
+                        safeFileSystemIndexName.Equals(IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(x), StringComparison.OrdinalIgnoreCase));
+
+                    throw new RachisApplyException(
+                        $"Could not create index '{definition.Name}' because it would result in directory name collision with '{existingIndexName}' index");
+                }
+            }
         }
     }
 }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
@@ -42,7 +42,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             {
                 var indexNames = record.Indexes.Select(x => x.Value.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-                if (indexNames.Add(Definition.Name) == false && record.Indexes.TryGetValue(Definition.Name, out var definition) == false)
+                if (indexNames.Add(Definition.Name) == false && record.Indexes.TryGetValue(Definition.Name, out _) == false)
                 {
                     throw new InvalidOperationException($"Can not add index: {Definition.Name} because an index with the same name but different casing already exist");
                 }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
@@ -47,11 +47,10 @@ namespace Raven.Server.ServerWide.Commands.Indexes
             try
             {
                 record.AddIndex(Definition, Source, CreatedAt, etag, RevisionsToKeep, DefaultDeploymentMode ?? IndexDeploymentMode.Parallel);
-
             }
             catch (Exception e)
             {
-                throw new RachisApplyException("Failed to update index", e);
+                throw new RachisApplyException($"Failed to update index '{Definition.Name}'", e);
             }
         }
 

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Extensions;
@@ -99,7 +100,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
 
                 if (_indexNames.Add(definition.Name) == false)
                 {
-                    throw new RachisApplyException($"Can not add index: {definition.Name} because an index with the same name but different casing already exist");
+                    throw new IndexCreationException($"Can not add index: {definition.Name} because an index with the same name but different casing already exist");
                 }
 
                 var safeFileSystemIndexName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(definition.Name);
@@ -109,7 +110,7 @@ namespace Raven.Server.ServerWide.Commands.Indexes
                         x.Equals(definition.Name, StringComparison.OrdinalIgnoreCase) == false &&
                         safeFileSystemIndexName.Equals(IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(x), StringComparison.OrdinalIgnoreCase));
 
-                    throw new RachisApplyException(
+                    throw new IndexCreationException(
                         $"Could not create index '{definition.Name}' because it would result in directory name collision with '{existingIndexName}' index");
                 }
             }

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexesCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexesCommand.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.ServerWide;
 using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
+using Raven.Server.Rachis;
+using Raven.Server.Documents.Indexes;
 
 namespace Raven.Server.ServerWide.Commands.Indexes
 {
@@ -40,11 +43,29 @@ namespace Raven.Server.ServerWide.Commands.Indexes
 
         public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
         {
-
             if (Static != null)
             {
+                var indexNames = record.Indexes.Select(x => x.Value.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
                 foreach (var definition in Static)
+                {
+                    var safeFileSystemIndexName = IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(definition.Name);
+
+                    var indexWithFileSystemNameCollision = indexNames.FirstOrDefault(x =>
+                        x.Equals(definition.Name, StringComparison.OrdinalIgnoreCase) == false &&
+                        safeFileSystemIndexName.Equals(IndexDefinitionBaseServerSide.GetIndexNameSafeForFileSystem(x), StringComparison.OrdinalIgnoreCase));
+
+                    if (indexWithFileSystemNameCollision != null)
+                        throw new RachisApplyException(
+                            $"Could not create index '{definition.Name}' because it would result in directory name collision with '{indexWithFileSystemNameCollision}' index");
+
+                    if (indexNames.Add(definition.Name) == false && record.Indexes.TryGetValue(definition.Name, out _) == false)
+                    {
+                        throw new RachisApplyException($"Can not add index: {definition.Name} because an index with the same name but different casing already exist");
+                    }
+
                     record.AddIndex(definition, Source, CreatedAt, etag, RevisionsToKeep, DefaultStaticDeploymentMode ?? IndexDeploymentMode.Parallel);
+                }
             }
 
             if (Auto != null)
@@ -52,7 +73,6 @@ namespace Raven.Server.ServerWide.Commands.Indexes
                 foreach (var definition in Auto)
                     record.AddIndex(definition, CreatedAt, etag, DefaultAutoDeploymentMode ?? IndexDeploymentMode.Parallel);
             }
-
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexesCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Indexes/PutIndexesCommand.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.ServerWide;
+using Raven.Server.Rachis;
 using Raven.Server.Utils;
 using Sparrow.Json.Parsing;
 
@@ -48,14 +49,30 @@ namespace Raven.Server.ServerWide.Commands.Indexes
                 {
                     indexValidator.Validate(definition);
 
-                    record.AddIndex(definition, Source, CreatedAt, etag, RevisionsToKeep, DefaultStaticDeploymentMode ?? IndexDeploymentMode.Parallel);
+                    try
+                    {
+                        record.AddIndex(definition, Source, CreatedAt, etag, RevisionsToKeep, DefaultStaticDeploymentMode ?? IndexDeploymentMode.Parallel);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RachisApplyException($"Failed to update index '{definition.Name}'", e);
+                    }
                 }
             }
 
             if (Auto != null)
             {
                 foreach (var definition in Auto)
-                    record.AddIndex(definition, CreatedAt, etag, DefaultAutoDeploymentMode ?? IndexDeploymentMode.Parallel);
+                {
+                    try
+                    {
+                        record.AddIndex(definition, CreatedAt, etag, DefaultAutoDeploymentMode ?? IndexDeploymentMode.Parallel);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RachisApplyException($"Failed to update index '{definition.Name}'", e);
+                    }
+                }
             }
         }
 

--- a/src/Raven.Server/Smuggler/Documents/Actions/DatabaseIndexActions.cs
+++ b/src/Raven.Server/Smuggler/Documents/Actions/DatabaseIndexActions.cs
@@ -39,7 +39,7 @@ public sealed class DatabaseIndexActions : IIndexActions
 
         if (_batch != null)
         {
-            await _batch.AddIndexAsync(indexDefinition, _source, _time.GetUtcNow(), RaftIdGenerator.DontCareId, _configuration.Indexing.HistoryRevisionsNumber);
+            await _batch.AddIndexAsync(indexDefinition, _source, _time.GetUtcNow(), RaftIdGenerator.DontCareId);
             await _batch.SaveIfNeeded();
             return;
         }
@@ -60,7 +60,7 @@ public sealed class DatabaseIndexActions : IIndexActions
 
         if (_batch != null)
         {
-            await _batch.AddIndexAsync(indexDefinition, _source, _time.GetUtcNow(), RaftIdGenerator.DontCareId, _configuration.Indexing.HistoryRevisionsNumber);
+            await _batch.AddIndexAsync(indexDefinition, _source, _time.GetUtcNow(), RaftIdGenerator.DontCareId);
             await _batch.SaveIfNeeded();
             return;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22873/Improve-the-deployment-of-multiple-indexes

### Additional description

The endpoint that executes `IndexCreation.CreateIndexes` currently deploys indexes one by one.
Deploying indexes one by one generates a separate task for each index that executes the HandleDatabaseRecordChanged. This results in significant pressure on the cluster.
The optimization is achieved by using the approach applied in Smuggler, where indexes are deployed in batches of 50.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
