### PR TITLE
RavenDB-22363 Test fix: there is a chance of race condition between finishing replacement (pausing and rerunning the index) and receiving information from the database record during `WaitForIndexing`.

### DIFF
--- a/test/SlowTests/Issues/RavenDB_22363.cs
+++ b/test/SlowTests/Issues/RavenDB_22363.cs
@@ -1,4 +1,4 @@
-﻿ using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -250,8 +250,8 @@ public class RavenDB_22363 : RavenTestBase
         Indexes.WaitForIndexing(store);
         new IndexUpdate().Execute(store);
         Indexes.WaitForIndexing(store);
-        var status = store.Maintenance.Send(new GetIndexingStatusOperation());
-        Assert.Equal(IndexRunningStatus.Running, status.Indexes[0].Status);
+        var status = WaitForValue(() => store.Maintenance.Send(new GetIndexingStatusOperation()).Indexes[0].Status, IndexRunningStatus.Running);
+        Assert.Equal(IndexRunningStatus.Running, status);
     }
 
     private class Product


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22363

### Additional description

There is a chance that the index is non-stale, but during the replacement mechanism, we haven't finished starting the index:

https://github.com/ravendb/ravendb/blob/0180f2d4da33a9cfbbf372834efe6c057d1e667e/src/Raven.Server/Documents/Indexes/IndexStore.cs#L2022-L2048

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
