### PR TITLE
RavenDB-22959 - Add IncludeAllTimeSeries(DateTime? from = null, DateTime? to = null) method

### DIFF
--- a/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
@@ -51,6 +51,8 @@ namespace Raven.Client.Documents.Session.Loaders
         TBuilder IncludeAllTimeSeries(TimeSeriesRangeType type, TimeValue time);
 
         TBuilder IncludeAllTimeSeries(TimeSeriesRangeType type, int count);
+
+        TBuilder IncludeAllTimeSeries(DateTime? from = null, DateTime? to = null);
     }
 
     public interface IRevisionIncludeBuilder<T, out TBuilder> 
@@ -436,6 +438,12 @@ namespace Raven.Client.Documents.Session.Loaders
             return this;
         }
 
+        IIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, IIncludeBuilder<T>>.IncludeAllTimeSeries(DateTime? from = null, DateTime? to = null)
+        {
+            IncludeTimeSeriesFromTo(string.Empty, Constants.TimeSeries.All, from, to);
+            return this;
+        }
+
         IQueryIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeTimeSeries(string name, TimeSeriesRangeType type, TimeValue time)
         {
             IncludeTimeSeriesByRangeTypeAndTime(string.Empty, name, type, time);
@@ -472,6 +480,12 @@ namespace Raven.Client.Documents.Session.Loaders
             return this;
         }
 
+        IQueryIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeAllTimeSeries(DateTime? from = null, DateTime? to = null)
+        {
+            IncludeTimeSeriesFromTo(string.Empty, Constants.TimeSeries.All, from, to);
+            return this;
+        }
+
         ISubscriptionIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, ISubscriptionIncludeBuilder<T>>.IncludeTimeSeries(string name, TimeSeriesRangeType type, TimeValue time)
         {
             IncludeTimeSeriesByRangeTypeAndTime(string.Empty, name, type, time);
@@ -505,6 +519,12 @@ namespace Raven.Client.Documents.Session.Loaders
         ISubscriptionIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, ISubscriptionIncludeBuilder<T>>.IncludeAllTimeSeries(TimeSeriesRangeType type, int count)
         {
             IncludeTimeSeriesByRangeTypeAndCount(string.Empty, Constants.TimeSeries.All, type, count);
+            return this;
+        }
+
+        ISubscriptionIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, ISubscriptionIncludeBuilder<T>>.IncludeAllTimeSeries(DateTime? from = null, DateTime? to = null)
+        {
+            IncludeTimeSeriesFromTo(string.Empty, Constants.TimeSeries.All, from, to);
             return this;
         }
 

--- a/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
@@ -40,18 +40,64 @@ namespace Raven.Client.Documents.Session.Loaders
 
     public interface IAbstractTimeSeriesIncludeBuilder<T, out TBuilder>
     {
+        /// <summary>
+        /// Includes a specific time series by name and range type, with a specified time value.
+        /// </summary>
+        /// <param name="name">The name of the time series to include.</param>
+        /// <param name="type">The type of range to include, such as from a start time or for a duration.</param>
+        /// <param name="time">The time value defining the range.</param>
+        /// <returns>An instance of the builder for method chaining.</returns>
         TBuilder IncludeTimeSeries(string name, TimeSeriesRangeType type, TimeValue time);
 
+        /// <summary>
+        /// Includes a specific time series by name and range type, with a specified count of entries.
+        /// </summary>
+        /// <param name="name">The name of the time series to include.</param>
+        /// <param name="type">The type of range to include, such as from a start time or for a duration.</param>
+        /// <param name="count">The number of entries to include.</param>
+        /// <returns>An instance of the builder for method chaining.</returns>
         TBuilder IncludeTimeSeries(string name, TimeSeriesRangeType type, int count);
 
+        /// <summary>
+        /// Includes multiple time series by their names and range type, with a specified time value.
+        /// </summary>
+        /// <param name="names">An array of time series names to include.</param>
+        /// <param name="type">The type of range to include, such as from a start time or for a duration.</param>
+        /// <param name="time">The time value defining the range.</param>
+        /// <returns>An instance of the builder for method chaining.</returns>
         TBuilder IncludeTimeSeries(string[] names, TimeSeriesRangeType type, TimeValue time);
 
+        /// <summary>
+        /// Includes multiple time series by their names and range type, with a specified count of entries.
+        /// </summary>
+        /// <param name="names">An array of time series names to include.</param>
+        /// <param name="type">The type of range to include, such as from a start time or for a duration.</param>
+        /// <param name="count">The number of entries to include.</param>
+        /// <returns>An instance of the builder for method chaining.</returns>
         TBuilder IncludeTimeSeries(string[] names, TimeSeriesRangeType type, int count);
 
+        /// <summary>
+        /// Includes all time series of the entity, filtered by a range type and time value.
+        /// </summary>
+        /// <param name="type">The type of range to include, such as from a start time or for a duration.</param>
+        /// <param name="time">The time value defining the range.</param>
+        /// <returns>An instance of the builder for method chaining.</returns>
         TBuilder IncludeAllTimeSeries(TimeSeriesRangeType type, TimeValue time);
 
+        /// <summary>
+        /// Includes all time series of the entity, filtered by a range type and a specified count of entries.
+        /// </summary>
+        /// <param name="type">The type of range to include, such as from a start time or for a duration.</param>
+        /// <param name="count">The number of entries to include.</param>
+        /// <returns>An instance of the builder for method chaining.</returns>
         TBuilder IncludeAllTimeSeries(TimeSeriesRangeType type, int count);
 
+        /// <summary>
+        /// Includes all time series of the entity, optionally filtered by a specific time range.
+        /// </summary>
+        /// <param name="from">The start date and time for the range to include. Can be <c>null</c> for no lower bound.</param>
+        /// <param name="to">The end date and time for the range to include. Can be <c>null</c> for no upper bound.</param>
+        /// <returns>An instance of the builder for method chaining.</returns>
         TBuilder IncludeAllTimeSeries(DateTime? from = null, DateTime? to = null);
     }
 

--- a/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
+++ b/src/Raven.Client/Documents/Session/Loaders/IncludeBuilder.cs
@@ -438,7 +438,7 @@ namespace Raven.Client.Documents.Session.Loaders
             return this;
         }
 
-        IIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, IIncludeBuilder<T>>.IncludeAllTimeSeries(DateTime? from = null, DateTime? to = null)
+        IIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, IIncludeBuilder<T>>.IncludeAllTimeSeries(DateTime? from, DateTime? to)
         {
             IncludeTimeSeriesFromTo(string.Empty, Constants.TimeSeries.All, from, to);
             return this;
@@ -480,7 +480,7 @@ namespace Raven.Client.Documents.Session.Loaders
             return this;
         }
 
-        IQueryIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeAllTimeSeries(DateTime? from = null, DateTime? to = null)
+        IQueryIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, IQueryIncludeBuilder<T>>.IncludeAllTimeSeries(DateTime? from, DateTime? to)
         {
             IncludeTimeSeriesFromTo(string.Empty, Constants.TimeSeries.All, from, to);
             return this;
@@ -522,7 +522,7 @@ namespace Raven.Client.Documents.Session.Loaders
             return this;
         }
 
-        ISubscriptionIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, ISubscriptionIncludeBuilder<T>>.IncludeAllTimeSeries(DateTime? from = null, DateTime? to = null)
+        ISubscriptionIncludeBuilder<T> IAbstractTimeSeriesIncludeBuilder<T, ISubscriptionIncludeBuilder<T>>.IncludeAllTimeSeries(DateTime? from, DateTime? to)
         {
             IncludeTimeSeriesFromTo(string.Empty, Constants.TimeSeries.All, from, to);
             return this;

--- a/test/SlowTests/Issues/RavenDB-22959.cs
+++ b/test/SlowTests/Issues/RavenDB-22959.cs
@@ -1,0 +1,304 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.TimeSeries;
+using Raven.Client.Documents.Session.TimeSeries;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22959 : RavenTestBase
+    {
+        public RavenDB_22959(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
+        public async Task SessionLoadWithIncludeAllTimeSeriesByRange()
+        {
+            var baseTime = new DateTime(year: 2024, month: 1, day: 1, hour: 1, minute: 30, second: 0);
+
+            using var store = GetDocumentStore();
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            db.Time.UtcDateTime = () => baseTime;
+
+            var tags = new string[] { "watches/apple", "watches/galaxy", "watches/fitbit", "watches/garmin" };
+
+            var time = baseTime;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Id = "Users/1", Name = "Shahar" });
+                await session.SaveChangesAsync();
+
+                for (int i = 0; i < tags.Length; i++)
+                {
+                    for (int t = 1; t <= 3; t++)
+                    {
+                        var tsf = session.TimeSeriesFor("Users/1", "TimeSeries"+t);
+                        var val = (double)(t*10+i);
+                        var tag = tags[i];
+                        tsf.Append(time, new[] { val }, tag);
+                    }
+                    await session.SaveChangesAsync();
+
+                    time += TimeSpan.FromDays(1);
+                    db.Time.UtcDateTime = () => time;
+                }
+
+            }
+
+
+            var from = baseTime + TimeSpan.FromDays(0.5);
+            var to = baseTime + TimeSpan.FromDays(2.5);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var queryResults = await session.Query<User>()
+                    .Where(u => u.Id == "Users/1")
+                    .Include(includeBuilder => includeBuilder.IncludeAllTimeSeries(from, to))
+                    .ToListAsync();
+
+                Assert.Equal(1, queryResults.Count);
+                var user = queryResults.FirstOrDefault();
+
+                var entries1 = await session.TimeSeriesFor(user, "TimeSeries1").GetAsync(from, to);
+                Assert.Equal(2, entries1.Length);
+                Assert.Equal(tags[1], entries1[0].Tag);
+                Assert.Equal(tags[2], entries1[1].Tag);
+                var entries2 = await session.TimeSeriesFor(user, "TimeSeries2").GetAsync(from, to);
+                Assert.Equal(2, entries2.Length);
+                Assert.Equal(tags[1], entries2[0].Tag);
+                Assert.Equal(tags[2], entries2[1].Tag);
+                var entries3 = await session.TimeSeriesFor(user, "TimeSeries3").GetAsync(from, to);
+                Assert.Equal(2, entries3.Length);
+                Assert.Equal(tags[1], entries3[0].Tag);
+                Assert.Equal(tags[2], entries3[1].Tag);
+
+                Assert.Equal(1, session.Advanced.NumberOfRequests);
+            }
+
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>("Users/1", includeBuilder => includeBuilder.IncludeAllTimeSeries(from, to));
+                    
+                var entries1 = await session.TimeSeriesFor(user, "TimeSeries1").GetAsync(from, to);
+                Assert.Equal(2, entries1.Length);
+                Assert.Equal(tags[1], entries1[0].Tag);
+                Assert.Equal(tags[2], entries1[1].Tag);
+                var entries2 = await session.TimeSeriesFor(user, "TimeSeries2").GetAsync(from, to);
+                Assert.Equal(2, entries2.Length);
+                Assert.Equal(tags[1], entries2[0].Tag);
+                Assert.Equal(tags[2], entries2[1].Tag);
+                var entries3 = await session.TimeSeriesFor(user, "TimeSeries3").GetAsync(from, to);
+                Assert.Equal(2, entries3.Length);
+                Assert.Equal(tags[1], entries3[0].Tag);
+                Assert.Equal(tags[2], entries3[1].Tag);
+
+                Assert.Equal(1, session.Advanced.NumberOfRequests);
+            }
+
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var queryResults = await session.Query<User>()
+                    .Where(u => u.Id == "Users/1")
+                    .Include(includeBuilder => includeBuilder.IncludeAllTimeSeries())
+                    .ToListAsync();
+
+                Assert.Equal(1, queryResults.Count);
+                var user = queryResults.FirstOrDefault();
+
+                var entries1 = await session.TimeSeriesFor(user, "TimeSeries1").GetAsync();
+                Assert.Equal(4, entries1.Length);
+                var entries2 = await session.TimeSeriesFor(user, "TimeSeries2").GetAsync();
+                Assert.Equal(4, entries2.Length);
+                var entries3 = await session.TimeSeriesFor(user, "TimeSeries3").GetAsync();
+                Assert.Equal(4, entries3.Length);
+
+                Assert.Equal(1, session.Advanced.NumberOfRequests);
+            }
+
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>("Users/1", includeBuilder => includeBuilder.IncludeAllTimeSeries());
+
+                var entries1 = await session.TimeSeriesFor(user, "TimeSeries1").GetAsync();
+                Assert.Equal(4, entries1.Length);
+                var entries2 = await session.TimeSeriesFor(user, "TimeSeries2").GetAsync();
+                Assert.Equal(4, entries2.Length);
+                var entries3 = await session.TimeSeriesFor(user, "TimeSeries3").GetAsync();
+                Assert.Equal(4, entries3.Length);
+
+                Assert.Equal(1, session.Advanced.NumberOfRequests);
+            }
+
+        }
+
+        [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
+        public async Task SessionLoadWithIncludeAllTimeSeriesByRangeWithMultipleDocs()
+        {
+            var baseTime = new DateTime(year: 2024, month: 1, day: 1, hour: 1, minute: 30, second: 0);
+
+            using var store = GetDocumentStore();
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+            db.Time.UtcDateTime = () => baseTime;
+
+            var ids = new string[] { "Users/1", "Users/2", "Users/3", "Users/4" };
+
+            var tags = new string[] { "watches/apple", "watches/galaxy", "watches/fitbit", "watches/garmin" };
+
+            var time = baseTime;
+
+
+
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < ids.Length; i++)
+                {
+                    var name = i % 2 == 0 ? "Shahar" : "Omer";
+                    await session.StoreAsync(new User { Id = ids[i], Name = name });
+                    await session.SaveChangesAsync();
+                }
+
+                for (int i = 0; i < tags.Length; i++)
+                {
+                    for (int t = 1; t <= 3; t++)
+                    {
+                        foreach (var docId in ids)
+                        {
+                            var tsf = session.TimeSeriesFor(docId, "TimeSeries" + t);
+                            var val = (double)(t * 10 + i);
+                            var tag = tags[i];
+                            tsf.Append(time, new[] { val }, tag);
+                        }
+                    }
+                    await session.SaveChangesAsync();
+
+                    time += TimeSpan.FromDays(1);
+                    db.Time.UtcDateTime = () => time;
+                }
+
+            }
+
+
+            var from = baseTime + TimeSpan.FromDays(0.5);
+            var to = baseTime + TimeSpan.FromDays(2.5);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var queryResults = await session.Query<User>()
+                    .Where(u => u.Name == "Shahar")
+                    .Include(includeBuilder => includeBuilder.IncludeAllTimeSeries(from, to))
+                    .ToListAsync();
+
+                Assert.Equal(2, queryResults.Count);
+                foreach (var user in queryResults)
+                {
+                    var entries1 = await session.TimeSeriesFor(user, "TimeSeries1").GetAsync(from, to);
+                    Assert.Equal(2, entries1.Length);
+                    Assert.Equal(tags[1], entries1[0].Tag);
+                    Assert.Equal(tags[2], entries1[1].Tag);
+                    var entries2 = await session.TimeSeriesFor(user, "TimeSeries2").GetAsync(from, to);
+                    Assert.Equal(2, entries2.Length);
+                    Assert.Equal(tags[1], entries2[0].Tag);
+                    Assert.Equal(tags[2], entries2[1].Tag);
+                    var entries3 = await session.TimeSeriesFor(user, "TimeSeries3").GetAsync(from, to);
+                    Assert.Equal(2, entries3.Length);
+                    Assert.Equal(tags[1], entries3[0].Tag);
+                    Assert.Equal(tags[2], entries3[1].Tag);
+                }
+
+                Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+                queryResults = await session.Query<User>()
+                    .Where(u => u.Name == "Omer")
+                    .ToListAsync();
+
+                foreach (var user in queryResults)
+                {
+                    var entries1 = await session.TimeSeriesFor(user, "TimeSeries1").GetAsync(from, to);
+                    Assert.Equal(2, entries1.Length);
+                    Assert.Equal(tags[1], entries1[0].Tag);
+                    Assert.Equal(tags[2], entries1[1].Tag);
+                    var entries2 = await session.TimeSeriesFor(user, "TimeSeries2").GetAsync(from, to);
+                    Assert.Equal(2, entries2.Length);
+                    Assert.Equal(tags[1], entries2[0].Tag);
+                    Assert.Equal(tags[2], entries2[1].Tag);
+                    var entries3 = await session.TimeSeriesFor(user, "TimeSeries3").GetAsync(from, to);
+                    Assert.Equal(2, entries3.Length);
+                    Assert.Equal(tags[1], entries3[0].Tag);
+                    Assert.Equal(tags[2], entries3[1].Tag);
+                }
+
+                Assert.Equal(8, session.Advanced.NumberOfRequests);
+            }
+            
+            using (var session = store.OpenAsyncSession())
+            {
+                var queryResults = await session.Query<User>()
+                    .Where(u => u.Name == "Shahar")
+                    .Include(includeBuilder => includeBuilder.IncludeAllTimeSeries())
+                    .ToListAsync();
+
+                Assert.Equal(2, queryResults.Count);
+                foreach (var user in queryResults)
+                {
+                    var entries1 = await session.TimeSeriesFor(user, "TimeSeries1").GetAsync(from, to);
+                    Assert.Equal(2, entries1.Length);
+                    Assert.Equal(tags[1], entries1[0].Tag);
+                    Assert.Equal(tags[2], entries1[1].Tag);
+                    var entries2 = await session.TimeSeriesFor(user, "TimeSeries2").GetAsync(from, to);
+                    Assert.Equal(2, entries2.Length);
+                    Assert.Equal(tags[1], entries2[0].Tag);
+                    Assert.Equal(tags[2], entries2[1].Tag);
+                    var entries3 = await session.TimeSeriesFor(user, "TimeSeries3").GetAsync(from, to);
+                    Assert.Equal(2, entries3.Length);
+                    Assert.Equal(tags[1], entries3[0].Tag);
+                    Assert.Equal(tags[2], entries3[1].Tag);
+                }
+
+                Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+                queryResults = await session.Query<User>()
+                    .Where(u => u.Name == "Omer")
+                    .ToListAsync();
+
+                foreach (var user in queryResults)
+                {
+                    var entries1 = await session.TimeSeriesFor(user, "TimeSeries1").GetAsync(from, to);
+                    Assert.Equal(2, entries1.Length);
+                    Assert.Equal(tags[1], entries1[0].Tag);
+                    Assert.Equal(tags[2], entries1[1].Tag);
+                    var entries2 = await session.TimeSeriesFor(user, "TimeSeries2").GetAsync(from, to);
+                    Assert.Equal(2, entries2.Length);
+                    Assert.Equal(tags[1], entries2[0].Tag);
+                    Assert.Equal(tags[2], entries2[1].Tag);
+                    var entries3 = await session.TimeSeriesFor(user, "TimeSeries3").GetAsync(from, to);
+                    Assert.Equal(2, entries3.Length);
+                    Assert.Equal(tags[1], entries3[0].Tag);
+                    Assert.Equal(tags[2], entries3[1].Tag);
+                }
+
+                Assert.Equal(8, session.Advanced.NumberOfRequests);
+            }
+
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22959/Add-support-for-including-all-timeseries-by-from-to-dates

### Additional description

Add Add IncludeAllTimeSeries(DateTime? from = null, DateTime? to = null)
equivalent to IncludeTimeSeries(string name, DateTime? from = null, DateTime? to = null); but for *all* timeseries

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
