### PR TITLE
RavenDB-22979 avoid creating a new Guid for each stream, we are not using those internal Ids for tracking

### DIFF
--- a/src/Sparrow/RecyclableMemoryStreamFactory.cs
+++ b/src/Sparrow/RecyclableMemoryStreamFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Microsoft.IO;
 using Sparrow.Global;
 
@@ -20,12 +21,12 @@ internal class RecyclableMemoryStreamFactory
 
     public static RecyclableMemoryStream GetRecyclableStream()
     {
-        return Manager.GetStream();
+        return Manager.GetStream(Guid.Empty);
     }
 
     public static RecyclableMemoryStream GetRecyclableStream(long requiredSize)
     {
-        return Manager.GetStream(null, requiredSize);
+        return Manager.GetStream(Guid.Empty, null, requiredSize);
     }
 
     public static MemoryStream GetMemoryStream()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22979

### Additional description

If we will not pass any ID, internally Guid.NewGuid is called, it is not a necessary call for us, so we are avoiding it

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
