### PR TITLE
RavenDB-20951 Fix cluster dashboard nodes container

### DIFF
--- a/src/Raven.Studio/typescript/models/resources/widgets/gcInfo.ts
+++ b/src/Raven.Studio/typescript/models/resources/widgets/gcInfo.ts
@@ -33,7 +33,7 @@ class gcInfo extends historyAwareNodeStats<GcInfoNormalizedData> {
         const fragmentationLoh = this.lohFragmentationFormatted();
         const fragmentationPoh = this.pinnedFragmentationFormatted();
         
-        return `<div>
+        return `<div class="padding-xs">
                     <h3 class="text-center">Heap Fragmentation</h3>
                     <div class="details-item gen-0">
                         <div class="details-item-name">Gen0 <span class="rect"></span></div>

--- a/src/Raven.Studio/wwwroot/App/views/resources/widgets/gcInfoWidget.html
+++ b/src/Raven.Studio/wwwroot/App/views/resources/widgets/gcInfoWidget.html
@@ -31,19 +31,19 @@
                         </div>
 
                         <div class="details-list">
-                            <div class="details-item">
+                            <div class="details-item flex-row align-items-center">
                                 <div class="details-item-name">GC Kind</div>
                                 <div class="details-item-value" data-bind="text: type"></div>
                             </div>
-                            <div class="details-item">
+                            <div class="details-item flex-row align-items-center">
                                 <div class="details-item-name">Concurrent</div>
                                 <div class="details-item-value" data-bind="text: concurrent"></div>
                             </div>
-                            <div class="details-item">
+                            <div class="details-item flex-row align-items-center">
                                 <div class="details-item-name">Compacted</div>
                                 <div class="details-item-value" data-bind="text: compacted"></div>
                             </div>
-                            <div class="details-item">
+                            <div class="details-item flex-row align-items-center">
                                 <div class="details-item-name">Generation</div>
                                 <div class="details-item-value" data-bind="text: generation"></div>
                             </div>
@@ -54,31 +54,31 @@
                                 <span data-bind="visible: $index() === 0">Generations (before GC → after GC)</span>
                             </h4>
                             <div data-toggle="tooltip" data-html="true" data-animation="true" data-placement="bottom" data-bind="tooltipText: fragmentationInfo">
-                                <div class="details-item gen-0">
+                                <div class="details-item flex-row align-items-center gen-0">
                                     <div class="details-item-name" data-bind="visible: $index() === $parent.nodeStats().length - 1">
                                         Gen0 <span class="rect"></span>
                                     </div>
                                     <div class="details-item-value" data-bind="text: gen0Formatted"></div>
                                 </div>
-                                <div class="details-item gen-1">
+                                <div class="details-item flex-row align-items-center gen-1">
                                     <div class="details-item-name" data-bind="visible: $index() === $parent.nodeStats().length - 1">
                                         Gen1 <span class="rect"></span>
                                     </div>
                                     <div class="details-item-value" data-bind="text: gen1Formatted"></div>
                                 </div>
-                                <div class="details-item gen-2">
+                                <div class="details-item flex-row align-items-center gen-2">
                                     <div class="details-item-name" data-bind="visible: $index() === $parent.nodeStats().length - 1">
                                         Gen2 <span class="rect"></span>
                                     </div>
                                     <div class="details-item-value" data-bind="text: gen2Formatted"></div>
                                 </div>
-                                <div class="details-item loh">
+                                <div class="details-item flex-row align-items-center loh">
                                     <div class="details-item-name" title="Large object heap" data-bind="visible: $index() === $parent.nodeStats().length - 1">
                                         LOH <span class="rect"></span>
                                     </div>
                                     <div class="details-item-value" data-bind="text: lohFormatted"></div>
                                 </div>
-                                <div class="details-item pinned">
+                                <div class="details-item flex-row align-items-center pinned">
                                     <div class="details-item-name" title="Pinned object heap" data-bind="visible: $index() === $parent.nodeStats().length - 1">
                                         POH <span class="rect"></span>
                                     </div>

--- a/src/Raven.Studio/wwwroot/Content/css/pages/cluster-dashboard.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/cluster-dashboard.less
@@ -274,7 +274,7 @@
 
             .nodes-container {
                 display: grid;
-                grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+                grid-template-columns: repeat(auto-fill, minmax(20%, 1fr));
                 flex-grow: 1;
                 padding: @gutter-xxs;
                 gap: @gutter-xxs @gutter-xs;

--- a/src/Raven.Studio/wwwroot/Content/css/styles-common-scoped.less
+++ b/src/Raven.Studio/wwwroot/Content/css/styles-common-scoped.less
@@ -393,7 +393,7 @@ a {
     flex-direction: column;
 
     @media (min-width: @screen-sm) {
-        flex-direction: row;
+        flex-direction: row !important;
         flex-wrap: wrap;
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20951

### Additional description

Fixed nodes container layout - now single item will take **at least** 20% of space available in a row

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
