### PR TITLE
RavenDB-21326 - Switch between decrementing _lowLevelTransaction.DecompressedBufferBytes and Allocator.Release on Transaction.ForgetAbout

### DIFF
--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -714,8 +714,8 @@ namespace Voron.Impl
 
             if (_cachedDecompressedBuffersByStorageId.Remove(storageId, out var t))
             {
-                Allocator.Release(ref t);
                 _lowLevelTransaction.DecompressedBufferBytes -= t.Length;
+                Allocator.Release(ref t);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21326/Automatic-revision-bin-cleaning

### Additional description

Switch between decrementing _lowLevelTransaction.DecompressedBufferBytes and Allocator.Release on Transaction.ForgetAbout
Requested In here: https://github.com/ravendb/ravendb/pull/19355#discussion_r1846025645

`t.Length` is 0 after `Allocator.Release(ref t);` so we decrement `_lowLevelTransaction.DecompressedBufferBytes` by 0 instead of the actual `t.Length`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
