### PR TITLE
RavenDB-23100 - clear the leftovers of a non existing document

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Raven.Client.Documents.Indexes;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Static;
@@ -388,12 +389,22 @@ namespace Raven.Server.Documents.Indexes.Workers
         private IEnumerable<IndexItem> GetItemsFromCollectionThatReference(QueryOperationContext queryContext, TransactionOperationContext indexContext,
             string collection, Reference referencedItem, long lastIndexedEtag, HashSet<string> indexed, ReferencesState.ReferenceState referenceState)
         {
+            List<Slice> keysToRemove = null;
+
             var lastProcessedItemId = referenceState?.GetLastProcessedItemId(referencedItem);
             foreach (var key in _referencesStorage.GetItemKeysFromCollectionThatReference(collection, referencedItem.Key, indexContext.Transaction, lastProcessedItemId))
             {
                 var item = GetItem(queryContext.Documents, key);
                 if (item == null)
+                {
+                    if (_index.SourceType == IndexSourceType.Documents)
+                    {
+                        // the document doesn't exist, we need to clean up any leftovers
+                        keysToRemove ??= new List<Slice>();
+                        keysToRemove.Add(key.Clone(queryContext.Documents.Allocator));
+                    }
                     continue;
+                }
 
                 if (indexed.Add(item.Id) == false)
                 {
@@ -415,6 +426,15 @@ namespace Raven.Server.Documents.Indexes.Workers
                 }
 
                 yield return item;
+
+                if (keysToRemove != null)
+                {
+                    foreach (var keyToRemove in keysToRemove)
+                    {
+                        _referencesStorage.RemoveReferences(keyToRemove, collection, null, indexContext.Transaction);
+                        keyToRemove.Release(queryContext.Documents.Allocator);
+                    }
+                }
 
                 void DisposeItem()
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23100/Map-reduce-index-with-references-with-a-very-long-running-batch

### Additional description

Clearing the document references of a non existing document which won't be needed anymore.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
