### PR TITLE
RavenDB-23158 Cache the table instances (and the associated new page …

### DIFF
--- a/src/Raven.Server/Documents/CountersStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/CountersStorage.Sharding.cs
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents
 
         public IEnumerable<CounterTombstoneDetail> GetCounterTombstonesByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
         {
-            var table = context.CountersTable(this);
+            var table = context.CountersTombstonesTable(this);
 
             foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, CounterTombstonesSchema.DynamicKeyIndexes[CounterTombstonesBucketAndEtagSlice], bucket, etag))
             {

--- a/src/Raven.Server/Documents/CountersStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/CountersStorage.Sharding.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Documents
     {
         public IEnumerable<ReplicationBatchItem> GetCountersByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
         {
-            var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
+            var table = context.CountersTable(this);
 
             foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, CountersSchema.DynamicKeyIndexes[CountersBucketAndEtagSlice], bucket, etag))
             {
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents
 
         public IEnumerable<CounterTombstoneDetail> GetCounterTombstonesByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
         {
-            var table = new Table(CounterTombstonesSchema, context.Transaction.InnerTransaction);
+            var table = context.CountersTable(this);
 
             foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, CounterTombstonesSchema.DynamicKeyIndexes[CounterTombstonesBucketAndEtagSlice], bucket, etag))
             {

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -1873,7 +1873,7 @@ namespace Raven.Server.Documents
 
         public IEnumerable<CounterTombstoneDetail> GetCounterTombstonesFrom(DocumentsOperationContext context, long etag, long toEtag = long.MaxValue)
         {
-            var table = context.CountersTable(this);
+            var table = context.CountersTombstonesTable(this);
 
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(CounterTombstonesSchema.FixedSizeIndexes[AllCounterTombstonesEtagSlice], etag, 0))

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -110,7 +110,7 @@ namespace Raven.Server.Documents
 
         public IEnumerable<ReplicationBatchItem> GetCountersFrom(DocumentsOperationContext context, long etag, bool caseInsensitiveNames = true)
         {
-            var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
+            var table = context.CountersTable(this);
 
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(CountersSchema.FixedSizeIndexes[AllCountersEtagSlice], etag, 0))
@@ -167,7 +167,7 @@ namespace Raven.Server.Documents
 
         public IEnumerable<CounterGroupDetail> GetCountersFrom(DocumentsOperationContext context, long etag, long skip, long take)
         {
-            var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
+            var table = context.CountersTable(this);
 
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(CountersSchema.FixedSizeIndexes[AllCountersEtagSlice], etag, skip))
@@ -1443,7 +1443,7 @@ namespace Raven.Server.Documents
 
         public IEnumerable<string> GetCountersForDocument(DocumentsOperationContext context, string docId)
         {
-            var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
+            var table = context.CountersTable(this);
 
             foreach (string c in GetCountersForDocumentInternal(context, docId, table))
                 yield return c;
@@ -1453,7 +1453,7 @@ namespace Raven.Server.Documents
         {
             // for testing purposes only
             // get the number of counters without skipping the deleted counters
-            var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
+            var table = context.CountersTable(this);
 
             var countersCount = 0L;
             using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice key, separator: SpecialChars.RecordSeparator))
@@ -1549,7 +1549,7 @@ namespace Raven.Server.Documents
         {
             blob = null;
             etag = -1;
-            var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
+            var table = context.CountersTable(this);
 
             using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice documentIdPrefix, separator: SpecialChars.RecordSeparator))
             using (DocumentIdWorker.GetLower(context.Allocator, counterName, out Slice counterNameSlice))
@@ -1586,7 +1586,7 @@ namespace Raven.Server.Documents
             if (string.IsNullOrEmpty(counterName))
                 yield break;
 
-            var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
+            var table = context.CountersTable(this);
 
             using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice documentIdPrefix, separator: SpecialChars.RecordSeparator))
             using (DocumentIdWorker.GetLower(context.Allocator, counterName, out Slice counterNameSlice))
@@ -1661,7 +1661,7 @@ namespace Raven.Server.Documents
 
         internal IEnumerable<CounterGroupDetail> GetCounterValuesForDocument(DocumentsOperationContext context, string docId)
         {
-            var table = new Table(CountersSchema, context.Transaction.InnerTransaction);
+            var table = context.CountersTable(this);
 
             using (DocumentIdWorker.GetSliceFromId(context, docId, out Slice key, separator: SpecialChars.RecordSeparator))
             {
@@ -1873,7 +1873,7 @@ namespace Raven.Server.Documents
 
         public IEnumerable<CounterTombstoneDetail> GetCounterTombstonesFrom(DocumentsOperationContext context, long etag, long toEtag = long.MaxValue)
         {
-            var table = new Table(CounterTombstonesSchema, context.Transaction.InnerTransaction);
+            var table = context.CountersTable(this);
 
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(CounterTombstonesSchema.FixedSizeIndexes[AllCounterTombstonesEtagSlice], etag, 0))
@@ -2429,7 +2429,7 @@ namespace Raven.Server.Documents
 
             public CounterGroupItemMetadata GetCountersMetadata(DocumentsOperationContext context, long etag)
             {
-                var table = new Table(_countersStorage.CountersSchema, context.Transaction.InnerTransaction);
+                var table = context.CountersTable(_countersStorage);
                 var index = _countersStorage.CountersSchema.FixedSizeIndexes[AllCountersEtagSlice];
 
                 if (table.Read(context.Allocator, index, etag, out var tvr) == false)
@@ -2443,7 +2443,7 @@ namespace Raven.Server.Documents
 
             public CounterGroupItemMetadata GetCountersMetadata(DocumentsOperationContext context, Slice counterKeySlice)
             {
-                var table = new Table(_countersStorage.CountersSchema, context.Transaction.InnerTransaction);
+                var table = context.CountersTable(_countersStorage);
 
                 using (ExtractDocumentIdAndCounterNameFromKey(context, counterKeySlice, out var documentIdPrefix, out var loweredCounterNameSlice))
                 {
@@ -2468,7 +2468,7 @@ namespace Raven.Server.Documents
 
             public IEnumerable<CounterGroupItemMetadata> GetCountersMetadataFrom(DocumentsOperationContext context, long etag, long skip, long take)
             {
-                var table = new Table(_countersStorage.CountersSchema, context.Transaction.InnerTransaction);
+                var table = context.CountersTable(_countersStorage);
 
                 foreach (var result in table.SeekForwardFrom(_countersStorage.CountersSchema.FixedSizeIndexes[AllCountersEtagSlice], etag, skip))
                 {

--- a/src/Raven.Server/Documents/DocumentsStorage.Debug.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.Debug.cs
@@ -22,7 +22,7 @@ namespace Raven.Server.Documents
                 using (_storage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    var table = new Table(_storage.DocsSchema, context.Transaction.InnerTransaction);
+                    var table = context.DocumentsTable(_storage);
                     var index = _storage.DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice];
 
                     if (table.FindByIndex(index, etag, out var reader))

--- a/src/Raven.Server/Documents/DocumentsTransaction.cs
+++ b/src/Raven.Server/Documents/DocumentsTransaction.cs
@@ -69,6 +69,7 @@ namespace Raven.Server.Documents
         {
             BeforeCommit();
             _replaced = true;
+            _context.ResetTablesCache();
             var tx = InnerTransaction.BeginAsyncCommitAndStartNewTransaction(context.PersistentContext);
             return new DocumentsTransaction(context, tx, _changes);
         }
@@ -113,6 +114,7 @@ namespace Raven.Server.Documents
                 if (_context.Transaction != null && _context.Transaction != this)
                     ThrowInvalidTransactionUsage();
 
+                _context.ResetTablesCache();
                 _context.Transaction = null;
             }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainSourceEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainSourceEnumerator.cs
@@ -43,7 +43,7 @@ public class CoraxDocumentTrainSourceEnumerator
 
     public IEnumerable<Document> GetDocumentsForDictionaryTraining(DocumentsOperationContext context, CoraxDocumentTrainSourceState state, DocumentFields fields = DocumentFields.All)
     {
-        var table = new Table(_documentsStorage.DocsSchema, context.Transaction.InnerTransaction);
+        var table = context.DocumentsTable(_documentsStorage);
         state.InitializeState(table);
         foreach (var (key, result) in table.IterateForDictionaryTraining(_documentsStorage.DocsSchema.FixedSizeIndexes[Schemas.Documents.AllDocsEtagsSlice], state.DocumentSkip, state.CurrentKey))
         {

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.Sharding.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Documents.Revisions
     {
         public IEnumerable<Document> GetRevisionsByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
         {
-            var table = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
+            var table = context.RevisionsTable(this);
 
             foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, RevisionsSchema.DynamicKeyIndexes[RevisionsBucketAndEtagSlice], bucket, etag))
             {

--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentsStorage.cs
@@ -78,7 +78,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
 
     public IEnumerable<Document> GetDocumentsByBucketFrom(DocumentsOperationContext context, int bucket, long etag, long skip = 0, long take = long.MaxValue, DocumentFields fields = DocumentFields.All)
     {
-        var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+        var table = context.DocumentsTable(this);
 
         foreach (var result in GetItemsByBucket(context.Allocator, table, DocsSchema.DynamicKeyIndexes[AllDocsBucketAndEtagSlice], bucket, etag, skip, take))
         {
@@ -304,7 +304,7 @@ public sealed unsafe class ShardedDocumentsStorage : DocumentsStorage
 
     public IEnumerable<Tombstone> RetrieveTombstonesByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
     {
-        var table = new Table(TombstonesSchema, context.Transaction.InnerTransaction);
+        var table = context.TombstonesTable(this);
 
         foreach (var result in GetItemsByBucket(context.Allocator, table, TombstonesSchema.DynamicKeyIndexes[TombstonesBucketAndEtagSlice], bucket, etag))
         {

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
@@ -131,7 +131,7 @@ namespace Raven.Server.Documents.TimeSeries
             _context = context;
             _documentId = documentId;
             _name = name.ToLowerInvariant();
-            _table = new Table(context.DocumentDatabase.DocumentsStorage.TimeSeriesStorage.TimeSeriesSchema, context.Transaction.InnerTransaction);
+            _table = context.TimesSeriesTable(context.DocumentDatabase.DocumentsStorage.TimeSeriesStorage);
             _tag = new LazyStringValue(null, null, 0, context);
             _offset = offset;
             _token = token;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -21,7 +21,7 @@ namespace Raven.Server.Documents.TimeSeries
         private static readonly Slice TimeSeriesStatsKey;
         private static readonly Slice PolicyIndex;
         private static readonly Slice StartTimeIndex;
-        private static readonly TableSchema TimeSeriesStatsSchema = new TableSchema();
+        public static readonly TableSchema TimeSeriesStatsSchema = new TableSchema();
 
         private enum StatsColumns
         {
@@ -306,7 +306,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public (long Count, DateTime Start, DateTime End) GetStats(DocumentsOperationContext context, Slice statsKey)
         {
-            var table = new Table(TimeSeriesStatsSchema, context.Transaction.InnerTransaction);
+            var table = context.TimeSeriesStatsTable();
             if (table.ReadByKey(statsKey, out var tvr) == false)
                 return default;
 
@@ -324,7 +324,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public IEnumerable<string> GetTimeSeriesNamesForDocumentOriginalCasing(DocumentsOperationContext context, string docId)
         {
-            var table = new Table(TimeSeriesStatsSchema, context.Transaction.InnerTransaction);
+            var table = context.TimeSeriesStatsTable();
             using (DocumentIdWorker.GetSliceFromId(context, docId, out var documentKeyPrefix, SpecialChars.RecordSeparator))
             {
                 foreach (var result in table.SeekByPrimaryKeyPrefix(documentKeyPrefix, Slices.Empty, 0))
@@ -340,7 +340,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public LazyStringValue GetTimeSeriesNameOriginalCasing(DocumentsOperationContext context, Slice key)
         {
-            var table = new Table(TimeSeriesStatsSchema, context.Transaction.InnerTransaction);
+            var table = context.TimeSeriesStatsTable();
             if (table.ReadByKey(key, out var tvr) == false)
                 return null;
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.Sharding.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Documents.TimeSeries
     {
         public IEnumerable<TimeSeriesReplicationItem> GetSegmentsByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
         {
-            var table = new Table(TimeSeriesSchema, context.Transaction.InnerTransaction);
+            var table = context.TimesSeriesTable(this);
 
             foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, TimeSeriesSchema.DynamicKeyIndexes[TimeSeriesBucketAndEtagSlice], bucket, etag))
             {
@@ -25,7 +25,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public IEnumerable<TimeSeriesDeletedRangeItem> GetDeletedRangesByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
         {
-            var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
+            var table = context.DeleteRangesTable(this);
 
             foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, DeleteRangesSchema.DynamicKeyIndexes[DeletedRangesBucketAndEtagSlice], bucket, etag))
             {

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -2342,7 +2342,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public IEnumerable<TimeSeriesReplicationItem> GetSegmentsFrom(DocumentsOperationContext context, long etag)
         {
-            var table = new Table(TimeSeriesSchema, context.Transaction.InnerTransaction);
+            var table =  context.TimesSeriesTable(this);
 
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(TimeSeriesSchema.FixedSizeIndexes[AllTimeSeriesEtagSlice], etag, 0))
@@ -2394,7 +2394,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public IEnumerable<TimeSeriesDeletedRangeItem> GetDeletedRangesFrom(DocumentsOperationContext context, long etag)
         {
-            var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
+            var table = context.DeleteRangesTable(this);
 
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(DeleteRangesSchema.FixedSizeIndexes[AllDeletedRangesEtagSlice], etag, 0))
@@ -2421,7 +2421,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public IEnumerable<TimeSeriesDeletedRangeItem> GetDeletedRangesForDoc(DocumentsOperationContext context, string docId)
         {
-            var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
+            var table = context.DeleteRangesTable(this);
             using var dispose = DocumentIdWorker.GetSliceFromId(context, docId, out var documentKeyPrefix, SpecialChars.RecordSeparator);
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach ((_, Table.TableValueHolder tvh) in table.SeekByPrimaryKeyPrefix(documentKeyPrefix, Slices.Empty, 0))
@@ -2461,7 +2461,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public TimeSeriesSegmentEntry GetTimeSeries(DocumentsOperationContext context, Slice key, TimeSeriesSegmentEntryFields fields = TimeSeriesSegmentEntryFields.All)
         {
-            var table = new Table(TimeSeriesSchema, context.Transaction.InnerTransaction);
+            var table =  context.TimesSeriesTable(this);
 
             if (table.ReadByKey(key, out var reader) == false)
                 return null;
@@ -2471,7 +2471,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public TimeSeriesSegmentEntry GetTimeSeries(DocumentsOperationContext context, long etag, TimeSeriesSegmentEntryFields fields = TimeSeriesSegmentEntryFields.All)
         {
-            var table = new Table(TimeSeriesSchema, context.Transaction.InnerTransaction);
+            var table = context.TimesSeriesTable(this);
             var index = TimeSeriesSchema.FixedSizeIndexes[AllTimeSeriesEtagSlice];
 
             if (table.Read(context.Allocator, index, etag, out var tvr) == false)
@@ -2482,7 +2482,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public TimeSeriesDeletedRangeEntry GetTimeSeriesDeletedRange(DocumentsOperationContext context, long etag)
         {
-            var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
+            var table = context.DeleteRangesTable(this);
             var index = DeleteRangesSchema.FixedSizeIndexes[AllDeletedRangesEtagSlice];
 
             if (table.Read(context.Allocator, index, etag, out var tvr) == false)
@@ -2512,7 +2512,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         private IEnumerable<TimeSeriesSegmentEntry> GetTimeSeries(DocumentsOperationContext context, long fromEtag, long toEtag, long take = long.MaxValue, TimeSeriesSegmentEntryFields fields = TimeSeriesSegmentEntryFields.All)
         {
-            var table = new Table(TimeSeriesSchema, context.Transaction.InnerTransaction);
+            var table =  context.TimesSeriesTable(this);
 
             foreach (var result in table.SeekForwardFrom(TimeSeriesSchema.FixedSizeIndexes[AllTimeSeriesEtagSlice], fromEtag, 0))
             {
@@ -2532,7 +2532,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         private IEnumerable<TombstoneIndexItem> GetTimeSeriesDeletedRangeIndexItems(DocumentsOperationContext context, long fromEtag, long toEtag, long take = long.MaxValue)
         {
-            var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
+            var table = context.DeleteRangesTable(this);
 
             foreach (var result in table.SeekForwardFrom(DeleteRangesSchema.FixedSizeIndexes[AllDeletedRangesEtagSlice], fromEtag, 0))
             {
@@ -2841,7 +2841,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public long GetLastTimeSeriesEtag(DocumentsOperationContext context)
         {
-            var table = new Table(TimeSeriesSchema, context.Transaction.InnerTransaction);
+            var table =  context.TimesSeriesTable(this);
 
             var result = table.ReadLast(TimeSeriesSchema.FixedSizeIndexes[AllTimeSeriesEtagSlice]);
             if (result == null)
@@ -2871,7 +2871,7 @@ namespace Raven.Server.Documents.TimeSeries
 
         public long GetLastTimeSeriesDeletedRangesEtag(DocumentsOperationContext context)
         {
-            var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
+            var table = context.DeleteRangesTable(this);
 
             var result = table.ReadLast(DeleteRangesSchema.FixedSizeIndexes[AllDeletedRangesEtagSlice]);
             if (result == null)

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -399,7 +399,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 {
                     report.LastEtag = documentsStorage.ReadLastEtag(tx.InnerTransaction);
                     report.LastTombstoneEtag = DocumentsStorage.ReadLastTombstoneEtag(tx.InnerTransaction);
-                    report.NumberOfConflicts = documentsStorage.ConflictsStorage.GetNumberOfConflicts(tx.InnerTransaction);
+                    report.NumberOfConflicts = documentsStorage.ConflictsStorage.GetNumberOfConflicts(context);
                     report.NumberOfDocuments = documentsStorage.GetNumberOfDocuments(context);
                     report.DatabaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
                 }

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableFormatTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableFormatTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;


### PR DESCRIPTION
…allocator) at the context level

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23158 

### Additional description

Caching a table instance for the lifetime of a transaction instead of creating a new one each time.



### Type of change

- [x] Optimization

### How risky is the change?

- [x] Low 

### Backward compatibility
- [x] Not relevant
