### PR TITLE
RavenDB-23091 - Retention stopped working

### DIFF
--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesPolicyRunner.cs
@@ -407,7 +407,7 @@ namespace Raven.Server.Documents.TimeSeries
 
                 using (context.OpenReadTransaction())
                 {
-                    foreach (var item in tss.Stats.GetTimeSeriesByPolicyFromStartDate(context, collectionName, policy.Name, to, TimeSeriesRollups.TimeSeriesRetentionCommand.BatchSize))
+                    foreach (var item in tss.Stats.GetTimeSeriesByPolicyFromStartDate(context, collectionName, policy.Name, to, TimeSeriesRollups.TimeSeriesRetentionCommand.BatchSize, Logger))
                     {
                         if (RequiredForNextPolicy(context, config, policy, item, to)) 
                             continue;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -423,8 +423,8 @@ namespace Raven.Server.Documents.TimeSeries
                     var currentStart = new DateTime(Bits.SwapBytes(DocumentsStorage.TableValueToLong((int)StatsColumns.Start, ref result.Result.Reader)));
                     if (currentStart > start)
                     {
-                        if (logger.IsOperationsEnabled)
-                            logger.Operations($"Finished collecting time-series for retention. Stopped fetching at start-time {currentStart} while retention time was {start} (time-series key: `{result.Key}`).");
+                        if (logger.IsInfoEnabled)
+                            logger.Info($"Finished collecting time-series for retention. Stopped fetching at start-time {currentStart} while retention time was {start} (time-series key: `{result.Key}`).");
 
                         yield break;
 }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Binary;
 using Sparrow.Json;
+using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
@@ -405,7 +406,7 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        public IEnumerable<Slice> GetTimeSeriesByPolicyFromStartDate(DocumentsOperationContext context, CollectionName collection, string policy, DateTime start, long take)
+        public IEnumerable<Slice> GetTimeSeriesByPolicyFromStartDate(DocumentsOperationContext context, CollectionName collection, string policy, DateTime start, long take, Logger logger)
         {
             var table = GetOrCreateTable(context.Transaction.InnerTransaction, collection);
             if (table == null)
@@ -419,10 +420,15 @@ namespace Raven.Server.Documents.TimeSeries
                     if (stats.Count == 0)
                         continue;
 
-                    DocumentsStorage.TableValueToSlice(context, (int)StatsColumns.Key, ref result.Result.Reader, out var slice);
                     var currentStart = new DateTime(Bits.SwapBytes(DocumentsStorage.TableValueToLong((int)StatsColumns.Start, ref result.Result.Reader)));
                     if (currentStart > start)
+                    {
+                        if (logger.IsOperationsEnabled)
+                            logger.Operations($"Finished collecting time-series for retention. Stopped fetching at start-time {currentStart} while retention time was {start} (time-series key: `{result.Key}`).");
+
                         yield break;
+}
+                    DocumentsStorage.TableValueToSlice(context, (int)StatsColumns.Key, ref result.Result.Reader, out var slice);
 
                     yield return slice;
 

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1353,6 +1353,12 @@ namespace Voron.Data.Tables
                         yield break;
                 }
 
+                if (SliceComparer.CompareInline(it.CurrentKey, last) > 0)
+                {
+                    if (it.MovePrev() == false)
+                        yield break;
+                }
+
                 do
                 {
                     foreach (var result in GetBackwardSecondaryIndexForValue(tree, it.CurrentKey.Clone(_tx.Allocator), index))

--- a/test/SlowTests/Issues/RavenDB_23091.cs
+++ b/test/SlowTests/Issues/RavenDB_23091.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.TimeSeries;
+using SlowTests.Core.Utils.Entities;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23091 : RavenTestBase
+    {
+        public RavenDB_23091(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.TimeSeries)]
+        public async Task ShouldRemoveTimeSeriesAfterRetention()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var raw = new RawTimeSeriesPolicy(TimeValue.FromHours(24));
+
+                var config = new TimeSeriesConfiguration
+                {
+                    Collections = new Dictionary<string, TimeSeriesCollectionConfiguration>
+                    {
+                        ["Users"] = new TimeSeriesCollectionConfiguration
+                        {
+                            RawPolicy = raw
+                        }
+                    },
+                    PolicyCheckFrequency = TimeSpan.FromSeconds(1)
+                };
+                await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
+
+                var now = DateTime.UtcNow;
+               
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Karmel" }, "users/karmel");
+                    session.TimeSeriesFor("users/karmel", "Heartrate").Append(now.AddDays(-2), 69d, "watches/fitbit");
+
+                    session.SaveChanges();
+                }
+
+                var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+                await database.TimeSeriesPolicyRunner.DoRetention();
+
+                using (var session = store.OpenSession())
+                {
+                    session.TimeSeriesFor("users/karmel", "Heartrate").Append(now, 88d, "watches/fitbit");
+
+                    session.Store(new User { Name = "Karmel2" }, "users/karmel2");
+                    session.TimeSeriesFor("users/karmel2", "Heartrate2").Append(now.AddDays(-2), 77d, "watches/fitbit");
+
+                    session.SaveChanges();
+                }
+               
+                await database.TimeSeriesPolicyRunner.DoRetention();
+
+                using (var session = store.OpenSession())
+                {
+                    var ts = session.TimeSeriesFor("users/karmel2", "Heartrate2").Get();
+                    Assert.Null(ts);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_23091.cs
+++ b/test/SlowTests/Issues/RavenDB_23091.cs
@@ -32,8 +32,7 @@ namespace SlowTests.Issues
                         {
                             RawPolicy = raw
                         }
-                    },
-                    PolicyCheckFrequency = TimeSpan.FromSeconds(1)
+                    }
                 };
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23091/Retention-stopped-working

### Additional description

Time series was not executing retention due to multiple time-series under the same policy.
We fetch all different time-series whose start-time is smaller than retention-time. We use `SeekBackwardFrom()` to go over the index which is sorted by start-time.
However, when we seek the retention-time we want to start iterating from, we "land" on the entry with a bigger start-time than retention time, and stop our iteration immediately, thinking this is the smallest time existing.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
