### PR TITLE
RavenDB-23072 Limit cluster transaction database command batch by space size

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -541,7 +541,7 @@ namespace Raven.Server.Documents
         {
             var batch = new List<ClusterTransactionCommand.SingleClusterDatabaseCommand>(
                 ClusterTransactionCommand.ReadCommandsBatch(context, Name, fromCount: _nextClusterCommand, 
-                    lastCompletedClusterTransactionIndex: ClusterWideTransactionIndexWaiter.LastIndex, take: batchSize));
+                    lastCompletedClusterTransactionIndex: ClusterWideTransactionIndexWaiter.LastIndex, take: batchSize, maxBytesToRead: _maxTransactionSize.GetValue(SizeUnit.Bytes)));
             
             ServerStore.ForTestingPurposes?.BeforeExecuteClusterTransactionBatch?.Invoke(Name, batch);
 

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -22,7 +22,6 @@ using Voron;
 using Voron.Data.BTrees;
 using Voron.Data.Tables;
 using static Raven.Client.Exceptions.ClusterTransactionConcurrencyException;
-using static Sparrow.Server.Utils.ThreadNames.ThreadDetails;
 
 namespace Raven.Server.ServerWide.Commands
 {
@@ -635,16 +634,20 @@ namespace Raven.Server.ServerWide.Commands
         }
 
 
-        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long? lastCompletedClusterTransactionIndex = null, long take = 128)
+        public static IEnumerable<SingleClusterDatabaseCommand> ReadCommandsBatch<TTransaction>(TransactionOperationContext<TTransaction> context, string database, long? fromCount, long? lastCompletedClusterTransactionIndex = null, long take = 128, long maxBytesToRead = long.MaxValue)
             where TTransaction : RavenTransaction
         {
             var lowerDb = database.ToLowerInvariant();
             var items = context.Transaction.InnerTransaction.OpenTable(ClusterStateMachine.TransactionCommandsSchema, ClusterStateMachine.TransactionCommands);
             using (GetPrefix(context, database, out Slice prefixSlice, fromCount))
             {
+                var readSize = 0;
                 var commandsBulk = items.SeekByPrimaryKey(prefixSlice, 0);
                 foreach (var command in commandsBulk)
                 {
+                    if (take <= 0)
+                        yield break;
+
                     var reader = command.Reader;
                     var result = ReadCommand(context, reader);
                     if (result == null)
@@ -669,11 +672,12 @@ namespace Raven.Server.ServerWide.Commands
                         continue;
                     }
 
-                    if (take <= 0)
-                        yield break;
-
                     take--;
                     yield return result;
+
+                    readSize += reader.Size;
+                    if(readSize > maxBytesToRead)
+                        yield break;
                 }
             }
         }

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -29,8 +29,8 @@ using Raven.Server.Documents;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
-using Raven.Server.ServerWide.Maintenance;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -2106,6 +2106,48 @@ select incl(c)"
                     _ = await session.LoadAsync<User>(id);
                     Assert.Equal(0, ((ClusterTransactionOperationsBase)session.Advanced.ClusterTransaction).NumberOfTrackedCompareExchangeValues);
                 }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task ClusterWideTrx_WhenExecutedBatchExceedsSpaceLimit_ShouldStoreAllDocumentsSuccessfully(Options options)
+        {
+            int count = 256;
+
+            using var store = GetDocumentStore(options);
+
+            var database = await GetDatabase(store.Database);
+            var guidSize = Guid.NewGuid().ToString().Length;
+            var value = (int)(2*database._maxTransactionSize.GetValue(SizeUnit.Bytes)/guidSize/count); //To ensure that the total size of the batch exceeds the space limit for cluster transactions.
+
+            var manualResetEvent = new ManualResetEvent(false);
+            var handCommandTask = database.TxMerger.Enqueue(new TestCommand(manualResetEvent, TimeSpan.FromSeconds(15)));
+            var tasks = Task.WhenAll(Enumerable.Range(0, count).Select(async i =>
+            {
+                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                {
+                    await session.StoreAsync(new TestObj { Prop = string.Join("", Enumerable.Range(0, value).Select(_ => Guid.NewGuid().ToString())) }, $"TestObjs/{i}");
+                    await session.SaveChangesAsync();
+                }
+            }));
+
+            using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+            {
+                await AssertWaitForTrueAsync(() =>
+                {
+                    using (context.OpenReadTransaction())
+                        return Task.FromResult(count <= ClusterTransactionCommand.ReadCommandsBatch(context, store.Database, 0, take:long.MaxValue).Count());
+                });
+            }
+
+            manualResetEvent.Set();
+            await handCommandTask;
+            await tasks;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                Assert.Equal(count, await session.Query<TestObj>().CountAsync());
             }
         }
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23072

### Additional description
We have a configurable limit on cluster-wide transactions based on the number of commands. 
However, a small number of commands can still consume a large amount of space, even if the number does not exceed the limit. 
This PR adds a check for the batch's space size to prevent batches from becoming too large.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
