### PR TITLE
RavenDB-23132 - NotSupportedException: Deleting index entries by id()

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupTimeSeriesForMapReduce.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Cleanup/CleanupTimeSeriesForMapReduce.cs
@@ -27,7 +27,6 @@ namespace Raven.Server.Documents.Indexes.Workers.Cleanup
             QueryOperationContext queryContext, TransactionOperationContext indexContext, IndexingStatsScope stats)
         {
             _mapReduceIndex.HandleTimeSeriesDelete(tombstone, indexContext);
-            base.HandleTimeSeriesDelete(tombstone, collection, writer, queryContext, indexContext, stats);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB_23132.cs
+++ b/test/SlowTests/Issues/RavenDB_23132.cs
@@ -22,10 +22,8 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
-        [RavenData(Data = [true], SearchEngineMode = RavenSearchEngineMode.Corax)]
-        [RavenData(Data = [true], SearchEngineMode = RavenSearchEngineMode.Lucene)]
-        [RavenData(Data = [false], SearchEngineMode = RavenSearchEngineMode.Corax)]
-        [RavenData(Data = [false], SearchEngineMode = RavenSearchEngineMode.Lucene)]
+        [RavenData(Data = [true], SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData(Data = [false], SearchEngineMode = RavenSearchEngineMode.All)]
         public async Task DeleteTimeSeriesShouldNotThrowNotSupportedException_mapReduceIndexWithOutputToCollection(Options options, bool deleteDocument)
         {
             using (var store = GetDocumentStore())

--- a/test/SlowTests/Issues/RavenDB_23132.cs
+++ b/test/SlowTests/Issues/RavenDB_23132.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Smuggler;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23132 : RavenTestBase
+    {
+        private readonly DatabaseItemType _operateOnTypes = DatabaseItemType.Documents |
+                                                            DatabaseItemType.Indexes |
+                                                            DatabaseItemType.TimeSeries;
+
+        public RavenDB_23132(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
+        public async Task DeleteTimeSeriesShouldNotThrowNotSupportedException_mapReduceIndexWithOutputToCollection()
+        {
+            using (var store = GetDocumentStore())
+            {
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(operateOnTypes: _operateOnTypes));
+
+                var indexName = "Companies/StockPrices/TradeVolumeByMonth";
+
+                await WaitAndAssertForValueAsync(async () =>
+                {
+                    var indexNames = await store.Maintenance.SendAsync(new GetIndexNamesOperation(start: 0, pageSize: int.MaxValue));
+                    return indexNames.Contains(indexName, StringComparer.OrdinalIgnoreCase);
+                }, true);
+
+                // add OutputReduceToCollection
+                var index = await store.Maintenance.SendAsync(new GetIndexOperation(indexName));
+                index.OutputReduceToCollection = "StockPricesTradeVolumeByMonth";
+                await store.Maintenance.SendAsync(new PutIndexesOperation(index));
+
+                try
+                {
+                    Indexes.WaitForIndexing(store);
+                }
+                catch
+                {
+                    // do nothing...
+                }
+
+                var indexErrors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { indexName }));
+
+                Assert.Single(indexErrors);
+                Assert.Empty(indexErrors[0].Errors);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 1; i < 5; i++)
+                        session.Delete($"companies/{i}-A");
+
+                    await session.SaveChangesAsync();
+                }
+
+                try
+                {
+                    Indexes.WaitForIndexing(store);
+                }
+                catch
+                {
+                    // do nothing...
+                }
+
+                indexErrors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { indexName }));
+
+                Assert.Single(indexErrors);
+                Assert.Empty(indexErrors[0].Errors);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries)]
+        public async Task DeleteTimeSeriesShouldNotThrowNotSupportedException_mapReduceIndexWithOutputToCollection2()
+        {
+            using (var store = GetDocumentStore())
+            {
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation(operateOnTypes: _operateOnTypes));
+
+                var indexName = "Companies/StockPrices/TradeVolumeByMonth";
+
+                await WaitAndAssertForValueAsync(async () =>
+                {
+                    var indexNames = await store.Maintenance.SendAsync(new GetIndexNamesOperation(start: 0, pageSize: int.MaxValue));
+                    return indexNames.Contains(indexName, StringComparer.OrdinalIgnoreCase);
+                }, true);
+
+                // add OutputReduceToCollection
+                var index = await store.Maintenance.SendAsync(new GetIndexOperation(indexName));
+                index.OutputReduceToCollection = "StockPricesTradeVolumeByMonth";
+                await store.Maintenance.SendAsync(new PutIndexesOperation(index));
+
+                try
+                {
+                    Indexes.WaitForIndexing(store);
+                }
+                catch
+                {
+                    // do nothing...
+                }
+
+                var indexErrors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { indexName }));
+
+                Assert.Single(indexErrors);
+                Assert.Empty(indexErrors[0].Errors);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 1; i < 5; i++)
+                        session.TimeSeriesFor($"companies/{i}-A", "StockPrices").Delete();
+
+                    await session.SaveChangesAsync();
+                }
+
+                try
+                {
+                    Indexes.WaitForIndexing(store);
+                }
+                catch
+                {
+                    // do nothing...
+                }
+
+                indexErrors = await store.Maintenance.SendAsync(new GetIndexErrorsOperation(new[] { indexName }));
+
+                Assert.Single(indexErrors);
+                Assert.Equal(indexName, indexErrors[0].Name, StringComparer.OrdinalIgnoreCase);
+                Assert.Empty(indexErrors[0].Errors);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23132/NotSupportedException-Deleting-index-entries-by-id-field-isnt-supported-by-map-reduce-indexes

### Additional description

Custom build with the following fix: https://github.com/ravendb/ravendb/pull/19602

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
