### PR TITLE
RavenDB-22637 : XML documentation of IOperation - revert properties back to fields

### DIFF
--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
@@ -13,10 +13,10 @@ namespace Raven.Client.Documents.Operations.Counters
     public sealed class CounterBatch
     {
         /// <summary>
-        /// Gets or sets a value indicating whether the response should include counter values from all nodes.
+        /// A value indicating whether the response should include counter values from all nodes.
         /// When set to <c>true</c>, the response includes the values of each counter from all nodes in the cluster.
         /// </summary>
-        public bool ReplyWithAllNodesValues { get; set; }
+        public bool ReplyWithAllNodesValues;
 
         /// <summary>
         /// Gets or sets the list of counter operations to be performed on the specified documents.
@@ -37,23 +37,23 @@ namespace Raven.Client.Documents.Operations.Counters
     public sealed class DocumentCountersOperation
     {
         /// <summary>
-        /// Gets or sets the list of counter operations to be performed on the specified document.
+        /// A list of counter operations to be performed on the specified document.
         /// Each operation in the list specifies an action, such as incrementing or deleting a counter.
         /// </summary>
         /// <remarks>
-        /// The <see cref="Operations"/> property is mandatory and must be populated before the batch operation is executed.
+        /// The <see cref="Operations"/> field is mandatory and must be populated before the batch operation is executed.
         /// If it is not set or is empty, an exception will be thrown during parsing or execution.
         /// </remarks>
-        public List<CounterOperation> Operations { get; set; }
+        public List<CounterOperation> Operations;
 
         /// <summary>
-        /// Gets or sets the ID of the document on which the counter operations are to be performed.
+        /// The ID of the document on which the counter operations are to be performed.
         /// </summary>
         /// <remarks>
-        /// The <see cref="DocumentId"/> property is mandatory and identifies the target document for the counter operations.
+        /// The <see cref="DocumentId"/> field is mandatory and identifies the target document for the counter operations.
         /// If it is not set, an exception will be thrown during parsing or execution.
         /// </remarks>
-        public string DocumentId { get; set; }
+        public string DocumentId;
         
         public static DocumentCountersOperation Parse(BlittableJsonReaderObject input)
         {
@@ -150,7 +150,7 @@ namespace Raven.Client.Documents.Operations.Counters
     public sealed class CounterOperation
     {
         /// <summary>
-        /// Gets or sets the type of the counter operation to be performed.
+        /// The type of the counter operation to be performed.
         /// Specifies the action, such as incrementing, deleting, or retrieving a counter value.
         /// </summary>
         /// <remarks>
@@ -160,27 +160,27 @@ namespace Raven.Client.Documents.Operations.Counters
         /// - <see cref="CounterOperationType.Get"/>: Retrieves the value of the counter.
         /// - <see cref="CounterOperationType.GetAll"/>: Retrieves all counters for a document.
         /// </remarks>
-        public CounterOperationType Type { get; set; }
+        public CounterOperationType Type;
 
         /// <summary>
-        /// Gets or sets the name of the counter to be operated on.
+        /// The name of the counter to be operated on.
         /// </summary>
         /// <remarks>
-        /// - The <see cref="CounterName"/> property is mandatory for operations of type <see cref="CounterOperationType.Increment"/>, <see cref="CounterOperationType.Delete"/>, and <see cref="CounterOperationType.Get"/>.
-        /// - For <see cref="CounterOperationType.GetAll"/>, the <see cref="CounterName"/> property is not used and can be <c>null</c>.
+        /// - The <see cref="CounterName"/> field is mandatory for operations of type <see cref="CounterOperationType.Increment"/>, <see cref="CounterOperationType.Delete"/>, and <see cref="CounterOperationType.Get"/>.
+        /// - For <see cref="CounterOperationType.GetAll"/>, the <see cref="CounterName"/> field is not used and can be <c>null</c>.
         /// - If <see cref="CounterName"/> is required but not set, an exception will be thrown during parsing or execution.
         /// </remarks>
-        public string CounterName { get; set; }
+        public string CounterName;
 
         /// <summary>
-        /// Gets or sets the value by which the counter should be incremented or decremented.
+        /// The value by which the counter should be incremented or decremented.
         /// </summary>
         /// <remarks>
         /// - Used only for operations of type <see cref="CounterOperationType.Increment"/>.
         /// - For <see cref="CounterOperationType.Put"/>, this specifies the exact value to set for the counter but is used internally and not intended for external use.
-        /// - For other operation types, this property is ignored.
+        /// - For other operation types, this field is ignored.
         /// </remarks>
-        public long Delta { get; set; }
+        public long Delta;
 
         internal string ChangeVector;
         internal string DocumentId;

--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesOperation.cs
@@ -79,14 +79,14 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         internal List<DeleteOperation> Deletes;
 
         /// <summary>
-        /// Gets or sets the name of the time series on which the operations are performed.
-        /// This property is mandatory and must be set before executing the <see cref="TimeSeriesBatchOperation"/> that contains this <see cref="TimeSeriesOperation"/>.
+        /// The name of the time series on which the operations are performed.
+        /// This field is mandatory and must be set before executing the <see cref="TimeSeriesBatchOperation"/> that contains this <see cref="TimeSeriesOperation"/>.
         /// </summary>
         /// <remarks>
-        /// The <see cref="Name"/> property identifies the time series within the document to which the batch operations apply.
-        /// If this property is not set, an exception will be thrown when attempting to execute the batch operation.
+        /// The <see cref="Name"/> field identifies the time series within the document to which the batch operations apply.
+        /// If this field is not set, an exception will be thrown when attempting to execute the batch operation.
         /// </remarks>
-        public string Name { get; set; }
+        public string Name;
 
         /// <summary>
         /// Adds an append operation to the batch.
@@ -334,22 +334,23 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         public sealed class AppendOperation
         {
             /// <summary>
-            /// Gets or sets the timestamp of the data point to be appended.
+            /// The timestamp of the data point to be appended.
             /// This specifies when the data point occurred.
             /// </summary>
-            public DateTime Timestamp { get; set; }
+            public DateTime Timestamp;
 
             /// <summary>
-            /// Gets or sets the values associated with the data point.
+            /// The values associated with the data point.
             /// These are the numeric measurements recorded at the specified <see cref="Timestamp"/>.
             /// </summary>
-            public double[] Values { get; set; }
+            public double[] Values;
 
             /// <summary>
-            /// Gets or sets an optional tag for the data point.
+            /// An optional tag for the data point.
             /// The tag can provide additional context or metadata for the appended data, such as the source or a descriptive label.
             /// </summary>
-            public string Tag { get; set; }
+            public string Tag;
+
             internal static AppendOperation Parse(BlittableJsonReaderObject input)
             {
                 if (input.TryGet(nameof(Timestamp), out DateTime ts) == false)
@@ -397,18 +398,18 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         public sealed class DeleteOperation
         {
             /// <summary>
-            /// Gets or sets the start of the range for the delete operation.
+            /// The start of the range for the delete operation.
             /// Data points from this timestamp (inclusive) will be considered for deletion.
             /// If <c>null</c>, the range starts from the beginning of the time series.
             /// </summary>
-            public DateTime? From { get; set; }
+            public DateTime? From;
 
             /// <summary>
-            /// Gets or sets the end of the range for the delete operation.
+            /// The end of the range for the delete operation.
             /// Data points up to this timestamp (inclusive) will be considered for deletion.
             /// If <c>null</c>, the range extends to the end of the time series.
             /// </summary>
-            public DateTime? To { get; set; }
+            public DateTime? To;
 
             internal static DeleteOperation Parse(BlittableJsonReaderObject input)
             {
@@ -438,16 +439,16 @@ namespace Raven.Client.Documents.Operations.TimeSeries
         public sealed class IncrementOperation
         {
             /// <summary>
-            /// Gets or sets the timestamp of the data point to be incremented.
+            /// The timestamp of the data point to be incremented.
             /// This specifies the exact point in time where the values should be adjusted.
             /// </summary>
-            public DateTime Timestamp { get; set; }
+            public DateTime Timestamp;
 
             /// <summary>
-            /// Gets or sets the values to increment at the specified <see cref="Timestamp"/>.
+            /// The values to increment at the specified <see cref="Timestamp"/>.
             /// Each value corresponds to a numeric field in the time series, and the increment operation adds the specified amount to the current values.
             /// </summary>
-            public double[] Values { get; set; }
+            public double[] Values;
 
             internal int? ValuesLength;
 

--- a/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesRange.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/TimeSeriesRange.cs
@@ -9,18 +9,18 @@ namespace Raven.Client.Documents.Operations.TimeSeries
     public sealed class TimeSeriesRange : AbstractTimeSeriesRange
     {
         /// <summary>
-        /// Gets or sets the start time of the range.
+        /// The start time of the range.
         /// Data points from this timestamp (inclusive) will be included in the range.
         /// If <c>null</c>, the range starts from the beginning of the time series.
         /// </summary>
-        public DateTime? From { get; set; }
+        public DateTime? From;
 
         /// <summary>
-        /// Gets or sets the end time of the range.
+        /// The end time of the range.
         /// Data points up to this timestamp (inclusive) will be included in the range.
         /// If <c>null</c>, the range extends to the end of the time series.
         /// </summary>
-        public DateTime? To { get; set; }
+        public DateTime? To;
     }
 
     internal sealed class TimeSeriesTimeRange : AbstractTimeSeriesRange
@@ -41,12 +41,12 @@ namespace Raven.Client.Documents.Operations.TimeSeries
     public abstract class AbstractTimeSeriesRange
     {
         /// <summary>
-        /// Gets or sets the name of the time series.
+        /// The name of the time series.
         /// </summary>
         /// <remarks>
-        /// This property identifies the time series on which the range operations will be performed.
+        /// This field identifies the time series on which the range operations will be performed.
         /// </remarks>
-        public string Name { get; set; }
+        public string Name;
     }
 
     /// <summary>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22637/XML-documentation-of-IOperation

### Additional description

revert changes made in https://github.com/ravendb/ravendb/pull/19536 : 
change from properties back to fields, in order to avoid introducing breaking changes