### PR TITLE
RavenDB-23054: Added delete and stream for Incremental Async Session

### DIFF
--- a/src/Raven.Client/Documents/Session/IAsyncSessionDocumentTimeSeries.cs
+++ b/src/Raven.Client/Documents/Session/IAsyncSessionDocumentTimeSeries.cs
@@ -70,7 +70,9 @@ namespace Raven.Client.Documents.Session
     ///     Advanced async TimeSeries session operations
     /// </summary>
     public interface IAsyncSessionDocumentIncrementalTimeSeries :
-        ISessionDocumentIncrementTimeSeriesBase
+        IAsyncTimeSeriesStreamingBase<TimeSeriesEntry>,
+        ISessionDocumentIncrementTimeSeriesBase,
+        ISessionDocumentDeleteTimeSeriesBase
     {
         Task<TimeSeriesEntry[]> GetAsync(DateTime? from = null, DateTime? to = null, int start = 0, int pageSize = int.MaxValue,
             CancellationToken token = default);

--- a/test/SlowTests/Client/TimeSeries/Session/TimeSeriesStreamingTests.cs
+++ b/test/SlowTests/Client/TimeSeries/Session/TimeSeriesStreamingTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client;
 using Raven.Client.Documents.Queries.TimeSeries;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
@@ -89,6 +90,46 @@ namespace SlowTests.Client.TimeSeries.Session
                             Assert.Equal("stream", entry.Tag);
                             i++;
                         }
+                    }
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public async Task CanStreamIncrementalTimeSeriesAsync(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var timeSeriesName = Constants.Headers.IncrementalTimeSeriesPrefix + "heartrate";
+                var baseline = DateTime.UtcNow.EnsureMilliseconds();
+                using (var session = store.OpenAsyncSession())
+                {
+
+                    await session.StoreAsync(new User(), "karmel");
+                    var ts = session.IncrementalTimeSeriesFor("karmel", timeSeriesName);
+                    for (int i = 0; i < 10; i++)
+                    {
+                        ts.Increment(baseline.AddMinutes(i), i);
+                    }
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var ts = session.IncrementalTimeSeriesFor("karmel", timeSeriesName);
+                    var it = await ts.StreamAsync();
+                    await using (it)
+                    {
+                        var i = 0;
+                        while (await it.MoveNextAsync())
+                        {
+                            var entry = it.Current;
+                            Assert.Equal(baseline.AddMinutes(i), entry.Timestamp);
+                            Assert.Equal(i, entry.Value);
+                            i++;
+                        }
+                        Assert.Equal(10, i);
                     }
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23054

### Additional description

Adds support for Delete and Stream operations in IAsyncSessionDocumentIncrementalTimeSeries. This includes both implementation and testing.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
