### PR TITLE
RavenDB-23183 - Ensure the cached items are cleared before returning the array to the ArrayPool [TESTING ONLY]

### DIFF
--- a/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
@@ -381,6 +381,8 @@ namespace Raven.Client.Documents.Commands.MultiGet
                 for (int i = 0; i < _size; i++)
                 {
                     Values[i].Release.Dispose();
+                    Values[i].Release = default;
+                    Values[i].Cached = null;
                 }
                 ArrayPool<(HttpCache.ReleaseCacheItem, BlittableJsonReaderObject)>.Shared.Return(Values);
                 Values = null;

--- a/test/StressTests/Client/MultiGet.cs
+++ b/test/StressTests/Client/MultiGet.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Tests.Core.Utils.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Client
+{
+    public class MultiGet : RavenTestBase
+    {
+        public MultiGet(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task MultiGetCanGetFromCache()
+        {
+            var store = GetDocumentStore();
+
+            using (var bulk = store.BulkInsert())
+            {
+                for (var i = 0; i < 10_000; i++)
+                {
+                    await bulk.StoreAsync(new User { Id = $"Users/{i}", Count = i });
+                }
+            }
+
+            async Task Fetch()
+            {
+                for (var i = 0; i < 64; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var n1 = Random.Shared.Next(0, 10_000);
+                        var n2 = Random.Shared.Next(0, 10_000);
+                        session.Advanced.Lazily.LoadAsync<User>($"Users/{n1}");
+                        session.Advanced.Lazily.LoadAsync<User>($"Users/{n2}");
+                        await session.Advanced.Eagerly.ExecuteAllPendingLazyOperationsAsync();
+
+                        var loaded1 = await session.LoadAsync<User>($"Users/{n1}");
+                        Assert.Equal(n1, loaded1.Count);
+
+                        var loaded2 = await session.LoadAsync<User>($"Users/{n2}");
+                        Assert.Equal(n2, loaded2.Count);
+                    }
+                }
+            }
+
+            var tasks = new List<Task>();
+            for (var i = 0; i < 100; i++)
+            {
+                tasks.Add(Task.Run(Fetch));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-...

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
