### PR TITLE
RavenDB-23131 introduced internal ConfigureHttpMessageHandler method to inject different certificate validation callback for sharding

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -393,6 +393,7 @@ namespace Raven.Client.Documents.Conventions
 #endif
         private Type _httpClientType;
         private Func<HttpClientHandler, HttpClient> _createHttpClient;
+        private Action<HttpMessageHandler> _configureHttpMessageHandler;
 #if NETCOREAPP3_1_OR_GREATER
         private TimeSpan? _httpPooledConnectionLifetime;
         private TimeSpan? _httpPooledConnectionIdleTimeout;
@@ -490,6 +491,16 @@ namespace Raven.Client.Documents.Conventions
             {
                 AssertNotFrozen();
                 _createHttpClient = value;
+            }
+        }
+
+        internal Action<HttpMessageHandler> ConfigureHttpMessageHandler
+        {
+            get => _configureHttpMessageHandler;
+            set
+            {
+                AssertNotFrozen();
+                _configureHttpMessageHandler = value;
             }
         }
 

--- a/src/Raven.Client/Http/DefaultRavenHttpClientFactory.cs
+++ b/src/Raven.Client/Http/DefaultRavenHttpClientFactory.cs
@@ -64,7 +64,8 @@ internal sealed class DefaultRavenHttpClientFactory : IRavenHttpClientFactory
             useHttpDecompression: key.UseHttpDecompression,
             hasExplicitlySetDecompressionUsage: key.HasExplicitlySetDecompressionUsage,
             key.PooledConnectionLifetime,
-            key.PooledConnectionIdleTimeout
+            key.PooledConnectionIdleTimeout,
+            key.ConfigureHttpMessageHandler
         );
 
         var httpClient = createHttpClient(httpMessageHandler);
@@ -79,16 +80,16 @@ internal sealed class DefaultRavenHttpClientFactory : IRavenHttpClientFactory
         httpClient.Timeout = timeout;
     }
 
-    internal static HttpClientHandler CreateHttpMessageHandler(X509Certificate2 certificate, bool setSslProtocols, bool useHttpDecompression, bool hasExplicitlySetDecompressionUsage = false, TimeSpan? pooledConnectionLifetime = null, TimeSpan? pooledConnectionIdleTimeout = null)
+    internal static HttpClientHandler CreateHttpMessageHandler(X509Certificate2 certificate, bool setSslProtocols, bool useHttpDecompression, bool hasExplicitlySetDecompressionUsage = false, TimeSpan? pooledConnectionLifetime = null, TimeSpan? pooledConnectionIdleTimeout = null, Action<HttpMessageHandler> configureHttpMessageHandler = null)
     {
         var httpMessageHandler = new HttpClientHandler();
 
-        ConfigureHttpMessageHandler(httpMessageHandler, certificate, setSslProtocols, useHttpDecompression, hasExplicitlySetDecompressionUsage, pooledConnectionLifetime, pooledConnectionIdleTimeout);
+        ConfigureHttpMessageHandler(httpMessageHandler, certificate, setSslProtocols, useHttpDecompression, hasExplicitlySetDecompressionUsage, pooledConnectionLifetime, pooledConnectionIdleTimeout, configureHttpMessageHandler);
 
         return httpMessageHandler;
     }
 
-    internal static void ConfigureHttpMessageHandler(HttpClientHandler httpMessageHandler, X509Certificate2 certificate, bool setSslProtocols, bool useCompression, bool hasExplicitlySetCompressionUsage = false, TimeSpan? pooledConnectionLifetime = null, TimeSpan? pooledConnectionIdleTimeout = null)
+    internal static void ConfigureHttpMessageHandler(HttpClientHandler httpMessageHandler, X509Certificate2 certificate, bool setSslProtocols, bool useCompression, bool hasExplicitlySetCompressionUsage = false, TimeSpan? pooledConnectionLifetime = null, TimeSpan? pooledConnectionIdleTimeout = null, Action<HttpMessageHandler> configureHttpMessageHandler = null)
     {
         try
         {
@@ -139,6 +140,8 @@ internal sealed class DefaultRavenHttpClientFactory : IRavenHttpClientFactory
 
             ValidateClientKeyUsages(certificate);
         }
+
+        configureHttpMessageHandler?.Invoke(httpMessageHandler);
     }
 
     private static void ValidateClientKeyUsages(X509Certificate2 certificate)

--- a/src/Raven.Client/Http/HttpClientCacheKey.cs
+++ b/src/Raven.Client/Http/HttpClientCacheKey.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Raven.Client.Http;
@@ -13,10 +14,11 @@ internal readonly struct HttpClientCacheKey
     internal readonly TimeSpan? PooledConnectionIdleTimeout;
     internal readonly TimeSpan GlobalHttpClientTimeout;
     private readonly Type _httpClientType;
+    internal readonly Action<HttpMessageHandler> ConfigureHttpMessageHandler;
 
     public readonly string AsString;
 
-    internal HttpClientCacheKey(X509Certificate2 certificate, bool useHttpDecompression, bool hasExplicitlySetDecompressionUsage, TimeSpan? pooledConnectionLifetime, TimeSpan? pooledConnectionIdleTimeout, TimeSpan globalHttpClientTimeout, Type httpClientType)
+    internal HttpClientCacheKey(X509Certificate2 certificate, bool useHttpDecompression, bool hasExplicitlySetDecompressionUsage, TimeSpan? pooledConnectionLifetime, TimeSpan? pooledConnectionIdleTimeout, TimeSpan globalHttpClientTimeout, Type httpClientType, Action<HttpMessageHandler> configureHttpMessageHandler)
     {
         Certificate = certificate;
         _certificateThumbprint = certificate?.Thumbprint ?? string.Empty;
@@ -26,8 +28,9 @@ internal readonly struct HttpClientCacheKey
         PooledConnectionIdleTimeout = pooledConnectionIdleTimeout;
         GlobalHttpClientTimeout = globalHttpClientTimeout;
         _httpClientType = httpClientType;
+        ConfigureHttpMessageHandler = configureHttpMessageHandler;
 
-        AsString = $"{_certificateThumbprint}|{UseHttpDecompression}|{pooledConnectionIdleTimeout?.TotalMilliseconds}|{pooledConnectionIdleTimeout?.TotalMilliseconds}|{globalHttpClientTimeout.TotalMilliseconds}|{httpClientType.Name}";
+        AsString = $"{_certificateThumbprint}|{UseHttpDecompression}|{pooledConnectionIdleTimeout?.TotalMilliseconds}|{pooledConnectionIdleTimeout?.TotalMilliseconds}|{globalHttpClientTimeout.TotalMilliseconds}|{httpClientType.Name}|{configureHttpMessageHandler?.Method.Name}";
     }
 
     private bool Equals(HttpClientCacheKey other)

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -96,7 +96,7 @@ namespace Raven.Client.Http
                 if (HttpClientFactory.CanCacheHttpClient)
                     _cachedHttpClient = httpClient;
 
-                    return httpClient;
+                return httpClient;
             }
         }
 
@@ -243,7 +243,7 @@ namespace Raven.Client.Http
                 _cachedHttpClient = null;
 
             return removed;
-            }
+        }
 
         private HttpClientCacheKey GetHttpClientCacheKey()
         {
@@ -255,7 +255,7 @@ namespace Raven.Client.Http
             TimeSpan? httpPooledConnectionIdleTimeout = null;
 #endif
 
-            return new HttpClientCacheKey(Certificate, Conventions.UseHttpDecompression, Conventions.HasExplicitlySetDecompressionUsage, httpPooledConnectionLifetime, httpPooledConnectionIdleTimeout, GlobalHttpClientTimeout, Conventions.HttpClientType);
+            return new HttpClientCacheKey(Certificate, Conventions.UseHttpDecompression, Conventions.HasExplicitlySetDecompressionUsage, httpPooledConnectionLifetime, httpPooledConnectionIdleTimeout, GlobalHttpClientTimeout, Conventions.HttpClientType, Conventions.ConfigureHttpMessageHandler);
         }
 
         private static bool ShouldRemoveHttpClient(SocketException exception)
@@ -717,10 +717,10 @@ namespace Raven.Client.Http
             {
                 try
                 {
-                    if(serverNode.ServerRole != ServerNode.Role.Member)
+                    if (serverNode.ServerRole != ServerNode.Role.Member)
                         continue;
 
-                    await requestExecutor.UpdateTopologyAsync(new UpdateTopologyParameters(serverNode) {TimeoutInMs = 0, DebugTag = $"timer-callback-node-{serverNode.ClusterTag}"})
+                    await requestExecutor.UpdateTopologyAsync(new UpdateTopologyParameters(serverNode) { TimeoutInMs = 0, DebugTag = $"timer-callback-node-{serverNode.ClusterTag}" })
                         .ConfigureAwait(false);
                 }
                 catch (Exception e)
@@ -1026,7 +1026,7 @@ namespace Raven.Client.Http
 
                         return; // we either handled this already in the unsuccessful response or we are throwing
                     }
-                    
+
                     if (sessionInfo != null && response.Headers.TryGetValues(Constants.Headers.DatabaseClusterTransactionId, out var clusterTransactionId))
                     {
                         sessionInfo.ClusterTransactionId = clusterTransactionId.First();

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -46,7 +46,7 @@ namespace Raven.Server.ServerWide
             var cmd = new SourceMigrationSendCompletedCommand(bucket, migrationIndex, lastChangeVector, database, raftId ?? RaftIdGenerator.NewId());
             return _serverStore.SendToLeaderAsync(cmd);
         }
-        
+
         public static string GenerateDestinationMigrationConfirmRaftId(int bucket, long migrationIndex, string node) => $"Confirm-{bucket}@{migrationIndex}/{node}";
 
         public Task<(long Index, object Result)> DestinationMigrationConfirm(string database, int bucket, long migrationIndex)
@@ -95,10 +95,10 @@ namespace Raven.Server.ServerWide
                 HttpClientType = typeof(ShardingStore),
                 DisableTopologyCache = DocumentConventions.DefaultForServer.DisableTopologyCache,
                 DisposeCertificate = DocumentConventions.DefaultForServer.DisposeCertificate,
-                CreateHttpClient = handler =>
+                ConfigureHttpMessageHandler = h =>
                 {
+                    var handler = (HttpClientHandler)h;
                     handler.ServerCertificateCustomValidationCallback = ShardingCustomValidationCallback;
-                    return new HttpClient(handler);
                 }
             };
 

--- a/src/Raven.Server/Utils/RavenServerHttpClientFactory.cs
+++ b/src/Raven.Server/Utils/RavenServerHttpClientFactory.cs
@@ -83,7 +83,7 @@ internal class RavenServerHttpClientFactory : IRavenHttpClientFactory
                 if (h is not HttpClientHandler httpMessageHandler)
                     throw new InvalidOperationException($"Was expecting handler of type '{nameof(HttpClientHandler)}' but got '{h.GetType().Name}'.");
 
-                DefaultRavenHttpClientFactory.ConfigureHttpMessageHandler(httpMessageHandler, key.Certificate, setSslProtocols: true, key.UseHttpDecompression, key.HasExplicitlySetDecompressionUsage, key.PooledConnectionLifetime, key.PooledConnectionIdleTimeout);
+                DefaultRavenHttpClientFactory.ConfigureHttpMessageHandler(httpMessageHandler, key.Certificate, setSslProtocols: true, key.UseHttpDecompression, key.HasExplicitlySetDecompressionUsage, key.PooledConnectionLifetime, key.PooledConnectionIdleTimeout, key.ConfigureHttpMessageHandler);
             });
         }
     }

--- a/test/FastTests/Issues/RavenDB_22436.cs
+++ b/test/FastTests/Issues/RavenDB_22436.cs
@@ -29,7 +29,7 @@ public class RavenDB_22436 : NoDisposalNeeded
         if (getUnderlyingHandler == null)
             throw new InvalidOperationException("Could not get underlying handler field from HttpClientHandler.");
 
-        var key = new HttpClientCacheKey(certificate: null, useHttpDecompression: true, hasExplicitlySetDecompressionUsage: false, pooledConnectionLifetime: TimeSpan.FromMinutes(3), pooledConnectionIdleTimeout: TimeSpan.FromMinutes(1), DocumentConventions.Default.GlobalHttpClientTimeout, typeof(HttpClient));
+        var key = new HttpClientCacheKey(certificate: null, useHttpDecompression: true, hasExplicitlySetDecompressionUsage: false, pooledConnectionLifetime: TimeSpan.FromMinutes(3), pooledConnectionIdleTimeout: TimeSpan.FromMinutes(1), DocumentConventions.Default.GlobalHttpClientTimeout, typeof(HttpClient), configureHttpMessageHandler: null);
 
         var httpClient = DefaultRavenHttpClientFactory.Instance.GetHttpClient(key, handler => new HttpClient(handler));
         AssertHttpClient(httpClient);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23131

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
