### PR TITLE
RavenDB-23231 - Changed from blocking the thread to using await for asynchronous execution

### DIFF
--- a/test/FastTests/Server/Basic/IdleOperations.cs
+++ b/test/FastTests/Server/Basic/IdleOperations.cs
@@ -20,11 +20,11 @@ namespace FastTests.Server.Basic
         }
 
         [Fact]
-        public void Should_Update_LastIdle()
+        public async Task Should_Update_LastIdle()
         {
             using (var store = GetDocumentStore())
             {
-                var db = GetDatabase(store.Database).Result;
+                var db = await GetDatabase(store.Database);
 
                 var lastIdleTime = db.LastIdleTime;
 

--- a/test/SlowTests/Issues/RavenDB-15807.cs
+++ b/test/SlowTests/Issues/RavenDB-15807.cs
@@ -85,9 +85,8 @@ namespace SlowTests.Issues
 
                     using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                     {
-                        var task = sinkServer.ServerStore.UpdatePullReplicationAsSink(sinkStore.Database, reader, Guid.NewGuid().ToString(), out PullReplicationAsSink pullReplication);
-                        Task.WaitAll(task);
-                        taskId = task.Result.Index;
+                        var result = await sinkServer.ServerStore.UpdatePullReplicationAsSink(sinkStore.Database, reader, Guid.NewGuid().ToString(), out PullReplicationAsSink pullReplication);
+                        taskId = result.Index;
                         Assert.NotNull(pullReplication.CertificateWithPrivateKey);
                     }
                 }

--- a/test/SlowTests/Issues/RavenDB-20136.cs
+++ b/test/SlowTests/Issues/RavenDB-20136.cs
@@ -42,8 +42,8 @@ namespace SlowTests.Issues
                 
                 if (loadDone1.Wait(TimeSpan.FromSeconds(30)) == false)
                 {
-                    TryGetLoadError(src.Database, configuration, out var loadError);
-                    TryGetTransformationError(src.Database, configuration, out var transformationError);
+                    var loadError = await TryGetLoadError(src.Database, configuration);
+                    var transformationError = await TryGetTransformationError(src.Database, configuration);
 
                     Assert.True(false, $"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
                 }
@@ -63,8 +63,8 @@ namespace SlowTests.Issues
                 
                 if (loadDone2.Wait(TimeSpan.FromSeconds(30)) == false)
                 {
-                    TryGetLoadError(src.Database, configuration, out var loadError);
-                    TryGetTransformationError(src.Database, configuration, out var transformationError);
+                    var loadError = await TryGetLoadError(src.Database, configuration);
+                    var transformationError = await TryGetTransformationError(src.Database, configuration);
 
                     Assert.True(false, $"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
                 }

--- a/test/SlowTests/Issues/RavenDB_12725_Raven.cs
+++ b/test/SlowTests/Issues/RavenDB_12725_Raven.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Server.Config;
 using Raven.Server.Documents;
@@ -17,7 +18,7 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public void CanLoadDatabaseAndIgnoreMissingJournals()
+        public async Task CanLoadDatabaseAndIgnoreMissingJournals()
         {
             UseNewLocalServer(new Dictionary<string, string>
             {
@@ -33,8 +34,8 @@ namespace SlowTests.Issues
                 Path = path
             }))
             {
-                db = GetDatabase(store.Database).Result;
-                store.Maintenance.Send(new CreateSampleDataOperation());
+                db = await GetDatabase(store.Database);
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation());
             }
 
             db.Dispose();

--- a/test/SlowTests/Issues/RavenDB_15163.cs
+++ b/test/SlowTests/Issues/RavenDB_15163.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
@@ -18,22 +19,22 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public void FailureDuringIndexReplacementMustNotCauseProblemsWith()
+        public async Task FailureDuringIndexReplacementMustNotCauseProblemsWith()
         {
             using (var store = GetDocumentStore(new Options {Path = NewDataPath()}))
             {
-                var database = GetDatabase(store.Database).Result;
+                var database = await GetDatabase(store.Database);
 
-                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                await store.Maintenance.SendAsync(new PutIndexesOperation(new IndexDefinition
                 {
                     Maps = { "from user in docs.Users select new { user.FirstName }" },
                     Type = IndexType.Map,
                     Name = "Users/ByName"
                 }));
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
-                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                await store.Maintenance.SendAsync(new PutIndexesOperation(new IndexDefinition
                 {
                     Maps = { "from user in docs.Users select new { user.LastName }" },
                     Type = IndexType.Map,
@@ -65,7 +66,7 @@ namespace SlowTests.Issues
                 Assert.Equal("Users/ByName", indexes[0].Name);
                 Assert.Same(replacementIndexInstance, indexes[0]);
 
-                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                await store.Maintenance.SendAsync(new PutIndexesOperation(new IndexDefinition
                 {
                     Maps = { "from user in docs.Users select new { user.LastName2 }" },
                     Type = IndexType.Map,
@@ -98,7 +99,7 @@ namespace SlowTests.Issues
 
                 Server.ServerStore.DatabasesLandlord.UnloadDirectly(database.Name);
 
-                database = GetDatabase(store.Database).Result;
+                database = await GetDatabase(store.Database);
 
                 Indexes.WaitForIndexing(store); // old index could be opened as well, so we wait until replacement is done and switches the index
 

--- a/test/SlowTests/Issues/RavenDB_16303.cs
+++ b/test/SlowTests/Issues/RavenDB_16303.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 using Npgsql;
 using Oracle.ManagedDataAccess.Client;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -27,7 +28,7 @@ namespace SlowTests.Issues
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
-        public void CanCreateSqlEtlTransformScriptWithGuidWhenTableTypeGuid(MigrationProvider provider)
+        public async Task CanCreateSqlEtlTransformScriptWithGuidWhenTableTypeGuid(MigrationProvider provider)
         {
             using (var store = GetDocumentStore())
             {
@@ -45,7 +46,7 @@ namespace SlowTests.Issues
                         ConnectionString = connectionString
                     });
 
-                    store.Maintenance.Send(operation);
+                    await store.Maintenance.SendAsync(operation);
 
                     var etlDone = new ManualResetEventSlim();
                     var configuration = new SqlEtlConfiguration
@@ -70,8 +71,8 @@ loadToTestGuidEtls(item);"
                         }
                     };
 
-                    store.Maintenance.Send(new AddEtlOperation<SqlConnectionString>(configuration));
-                    var database = GetDatabase(store.Database).Result;
+                    await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(configuration));
+                    var database = await GetDatabase(store.Database);
                     var errors = 0;
                     database.EtlLoader.BatchCompleted += x =>
                     {
@@ -85,10 +86,10 @@ loadToTestGuidEtls(item);"
                         }
                     };
                     var guid = Guid.NewGuid();
-                    using (var session = store.OpenSession())
+                    using (var session = store.OpenAsyncSession())
                     {
-                        session.Store(new TestGuidEtl() { Guid = guid });
-                        session.SaveChanges();
+                        await session.StoreAsync(new TestGuidEtl() { Guid = guid });
+                        await session.SaveChangesAsync();
                     }
 
                     etlDone.Wait(TimeSpan.FromMinutes(5));
@@ -105,7 +106,7 @@ loadToTestGuidEtls(item);"
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
-        public void CanCreateSqlEtlTransformScriptWithGuidWhenTableTypeVarchar(MigrationProvider provider)
+        public async Task CanCreateSqlEtlTransformScriptWithGuidWhenTableTypeVarchar(MigrationProvider provider)
         {
             using (var store = GetDocumentStore())
             {
@@ -123,7 +124,7 @@ loadToTestGuidEtls(item);"
                         ConnectionString = connectionString
                     });
 
-                    store.Maintenance.Send(operation);
+                    await store.Maintenance.SendAsync(operation);
 
                     var etlDone = new ManualResetEventSlim();
                     var configuration = new SqlEtlConfiguration
@@ -148,8 +149,8 @@ loadToTestGuidEtls(item);"
                         }
                     };
 
-                    store.Maintenance.Send(new AddEtlOperation<SqlConnectionString>(configuration));
-                    var database = GetDatabase(store.Database).Result;
+                    await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(configuration));
+                    var database = await GetDatabase(store.Database);
                     var errors = 0;
                     database.EtlLoader.BatchCompleted += x =>
                     {

--- a/test/SlowTests/Issues/RavenDB_16656.cs
+++ b/test/SlowTests/Issues/RavenDB_16656.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FastTests;
 using Orders;
 using Raven.Client.Documents.Indexes;
@@ -15,38 +16,38 @@ namespace SlowTests.Issues
         }
 
         [Fact]
-        public void ShouldIncludeReferenceIndexingDetails()
+        public async Task ShouldIncludeReferenceIndexingDetails()
         {
             using (var store = GetDocumentStore())
             {
                 var index = new Products_ByCategory();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new Category { Id = "categories/0", Name = "foo"});
-                    session.Store(new Category { Id = "categories/1", Name = "bar"});
+                    await session.StoreAsync(new Category { Id = "categories/0", Name = "foo"});
+                    await session.StoreAsync(new Category { Id = "categories/1", Name = "bar"});
 
                     for (int i = 0; i < 200; i++)
                     {
-                        session.Store(new Product { Category = $"categories/{i % 2}"});
+                        await session.StoreAsync(new Product { Category = $"categories/{i % 2}"});
                     }
 
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 Indexes.WaitForIndexing(store);
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new Category { Id = "categories/1", Name = "baz" });
+                    await session.StoreAsync(new Category { Id = "categories/1", Name = "baz" });
 
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 Indexes.WaitForIndexing(store);
 
-                var indexInstance = GetDatabase(store.Database).Result.IndexStore.GetIndex(index.IndexName);
+                var indexInstance = (await GetDatabase(store.Database)).IndexStore.GetIndex(index.IndexName);
 
                 var stats = indexInstance.GetIndexingPerformance();
 

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Nest;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.ETL;
@@ -134,12 +135,12 @@ loadToOrders" + IndexSuffix + @"(orderData);";
             }
         }
 
-        protected void AssertEtlDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, ElasticSearchEtlConfiguration config)
+        protected async Task AssertEtlDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, ElasticSearchEtlConfiguration config)
         {
             if (etlDone.Wait(timeout) == false)
             {
-                TryGetLoadError(databaseName, config, out var loadError);
-                TryGetTransformationError(databaseName, config, out var transformationError);
+                var loadError = await TryGetLoadError(databaseName, config);
+                var transformationError = await TryGetTransformationError(databaseName, config);
 
                 Assert.True(false, $"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
             }

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17477.cs
@@ -45,11 +45,10 @@ loadTo" + OrdersIndexName + @"(orderData);",
                     session.SaveChanges();
                 }
 
-                var alert = await AssertWaitForNotNullAsync(() =>
+                var alert = await AssertWaitForNotNullAsync(async () =>
                 {
-                    TryGetLoadError(store.Database, config, out var error);
-
-                    return Task.FromResult(error);
+                    var error = await TryGetLoadError(store.Database, config);
+                    return error;
                 }, timeout: (int)TimeSpan.FromMinutes(1).TotalMilliseconds);
 
                 Assert.Contains($"The index '{OrdersIndexName}' has invalid mapping for 'Id' property.", alert.Error);

--- a/test/SlowTests/Server/Documents/ETL/EtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlTestBase.cs
@@ -203,9 +203,9 @@ namespace SlowTests.Server.Documents.ETL
             });
         }
 
-        protected bool TryGetLoadError<T>(string databaseName, EtlConfiguration<T> config, out EtlErrorInfo error) where T : ConnectionString
+        protected async Task<EtlErrorInfo> TryGetLoadError<T>(string databaseName, EtlConfiguration<T> config) where T : ConnectionString
         {
-            var database = GetDatabase(databaseName).Result;
+            var database = await GetDatabase(databaseName);
 
             string tag;
 
@@ -224,20 +224,12 @@ namespace SlowTests.Server.Documents.ETL
 
             var loadAlert = database.NotificationCenter.EtlNotifications.GetAlert<EtlErrorsDetails>(tag, $"{config.Name}/{config.Transforms.First().Name}", AlertType.Etl_LoadError);
 
-            if (loadAlert.Errors.Count != 0)
-            {
-                error = loadAlert.Errors.First();
-
-                return true;
-            }
-
-            error = null;
-            return false;
+            return loadAlert.Errors.Count != 0 ? loadAlert.Errors.First() : null;
         }
 
-        protected bool TryGetTransformationError<T>(string databaseName, EtlConfiguration<T> config, out EtlErrorInfo error) where T : ConnectionString
+        protected async Task<EtlErrorInfo> TryGetTransformationError<T>(string databaseName, EtlConfiguration<T> config) where T : ConnectionString
         {
-            var database = GetDatabase(databaseName).Result;
+            var database = await GetDatabase(databaseName);
 
             string tag;
 
@@ -256,15 +248,7 @@ namespace SlowTests.Server.Documents.ETL
             
             var loadAlert = database.NotificationCenter.EtlNotifications.GetAlert<EtlErrorsDetails>(tag, $"{config.Name}/{config.Transforms.First().Name}", AlertType.Etl_TransformationError);
 
-            if (loadAlert.Errors.Count != 0)
-            {
-                error = loadAlert.Errors.First();
-
-                return true;
-            }
-
-            error = null;
-            return false;
+            return loadAlert.Errors.Count != 0 ? loadAlert.Errors.First() : null;
         }
 
         public override void Dispose()

--- a/test/SlowTests/Server/Documents/ETL/Queue/KafkaEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/KafkaEtlTests.cs
@@ -51,16 +51,16 @@ public class KafkaEtlTests : KafkaEtlTestBase
     }
 
     [RequiresKafkaRetryFact]
-    public void SimpleScript()
+    public async Task SimpleScript()
     {
         using (var store = GetDocumentStore())
         {
             var config = SetupQueueEtlToKafka(store, DefaultScript, DefaultCollections);
             var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new Order
+                await session.StoreAsync(new Order
                 {
                     Id = "orders/1-A",
                     OrderLines = new List<OrderLine>
@@ -69,10 +69,10 @@ public class KafkaEtlTests : KafkaEtlTestBase
                         new OrderLine { Cost = 4, Product = "Bear", Quantity = 1 },
                     }
                 });
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(DefaultTopics.Select(x => x.Name));
 
@@ -91,16 +91,16 @@ public class KafkaEtlTests : KafkaEtlTestBase
     }
     
     [RequiresKafkaRetryFact]
-    public void TestAreHeadersPresent()
+    public async Task TestAreHeadersPresent()
     {
         using (var store = GetDocumentStore())
         {
             var config = SetupQueueEtlToKafka(store, DefaultScript, DefaultCollections);
             var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new Order
+                await session.StoreAsync(new Order
                 {
                     Id = "orders/1-A",
                     OrderLines = new List<OrderLine>
@@ -109,10 +109,10 @@ public class KafkaEtlTests : KafkaEtlTestBase
                         new OrderLine { Cost = 4, Product = "Bear", Quantity = 1 },
                     }
                 });
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(DefaultTopics.Select(x => x.Name));
 
@@ -132,7 +132,7 @@ public class KafkaEtlTests : KafkaEtlTestBase
     }
 
     [RequiresKafkaRetryFact]
-    public void SimpleScriptWithManyDocuments()
+    public async Task SimpleScriptWithManyDocuments()
     {
         using var store = GetDocumentStore();
 
@@ -144,7 +144,7 @@ public class KafkaEtlTests : KafkaEtlTestBase
 
         for (int i = 0; i < numberOfOrders; i++)
         {
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 Order order = new Order { OrderLines = new List<OrderLine>() };
 
@@ -153,13 +153,12 @@ public class KafkaEtlTests : KafkaEtlTestBase
                     order.OrderLines.Add(new OrderLine { Cost = j + 1, Product = "foos/" + j, Quantity = (i * j) % 10 });
                 }
 
-                session.Store(order, "orders/" + i);
-
-                session.SaveChanges();
+                await session.StoreAsync(order, "orders/" + i);
+                await session.SaveChangesAsync();
             }
         }
 
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(DefaultTopics.Select(x => x.Name));
 
@@ -183,8 +182,8 @@ public class KafkaEtlTests : KafkaEtlTestBase
         }
     }
 
-    [RequiresKafkaRetryFact()]
-    public void Docs_from_two_collections_loaded_to_single_one()
+    [RequiresKafkaRetryFact]
+    public async Task Docs_from_two_collections_loaded_to_single_one()
     {
         using var store = GetDocumentStore();
 
@@ -192,14 +191,14 @@ public class KafkaEtlTests : KafkaEtlTestBase
             @"var userData = { UserId: id(this), Name: this.Name }; loadToUsers" + TopicSuffix + @"(userData)", new[] { "Users", "People" });
         var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession())
         {
-            session.Store(new User { Name = "Joe Doe" }, "users/1");
-            session.Store(new Person { Name = "James Smith" }, "people/1");
-            session.SaveChanges();
+            await session.StoreAsync(new User { Name = "Joe Doe" }, "users/1");
+            await session.StoreAsync(new Person { Name = "James Smith" }, "people/1");
+            await session.SaveChangesAsync();
         }
 
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(new List<string> { $"Users{TopicSuffix}" });
 
@@ -349,7 +348,7 @@ output('test output')"
     }
 
     [RequiresKafkaRetryFact]
-    public void CanPassAttributesToLoadToMethod()
+    public async Task CanPassAttributesToLoadToMethod()
     {
         using (var store = GetDocumentStore())
         {
@@ -363,16 +362,16 @@ output('test output')"
 
             var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new User
+                await session.StoreAsync(new User
                 {
                     Name = "Arek"
                 });
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(new[] { $"Users{TopicSuffix}" });
 
@@ -400,7 +399,7 @@ output('test output')"
     }
 
     [RequiresKafkaRetryFact]
-    public void ShouldDeleteDocumentsAfterProcessing()
+    public async Task ShouldDeleteDocumentsAfterProcessing()
     {
         using (var store = GetDocumentStore())
         {
@@ -415,17 +414,17 @@ output('test output')"
 
             var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new User
+                await session.StoreAsync(new User
                 {
                     Id = "users/1",
                     Name = "Arek"
                 });
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(new[] { $"Users{TopicSuffix}" });
 
@@ -439,9 +438,9 @@ output('test output')"
 
             consumer.Close();
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                var entity = session.Load<User>("users/1");
+                var entity = await session.LoadAsync<User>("users/1");
                 Assert.Null(entity);
             }
         }

--- a/test/SlowTests/Server/Documents/ETL/Queue/QueueEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/QueueEtlTestBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,12 +13,12 @@ public class QueueEtlTestBase : EtlTestBase
     {
     }
 
-    protected void AssertEtlDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, QueueEtlConfiguration config)
+    protected async Task AssertEtlDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, QueueEtlConfiguration config)
     {
         if (etlDone.Wait(timeout) == false)
         {
-            TryGetLoadError(databaseName, config, out var loadError);
-            TryGetTransformationError(databaseName, config, out var transformationError);
+            var loadError = await TryGetLoadError(databaseName, config);
+            var transformationError = await TryGetTransformationError(databaseName, config);
 
             Assert.True(false, $"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
         }

--- a/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
@@ -26,16 +26,16 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void SimpleScript()
+    public async Task SimpleScript()
     {
         using (var store = GetDocumentStore())
         {
             var config = SetupQueueEtlToRabbitMq(store, DefaultScript, DefaultCollections);
             var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new Order
+                await session.StoreAsync(new Order
                 {
                     Id = "orders/1-A",
                     OrderLines = new List<OrderLine>
@@ -44,10 +44,10 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
                         new OrderLine { Cost = 4, Product = "Bear", Quantity = 1 },
                     }
                 });
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);
@@ -71,7 +71,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void CanUseRoutingKeyWithAutomaticDeclarations()
+    public async Task CanUseRoutingKeyWithAutomaticDeclarations()
     {
         using var store = GetDocumentStore();
 
@@ -81,14 +81,14 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
 
         var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession())
         {
-            session.Store(new User { Name = "Joe Doe" }, "users/1");
-            session.Store(new Person { Name = "James Smith" }, "people/1");
-            session.SaveChanges();
+            await session.StoreAsync(new User { Name = "Joe Doe" }, "users/1");
+            await session.StoreAsync(new Person { Name = "James Smith" }, "people/1");
+            await session.SaveChangesAsync();
         }
         
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -119,7 +119,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void CanUseRoutingKeyWithCustomDeclarations()
+    public async Task CanUseRoutingKeyWithCustomDeclarations()
     {
         using var store = GetDocumentStore();
 
@@ -149,7 +149,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
             session.SaveChanges();
         }
 
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         channel.BasicConsume(queue: queueName, autoAck: true, consumer: consumer);
 
@@ -178,7 +178,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
 
 
     [RequiresRabbitMqRetryFact]
-    public void CanPushDirectlyToTheQueue()
+    public async Task CanPushDirectlyToTheQueue()
     {
         using var store = GetDocumentStore();
 
@@ -188,13 +188,13 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
 
         var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession())
         {
-            session.Store(new User { Name = "Joe Doe" }, "users/1");
-            session.SaveChanges();
+            await session.StoreAsync(new User { Name = "Joe Doe" }, "users/1");
+            await session.SaveChangesAsync();
         }
 
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -214,16 +214,16 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void TestAreHeadersPresent()
+    public async Task TestAreHeadersPresent()
     {
         using (var store = GetDocumentStore())
         {
             var config = SetupQueueEtlToRabbitMq(store, DefaultScript, DefaultCollections);
             var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new Order
+                await session.StoreAsync(new Order
                 {
                     Id = "orders/1-A",
                     OrderLines = new List<OrderLine>
@@ -232,10 +232,10 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
                         new OrderLine { Cost = 4, Product = "Bear", Quantity = 1 },
                     }
                 });
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using var channel = CreateRabbitMqChannel();
 
@@ -258,7 +258,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void SimpleScriptWithManyDocuments()
+    public async Task SimpleScriptWithManyDocuments()
     {
         using var store = GetDocumentStore();
 
@@ -270,7 +270,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
 
         for (int i = 0; i < numberOfOrders; i++)
         {
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 Order order = new Order { OrderLines = new List<OrderLine>() };
 
@@ -279,13 +279,12 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
                     order.OrderLines.Add(new OrderLine { Cost = j + 1, Product = "foos/" + j, Quantity = (i * j) % 10 });
                 }
 
-                session.Store(order, "orders/" + i);
-
-                session.SaveChanges();
+                await session.StoreAsync(order, "orders/" + i);
+                await session.SaveChangesAsync();
             }
         }
 
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
         
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -309,7 +308,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void Docs_from_two_collections_loaded_to_single_one()
+    public async Task Docs_from_two_collections_loaded_to_single_one()
     {
         using var store = GetDocumentStore();
 
@@ -318,14 +317,14 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
             new[] { "Users", "People" });
         var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession())
         {
-            session.Store(new User { Name = "Joe Doe" }, "users/1");
-            session.Store(new Person { Name = "James Smith" }, "people/1");
-            session.SaveChanges();
+            await session.StoreAsync(new User { Name = "Joe Doe" }, "users/1");
+            await session.StoreAsync(new Person { Name = "James Smith" }, "people/1");
+            await session.SaveChangesAsync();
         }
 
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
         
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -500,7 +499,7 @@ output('test output')"
     }
 
     [RequiresRabbitMqRetryFact]
-    public void CanPassAttributesToLoadToMethod()
+    public async Task CanPassAttributesToLoadToMethod()
     {
         using (var store = GetDocumentStore())
         {
@@ -514,13 +513,13 @@ output('test output')"
 
             var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new User { Name = "Arek" }, "users/1");
-                session.SaveChanges();
+                await session.StoreAsync(new User { Name = "Arek" }, "users/1");
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
             
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);
@@ -547,7 +546,7 @@ output('test output')"
     }
 
     [RequiresRabbitMqRetryFact]
-    public void ShouldDeleteDocumentsAfterProcessing()
+    public async Task ShouldDeleteDocumentsAfterProcessing()
     {
         using (var store = GetDocumentStore())
         {
@@ -557,13 +556,13 @@ output('test output')"
 
             var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new User { Id = "users/1", Name = "Arek" });
-                session.SaveChanges();
+                await session.StoreAsync(new User { Id = "users/1", Name = "Arek" });
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
             
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);
@@ -580,9 +579,9 @@ output('test output')"
             Assert.NotNull(user);
             Assert.Equal(user.Name, "Arek");
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                var entity = session.Load<User>("users/1");
+                var entity = await session.LoadAsync<User>("users/1");
                 Assert.Null(entity);
             }
         }

--- a/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_Kafka.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_Kafka.cs
@@ -1,6 +1,7 @@
 ﻿using Confluent.Kafka;
 using System;
 using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -16,7 +17,7 @@ public class RavenDB_21659_Kafka : KafkaEtlTestBase
     }
 
     [RequiresKafkaRetryFact]
-    public void CanPassOptionalAttributesToLoadToMethod()
+    public async Task CanPassOptionalAttributesToLoadToMethod()
     {
         using (var store = GetDocumentStore())
         {
@@ -29,16 +30,16 @@ public class RavenDB_21659_Kafka : KafkaEtlTestBase
 
             var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new User
+                await session.StoreAsync(new User
                 {
                     Name = "Arek"
                 });
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(new[] { $"Users{TopicSuffix}" });
 

--- a/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_RabbitMq.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_RabbitMq.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using RabbitMQ.Client;
 using Raven.Tests.Core.Utils.Entities;
@@ -17,7 +18,7 @@ public class RavenDB_21659_RabbitMq : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void CanPassOptionalAttributesToLoadToMethod()
+    public async Task CanPassOptionalAttributesToLoadToMethod()
     {
         using (var store = GetDocumentStore())
         {
@@ -30,13 +31,13 @@ public class RavenDB_21659_RabbitMq : RabbitMqEtlTestBase
 
             var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new User { Name = "Arek" }, "users/1");
-                session.SaveChanges();
+                await session.StoreAsync(new User { Name = "Arek" }, "users/1");
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_12800.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_12800.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Server.Config;
 using Raven.Server.Documents.ETL.Providers.Raven;
 using Raven.Tests.Core.Utils.Entities;
@@ -26,7 +27,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
             }
         ")]
         [InlineData(null)]
-        public void Should_stop_batch_if_size_limit_exceeded(string script)
+        public async Task Should_stop_batch_if_size_limit_exceeded(string script)
         {
             using (var src = GetDocumentStore(new Options
             {
@@ -34,13 +35,12 @@ namespace SlowTests.Server.Documents.ETL.Raven
             }))
             using (var dest = GetDocumentStore())
             {
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
-
                     for (int i = 0; i < 6; i++)
                     {
                         var user = new User();
-                        session.Store(user);
+                        await session.StoreAsync(user);
 
                         var r = new Random(i);
 
@@ -51,7 +51,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                         session.Advanced.Attachments.Store(user, "my-attachment", new MemoryStream(bytes));
                     }
 
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 AddEtl(src, dest, "Users", script: script);
@@ -60,7 +60,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                var database = GetDatabase(src.Database).Result;
+                var database = await GetDatabase(src.Database);
 
                 var etlProcess = (RavenEtl)database.EtlLoader.Processes.First();
 

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_9072.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_9072.cs
@@ -99,19 +99,17 @@ loadToOrders(orderData);"
         }
 
         [Fact]
-        public void CanTestScriptSpecifiedOnMultipleCollections()
+        public async Task CanTestScriptSpecifiedOnMultipleCollections()
         {
             using (var store = GetDocumentStore())
             {
-
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new Order());
-
-                    session.SaveChanges();
+                    await session.StoreAsync(new Order());
+                    await session.SaveChangesAsync();
                 }
 
-                var database = GetDatabase(store.Database).Result;
+                var database = await GetDatabase(store.Database);
 
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
@@ -143,19 +141,17 @@ loadToOrders(this);"
         }
 
         [Fact]
-        public void ShouldThrowIfTestingOnDocumentBelongingToDifferentCollection()
+        public async Task ShouldThrowIfTestingOnDocumentBelongingToDifferentCollection()
         {
             using (var store = GetDocumentStore())
             {
-
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new Order());
-
-                    session.SaveChanges();
+                    await session.StoreAsync(new Order());
+                    await session.SaveChangesAsync();
                 }
 
-                var database = GetDatabase(store.Database).Result;
+                var database = await GetDatabase(store.Database);
 
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
@@ -197,7 +193,6 @@ loadToDifferentCollection(this);"
                 using (var session = store.OpenAsyncSession())
                 {
                     await session.StoreAsync(new Order());
-
                     await session.SaveChangesAsync();
 
                     var database = await GetDatabase(store.Database);

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_10674.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_10674.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Tests.Core.Utils.Entities;
 using Xunit;
@@ -14,15 +15,14 @@ namespace SlowTests.Server.Documents.ETL
         }
 
         [Fact]
-        public void EntersFallbackModeIfCantConnectTheDestination()
+        public async Task EntersFallbackModeIfCantConnectTheDestination()
         {
             using (var src = GetDocumentStore())
             {
-                using (var store = src.OpenSession())
+                using (var store = src.OpenAsyncSession())
                 {
-                    store.Store(new User());
-
-                    store.SaveChanges();
+                    await store.StoreAsync(new User());
+                    await store.SaveChangesAsync();
                 }
 
                 var configuration = new RavenEtlConfiguration()
@@ -46,7 +46,7 @@ namespace SlowTests.Server.Documents.ETL
                     Database = "test",
                 });
 
-                var process = GetDatabase(src.Database).Result.EtlLoader.Processes[0];
+                var process = (await GetDatabase(src.Database)).EtlLoader.Processes[0];
 
                 Assert.True(SpinWait.SpinUntil(() =>
                 {

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_12079.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_12079.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Server.Documents.ETL;
@@ -19,14 +20,14 @@ namespace SlowTests.Server.Documents.ETL
         }
 
         [Fact]
-        public void Processing_in_low_memory_mode()
+        public async Task Processing_in_low_memory_mode()
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
             {
                 AddEtl(src, dest, "Users", script: null);
 
-                var database = GetDatabase(src.Database).Result;
+                var database = await GetDatabase(src.Database);
 
                 var etlProcess = (RavenEtl)database.EtlLoader.Processes.First();
 
@@ -36,26 +37,26 @@ namespace SlowTests.Server.Documents.ETL
 
                 var etlDone = WaitForEtl(src, (n, s) => s.LoadSuccesses >= numberOfDocs);
 
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
                     for (int i = 0; i < numberOfDocs; i++)
                     {
-                        session.Store(new User()
+                        await session.StoreAsync(new User
                         {
                             Name = "Joe Doe"
                         }, $"users/{i}");
                     }
 
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
                 for (int i = 0; i < numberOfDocs; i++)
                 {
-                    using (var session = dest.OpenSession())
+                    using (var session = dest.OpenAsyncSession())
                     {
-                        var user = session.Load<User>($"users/{i}");
+                        var user = await session.LoadAsync<User>($"users/{i}");
 
                         Assert.NotNull(user);
                     }

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_12809.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_12809.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Xunit;
@@ -16,7 +17,7 @@ namespace SlowTests.Server.Documents.ETL
         }
 
         [Fact]
-        public void Can_setup_etl_from_encrypted_to_non_encrypted_db()
+        public async Task Can_setup_etl_from_encrypted_to_non_encrypted_db()
         {
             var certificates = Certificates.SetupServerAuthentication();
             var dbName = GetDatabaseName();
@@ -76,7 +77,7 @@ namespace SlowTests.Server.Documents.ETL
                     Database = "Northwind",
                 });
 
-                var db = GetDatabase(src.Database).Result;
+                var db = await GetDatabase(src.Database);
 
                 Assert.Equal(1, db.EtlLoader.Processes.Length);
             }

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -701,7 +701,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
                     }));
                     Assert.NotNull(result1.RaftCommandIndex);
 
-                    var database = GetDatabase(store.Database).Result;
+                    var database = await GetDatabase(store.Database);
 
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     {
@@ -783,7 +783,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
                     }));
                     Assert.NotNull(result1.RaftCommandIndex);
 
-                    var database = GetDatabase(store.Database).Result;
+                    var database = await GetDatabase(store.Database);
 
                     using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                     {
@@ -1222,7 +1222,7 @@ loadToUsers(
         }
 
         [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
-        public void Should_stop_batch_if_size_limit_exceeded_RavenDB_12800()
+        public async Task Should_stop_batch_if_size_limit_exceeded_RavenDB_12800()
         {
             using (var store = GetDocumentStore(new Options { ModifyDatabaseRecord = x => x.Settings[RavenConfiguration.GetKey(c => c.Etl.MaxBatchSize)] = "5" }))
             {
@@ -1235,13 +1235,12 @@ CREATE TABLE [dbo].[Orders]
     [Pic] [varbinary](max) NULL
 )
 ");
-                    using (var session = store.OpenSession())
+                    using (var session = store.OpenAsyncSession())
                     {
-
                         for (int i = 0; i < 6; i++)
                         {
                             var order = new Orders.Order();
-                            session.Store(order);
+                            await session.StoreAsync(order);
 
                             var r = new Random(i);
 
@@ -1252,7 +1251,7 @@ CREATE TABLE [dbo].[Orders]
                             session.Advanced.Attachments.Store(order, "my-attachment", new MemoryStream(bytes));
                         }
 
-                        session.SaveChanges();
+                        await session.SaveChangesAsync();
                     }
 
                     var etlDone = WaitForEtl(store, (n, statistics) => statistics.LoadSuccesses >= 5);
@@ -1269,7 +1268,7 @@ loadToOrders(orderData);
 
                     etlDone.Wait(TimeSpan.FromMinutes(5));
 
-                    var database = GetDatabase(store.Database).Result;
+                    var database = await GetDatabase(store.Database);
 
                     var etlProcess = (SqlEtl)database.EtlLoader.Processes.First();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23231/Hanged-test-suite

### Additional description

Changed from blocking the thread to using await for asynchronous execution.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
