### PR TITLE
RavenDB-22997 Move query timings into a separate column

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
@@ -492,9 +492,8 @@ class trafficWatch extends viewModelBase {
                     $(".virtual-grid").on("click", `#show-timings-${id}`, () => {
                         app.showBootstrapDialog(new queryTimingsDialog(item.QueryTimings, item.CustomInfo));
                     });
-
-                    // TODO @mateuszbartosik: add button styling
-                    return `<button id="show-timings-${id}" class="text-info margin-right margin-right-xs" title="Open query timings">
+                    
+                    return `<button id="show-timings-${id}" class="text-primary margin-right margin-right-xs btn-link text-decoration-none hover-filter" title="Open query timings">
                             <i class="icon-stats"></i>
                         </button>`;
                 }

--- a/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
@@ -24,30 +24,6 @@ type trafficChangeType =
     Raven.Client.Documents.Changes.TrafficWatchChangeType
     | Raven.Client.ServerWide.Tcp.TcpConnectionHeaderMessage.OperationTypes;
 
-
-class showTimingsFeature implements columnPreviewFeature {
-    install($tooltip: JQuery, valueProvider: () => any, elementProvider: () => Raven.Client.Documents.Changes.TrafficWatchHttpChange) {
-        $tooltip.on("click", ".show-timings", () => {
-            const item = elementProvider();
-            
-            app.showBootstrapDialog(new queryTimingsDialog(item.QueryTimings, item.CustomInfo));
-        });
-    }
-    
-    syntax(column: virtualColumn, escapedValue: any, element: Raven.Client.Documents.Changes.TrafficWatchChangeBase) {
-        console.log(column, escapedValue, element);
-        if (column.header !== "Duration" || escapedValue === generalUtils.escapeHtml("n/a")) {
-            return "";
-        }
-
-        if (!trafficWatch.isHttpItem(element) || !element.QueryTimings) {
-            return "";
-        }
-
-        return `<button class="btn btn-default btn-sm show-timings"><i class="icon-stats"></i><span>Show timings</span></button>`;
-    }
-}
-
 class runQueryFeature implements columnPreviewFeature {
 
     private queryList: string[] = [];
@@ -501,13 +477,34 @@ class trafficWatch extends viewModelBase {
         };
         
         const durationProvider = (item: Raven.Client.Documents.Changes.TrafficWatchChangeBase) => {
-            if (trafficWatch.isHttpItem(item)) { 
-                const timingsPart = item.QueryTimings ? `<span class="icon-stats text-info margin-right margin-right-xs"></span>` : ""; 
-                return item.ElapsedMilliseconds.toLocaleString() + " " + timingsPart;
+            if (trafficWatch.isHttpItem(item)) {
+                return item.ElapsedMilliseconds.toLocaleString();
             } else {
                 return "n/a";
             }
         }
+
+        const timingsProvider = (item: Raven.Client.Documents.Changes.TrafficWatchChangeBase) => {
+            if (trafficWatch.isHttpItem(item)) {
+                if (item.QueryTimings) {
+                    const id = _.uniqueId();
+
+                    $(".virtual-grid").on("click", `#show-timings-${id}`, () => {
+                        app.showBootstrapDialog(new queryTimingsDialog(item.QueryTimings, item.CustomInfo));
+                    });
+
+                    // TODO @mateuszbartosik: add button styling
+                    return `<button id="show-timings-${id}" class="text-info margin-right margin-right-xs" title="Open query timings">
+                            <i class="icon-stats"></i>
+                        </button>`;
+                }
+
+                return "";
+            }
+
+            return "n/a";
+        }
+        
         
         const grid = this.gridController();
         grid.headerVisible(true);
@@ -527,7 +524,7 @@ class trafficWatch extends viewModelBase {
                 }),
                 new textColumn<Raven.Client.Documents.Changes.TrafficWatchChangeBase>(grid, 
                     x => trafficWatch.isHttpItem(x) ? x.ResponseStatusCode : "n/a",
-                    "HTTP Status", "8%", {
+                    "HTTP Status", "4%", {
                         extraClass: rowHighlightRules,
                         sortable: "number"
                 }),
@@ -583,12 +580,18 @@ class trafficWatch extends viewModelBase {
                     "Details", "20%", {
                         extraClass: rowHighlightRules,
                         sortable: "string"
-                })
+                    }),
+                new textColumn<Raven.Client.Documents.Changes.TrafficWatchChangeBase>(grid,
+                    x => trafficWatch.isHttpItem(x) ? x.QueryTimings : null,
+                    "<i class='icon-play' title='Query timings'></i>", "4%", {
+                        extraClass: rowHighlightRules,
+                        transformValue: (_, item) => timingsProvider(item),
+                        useRawValue: () => true,
+                    })
             ]
         );
 
         const runQuery = new runQueryFeature();
-        const showTimings = new showTimingsFeature();
         
         this.columnPreview.install("virtual-grid", ".js-traffic-watch-tooltip",
             (item: Raven.Client.Documents.Changes.TrafficWatchChangeBase, column: textColumn<Raven.Client.Documents.Changes.TrafficWatchChangeBase>,
@@ -605,7 +608,7 @@ class trafficWatch extends viewModelBase {
                     onValue(this.formatSource(item, true), this.formatSource(item, false), false);
                 }
             }, {
-                additionalFeatures: [runQuery, showTimings]
+                additionalFeatures: [runQuery]
             });
 
         $(".traffic-watch .viewport").on("scroll", () => {

--- a/src/Raven.Studio/wwwroot/Content/css/styles-common-scoped.less
+++ b/src/Raven.Studio/wwwroot/Content/css/styles-common-scoped.less
@@ -2347,6 +2347,19 @@ ul.properties {
     height: 100%;
 }
 
+.text-decoration-none {
+    text-decoration: none;
+    &:hover, &:active, &:focus {
+        text-decoration: none;
+    }
+}
+
+.hover-filter {
+    &:hover {
+        filter: var(--hover-filter);
+    }
+}
+
 @import "prism.less";
 @import "ace.less";
 @import "leaflet.less";


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22997

### Additional description

Query timings were moved into a separate column in order to avoid confusion and mixing that with duration

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
