### PR TITLE
RavenDB-23157 Admin logs: minor fixes

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/AdminLogs.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/AdminLogs.tsx
@@ -91,7 +91,7 @@ export default function AdminLogs() {
                             </h4>
                             <div className="d-flex align-items-center">
                                 <Icon icon="logs" addon="arrow-filled-up" />
-                                Level:{" "}
+                                Min level:{" "}
                                 <Select
                                     value={logLevelOptions.find(
                                         (x) => x.value === configs?.adminLogsConfig?.AdminLogs?.CurrentMinLevel
@@ -169,7 +169,7 @@ export default function AdminLogs() {
                             </h4>
                             <div className="d-flex align-items-center">
                                 <Icon icon="logs" addon="arrow-filled-up" />
-                                Level:{" "}
+                                Min level:{" "}
                                 {configsLoadStatus === "loading" ? (
                                     <LazyLoad active>
                                         <div>?????</div>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/bits/AdminLogsVirtualList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/bits/AdminLogsVirtualList.tsx
@@ -9,7 +9,7 @@ import {
 import { useAppDispatch, useAppSelector } from "components/store";
 import assertUnreachable from "components/utils/assertUnreachable";
 import { useRef, useEffect } from "react";
-import { Collapse, Table } from "reactstrap";
+import { Table } from "reactstrap";
 
 export default function AdminLogsVirtualList(props: { availableHeightInPx: number }) {
     const dispatch = useAppDispatch();
@@ -48,6 +48,7 @@ export default function AdminLogsVirtualList(props: { availableHeightInPx: numbe
                             key={virtualRow.key}
                             data-index={virtualRow.index}
                             ref={virtualizer.measureElement}
+                            className="hover-filter"
                             style={{
                                 position: "absolute",
                                 top: 0,
@@ -55,6 +56,7 @@ export default function AdminLogsVirtualList(props: { availableHeightInPx: numbe
                                 width: "100%",
                                 transform: `translateY(${virtualRow.start}px)`,
                                 padding: "2px 0px",
+                                transition: "unset",
                             }}
                         >
                             <div
@@ -88,31 +90,33 @@ export default function AdminLogsVirtualList(props: { availableHeightInPx: numbe
                                         <LogItemTitleFieldValue value={log.Message} />
                                     </span>
                                 </div>
-                                <Collapse isOpen={log._meta.isExpanded} className="vstack gap-2 p-2">
-                                    <Code
-                                        code={log.Message}
-                                        elementToCopy={log.Message}
-                                        language="plaintext"
-                                        codeClassName="wrapped pe-4"
-                                    />
-                                    <div className="p-2">
-                                        <Table size="sm" className="m-0">
-                                            <tbody>
-                                                {Object.keys(log)
-                                                    .filter(
-                                                        (key: keyof AdminLogsMessage) =>
-                                                            key !== "_meta" && key !== "Message"
-                                                    )
-                                                    .map((key: keyof AdminLogsMessage) => (
-                                                        <tr key={key}>
-                                                            <td>{getFormattedFieldName(key)}</td>
-                                                            <td>{String(log[key] ?? "-")}</td>
-                                                        </tr>
-                                                    ))}
-                                            </tbody>
-                                        </Table>
+                                {log._meta.isExpanded && (
+                                    <div className="vstack gap-2 p-2">
+                                        <Code
+                                            code={log.Message}
+                                            elementToCopy={log.Message}
+                                            language="plaintext"
+                                            codeClassName="wrapped pe-4"
+                                        />
+                                        <div className="p-2">
+                                            <Table size="sm" className="m-0">
+                                                <tbody>
+                                                    {Object.keys(log)
+                                                        .filter(
+                                                            (key: keyof AdminLogsMessage) =>
+                                                                key !== "_meta" && key !== "Message"
+                                                        )
+                                                        .map((key: keyof AdminLogsMessage) => (
+                                                            <tr key={key}>
+                                                                <td>{getFormattedFieldName(key)}</td>
+                                                                <td>{String(log[key] ?? "-")}</td>
+                                                            </tr>
+                                                        ))}
+                                                </tbody>
+                                            </Table>
+                                        </div>
                                     </div>
-                                </Collapse>
+                                )}
                             </div>
                         </div>
                     );

--- a/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
@@ -619,11 +619,6 @@ $filtering-input-bg: $toggle-bg !default;
     padding-right: $gutter-sm;
 }
 
-.hover-filter {
-    filter: $hover-filter-var;
-    transition: $global-easing-in-out;
-}
-
 .list-group-item {
     &.disabled {
         cursor: unset;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23157/Admin-logs-improvements

### Additional description

I removed .hover-filter from _bs5extend.scss because it is also defined in _layout-tools.scss.

- add hover effect to log entry
- reduce the expand entry time
- 'Level' -> 'Min level'

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
