### PR TITLE
RavenDB-23148: Write amplification issues 

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -61,7 +61,7 @@ namespace Raven.Server.Config.Categories
         public int NumberOfConcurrentSyncsPerPhysicalDrive { get; set; }
 
         [Description("Compress transactions above size (value in KB)")]
-        [DefaultValue(512)]
+        [DefaultValue(32)]
         [SizeUnit(SizeUnit.Kilobytes)]
         [ConfigurationEntry("Storage.CompressTxAboveSizeInKb", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public Size CompressTxAboveSize { get; set; }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -2087,8 +2087,6 @@ FinishJournalRecovery:
                 pagesCountIncludingAllOverflowPages += page.NumberOfPages;
             }
 
-            var performCompression = pagesCountIncludingAllOverflowPages > _env.Options.CompressTxAboveSizeInBytes / Constants.Storage.PageSize;
-
             var sizeOfPagesHeader = numberOfPages * sizeof(TransactionHeaderPageInfo);
             var overhead = sizeOfPagesHeader + (long)numberOfPages * sizeof(long);
             var overheadInPages = checked((int)(overhead / Constants.Storage.PageSize + (overhead % Constants.Storage.PageSize == 0 ? 0 : 1)));
@@ -2144,7 +2142,7 @@ FinishJournalRecovery:
                 *(long*)write = pageHeader->PageNumber;
                 write += sizeof(long);
 
-                if (_env.Options.Encryption.IsEnabled == false && performCompression)
+                if (_env.Options.Encryption.IsEnabled == false)
                 {
                     _diffPage.Output = write;
 
@@ -2190,6 +2188,12 @@ FinishJournalRecovery:
 
             long compressedLen = 0;
 
+            // We want to do compression when the size of the data to store is bigger than the threshold.
+            // This is essentially a threshold between IO blocks usage and the CPU consumption of LZ4
+            // PERF: Before v7.0 we would avoid doing the diff if the amount of pages was big, however,
+            // the speed of diffing is roughly that of a memory copy, which is so fast that the benefit of always doing
+            // it is big enough to just do it every time. 
+            var performCompression = totalSizeWritten > _env.Options.CompressTxAboveSizeInBytes;
             if (performCompression)
             {
                 var outputBufferSize = LZ4.MaximumOutputLength(totalSizeWritten);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23148

### Additional description

By changing the Storage.CompressTxAboveSizeInKb we get much better performance as we are aligning with the block size of the storage.
https://ravendb.net/docs/article-page/6.0/csharp/server/configuration/storage-configuration#storage.compresstxabovesizeinkb

However, the current behavior is still not good enough. By skipping the diffing process when we are not going to compress, we cause a much worse behavior overall. The diff cost on CPU is roughly the cost of a memory copy, therefore not performing the diff is counterproductive even if we not going to compress. We need to change the heuristic itself.

The impact of just enabling the new heuristic shows why.

With the new heuristic and the bad default:
```
[OVERALL], RunTime(ms), 78057
[OVERALL], Throughput(ops/sec), 12811.150825678671
```
With the new heuristic and the new default (32Kb)
```
[OVERALL], RunTime(ms), 62742
[OVERALL], Throughput(ops/sec), 15938.2869529183
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
