### PR TITLE
RavenDB-14963 - Add CountOfRevisions to Notifications.DatabaseStatsChanged info

### DIFF
--- a/src/Raven.Server/NotificationCenter/BackgroundWork/AbstractDatabaseStatsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/AbstractDatabaseStatsSender.cs
@@ -48,7 +48,8 @@ public abstract class AbstractDatabaseStatsSender : BackgroundWorkBase
             current.LastEtag,
             current.CountOfIndexingErrors,
             current.LastIndexingErrorTime,
-            modifiedCollections));
+            modifiedCollections,
+            current.CountOfRevisions));
 
         _latest = current;
     }

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/DatabaseStatsSender.cs
@@ -67,7 +67,8 @@ public sealed class DatabaseStatsSender : AbstractDatabaseStatsSender
                 GlobalChangeVector = DocumentsStorage.GetDatabaseChangeVector(context.Documents),
                 LastIndexingErrorTime = lastIndexingErrorTime,
                 Collections = database.DocumentsStorage.GetCollections(context.Documents)
-                    .ToDictionary(x => x.Name, x => new DatabaseStatsChanged.ModifiedCollection(x.Name, x.Count, database.DocumentsStorage.GetLastDocumentChangeVector(context.Documents.Transaction.InnerTransaction, context.Documents, x.Name)))
+                    .ToDictionary(x => x.Name, x => new DatabaseStatsChanged.ModifiedCollection(x.Name, x.Count, database.DocumentsStorage.GetLastDocumentChangeVector(context.Documents.Transaction.InnerTransaction, context.Documents, x.Name))),
+                CountOfRevisions = database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionDocuments(context.Documents)
             };
         }
     }

--- a/src/Raven.Server/NotificationCenter/BackgroundWork/NotificationCenterDatabaseStats.cs
+++ b/src/Raven.Server/NotificationCenter/BackgroundWork/NotificationCenterDatabaseStats.cs
@@ -29,6 +29,8 @@ public sealed class NotificationCenterDatabaseStats
 
     public Dictionary<string, DatabaseStatsChanged.ModifiedCollection> Collections;
 
+    public long CountOfRevisions;
+
     public bool Equals(NotificationCenterDatabaseStats other)
     {
         if (ReferenceEquals(null, other))
@@ -42,7 +44,8 @@ public sealed class NotificationCenterDatabaseStats
                LastEtag == other.LastEtag &&
                CountOfStaleIndexes == other.CountOfStaleIndexes &&
                GlobalChangeVector == other.GlobalChangeVector &&
-               DictionaryExtensions.ContentEquals(Collections, other.Collections);
+               DictionaryExtensions.ContentEquals(Collections, other.Collections) &&
+               CountOfRevisions == other.CountOfRevisions;
     }
 
     public override bool Equals(object obj)
@@ -70,6 +73,7 @@ public sealed class NotificationCenterDatabaseStats
             hashCode = (hashCode * 397) ^ CountOfStaleIndexes.GetHashCode();
             hashCode = (hashCode * 397) ^ GlobalChangeVector.GetHashCode();
             hashCode = (hashCode * 397) ^ (Collections != null ? Collections.GetHashCode() : 0);
+            hashCode = (hashCode * 397) ^ CountOfRevisions.GetHashCode();
             return hashCode;
         }
     }
@@ -77,6 +81,7 @@ public sealed class NotificationCenterDatabaseStats
     public void CombineWith(NotificationCenterDatabaseStats stats,  IChangeVectorOperationContext context)
     {
         CountOfDocuments += stats.CountOfDocuments;
+        CountOfRevisions += stats.CountOfRevisions;
         CountOfConflicts += stats.CountOfConflicts;
         
         CountOfIndexes = stats.CountOfIndexes; // every node has the same amount of indexes

--- a/src/Raven.Server/NotificationCenter/Notifications/DatabaseStatsChanged.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/DatabaseStatsChanged.cs
@@ -33,6 +33,8 @@ namespace Raven.Server.NotificationCenter.Notifications
 
         public List<ModifiedCollection> ModifiedCollections { get; private set; }
 
+        public long CountOfRevisions;
+
         public override DynamicJsonValue ToJson()
         {
             var json = base.ToJson();
@@ -46,6 +48,7 @@ namespace Raven.Server.NotificationCenter.Notifications
             json[nameof(CountOfIndexingErrors)] = CountOfIndexingErrors;
             json[nameof(LastIndexingErrorTime)] = LastIndexingErrorTime;
             json[nameof(ModifiedCollections)] = new DynamicJsonArray(ModifiedCollections.Select(x => x.ToJson()));
+            json[nameof(CountOfRevisions)] = CountOfRevisions;
 
             return json;
         }
@@ -60,7 +63,8 @@ namespace Raven.Server.NotificationCenter.Notifications
             long lastEtag,
             long countOfIndexingErrors,
             DateTime? lastIndexingErrorTime,
-            List<ModifiedCollection> modifiedCollections)
+            List<ModifiedCollection> modifiedCollections,
+            long countOfRevisions)
         {
             return new DatabaseStatsChanged(database)
             {
@@ -76,7 +80,8 @@ namespace Raven.Server.NotificationCenter.Notifications
                 CountOfIndexes = countOfIndexes,
                 CountOfStaleIndexes = countOfStaleIndexes,
                 LastIndexingErrorTime = lastIndexingErrorTime,
-                ModifiedCollections = modifiedCollections
+                ModifiedCollections = modifiedCollections,
+                CountOfRevisions = countOfRevisions
             };
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14963/All-revisions-view

### Additional description

add CountOfRevisions to Raven.Server.NotificationCenter.Notifications.DatabaseStatsChanged class, 
so it will be sent through ws ws://databases/*/notification-center/watch
For Damian request
![image](https://github.com/user-attachments/assets/66a9d017-3d40-4582-9c21-507e41115804)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
