### PR TITLE
RavenDB-23202 On node B "Open Faulty Index" button calls wrong node

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -100,8 +100,8 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
     const { value: panelCollapsed, toggle: togglePanelCollapsed } = useBoolean(true);
 
     const isReplacement = IndexUtils.isSideBySide(index);
-    const isFaulty = IndexUtils.hasAnyFaultyNode(index);
-    const faultyLocation = getFaultyLocation(index, localNodeTag);
+    const isAnyFaulty = IndexUtils.hasAnyFaultyNode(index);
+    const localFaultyNodeInfo = IndexUtils.getFaultyNodeInfo(index, localNodeTag);
 
     const eventsCollector = useEventsCollector();
 
@@ -367,7 +367,9 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                             )}
                         </ButtonGroup>
 
-                        {isFaulty && <Button onClick={() => openFaulty(faultyLocation)}>Open faulty index</Button>}
+                        {localFaultyNodeInfo && (
+                            <Button onClick={() => openFaulty(localFaultyNodeInfo.location)}>Open faulty index</Button>
+                        )}
                         {!IndexUtils.isAutoIndex(index) && (
                             <>
                                 <Button title="Export index" onClick={toggleIsExportIndexModalOpen}>
@@ -465,7 +467,7 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                             )}
                         </RichPanelDetailItem>
                     )}
-                    <RichPanelDetailItem className={isFaulty ? "text-danger" : ""}>
+                    <RichPanelDetailItem className={isAnyFaulty ? "text-danger" : ""}>
                         <Icon icon={IndexUtils.indexTypeIcon(index.type)} />
                         {IndexUtils.formatType(index.type)}
                     </RichPanelDetailItem>
@@ -475,7 +477,7 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                         {index.searchEngine}
                     </RichPanelDetailItem>
 
-                    {!isFaulty && (
+                    {!isAnyFaulty && (
                         <InlineDetails
                             index={index}
                             toggleLocationDetails={togglePanelCollapsed}
@@ -590,17 +592,4 @@ function getSideBySideResetDisabledReason(index: IndexSharedInfo) {
     }
 
     return null;
-}
-
-function getFaultyLocation(index: IndexSharedInfo, localNodeTag: string): databaseLocationSpecifier {
-    if (!IndexUtils.hasAnyFaultyNode(index)) {
-        return null;
-    }
-
-    const localFaultyInfo = index.nodesInfo.find((x) => x.details?.faulty && x.location.nodeTag === localNodeTag);
-    if (localFaultyInfo) {
-        return localFaultyInfo.location;
-    }
-
-    return index.nodesInfo.find((x) => x.details?.faulty)?.location;
 }

--- a/src/Raven.Studio/typescript/components/utils/IndexUtils.ts
+++ b/src/Raven.Studio/typescript/components/utils/IndexUtils.ts
@@ -1,6 +1,6 @@
 import assertUnreachable from "./assertUnreachable";
 import IndexLockMode = Raven.Client.Documents.Indexes.IndexLockMode;
-import { IndexNodeInfoDetails, IndexSharedInfo, IndexStatus } from "../models/indexes";
+import { IndexNodeInfo, IndexNodeInfoDetails, IndexSharedInfo, IndexStatus } from "../models/indexes";
 import collection from "models/database/documents/collection";
 import IndexRunningStatus = Raven.Client.Documents.Indexes.IndexRunningStatus;
 import IconName from "typings/server/icons";
@@ -132,6 +132,10 @@ export default class IndexUtils {
 
     static hasAnyFaultyNode(index: IndexSharedInfo) {
         return index.nodesInfo.some((x) => x.details?.faulty);
+    }
+
+    static getFaultyNodeInfo(index: IndexSharedInfo, nodeTag: string): IndexNodeInfo {
+        return index.nodesInfo.find((x) => x.details?.faulty && x.location.nodeTag === nodeTag);
     }
 
     static isErrorState(index: IndexNodeInfoDetails) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23202/On-node-B-Open-Faulty-Index-button-calls-wrong-node

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
