### PR TITLE
RavenDB-23089 Testfix: wait for the error to be persisted before reading it in the test.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-22369.cs
+++ b/test/SlowTests/Issues/RavenDB-22369.cs
@@ -30,10 +30,16 @@ public class RavenDB_22369 : RavenTestBase
         var index = new TIndex();
         index.Execute(store);
         Indexes.WaitForIndexing(store, allowErrors: true);
+        WaitForValue(ErrorExist, true);
         var indexErrors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] {index.IndexName}));
-        Assert.NotEmpty(indexErrors);
         Assert.Contains($"Your spatial field 'Location' has 'Indexing' set to 'No'. Spatial fields cannot be stored, so this field is useless because it cannot be searched or retrieved.",
             indexErrors[0].Errors[0].ToString());
+
+        bool ErrorExist()
+        {
+            var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { index.IndexName }));
+            return errors != null && errors.Length > 0 && errors[0].Errors != null && errors[0].Errors.Length > 0;
+        }
     }
 
     [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Corax)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23089 

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
