### PR TITLE
RavenDB-23231 - Changed from blocking the thread to using await for asynchronous execution

### DIFF
--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Newtonsoft.Json;
 using Raven.Client.Exceptions.Commercial;
 using Raven.Client.Properties;
+using Raven.Client.Util;
 using Raven.Server.Commercial.LetsEncrypt;
 using Raven.Server.Config;
 using Raven.Server.Json;
@@ -298,7 +299,8 @@ namespace Raven.Server.Commercial
             {
                 if (TryValidateLicenseExpirationDate(deserializedLicense, out var deserializedLicenseExpirationDate))
                 {
-                    serverStore.LicenseManager.OnBeforeInitialize += () => serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).Wait(serverStore.ServerShutdown);
+                    serverStore.LicenseManager.OnBeforeInitialize += () => AsyncHelpers.RunSync(() => serverStore.LicenseManager.TryActivateLicenseAsync
+                        (throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).WaitAsync(TimeSpan.FromSeconds(30)));
                     return true;
                 }
 

--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -300,7 +300,7 @@ namespace Raven.Server.Commercial
                 if (TryValidateLicenseExpirationDate(deserializedLicense, out var deserializedLicenseExpirationDate))
                 {
                     serverStore.LicenseManager.OnBeforeInitialize += () => AsyncHelpers.RunSync(() => serverStore.LicenseManager.TryActivateLicenseAsync
-                        (throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).WaitAsync(TimeSpan.FromSeconds(30)));
+                        (throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).WaitAsync(serverStore.ServerShutdown));
                     return true;
                 }
 

--- a/test/BenchmarkTests/BenchmarkTestBase.cs
+++ b/test/BenchmarkTests/BenchmarkTestBase.cs
@@ -170,13 +170,13 @@ namespace BenchmarkTests
             throw new TimeoutException($"The index '{indexName}' stayed stale for more than {timeout.Value}.");
         }
 
-        protected DatabaseRecord CreateDatabaseRecord(string databaseName)
+        protected async Task <DatabaseRecord> CreateDatabaseRecord(string databaseName)
         {
             var databaseRecord = new DatabaseRecord(databaseName);
 
             if (Encrypted)
             {
-                Encryption.PutSecretKeyForDatabaseInServerStore(databaseName, Server);
+                await Encryption.PutSecretKeyForDatabaseInServerStoreAsync(databaseName, Server);
                 databaseRecord.Encrypted = true;
             }
 

--- a/test/BenchmarkTests/Indexing/Index.cs
+++ b/test/BenchmarkTests/Indexing/Index.cs
@@ -192,8 +192,8 @@ namespace BenchmarkTests.Indexing
 
         public override async Task InitAsync(DocumentStore store)
         {
-            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(CreateDatabaseRecord(IndexDatabaseName)));
-            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(CreateDatabaseRecord(ReIndexDatabaseName)));
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(await CreateDatabaseRecord(IndexDatabaseName)));
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(await CreateDatabaseRecord(ReIndexDatabaseName)));
 
             await new Simple_Map_Index().ExecuteAsync(store, database: ReIndexDatabaseName);
             await new Simple_MapReduce_Index().ExecuteAsync(store, database: ReIndexDatabaseName);

--- a/test/BenchmarkTests/Patching/Patch.cs
+++ b/test/BenchmarkTests/Patching/Patch.cs
@@ -108,9 +108,9 @@ update
 
         public override async Task InitAsync(DocumentStore store)
         {
-            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(CreateDatabaseRecord("1M_Companies_Patch")));
-            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(CreateDatabaseRecord("1M_Companies_Patch_Put")));
-            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(CreateDatabaseRecord("1M_Companies_Patch_Delete")));
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(await CreateDatabaseRecord("1M_Companies_Patch")));
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(await CreateDatabaseRecord("1M_Companies_Patch_Put")));
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(await CreateDatabaseRecord("1M_Companies_Patch_Delete")));
 
             using (var bulkInsert1 = store.BulkInsert("1M_Companies_Patch"))
             using (var bulkInsert2 = store.BulkInsert("1M_Companies_Patch_Put"))

--- a/test/SlowTests/Client/Attachments/AttachmentsBigFiles.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsBigFiles.cs
@@ -24,9 +24,8 @@ namespace SlowTests.Client.Attachments
             X509Certificate2 adminCert = null;
             if (encrypted)
             {
-                var backupPath = NewDataPath(suffix: "BackupFolder");
-                var key = Encryption.EncryptedServer(out var certificates, out dbName);
-                adminCert = certificates.ServerCertificate.Value;
+                var result = await Encryption.EncryptedServerAsync();
+                adminCert = result.Certificates.ServerCertificate.Value;
             }
             else
             {
@@ -85,9 +84,8 @@ namespace SlowTests.Client.Attachments
             X509Certificate2 adminCert = null;
             if (encrypted)
             {
-                var backupPath = NewDataPath(suffix: "BackupFolder");
-                var key = Encryption.EncryptedServer(out var certificates, out dbName);
-                adminCert = certificates.ServerCertificate.Value;
+                var result = await Encryption.EncryptedServerAsync();
+                adminCert = result.Certificates.ServerCertificate.Value;
             }
             else
             {

--- a/test/SlowTests/Client/Counters/CountersCluster.cs
+++ b/test/SlowTests/Client/Counters/CountersCluster.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Client.Counters
                     tasks.Add(task);
                 }
 
-                Task.WaitAll(tasks.ToArray());
+                await Task.WhenAll(tasks);
 
                 using (var session = stores[0].OpenSession())
                 {
@@ -134,7 +134,7 @@ namespace SlowTests.Client.Counters
                     tasks.Add(task);
                 }
 
-                Task.WaitAll(tasks.ToArray());
+                await Task.WhenAll(tasks);
 
                 // wait for replication and verify that all 
                 // stores have the correct accumulated counter-value

--- a/test/SlowTests/Client/Subscriptions/RavenDB_3491.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_3491.cs
@@ -295,8 +295,8 @@ namespace SlowTests.Client.Subscriptions
                     }
                 }
 
-                Assert.True(Task.WaitAll(new[] {subscriptionReleasedAwaiter}, 250));
-                
+                await subscriptionReleasedAwaiter.WaitAsync(TimeSpan.FromMilliseconds(250));
+
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(subscriptionName) {
                     TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(5)
                 }))

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -30,8 +30,7 @@ namespace SlowTests.Issues
         {
             DebuggerAttachedTimeout.DisableLongTimespan = true;
             var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(3, watcherCluster: true);
-
-            Encryption.EncryptedCluster(nodes, certificates, out var databaseName);
+            var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
             var options = new Options
             {
@@ -74,8 +73,7 @@ namespace SlowTests.Issues
         {
             DebuggerAttachedTimeout.DisableLongTimespan = true;
             var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(3, watcherCluster: true);
-
-            Encryption.EncryptedCluster(nodes, certificates, out var databaseName);
+            var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
             var options = new Options
             {
@@ -141,8 +139,7 @@ namespace SlowTests.Issues
         public async Task AddingNodeToEncryptedDatabaseGroupShouldThrow()
         {
             var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(3);
-
-            Encryption.EncryptedCluster(nodes, certificates, out var databaseName);
+            var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
             var options = new Options
             {
@@ -172,7 +169,7 @@ namespace SlowTests.Issues
                 }))
                 {
                     await Assert.ThrowsAsync<DatabaseLoadFailureException>(async () => await TrySavingDocument(notInDbGroupStore));
-                    Encryption.PutSecretKeyForDatabaseInServerStore(databaseName, notInDbGroupServer);
+                    await Encryption.PutSecretKeyForDatabaseInServerStoreAsync(databaseName, notInDbGroupServer);
                     await notInDbGroupServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName, ignoreDisabledDatabase: true);
                     await TrySavingDocument(notInDbGroupStore);
                 }
@@ -194,13 +191,13 @@ namespace SlowTests.Issues
         [Fact]
         public async Task DeletingMasterKeyForExistedEncryptedDatabaseShouldFail()
         {
-            Encryption.EncryptedServer(out var certificates, out var databaseName);
+            var result = await Encryption.EncryptedServerAsync();
 
             var options = new Options
             {
-                ModifyDatabaseName = _ => databaseName,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                ModifyDatabaseName = _ => result.DatabaseName,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
                 Encrypted = true
             };
 
@@ -227,8 +224,7 @@ namespace SlowTests.Issues
         public async Task DeletingEncryptedDatabaseFromDatabaseGroup()
         {
             var (nodes, server, certificates) = await CreateRaftClusterWithSsl(3);
-
-            Encryption.EncryptedCluster(nodes, certificates, out var databaseName);
+            var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
             var options = new Options
             {

--- a/test/SlowTests/Issues/RavenDB-15807.cs
+++ b/test/SlowTests/Issues/RavenDB-15807.cs
@@ -108,8 +108,7 @@ namespace SlowTests.Issues
 
                     using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
                     {
-                        var task = sinkServer.ServerStore.UpdatePullReplicationAsSink(sinkStore.Database, reader, Guid.NewGuid().ToString(), out PullReplicationAsSink pullReplication);
-                        Task.WaitAll(task);
+                        await sinkServer.ServerStore.UpdatePullReplicationAsSink(sinkStore.Database, reader, Guid.NewGuid().ToString(), out PullReplicationAsSink pullReplication);
                         Assert.Null(pullReplication.CertificateWithPrivateKey);
                     }
                 }

--- a/test/SlowTests/Issues/RavenDB_13972.cs
+++ b/test/SlowTests/Issues/RavenDB_13972.cs
@@ -241,29 +241,29 @@ namespace SlowTests.Issues
             }
         }
 
-        protected void CanStreamQueryWithPulsatingReadTransaction_ActualTest(int numberOfUsers, DocumentStore store)
+        protected async Task CanStreamQueryWithPulsatingReadTransaction_ActualTestAsync(int numberOfUsers, DocumentStore store)
         {
-            using (var bulk = store.BulkInsert())
+            await using (var bulk = store.BulkInsert())
             {
                 for (int i = 0; i < numberOfUsers; i++)
                 {
-                    bulk.Store(new User(), "users/" + i);
+                    await bulk.StoreAsync(new User(), "users/" + i);
                 }
             }
 
-            new Users_ByName().Execute(store);
+            await new Users_ByName().ExecuteAsync(store);
 
             Indexes.WaitForIndexing(store);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 var query = session.Query<User, Users_ByName>();
 
-                var enumerator = session.Advanced.Stream<User>(query);
+                var enumerator = await session.Advanced.StreamAsync<User>(query);
 
                 var count = 0;
 
-                while (enumerator.MoveNext())
+                while (await enumerator.MoveNextAsync())
                 {
                     count++;
                 }
@@ -272,30 +272,30 @@ namespace SlowTests.Issues
             }
         }
 
-        protected static void CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTest(int numberOfUsers, DocumentStore store)
+        protected static async Task CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTestAsync(int numberOfUsers, DocumentStore store)
         {
             var uniqueUserNames = _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10;
 
-            using (var bulk = store.BulkInsert())
+            await using (var bulk = store.BulkInsert())
             {
                 for (int i = 0; i < numberOfUsers; i++)
                 {
-                    bulk.Store(new User()
-                        {
-                            Name = "users-" + (i % uniqueUserNames)
-                        }, "users/" + i);
+                    await bulk.StoreAsync(new User()
+                    {
+                        Name = "users-" + (i % uniqueUserNames)
+                    }, "users/" + i);
                 }
             }
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 var query = session.Query<User>();
 
-                var enumerator = session.Advanced.Stream<User>(query);
+                var enumerator = await session.Advanced.StreamAsync<User>(query);
 
                 var count = 0;
 
-                while (enumerator.MoveNext())
+                while (await enumerator.MoveNextAsync())
                 {
                     count++;
                 }
@@ -305,18 +305,18 @@ namespace SlowTests.Issues
 
             // distinct
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 var query = session.Query<User>().Select(x => new User
                 {
                     Name = x.Name
                 }).Distinct();
 
-                var enumerator = session.Advanced.Stream(query);
+                var enumerator = await session.Advanced.StreamAsync(query);
 
                 var count = 0;
 
-                while (enumerator.MoveNext())
+                while (await enumerator.MoveNextAsync())
                 {
                     count++;
                 }
@@ -326,18 +326,18 @@ namespace SlowTests.Issues
 
             // paging
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 var skip = 100;
                 var take = _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10;
 
                 var query = session.Query<User>().Skip(skip).Take(take);
 
-                var enumerator = session.Advanced.Stream<User>(query);
+                var enumerator = await session.Advanced.StreamAsync<User>(query);
 
                 var count = 0;
 
-                while (enumerator.MoveNext())
+                while (await enumerator.MoveNextAsync())
                 {
                     count++;
                 }

--- a/test/SlowTests/Issues/RavenDB_13972_32_bits.cs
+++ b/test/SlowTests/Issues/RavenDB_13972_32_bits.cs
@@ -86,7 +86,7 @@ namespace SlowTests.Issues
         [Theory]
         [InlineData(2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3)]
-        public void CanStreamQueryWithPulsatingReadTransaction(int numberOfUsers)
+        public async Task CanStreamQueryWithPulsatingReadTransaction(int numberOfUsers)
         {
             using (var server = GetNewServer(new ServerCreationOptions
             {
@@ -105,14 +105,14 @@ namespace SlowTests.Issues
                 }
             }))
             {
-                CanStreamQueryWithPulsatingReadTransaction_ActualTest(numberOfUsers, store);
+                await CanStreamQueryWithPulsatingReadTransaction_ActualTestAsync(numberOfUsers, store);
             }
         }
 
         [Theory]
         [InlineData(2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3)]
-        public void CanStreamCollectionQueryWithPulsatingReadTransaction(int numberOfUsers)
+        public async Task CanStreamCollectionQueryWithPulsatingReadTransaction(int numberOfUsers)
         {
             using (var server = GetNewServer(new ServerCreationOptions
             {
@@ -130,7 +130,7 @@ namespace SlowTests.Issues
                 }
             }))
             {
-                CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTest(numberOfUsers, store);
+                await CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTestAsync(numberOfUsers, store);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_13972_encrypted.cs
+++ b/test/SlowTests/Issues/RavenDB_13972_encrypted.cs
@@ -25,14 +25,13 @@ namespace SlowTests.Issues
         {
             var file = GetTempFileName();
             var fileAfterDeletions = GetTempFileName();
-
-            Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var storeToExport = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
                     record.Settings[RavenConfiguration.GetKey(x => x.Databases.PulseReadTransactionLimit)] = "0";
@@ -58,15 +57,15 @@ namespace SlowTests.Issues
         [InlineData(2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10, 2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10, 3)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3, 0, 3)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3, 4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3, 2)]
-        public void CanStreamDocumentsWithPulsatingReadTransaction(int numberOfUsers, int numberOfOrders, int deleteUserFactor)
+        public async Task CanStreamDocumentsWithPulsatingReadTransaction(int numberOfUsers, int numberOfOrders, int deleteUserFactor)
         {
-            Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
                     record.Settings[RavenConfiguration.GetKey(x => x.Databases.PulseReadTransactionLimit)] = "0";
@@ -82,15 +81,15 @@ namespace SlowTests.Issues
         [InlineData(2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3)]
         [InlineData(10 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3)]
-        public void CanStreamQueryWithPulsatingReadTransaction(int numberOfUsers)
+        public async Task CanStreamQueryWithPulsatingReadTransaction(int numberOfUsers)
         {
-            Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
                     record.Settings[RavenConfiguration.GetKey(x => x.Databases.PulseReadTransactionLimit)] = "0";
@@ -98,22 +97,22 @@ namespace SlowTests.Issues
                 }
             }))
             {
-                CanStreamQueryWithPulsatingReadTransaction_ActualTest(numberOfUsers, store);
+                await CanStreamQueryWithPulsatingReadTransaction_ActualTestAsync(numberOfUsers, store);
             }
         }
 
         [Theory]
         [InlineData(2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3)]
-        public void CanStreamCollectionQueryWithPulsatingReadTransaction(int numberOfUsers)
+        public async Task CanStreamCollectionQueryWithPulsatingReadTransaction(int numberOfUsers)
         {
-            Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
                     record.Settings[RavenConfiguration.GetKey(x => x.Databases.PulseReadTransactionLimit)] = "0";
@@ -121,7 +120,7 @@ namespace SlowTests.Issues
                 }
             }))
             {
-                CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTest(numberOfUsers, store);
+                await CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTestAsync(numberOfUsers, store);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_18496.cs
+++ b/test/SlowTests/Issues/RavenDB_18496.cs
@@ -19,16 +19,16 @@ namespace SlowTests.Issues
         [Fact]
         public async Task ReplicationShouldNotGetStuckWhenEncryptionBufferSizeIsGreaterThanMaxSizeToSend()
         {
-            Encryption.EncryptedServer(out var certificates, out var databaseName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var encryptedStore = GetDocumentStore(new Options
             {
-                ModifyDatabaseName = _ => databaseName,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                ModifyDatabaseName = _ => result.DatabaseName,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
                 Encrypted = true
             }))
-            using (var store2 = GetDocumentStore(new Options { ClientCertificate = certificates.ServerCertificate.Value }))
+            using (var store2 = GetDocumentStore(new Options { ClientCertificate = result.Certificates.ServerCertificate.Value }))
             {
                 var db = await Databases.GetDocumentDatabaseInstanceFor(encryptedStore);
                 var maxSizeToSend = new Size(16, SizeUnit.Kilobytes);
@@ -64,7 +64,7 @@ namespace SlowTests.Issues
 
                 Assert.True(WaitForDocument(store2, docId));
 
-                await EnsureNoReplicationLoop(Server, databaseName);
+                await EnsureNoReplicationLoop(Server, result.DatabaseName);
             }
         }
     }

--- a/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
@@ -13,7 +13,6 @@ using Raven.Client.Exceptions;
 using Raven.Server.Config;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Platform;
-using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -30,13 +29,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_encrypted_backup_use_db_key_1()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -51,7 +50,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }
 
                 var config = Backup.CreateBackupConfiguration(backupPath);
-                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
 
                 var databaseName = $"restored_database-{Guid.NewGuid()}";
 
@@ -62,7 +61,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseProvidedKey,
-                        Key = key
+                        Key = result.Key
                     }
                 }))
                 {
@@ -80,13 +79,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_encrypted_backup_use_db_key_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -115,7 +114,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseProvidedKey,
-                        Key = key
+                        Key = result.Key
                     }
                 }))
                 {
@@ -133,13 +132,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_encrypted_backup_use_new_key()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -186,13 +185,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_encrypted_backup_use_db_key_1()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -219,7 +218,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseProvidedKey,
-                        Key = key
+                        Key = result.Key
                     }
                 }))
                 {
@@ -237,13 +236,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_encrypted_backup_use_db_key_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -273,7 +272,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseProvidedKey,
-                        Key = key
+                        Key = result.Key
                     }
                 }))
                 {
@@ -291,13 +290,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_encrypted_backup_use_new_key()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -344,13 +343,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_unencrypted_backup()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -392,13 +391,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_unencrypted_backup()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -442,13 +441,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
 
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -470,7 +469,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     BackupLocation = Directory.GetDirectories(backupPath).First(),
                     DatabaseName = databaseName,
-                    EncryptionKey = key,
+                    EncryptionKey = result.Key,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseDatabaseKey
@@ -490,13 +489,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task snapshot_encrypted_db_and_restore_to_encrypted_DB_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -522,7 +521,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     BackupLocation = Directory.GetDirectories(backupPath).First(),
                     DatabaseName = databaseName,
-                    EncryptionKey = key,
+                    EncryptionKey = result.Key,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseDatabaseKey
@@ -543,15 +542,15 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
 
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             const string key1 = "users/1";
             const string key2 = "users/2";
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -584,7 +583,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     BackupLocation = Directory.GetDirectories(backupPath).First(),
                     DatabaseName = databaseName,
-                    EncryptionKey = key,
+                    EncryptionKey = result.Key,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseDatabaseKey
@@ -1046,13 +1045,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task snapshot_encrypted_db_with_new_key_fail()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -1195,13 +1194,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_without_backup_encryption_configuration(BackupType backupType, string expectedExtension)
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -1231,7 +1230,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     BackupLocation = folderPath,
                     DatabaseName = databaseName,
-                    EncryptionKey = key,
+                    EncryptionKey = result.Key,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseDatabaseKey

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -190,14 +190,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
         protected async Task incremental_and_full_backup_encrypted_db_and_restore_to_encrypted_DB_with_database_key_internal(BackupUploadMode backupUploadMode)
         {
             var s3Settings = GetS3Settings();
-
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -239,7 +238,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
                     DatabaseName = databaseName,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
-                        Key = key,
+                        Key = result.Key,
                         EncryptionMode = EncryptionMode.UseProvidedKey
                     }
                 }))
@@ -326,13 +325,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
         protected async Task incremental_and_full_backup_encrypted_db_and_restore_to_encrypted_DB_with_provided_key_internal()
         {
             var s3Settings = GetS3Settings();
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -393,14 +392,14 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
 
         protected async Task snapshot_encrypted_db_and_restore_to_encrypted_DB_internal(BackupUploadMode backupUploadMode)
         {
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             var s3Settings = GetS3Settings();
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true
             }))
             {
@@ -424,7 +423,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
                 {
                     Settings = s3Settings,
                     DatabaseName = databaseName,
-                    EncryptionKey = key,
+                    EncryptionKey = result.Key,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseDatabaseKey

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -553,13 +553,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task ServerWideBackupShouldBeEncryptedForEncryptedDatabase(EncryptionMode encryptionMode)
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -630,7 +630,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseProvidedKey,
-                        Key = key
+                        Key = result.Key
                     }
                 }))
                 {

--- a/test/SlowTests/Server/NotificationCenter/OutOfMemoryNotificationTests.cs
+++ b/test/SlowTests/Server/NotificationCenter/OutOfMemoryNotificationTests.cs
@@ -169,7 +169,7 @@ namespace SlowTests.Server.NotificationCenter
 
                     taskList.Add(Task.Run(() => database.NotificationCenter.OutOfMemory.Add(environment, new Exception("Second Message"))));
 
-                    Task.WaitAll(taskList.ToArray());
+                    await Task.WhenAll(taskList);
                 }
 
                 using (database.NotificationCenter.GetStored(out var notifications))

--- a/test/StressTests/Server/Encryption/EncryptionStressTests.cs
+++ b/test/StressTests/Server/Encryption/EncryptionStressTests.cs
@@ -34,8 +34,7 @@ namespace StressTests.Server.Encryption
             {
                 DebuggerAttachedTimeout.DisableLongTimespan = true;
                 var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(7, watcherCluster: true);
-
-                Encryption.EncryptedCluster(nodes, certificates, out var databaseName);
+                var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
                 var options = new Options
                 {

--- a/test/Tests.Infrastructure/RavenTestBase.Encryption.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Encryption.cs
@@ -4,10 +4,10 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server;
 using Sparrow.Platform;
-using Xunit;
 
 namespace FastTests;
 
@@ -26,10 +26,11 @@ public partial class RavenTestBase
             _parent = parent ?? throw new ArgumentNullException(nameof(parent));
         }
 
-        public string EncryptedServer(out TestCertificatesHolder certificates, out string databaseName)
+        public async Task<EncryptServerResult> EncryptedServerAsync()
         {
-            certificates = _parent.Certificates.SetupServerAuthentication();
-            databaseName = _parent.GetDatabaseName();
+            var certificates = _parent.Certificates.SetupServerAuthentication();
+            var databaseName = _parent.GetDatabaseName();
+
             _parent.Certificates.RegisterClientCertificate(certificates, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             var buffer = new byte[32];
@@ -60,16 +61,23 @@ public partial class RavenTestBase
             if (canUseProtect == false) // fall back to a file
                 _parent.Server.ServerStore.Configuration.Security.MasterKeyPath = _parent.GetTempFileName();
 
-            Assert.True(_parent.Server.ServerStore.EnsureNotPassiveAsync().Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
-            Assert.True(_parent.Server.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
+            // activate license so we can insert the secret key
+            await _parent.Server.ServerStore.EnsureNotPassiveAsync().WaitAsync(TimeSpan.FromSeconds(30));
+            await _parent.Server.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).WaitAsync(TimeSpan.FromSeconds(30));
+
             _parent.Server.ServerStore.PutSecretKey(base64Key, databaseName, overwrite: true);
 
-            return Convert.ToBase64String(buffer);
+            return new EncryptServerResult
+            {
+                Certificates = certificates,
+                DatabaseName = databaseName,
+                Key = Convert.ToBase64String(buffer)
+            };
         }
 
-        public void EncryptedCluster(List<RavenServer> nodes, TestCertificatesHolder certificates, out string databaseName)
+        public async Task<string> EncryptedClusterAsync(List<RavenServer> nodes, TestCertificatesHolder certificates)
         {
-            databaseName = _parent.GetDatabaseName();
+            var databaseName = _parent.GetDatabaseName();
 
             foreach (var node in nodes)
             {
@@ -79,22 +87,26 @@ public partial class RavenTestBase
 
                 EnsureServerMasterKeyIsSetup(node);
 
-                Assert.True(node.ServerStore.EnsureNotPassiveAsync().Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
-                Assert.True(node.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
+                // activate license so we can insert the secret key
+                await _parent.Server.ServerStore.EnsureNotPassiveAsync().WaitAsync(TimeSpan.FromSeconds(30));
+                await _parent.Server.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).WaitAsync(TimeSpan.FromSeconds(30));
 
                 node.ServerStore.PutSecretKey(base64Key, databaseName, overwrite: true);
             }
+
+            return databaseName;
         }
 
-        public void PutSecretKeyForDatabaseInServerStore(string databaseName, RavenServer server)
+        public async Task PutSecretKeyForDatabaseInServerStoreAsync(string databaseName, RavenServer server)
         {
             var base64key = CreateMasterKey(out _);
             var base64KeyClone = new string(base64key.ToCharArray());
 
             EnsureServerMasterKeyIsSetup(server);
 
-            Assert.True(server.ServerStore.EnsureNotPassiveAsync().Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
-            Assert.True(server.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
+            // activate license so we can insert the secret key
+            await _parent.Server.ServerStore.EnsureNotPassiveAsync().WaitAsync(TimeSpan.FromSeconds(30));
+            await _parent.Server.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).WaitAsync(TimeSpan.FromSeconds(30));
 
             server.ServerStore.PutSecretKey(base64key, databaseName, overwrite: true);
 
@@ -164,6 +176,15 @@ public partial class RavenTestBase
 
             var base64Key = Convert.ToBase64String(buffer);
             return base64Key;
+        }
+
+        public class EncryptServerResult
+        {
+            public TestCertificatesHolder Certificates { get; set; }
+
+            public string DatabaseName { get; set; }
+
+            public string Key { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23231/Hanged-test-suite

### Additional description

Changed from blocking the thread to using await for asynchronous execution.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
