### PR TITLE
RavenDB-23100 - better way of handling the deletion of leftovers when the batch is stopped

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -36,6 +36,8 @@ namespace Raven.Server.Documents.Indexes.Static
         /// [collection: [key: [referenceKeys]]]
         public Dictionary<string, Dictionary<Slice, HashSet<Slice>>> ReferencesByCollectionForCompareExchange;
 
+        public List<Slice> ReferencesToDelete;
+
         public MismatchedReferencesWarningHandler MismatchedReferencesWarningHandler;
 
         [ThreadStatic]

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -172,7 +172,7 @@ namespace Raven.Server.Documents.Indexes.Workers
 
                         while (keepRunning)
                         {
-                            UpdateReferences(indexContext, collection);
+                            UpdateReferences(collection, queryContext, indexContext);
 
                             var hasChanges = false;
                             earlyExit = false;
@@ -325,6 +325,8 @@ namespace Raven.Server.Documents.Indexes.Workers
                             }
                         }
 
+                        DeleteReferences(collection, queryContext.Documents, indexContext);
+
                         if (lastReferenceEtag == lastEtag)
                         {
                             // the last referenced etag hasn't changed
@@ -363,7 +365,7 @@ namespace Raven.Server.Documents.Indexes.Workers
             return (moreWorkFound, batchContinuationResult);
         }
 
-        private void UpdateReferences(TransactionOperationContext indexContext, string collection)
+        private void UpdateReferences(string collection, QueryOperationContext queryContext, TransactionOperationContext indexContext)
         {
             // References were found during handling references
             // (HandleReferences is the first worker that is running so those references were found here).
@@ -384,13 +386,27 @@ namespace Raven.Server.Documents.Indexes.Workers
                 _indexStorage.ReferencesForCompareExchange.WriteReferencesForSingleCollection(collection, values, indexContext.Transaction);
                 values.Clear();
             }
+
+            DeleteReferences(collection, queryContext.Documents, indexContext);
+        }
+
+        private void DeleteReferences(string collection, DocumentsOperationContext databaseContext, TransactionOperationContext indexContext)
+        {
+            if (CurrentIndexingScope.Current.ReferencesToDelete == null)
+                return;
+
+            foreach (var keyToRemove in CurrentIndexingScope.Current.ReferencesToDelete)
+            {
+                _referencesStorage.RemoveReferences(keyToRemove, collection, null, indexContext.Transaction);
+                keyToRemove.Release(databaseContext.Allocator);
+            }
+
+            CurrentIndexingScope.Current.ReferencesToDelete.Clear();
         }
 
         private IEnumerable<IndexItem> GetItemsFromCollectionThatReference(QueryOperationContext queryContext, TransactionOperationContext indexContext,
             string collection, Reference referencedItem, long lastIndexedEtag, HashSet<string> indexed, ReferencesState.ReferenceState referenceState)
         {
-            List<Slice> keysToRemove = null;
-
             var lastProcessedItemId = referenceState?.GetLastProcessedItemId(referencedItem);
             foreach (var key in _referencesStorage.GetItemKeysFromCollectionThatReference(collection, referencedItem.Key, indexContext.Transaction, lastProcessedItemId))
             {
@@ -400,8 +416,8 @@ namespace Raven.Server.Documents.Indexes.Workers
                     if (_index.SourceType == IndexSourceType.Documents)
                     {
                         // the document doesn't exist, we need to clean up any leftovers
-                        keysToRemove ??= new List<Slice>();
-                        keysToRemove.Add(key.Clone(queryContext.Documents.Allocator));
+                        CurrentIndexingScope.Current.ReferencesToDelete ??= new List<Slice>();
+                        CurrentIndexingScope.Current.ReferencesToDelete.Add(key.Clone(queryContext.Documents.Allocator));
                     }
                     continue;
                 }
@@ -426,15 +442,6 @@ namespace Raven.Server.Documents.Indexes.Workers
                 }
 
                 yield return item;
-
-                if (keysToRemove != null)
-                {
-                    foreach (var keyToRemove in keysToRemove)
-                    {
-                        _referencesStorage.RemoveReferences(keyToRemove, collection, null, indexContext.Transaction);
-                        keyToRemove.Release(queryContext.Documents.Allocator);
-                    }
-                }
 
                 void DisposeItem()
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23100

### Additional description

Delete the leftovers when the batch is stopped.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
