### PR TITLE
RavenDB-23129 Making sure that JournalReader.Complete is always called so we'll unmap file mappings when using 32-bits pagers

### DIFF
--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -21,7 +21,7 @@ using Sparrow.Json;
 
 namespace Voron.Impl.Journal
 {
-    public sealed unsafe class JournalReader : IDisposable
+    public sealed unsafe class JournalReader
     {
         private readonly StorageEnvironment _environment;
         private readonly Pager _journalPager;
@@ -754,10 +754,6 @@ namespace Voron.Impl.Journal
         public override string ToString()
         {
             return _journalPager.ToString();
-        }
-
-        public void Dispose()
-        {
         }
 
         public void Complete(ref Pager.State state, ref Pager.PagerTransactionState txState)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23129/FailingTests-System.AggregateException-Could-not-dispose-Storage-test.

### Additional description

The problem was that the logic that previously (< 7.0) was executed in `JournalReader.Dispose()` was moved to `JournalReader.Complete()` but it was not executed when encountering an error no journal reader.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [x] Yes - In general it's a but, but it affected tests on 32 bits so we found the issue
- [ ] No


### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests executed on x86 will verify the fix 

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
