### PR TITLE
RavenDB-23217 - Revision results when including revisions in GetDocumentsCommand

### DIFF
--- a/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Includes
         {
             _revisionsChangeVectors = revisionIncludeField?.RevisionsChangeVectors ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             _pathsForRevisionsChangeVectors = revisionIncludeField?.RevisionsChangeVectorsPaths ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase); 
-            _revisionsBeforeDateTime = revisionIncludeField?.RevisionsBeforeDateTime ?? new DateTime();
+            _revisionsBeforeDateTime = revisionIncludeField?.RevisionsBeforeDateTime;
         }
 
         public void Fill(Document document)
@@ -36,11 +36,7 @@ namespace Raven.Server.Documents.Includes
             if (document == null)
                 return;
 
-
-            if (AddRevisionByDateTimeBefore(_revisionsBeforeDateTime, document.Id) == false)
-            {
-                return;
-            }
+            AddRevisionByDateTimeBefore(_revisionsBeforeDateTime, document.Id);
 
             if (_revisionsChangeVectors?.Count > 0)
             {
@@ -49,9 +45,10 @@ namespace Raven.Server.Documents.Includes
                     RevisionsChangeVectorResults ??= new Dictionary<string, Document>(StringComparer.OrdinalIgnoreCase);
                     if (RevisionsChangeVectorResults.ContainsKey(changeVector))
                         continue;
-                    var doc  = _database.DocumentsStorage.RevisionsStorage.GetRevision(context: _context, changeVector:changeVector);
-                    if (doc is null) return;
-                    RevisionsChangeVectorResults[changeVector] = doc;
+
+                    var revision  = _database.DocumentsStorage.RevisionsStorage.GetRevision(context: _context, changeVector:changeVector);
+                    if (revision is not null)
+                        RevisionsChangeVectorResults[changeVector] = revision;
                 }
             }
 
@@ -73,9 +70,9 @@ namespace Raven.Server.Documents.Includes
                                   RevisionsChangeVectorResults ??= new Dictionary<string, Document>(StringComparer.OrdinalIgnoreCase);
                                   if (RevisionsChangeVectorResults.ContainsKey(changeVector))
                                       continue;
-                                  var doc  = _database.DocumentsStorage.RevisionsStorage.GetRevision(context: _context, changeVector:changeVector);
-                                  if (doc is null) return;
-                                  RevisionsChangeVectorResults[changeVector] = doc;
+                                  var revision  = _database.DocumentsStorage.RevisionsStorage.GetRevision(context: _context, changeVector:changeVector);
+                                  if (revision is not null)
+                                    RevisionsChangeVectorResults[changeVector] = revision;
                               }
                               break;
                           }
@@ -85,9 +82,9 @@ namespace Raven.Server.Documents.Includes
                               RevisionsChangeVectorResults ??= new Dictionary<string, Document>(StringComparer.OrdinalIgnoreCase);
                               if (RevisionsChangeVectorResults.ContainsKey(cvAsLazyStringValue))
                                   continue;
-                              var doc  = _database.DocumentsStorage.RevisionsStorage.GetRevision(context: _context, changeVector:cvAsLazyStringValue);
-                              if (doc is null) return;
-                              RevisionsChangeVectorResults[cvAsLazyStringValue] = doc;
+                              var revision  = _database.DocumentsStorage.RevisionsStorage.GetRevision(context: _context, changeVector:cvAsLazyStringValue);
+                              if (revision is not null)
+                                RevisionsChangeVectorResults[cvAsLazyStringValue] = revision;
                               break;
                           }
                                     
@@ -97,9 +94,9 @@ namespace Raven.Server.Documents.Includes
                               RevisionsChangeVectorResults ??= new Dictionary<string, Document>(StringComparer.OrdinalIgnoreCase);
                               if (RevisionsChangeVectorResults.ContainsKey(cvAsLazyStringValue))
                                   continue;
-                              var doc  = _database.DocumentsStorage.RevisionsStorage.GetRevision(context: _context, changeVector:cvAsLazyStringValue);
-                              if (doc is null) return;
-                              RevisionsChangeVectorResults[cvAsLazyStringValue] = doc;
+                              var revision  = _database.DocumentsStorage.RevisionsStorage.GetRevision(context: _context, changeVector:cvAsLazyStringValue);
+                              if (revision is not null)
+                                RevisionsChangeVectorResults[cvAsLazyStringValue] = revision;
                               break;
                           }
                       }
@@ -121,19 +118,17 @@ namespace Raven.Server.Documents.Includes
             }  
         }
         
-        public bool AddRevisionByDateTimeBefore(DateTime? dateTime, string documentId)
+        public void AddRevisionByDateTimeBefore(DateTime? dateTime, string documentId)
         {
             if (dateTime.HasValue == false)
-                return true;
+                return;
 
             var doc = _database.DocumentsStorage.RevisionsStorage.GetRevisionBefore(context: _context, id: documentId, max: dateTime.Value); 
             if (doc is null)
-                return false;
+                return;
             
             IdByRevisionsByDateTimeResults ??= new Dictionary<string, Dictionary<DateTime, Document>>(StringComparer.OrdinalIgnoreCase); 
             IdByRevisionsByDateTimeResults[documentId] = new Dictionary<DateTime, Document> (){{dateTime.Value, doc}};
-
-            return true;
         }
 
        

--- a/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
@@ -35,13 +35,11 @@ namespace Raven.Server.Documents.Includes
         {
             if (document == null)
                 return;
-            
-            if (_revisionsBeforeDateTime != default(DateTime))
+
+
+            if (AddRevisionByDateTimeBefore(_revisionsBeforeDateTime, document.Id) == false)
             {
-                var doc = _database.DocumentsStorage.RevisionsStorage.GetRevisionBefore(context: _context, id: document.Id, max: _revisionsBeforeDateTime.Value); 
-                if (doc is null) return; 
-                IdByRevisionsByDateTimeResults ??= new Dictionary<string, Dictionary<DateTime, Document>>(StringComparer.OrdinalIgnoreCase); 
-                IdByRevisionsByDateTimeResults[document.Id] = new Dictionary<DateTime, Document> (){{_revisionsBeforeDateTime.Value, doc}};
+                return;
             }
 
             if (_revisionsChangeVectors?.Count > 0)
@@ -123,19 +121,19 @@ namespace Raven.Server.Documents.Includes
             }  
         }
         
-        public void AddRevisionByDateTimeBefore(DateTime? dateTime, string documentId)
+        public bool AddRevisionByDateTimeBefore(DateTime? dateTime, string documentId)
         {
             if (dateTime.HasValue == false)
-                return;
+                return true;
 
             var doc = _database.DocumentsStorage.RevisionsStorage.GetRevisionBefore(context: _context, id: documentId, max: dateTime.Value); 
             if (doc is null)
-                return;
+                return false;
             
-            RevisionsChangeVectorResults ??= new Dictionary<string, Document>(StringComparer.OrdinalIgnoreCase); 
             IdByRevisionsByDateTimeResults ??= new Dictionary<string, Dictionary<DateTime, Document>>(StringComparer.OrdinalIgnoreCase); 
-            RevisionsChangeVectorResults[doc.ChangeVector] = doc;
             IdByRevisionsByDateTimeResults[documentId] = new Dictionary<DateTime, Document> (){{dateTime.Value, doc}};
+
+            return true;
         }
 
        

--- a/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/Includes/IncludeRevisionsCommand.cs
@@ -40,9 +40,7 @@ namespace Raven.Server.Documents.Includes
             {
                 var doc = _database.DocumentsStorage.RevisionsStorage.GetRevisionBefore(context: _context, id: document.Id, max: _revisionsBeforeDateTime.Value); 
                 if (doc is null) return; 
-                RevisionsChangeVectorResults ??= new Dictionary<string, Document>(StringComparer.OrdinalIgnoreCase); 
                 IdByRevisionsByDateTimeResults ??= new Dictionary<string, Dictionary<DateTime, Document>>(StringComparer.OrdinalIgnoreCase); 
-                RevisionsChangeVectorResults[doc.ChangeVector] = doc;
                 IdByRevisionsByDateTimeResults[document.Id] = new Dictionary<DateTime, Document> (){{_revisionsBeforeDateTime.Value, doc}};
             }
 

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1590,15 +1590,15 @@ namespace Raven.Server.Json
                 
                     writer.WriteStartObject();
                 
-                    writer.WritePropertyName("ChangeVector");
+                    writer.WritePropertyName(nameof(RevisionIncludeResult.ChangeVector));
                     writer.WriteString(key);
                     writer.WriteComma();
                 
-                    writer.WritePropertyName("Id");
+                    writer.WritePropertyName(nameof(RevisionIncludeResult.Before));
                     writer.WriteString(document.Id.ToString());
                     writer.WriteComma();
                 
-                    writer.WritePropertyName("Revision");
+                    writer.WritePropertyName(nameof(RevisionIncludeResult.Revision));
                     WriteDocument(writer, context, metadataOnly: false, document: document);
                     await writer.MaybeFlushAsync(token);
                 

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1594,7 +1594,7 @@ namespace Raven.Server.Json
                     writer.WriteString(key);
                     writer.WriteComma();
                 
-                    writer.WritePropertyName(nameof(RevisionIncludeResult.Before));
+                    writer.WritePropertyName(nameof(RevisionIncludeResult.Id));
                     writer.WriteString(document.Id.ToString());
                     writer.WriteComma();
                 

--- a/test/SlowTests/Issues/RavenDB-23217.cs
+++ b/test/SlowTests/Issues/RavenDB-23217.cs
@@ -1,40 +1,27 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using FastTests;
 using FastTests.Server.Replication;
 using FastTests.Utils;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Raven.Client.Documents;
-using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client;
+using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Commands;
-using Raven.Client.Http;
-using Raven.Client.Json;
-using Raven.Client.ServerWide;
-using Raven.Client.ServerWide.Operations;
-using Raven.Server.Documents;
-using Raven.Server.Documents.Handlers.Admin;
-using Raven.Server.ServerWide;
-using Sparrow.Json;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 
-namespace StressTests.Issues
+namespace SlowTests.Issues
 {
-    internal class RavenDB_23217 : ReplicationTestBase
+    public class RavenDB_23217 : ReplicationTestBase
     {
         public RavenDB_23217(ITestOutputHelper output) : base(output)
         {
         }
 
+        [RavenFact(RavenTestCategory.ClientApi)]
         public async Task Shuould_Include_One_Revision_When_Using_RevisionBefore_Only_On_GetDocumentsCommand()
         {
             using var store = GetDocumentStore();
@@ -102,6 +89,7 @@ namespace StressTests.Issues
             }
 
         }
+
         private class User
         {
             public string Id { get; set; }

--- a/test/StressTests/Issues/RavenDB-23217.cs
+++ b/test/StressTests/Issues/RavenDB-23217.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.Admin;
+using Raven.Server.ServerWide;
+using Sparrow.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace StressTests.Issues
+{
+    internal class RavenDB_23217 : ReplicationTestBase
+    {
+        public RavenDB_23217(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        public async Task Shuould_Include_One_Revision_When_Using_RevisionBefore_Only_On_GetDocumentsCommand()
+        {
+            using var store = GetDocumentStore();
+
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                    MinimumRevisionsToKeep = 100
+                }
+            };
+            await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+            // Create a doc with 4 revisions
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Old" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New1" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "New2" }, "Docs/1");
+                await session.SaveChangesAsync();
+            }
+
+            string[] revisionsChangeVectors = null;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                revisionsChangeVectors = (await session.Advanced.Revisions.GetMetadataForAsync("Docs/1")).Select(metadata =>
+                {
+                    metadata.TryGetValue(Constants.Documents.Metadata.ChangeVector, out string cv);
+                    return cv;
+                }).ToArray();
+            }
+
+            var command = new GetDocumentsCommand(
+                ids: new[] { "Docs/1" },
+                includes: null,
+                counterIncludes: null,
+                // Specify the change-vectors of the revisions to include
+                null,
+                revisionIncludeByDateTimeBefore: DateTime.Now + TimeSpan.FromDays(15),
+                timeSeriesIncludes: null,
+                compareExchangeValueIncludes: null,
+                metadataOnly: false);
+
+            using (var requestExecutor = store.GetRequestExecutor())
+            using (requestExecutor.ContextPool.AllocateOperationContext(out var ctx))
+            {
+                await requestExecutor.ExecuteAsync(command, ctx);
+
+                Assert.Equal(1, command.Result.RevisionIncludes.Length); // Fail - it is 2 - same revision is shown twice
+            }
+
+        }
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23217/Revision-results-when-including-revisions-in-GetDocumentsCommand

### Additional description

When sending `GetDocumentsCommand` with `revisionIncludeByDateTimeBefore` parameter (on the client side), we get the same revision twice on the result (on `Results.RevisionsIncludes` field)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
