### PR TITLE
RavenDB-22345 - CanCreateClusterTransactionRequest2

### DIFF
--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -187,7 +187,7 @@ namespace Raven.Client.Exceptions
                 throw ctxConcurrencyException;
             }
 
-            var concurrencyException = new ConcurrencyException(schema.Message);
+            var concurrencyException = new ConcurrencyException(schema.Message, new RavenException(schema.Error));
 
             if (json.TryGet(nameof(ConcurrencyException.Id), out docId))
                 concurrencyException.Id = docId;

--- a/src/Raven.Server/Rachis/Follower.cs
+++ b/src/Raven.Server/Rachis/Follower.cs
@@ -169,7 +169,7 @@ namespace Raven.Server.Rachis
                                 // on raft protocol violation propagate the error and close this follower. 
                                 throw;
                             }
-                            catch (ConcurrencyException)
+                            catch (TermValidationException)
                             {
                                 // the term was changed
                                 throw;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22345/StressTests.Cluster.ClusterTransactionTestsStress.CanCreateClusterTransactionRequest2options-DatabaseMode-Single

### Additional description

Add server stack trace to ConcurrencyException that is thrown on the client - For **Debug info** and for Building a correct and informative expression in the client,
Fix endless loop on FollowerSteadyState - when `ApplyLeaderStateToLocalState` throws `TermValidationException`


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
