### PR TITLE
RavenDB-23100 - add MultiExists to check for already existing value before calling MultiAdd

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -706,8 +706,11 @@ namespace Raven.Server.Documents.Indexes
                     var key = keys.Key;
                     foreach (var referenceKey in keys.Value)
                     {
-                        collectionTree.MultiAdd(referenceKey, key);
-                        referencesTree.MultiAdd(key, referenceKey);
+                        if (collectionTree.MultiExists(referenceKey, key) == false)
+                            collectionTree.MultiAdd(referenceKey, key);
+
+                        if (referencesTree.MultiExists(key, referenceKey) == false)
+                            referencesTree.MultiAdd(key, referenceKey);
                     }
 
                     RemoveReferences(key, collection, keys.Value, tx);

--- a/src/Voron/Data/BTrees/Tree.Extensions.cs
+++ b/src/Voron/Data/BTrees/Tree.Extensions.cs
@@ -108,6 +108,18 @@ namespace Voron.Data.BTrees
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool MultiExists(string key, string value)
+        {
+            Slice keySlice;
+            Slice valueSlice;
+            using (Slice.From(_llt.Allocator, key, ByteStringType.Immutable, out keySlice))
+            using (Slice.From(_llt.Allocator, value, ByteStringType.Immutable, out valueSlice))
+            {
+                return MultiExists(keySlice, valueSlice);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public void MultiAdd(string key, string value)
         {
             Slice keySlice;

--- a/src/Voron/Data/BTrees/Tree.MultiTree.cs
+++ b/src/Voron/Data/BTrees/Tree.MultiTree.cs
@@ -34,9 +34,47 @@ namespace Voron.Data.BTrees
     {
         public bool IsMultiValueTree { get; set; }
 
+        public bool MultiExists(Slice key, Slice value)
+        {
+            if (value.HasValue == false)
+                throw new ArgumentNullException(nameof(value));
+
+            var page = FindPageFor(key, out var node);
+            if (page == null || page.LastMatch != 0)
+                return false;
+
+            var item = page.GetNode(page.LastSearchPosition);
+            if (item->Flags == TreeNodeFlags.MultiValuePageRef)
+            {
+                var existingTree = OpenMultiValueTree(key, item);
+                return existingTree.Exists(value);
+            }
+
+            if (item->Flags == TreeNodeFlags.PageRef)
+                throw new InvalidOperationException("Multi trees don't use overflows");
+
+            var nestedPagePtr = DirectAccessFromHeader(item);
+
+            var nestedPage = new TreePage(nestedPagePtr, (ushort)GetDataSize(item));
+            var existingItem = nestedPage.Search(_llt, value);
+            if (nestedPage.LastMatch != 0)
+            {
+                // not an actual match, just greater than
+                return false;
+            }
+
+            using (TreeNodeHeader.ToSlicePtr(_llt.Allocator, existingItem, out Slice tmpValue))
+            {
+                if (SliceComparer.Equals(tmpValue, value))
+                    return true;
+            }
+
+            return false;
+        }
+
         public void MultiAdd(Slice key, Slice value)
         {
-            if (!value.HasValue)
+            if (value.HasValue == false)
                 throw new ArgumentNullException(nameof(value));
 
             int maxNodeSize = Llt.DataPager.NodeMaxSize;

--- a/test/FastTests/Voron/MultiValueTree.cs
+++ b/test/FastTests/Voron/MultiValueTree.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Tests.Infrastructure;
 using Voron;
 using Voron.Data;
 using Xunit;
@@ -353,6 +354,42 @@ namespace FastTests.Voron
             }
 
             ValidateInputExistence(inputData, CHILDTREE_KEY, INPUT_DATA_SIZE, "foo");
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(16)]
+        [InlineData(2048)]
+        public void MultiExists(int inputCount)
+        {
+            const int INPUT_DATA_SIZE = 32;
+            const string CHILDTREE_KEY = "ChildTree";
+
+            var inputData = new List<string>();
+            for (int i = 0; i < inputCount; i++)
+            {
+                inputData.Add(RandomString(INPUT_DATA_SIZE));
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+
+                for (int i = 0; i < inputCount; i++)
+                {
+                    tree.MultiAdd(CHILDTREE_KEY, inputData[i]);
+                }
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.CreateTree("foo");
+
+                for (int i = 0; i < inputCount; i++)
+                {
+                    Assert.True(tree.MultiExists(CHILDTREE_KEY, inputData[i]));
+                }
+            }
         }
 
         private void ValidateInputExistence(List<string> inputData, string childtreeKey, int inputDataSize, string treeName)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23100/Map-reduce-index-with-references-with-a-very-long-running-batch

### Additional description

During the indexing of references, we update internal structures to track changes in the referenced documents. However, during a reindexing process, updating these structures may not always be necessary. This optimization reduces the amount of data written and speeds up the process.

**1.8M documents to update due to references changes**

_Before_
Update references: 1435ms
Modified pages: 66270 ~ 518MB
Written pages to disk: 9460 - 74MB

_After_
Update references: 774ms
Modified pages: 12245 - 95MB
Written pages to disk: 6707 - 47MB


**New indexing of 1.8 documents**

_Before_
Update references: 3276ms
Modified pages: 69032 - 539MB
Written pages to disk: 19625 - 153MB

_After_
Update references: 3696ms
Modified pages: 69032 - 539MB
Written pages to disk: 19625 - 153MB

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
