### PR TITLE
RavenDB-23183 - Ensure the cached items are cleared before returning the array to the ArrayPool

### DIFF
--- a/test/StressTests/Client/MultiGet.cs
+++ b/test/StressTests/Client/MultiGet.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Client
+{
+    public class MultiGet : RavenTestBase
+    {
+        public MultiGet(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task MultiGetCanGetFromCache()
+        {
+            var store = GetDocumentStore();
+
+            using (var bulk = store.BulkInsert())
+            {
+                for (var i = 0; i < 10_000; i++)
+                {
+                    await bulk.StoreAsync(new User { Id = $"Users/{i}", Count = i });
+                }
+            }
+
+            async Task Fetch()
+            {
+                for (var i = 0; i < 64; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var n1 = Random.Shared.Next(0, 10_000);
+                        var n2 = Random.Shared.Next(0, 10_000);
+                        session.Advanced.Lazily.LoadAsync<User>($"Users/{n1}");
+                        session.Advanced.Lazily.LoadAsync<User>($"Users/{n2}");
+                        await session.Advanced.Eagerly.ExecuteAllPendingLazyOperationsAsync();
+
+                        var loaded1 = await session.LoadAsync<User>($"Users/{n1}");
+                        Assert.Equal(n1, loaded1.Count);
+
+                        var loaded2 = await session.LoadAsync<User>($"Users/{n2}");
+                        Assert.Equal(n2, loaded2.Count);
+                    }
+                }
+            }
+
+            var tasks = new List<Task>();
+            for (var i = 0; i < 100; i++)
+            {
+                tasks.Add(Task.Run(Fetch));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23183/Errors-when-using-MultiGet

### Additional description

The change fixes a problem where arrays from the pool weren’t cleared before being returned. Without clearing, leftover items could cause issues if reused, like accidentally disposing the same cached item twice. It also prevents a potential memory leak where the array pool could hold references to Blittable objects that were already disposed, stopping the garbage collector from cleaning them up. By clearing the arrays, the new code ensures everything is reset, making it safe for future use and avoiding these issues.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
