### PR TITLE
RavenDB-23192 Create database wizard doesn't refresh required wizard steps after enabling & disabling Sharding

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepReplicationAndSharding.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/create/regular/steps/CreateDatabaseRegularStepReplicationAndSharding.tsx
@@ -27,7 +27,7 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
         hash: "VKF52P",
     });
 
-    const { control, setValue } = useFormContext<CreateDatabaseRegularFormData>();
+    const { control, setValue, watch } = useFormContext<CreateDatabaseRegularFormData>();
     const {
         basicInfoStep: { isEncrypted },
         replicationAndShardingStep: { isSharded, shardsCount, replicationFactor, isManualReplication },
@@ -48,6 +48,17 @@ export default function CreateDatabaseRegularStepReplicationAndSharding() {
     const isNotBootstrapped = nodeTagsCount === 0;
     const isManualReplicationRequiredForEncryption =
         createDatabaseRegularDataUtils.getIsManualReplicationRequiredForEncryption(nodeTagsCount, isEncrypted);
+
+    // Disable prefixes for shards when sharding is disabled
+    useEffect(() => {
+        const { unsubscribe } = watch((values, { name }) => {
+            if (name === "replicationAndShardingStep.isSharded" && !values.replicationAndShardingStep.isSharded) {
+                setValue("replicationAndShardingStep.isPrefixesForShards", false, { shouldValidate: true });
+            }
+        });
+
+        return () => unsubscribe();
+    }, [setValue, watch]);
 
     useEffect(() => {
         if (isSharded && replicationFactor > maxReplicationFactorForSharding) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23192/Create-database-wizard-doesnt-refresh-required-wizard-steps-after-enabling-disabling-Sharding

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
