### PR TITLE
RavenDB-23094 When freeing scratch pages allocated in current write transaction then we should mark them as immediately available for allocation

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -846,7 +846,7 @@ namespace Voron.Impl
             {
                 _transactionPages.Remove(scratchPage);
 
-                _env.ScratchBufferPool.Free(this, scratchPage.File.Number, scratchPage.PositionInScratchBuffer);
+                _env.ScratchBufferPool.FreeImmediately(this, scratchPage.File.Number, scratchPage.PositionInScratchBuffer);
 
                 if (_env.Options.Encryption.IsEnabled)
                 {
@@ -1215,7 +1215,7 @@ namespace Voron.Impl
                 if(maybeRollBack.AllocatedInTransaction != Id)
                     continue; // from a committed transaction, can keep
                 
-                _env.ScratchBufferPool.Free(this, maybeRollBack.File.Number, maybeRollBack.PositionInScratchBuffer);
+                _env.ScratchBufferPool.FreeImmediately(this, maybeRollBack.File.Number, maybeRollBack.PositionInScratchBuffer);
             }
 
             RolledBack = true;

--- a/src/Voron/Impl/Scratch/ScratchBufferPool.cs
+++ b/src/Voron/Impl/Scratch/ScratchBufferPool.cs
@@ -218,6 +218,15 @@ namespace Voron.Impl.Scratch
             }
         }
 
+        public void FreeImmediately(LowLevelTransaction tx, int scratchNumber, long page)
+        {
+            var scratch = _scratchBuffers[scratchNumber];
+            if (scratch.File.Free(tx, asOfTxId: -1, page))
+            {
+                MaybeRecycleFile(tx, scratch);
+            }
+        }
+
         private void MaybeRecycleFile(LowLevelTransaction tx, ScratchBufferItem scratch)
         {
             List<ScratchBufferFile> recycledScratchesToDispose = null;

--- a/test/SlowTests/Voron/Issues/RavenDB_16023.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_16023.cs
@@ -217,8 +217,9 @@ namespace SlowTests.Voron.Issues
 
                 var state = tx.LowLevelTransaction.PagerTransactionState.ForCrypto![scratchFile.Pager];
 
-                Assert.True(state[66].SkipOnTxCommit); // page 66 is PositionInScratchBuffer of the age #21 that was freed at the beginning of this transaction
-                Assert.True(state[83].SkipOnTxCommit); // page 83 is PositionInScratchBuffer of the age #20 that was freed in this transaction
+                // page 66 is PositionInScratchBuffer of the page #21 that was freed at the beginning of this transaction,
+                // and it was reused by page #20 that was freed in this transaction later on
+                Assert.True(state[66].SkipOnTxCommit);
 
                 tx.Commit();
             }
@@ -278,8 +279,9 @@ namespace SlowTests.Voron.Issues
 
                 var state = tx.LowLevelTransaction.PagerTransactionState.ForCrypto![scratchFile.Pager];
 
-                Assert.True(state[66].SkipOnTxCommit); // page 66 is PositionInScratchBuffer of the age #21 that was freed at the beginning of this transaction
-                Assert.True(state[83].SkipOnTxCommit); // page 83 is PositionInScratchBuffer of the age #20 that was freed in this transaction
+                // page 66 is PositionInScratchBuffer of the page #21 that was freed at the beginning of this transaction,
+                // and it was reused by page #20 that was freed in this transaction later on
+                Assert.True(state[66].SkipOnTxCommit);
 
                 tx.Commit();
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23094/investigate-why-test-take-100-memory-usage

### Additional description

This is a regression introduced in by commit https://github.com/ravendb/ravendb/commit/362d672c766a1b07b978b25493b34a66628eb11 in https://github.com/ravendb/ravendb/pull/18908. More specifically it's about:

> _freePagesBySizeAvailableImmediately was removed from ScratchBufferFile - only useful for rollback, and they are rare enough that we shouldn't worry about them

(For reference - `_freePagesBySizeAvailableImmediately ` have been introduced in https://github.com/ravendb/ravendb/commit/b50bacfa3bf5f5cf0173203a85fe0411c2272ac2)

The problem is that `SlowTests.Voron.MutipleScratchBuffersUsage.CanAddContinuallyGrowingValue_ButNotCommitting` test was checking explicitly that scenario - not committing write transactions so allocated pages were rolled back.

The problem was that we were no longer reusing those scratch pages, hence we started to allocate more and more scratch files.

The solution is to mark scratch pages as immediately available to allocate when freeing from `Rollback()`.

Additionally the same was applied to `DiscardScratchModificationOn()`, since it's the same case there - a write transaction allocated a scratch paged and freed it (so nobody else is looking at it yet). This change required to adjust tests in `RavenDB_16023.cs
` as we do less allocation of scratch pages now.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests will verify the fix

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
