### PR TITLE
RavenDB-23167 - fix SeekBackward giving greater keys than the last key that passed

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1568,13 +1568,19 @@ namespace Raven.Server.Documents.Revisions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe ByteStringContext.InternalScope GetKeyPrefix(DocumentsOperationContext context, Slice lowerId, out Slice prefixSlice)
         {
-            return GetKeyPrefix(context, lowerId.Content.Ptr, lowerId.Size, out prefixSlice);
+            return GetKeyPrefix(context.Allocator, lowerId.Content.Ptr, lowerId.Size, out prefixSlice);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe ByteStringContext.InternalScope GetKeyPrefix(DocumentsOperationContext context, byte* lowerId, int lowerIdSize, out Slice prefixSlice)
+        public static unsafe ByteStringContext.InternalScope GetKeyPrefix(ByteStringContext allocator, Slice lowerId, out Slice prefixSlice)
         {
-            var scope = context.Allocator.Allocate(lowerIdSize + 1, out ByteString keyMem);
+            return GetKeyPrefix(allocator, lowerId.Content.Ptr, lowerId.Size, out prefixSlice);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe ByteStringContext.InternalScope GetKeyPrefix(ByteStringContext allocator, byte* lowerId, int lowerIdSize, out Slice prefixSlice)
+        {
+            var scope = allocator.Allocate(lowerIdSize + 1, out ByteString keyMem);
 
             Memory.Copy(keyMem.Ptr, lowerId, lowerIdSize);
             keyMem.Ptr[lowerIdSize] = SpecialChars.RecordSeparator;
@@ -1591,7 +1597,13 @@ namespace Raven.Server.Documents.Revisions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(DocumentsOperationContext context, Slice lowerId, long etag, out Slice prefixSlice)
         {
-            var scope = context.Allocator.Allocate(lowerId.Size + 1 + sizeof(long), out ByteString keyMem);
+            return GetKeyWithEtag(context.Allocator, lowerId, etag, out prefixSlice);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(ByteStringContext allocator, Slice lowerId, long etag, out Slice prefixSlice)
+        {
+            var scope = allocator.Allocate(lowerId.Size + 1 + sizeof(long), out ByteString keyMem);
 
             Memory.Copy(keyMem.Ptr, lowerId.Content.Ptr, lowerId.Size);
             keyMem.Ptr[lowerId.Size] = SpecialChars.RecordSeparator;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1595,13 +1595,13 @@ namespace Raven.Server.Documents.Revisions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(DocumentsOperationContext context, Slice lowerId, long etag, out Slice prefixSlice)
+        internal static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(DocumentsOperationContext context, Slice lowerId, long etag, out Slice prefixSlice)
         {
             return GetKeyWithEtag(context.Allocator, lowerId, etag, out prefixSlice);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(ByteStringContext allocator, Slice lowerId, long etag, out Slice prefixSlice)
+        internal static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(ByteStringContext allocator, Slice lowerId, long etag, out Slice prefixSlice)
         {
             var scope = allocator.Allocate(lowerId.Size + 1 + sizeof(long), out ByteString keyMem);
 
@@ -2414,11 +2414,11 @@ namespace Raven.Server.Documents.Revisions
 
         public (Document[] Revisions, long Count) GetRevisions(DocumentsOperationContext context, string id, long start, long take)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice idSlice))
-            using (GetKeyPrefix(context, idSlice, out Slice prefixSlice))
-            using (GetKeyWithEtag(context, idSlice, etag: long.MaxValue, out var compoundLastKey))
+            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
+            using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
+            using (GetLastKey(context, lowerId, out var lastKey))
             {
-                var revisions = GetRevisions(context, prefixSlice: prefixSlice, lastKey: compoundLastKey, start, take).ToArray();
+                var revisions = GetRevisions(context, prefixSlice: prefixSlice, lastKey: lastKey, start, take).ToArray();
                 var count = CountOfRevisions(context, prefixSlice);
                 return (revisions, count);
             }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Revisions
 {
     public partial class RevisionsStorage
     {
-        private static readonly Slice IdAndEtagSlice;
+        public static readonly Slice IdAndEtagSlice;
         public static readonly Slice DeleteRevisionEtagSlice;
         public static readonly Slice AllRevisionsEtagsSlice;
         public static readonly Slice CollectionRevisionsEtagsSlice;
@@ -1566,7 +1566,7 @@ namespace Raven.Server.Documents.Revisions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe ByteStringContext.InternalScope GetKeyPrefix(DocumentsOperationContext context, Slice lowerId, out Slice prefixSlice)
+        public unsafe ByteStringContext.InternalScope GetKeyPrefix(DocumentsOperationContext context, Slice lowerId, out Slice prefixSlice)
         {
             return GetKeyPrefix(context, lowerId.Content.Ptr, lowerId.Size, out prefixSlice);
         }
@@ -1589,7 +1589,7 @@ namespace Raven.Server.Documents.Revisions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(DocumentsOperationContext context, Slice lowerId, long etag, out Slice prefixSlice)
+        public static unsafe ByteStringContext<ByteStringMemoryCache>.InternalScope GetKeyWithEtag(DocumentsOperationContext context, Slice lowerId, long etag, out Slice prefixSlice)
         {
             var scope = context.Allocator.Allocate(lowerId.Size + 1 + sizeof(long), out ByteString keyMem);
 
@@ -2402,11 +2402,11 @@ namespace Raven.Server.Documents.Revisions
 
         public (Document[] Revisions, long Count) GetRevisions(DocumentsOperationContext context, string id, long start, long take)
         {
-            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice lowerId))
-            using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
-            using (GetLastKey(context, lowerId, out Slice lastKey))
+            using (DocumentIdWorker.GetSliceFromId(context, id, out Slice idSlice))
+            using (GetKeyPrefix(context, idSlice, out Slice prefixSlice))
+            using (GetKeyWithEtag(context, idSlice, etag: long.MaxValue, out var compoundLastKey))
             {
-                var revisions = GetRevisions(context, prefixSlice, lastKey, start, take).ToArray();
+                var revisions = GetRevisions(context, prefixSlice: prefixSlice, lastKey: Slices.AfterAllKeys, start, take).ToArray();
                 var count = CountOfRevisions(context, prefixSlice);
                 return (revisions, count);
             }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2406,7 +2406,7 @@ namespace Raven.Server.Documents.Revisions
             using (GetKeyPrefix(context, idSlice, out Slice prefixSlice))
             using (GetKeyWithEtag(context, idSlice, etag: long.MaxValue, out var compoundLastKey))
             {
-                var revisions = GetRevisions(context, prefixSlice: prefixSlice, lastKey: Slices.AfterAllKeys, start, take).ToArray();
+                var revisions = GetRevisions(context, prefixSlice: prefixSlice, lastKey: compoundLastKey, start, take).ToArray();
                 var count = CountOfRevisions(context, prefixSlice);
                 return (revisions, count);
             }

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -724,9 +724,9 @@ namespace Voron.Data.BTrees
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int SetLastSearchPosition(Slice key, TreePage p, ref bool leftmostPage, ref bool rightmostPage, bool backward = false)
+        private int SetLastSearchPosition(Slice key, TreePage p, ref bool leftmostPage, ref bool rightmostPage)
         {
-            if (p.Search(_llt, key, backward) != null)
+            if (p.Search(_llt, key) != null)
             {
                 if (p.LastMatch != 0)
                 {
@@ -774,7 +774,7 @@ namespace Voron.Data.BTrees
                 }
                 else
                 {
-                    nodePos = SetLastSearchPosition(key, p, ref leftmostPage, ref rightmostPage, backward);
+                    nodePos = SetLastSearchPosition(key, p, ref leftmostPage, ref rightmostPage);
                 }
 
                 var pageNode = p.GetNode(nodePos);

--- a/src/Voron/Data/BTrees/TreeIterator.cs
+++ b/src/Voron/Data/BTrees/TreeIterator.cs
@@ -81,11 +81,15 @@ namespace Voron.Data.BTrees
 
             if (backward)
             {
-                _currentPage.LastSearchPosition = -1; // force next MoveNext to move to the next _page_.
+                // We know that the exact value isn't there, but it is possible that the previous page has values 
+                // that is actually less than the key, so we need to check it as well.
+                _currentPage.LastSearchPosition = -1; // force next MovePrev to move to the previous _page_.
                 return MovePrev();
             }
             else
             {
+                // We know that the exact value isn't there, but it is possible that the next page has values 
+                // that is actually greater than the key, so we need to check it as well.
                 _currentPage.LastSearchPosition = _currentPage.NumberOfEntries; // force next MoveNext to move to the next _page_.
                 return MoveNext();
             }

--- a/src/Voron/Data/BTrees/TreePage.cs
+++ b/src/Voron/Data/BTrees/TreePage.cs
@@ -189,7 +189,12 @@ namespace Voron.Data.BTrees
                 LastMatch = lastMatch;
                 LastSearchPosition = lastSearchPosition;
 
-                if (lastSearchPosition<=-1 || lastSearchPosition >= numberOfEntries)
+                if (backward)
+                {
+                    if (lastSearchPosition <= -1)
+                        return null;
+                }
+                else if (lastSearchPosition >= numberOfEntries)
                     return null;
 
                 return GetNode(lastSearchPosition);

--- a/src/Voron/Data/BTrees/TreePage.cs
+++ b/src/Voron/Data/BTrees/TreePage.cs
@@ -132,7 +132,7 @@ namespace Voron.Data.BTrees
                 if (backward)
                 {
                     if (lastMatch < 0)  // found entry greater than key
-                        position--;
+                        position--; // move to the largest entry smaller than the key
                 }
                 else
                 {

--- a/src/Voron/Data/BTrees/TreePageIterator.cs
+++ b/src/Voron/Data/BTrees/TreePageIterator.cs
@@ -38,11 +38,21 @@ namespace Voron.Data.BTrees
             OnDisposal?.Invoke(this);
         }
 
+        public bool SeekBackward(Slice key)
+        {
+            return SeekInternal(key, backward: true);
+        }
+
         public bool Seek(Slice key)
+        {
+            return SeekInternal(key, backward: false);
+        }
+
+        private bool SeekInternal(Slice key, bool backward)
         {
             if (_disposed)
                 throw new ObjectDisposedException("PageIterator");
-            var current = _page.Search(_tx, key);
+            var current = _page.Search(_tx, key, backward);
             if (current == null)
                 return false;
 

--- a/src/Voron/Data/EmptyIterator.cs
+++ b/src/Voron/Data/EmptyIterator.cs
@@ -11,6 +11,11 @@ namespace Voron.Data
             return false;
         }
 
+        public bool SeekBackward(Slice key)
+        {
+            return false;
+        }
+
         public bool DoRequireValidation
         {
             get { throw new InvalidOperationException("No current page"); }

--- a/src/Voron/Data/IIterator.cs
+++ b/src/Voron/Data/IIterator.cs
@@ -11,6 +11,7 @@ namespace Voron.Data
         Slice MaxKey { get; set; }
 
         bool Seek(Slice key);
+        bool SeekBackward(Slice key);
         bool MoveNext();
         bool MovePrev();
         bool Skip(long count);

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1343,17 +1343,11 @@ namespace Voron.Data.Tables
 
             using (var it = tree.Iterate(true))
             {
-                if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
+                if (it.SeekBackward(last) == false)
                     yield break;
 
                 it.SetRequiredPrefix(prefix);
                 if (SliceComparer.StartWith(it.CurrentKey, it.RequiredPrefix) == false)
-                {
-                    if (it.MovePrev() == false)
-                        yield break;
-                }
-
-                if (SliceComparer.CompareInline(it.CurrentKey, last) > 0)
                 {
                     if (it.MovePrev() == false)
                         yield break;
@@ -1381,7 +1375,7 @@ namespace Voron.Data.Tables
 
             using (var it = tree.Iterate(true))
             {
-                if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
+                if (it.SeekBackward(last) == false)
                     yield break;
 
                 do
@@ -1406,7 +1400,7 @@ namespace Voron.Data.Tables
 
             using (var it = tree.Iterate(true))
             {
-                if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
+                if (it.SeekBackward(last) == false)
                     return null;
 
                 it.SetRequiredPrefix(prefix);

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1302,7 +1302,7 @@ namespace Voron.Data.Tables
 
             using (var it = tree.Iterate(true))
             {
-                if (it.Seek(last) == false && it.Seek(Slices.AfterAllKeys) == false)
+                if (it.SeekBackward(last) == false)
                     yield break;
 
                 if (prefix != null)
@@ -1747,8 +1747,7 @@ namespace Voron.Data.Tables
             var fst = GetFixedSizeTree(index);
             using (var it = fst.Iterate())
             {
-                if (it.Seek(key) == false &&
-                    it.SeekToLast() == false)
+                if (it.SeekBackward(key) == false)
                     yield break;
 
                 if (it.Skip(-skip) == false)
@@ -1757,9 +1756,6 @@ namespace Voron.Data.Tables
                 var result = new TableValueHolder();
                 do
                 {
-                    if (it.CurrentKey > key)
-                        continue;
-
                     GetTableValueReader(it, out result.Reader);
                     yield return result;
                 } while (it.MovePrev());

--- a/test/SlowTests/Issues/RavenDB-23167-Voron.cs
+++ b/test/SlowTests/Issues/RavenDB-23167-Voron.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Linq;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Revisions;
+using Sparrow.Server;
+using Sparrow.Server.Utils;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Tables;
+using Xunit;
+using Xunit.Abstractions;
+using Voron.Impl;
+using static Voron.Data.Tables.TableSchema;
+using Sparrow.Binary;
+using Sparrow.Threading;
+using FastTests.Voron;
+using Sparrow.Json;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23167_Voron : StorageTest
+    {
+        public RavenDB_23167_Voron(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [RavenFact(RavenTestCategory.Revisions)]
+        public void SeekBackwardFrom_VoronOverloads()
+        {
+            RequireFileBasedPager();
+
+            using (var allocator = new ByteStringContext(SharedMultipleUseFlag.None))
+            using (Slice.From(allocator, "PK", out var pk))
+            using (Slice.From(allocator, "Etags", out var etagsSlice))
+            using (Slice.From(allocator, "RevisionsIdAndEtag", out var idAndEtagSlice))
+            using (Slice.From(allocator, "Table", out var tableName))
+            {
+                var etagsIndex = new FixedSizeSchemaIndexDef { Name = etagsSlice, IsGlobal = false, StartIndex = 0 };
+                var idAndEtagIndex = new SchemaIndexDef { StartIndex = 1, Count = 3, Name = idAndEtagSlice };
+                var schema = new TableSchema()
+                    .DefineKey(new SchemaIndexDef { Name = pk, IsGlobal = false, StartIndex = 0, Count = 1 })
+                    .DefineFixedSizeIndex(etagsIndex)
+                    .DefineIndex(idAndEtagIndex);
+
+                using (var tx = Env.WriteTransaction())
+                {
+                    schema.Create(tx, tableName, null);
+                    tx.Commit();
+                }
+
+                using (var tx = Env.WriteTransaction())
+                {
+                    using var table = tx.OpenTable(schema, tableName);
+
+                    InsertToTable(tx, table, 2, "foo/bar");
+                    InsertToTable(tx, table, 4, "foo/bar1");
+                    InsertToTable(tx, table, 6, "foo/bar");
+
+                    tx.Commit();
+                }
+
+                using (var tx = Env.ReadTransaction())
+                {
+                    using var table = tx.OpenTable(schema, tableName);
+
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: 3, empty: false, expectedEtag: 2);
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: 0, empty: true);
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: 10, empty: false, expectedEtag: 6);
+                    AssertSeekBackwardForFixedSizeTrees(table, etagsIndex, endEtag: long.MaxValue, empty: false, expectedEtag: 6);
+
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar", endEtag: 3, empty: false, expectedEtag: 2);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar", endEtag: 0, empty: true);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar", endEtag: 10, empty: false, expectedEtag: 6);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar", endEtag: long.MaxValue, empty: false, expectedEtag: 6);
+
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar", endEtag: 5, empty: false, expectedEtag: 2);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/bar1", endEtag: 5, empty: false, expectedEtag: 4);
+                    AssertSeekBackward(tx.Allocator, table, idAndEtagIndex, "foo/ba", endEtag: 5, empty: true);
+
+                    AssertSeekBackwardAfterAllKeys(tx.Allocator, table, idAndEtagIndex, "foo/bar", empty: false, expectedEtag: 6);
+                    AssertSeekBackwardAfterAllKeys(tx.Allocator, table, idAndEtagIndex, "foo/ba", empty: true);
+                }
+            }
+        }
+
+        private static void AssertSeekBackwardForFixedSizeTrees(Table table, FixedSizeSchemaIndexDef voronIndex, long endEtag, bool empty, long? expectedEtag = null)
+        {
+            var tvhs = table.SeekBackwardFrom(voronIndex, endEtag);
+            var keys = tvhs.Select(tvh => DocumentsStorage.TableValueToEtag((int)TestTable.KeyEtag, ref tvh.Reader)).ToList();
+
+            if (empty)
+            {
+                Assert.Empty(keys);
+                if (expectedEtag.HasValue)
+                    throw new InvalidOperationException("Cannot pass `expectedEtag` when `empty` is true");
+            }
+            else
+            {
+                Assert.NotEmpty(keys);
+                var lastLocalKey = keys[0];
+            
+                if (expectedEtag.HasValue)
+                    Assert.Equal(expectedEtag.Value, lastLocalKey);
+                else
+                    Assert.True(endEtag >= lastLocalKey, $"endEtag {endEtag}, lastLocalEtag: {lastLocalKey}");
+            }
+        }
+
+        private static void AssertSeekBackward(ByteStringContext allocator, Table table, SchemaIndexDef voronIndex, 
+            string id, long endEtag, bool empty, long? expectedEtag = null)
+        {
+            using (Slice.From(allocator, id, out var idSlice))
+            using (RevisionsStorage.GetKeyPrefix(allocator, idSlice, out Slice prefixSlice))
+            using (RevisionsStorage.GetKeyWithEtag(allocator, idSlice, endEtag, out var compoundPrefix))
+            {
+                var seekResults = table.SeekBackwardFrom(voronIndex, prefixSlice, compoundPrefix, 0).ToList();
+
+                if (empty)
+                {
+                    Assert.Empty(seekResults);
+                    if (expectedEtag.HasValue)
+                        throw new InvalidOperationException("Cannot pass `expectedEtag` when `empty` is true");
+                }
+                else
+                {
+                    Assert.NotEmpty(seekResults);
+                    using var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None);
+
+                    var tvr = seekResults[0].Result.Reader;
+
+                    var lastLocalEtag = DocumentsStorage.TableValueToEtag((int)TestTable.Etag, ref tvr);
+                    
+                    if (expectedEtag.HasValue)
+                        Assert.Equal(expectedEtag.Value, lastLocalEtag);
+                    else
+                        Assert.True(endEtag >= lastLocalEtag, $"endEtag {endEtag}, lastLocalEtag: {lastLocalEtag}");
+                    
+
+                    var lastLocalId = DocumentsStorage.TableValueToString(ctx, (int)TestTable.LowerId, ref tvr);
+                    Assert.Equal(id, lastLocalId);
+
+                }
+            }
+        }
+
+        private static void AssertSeekBackwardAfterAllKeys(ByteStringContext allocator, Table table, SchemaIndexDef voronIndex, string id, bool empty = false, long? expectedEtag = null)
+        {
+            using (Slice.From(allocator, id, out var idSlice))
+            using (RevisionsStorage.GetKeyPrefix(allocator, idSlice, out Slice prefixSlice))
+            {
+                var seekResults = table.SeekBackwardFrom(voronIndex, prefixSlice, Slices.AfterAllKeys, 0).ToList();
+
+                if (empty)
+                {
+                    Assert.Empty(seekResults);
+                    if (expectedEtag.HasValue)
+                        throw new InvalidOperationException("Cannot pass `expectedEtag` when `empty` is true");
+                }
+                else
+                {
+                    Assert.NotEmpty(seekResults);
+                    using var ctx = new JsonOperationContext(4096, 16 * 1024, 32 * 1024, SharedMultipleUseFlag.None);
+
+                    var tvr = seekResults[0].Result.Reader;
+
+                    if (expectedEtag.HasValue)
+                    {
+                        var lastLocalEtag = DocumentsStorage.TableValueToEtag((int)TestTable.Etag, ref tvr);
+                        Assert.Equal(expectedEtag.Value, lastLocalEtag);
+                    }
+
+                    string lastLocalId = DocumentsStorage.TableValueToString(ctx, (int)TestTable.LowerId, ref tvr).ToString();
+                    Assert.Equal(id, lastLocalId);
+                }
+            }
+        }
+
+        private static void InsertToTable(Transaction tx, Table table, long etag, string id)
+        {
+            using (Slice.From(tx.Allocator, id, ByteStringType.Immutable, out var idSlice))
+            using (table.Allocate(out TableValueBuilder tvb))
+            {
+                tvb.Add(Bits.SwapBytes(etag));
+                tvb.Add(idSlice); // Adding the same slice as the value for simplicity
+                tvb.Add(SpecialChars.RecordSeparator);
+                tvb.Add(Bits.SwapBytes(etag));
+                table.Insert(tvb);
+            }
+        }
+
+        private enum TestTable
+        {
+            KeyEtag = 0,
+            LowerId = 1,
+            RecordSeparator = 2,
+            Etag = 3
+        }
+
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23167.cs
+++ b/test/SlowTests/Issues/RavenDB-23167.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Server.Replication;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Revisions;
+using Raven.Server.ServerWide.Context;
+using SlowTests.Voron.Bugs;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Fixed;
+using Voron.Data.Tables;
+using Xunit;
+using Xunit.Abstractions;
+using static Lucene.Net.Search.SpanFilterResult;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23167 : ReplicationTestBase
+    {
+        public RavenDB_23167(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Revisions)]
+        public async Task SeekBackwardGivingGreaterKeysThanTheLastKeyThatPassed()
+        {
+            using var store = GetDocumentStore();
+            var configuration = new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration
+                {
+                    Disabled = false,
+                }
+            };
+            await RevisionsHelper.SetupRevisions(store, Server.ServerStore, configuration: configuration);
+
+            var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            // Create a doc with 2 revisions
+            using (var session = store.OpenAsyncSession())
+            {
+                var person = new Person
+                {
+                    Name = "Name1"
+                };
+                await session.StoreAsync(person, "foo/bar");
+                await session.SaveChangesAsync();
+                // cv: A:1, (local) etag: 2
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var person = new Person
+                {
+                    Name = "Name2"
+                };
+                await session.StoreAsync(person, "foo/bar1");
+                await session.SaveChangesAsync();
+                // cv: A:3, etag: 4
+            }
+
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var person = new Person
+                {
+                    Name = "Name3"
+                };
+                await session.StoreAsync(person, "foo/bar");
+                await session.SaveChangesAsync();
+                // cv: A:5, etag: 6
+            }
+            
+            AssertSeekBackwardForFixedSizeTrees(db, endEtag: 3, empty: false);
+            AssertSeekBackwardForFixedSizeTrees(db, endEtag: 0, empty: true);
+            AssertSeekBackwardForFixedSizeTrees(db, endEtag: 10, empty: false);
+            AssertSeekBackward(db, "foo/bar", endEtag: 3, empty: false);
+            AssertSeekBackward(db, "foo/bar", endEtag: 0, empty: true);
+            AssertSeekBackward(db, "foo/bar", endEtag: 10, empty: false);
+            AssertSeekBackward(db, "foo/bar", endEtag: long.MaxValue, empty: false);
+            AssertSeekBackwardAfterAllKeys(db, "foo/bar", empty: false);
+        }
+
+        private static void AssertSeekBackwardForFixedSizeTrees(DocumentDatabase db, long endEtag, bool empty = false)
+        {
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var table = new Table(RevisionsStorage.RevisionsSchema, context.Transaction.InnerTransaction);
+                var voronIndex = RevisionsStorage.RevisionsSchema.FixedSizeIndexes[RevisionsStorage.AllRevisionsEtagsSlice];
+                var tvhs = table.SeekBackwardFrom(voronIndex, endEtag);
+                var revisions = tvhs.Select(tvh => RevisionsStorage.TableValueToRevision(context, ref tvh.Reader, DocumentFields.ChangeVector)).ToList();
+
+                if (empty)
+                    Assert.Empty(revisions);
+                else
+                {
+                    Assert.NotEmpty(revisions);
+                    var lastLocalEtag = revisions[0].Etag;
+                    Assert.True(endEtag >= lastLocalEtag, $"endEtag {endEtag}, lastLocalEtag: {lastLocalEtag}");
+                }
+            }
+        }
+
+        private static void AssertSeekBackward(DocumentDatabase db, string id, long endEtag, bool empty = false)
+        {
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            using (DocumentIdWorker.GetSliceFromId(context, id, out var idSlice))
+            using (db.DocumentsStorage.RevisionsStorage.GetKeyPrefix(context, idSlice, out Slice prefixSlice))
+            using (RevisionsStorage.GetKeyWithEtag(context, idSlice, endEtag, out var compoundPrefix))
+            {
+                var table = new Table(RevisionsStorage.RevisionsSchema, context.Transaction.InnerTransaction);
+                var voronIndex = RevisionsStorage.RevisionsSchema.Indexes[RevisionsStorage.IdAndEtagSlice];
+                var trvs = table.SeekBackwardFrom(voronIndex, prefixSlice, compoundPrefix, 0);
+                var revisions = trvs.Select(tvr => RevisionsStorage.TableValueToRevision(context, ref tvr.Result.Reader, DocumentFields.ChangeVector)).ToList();
+                
+                if (empty)
+                    Assert.Empty(revisions);
+                else
+                {
+                    Assert.NotEmpty(revisions);
+                    var lastLocalEtag = revisions[0].Etag;
+                    Assert.True(endEtag >= lastLocalEtag, $"endEtag {endEtag}, lastLocalEtag: {lastLocalEtag}");
+                }
+            }
+        }
+
+        private static void AssertSeekBackwardAfterAllKeys(DocumentDatabase db, string id, bool empty = false)
+        {
+            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            using (DocumentIdWorker.GetSliceFromId(context, id, out var idSlice))
+            using (db.DocumentsStorage.RevisionsStorage.GetKeyPrefix(context, idSlice, out Slice prefixSlice))
+            {
+                var table = new Table(RevisionsStorage.RevisionsSchema, context.Transaction.InnerTransaction);
+                var voronIndex = RevisionsStorage.RevisionsSchema.Indexes[RevisionsStorage.IdAndEtagSlice];
+                var trvs = table.SeekBackwardFrom(voronIndex, prefixSlice, Slices.AfterAllKeys, 0);
+                var revisions = trvs.Select(tvr => RevisionsStorage.TableValueToRevision(context, ref tvr.Result.Reader, DocumentFields.ChangeVector)).ToList();
+
+                if (empty)
+                    Assert.Empty(revisions);
+                else
+                {
+                    Assert.NotEmpty(revisions);
+                    var lastLocalEtag = revisions[0].Etag;
+                }
+            }
+        }
+
+        private class Person
+        {
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+
+            public string AddressId { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23167/SeekBackwardFrom-with-last-parameter-not-seeking-properly

### Additional description

Some SeekBackwardFrom() functions such as
public IEnumerable<SeekResult> SeekBackwardFrom(TableSchema.AbstractTreeIndexDef index, Slice prefix, Slice last)
are seeking the 'last' key parameter and start iterating backwards from the wrong adjacent value.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
