### PR TITLE
RavenDB-14541 - added RavenQuery.Include for documents

### DIFF
--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -632,5 +632,9 @@ namespace Raven.Client.Documents.Linq
             return mce.Method.DeclaringType == typeof(RavenQuery) && mce.Method.Name == nameof(RavenQuery.Metadata);
         }
 
+        public bool IsIncludeCall(MethodCallExpression mce)
+        {
+            return mce.Method.DeclaringType == typeof(RavenQuery) && mce.Method.Name == nameof(RavenQuery.Include);
+        }
     }
 }

--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -632,7 +632,7 @@ namespace Raven.Client.Documents.Linq
             return mce.Method.DeclaringType == typeof(RavenQuery) && mce.Method.Name == nameof(RavenQuery.Metadata);
         }
 
-        public bool IsIncludeCall(MethodCallExpression mce)
+        public static bool IsIncludeCall(MethodCallExpression mce)
         {
             return mce.Method.DeclaringType == typeof(RavenQuery) && mce.Method.Name == nameof(RavenQuery.Include);
         }

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2738,12 +2738,29 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     }
                     if (LinqPathProvider.IsIncludeCall(mce))
                     {
-                        if (FromAlias == null)
+                        var name = field.Member.Name;
+                        if (name.All(c => c == '_') == false)
                         {
-                            AddFromAlias(lambdaExpression?.Parameters[0].Name);
+                            throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
                         }
-                        _declareBuilder ??= new();
-                        AddReturnStatementToOutputFunction(memberInitExpression);
+                        if (mce.Arguments[0] is UnaryExpression unaryExpr && unaryExpr.Operand is LambdaExpression lambdaExpr)
+                        {
+                            if (lambdaExpr.Body is MemberExpression memberExpr)
+                            {
+                                string fieldName = memberExpr.Member.Name;
+                                DocumentQuery.Include(fieldName);
+                                continue;
+                            }
+                            else
+                            {
+                                if (FromAlias == null)
+                                {
+                                    AddFromAlias(lambdaExpression?.Parameters[0].Name);
+                                }
+                                _declareBuilder ??= new();
+                                AddReturnStatementToOutputFunction(memberInitExpression);
+                            }
+                        }
                         return;
                     }
                 }
@@ -2830,14 +2847,34 @@ The recommended method is to use full text search (mark the field as Analyzed an
                         HandleSelectId(GetSelectPath(newExpression.Members[index]));
                         continue;
                     }
+
                     if (LinqPathProvider.IsIncludeCall(mce))
                     {
-                        if (FromAlias == null)
+                        var name = newExpression.Members[index].Name;
+                        if (name.All(c => c == '_') == false)
                         {
-                            AddFromAlias(lambdaExpression?.Parameters[0].Name);
+                            throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
                         }
-                        _declareBuilder ??= new();
-                        AddReturnStatementToOutputFunction(newExpression);
+
+                        if (mce.Arguments[0] is UnaryExpression unaryExpr && unaryExpr.Operand is LambdaExpression lambdaExpr)
+                        {
+                            if (lambdaExpr.Body is MemberExpression memberExpr)
+                            {
+                                string fieldName = memberExpr.Member.Name;
+                                DocumentQuery.Include(fieldName);
+                                continue;
+                            }
+                            else
+                            {
+                                if (FromAlias == null)
+                                {
+                                    AddFromAlias(lambdaExpression?.Parameters[0].Name);
+                                }
+
+                                _declareBuilder ??= new();
+                                AddReturnStatementToOutputFunction(newExpression);
+                            }
+                        }
                         return;
                     }
                 }
@@ -2850,6 +2887,14 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
                 FieldsToFetch?.Clear();
                 _jsSelectBody = TranslateSelectBodyToJs(newExpression);
+                if (_includeSupport?.IncludeFunctions != null)
+                {
+                    foreach (var includeFunction in _includeSupport?.IncludeFunctions)
+                    {
+                        var includeName = includeFunction.Split('.')[1];
+                        DocumentQuery.Include(includeName);
+                    }
+                }
                 break;
             }
         }
@@ -3017,6 +3062,32 @@ The recommended method is to use full text search (mark the field as Analyzed an
             if (_insideWhereOrSearchCounter > 0)
                 throw new NotSupportedException("Queries with a LET clause before a WHERE clause are not supported. " +
                                                 "WHERE clauses should appear before any LET clauses.");
+
+            var includeMethodCall = expression.Arguments
+                .OfType<MethodCallExpression>()
+                .FirstOrDefault(methodCall =>
+                    methodCall.Method.DeclaringType == typeof(RavenQuery) &&
+                    methodCall.Method.Name == "Include");
+
+            if (includeMethodCall != null)
+            {
+                var name = expression.Members[expression.Arguments.IndexOf(includeMethodCall)].Name;
+                if (name.All(c => c == '_') == false)
+                {
+                    throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
+                }
+                if (includeMethodCall.Arguments[0] is UnaryExpression unaryExpr &&
+                    unaryExpr.Operand is LambdaExpression lambdaExpr)
+                {
+                    if (lambdaExpr.Body is MemberExpression memberExpr)
+                    {
+                        string fieldName = memberExpr.Member.Name;
+                        string fullFieldName = $"{fieldName}";
+                        DocumentQuery.Include(fullFieldName);
+                        return;
+                    }
+                }
+            }
 
             if (FromAlias == null)
             {
@@ -3363,7 +3434,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
                     if (null != _includeSupport?.IncludeFunctions?.Count)
                     {
-                        AddJsProjection(name, field.Expression, sb, index - _includeSupport?.IncludeFunctions.Count != 0);
+                        AddJsProjection(name, field.Expression, sb, index - _includeSupport?.IncludeFunctions.Count > 0);
                     }
                     else
                     {

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2736,6 +2736,16 @@ The recommended method is to use full text search (mark the field as Analyzed an
                         HandleSelectId(GetSelectPath(field.Member));
                         continue;
                     }
+                    if (LinqPathProvider.IsIncludeCall(mce))
+                    {
+                        if (FromAlias == null)
+                        {
+                            AddFromAlias(lambdaExpression?.Parameters[0].Name);
+                        }
+                        _declareBuilder ??= new();
+                        AddReturnStatementToOutputFunction(memberInitExpression);
+                        return;
+                    }
                 }
 
                 //lambda 2 js
@@ -2819,6 +2829,16 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     {
                         HandleSelectId(GetSelectPath(newExpression.Members[index]));
                         continue;
+                    }
+                    if (LinqPathProvider.IsIncludeCall(mce))
+                    {
+                        if (FromAlias == null)
+                        {
+                            AddFromAlias(lambdaExpression?.Parameters[0].Name);
+                        }
+                        _declareBuilder ??= new();
+                        AddReturnStatementToOutputFunction(newExpression);
+                        return;
                     }
                 }
 
@@ -2952,6 +2972,14 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 _typedParameterSupport = new JavascriptConversionExtensions.TypedParameterSupport(_manualLet.Name);
             }
             var js = TranslateSelectBodyToJs(expression);
+            if (null != _includeSupport?.IncludeFunctions)
+            {
+                foreach (var include in _includeSupport.IncludeFunctions)
+                {
+                    _declareBuilder.Append("\tinclude(").Append(include).AppendLine(");");
+
+                }
+            }
             _declareBuilder.Append('\t').Append("return ").Append(js).Append(';');
 
             var paramBuilder = new StringBuilder();
@@ -3228,10 +3256,14 @@ The recommended method is to use full text search (mark the field as Analyzed an
             }
 
             _declareBuilder ??= new StringBuilder();
-            _declareBuilder.Append('\t')
-                .Append("var ").Append(name)
-                .Append(" = ").Append(js).Append(';')
-                .Append(Environment.NewLine);
+            if (String.IsNullOrEmpty(js) == false)
+            {
+                _declareBuilder.Append('\t')
+                    .Append("var ").Append(name)
+                    .Append(" = ").Append(js).Append(';')
+                    .Append(Environment.NewLine);
+
+            }
         }
 
         private static void AddPropertyToWrapperObject(string name, string js, StringBuilder wrapper)
@@ -3329,7 +3361,14 @@ The recommended method is to use full text search (mark the field as Analyzed an
                         continue;
                     }
 
-                    AddJsProjection(name, field.Expression, sb, index != 0);
+                    if (null != _includeSupport?.IncludeFunctions?.Count)
+                    {
+                        AddJsProjection(name, field.Expression, sb, index - _includeSupport?.IncludeFunctions.Count != 0);
+                    }
+                    else
+                    {
+                        AddJsProjection(name, field.Expression, sb, index != 0);
+                    }
 
                 }
                 sb.Append(" }");
@@ -3337,7 +3376,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (expression is MemberExpression or MethodCallExpression)
             {
-                if (_includeSupport is not null && _includeSupport.HadAnyIncludes)
+                if (_includeSupport is not null && _includeSupport.IncludeFunctions.IsNullOrEmpty() == false)
                 {
                     sb.Append('{');
                     var name = GetMember(expression);
@@ -3350,7 +3389,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     script = ToJs(expression);
 
                 sb.Append(script);
-                if (_includeSupport is not null && _includeSupport.HadAnyIncludes)
+                if (_includeSupport is not null && _includeSupport.IncludeFunctions.IsNullOrEmpty() == false)
                 {
                     sb.Append("}");
                 }
@@ -3370,11 +3409,14 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (_includeSupport?.HasInclude == true)
             {
-                _includeSupport.HasInclude = false;
                 if (name.All(c => c == '_') == false)
                 {
                     throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
                 }
+
+                _jsProjectionNames.Remove(name);
+                _includeSupport.HasInclude = false;
+                return;
             }
 
             if (QueryGenerator.Conventions.FindProjectedPropertyNameForIndex != null)
@@ -4019,7 +4061,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (_jsSelectBody != null)
             {
-                return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true, hadAnyInclude: _includeSupport?.HadAnyIncludes ?? false)
+                return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true, hadAnyInclude: _includeSupport?.IncludeFunctions.IsNullOrEmpty() == false)
                 {
                     QueryStatistics = _queryStatistics
                 });
@@ -4137,7 +4179,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             // used only for DocumentQuery
             var finalQuery = ((DocumentQuery<T>)DocumentQuery).CreateDocumentQueryInternal<TProjection>(
-                new QueryData(fields, projections, FromAlias, _declareTokens, _loadTokens, _declareTokens != null || _jsSelectBody != null, _includeSupport?.HadAnyIncludes ?? false)
+                new QueryData(fields, projections, FromAlias, _declareTokens, _loadTokens, _declareTokens != null || _jsSelectBody != null, _includeSupport?.IncludeFunctions.IsNullOrEmpty() == false)
                 {
                     IsProjectInto = _isProjectInto,
                     QueryStatistics =  _queryStatistics

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3376,7 +3376,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (expression is MemberExpression or MethodCallExpression)
             {
-                if (_includeSupport is not null && _includeSupport.IncludeFunctions.IsNullOrEmpty() == false)
+                var anyInclude = (_includeSupport is not null && _includeSupport.IncludeFunctions.IsNullOrEmpty() == false);
+                var containsDot = GetMember(expression).Path.Contains('.');
+                if (anyInclude && containsDot)
                 {
                     sb.Append('{');
                     var name = GetMember(expression);
@@ -3389,7 +3391,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     script = ToJs(expression);
 
                 sb.Append(script);
-                if (_includeSupport is not null && _includeSupport.IncludeFunctions.IsNullOrEmpty() == false)
+                if (anyInclude && containsDot)
                 {
                     sb.Append("}");
                 }

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3045,14 +3045,14 @@ The recommended method is to use full text search (mark the field as Analyzed an
                                          (!(arg is MethodCallExpression methodCall) || methodCall.Method.Name == nameof(RavenQuery.Load));
 
                 var loadSupport = new JavascriptConversionExtensions.LoadSupport(_loadTypes) { DoNotTranslate = shouldUseLoadToken };
-                var js = ToJs(arg, false, loadSupport, name);
+                var js = ToJs(arg, false, loadSupport);
 
                 if (_includeSupport.HasInclude)
                 {
                     _includeSupport.HasInclude = false;
                     if (name.All(c => c == '_') == false)
                     {
-                        throw new InvalidOperationException("Include variable can only be named by discard('_') character");
+                        throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
                     }
                 }
                 if (loadSupport.HasLoad && shouldUseLoadToken)
@@ -3337,7 +3337,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (expression is MemberExpression or MethodCallExpression)
             {
-                if (_includeSupport.HadAnyIncludes)
+                if (_includeSupport is not null && _includeSupport.HadAnyIncludes)
                 {
                     sb.Append('{');
                     var name = GetMember(expression);
@@ -3350,7 +3350,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     script = ToJs(expression);
 
                 sb.Append(script);
-                if (_includeSupport.HadAnyIncludes)
+                if (_includeSupport is not null && _includeSupport.HadAnyIncludes)
                 {
                     sb.Append("}");
                 }
@@ -3365,7 +3365,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (IsRawOrTimeSeriesCall(expression, out string script) == false)
             {
-                script = ToJs(expression, name:name);
+                script = ToJs(expression);
             }
 
             if (_includeSupport?.HasInclude == true)
@@ -3373,7 +3373,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 _includeSupport.HasInclude = false;
                 if (name.All(c => c == '_') == false)
                 {
-                    throw new InvalidOperationException("Include variable can only be named by discard('_') character");
+                    throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
                 }
             }
 
@@ -3409,7 +3409,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
             return mce.Method.DeclaringType == typeof(RavenQuery) && mce.Method.Name == "Raw";
         }
 
-        private string ToJs(Expression expression, bool loadArg = false, JavascriptConversionExtensions.LoadSupport loadSupport = null, string name = null)
+        private string ToJs(Expression expression, bool loadArg = false, JavascriptConversionExtensions.LoadSupport loadSupport = null)
         {
             var extensions = new JavascriptConversionExtension[]
             {

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2736,10 +2736,11 @@ The recommended method is to use full text search (mark the field as Analyzed an
                         HandleSelectId(GetSelectPath(field.Member));
                         continue;
                     }
+
                     if (LinqPathProvider.IsIncludeCall(mce))
                     {
-                        var discardName = field.Member.Name;
-                        if (ProcessIncludeCall(mce, discardName, lambdaExpression, memberInitExpression))
+                        var name = field.Member.Name;
+                        if (TryProcessIncludeCall(mce, name, lambdaExpression, memberInitExpression))
                             continue;
                         return;
                     }
@@ -2830,8 +2831,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
                     if (LinqPathProvider.IsIncludeCall(mce))
                     {
-                        var discardName = newExpression.Members[index].Name;
-                        if (ProcessIncludeCall(mce, discardName, lambdaExpression, newExpression))
+                        var name = newExpression.Members[index].Name;
+                        if (TryProcessIncludeCall(mce, name, lambdaExpression, newExpression))
                             continue;
                         return;
                     }
@@ -2857,30 +2858,27 @@ The recommended method is to use full text search (mark the field as Analyzed an
             }
         }
 
-        private bool ProcessIncludeCall(MethodCallExpression mce, string discardName, LambdaExpression lambdaExpression, Expression memberInitOrNewExpression)
+        private bool TryProcessIncludeCall(MethodCallExpression mce, string name, LambdaExpression lambdaExpression, Expression memberInitOrNewExpression)
         {
-            if (discardName.All(c => c == '_') == false)
-                throw new InvalidOperationException("result of an Include can only be assigned to the discard symbol (_)");
+            AssertNameForInclude(name);
 
-            if (mce.Arguments[0] is UnaryExpression unaryExpr && unaryExpr.Operand is LambdaExpression lambdaExpr)
-            {
-                if (lambdaExpr.Body is MemberExpression memberExpr)
-                {
-                    string fieldName = memberExpr.Member.Name;
-                    DocumentQuery.Include(fieldName);
-                    return true;
-                }
-
-                if (FromAlias == null)
-                {
-                    AddFromAlias(lambdaExpression?.Parameters[0].Name);
-                }
-
-                _declareBuilder ??= new();
-                AddReturnStatementToOutputFunction(memberInitOrNewExpression);
+            if ((mce.Arguments[0] is UnaryExpression unaryExpr && unaryExpr.Operand is LambdaExpression lambdaExpr) == false) 
                 return false;
+
+            if (lambdaExpr.Body is MemberExpression memberExpr)
+            {
+                string fieldName = memberExpr.Member.Name;
+                DocumentQuery.Include(fieldName);
+                return true;
             }
 
+            if (FromAlias == null)
+            {
+                AddFromAlias(lambdaExpression?.Parameters[0].Name);
+            }
+
+            _declareBuilder ??= new();
+            AddReturnStatementToOutputFunction(memberInitOrNewExpression);
             return false;
         }
 
@@ -3065,10 +3063,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
             if (includeMethodCall != null && includeIndex != -1 && expression.Members != null)
             {
                 var name = expression.Members[includeIndex].Name;
-                if (name.All(c => c == '_') == false)
-                {
-                    throw new InvalidOperationException("result of an Include can only be assigned to the discard symbol (_)");
-                }
+                AssertNameForInclude(name);
 
                 if (includeMethodCall.Arguments[0] is UnaryExpression unaryExpr &&
                     unaryExpr.Operand is LambdaExpression lambdaExpr)
@@ -3149,11 +3144,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 if (_includeSupport.HasInclude)
                 {
                     _includeSupport.HasInclude = false;
-                    if (name.All(c => c == '_') == false)
-                    {
-                        throw new InvalidOperationException("result of an Include can only be assigned to the discard symbol (_)");
-                    }
+                    AssertNameForInclude(name);
                 }
+
                 if (loadSupport.HasLoad && shouldUseLoadToken)
                 {
                     HandleLoad(arg, loadSupport, name, js, wrapper);
@@ -3386,7 +3379,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
         private string TranslateSelectBodyToJs(Expression expression)
         {
             var sb = new StringBuilder();
-          
+
             if (expression is NewExpression newExpression)
             {
                 sb.Append("{ ");
@@ -3408,6 +3401,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                         AddJsProjection(name, newExpression.Arguments[index], sb, index != 0);
                     }
                 }
+
                 sb.Append(" }");
             }
 
@@ -3442,8 +3436,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     {
                         AddJsProjection(name, field.Expression, sb, index != 0);
                     }
-
                 }
+
                 sb.Append(" }");
             }
 
@@ -3469,14 +3463,12 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 }
 
                 sb.Append(script);
-                if (expression is MemberExpression)
+                if (expression is MemberExpression && anyInclude && containsDot)
                 {
-                    if (anyInclude && containsDot)
-                    {
-                        sb.Append('}');
-                    }
+                    sb.Append('}');
                 }
             }
+
             return sb.ToString();
         }
 
@@ -3491,10 +3483,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (_includeSupport?.HasInclude == true)
             {
-                if (name.All(c => c == '_') == false)
-                {
-                    throw new InvalidOperationException("result of an Include can only be assigned to the discard symbol (_)");
-                }
+                AssertNameForInclude(name);
+
                 _jsProjectionNames.Remove(name);
                 _includeSupport.HasInclude = false;
                 if (_includeSupport?.IncludeSimpleFunctions != null)
@@ -3534,6 +3524,14 @@ The recommended method is to use full text search (mark the field as Analyzed an
             }
 
             sb.Append(name).Append(" : ").Append(script);
+        }
+
+        private void AssertNameForInclude(string name)
+        {
+            if (string.IsNullOrEmpty(name) || !name.All(c => c == '_'))
+            {
+                throw new InvalidOperationException("The result of an Include can only be assigned to the discard symbol (_)");
+            }
         }
 
         private static bool IsRawCall(MethodCallExpression mce)

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -3415,7 +3415,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
             {
                 new JavascriptConversionExtensions.DictionarySupport(),
                 JavascriptConversionExtensions.LinqMethodsSupport.Instance,
-                _includeSupport ??= new JavascriptConversionExtensions.IncludeSupport(),
+                _includeSupport ??= new JavascriptConversionExtensions.IncludeSupport(FromAlias),
                 loadSupport ?? new JavascriptConversionExtensions.LoadSupport(_loadTypes ??= new()),
                 JavascriptConversionExtensions.MetadataSupport.Instance,
                 JavascriptConversionExtensions.CompareExchangeSupport.Instance,

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -2738,29 +2738,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     }
                     if (LinqPathProvider.IsIncludeCall(mce))
                     {
-                        var name = field.Member.Name;
-                        if (name.All(c => c == '_') == false)
-                        {
-                            throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
-                        }
-                        if (mce.Arguments[0] is UnaryExpression unaryExpr && unaryExpr.Operand is LambdaExpression lambdaExpr)
-                        {
-                            if (lambdaExpr.Body is MemberExpression memberExpr)
-                            {
-                                string fieldName = memberExpr.Member.Name;
-                                DocumentQuery.Include(fieldName);
-                                continue;
-                            }
-                            else
-                            {
-                                if (FromAlias == null)
-                                {
-                                    AddFromAlias(lambdaExpression?.Parameters[0].Name);
-                                }
-                                _declareBuilder ??= new();
-                                AddReturnStatementToOutputFunction(memberInitExpression);
-                            }
-                        }
+                        var discardName = field.Member.Name;
+                        if (ProcessIncludeCall(mce, discardName, lambdaExpression, memberInitExpression))
+                            continue;
                         return;
                     }
                 }
@@ -2850,31 +2830,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
                     if (LinqPathProvider.IsIncludeCall(mce))
                     {
-                        var name = newExpression.Members[index].Name;
-                        if (name.All(c => c == '_') == false)
-                        {
-                            throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
-                        }
-
-                        if (mce.Arguments[0] is UnaryExpression unaryExpr && unaryExpr.Operand is LambdaExpression lambdaExpr)
-                        {
-                            if (lambdaExpr.Body is MemberExpression memberExpr)
-                            {
-                                string fieldName = memberExpr.Member.Name;
-                                DocumentQuery.Include(fieldName);
-                                continue;
-                            }
-                            else
-                            {
-                                if (FromAlias == null)
-                                {
-                                    AddFromAlias(lambdaExpression?.Parameters[0].Name);
-                                }
-
-                                _declareBuilder ??= new();
-                                AddReturnStatementToOutputFunction(newExpression);
-                            }
-                        }
+                        var discardName = newExpression.Members[index].Name;
+                        if (ProcessIncludeCall(mce, discardName, lambdaExpression, newExpression))
+                            continue;
                         return;
                     }
                 }
@@ -2887,9 +2845,9 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
                 FieldsToFetch?.Clear();
                 _jsSelectBody = TranslateSelectBodyToJs(newExpression);
-                if (_includeSupport?.IncludeFunctions != null)
+                if (_includeSupport?.IncludeSimpleFunctions != null)
                 {
-                    foreach (var includeFunction in _includeSupport?.IncludeFunctions)
+                    foreach (var includeFunction in _includeSupport.IncludeSimpleFunctions)
                     {
                         var includeName = includeFunction.Split('.')[1];
                         DocumentQuery.Include(includeName);
@@ -2897,6 +2855,33 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 }
                 break;
             }
+        }
+
+        private bool ProcessIncludeCall(MethodCallExpression mce, string discardName, LambdaExpression lambdaExpression, Expression memberInitOrNewExpression)
+        {
+            if (discardName.All(c => c == '_') == false)
+                throw new InvalidOperationException("result of an Include can only be assigned to the discard symbol (_)");
+
+            if (mce.Arguments[0] is UnaryExpression unaryExpr && unaryExpr.Operand is LambdaExpression lambdaExpr)
+            {
+                if (lambdaExpr.Body is MemberExpression memberExpr)
+                {
+                    string fieldName = memberExpr.Member.Name;
+                    DocumentQuery.Include(fieldName);
+                    return true;
+                }
+
+                if (FromAlias == null)
+                {
+                    AddFromAlias(lambdaExpression?.Parameters[0].Name);
+                }
+
+                _declareBuilder ??= new();
+                AddReturnStatementToOutputFunction(memberInitOrNewExpression);
+                return false;
+            }
+
+            return false;
         }
 
         private void SelectMemberAccess(Expression body)
@@ -3017,12 +3002,11 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 _typedParameterSupport = new JavascriptConversionExtensions.TypedParameterSupport(_manualLet.Name);
             }
             var js = TranslateSelectBodyToJs(expression);
-            if (null != _includeSupport?.IncludeFunctions)
+            if (_includeSupport?.IncludeComplexFunctions != null)
             {
-                foreach (var include in _includeSupport.IncludeFunctions)
+                foreach (var include in _includeSupport.IncludeComplexFunctions)
                 {
                     _declareBuilder.Append("\tinclude(").Append(include).AppendLine(");");
-
                 }
             }
             _declareBuilder.Append('\t').Append("return ").Append(js).Append(';');
@@ -3062,28 +3046,44 @@ The recommended method is to use full text search (mark the field as Analyzed an
             if (_insideWhereOrSearchCounter > 0)
                 throw new NotSupportedException("Queries with a LET clause before a WHERE clause are not supported. " +
                                                 "WHERE clauses should appear before any LET clauses.");
+            MethodCallExpression includeMethodCall = null;
+            int includeIndex = -1;
 
-            var includeMethodCall = expression.Arguments
-                .OfType<MethodCallExpression>()
-                .FirstOrDefault(methodCall =>
-                    methodCall.Method.DeclaringType == typeof(RavenQuery) &&
-                    methodCall.Method.Name == "Include");
-
-            if (includeMethodCall != null)
+            for (int i = 0; i < expression.Arguments.Count; i++)
             {
-                var name = expression.Members[expression.Arguments.IndexOf(includeMethodCall)].Name;
+                var argument = expression.Arguments[i];
+                if (argument is MethodCallExpression methodCall &&
+                    methodCall.Method.DeclaringType == typeof(RavenQuery) &&
+                    methodCall.Method.Name == "Include")
+                {
+                    includeMethodCall = methodCall;
+                    includeIndex = i;
+                    break;
+                }
+            }
+
+            if (includeMethodCall != null && includeIndex != -1 && expression.Members != null)
+            {
+                var name = expression.Members[includeIndex].Name;
                 if (name.All(c => c == '_') == false)
                 {
-                    throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
+                    throw new InvalidOperationException("result of an Include can only be assigned to the discard symbol (_)");
                 }
+
                 if (includeMethodCall.Arguments[0] is UnaryExpression unaryExpr &&
                     unaryExpr.Operand is LambdaExpression lambdaExpr)
                 {
                     if (lambdaExpr.Body is MemberExpression memberExpr)
                     {
                         string fieldName = memberExpr.Member.Name;
-                        string fullFieldName = $"{fieldName}";
-                        DocumentQuery.Include(fullFieldName);
+                        DocumentQuery.Include(fieldName);
+
+                        if (FromAlias == null)
+                        {
+                            var parameter = expression.Arguments[0] as ParameterExpression;
+                            AddFromAlias(parameter?.Name);
+                        }
+
                         return;
                     }
                 }
@@ -3151,7 +3151,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     _includeSupport.HasInclude = false;
                     if (name.All(c => c == '_') == false)
                     {
-                        throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
+                        throw new InvalidOperationException("result of an Include can only be assigned to the discard symbol (_)");
                     }
                 }
                 if (loadSupport.HasLoad && shouldUseLoadToken)
@@ -3327,13 +3327,13 @@ The recommended method is to use full text search (mark the field as Analyzed an
             }
 
             _declareBuilder ??= new StringBuilder();
-            if (String.IsNullOrEmpty(js) == false)
+
+            if (string.IsNullOrEmpty(js) == false)
             {
                 _declareBuilder.Append('\t')
                     .Append("var ").Append(name)
                     .Append(" = ").Append(js).Append(';')
                     .Append(Environment.NewLine);
-
             }
         }
 
@@ -3432,9 +3432,11 @@ The recommended method is to use full text search (mark the field as Analyzed an
                         continue;
                     }
 
-                    if (null != _includeSupport?.IncludeFunctions?.Count)
+                    if (_includeSupport?.IncludeComplexFunctions != null || _includeSupport?.IncludeSimpleFunctions != null)
                     {
-                        AddJsProjection(name, field.Expression, sb, index - _includeSupport?.IncludeFunctions.Count > 0);
+                        var totalIncludes = (_includeSupport.IncludeComplexFunctions?.Count ?? 0)
+                                            + (_includeSupport.IncludeSimpleFunctions?.Count ?? 0);
+                        AddJsProjection(name, field.Expression, sb, index - totalIncludes > 0);
                     }
                     else
                     {
@@ -3447,27 +3449,34 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (expression is MemberExpression or MethodCallExpression)
             {
-                var anyInclude = (_includeSupport is not null && _includeSupport.IncludeFunctions.IsNullOrEmpty() == false);
-                var containsDot = GetMember(expression).Path.Contains('.');
-                if (anyInclude && containsDot)
-                {
-                    sb.Append('{');
-                    var name = GetMember(expression);
-                    var newName = name.Path.Split('.')[1];
-                    sb.Append(newName);
-                    sb.Append(':');
-                }
-
                 if (IsRawOrTimeSeriesCall(expression, out string script) == false)
                     script = ToJs(expression);
 
-                sb.Append(script);
-                if (anyInclude && containsDot)
+                var anyInclude = false;
+                var containsDot = false;
+                if (expression is MemberExpression)
                 {
-                    sb.Append("}");
+                    anyInclude = (_includeSupport is not null && _includeSupport.IncludeComplexFunctions.IsNullOrEmpty() == false);
+                    containsDot = GetMember(expression).Path.Contains('.');
+                    if (anyInclude && containsDot)
+                    {
+                        sb.Append('{');
+                        var name = GetMember(expression);
+                        var newName = name.Path.Split('.')[1];
+                        sb.Append(newName);
+                        sb.Append(':');
+                    }
+                }
+
+                sb.Append(script);
+                if (expression is MemberExpression)
+                {
+                    if (anyInclude && containsDot)
+                    {
+                        sb.Append('}');
+                    }
                 }
             }
-
             return sb.ToString();
         }
 
@@ -3484,12 +3493,20 @@ The recommended method is to use full text search (mark the field as Analyzed an
             {
                 if (name.All(c => c == '_') == false)
                 {
-                    throw new InvalidOperationException("The include variable can only be assigned to the discard character (_)");
+                    throw new InvalidOperationException("result of an Include can only be assigned to the discard symbol (_)");
                 }
-
                 _jsProjectionNames.Remove(name);
                 _includeSupport.HasInclude = false;
+                if (_includeSupport?.IncludeSimpleFunctions != null)
+                {
+                    foreach (var includeFunction in _includeSupport.IncludeSimpleFunctions)
+                    {
+                        var includeName = includeFunction.Split('.')[1];
+                        DocumentQuery.Include(includeName);
+                    }
+                }
                 return;
+
             }
 
             if (QueryGenerator.Conventions.FindProjectedPropertyNameForIndex != null)
@@ -4134,7 +4151,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (_jsSelectBody != null)
             {
-                return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true, hadAnyInclude: _includeSupport?.IncludeFunctions.IsNullOrEmpty() == false)
+                return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true, hadAnyInclude: _includeSupport?.IncludeComplexFunctions.IsNullOrEmpty() == false)
                 {
                     QueryStatistics = _queryStatistics
                 });
@@ -4252,7 +4269,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             // used only for DocumentQuery
             var finalQuery = ((DocumentQuery<T>)DocumentQuery).CreateDocumentQueryInternal<TProjection>(
-                new QueryData(fields, projections, FromAlias, _declareTokens, _loadTokens, _declareTokens != null || _jsSelectBody != null, _includeSupport?.IncludeFunctions.IsNullOrEmpty() == false)
+                new QueryData(fields, projections, FromAlias, _declareTokens, _loadTokens, _declareTokens != null || _jsSelectBody != null, _includeSupport?.IncludeComplexFunctions.IsNullOrEmpty() == false)
                 {
                     IsProjectInto = _isProjectInto,
                     QueryStatistics =  _queryStatistics

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -30,6 +30,7 @@ using Raven.Client.Documents.Session.Tokens;
 using Raven.Client.Exceptions;
 using Raven.Client.Extensions;
 using Raven.Client.Util;
+using static Raven.Client.Util.JavascriptConversionExtensions;
 using MethodCallExpression = System.Linq.Expressions.MethodCallExpression;
 using NotSupportedException = System.NotSupportedException;
 
@@ -80,6 +81,7 @@ namespace Raven.Client.Documents.Linq
         private bool _addedDefaultAlias;
         private Type _ofType;
         private bool _isSelectArg;
+        private IncludeSupport _includeSupport;
         private (bool IsSet, string Name) _manualLet;
         private JavascriptConversionExtensions.TypedParameterSupport _typedParameterSupport;
 
@@ -3043,8 +3045,16 @@ The recommended method is to use full text search (mark the field as Analyzed an
                                          (!(arg is MethodCallExpression methodCall) || methodCall.Method.Name == nameof(RavenQuery.Load));
 
                 var loadSupport = new JavascriptConversionExtensions.LoadSupport(_loadTypes) { DoNotTranslate = shouldUseLoadToken };
-                var js = ToJs(arg, false, loadSupport);
+                var js = ToJs(arg, false, loadSupport, name);
 
+                if (_includeSupport.HasInclude)
+                {
+                    _includeSupport.HasInclude = false;
+                    if (name.All(c => c == '_') == false)
+                    {
+                        throw new InvalidOperationException("Include variable can only be named by discard('_') character");
+                    }
+                }
                 if (loadSupport.HasLoad && shouldUseLoadToken)
                 {
                     HandleLoad(arg, loadSupport, name, js, wrapper);
@@ -3060,7 +3070,6 @@ The recommended method is to use full text search (mark the field as Analyzed an
                 AppendLineToOutputFunction(_manualLet.Name, wrapper.ToString());
             }
         }
-
 
         private void HandleLoad(Expression expression, JavascriptConversionExtensions.LoadSupport loadSupport, string name, string js, StringBuilder wrapper)
         {
@@ -3327,11 +3336,24 @@ The recommended method is to use full text search (mark the field as Analyzed an
             }
 
             if (expression is MemberExpression or MethodCallExpression)
-            { 
+            {
+                if (_includeSupport.HadAnyIncludes)
+                {
+                    sb.Append('{');
+                    var name = GetMember(expression);
+                    var newName = name.Path.Split('.')[1];
+                    sb.Append(newName);
+                    sb.Append(':');
+                }
+
                 if (IsRawOrTimeSeriesCall(expression, out string script) == false)
                     script = ToJs(expression);
-                
+
                 sb.Append(script);
+                if (_includeSupport.HadAnyIncludes)
+                {
+                    sb.Append("}");
+                }
             }
 
             return sb.ToString();
@@ -3343,9 +3365,18 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (IsRawOrTimeSeriesCall(expression, out string script) == false)
             {
-                script = ToJs(expression);
+                script = ToJs(expression, name:name);
             }
-            
+
+            if (_includeSupport?.HasInclude == true)
+            {
+                _includeSupport.HasInclude = false;
+                if (name.All(c => c == '_') == false)
+                {
+                    throw new InvalidOperationException("Include variable can only be named by discard('_') character");
+                }
+            }
+
             if (QueryGenerator.Conventions.FindProjectedPropertyNameForIndex != null)
             {
                 var firstDotIndex = script.IndexOf('.');
@@ -3378,12 +3409,13 @@ The recommended method is to use full text search (mark the field as Analyzed an
             return mce.Method.DeclaringType == typeof(RavenQuery) && mce.Method.Name == "Raw";
         }
 
-        private string ToJs(Expression expression, bool loadArg = false, JavascriptConversionExtensions.LoadSupport loadSupport = null)
+        private string ToJs(Expression expression, bool loadArg = false, JavascriptConversionExtensions.LoadSupport loadSupport = null, string name = null)
         {
             var extensions = new JavascriptConversionExtension[]
             {
                 new JavascriptConversionExtensions.DictionarySupport(),
                 JavascriptConversionExtensions.LinqMethodsSupport.Instance,
+                _includeSupport ??= new JavascriptConversionExtensions.IncludeSupport(),
                 loadSupport ?? new JavascriptConversionExtensions.LoadSupport(_loadTypes ??= new()),
                 JavascriptConversionExtensions.MetadataSupport.Instance,
                 JavascriptConversionExtensions.CompareExchangeSupport.Instance,
@@ -3987,7 +4019,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             if (_jsSelectBody != null)
             {
-                return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true)
+                return documentQuery.CreateDocumentQueryInternal<T>(new QueryData(new[] { _jsSelectBody }, _jsProjectionNames, FromAlias, _declareTokens, _loadTokens, true, hadAnyInclude: _includeSupport?.HadAnyIncludes ?? false)
                 {
                     QueryStatistics = _queryStatistics
                 });
@@ -4105,7 +4137,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
 
             // used only for DocumentQuery
             var finalQuery = ((DocumentQuery<T>)DocumentQuery).CreateDocumentQueryInternal<TProjection>(
-                new QueryData(fields, projections, FromAlias, _declareTokens, _loadTokens, _declareTokens != null || _jsSelectBody != null)
+                new QueryData(fields, projections, FromAlias, _declareTokens, _loadTokens, _declareTokens != null || _jsSelectBody != null, _includeSupport?.HadAnyIncludes ?? false)
                 {
                     IsProjectInto = _isProjectInto,
                     QueryStatistics =  _queryStatistics

--- a/src/Raven.Client/Documents/Queries/QueryData.cs
+++ b/src/Raven.Client/Documents/Queries/QueryData.cs
@@ -13,6 +13,8 @@ namespace Raven.Client.Documents.Queries
 {
     public sealed class QueryData
     {
+        public bool HadAnyInclude { get; set; }
+
         public string[] Fields { get; set; }
 
         public IEnumerable<string> Projections { get; set; }
@@ -33,8 +35,9 @@ namespace Raven.Client.Documents.Queries
 
         public ProjectionBehavior? ProjectionBehavior { get; set; }
 
-        public QueryData(string[] fields, IEnumerable<string> projections, string fromAlias = null, IEnumerable<DeclareToken> declareTokens = null, List<LoadToken> loadTokens = null, bool isCustomFunction = false)
+        public QueryData(string[] fields, IEnumerable<string> projections, string fromAlias = null, IEnumerable<DeclareToken> declareTokens = null, List<LoadToken> loadTokens = null, bool isCustomFunction = false, bool hadAnyInclude = false)
         {
+            HadAnyInclude = hadAnyInclude;
             Fields = fields;
             Projections = projections;
             FromAlias = fromAlias;

--- a/src/Raven.Client/Documents/Queries/RavenQuery.cs
+++ b/src/Raven.Client/Documents/Queries/RavenQuery.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using Raven.Client.Documents.Queries.TimeSeries;
 using Raven.Client.Documents.Session;
 
@@ -11,7 +12,7 @@ namespace Raven.Client.Documents.Queries
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
-        
+
         public static string Id(object documentInstance)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
@@ -31,7 +32,7 @@ namespace Raven.Client.Documents.Queries
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
-        
+
         public static DateTime LastModified<T>(T instance)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
@@ -92,9 +93,10 @@ namespace Raven.Client.Documents.Queries
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
-        public static object Include(string str)
+        public static object Include<T>(Expression<Func<T, string>> path)
         {
-            throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
+            throw new NotSupportedException(
+                "This method is here for strongly type support of server-side calls during LINQ queries and should never be directly called.");
         }
     }
 }

--- a/src/Raven.Client/Documents/Queries/RavenQuery.cs
+++ b/src/Raven.Client/Documents/Queries/RavenQuery.cs
@@ -91,5 +91,10 @@ namespace Raven.Client.Documents.Queries
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
+
+        public static object Include(string str)
+        {
+            throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
+        }
     }
 }

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1927,7 +1927,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             return OrderByTokens;
         }
 
-        protected void UpdateFieldsToFetchToken(FieldsToFetchToken fieldsToFetch)
+        protected void UpdateFieldsToFetchToken(FieldsToFetchToken fieldsToFetch, bool hadInclude = false)
         {
             FieldsToFetchToken = fieldsToFetch;
 
@@ -1935,7 +1935,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             {
                 SelectTokens.AddLast(fieldsToFetch);
             }
-            else
+            else if (hadInclude == false)
             {
                 var current = SelectTokens.First;
                 var replaced = false;

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -1058,7 +1058,7 @@ namespace Raven.Client.Documents.Session
             }
 
             if (newFieldsToFetch != null)
-                UpdateFieldsToFetchToken(newFieldsToFetch);
+                UpdateFieldsToFetchToken(newFieldsToFetch, hadInclude: queryData.HadAnyInclude);
 
             var query = new AsyncDocumentQuery<TResult>(
                 TheSession,

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1043,7 +1043,7 @@ namespace Raven.Client.Documents.Session
             }
 
             if (newFieldsToFetch != null)
-                UpdateFieldsToFetchToken(newFieldsToFetch);
+                UpdateFieldsToFetchToken(newFieldsToFetch, queryData.HadAnyInclude);
 
             var query = new DocumentQuery<TResult>(
                 TheSession,

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -1240,20 +1240,29 @@ namespace Raven.Client.Util
             }
         }
 
-        internal sealed class ReplaceParameterWithNewName(ParameterExpression parameter, string newName) : JavascriptConversionExtension
+        internal sealed class ReplaceParameterWithNewName : JavascriptConversionExtension
         {
+            private readonly string _newName;
+            private readonly ParameterExpression _parameter;
+
+            public ReplaceParameterWithNewName(ParameterExpression parameter, string newName)
+            {
+                _newName = newName;
+                _parameter = parameter;
+            }
+
             public override void ConvertToJavascript(JavascriptConversionContext context)
             {
-                var parameter1 = context.Node as ParameterExpression;
-                if (parameter1 == null || parameter1 != parameter)
+                var parameter = context.Node as ParameterExpression;
+                if (parameter == null || parameter != _parameter)
                     return;
 
                 context.PreventDefault();
                 var writer = context.GetWriter();
 
-                using (writer.Operation(parameter1))
+                using (writer.Operation(parameter))
                 {
-                    writer.Write(newName);
+                    writer.Write(_newName);
                 }
             }
         }

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -1040,8 +1040,10 @@ namespace Raven.Client.Util
 
                 if (methodCallExpression.Method.DeclaringType != typeof(RavenQuery))
                     return;
+
                 if (methodCallExpression.Arguments.Count != 1)
                     return;
+
                 if (methodCallExpression.Arguments[0] is not UnaryExpression { Operand: LambdaExpression le })
                     return;
 

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -972,7 +972,7 @@ namespace Raven.Client.Util
             public LoadSupport()
             {
             }
-            
+
             public LoadSupport(HashSet<Type> loadedTypes)
             {
                 _loadedTypes = loadedTypes;
@@ -1024,13 +1024,11 @@ namespace Raven.Client.Util
             }
         }
 
-        internal sealed class IncludeSupport : JavascriptConversionExtension
+        internal sealed class IncludeSupport(string fromAlias) : JavascriptConversionExtension
         {
             public bool HasInclude;
             public bool HadAnyIncludes;
-            public IncludeSupport()
-            {
-            }
+            public readonly string Alias = fromAlias;
 
             public override void ConvertToJavascript(JavascriptConversionContext context)
             {
@@ -1041,6 +1039,14 @@ namespace Raven.Client.Util
 
                 if (methodCallExpression.Method.DeclaringType != typeof(RavenQuery))
                     return;
+                if (methodCallExpression.Arguments.Count != 1)
+                    return;
+                if (methodCallExpression.Arguments[0] is not UnaryExpression { Operand: LambdaExpression le })
+                    return;
+
+                var body = le.Body;
+                var parameter = le.Parameters[0];
+                var replacedBody = ReplaceParameter(body, parameter, Alias);
 
                 HasInclude = HadAnyIncludes = true;
                 context.PreventDefault();
@@ -1048,8 +1054,24 @@ namespace Raven.Client.Util
                 using (writer.Operation(methodCallExpression))
                 {
                     writer.Write("include(");
-                    context.Visitor.Visit(methodCallExpression.Arguments[0]);
+                    context.Visitor.Visit(replacedBody);
                     writer.Write(")");
+                }
+            }
+
+            private static Expression ReplaceParameter(Expression body, ParameterExpression oldParam, string alias)
+            {
+
+                var newParam = Expression.Parameter(oldParam.Type, alias);
+
+                var replacer = new ParameterReplacer(oldParam, newParam);
+                return replacer.Visit(body);
+            }
+            private class ParameterReplacer(ParameterExpression oldParam, ParameterExpression newParam) : ExpressionVisitor
+            {
+                protected override Expression VisitParameter(ParameterExpression node)
+                {
+                    return node == oldParam ? newParam : base.VisitParameter(node);
                 }
             }
         }
@@ -1225,29 +1247,20 @@ namespace Raven.Client.Util
             }
         }
 
-        internal sealed class ReplaceParameterWithNewName : JavascriptConversionExtension
+        internal sealed class ReplaceParameterWithNewName(ParameterExpression parameter, string newName) : JavascriptConversionExtension
         {
-            private readonly string _newName;
-            private readonly ParameterExpression _parameter;
-
-            public ReplaceParameterWithNewName(ParameterExpression parameter, string newName)
-            {
-                _newName = newName;
-                _parameter = parameter;
-            }
-
             public override void ConvertToJavascript(JavascriptConversionContext context)
             {
-                var parameter = context.Node as ParameterExpression;
-                if (parameter == null || parameter != _parameter)
+                var parameter1 = context.Node as ParameterExpression;
+                if (parameter1 == null || parameter1 != parameter)
                     return;
 
                 context.PreventDefault();
                 var writer = context.GetWriter();
 
-                using (writer.Operation(parameter))
+                using (writer.Operation(parameter1))
                 {
-                    writer.Write(_newName);
+                    writer.Write(newName);
                 }
             }
         }

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -1026,8 +1026,8 @@ namespace Raven.Client.Util
 
         internal sealed class IncludeSupport(string fromAlias) : JavascriptConversionExtension
         {
+            public List<string> IncludeFunctions;
             public bool HasInclude;
-            public bool HadAnyIncludes;
             public readonly string Alias = fromAlias;
 
             public override void ConvertToJavascript(JavascriptConversionContext context)
@@ -1047,23 +1047,16 @@ namespace Raven.Client.Util
                 var body = le.Body;
                 var parameter = le.Parameters[0];
                 var replacedBody = ReplaceParameter(body, parameter, Alias);
+                var replaced = replacedBody.CompileToJavascript(context.Options);
 
-                HasInclude = HadAnyIncludes = true;
+                (IncludeFunctions ??= new List<string>()).Add(replaced);
+                HasInclude = true;
                 context.PreventDefault();
-                var writer = context.GetWriter();
-                using (writer.Operation(methodCallExpression))
-                {
-                    writer.Write("include(");
-                    context.Visitor.Visit(replacedBody);
-                    writer.Write(")");
-                }
             }
 
             private static Expression ReplaceParameter(Expression body, ParameterExpression oldParam, string alias)
             {
-
                 var newParam = Expression.Parameter(oldParam.Type, alias);
-
                 var replacer = new ParameterReplacer(oldParam, newParam);
                 return replacer.Visit(body);
             }

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -1024,6 +1024,37 @@ namespace Raven.Client.Util
             }
         }
 
+        internal sealed class IncludeSupport : JavascriptConversionExtension
+        {
+            private readonly string _name;
+            public bool HasInclude;
+            public bool HadAnyIncludes;
+            public IncludeSupport()
+            {
+            }
+
+            public override void ConvertToJavascript(JavascriptConversionContext context)
+            {
+                var methodCallExpression = context.Node as MethodCallExpression;
+
+                if (methodCallExpression?.Method.Name != "Include")
+                    return;
+
+                if (methodCallExpression.Method.DeclaringType != typeof(RavenQuery))
+                    return;
+
+                HasInclude = HadAnyIncludes = true;
+                context.PreventDefault();
+                var writer = context.GetWriter();
+                using (writer.Operation(methodCallExpression))
+                {
+                    writer.Write("include(");
+                    context.Visitor.Visit(methodCallExpression.Arguments[0]);
+                    writer.Write(")");
+                }
+            }
+        }
+
         internal sealed class MathSupport : JavascriptConversionExtension
         {
             public static readonly MathSupport Instance = new MathSupport();

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -1026,7 +1026,6 @@ namespace Raven.Client.Util
 
         internal sealed class IncludeSupport : JavascriptConversionExtension
         {
-            private readonly string _name;
             public bool HasInclude;
             public bool HadAnyIncludes;
             public IncludeSupport()

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -1026,7 +1026,8 @@ namespace Raven.Client.Util
 
         internal sealed class IncludeSupport(string fromAlias) : JavascriptConversionExtension
         {
-            public List<string> IncludeFunctions;
+            public List<string> IncludeComplexFunctions;
+            public List<string> IncludeSimpleFunctions;
             public bool HasInclude;
             public readonly string Alias = fromAlias;
 
@@ -1049,7 +1050,14 @@ namespace Raven.Client.Util
                 var replacedBody = ReplaceParameter(body, parameter, Alias);
                 var replaced = replacedBody.CompileToJavascript(context.Options);
 
-                (IncludeFunctions ??= new List<string>()).Add(replaced);
+                if (body is MemberExpression)
+                {
+                    (IncludeSimpleFunctions ??= new List<string>()).Add(replaced);
+                }
+                else
+                {
+                    (IncludeComplexFunctions ??= new List<string>()).Add(replaced);
+                }
                 HasInclude = true;
                 context.PreventDefault();
             }

--- a/test/SlowTests/Client/Queries/RavenDB_14541.cs
+++ b/test/SlowTests/Client/Queries/RavenDB_14541.cs
@@ -79,7 +79,7 @@ namespace SlowTests.Client.Queries
                         session,
                         ["states/1", "states/2"],
                         query.ToString(),
-                        "from 'Addresses' select StateId include StateId");
+                        "from 'Addresses' as a select { StateId : a.StateId } include StateId");
 
                     var typedProjection = from a in session.Query<Address>()
                         let _ = RavenQuery.Include<Address>(a => a.StateId)
@@ -94,7 +94,44 @@ namespace SlowTests.Client.Queries
                         session,
                         ["states/1", "states/2"],
                         typedProjection.ToString(),
-                        "from 'Addresses' select StateId include StateId");
+                        "from 'Addresses' as a select { StateId : a.StateId } include StateId");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeWithMemberInitQuerySyntaxWithAdditionalLet()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from a in session.Query<Address>()
+                        let _ = RavenQuery.Include<Address>(e => e.StateId)
+                        let stateId = a.StateId
+                        select new { StateId = stateId, };
+                    _ = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        query.ToString(),
+                        "declare function output(a) {\r\n\tvar stateId = a.StateId;\r\n\treturn { StateId : stateId };\r\n}\r\nfrom 'Addresses' as a select output(a) include StateId");
+
+                    var typedProjection = from a in session.Query<Address>()
+                        let _ = RavenQuery.Include<Address>(a => a.StateId)
+                        let stateId = a.StateId
+                        select new Foo { StateId = stateId };
+
+                    _ = typedProjection.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        typedProjection.ToString(),
+                        "declare function output(a) {\r\n\tvar stateId = a.StateId;\r\n\treturn { StateId : stateId };\r\n}\r\nfrom 'Addresses' as a select output(a) include StateId");
                 }
             }
         }
@@ -166,7 +203,7 @@ namespace SlowTests.Client.Queries
                         session,
                         ["states/1", "states/2"],
                         query.ToString(),
-                        "from 'Addresses' select City as Name, StateId include StateId");
+                        "from 'Addresses' as a select { Name : a.City, StateId : a.StateId } include StateId");
 
                     var typedProjection = from a in session.Query<Address>()
                         let _ = RavenQuery.Include<Address>(x => x.StateId)
@@ -182,7 +219,7 @@ namespace SlowTests.Client.Queries
                         session,
                         ["states/1", "states/2"],
                         typedProjection.ToString(),
-                        "from 'Addresses' select City as Name, StateId include StateId");
+                        "from 'Addresses' as a select { Name : a.City, StateId : a.StateId } include StateId");
                 }
             }
         }
@@ -196,7 +233,7 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query1 = session.Query<Address>()
+                    var query = session.Query<Address>()
                         .Select(a => new
                         {
                             Name = a.City + a.StateId,
@@ -204,12 +241,12 @@ namespace SlowTests.Client.Queries
                             _ = RavenQuery.Include<Address>(a => a.StateId)
                         });
 
-                    _ = query1.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["states/1", "states/2"],
-                        query1.ToString(),
+                        query.ToString(),
                         "from 'Addresses' as a select { Name : a.City+a.StateId, StateId : a.StateId } include StateId");
                 }
             }
@@ -235,13 +272,13 @@ namespace SlowTests.Client.Queries
                                     Company = e.Company,
                                 };
 
-                    var result = query.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["Companies/Raven", "Companies/App", "states/1", "states/2"],
                         query.ToString(),
-                        "from 'Addresses' select City, StateId, Company include StateId,Company");
+                        "from 'Addresses' as e select { City : e.City, StateId : e.StateId, Company : e.Company } include StateId,Company");
                 }
             }
         }
@@ -266,19 +303,19 @@ namespace SlowTests.Client.Queries
                                     _ = RavenQuery.Include<Address>(e => e.Company) // Inside select
                                 };
 
-                    var result = query.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["Companies/Raven", "Companies/App", "states/1", "states/2"],
                         query.ToString(),
-                        "from 'Addresses' select City, StateId, Company include StateId,Company");
+                        "from 'Addresses' as e select { City : e.City, StateId : e.StateId, Company : e.Company } include StateId,Company");
                 }
             }
         }
 
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
-        public void IncludeWithMemberInitSplitTest()
+        public void IncludeWithMemberInitSplit()
         {
             using (var store = GetDocumentStore())
             {
@@ -286,19 +323,19 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query1 = session.Query<Employee, Employees_ByFirstName>()
+                    var query = session.Query<Employee, Employees_ByFirstName>()
                         .Select(a => new Foo
                         {
                             _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
                             Name = a.FirstName
                         });
 
-                    var res = query1.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session, 
                         ["Companies/App", "Companies/Raven"], 
-                        query1.ToString(), 
+                        query.ToString(), 
                         "declare function output(a) {\r\n\tinclude(a.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { Name : a.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as a select output(a)");
                 }
             }
@@ -335,6 +372,38 @@ namespace SlowTests.Client.Queries
         }
 
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeWithMemberInitSplitTestQueryStyleWithAdditionalLet()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData1(store);
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from e in session.Query<Address>()
+                        let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
+                        let __ = RavenQuery.Include<Address>(a => a.StateId)
+                        let company = e.Company
+                        let stateId = e.StateId
+                        select new
+                        {
+                            Company = company,
+                            StateId = stateId
+                        };
+
+                    _ = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["Companies/App", "Companies/Raven", "states/1", "states/2"],
+                        query.ToString(),
+                        "declare function output(e) {\r\n\tvar company = e.Company;\r\n\tvar stateId = e.StateId;\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { Company : company, StateId : stateId };\r\n}\r\nfrom 'Addresses' as e select output(e) include StateId");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void IncludeWithMemberInitSplitTestQueryStyleWithTypedProjection()
         {
             using (var store = GetDocumentStore())
@@ -343,7 +412,7 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query1 = from e in session.Query<Employee, Employees_ByFirstName>()
+                    var query = from e in session.Query<Employee, Employees_ByFirstName>()
                                 let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
                                 let __ = RavenQuery.Include<Address>(a => a.StateId)
                                 select new Foo
@@ -351,12 +420,12 @@ namespace SlowTests.Client.Queries
                                     Name = e.FirstName,
                                 };
                     
-                    _ = query1.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["Companies/App", "Companies/Raven"],
-                        query1.ToString(),
+                        query.ToString(),
                         "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { Name : e.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as e select output(e) include StateId");
                 }
             }
@@ -373,17 +442,17 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query3 = from e in session.Query<Address>()
+                    var query = from e in session.Query<Address>()
                         let _ = RavenQuery.Include<Address>(a => a.StateId)
                         select e.StateId;
 
-                    var results3 = query3.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["states/1", "states/2"],
-                        query3.ToString(),
-                        "from 'Addresses' select StateId include StateId"
+                        query.ToString(),
+                        "from 'Addresses' as e select e.StateId include StateId"
                     );
                 }
             }
@@ -398,7 +467,7 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query1 = session.Query<Employee, Employees_ByFirstName>()
+                    var query = session.Query<Employee, Employees_ByFirstName>()
                         .Select(a => new
                         {
                             Name = a.FirstName,
@@ -406,12 +475,12 @@ namespace SlowTests.Client.Queries
                             __ = RavenQuery.Include<Employee>(e => e.Company.Split('#', StringSplitOptions.None)[0])
                         });
 
-                    var results = query1.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["Companies/dd3", "Companies/dd1", "Companies/Raven", "Companies/App"],
-                        query1.ToString(),
+                        query.ToString(),
                         "declare function output(a) {\r\n\tinclude(\"Companies/dd\"+Math.round(a.Number));\r\n\tinclude(a.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { Name : a.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as a select output(a)");
                 }
             }
@@ -426,7 +495,7 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query1 = from doc in session.Query<Employee, Employees_ByFirstName>()
+                    var query = from doc in session.Query<Employee, Employees_ByFirstName>()
                         let name = doc.FirstName
                         select new
                         {
@@ -434,12 +503,12 @@ namespace SlowTests.Client.Queries
                             _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
                         };
 
-                    var results = query1.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["Companies/App", "Companies/Raven"], 
-                        query1.ToString(), 
+                        query.ToString(), 
                         "declare function output(doc) {\r\n\tvar name = doc.FirstName;\r\n\tinclude(doc.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { FirstName : name };\r\n}\r\nfrom index 'Employees/ByFirstName' as doc select output(doc)"
                     );
                 }
@@ -455,19 +524,19 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query2 = from e in session.Query<Employee>()
+                    var query = from e in session.Query<Employee>()
                         let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
                         select new
                         {
                             FirstName = e.FirstName
                         };
 
-                    var results = query2.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["Companies/App", "Companies/Raven"],
-                        query2.ToString(),
+                        query.ToString(),
                         "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { FirstName : e.FirstName };\r\n}\r\nfrom 'Employees' as e select output(e)");
                 }
             }
@@ -482,16 +551,16 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query3 = from e in session.Query<Employee>()
+                    var query = from e in session.Query<Employee>()
                         let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
                         select e.FirstName;
 
-                    var results3 = query3.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["Companies/Raven", "Companies/App"],
-                        query3.ToString(),
+                        query.ToString(),
                         "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn {FirstName:e.FirstName};\r\n}\r\nfrom 'Employees' as e select output(e)"
                         );
                 }
@@ -517,7 +586,7 @@ namespace SlowTests.Client.Queries
                             _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1]) // Inside select
                         };
 
-                   var result = query.ToList();
+                   _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
@@ -537,7 +606,7 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query4 = session.Query<Employee, Employees_ByFirstName>()
+                    var query = session.Query<Employee, Employees_ByFirstName>()
                         .Select
                         (e => new
                         {
@@ -546,12 +615,12 @@ namespace SlowTests.Client.Queries
                             __ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1])
                         });
 
-                    var res = query4.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session, 
                         ["Companies/Amaz", "Companies/App", "Companies/Raven", "Companies/App"], 
-                        query4.ToString(),
+                        query.ToString(),
                         "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[1]);\r\n\treturn { FirstName : e.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as e select output(e)");
                 }
             }
@@ -566,7 +635,7 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query4 = session.Query<Employee, Employees_ByFirstName>()
+                    var query = session.Query<Employee, Employees_ByFirstName>()
                         .Select
                         (e => new
                         {
@@ -575,12 +644,12 @@ namespace SlowTests.Client.Queries
                             __ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1])
                         });
 
-                    var res = query4.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session, 
                         ["Companies/Amaz", "Companies/App", "Companies/Raven", "Companies/App"], 
-                        query4.ToString(),
+                        query.ToString(),
                         "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[1]);\r\n\treturn { FirstName : e.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as e select output(e)");
                 }
             }
@@ -595,7 +664,7 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query5 = session.Query<Employee, Employees_ByFirstName>()
+                    var query = session.Query<Employee, Employees_ByFirstName>()
                         .Select(e => new
                         {
                             FirstName = e.FirstName,
@@ -603,8 +672,8 @@ namespace SlowTests.Client.Queries
                             Include = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1])
                         });
 
-                    var error = Assert.Throws<InvalidOperationException>(() => query5.ToList());
-                    Assert.Equal("The include variable can only be assigned to the discard character (_)", error.Message);
+                    var error = Assert.Throws<InvalidOperationException>(() => query.ToList());
+                    Assert.Equal("result of an Include can only be assigned to the discard symbol (_)", error.Message);
                 }
             }
         }
@@ -619,15 +688,15 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query5 = session.Query<Employee, Employees_ByFirstName>()
+                    var query = session.Query<Employee, Employees_ByFirstName>()
                         .Select(e => new
                         {
                             FirstName = e.FirstName,
                             Includy = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company)
                         });
 
-                    var error = Assert.Throws<InvalidOperationException>(() => query5.ToList());
-                    Assert.Equal("The include variable can only be assigned to the discard character (_)", error.Message);
+                    var error = Assert.Throws<InvalidOperationException>(() => query.ToList());
+                    Assert.Equal("result of an Include can only be assigned to the discard symbol (_)", error.Message);
                 }
             }
         }
@@ -643,14 +712,14 @@ namespace SlowTests.Client.Queries
                 {
                     using (var session = store.OpenSession())
                     {
-                        var query3 = from o in session.Query<Order>()
+                        var query = from o in session.Query<Order>()
                                      let includes = RavenQuery.Include<Order>(u => u.Employee)
                                      select new QueryResult { Comapny = o.Company };
 
-                        var results = query3.ToList();
+                        _ = query.ToList();
                     }
                 });
-                Assert.Equal("The include variable can only be assigned to the discard character (_)", error.Message);
+                Assert.Equal("result of an Include can only be assigned to the discard symbol (_)", error.Message);
             }
         }
 
@@ -663,19 +732,19 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var query3 = from a in session.Query<Address>()
+                    var query = from a in session.Query<Address>()
                         let _ = RavenQuery.Include<Address>(x => x.CountryState.Split('#', StringSplitOptions.None)[0])
                         select new
                         {
                             Name = a.City
                         };
 
-                    var res2 = query3.ToList();
+                    _ = query.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["states/1", "states/2"],
-                        query3.ToString(),
+                        query.ToString(),
                         "declare function output(a) {\r\n\tinclude(a.CountryState.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { Name : a.City };\r\n}\r\nfrom 'Addresses' as a select output(a)");
                 }
             }

--- a/test/SlowTests/Client/Queries/RavenDB_14541.cs
+++ b/test/SlowTests/Client/Queries/RavenDB_14541.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 using System.Linq;
 using FastTests;
-using Tests.Infrastructure;
-using Xunit.Abstractions;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Session;
-using Xunit;
+using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
-
+using Xunit;
+using Xunit.Abstractions;
 
 
 namespace SlowTests.Client.Queries
@@ -21,35 +20,83 @@ namespace SlowTests.Client.Queries
         }
 
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
-        public void IncludeWithSingleSplitTest()
+        public void IncludeWithMemberInitSplitTest()
         {
             using (var store = GetDocumentStore())
             {
-                InitializeData(store);
+                InitializeData1(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query1 = session.Query<Employee, Employees_ByFirstName>()
+                        .Select(a => new Foo()
+                        {
+                            _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
+                            Name = a.FirstName,
+                        });
+                    var res = query1.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session, 
+                        ["Companies/App", "Companies/Raven"], 
+                        query1.ToString(), 
+                        "declare function output(a) {\r\n\tinclude(a.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { Name : a.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as a select output(a)");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeWithSplitAndMathTest()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData1(store);
 
                 using (var session = store.OpenSession())
                 {
                     var query1 = session.Query<Employee, Employees_ByFirstName>()
                         .Select(a => new
                         {
-                            FirstName = a.FirstName,
-                            _ = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
+                            Name = a.FirstName,
+                            _ = RavenQuery.Include<Employee>(e => "Companies/dd"+Math.Round(e.Number)),
+                            __ = RavenQuery.Include<Employee>(e => e.Company.Split('#', StringSplitOptions.None)[0])
                         });
-
-                    var query1String = query1.ToString();
+                    
                     var results = query1.ToList();
 
-                    RavenTestHelper.AssertStartsWithRespectingNewLines("from index 'Employees/ByFirstName' as a select { FirstName : a.FirstName, _ : include(a.Company.split(new RegExp(\"#\", \"g\"))[0]) }",
-                        query1String);
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["Companies/dd3", "Companies/dd1", "Companies/Raven", "Companies/App"],
+                        query1.ToString(),
+                        "declare function output(a) {\r\n\tinclude(\"Companies/dd\"+Math.round(a.Number));\r\n\tinclude(a.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { Name : a.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as a select output(a)");
+                }
+            }
+        }
 
-                    var includedDocs = ((DocumentSession)session).IncludedDocumentsById;
-                    Assert.Equal(2, includedDocs.Count);
-                    Assert.Equal("Companies/App", includedDocs.First().Key);
-                    Assert.Equal("Companies/Raven", includedDocs.Last().Key);
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeWithLetSingleSplitTest()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData1(store);
 
-                    var numOfReq = session.Advanced.NumberOfRequests;
-                    var documents = session.Load<Company>(["Companies/Raven", "Companies/App"]);
-                    Assert.Equal(numOfReq, session.Advanced.NumberOfRequests);
+                using (var session = store.OpenSession())
+                {
+                    var query1 = from doc in session.Query<Employee, Employees_ByFirstName>()
+                        let name = doc.FirstName
+                        select new
+                        {
+                            FirstName = name,
+                            _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
+                        };
+
+                    var results = query1.ToList();
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["Companies/App", "Companies/Raven"], 
+                        query1.ToString(), 
+                        "declare function output(doc) {\r\n\tvar name = doc.FirstName;\r\n\tinclude(doc.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { FirstName : name };\r\n}\r\nfrom index 'Employees/ByFirstName' as doc select output(doc)"
+                    );
                 }
             }
         }
@@ -59,7 +106,7 @@ namespace SlowTests.Client.Queries
         {
             using (var store = GetDocumentStore())
             {
-                InitializeData(store);
+                InitializeData1(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -67,20 +114,12 @@ namespace SlowTests.Client.Queries
                         let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
                         select new { FirstName = e.FirstName };
 
-                    var query2String = query2.ToString();
-                    var results2 = query2.ToList();
-
-                    var includedDocs2 = ((DocumentSession)session).IncludedDocumentsById;
-                    RavenTestHelper.AssertStartsWithRespectingNewLines(
-                        "declare function output(e) {\r\n\tvar _ = include(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { FirstName : e.FirstName };\r\n}\r\nfrom 'Employees' as e select output(e)",
-                        query2String);
-                    Assert.Equal(2, includedDocs2.Count);
-                    Assert.Equal("Companies/App", includedDocs2.First().Key);
-                    Assert.Equal("Companies/Raven", includedDocs2.Last().Key);
-
-                    var numOfReq2 = session.Advanced.NumberOfRequests;
-                    var documents2 = session.Load<Company>(new[] { "Companies/Raven", "Companies/App" });
-                    Assert.Equal(numOfReq2, session.Advanced.NumberOfRequests);
+                    var results = query2.ToList();
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["Companies/App", "Companies/Raven"],
+                        query2.ToString(),
+                        "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { FirstName : e.FirstName };\r\n}\r\nfrom 'Employees' as e select output(e)");
                 }
             }
         }
@@ -90,27 +129,21 @@ namespace SlowTests.Client.Queries
         {
             using (var store = GetDocumentStore())
             {
-                InitializeData(store);
+                InitializeData1(store);
 
                 using (var session = store.OpenSession())
                 {
                     var query3 = from e in session.Query<Employee>()
                         let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
                         select e.FirstName;
-
-                    var results3String = query3.ToString();
                     var results3 = query3.ToList();
 
-                    var includedDocs3 = ((DocumentSession)session).IncludedDocumentsById;
-                    Assert.Equal(2, includedDocs3.Count);
-                    Assert.Equal(
-                        "declare function output(e) {\r\n\tvar _ = include(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn {FirstName:e.FirstName};\r\n}\r\nfrom 'Employees' as e select output(e)",
-                        results3String);
-                    Assert.NotEmpty(results3);
-
-                    var numOfReq3 = session.Advanced.NumberOfRequests;
-                    var documents3 = session.Load<Company>(new[] { "Companies/Raven", "Companies/App" });
-                    Assert.Equal(numOfReq3, session.Advanced.NumberOfRequests);
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["Companies/Raven", "Companies/App"],
+                        query3.ToString(),
+                        "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn {FirstName:e.FirstName};\r\n}\r\nfrom 'Employees' as e select output(e)"
+                        );
                 }
             }
         }
@@ -121,30 +154,25 @@ namespace SlowTests.Client.Queries
         {
             using (var store = GetDocumentStore())
             {
-                InitializeData(store);
+                InitializeData1(store);
 
                 using (var session = store.OpenSession())
                 {
                     var query4 = session.Query<Employee, Employees_ByFirstName>()
-                        .Select(e => new
+                        .Select
+                        (e => new
                         {
                             FirstName = e.FirstName,
-                            _ = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
-                            __ = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1])
+                            _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
+                            __ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1])
                         });
 
-                    var results4 = query4.ToList();
-                    var includedDocs4 = ((DocumentSession)session).IncludedDocumentsById;
-
-                    Assert.Equal(4, includedDocs4.Count);
-
-                    var keysList = includedDocs4.Keys.ToHashSet();
-
-                    Assert.Contains("Companies/Amaz", keysList);
-                    Assert.Contains("Companies/App", keysList);
-                    Assert.Contains("Companies/Micro", keysList);
-                    Assert.Contains("Companies/Raven", keysList);
-                    Assert.NotEmpty(results4);
+                    var res = query4.ToList();
+                    AssertIncludedDocsAndRql(
+                        session, 
+                        ["Companies/Amaz", "Companies/App", "Companies/Raven", "Companies/App"], 
+                        query4.ToString(),
+                        "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[1]);\r\n\treturn { FirstName : e.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as e select output(e)");
                 }
             }
         }
@@ -154,7 +182,7 @@ namespace SlowTests.Client.Queries
         {
             using (var store = GetDocumentStore())
             {
-                InitializeData(store);
+                InitializeData1(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -165,36 +193,11 @@ namespace SlowTests.Client.Queries
                             _ = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
                             Include = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1])
                         });
-
+                        
                     var error = Assert.Throws<InvalidOperationException>(() => query5.ToList());
                     Assert.Equal("The include variable can only be assigned to the discard character (_)", error.Message);
                 }
             }
-        }
-
-        private void InitializeData(IDocumentStore store)
-        {
-            using (var session = store.OpenSession())
-            {
-                var employee1 = new Employee { FirstName = "Golan", Company = "Companies/Raven#Companies/Micro" };
-                var employee2 = new Employee { FirstName = "Grisha", Company = "Companies/App#Companies/Amaz" };
-                var company1 = new Company { Name = "RavenDB" };
-                var company2 = new Company { Name = "App" };
-                var company3 = new Company { Name = "Micro" };
-                var company4 = new Company { Name = "Amaz" };
-
-                session.Store(employee1);
-                session.Store(employee2);
-                session.Store(company1, "Companies/Raven");
-                session.Store(company2, "Companies/App");
-                session.Store(company3, "Companies/Micro");
-                session.Store(company4, "Companies/Amaz");
-
-                session.SaveChanges();
-            }
-
-            new Employees_ByFirstName().Execute(store);
-            Indexes.WaitForIndexing(store);
         }
 
         [RavenFact(RavenTestCategory.Querying)]
@@ -202,28 +205,20 @@ namespace SlowTests.Client.Queries
         {
             using (DocumentStore store = GetDocumentStore())
             {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new Order { Company = "1", Employee = "employees/1" }, "orders/1-A");
-                    session.Store(new Order { Company = "2", Employee = "employees/2" }, "orders/2-A");
+                InitializeData2(store);
 
-                    session.Store(new Employee { FirstName = "a" }, "employees/1");
-                    session.Store(new Employee { FirstName = "b" }, "employees/2");
-
-                    session.SaveChanges();
-                }
-
-                Assert.Throws<InvalidOperationException>(() =>
+                var error = Assert.Throws<InvalidOperationException>(() =>
                 {
                     using (var session = store.OpenSession())
                     {
                         var query3 = from o in session.Query<Order>()
-                            let includes = RavenQuery.Include<Order>(u => u.Employee)
-                            select new QueryResult { Comapny = o.Company };
+                                     let includes = RavenQuery.Include<Order>(u => u.Employee)
+                                     select new QueryResult { Comapny = o.Company };
 
                         var results = query3.ToList();
                     }
                 });
+                Assert.Equal("The include variable can only be assigned to the discard character (_)", error.Message);
             }
         }
 
@@ -232,47 +227,30 @@ namespace SlowTests.Client.Queries
         {
             using (DocumentStore store = GetDocumentStore())
             {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new Address { CountryState = "states/1#zip07", City = "new-york", StateId = "states/1" });
-                    session.Store(new Address { CountryState = "states/2#zip05", City = "haifa", StateId = "states/2" });
-
-                    session.Store(new State { Name = "Alabama" }, "states/1");
-                    session.Store(new State { Name = "Minassota" }, "states/2");
-
-                    session.SaveChanges();
-                }
+                InitializeData2(store);
 
                 using (var session = store.OpenSession())
                 {
                     var query3 = from a in session.Query<Address>()
                         let _ = RavenQuery.Include<Address>(x => x.StateId)
                         select new { Name = a.City };
-                    var res2 = query3.ToList();
 
-                    var doc1 = session.Load<State>("states/1");
-                    var doc2 = session.Load<State>("states/2");
-
-                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                    query3.ToList();
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        query3.ToString(),
+                        "declare function output(a) {\r\n\tinclude(a.StateId);\r\n\treturn { Name : a.City };\r\n}\r\nfrom 'Addresses' as a select output(a)");
                 }
             }
         }
 
         [RavenFact(RavenTestCategory.Querying)]
-        public void SessionQuerySelectAdressFromIncludeDoc_UsingRavenQueryWithComplexLambdaExpression()
-        {
+        public void SessionQuerySelectAddressFromIncludeDoc_UsingRavenQueryWithComplexLambdaExpression()
+        { 
             using (DocumentStore store = GetDocumentStore())
             {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new Address { CountryState = "states/1#zip07", City = "new-york", StateId = "states/1" });
-                    session.Store(new Address { CountryState = "states/2#zip05", City = "haifa", StateId = "states/2" });
-
-                    session.Store(new State { Name = "Alabama" }, "states/1");
-                    session.Store(new State { Name = "Minassota" }, "states/2");
-
-                    session.SaveChanges();
-                }
+              InitializeData2(store);
 
                 using (var session = store.OpenSession())
                 {
@@ -284,16 +262,13 @@ namespace SlowTests.Client.Queries
                     var query3 = from a in session.Query<Address>()
                         let _ = RavenQuery.Include<Address>(x => x.CountryState.Split('#', StringSplitOptions.None)[0])
                         select new { Name = a.City };
-                    var res1 = query3.ToString();
+
                     var res2 = query3.ToList();
-                    Assert.Equal(2, res2.Count);
-                    Assert.Equal("new-york", res2[0].Name);
-                    Assert.Equal("haifa", res2[1].Name);
-
-                    var doc1 = session.Load<State>("states/1");
-                    var doc2 = session.Load<State>("states/2");
-
-                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        query3.ToString(),
+                        "declare function output(a) {\r\n\tinclude(a.CountryState.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { Name : a.City };\r\n}\r\nfrom 'Addresses' as a select output(a)");
                 }
             }
         }
@@ -301,37 +276,82 @@ namespace SlowTests.Client.Queries
         [RavenFact(RavenTestCategory.Querying)]
         public void SessionQuerySelectAdressFromIncludeDoc_UsingRavenQueryWithSimpleLambdaExpression()
         {
-            using (DocumentStore store = GetDocumentStore())
+            using (var store = GetDocumentStore())
             {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new Address { CountryState = "states/1#zip07", City = "new-york", StateId = "states/1" });
-                    session.Store(new Address { CountryState = "states/2#zip05", City = "haifa", StateId = "states/2" });
-
-                    session.Store(new State { Name = "Alabama" }, "states/1");
-                    session.Store(new State { Name = "Minassota" }, "states/2");
-
-                    session.SaveChanges();
-                }
-
+                InitializeData2(store);
                 using (var session = store.OpenSession())
                 {
                     var query3 = from a in session.Query<Address>()
                         let _ = RavenQuery.Include<Address>(x => x.StateId)
                         select new { Name = a.City };
-                    var res1 = query3.ToString();
                     var res2 = query3.ToList();
 
-                    Assert.Equal(2, res2.Count);
-                    Assert.Equal("new-york", res2[0].Name);
-                    Assert.Equal("haifa", res2[1].Name);
-
-                    var doc1 = session.Load<State>("states/1");
-                    var doc2 = session.Load<State>("states/2");
-
-                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        query3.ToString(),
+                        "declare function output(a) {\r\n\tinclude(a.StateId);\r\n\treturn { Name : a.City };\r\n}\r\nfrom 'Addresses' as a select output(a)");
                 }
             }
+        }
+            
+
+        private void InitializeData1(IDocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            {
+                var employee1 = new Employee { FirstName = "Golan", Number = 1.2, Company = "Companies/Raven#Companies/Micro" };
+                var employee2 = new Employee { FirstName = "Grisha", Number = 2.6, Company = "Companies/App#Companies/Amaz" };
+                var company1 = new Company { Name = "RavenDB" };
+                var company2 = new Company { Name = "App" };
+                var company3 = new Company { Name = "Micro" };
+                var company4 = new Company { Name = "Amaz" };
+                var company5 = new Company { Name = "dd1" };
+                var company6 = new Company { Name = "dd3" };
+
+                session.Store(employee1);
+                session.Store(employee2);
+                session.Store(company1, "Companies/Raven");
+                session.Store(company2, "Companies/App");
+                session.Store(company3, "Companies/Micro");
+                session.Store(company4, "Companies/Amaz");
+                session.Store(company5, "Companies/dd1");
+                session.Store(company6, "Companies/dd3");
+
+                session.SaveChanges();
+            }
+            new Employees_ByFirstName().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        private void InitializeData2(IDocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            {
+
+                session.Store(new Address { CountryState = "states/1#zip07", City = "new-york", StateId = "states/1" });
+                session.Store(new Address { CountryState = "states/2#zip05", City = "haifa", StateId = "states/2" });
+
+                session.Store(new State { Name = "Alabama" }, "states/1");
+                session.Store(new State { Name = "Minassota" }, "states/2");
+
+                session.SaveChanges();
+            }
+        }
+
+        private void AssertIncludedDocsAndRql(IDocumentSession session, string[] expectedKeys, string actualRql, string expectedRql)
+        {
+            var includedDocs = ((DocumentSession)session).IncludedDocumentsById;
+            Assert.Equal(expectedKeys.Length, includedDocs.Count);
+            foreach (var key in expectedKeys)
+            {
+                Assert.Contains(key, includedDocs.Keys);
+            }
+            var initialRequestCount = session.Advanced.NumberOfRequests;
+            var documents = session.Load<dynamic>(expectedKeys);
+            var finalRequestCount = session.Advanced.NumberOfRequests;
+            Assert.Equal(initialRequestCount, finalRequestCount);
+            RavenTestHelper.AssertStartsWithRespectingNewLines(expectedRql, actualRql);
         }
 
         private class Employees_ByFirstName : AbstractIndexCreationTask<Employee>
@@ -349,11 +369,20 @@ namespace SlowTests.Client.Queries
             }
         }
 
+
+        private class Foo
+        {
+            public object _ { get; set; }
+            public string Name { get; set; }
+        }
+
         private class Employee
         {
             public string Id { get; set; }
+            public double Number { get; set; }
             public string FirstName { get; set; }
             public string Company { get; set; }
+            public string[] List { get; set; }
         }
 
         private class Company
@@ -377,18 +406,6 @@ namespace SlowTests.Client.Queries
         private class QueryResult
         {
             public string Comapny { get; set; }
-        }
-
-        private class User
-        {
-            public string UserName { get; set; }
-            public string? StateId;
-            public string? CityId;
-        }
-
-        private class City
-        {
-            public string Name { get; set; }
         }
     }
 }

--- a/test/SlowTests/Client/Queries/RavenDB_14541.cs
+++ b/test/SlowTests/Client/Queries/RavenDB_14541.cs
@@ -44,6 +44,32 @@ namespace SlowTests.Client.Queries
                 }
             }
         }
+        [RavenFact(RavenTestCategory.Querying)]
+
+        public void IncludeWithSingleProperty()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query3 = from e in session.Query<Address>()
+                        let _ = RavenQuery.Include<Address>(a => a.StateId)
+                        select e;
+
+                    var results = query3.ToString();
+                    var results3 = query3.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        query3.ToString(),
+                        "declare function output(e) {\r\n\tinclude(e.StateId);\r\n\treturn e;\r\n}\r\nfrom 'Addresses' as e select output(e)"
+                    );
+                }
+            }
+        }
 
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void IncludeWithSplitAndMathTest()
@@ -147,7 +173,6 @@ namespace SlowTests.Client.Queries
                 }
             }
         }
-
 
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void MultipleIncludesInsideSelect()

--- a/test/SlowTests/Client/Queries/RavenDB_14541.cs
+++ b/test/SlowTests/Client/Queries/RavenDB_14541.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Xunit;
+
+
+namespace SlowTests.Client.Queries
+{
+    public class RavenDB_14541 : RavenTestBase
+    {
+        public RavenDB_14541(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void RavenQueryIncludeTest1()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query1 = session.Query<Employee, Employees_ByFirstName>()
+                        .Select(a => new
+                        {
+                            FirstName = a.FirstName, _ = Raven.Client.Documents.Queries.RavenQuery.Include(a.Company.Split('#', StringSplitOptions.None)[0]),
+                        });
+
+                    var query1String = query1.ToString();
+                    var results = query1.ToList();
+
+                    Assert.Equal("from index 'Employees/ByFirstName' as a select { FirstName : a.FirstName, _ : include(a.Company.split(new RegExp(\"#\", \"g\"))[0]) }",
+                        query1String);
+
+                    var includedDocs = ((DocumentSession)session).IncludedDocumentsById;
+                    Assert.Equal(2, includedDocs.Count);
+                    Assert.Equal("Companies/App", includedDocs.First().Key);
+                    Assert.Equal("Companies/Raven", includedDocs.Last().Key);
+
+                    var numOfReq = session.Advanced.NumberOfRequests;
+                    var documents = session.Load<Company>(["Companies/Raven", "Companies/App"]);
+                    Assert.Equal(numOfReq, session.Advanced.NumberOfRequests);
+                }
+            }
+        }
+
+
+        public void RavenQueryIncludeTest2()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query2 = from e in session.Query<Employee>()
+                        let _ = RavenQuery.Include(e.Company.Split('#', StringSplitOptions.None)[0])
+                        select new { FirstName = e.FirstName };
+
+                    var query2String = query2.ToString();
+                    var results2 = query2.ToList();
+
+                    var includedDocs2 = ((DocumentSession)session).IncludedDocumentsById;
+                    Assert.Equal(
+                        "declare function output(e) {\r\n\tvar _ = include(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { FirstName : e.FirstName };\r\n}\r\nfrom 'Employees' as e select output(e)",
+                        query2String);
+                    Assert.Equal(2, includedDocs2.Count);
+                    Assert.Equal("Companies/App", includedDocs2.First().Key);
+                    Assert.Equal("Companies/Raven", includedDocs2.Last().Key);
+
+                    var numOfReq2 = session.Advanced.NumberOfRequests;
+                    var documents2 = session.Load<Company>(new[] { "Companies/Raven", "Companies/App" });
+                    Assert.Equal(numOfReq2, session.Advanced.NumberOfRequests);
+                }
+            }
+        }
+
+
+        public void RavenQueryIncludeTest3()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query3 = from e in session.Query<Employee>()
+                        let _ = RavenQuery.Include(e.Company.Split('#', StringSplitOptions.None)[0])
+                        select e.FirstName;
+
+                    var results3String = query3.ToString();
+                    var results3 = query3.ToList();
+
+                    var includedDocs3 = ((DocumentSession)session).IncludedDocumentsById;
+                    Assert.Equal(2, includedDocs3.Count);
+                    Assert.Equal(
+                        "declare function output(e) {\r\n\tvar _ = include(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn {FirstName:e.FirstName};\r\n}\r\nfrom 'Employees' as e select output(e)",
+                        results3String);
+                    Assert.NotEmpty(results3);
+
+                    var numOfReq3 = session.Advanced.NumberOfRequests;
+                    var documents3 = session.Load<Company>(new[] { "Companies/Raven", "Companies/App" });
+                    Assert.Equal(numOfReq3, session.Advanced.NumberOfRequests);
+                }
+            }
+        }
+
+
+
+        public void RavenQueryIncludeTest4()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query4 = session.Query<Employee, Employees_ByFirstName>()
+                        .Select(a => new
+                        {
+                            FirstName = a.FirstName,
+                            _ = Raven.Client.Documents.Queries.RavenQuery.Include(a.Company.Split('#', StringSplitOptions.None)[0]),
+                            __ = Raven.Client.Documents.Queries.RavenQuery.Include(a.Company.Split('#', StringSplitOptions.None)[1])
+                        });
+
+                    var results4 = query4.ToList();
+                    var includedDocs4 = ((DocumentSession)session).IncludedDocumentsById;
+
+                    Assert.Equal(4, includedDocs4.Count);
+
+                    var keysList = includedDocs4.Keys.ToHashSet();
+
+                    Assert.Contains("Companies/Amaz", keysList);
+                    Assert.Contains("Companies/App", keysList);
+                    Assert.Contains("Companies/Micro", keysList);
+                    Assert.Contains("Companies/Raven", keysList);
+                    Assert.NotEmpty(results4);
+                }
+            }
+        }
+
+
+        public void RavenQueryIncludeTest5()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query5 = session.Query<Employee, Employees_ByFirstName>()
+                        .Select(a => new
+                        {
+                            FirstName = a.FirstName,
+                            _ = Raven.Client.Documents.Queries.RavenQuery.Include(a.Company.Split('#', StringSplitOptions.None)[0]),
+                            Include = Raven.Client.Documents.Queries.RavenQuery.Include(a.Company.Split('#', StringSplitOptions.None)[1])
+                        });
+
+                    var error = Assert.Throws<InvalidOperationException>(() => query5.ToList());
+                    Assert.Equal("Include variable can only be named by discard('_') character", error.Message);
+                }
+            }
+        }
+
+        private void InitializeData(IDocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            {
+                var employee1 = new Employee { FirstName = "Golan", Company = "Companies/Raven#Companies/Micro" };
+                var employee2 = new Employee { FirstName = "Grisha", Company = "Companies/App#Companies/Amaz" };
+                var company1 = new Company { Name = "RavenDB" };
+                var company2 = new Company { Name = "App" };
+                var company3 = new Company { Name = "Micro" };
+                var company4 = new Company { Name = "Amaz" };
+
+                session.Store(employee1);
+                session.Store(employee2);
+                session.Store(company1, "Companies/Raven");
+                session.Store(company2, "Companies/App");
+                session.Store(company3, "Companies/Micro");
+                session.Store(company4, "Companies/Amaz");
+
+                session.SaveChanges();
+            }
+
+            new Employees_ByFirstName().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        private class Employees_ByFirstName : AbstractIndexCreationTask<Employee>
+        {
+            public Employees_ByFirstName()
+            {
+                Map = employees => from employee in employees
+                    select new { FirstName = employee.FirstName, Company = employee.Company };
+            }
+
+            public class IndexEntry
+            {
+                public string Id { get; set; }
+                public string FirstName { get; set; }
+            }
+        }
+
+        private class Employee
+        {
+            public string Id { get; set; }
+            public string FirstName { get; set; }
+            public string Company { get; set; }
+        }
+
+        private class Company
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Client/Queries/RavenDB_14541.cs
+++ b/test/SlowTests/Client/Queries/RavenDB_14541.cs
@@ -20,6 +20,264 @@ namespace SlowTests.Client.Queries
         }
 
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeWithMemberInitMethodSyntax()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<Address>()
+                        .Select(a => new
+                        {
+                            _ = RavenQuery.Include<Address>(a => a.StateId),
+                            a.StateId
+                        });
+
+                    _ = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        query.ToString(),
+                        "from 'Addresses' select StateId include StateId");
+
+                    var typedProjection = session.Query<Address>()
+                        .Select(a => new Foo { _ = RavenQuery.Include<Address>(a => a.StateId), StateId = a.StateId, });
+
+                    _ = typedProjection.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        typedProjection.ToString(),
+                        "from 'Addresses' select StateId include StateId");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeWithMemberInitQuerySyntax()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from a in session.Query<Address>()
+                        let _ = RavenQuery.Include<Address>(a => a.StateId)
+                        select new
+                        {
+                            StateId = a.StateId,
+                        };
+
+                    _ = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        query.ToString(),
+                        "from 'Addresses' select StateId include StateId");
+
+                    var typedProjection = from a in session.Query<Address>()
+                        let _ = RavenQuery.Include<Address>(a => a.StateId)
+                        select new Foo
+                        {
+                            StateId = a.StateId
+                        };
+
+                    _ = typedProjection.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        typedProjection.ToString(),
+                        "from 'Addresses' select StateId include StateId");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void IncludeWithMemberInitAndProjectedFieldMethodSyntax()
+        {
+            using (DocumentStore store = GetDocumentStore())
+            {
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<Address>()
+                        .Select(a => new
+                        {
+                            _ = RavenQuery.Include<Address>(x => x.StateId),
+                            Name = a.City,
+                            StateId = a.StateId
+                        });
+
+                    _ = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        query.ToString(),
+                        "from 'Addresses' select City as Name, StateId include StateId");
+
+                    var typedProjection = session.Query<Address>()
+                        .Select(a => new Foo
+                        {
+                            _ = RavenQuery.Include<Address>(x => x.StateId),
+                            Name = a.City,
+                            StateId = a.StateId
+                        });
+
+                    _ = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        typedProjection.ToString(),
+                        "from 'Addresses' select City as Name, StateId include StateId");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void IncludeWithMemberInitAndProjectedFieldQuerySyntax()
+        {
+            using (DocumentStore store = GetDocumentStore())
+            {
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from a in session.Query<Address>()
+                        let _ = RavenQuery.Include<Address>(x => x.StateId)
+                        select new
+                        {
+                            Name = a.City,
+                            StateId = a.StateId
+                        };
+
+                    _ = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        query.ToString(),
+                        "from 'Addresses' select City as Name, StateId include StateId");
+
+                    var typedProjection = from a in session.Query<Address>()
+                        let _ = RavenQuery.Include<Address>(x => x.StateId)
+                        select new Foo
+                        {
+                            Name = a.City,
+                            StateId = a.StateId
+                        };
+
+                    _ = typedProjection.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        typedProjection.ToString(),
+                        "from 'Addresses' select City as Name, StateId include StateId");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void SelectAndProjectionWithInclude()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query1 = session.Query<Address>()
+                        .Select(a => new
+                        {
+                            Name = a.City + a.StateId,
+                            StateId = a.StateId,
+                            _ = RavenQuery.Include<Address>(a => a.StateId)
+                        });
+
+                    _ = query1.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["states/1", "states/2"],
+                        query1.ToString(),
+                        "from 'Addresses' as a select { Name : a.City+a.StateId, StateId : a.StateId } include StateId");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeTwoSelect()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData1(store);
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from e in session.Query<Address>()
+                                let _ = RavenQuery.Include<Address>(a => a.StateId)
+                                let __ = RavenQuery.Include<Address>(e => e.Company)
+                                select new
+                                {
+                                    City = e.City,
+                                    StateId = e.StateId,
+                                    Company = e.Company,
+                                };
+
+                    var result = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["Companies/Raven", "Companies/App", "states/1", "states/2"],
+                        query.ToString(),
+                        "from 'Addresses' select City, StateId, Company include StateId,Company");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeInsideAndOutsideSelect()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData1(store);
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from e in session.Query<Address>()
+                                let _ = RavenQuery.Include<Address>(a => a.StateId) // Outside select
+                                select new
+                                {
+                                    City = e.City,
+                                    StateId = e.StateId,
+                                    Company = e.Company,
+                                    _ = RavenQuery.Include<Address>(e => e.Company) // Inside select
+                                };
+
+                    var result = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["Companies/Raven", "Companies/App", "states/1", "states/2"],
+                        query.ToString(),
+                        "from 'Addresses' select City, StateId, Company include StateId,Company");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void IncludeWithMemberInitSplitTest()
         {
             using (var store = GetDocumentStore())
@@ -29,11 +287,12 @@ namespace SlowTests.Client.Queries
                 using (var session = store.OpenSession())
                 {
                     var query1 = session.Query<Employee, Employees_ByFirstName>()
-                        .Select(a => new Foo()
+                        .Select(a => new Foo
                         {
                             _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
-                            Name = a.FirstName,
+                            Name = a.FirstName
                         });
+
                     var res = query1.ToList();
 
                     AssertIncludedDocsAndRql(
@@ -44,8 +303,68 @@ namespace SlowTests.Client.Queries
                 }
             }
         }
-        [RavenFact(RavenTestCategory.Querying)]
 
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeWithMemberInitSplitTestQueryStyle()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData1(store);
+                InitializeData2(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from e in session.Query<Address>()
+                        let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
+                        let __ = RavenQuery.Include<Address>(a => a.StateId)
+                        select new
+                        {
+                            Company = e.Company,
+                            StateId = e.StateId
+                        };
+
+                    _ = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["Companies/App", "Companies/Raven", "states/1", "states/2"],
+                        query.ToString(),
+                        "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { Company : e.Company, StateId : e.StateId };\r\n}\r\nfrom 'Addresses' as e select output(e) include StateId");
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeWithMemberInitSplitTestQueryStyleWithTypedProjection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData1(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query1 = from e in session.Query<Employee, Employees_ByFirstName>()
+                                let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
+                                let __ = RavenQuery.Include<Address>(a => a.StateId)
+                                select new Foo
+                                {
+                                    Name = e.FirstName,
+                                };
+                    
+                    _ = query1.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["Companies/App", "Companies/Raven"],
+                        query1.ToString(),
+                        "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { Name : e.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as e select output(e) include StateId");
+                }
+            }
+        }
+
+        
+
+        [RavenFact(RavenTestCategory.Querying)]
         public void IncludeWithSingleProperty()
         {
             using (var store = GetDocumentStore())
@@ -56,16 +375,15 @@ namespace SlowTests.Client.Queries
                 {
                     var query3 = from e in session.Query<Address>()
                         let _ = RavenQuery.Include<Address>(a => a.StateId)
-                        select e;
+                        select e.StateId;
 
-                    var results = query3.ToString();
                     var results3 = query3.ToList();
 
                     AssertIncludedDocsAndRql(
                         session,
                         ["states/1", "states/2"],
                         query3.ToString(),
-                        "declare function output(e) {\r\n\tinclude(e.StateId);\r\n\treturn e;\r\n}\r\nfrom 'Addresses' as e select output(e)"
+                        "from 'Addresses' select StateId include StateId"
                     );
                 }
             }
@@ -87,7 +405,7 @@ namespace SlowTests.Client.Queries
                             _ = RavenQuery.Include<Employee>(e => "Companies/dd"+Math.Round(e.Number)),
                             __ = RavenQuery.Include<Employee>(e => e.Company.Split('#', StringSplitOptions.None)[0])
                         });
-                    
+
                     var results = query1.ToList();
 
                     AssertIncludedDocsAndRql(
@@ -117,6 +435,7 @@ namespace SlowTests.Client.Queries
                         };
 
                     var results = query1.ToList();
+
                     AssertIncludedDocsAndRql(
                         session,
                         ["Companies/App", "Companies/Raven"], 
@@ -138,9 +457,13 @@ namespace SlowTests.Client.Queries
                 {
                     var query2 = from e in session.Query<Employee>()
                         let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
-                        select new { FirstName = e.FirstName };
+                        select new
+                        {
+                            FirstName = e.FirstName
+                        };
 
                     var results = query2.ToList();
+
                     AssertIncludedDocsAndRql(
                         session,
                         ["Companies/App", "Companies/Raven"],
@@ -162,6 +485,7 @@ namespace SlowTests.Client.Queries
                     var query3 = from e in session.Query<Employee>()
                         let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
                         select e.FirstName;
+
                     var results3 = query3.ToList();
 
                     AssertIncludedDocsAndRql(
@@ -170,6 +494,36 @@ namespace SlowTests.Client.Queries
                         query3.ToString(),
                         "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn {FirstName:e.FirstName};\r\n}\r\nfrom 'Employees' as e select output(e)"
                         );
+                }
+            }
+        }
+
+        
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeInsideAndOutsideSelectComplex()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData1(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query = from e in session.Query<Employee, Employees_ByFirstName>()
+                         let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]) // Outside select
+                        select new
+                        {
+                            FirstName = e.FirstName,
+                            _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1]) // Inside select
+                        };
+
+                   var result = query.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session,
+                        ["Companies/Amaz", "Companies/App", "Companies/Raven", "Companies/App"],
+                        query.ToString(),
+                        "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[1]);\r\n\treturn { FirstName : e.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as e select output(e)");
                 }
             }
         }
@@ -193,6 +547,36 @@ namespace SlowTests.Client.Queries
                         });
 
                     var res = query4.ToList();
+
+                    AssertIncludedDocsAndRql(
+                        session, 
+                        ["Companies/Amaz", "Companies/App", "Companies/Raven", "Companies/App"], 
+                        query4.ToString(),
+                        "declare function output(e) {\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\tinclude(e.Company.split(new RegExp(\"#\", \"g\"))[1]);\r\n\treturn { FirstName : e.FirstName };\r\n}\r\nfrom index 'Employees/ByFirstName' as e select output(e)");
+                }
+            }
+        }
+        
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void NewTest()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData1(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query4 = session.Query<Employee, Employees_ByFirstName>()
+                        .Select
+                        (e => new
+                        {
+                            FirstName = e.FirstName,
+                            _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
+                            __ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1])
+                        });
+
+                    var res = query4.ToList();
+
                     AssertIncludedDocsAndRql(
                         session, 
                         ["Companies/Amaz", "Companies/App", "Companies/Raven", "Companies/App"], 
@@ -218,7 +602,30 @@ namespace SlowTests.Client.Queries
                             _ = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
                             Include = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1])
                         });
-                        
+
+                    var error = Assert.Throws<InvalidOperationException>(() => query5.ToList());
+                    Assert.Equal("The include variable can only be assigned to the discard character (_)", error.Message);
+                }
+            }
+        }
+
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
+        public void IncludeWithInvalidName2()
+        {
+            using (var store = GetDocumentStore())
+            {
+                InitializeData1(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var query5 = session.Query<Employee, Employees_ByFirstName>()
+                        .Select(e => new
+                        {
+                            FirstName = e.FirstName,
+                            Includy = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company)
+                        });
+
                     var error = Assert.Throws<InvalidOperationException>(() => query5.ToList());
                     Assert.Equal("The include variable can only be assigned to the discard character (_)", error.Message);
                 }
@@ -248,29 +655,6 @@ namespace SlowTests.Client.Queries
         }
 
         [RavenFact(RavenTestCategory.Querying)]
-        public void SessionQuerySelectAddressFromIncludeDoc_UsingRavenQueryStringWithStateObject()
-        {
-            using (DocumentStore store = GetDocumentStore())
-            {
-                InitializeData2(store);
-
-                using (var session = store.OpenSession())
-                {
-                    var query3 = from a in session.Query<Address>()
-                        let _ = RavenQuery.Include<Address>(x => x.StateId)
-                        select new { Name = a.City };
-
-                    query3.ToList();
-                    AssertIncludedDocsAndRql(
-                        session,
-                        ["states/1", "states/2"],
-                        query3.ToString(),
-                        "declare function output(a) {\r\n\tinclude(a.StateId);\r\n\treturn { Name : a.City };\r\n}\r\nfrom 'Addresses' as a select output(a)");
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Querying)]
         public void SessionQuerySelectAddressFromIncludeDoc_UsingRavenQueryWithComplexLambdaExpression()
         { 
             using (DocumentStore store = GetDocumentStore())
@@ -279,16 +663,15 @@ namespace SlowTests.Client.Queries
 
                 using (var session = store.OpenSession())
                 {
-                    var address = session.Include<Address>(x => x.CountryState.Split('#', StringSplitOptions.None)[0]).ToString();
-                }
-
-                using (var session = store.OpenSession())
-                {
                     var query3 = from a in session.Query<Address>()
                         let _ = RavenQuery.Include<Address>(x => x.CountryState.Split('#', StringSplitOptions.None)[0])
-                        select new { Name = a.City };
+                        select new
+                        {
+                            Name = a.City
+                        };
 
                     var res2 = query3.ToList();
+
                     AssertIncludedDocsAndRql(
                         session,
                         ["states/1", "states/2"],
@@ -297,29 +680,6 @@ namespace SlowTests.Client.Queries
                 }
             }
         }
-
-        [RavenFact(RavenTestCategory.Querying)]
-        public void SessionQuerySelectAdressFromIncludeDoc_UsingRavenQueryWithSimpleLambdaExpression()
-        {
-            using (var store = GetDocumentStore())
-            {
-                InitializeData2(store);
-                using (var session = store.OpenSession())
-                {
-                    var query3 = from a in session.Query<Address>()
-                        let _ = RavenQuery.Include<Address>(x => x.StateId)
-                        select new { Name = a.City };
-                    var res2 = query3.ToList();
-
-                    AssertIncludedDocsAndRql(
-                        session,
-                        ["states/1", "states/2"],
-                        query3.ToString(),
-                        "declare function output(a) {\r\n\tinclude(a.StateId);\r\n\treturn { Name : a.City };\r\n}\r\nfrom 'Addresses' as a select output(a)");
-                }
-            }
-        }
-            
 
         private void InitializeData1(IDocumentStore store)
         {
@@ -354,11 +714,21 @@ namespace SlowTests.Client.Queries
             using (var session = store.OpenSession())
             {
 
-                session.Store(new Address { CountryState = "states/1#zip07", City = "new-york", StateId = "states/1" });
-                session.Store(new Address { CountryState = "states/2#zip05", City = "haifa", StateId = "states/2" });
+                session.Store(new Address { CountryState = "states/1#zip07", City = "new-york", StateId = "states/1",
+                    Company = "Companies/Raven"});
+                session.Store(new Address { CountryState = "states/2#zip05", City = "haifa", StateId = "states/2",
+                    Company = "Companies/App" });
 
                 session.Store(new State { Name = "Alabama" }, "states/1");
                 session.Store(new State { Name = "Minassota" }, "states/2");
+                var company1 = new Company { Name = "RavenDB" };
+                var company2 = new Company { Name = "App" };
+                var company3 = new Company { Name = "Micro" };
+                var company4 = new Company { Name = "Amaz" };
+                session.Store(company1, "Companies/Raven");
+                session.Store(company2, "Companies/App");
+                session.Store(company3, "Companies/Micro");
+                session.Store(company4, "Companies/Amaz");
 
                 session.SaveChanges();
             }
@@ -399,6 +769,7 @@ namespace SlowTests.Client.Queries
         {
             public object _ { get; set; }
             public string Name { get; set; }
+            public string StateId { get; set; }
         }
 
         private class Employee
@@ -420,7 +791,8 @@ namespace SlowTests.Client.Queries
         {
             public string CountryState { get; set; }
             public string City { get; set; }
-            public string StateId;
+            public string StateId { get; set; }
+            public string Company { get; set; }
         }
 
         private class State

--- a/test/SlowTests/Client/Queries/RavenDB_14541.cs
+++ b/test/SlowTests/Client/Queries/RavenDB_14541.cs
@@ -8,6 +8,8 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Session;
 using Xunit;
+using Tests.Infrastructure.Entities;
+
 
 
 namespace SlowTests.Client.Queries
@@ -30,13 +32,14 @@ namespace SlowTests.Client.Queries
                     var query1 = session.Query<Employee, Employees_ByFirstName>()
                         .Select(a => new
                         {
-                            FirstName = a.FirstName, _ = Raven.Client.Documents.Queries.RavenQuery.Include(a.Company.Split('#', StringSplitOptions.None)[0]),
+                            FirstName = a.FirstName,
+                            _ = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
                         });
 
                     var query1String = query1.ToString();
                     var results = query1.ToList();
 
-                    Assert.Equal("from index 'Employees/ByFirstName' as a select { FirstName : a.FirstName, _ : include(a.Company.split(new RegExp(\"#\", \"g\"))[0]) }",
+                    RavenTestHelper.AssertStartsWithRespectingNewLines("from index 'Employees/ByFirstName' as a select { FirstName : a.FirstName, _ : include(a.Company.split(new RegExp(\"#\", \"g\"))[0]) }",
                         query1String);
 
                     var includedDocs = ((DocumentSession)session).IncludedDocumentsById;
@@ -51,7 +54,7 @@ namespace SlowTests.Client.Queries
             }
         }
 
-
+        [RavenFact(RavenTestCategory.Querying)]
         public void IncludeWithLet()
         {
             using (var store = GetDocumentStore())
@@ -61,14 +64,14 @@ namespace SlowTests.Client.Queries
                 using (var session = store.OpenSession())
                 {
                     var query2 = from e in session.Query<Employee>()
-                        let _ = RavenQuery.Include(e.Company.Split('#', StringSplitOptions.None)[0])
+                        let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
                         select new { FirstName = e.FirstName };
 
                     var query2String = query2.ToString();
                     var results2 = query2.ToList();
 
                     var includedDocs2 = ((DocumentSession)session).IncludedDocumentsById;
-                    Assert.Equal(
+                    RavenTestHelper.AssertStartsWithRespectingNewLines(
                         "declare function output(e) {\r\n\tvar _ = include(e.Company.split(new RegExp(\"#\", \"g\"))[0]);\r\n\treturn { FirstName : e.FirstName };\r\n}\r\nfrom 'Employees' as e select output(e)",
                         query2String);
                     Assert.Equal(2, includedDocs2.Count);
@@ -82,7 +85,7 @@ namespace SlowTests.Client.Queries
             }
         }
 
-
+        [RavenFact(RavenTestCategory.Querying)]
         public void IncludeWithSinglePropertyAndLet()
         {
             using (var store = GetDocumentStore())
@@ -92,7 +95,7 @@ namespace SlowTests.Client.Queries
                 using (var session = store.OpenSession())
                 {
                     var query3 = from e in session.Query<Employee>()
-                        let _ = RavenQuery.Include(e.Company.Split('#', StringSplitOptions.None)[0])
+                        let _ = RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0])
                         select e.FirstName;
 
                     var results3String = query3.ToString();
@@ -113,7 +116,7 @@ namespace SlowTests.Client.Queries
         }
 
 
-
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void MultipleIncludesInsideSelect()
         {
             using (var store = GetDocumentStore())
@@ -123,11 +126,11 @@ namespace SlowTests.Client.Queries
                 using (var session = store.OpenSession())
                 {
                     var query4 = session.Query<Employee, Employees_ByFirstName>()
-                        .Select(a => new
+                        .Select(e => new
                         {
-                            FirstName = a.FirstName,
-                            _ = Raven.Client.Documents.Queries.RavenQuery.Include(a.Company.Split('#', StringSplitOptions.None)[0]),
-                            __ = Raven.Client.Documents.Queries.RavenQuery.Include(a.Company.Split('#', StringSplitOptions.None)[1])
+                            FirstName = e.FirstName,
+                            _ = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
+                            __ = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1])
                         });
 
                     var results4 = query4.ToList();
@@ -146,7 +149,7 @@ namespace SlowTests.Client.Queries
             }
         }
 
-
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
         public void IncludeWithInvalidName()
         {
             using (var store = GetDocumentStore())
@@ -156,11 +159,11 @@ namespace SlowTests.Client.Queries
                 using (var session = store.OpenSession())
                 {
                     var query5 = session.Query<Employee, Employees_ByFirstName>()
-                        .Select(a => new
+                        .Select(e => new
                         {
-                            FirstName = a.FirstName,
-                            _ = Raven.Client.Documents.Queries.RavenQuery.Include(a.Company.Split('#', StringSplitOptions.None)[0]),
-                            Include = Raven.Client.Documents.Queries.RavenQuery.Include(a.Company.Split('#', StringSplitOptions.None)[1])
+                            FirstName = e.FirstName,
+                            _ = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[0]),
+                            Include = Raven.Client.Documents.Queries.RavenQuery.Include<Employee>(a => a.Company.Split('#', StringSplitOptions.None)[1])
                         });
 
                     var error = Assert.Throws<InvalidOperationException>(() => query5.ToList());
@@ -194,6 +197,143 @@ namespace SlowTests.Client.Queries
             Indexes.WaitForIndexing(store);
         }
 
+        [RavenFact(RavenTestCategory.Querying)]
+        public void ShouldThrowInvalidOperationExceptionHaveIncludesInsteadOf_()
+        {
+            using (DocumentStore store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order { Company = "1", Employee = "employees/1" }, "orders/1-A");
+                    session.Store(new Order { Company = "2", Employee = "employees/2" }, "orders/2-A");
+
+                    session.Store(new Employee { FirstName = "a" }, "employees/1");
+                    session.Store(new Employee { FirstName = "b" }, "employees/2");
+
+                    session.SaveChanges();
+                }
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (var session = store.OpenSession())
+                    {
+                        var query3 = from o in session.Query<Order>()
+                            let includes = RavenQuery.Include<Order>(u => u.Employee)
+                            select new QueryResult { Comapny = o.Company };
+
+                        var results = query3.ToList();
+                    }
+                });
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void SessionQuerySelectAddressFromIncludeDoc_UsingRavenQueryStringWithStateObject()
+        {
+            using (DocumentStore store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Address { CountryState = "states/1#zip07", City = "new-york", StateId = "states/1" });
+                    session.Store(new Address { CountryState = "states/2#zip05", City = "haifa", StateId = "states/2" });
+
+                    session.Store(new State { Name = "Alabama" }, "states/1");
+                    session.Store(new State { Name = "Minassota" }, "states/2");
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query3 = from a in session.Query<Address>()
+                        let _ = RavenQuery.Include<Address>(x => x.StateId)
+                        select new { Name = a.City };
+                    var res2 = query3.ToList();
+
+                    var doc1 = session.Load<State>("states/1");
+                    var doc2 = session.Load<State>("states/2");
+
+                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void SessionQuerySelectAdressFromIncludeDoc_UsingRavenQueryWithComplexLambdaExpression()
+        {
+            using (DocumentStore store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Address { CountryState = "states/1#zip07", City = "new-york", StateId = "states/1" });
+                    session.Store(new Address { CountryState = "states/2#zip05", City = "haifa", StateId = "states/2" });
+
+                    session.Store(new State { Name = "Alabama" }, "states/1");
+                    session.Store(new State { Name = "Minassota" }, "states/2");
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var address = session.Include<Address>(x => x.CountryState.Split('#', StringSplitOptions.None)[0]).ToString();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query3 = from a in session.Query<Address>()
+                        let _ = RavenQuery.Include<Address>(x => x.CountryState.Split('#', StringSplitOptions.None)[0])
+                        select new { Name = a.City };
+                    var res1 = query3.ToString();
+                    var res2 = query3.ToList();
+                    Assert.Equal(2, res2.Count);
+                    Assert.Equal("new-york", res2[0].Name);
+                    Assert.Equal("haifa", res2[1].Name);
+
+                    var doc1 = session.Load<State>("states/1");
+                    var doc2 = session.Load<State>("states/2");
+
+                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void SessionQuerySelectAdressFromIncludeDoc_UsingRavenQueryWithSimpleLambdaExpression()
+        {
+            using (DocumentStore store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Address { CountryState = "states/1#zip07", City = "new-york", StateId = "states/1" });
+                    session.Store(new Address { CountryState = "states/2#zip05", City = "haifa", StateId = "states/2" });
+
+                    session.Store(new State { Name = "Alabama" }, "states/1");
+                    session.Store(new State { Name = "Minassota" }, "states/2");
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query3 = from a in session.Query<Address>()
+                        let _ = RavenQuery.Include<Address>(x => x.StateId)
+                        select new { Name = a.City };
+                    var res1 = query3.ToString();
+                    var res2 = query3.ToList();
+
+                    Assert.Equal(2, res2.Count);
+                    Assert.Equal("new-york", res2[0].Name);
+                    Assert.Equal("haifa", res2[1].Name);
+
+                    var doc1 = session.Load<State>("states/1");
+                    var doc2 = session.Load<State>("states/2");
+
+                    Assert.Equal(1, session.Advanced.NumberOfRequests);
+                }
+            }
+        }
+
         private class Employees_ByFirstName : AbstractIndexCreationTask<Employee>
         {
             public Employees_ByFirstName()
@@ -219,6 +359,35 @@ namespace SlowTests.Client.Queries
         private class Company
         {
             public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class Address
+        {
+            public string CountryState { get; set; }
+            public string City { get; set; }
+            public string StateId;
+        }
+
+        private class State
+        {
+            public string Name { get; set; }
+        }
+
+        private class QueryResult
+        {
+            public string Comapny { get; set; }
+        }
+
+        private class User
+        {
+            public string UserName { get; set; }
+            public string? StateId;
+            public string? CityId;
+        }
+
+        private class City
+        {
             public string Name { get; set; }
         }
     }

--- a/test/SlowTests/Client/Queries/RavenDB_14541.cs
+++ b/test/SlowTests/Client/Queries/RavenDB_14541.cs
@@ -673,7 +673,7 @@ namespace SlowTests.Client.Queries
                         });
 
                     var error = Assert.Throws<InvalidOperationException>(() => query.ToList());
-                    Assert.Equal("result of an Include can only be assigned to the discard symbol (_)", error.Message);
+                    Assert.Equal("The result of an Include can only be assigned to the discard symbol (_)", error.Message);
                 }
             }
         }
@@ -696,7 +696,7 @@ namespace SlowTests.Client.Queries
                         });
 
                     var error = Assert.Throws<InvalidOperationException>(() => query.ToList());
-                    Assert.Equal("result of an Include can only be assigned to the discard symbol (_)", error.Message);
+                    Assert.Equal("The result of an Include can only be assigned to the discard symbol (_)", error.Message);
                 }
             }
         }
@@ -719,7 +719,7 @@ namespace SlowTests.Client.Queries
                         _ = query.ToList();
                     }
                 });
-                Assert.Equal("result of an Include can only be assigned to the discard symbol (_)", error.Message);
+                Assert.Equal("The result of an Include can only be assigned to the discard symbol (_)", error.Message);
             }
         }
 
@@ -782,7 +782,6 @@ namespace SlowTests.Client.Queries
         {
             using (var session = store.OpenSession())
             {
-
                 session.Store(new Address { CountryState = "states/1#zip07", City = "new-york", StateId = "states/1",
                     Company = "Companies/Raven"});
                 session.Store(new Address { CountryState = "states/2#zip05", City = "haifa", StateId = "states/2",

--- a/test/SlowTests/Client/Queries/RavenDB_14541.cs
+++ b/test/SlowTests/Client/Queries/RavenDB_14541.cs
@@ -19,7 +19,7 @@ namespace SlowTests.Client.Queries
         }
 
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Indexes)]
-        public void RavenQueryIncludeTest1()
+        public void IncludeWithSingleSplitTest()
         {
             using (var store = GetDocumentStore())
             {
@@ -52,7 +52,7 @@ namespace SlowTests.Client.Queries
         }
 
 
-        public void RavenQueryIncludeTest2()
+        public void IncludeWithLet()
         {
             using (var store = GetDocumentStore())
             {
@@ -83,7 +83,7 @@ namespace SlowTests.Client.Queries
         }
 
 
-        public void RavenQueryIncludeTest3()
+        public void IncludeWithSinglePropertyAndLet()
         {
             using (var store = GetDocumentStore())
             {
@@ -114,7 +114,7 @@ namespace SlowTests.Client.Queries
 
 
 
-        public void RavenQueryIncludeTest4()
+        public void MultipleIncludesInsideSelect()
         {
             using (var store = GetDocumentStore())
             {
@@ -147,7 +147,7 @@ namespace SlowTests.Client.Queries
         }
 
 
-        public void RavenQueryIncludeTest5()
+        public void IncludeWithInvalidName()
         {
             using (var store = GetDocumentStore())
             {
@@ -164,7 +164,7 @@ namespace SlowTests.Client.Queries
                         });
 
                     var error = Assert.Throws<InvalidOperationException>(() => query5.ToList());
-                    Assert.Equal("Include variable can only be named by discard('_') character", error.Message);
+                    Assert.Equal("The include variable can only be assigned to the discard character (_)", error.Message);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14541/Add-RavenQuery.Include

### Additional description

An extension to the existing document include functionality in RavenDB. Unlike the previous LINQ .Include() method, RavenQuery.Include allows for more complex operations, such as handling split keys with functions like .Split(). This makes it possible to efficiently include related documents based on parsed segments of document identifiers.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
