### PR TITLE
RavenDB-23081: Remove redundant work.

### DIFF
--- a/src/Voron/Data/BTrees/TreeCursor.cs
+++ b/src/Voron/Data/BTrees/TreeCursor.cs
@@ -9,33 +9,11 @@ namespace Voron.Data.BTrees
 {
     public sealed class TreeCursor : IDisposable
     {
-        private sealed class TreeCursorState
-        {
-            public readonly Dictionary<long, TreePage> PageByNum;
-            public readonly FastStack<TreePage> Pages;
-            
-            public TreeCursorState(int pageCapacity, int stackCapacity)
-            {
-                PageByNum = new(pageCapacity);
-                Pages = new(stackCapacity);
-            }
-            
-            public void Clear()
-            {
-                PageByNum.Clear();
-                Pages.Clear();
-            }
-        }
-        
-        private static readonly ObjectPool<TreeCursorState> _pagesByNumPool = new ObjectPool<TreeCursorState>(() => new TreeCursorState(50, 16));
-        private bool _anyOverrides;
-        private readonly TreeCursorState _state;
-        public FastStack<TreePage> Pages => _state.Pages;
+        private static readonly ObjectPool<FastStack<TreePage>> _treePageStackPool = new(() => new FastStack<TreePage>(16));
 
-        public TreeCursor()
-        {
-            _state = _pagesByNumPool.Allocate();
-        }
+        public readonly FastStack<TreePage> _statePages = _treePageStackPool.Allocate();
+
+        public FastStack<TreePage> Pages => _statePages;
 
         public void Dispose()
         {
@@ -46,78 +24,45 @@ namespace Voron.Data.BTrees
         // The bulk of the clean-up code is implemented in Dispose(bool)
         private void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                _state.Clear();
-                _pagesByNumPool.Free(_state);
-            }
+            if (disposing == false) 
+                return;
+
+            _statePages.WeakClear();
+            _treePageStackPool.Free(_statePages);
         }
 
         public void Update(FastStack<TreePage> stack, TreePage newVal)
         {
-            var oldNode = stack.Pop();
-            stack.Push(newVal);
-
-            var oldPageNumber = oldNode.PageNumber;
-            var newPageNumber = newVal.PageNumber;
-
-            if (oldPageNumber == newPageNumber)
-            {
-                _state.PageByNum[oldPageNumber] = newVal;
-                return;
-            }
-
-            _anyOverrides = true;
-            _state.PageByNum[oldPageNumber] = newVal;
-            _state.PageByNum.Add(newPageNumber, newVal);
+            ref var treePage = ref stack.TopByRef();
+            treePage = newVal;
         }
 
         public TreePage ParentPage
         {
             get
             {
-                TreePage result;
-                if (_state.Pages.TryPeek(2, out result))
+                if (_statePages.TryPeek(2, out TreePage result))
                     return result;
 
                 throw new InvalidOperationException("No parent page in cursor");
             }
         }
 
-        public TreePage CurrentPage => _state.Pages.Peek();
+        public TreePage CurrentPage => _statePages.Peek();
 
-        public int PageCount => _state.Pages.Count;
+        public int PageCount => _statePages.Count;
 
         public void Push(TreePage p)
         {
-            _state.Pages.Push(p);
-            _state.PageByNum.Add(p.PageNumber, p);
+            _statePages.Push(p);
         }
 
         public TreePage Pop()
         {
-            if (_state.Pages.Count == 0)
+            if (_statePages.Count == 0)
                 throw new InvalidOperationException("No page to pop");
 
-            var p = _state.Pages.Pop();
-
-            var removedPrimary = _state.PageByNum.Remove(p.PageNumber);
-            var removedSecondary = false;
-
-            if (_anyOverrides)
-            {
-                var pagesNumbersToRemove = new HashSet<long>();
-
-                foreach (var page in _state.PageByNum.Where(page => page.Value.PageNumber == p.PageNumber))
-                    pagesNumbersToRemove.Add(page.Key);
-
-                foreach (var pageToRemove in pagesNumbersToRemove)
-                    removedSecondary |= _state.PageByNum.Remove(pageToRemove);
-            }
-
-            Debug.Assert(removedPrimary || removedSecondary);
-
-            return p;
+            return _statePages.Pop();
         }
     }
 }

--- a/src/Voron/Data/CompactTrees/CompactKey.cs
+++ b/src/Voron/Data/CompactTrees/CompactKey.cs
@@ -1,14 +1,10 @@
 using System;
-using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 using System.Text;
 using Sparrow;
 using Sparrow.Binary;
-using Sparrow.Json;
-using Sparrow.Server;
 using Voron.Exceptions;
 using Voron.Global;
 using Voron.Impl;
@@ -22,22 +18,17 @@ public sealed unsafe class CompactKey : IDisposable
 {
     public static readonly CompactKey NullInstance = new();
 
-    [ThreadStatic]
-    private static ArrayPool<byte> StoragePool;
-    [ThreadStatic]
-    private static ArrayPool<long> KeyMappingPool;
-
     private LowLevelTransaction _owner;
 
     private const int MappingTableSize = 64;
     private const int MappingTableMask = MappingTableSize - 1;
 
-    private long[] _keyMappingCache;
+    private readonly long[] _keyMappingCache = new long[2 * MappingTableMask];
     private ref long KeyMappingCache(int i) => ref _keyMappingCache[i];
     private ref long KeyMappingCacheIndex(int i) => ref _keyMappingCache[MappingTableSize + i];
 
 
-    private byte[] _storage;
+    private byte[] _storage = new byte[2 * Constants.CompactTree.MaximumKeySize];
 
     // The storage data will be used in an arena fashion. If there is no enough, we just create a bigger one and
     // copy the content back. 
@@ -57,6 +48,7 @@ public sealed unsafe class CompactKey : IDisposable
 
     private const int Invalid = -1;
 
+
     public void Initialize(LowLevelTransaction tx)
     {
         _owner = tx;
@@ -68,20 +60,10 @@ public sealed unsafe class CompactKey : IDisposable
 
         _currentIdx = 0;
         MaxLength = 0;
-
-        StoragePool ??= ArrayPool<byte>.Create();
-        KeyMappingPool ??= ArrayPool<long>.Create();
-
-        _storage ??= StoragePool.Rent(2 * Constants.CompactTree.MaximumKeySize);
-        _keyMappingCache ??= KeyMappingPool.Rent(2 * MappingTableMask);
     }
 
     public void Reset()
     {
-        PortableExceptions.ThrowIf<InvalidOperationException>(
-            _storage is null || _keyMappingCache is null, 
-            "The key has not been initialized before calling reset.");
-
         _owner = null;
     }
 
@@ -224,12 +206,11 @@ public sealed unsafe class CompactKey : IDisposable
 
         // Request more memory, copy the content and return it.
         maxSize = Math.Max(maxSize, oldStorage.Length) * 2;
-
-        var storage = StoragePool.Rent(maxSize);
+        var storage = new byte[maxSize];
         _storage.AsSpan(0, _currentIdx).CopyTo(storage.AsSpan());
-        
-        StoragePool.Return(_storage); // Return old to pool.
-        _storage = storage; // Update the new references.
+
+        // Update the new references.
+        _storage = storage; 
     }
 
     public void Set(ReadOnlySpan<byte> key)
@@ -401,18 +382,6 @@ public sealed unsafe class CompactKey : IDisposable
     
     public void Dispose()
     {
-        if (_storage is not null)
-        {
-            StoragePool.Return(_storage);
-            _storage = null;
-        }
-
-        if (_keyMappingCache is not null)
-        {
-            KeyMappingPool.Return(_keyMappingCache);
-            _keyMappingCache = null;
-        }
-
         _owner = null;
     }
 

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -70,11 +70,15 @@ namespace Voron.Impl
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void EnsureTrees()
+        private bool EnsureTrees()
         {
             if (_trees != null)
-                return;
-            _trees = new Dictionary<Slice, Tree>(SliceStructComparer.Instance);
+                return false;
+
+            // PERF: By initializing with 11, we are trying to avoid resizes which are expensive and since
+            // most transactions will always use more than 2 items, the probability of resize is too big. 
+            _trees = new Dictionary<Slice, Tree>(11, SliceStructComparer.Instance);
+            return true;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -86,17 +90,9 @@ namespace Voron.Impl
 
         public Tree ReadTree(Slice treeName, RootObjectType type = RootObjectType.VariableSizeTree, bool isIndexTree = false, NewPageAllocator newPageAllocator = null)
         {
-            EnsureTrees();
-
-            if (_trees.TryGetValue(treeName, out var tree))
+            if(EnsureTrees() == false && _trees.TryGetValue(treeName, out var tree))
             {
-                if (tree == null)
-                    return null;
-
-                if (newPageAllocator == null)
-                    return tree;
-
-                if (tree.HasNewPageAllocator == false)
+                if (newPageAllocator != null && tree?.HasNewPageAllocator == false)
                     tree.SetNewPageAllocator(newPageAllocator);
 
                 return tree;
@@ -110,7 +106,6 @@ namespace Voron.Impl
                 tree = Tree.Open(_lowLevelTransaction, this, treeName, *header, isIndexTree, newPageAllocator);
 
                 _trees.Add(treeName, tree);
-
                 return tree;
             }
 
@@ -367,15 +362,14 @@ namespace Voron.Impl
 
         internal void AddTree(Slice name, Tree tree)
         {
-            EnsureTrees();
-
-            if (_trees.TryGetValue(name, out Tree value) && value != null)
+            // Either we haven't added this tree, or we added it as null (meaning it didn't exist)
+            if (EnsureTrees() || _trees.TryGetValue(name, out Tree value) == false || value == null)
             {
-                throw new InvalidOperationException("Tree already exists: " + name);
+                _trees[name] = tree;
+                return;
             }
 
-            // Either we haven't added this tree, or we added it as null (meaning it didn't exist)
-            _trees[name] = tree;
+            throw new InvalidOperationException("Tree already exists: " + name);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -489,7 +483,6 @@ namespace Voron.Impl
             AddTree(toName, fromTree);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public Tree CreateTree(string name, RootObjectType type = RootObjectType.VariableSizeTree, TreeFlags flags = TreeFlags.None, bool isIndexTree = false, NewPageAllocator newPageAllocator = null)
         {
             Slice.From(Allocator, name, ByteStringType.Immutable, out var treeNameSlice);


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23081

### Additional description

Redundant Voron code harms more Corax than Lucene. Improvements to it will impact both but it would provide more improvements to Corax.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
