### PR TITLE
RavenDB-23245 Reverse exposed scores in MaxHeapSorter

### DIFF
--- a/src/Corax/Querying/Matches/SortingMatches/NumericalMaxHeapSorter.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/NumericalMaxHeapSorter.cs
@@ -186,6 +186,8 @@ internal unsafe ref struct NumericalMaxHeapSorter<TTermType, TSecondaryComparer>
         // However, instead of rebuilding the heap as a MinHeap, let's add everything from the heap and call Reverse from the Span extension,
         // which is a vectorized operation.
         results.ToSpan().Slice(start).Reverse();
+        if (exposeScores)
+            scoreDestination.ToSpan().Slice(start).Reverse();
     }
 
     /// <summary>
@@ -234,6 +236,8 @@ internal unsafe ref struct NumericalMaxHeapSorter<TTermType, TSecondaryComparer>
         // Reversing the elements is done via Span<T>.Reverse, which is a vectorized operation.
         results.ToSpan().Slice(startDocuments, total).Reverse();
         terms.ToSpan().Slice(startTerms, total).Reverse();
+        if (exposeScores)
+            scoreDestination.ToSpan().Slice(startDocuments, total).Reverse();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/Querying/Matches/SortingMatches/TextualMaxHeapSorter.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/TextualMaxHeapSorter.cs
@@ -186,6 +186,8 @@ internal unsafe ref struct TextualMaxHeapSorter<TSecondaryComparer> where TSecon
         // should replace the max element in the heap (and then find the new maximum).
         // Reversing the elements is done via Span<T>.Reverse, which is a vectorized operation.
         results.ToSpan().Slice(start).Reverse();
+        if (exposeScore)
+            scoreDestination.ToSpan().Slice(start).Reverse();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/FastTests/Corax/Bugs/RavenDB_23245.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB_23245.cs
@@ -1,0 +1,102 @@
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq.Indexing;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs;
+
+public class RavenDB_23245 : RavenTestBase
+{
+    public RavenDB_23245(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void OrderByScoreScoreExposed()
+    {
+        using var store = GetDatabaseWithDocuments();
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.RawQuery<QueryResult>("from index 'Index' v where v.Text == 'text' select { Score: v['@metadata']['@index-score'] , Numerical: v.Numerical}").ToList();
+            
+            Assert.Equal(2, results.Count);
+            Assert.True(results[0].Numerical > results[1].Numerical);
+            Assert.True(results[0].Score > results[1].Score);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void OrderByNumScoreExposed()
+    {
+        using var store = GetDatabaseWithDocuments();
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.RawQuery<QueryResult>("from index 'Index' v where boost(v.Text == 'text', 10)" +
+                                                                 " order by v.Numerical as long asc, score() select { Score: v['@metadata']['@index-score'] , Numerical: v.Numerical}")
+                .ToList();
+            
+            Assert.Equal(2, results.Count);
+            Assert.True(results[0].Numerical < results[1].Numerical);
+            Assert.True(results[0].Score < results[1].Score);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    public void OrderByStringScoreExposed()
+    {
+        using var store = GetDatabaseWithDocuments();
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.RawQuery<QueryResult>("from index 'Index' v where boost(v.TextNormal == 'text text', 10)" +
+                                                                 " order by v.TextNormal, score() select { Score: v['@metadata']['@index-score'] , Numerical: v.Numerical}")
+                .ToList();
+            
+            Assert.Equal(2, results.Count);
+            Assert.True(results[0].Score > results[1].Score);
+        }
+    }
+
+    private IDocumentStore GetDatabaseWithDocuments()
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        options.ModifyDatabaseRecord += record =>
+        {
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = true.ToString();
+        };
+
+        var store = GetDocumentStore(options);
+        new Index().Execute(store);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Dto(10, "text text", 1));
+            session.Store(new Dto(20, "text text", 2));
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        return store;
+    }
+
+    private record Dto(float DocBoost, string Text, int Numerical);
+
+    private class QueryResult
+    {
+        public int Numerical { get; set; }
+        public float Score { get; set; }
+    }
+    
+    private class Index : AbstractIndexCreationTask<Dto>
+    {
+        public Index()
+        {
+            Map = dtos => from doc in dtos
+                select new { doc.Text, doc.Numerical, TextNormal = doc.Text }.Boost(doc.DocBoost);
+            Index(x => x.Text, FieldIndexing.Search);
+        }
+    }
+}

--- a/test/FastTests/Corax/Bugs/RavenDB_23245.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB_23245.cs
@@ -9,54 +9,62 @@ using Xunit.Abstractions;
 
 namespace FastTests.Corax.Bugs;
 
-public class RavenDB_23245 : RavenTestBase
+public class RavenDB_23245(ITestOutputHelper output) : RavenTestBase(output)
 {
-    public RavenDB_23245(ITestOutputHelper output) : base(output)
-    {
-    }
+    private static string OrderByClause(bool isDescending) => isDescending ? "desc" : "asc";
+    private static int CompareResult(bool isDescending) => isDescending ? -1 : 1; // note reverted arguments
 
-    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
-    public void OrderByScoreScoreExposed()
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void OrderByScoreScoreExposed(bool isDescending)
     {
         using var store = GetDatabaseWithDocuments();
         using (var session = store.OpenSession())
         {
-            var results = session.Advanced.RawQuery<QueryResult>("from index 'Index' v where v.Text == 'text' select { Score: v['@metadata']['@index-score'] , Numerical: v.Numerical}").ToList();
+            var results = session.Advanced.RawQuery<QueryResult>($"from index 'Index' v where v.Text == 'text' order by score() {OrderByClause(isDescending)} select {{ Score: v['@metadata']['@index-score'] , Numerical: v.Numerical}}").ToList();
             
             Assert.Equal(2, results.Count);
-            Assert.True(results[0].Numerical > results[1].Numerical);
-            Assert.True(results[0].Score > results[1].Score);
+            Assert.Equal(CompareResult(isDescending), results[0].Numerical.CompareTo(results[1].Numerical));
+            Assert.Equal(CompareResult(isDescending), results[0].Score.CompareTo(results[1].Score));
         }
     }
     
-    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
-    public void OrderByNumScoreExposed()
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void OrderByNumScoreExposed(bool isDescending)
     {
         using var store = GetDatabaseWithDocuments();
         using (var session = store.OpenSession())
         {
             var results = session.Advanced.RawQuery<QueryResult>("from index 'Index' v where boost(v.Text == 'text', 10)" +
-                                                                 " order by v.Numerical as long asc, score() select { Score: v['@metadata']['@index-score'] , Numerical: v.Numerical}")
+                                                                 $" order by v.EqualNumberForTestSecondParameter as long asc, score() {OrderByClause(isDescending)} select {{ Score: v['@metadata']['@index-score'] , Numerical: v.Numerical}}")
                 .ToList();
             
             Assert.Equal(2, results.Count);
-            Assert.True(results[0].Numerical < results[1].Numerical);
-            Assert.True(results[0].Score < results[1].Score);
+            Assert.Equal(CompareResult(isDescending), results[0].Score.CompareTo(results[1].Score));
+            Assert.Equal(CompareResult(isDescending), results[0].Numerical.CompareTo(results[1].Numerical));
         }
     }
     
-    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Querying)]
-    public void OrderByStringScoreExposed()
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void OrderByStringScoreExposed(bool isDescending)
     {
         using var store = GetDatabaseWithDocuments();
         using (var session = store.OpenSession())
         {
             var results = session.Advanced.RawQuery<QueryResult>("from index 'Index' v where boost(v.TextNormal == 'text text', 10)" +
-                                                                 " order by v.TextNormal, score() select { Score: v['@metadata']['@index-score'] , Numerical: v.Numerical}")
+                                                                 " order by v.TextNormal, " +
+                                                                 $"score() {OrderByClause(isDescending)} " +
+                                                                 "select { Score: v['@metadata']['@index-score'] , Numerical: v.Numerical}")
                 .ToList();
             
             Assert.Equal(2, results.Count);
-            Assert.True(results[0].Score > results[1].Score);
+            Assert.Equal(CompareResult(isDescending), results[0].Score.CompareTo(results[1].Score));
+            Assert.Equal(CompareResult(isDescending), results[0].Numerical.CompareTo(results[1].Numerical));
         }
     }
 
@@ -72,8 +80,8 @@ public class RavenDB_23245 : RavenTestBase
         new Index().Execute(store);
         using (var session = store.OpenSession())
         {
-            session.Store(new Dto(10, "text text", 1));
-            session.Store(new Dto(20, "text text", 2));
+            session.Store(new Dto(10, "text text", 1, 1));
+            session.Store(new Dto(20, "text text", 2, 1));
             session.SaveChanges();
         }
 
@@ -82,7 +90,7 @@ public class RavenDB_23245 : RavenTestBase
         return store;
     }
 
-    private record Dto(float DocBoost, string Text, int Numerical);
+    private record Dto(float DocBoost, string Text, int Numerical, int EqualNumberForTestSecondParameter);
 
     private class QueryResult
     {
@@ -95,7 +103,7 @@ public class RavenDB_23245 : RavenTestBase
         public Index()
         {
             Map = dtos => from doc in dtos
-                select new { doc.Text, doc.Numerical, TextNormal = doc.Text }.Boost(doc.DocBoost);
+                select new { doc.Text, doc.Numerical, TextNormal = doc.Text, doc.EqualNumberForTestSecondParameter }.Boost(doc.DocBoost);
             Index(x => x.Text, FieldIndexing.Search);
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23245

### Additional description

We've to reverse exposed score after pushing them to the buffer.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
