### PR TITLE
RavenDB-21764 Move identities to react

### DIFF
--- a/src/Raven.Studio/typescript/common/shell/menu/items/documents.ts
+++ b/src/Raven.Studio/typescript/common/shell/menu/items/documents.ts
@@ -2,6 +2,8 @@
 import leafMenuItem = require("common/shell/menu/leafMenuItem");
 import collectionMenuItem = require("common/shell/menu/collectionMenuItem");
 import collectionsTracker = require("common/helpers/database/collectionsTracker");
+import DocumentIdentities from "components/pages/database/documents/identities/DocumentIdentities";
+import { bridgeToReact } from "common/reactUtils";
 
 export = getDocumentsMenuItem;
 
@@ -63,7 +65,7 @@ function getDocumentsMenuItem(appUrls: computedAppUrls) {
         }),
         new leafMenuItem({
             route: "databases/identities",
-            moduleId: require("viewmodels/database/identities/identities"),
+            moduleId: bridgeToReact(DocumentIdentities, "nonShardedView"),
             shardingMode: "allShards",
             title: "Identities",
             nav: true,

--- a/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/accessManagerSliceSelectors.ts
@@ -49,6 +49,15 @@ const getHasDatabaseAccessWrite = (args: GetEffectiveAccessLevelArgs) => {
     return effectiveDatabaseAccessLevel === "DatabaseAdmin" || effectiveDatabaseAccessLevel === "DatabaseReadWrite";
 };
 
+const getHasDatabaseAccessRead = (args: GetEffectiveAccessLevelArgs) => {
+    const effectiveDatabaseAccessLevel = getEffectiveDatabaseAccessLevel(args);
+    return (
+        effectiveDatabaseAccessLevel === "DatabaseAdmin" ||
+        effectiveDatabaseAccessLevel === "DatabaseReadWrite" ||
+        effectiveDatabaseAccessLevel === "DatabaseRead"
+    );
+};
+
 // Selectors
 
 const selectIsOperatorOrAbove = createSelector(
@@ -114,6 +123,22 @@ const selectGetHasDatabaseAccessWrite = createSelector(
         }
 );
 
+const selectGetHasDatabaseAccessRead = createSelector(
+    [
+        (store: RootState) => store.accessManager.securityClearance,
+        (store: RootState) => store.accessManager.databaseAccess,
+        (store: RootState) => store.databases.activeDatabaseName,
+    ],
+    (
+        securityClearance: SecurityClearance,
+        databaseAccess: EntityState<DatabaseAccessInfo, string>,
+        activeDatabaseName: string
+    ) =>
+        (databaseName?: string) => {
+            return getHasDatabaseAccessRead({ securityClearance, databaseAccess, activeDatabaseName, databaseName });
+        }
+);
+
 const selectGetCanHandleOperation = createSelector(
     [
         (store: RootState) => store.accessManager.securityClearance,
@@ -169,6 +194,7 @@ export const accessManagerSelectors = {
     isClusterAdminOrClusterNode: selectIsClusterAdminOrClusterNode,
     getHasDatabaseAdminAccess: selectGetHasDatabaseAccessAdmin,
     getHasDatabaseWriteAccess: selectGetHasDatabaseAccessWrite,
+    getHasDatabaseReadAccess: selectGetHasDatabaseAccessRead,
     getEffectiveDatabaseAccessLevel: selectGetEffectiveDatabaseAccessLevel,
     getCanHandleOperation: selectGetCanHandleOperation,
 };

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentities.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentities.spec.tsx
@@ -1,0 +1,48 @@
+import { composeStories } from "@storybook/react";
+import * as stories from "./DocumentIdentities.stories";
+import { rtlRender } from "test/rtlTestUtils";
+import React from "react";
+
+const { DocumentIdentitiesStory } = composeStories(stories);
+
+const selectors = {
+    newIdentityBtn: "Add new identity",
+    tableEditColumn: "Edit",
+};
+
+describe("DocumentIdentities", () => {
+    beforeAll(() => {
+        Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+            configurable: true,
+            value: 500,
+        });
+    });
+
+    it("should render component with sample data and not be able to click btn", async () => {
+        const { screen } = rtlRender(<DocumentIdentitiesStory databaseAccess={"DatabaseRead"} />);
+
+        const addNewIdentityBtn = screen.getByRole("button", { name: selectors.newIdentityBtn });
+        expect(addNewIdentityBtn).toBeInTheDocument();
+        expect(addNewIdentityBtn).toBeDisabled();
+    });
+
+    it("should render component with sample data and not be able to click btn", async () => {
+        const { screen } = rtlRender(<DocumentIdentitiesStory databaseAccess={"DatabaseReadWrite"} />);
+
+        const addNewIdentityBtn = screen.getByRole("button", { name: selectors.newIdentityBtn });
+        expect(addNewIdentityBtn).toBeInTheDocument();
+        expect(addNewIdentityBtn).not.toBeDisabled();
+    });
+
+    it("should not see edit column", async () => {
+        const { screen } = rtlRender(<DocumentIdentitiesStory databaseAccess={"DatabaseRead"} />);
+
+        expect(screen.queryByText(selectors.tableEditColumn)).not.toBeInTheDocument();
+    });
+
+    it("should see edit column", async () => {
+        const { screen } = rtlRender(<DocumentIdentitiesStory databaseAccess={"DatabaseReadWrite"} />);
+
+        expect(screen.queryByText(selectors.tableEditColumn)).toBeInTheDocument();
+    });
+});

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentities.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentities.stories.tsx
@@ -1,0 +1,41 @@
+import { databaseAccessArgType, withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
+import { Meta, StoryObj } from "@storybook/react";
+import DocumentIdentities from "components/pages/database/documents/identities/DocumentIdentities";
+import { mockServices } from "test/mocks/services/MockServices";
+import { mockStore } from "test/mocks/store/MockStore";
+import { DatabasesStubs } from "test/stubs/DatabasesStubs";
+
+export default {
+    title: "Pages/Documents/Document Identities",
+    decorators: [withStorybookContexts, withBootstrap5],
+} satisfies Meta<typeof DocumentIdentities>;
+
+interface DocumentIdentitiesStoryArgs {
+    databaseAccess: databaseAccessLevel;
+    identities: Record<string, number>;
+}
+
+export const DocumentIdentitiesStory: StoryObj<DocumentIdentitiesStoryArgs> = {
+    name: "DocumentIdentities",
+    render: (args) => {
+        const { accessManager, license, databases } = mockStore;
+
+        const db = databases.withActiveDatabase_NonSharded_SingleNode();
+        accessManager.with_databaseAccess({
+            [db.name]: args.databaseAccess,
+        });
+        license.with_License();
+        const { databasesService } = mockServices;
+
+        databasesService.withSampleIdentities(args.identities);
+
+        return <DocumentIdentities />;
+    },
+    argTypes: {
+        databaseAccess: databaseAccessArgType,
+    },
+    args: {
+        databaseAccess: "DatabaseRead",
+        identities: DatabasesStubs.getIdentities(10),
+    },
+};

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentities.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentities.tsx
@@ -1,0 +1,125 @@
+import { Button, Card, CardBody, Col, Input, Row } from "reactstrap";
+import React, { ChangeEvent, useCallback, useState } from "react";
+import { AboutViewHeading } from "components/common/AboutView";
+import VirtualTable from "components/common/virtualTable/VirtualTable";
+import { getCoreRowModel, getFilteredRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
+import { useDocumentIdentitiesColumns } from "components/pages/database/documents/identities/useDocumentIdentitiesColumns";
+import SizeGetter from "components/common/SizeGetter";
+import DocumentIdentitiesAddModal from "components/pages/database/documents/identities/DocumentIdentitiesAddModal";
+import DocumentIdentitiesAboutView from "components/pages/database/documents/identities/DocumentIdentitiesAboutView";
+import { useServices } from "hooks/useServices";
+import { useAsync } from "react-async-hook";
+import { debounce } from "lodash";
+import { Icon } from "components/common/Icon";
+import { useAppSelector } from "components/store";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+
+interface DocumentIdentitiesWithSizeProps {
+    width: number;
+}
+
+export default function DocumentIdentities() {
+    return (
+        <div className="content-padding">
+            <SizeGetter render={({ width }) => <DocumentIdentitiesWithSize width={width} />} />
+        </div>
+    );
+}
+
+interface Identity {
+    prefix: string;
+    value: number;
+}
+
+function DocumentIdentitiesWithSize({ width }: DocumentIdentitiesWithSizeProps) {
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+
+    const { identitiesColumns } = useDocumentIdentitiesColumns(width);
+    const databaseAccessWrite = useAppSelector(accessManagerSelectors.getHasDatabaseWriteAccess)();
+    const [isOpen, setIsOpen] = React.useState(false);
+    const [globalFilter, setGlobalFilter] = React.useState("");
+
+    const toggleModal = (value: boolean) => setIsOpen(value);
+
+    const { loading, identities } = useGetIdentities(databaseName);
+
+    const identitiesTable = useReactTable({
+        columns: identitiesColumns,
+        data: identities,
+        columnResizeMode: "onChange",
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        onGlobalFilterChange: setGlobalFilter,
+        globalFilterFn: "includesString",
+        filterFns: {},
+        state: {
+            globalFilter,
+        },
+    });
+
+    const debouncedSearch = useCallback(
+        debounce((e: ChangeEvent<HTMLInputElement>) => setGlobalFilter(e.target.value), 300),
+        []
+    );
+
+    return (
+        <>
+            <div className="content-margin">
+                <Col xs={12} md={12} lg={7}>
+                    <AboutViewHeading title="Identities" icon="identities" />
+                    <Row className="justify-content-between rows-cols-lg-2 row-cols-1 mb-4">
+                        <Col md={12} lg={8} xl={9}>
+                            <Button
+                                color="primary"
+                                onClick={() => setIsOpen(true)}
+                                disabled={!databaseAccessWrite}
+                                className="add-new-identity-btn py-2"
+                            >
+                                <Icon icon="plus" className="mr-2" />
+                                Add new identity
+                            </Button>
+                        </Col>
+                        <Col md={12} lg={4} xl={3}>
+                            <Input onChange={debouncedSearch} placeholder="Filter prefix" />
+                        </Col>
+                    </Row>
+
+                    <Card>
+                        <CardBody>
+                            <VirtualTable
+                                table={identitiesTable}
+                                className="mt-3"
+                                isLoading={loading}
+                                heightInPx={800}
+                            />
+                        </CardBody>
+                    </Card>
+                </Col>
+                <Col xs={12} md={12} lg={5}>
+                    <DocumentIdentitiesAboutView />
+                </Col>
+            </div>
+            <DocumentIdentitiesAddModal isOpen={isOpen} toggleModal={toggleModal} />
+        </>
+    );
+}
+
+function useGetIdentities(database: string) {
+    const [identities, setIdentities] = useState<Identity[]>([]);
+    const { databasesService } = useServices();
+    const asyncGetIdentities = useAsync(() => databasesService.getIdentities(database), [], {
+        onSuccess: (result) =>
+            setIdentities(
+                Object.keys(result)
+                    .map((identity) => ({
+                        prefix: identity,
+                        value: result[identity],
+                    }))
+                    .filter(Boolean)
+            ),
+    });
+
+    return { identities, status: asyncGetIdentities.status, loading: asyncGetIdentities.loading };
+}

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentities.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentities.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, CardBody, Col, Input, Row } from "reactstrap";
-import React, { ChangeEvent, useCallback, useState } from "react";
+import React, { ChangeEvent, useState } from "react";
 import { AboutViewHeading } from "components/common/AboutView";
 import VirtualTable from "components/common/virtualTable/VirtualTable";
 import { getCoreRowModel, getFilteredRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
@@ -59,10 +59,7 @@ function DocumentIdentitiesWithSize({ width }: DocumentIdentitiesWithSizeProps) 
         },
     });
 
-    const debouncedSearch = useCallback(
-        debounce((e: ChangeEvent<HTMLInputElement>) => setGlobalFilter(e.target.value), 300),
-        []
-    );
+    const debouncedSearch = debounce((e: ChangeEvent<HTMLInputElement>) => setGlobalFilter(e.target.value), 300);
 
     return (
         <>

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesAboutView.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesAboutView.tsx
@@ -1,0 +1,26 @@
+import { AboutViewAnchored, AccordionItemWrapper } from "components/common/AboutView";
+import React from "react";
+import { todo } from "common/developmentHelper";
+
+todo(
+    "Other",
+    "Danielle",
+    "It is necessary to write a text to this about view.",
+    "https://issues.hibernatingrhinos.com/issue/RavenDB-21764/Move-identities-to-react"
+);
+
+export default function DocumentIdentitiesAboutView() {
+    return (
+        <AboutViewAnchored className="my-4">
+            <AccordionItemWrapper
+                targetId="1"
+                icon="about"
+                color="info"
+                description="Get additional info on what this feature can offer you"
+                heading="About this view"
+            >
+                <div></div>
+            </AccordionItemWrapper>
+        </AboutViewAnchored>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesAddModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesAddModal.tsx
@@ -1,0 +1,157 @@
+import { ModalProps } from "reactstrap/types/lib/Modal";
+import { Button, InputGroup, Label, Modal, ModalBody, ModalFooter } from "reactstrap";
+import React, { ComponentPropsWithoutRef, useCallback, useMemo, useState } from "react";
+import { Icon } from "components/common/Icon";
+import { FormInput } from "components/common/Form";
+import { Control, SubmitHandler, useForm, useWatch } from "react-hook-form";
+import classNames from "classnames";
+import {
+    AddIdentitiesFormData,
+    addIdentitiesYupResolver,
+} from "components/pages/database/documents/identities/DocumentIdentitiesValidation";
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import { useServices } from "hooks/useServices";
+import { useAppSelector } from "components/store";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+
+interface DocumentIdentitiesAddModalProps extends ModalProps {
+    toggleModal: (value: boolean) => void;
+    defaultValues?: AddIdentitiesFormData;
+}
+
+export default function DocumentIdentitiesAddModal({
+                                                       defaultValues,
+                                                       contentClassName,
+                                                       wrapClassName,
+                                                       ...props
+                                                   }: DocumentIdentitiesAddModalProps) {
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const { databasesService } = useServices();
+    const form = useForm<AddIdentitiesFormData>({
+        resolver: addIdentitiesYupResolver,
+        defaultValues,
+    });
+    const [isLoading, setIsLoading] = useState(false);
+    const isEditing = !!defaultValues;
+
+    const formValues = useWatch({ control: form.control });
+    const onSubmit: SubmitHandler<AddIdentitiesFormData> = useCallback(async ({ prefix, value }) => {
+        setIsLoading(true);
+        try {
+            await databasesService.seedIdentity(databaseName, prefix, value);
+            form.reset();
+            props.toggleModal(false);
+        } catch (e) {
+            console.error(e);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    return (
+        <Modal
+            contentClassName={classNames("modal-border bulge-primary", contentClassName)}
+            wrapClassName={classNames("bs5", wrapClassName)}
+            size="lg"
+            {...props}
+        >
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+                <ModalBody>
+                    <div className="position-absolute m-2 end-0 top-0">
+                        <Button close onClick={() => props.toggleModal(false)} />
+                    </div>
+                    <div className="w-100 d-flex align-items-center justify-content-center flex-column">
+                        <Icon size="xl" icon="identities" color="primary" margin="me-0" />
+                        <h4>{isEditing ? "Edit Identity" : "Add new identity"}</h4>
+                    </div>
+                    <div className="w-100 d-flex flex-column gap-4 mb-4">
+                        <DocumentIdentitiesAddModalForm isEditing={isEditing} control={form.control} />
+                    </div>
+                    {formValues?.value && formValues.prefix && <InformationBadge />}
+                </ModalBody>
+                <ModalFooter>
+                    <Button
+                        className="border-0 btn-dark text-muted"
+                        onClick={() => props.toggleModal(false)}
+                        type="button"
+                    >
+                        Close
+                    </Button>
+                    <ButtonWithSpinner
+                        className="rounded-pill btn-success px-2 py-1"
+                        icon="save"
+                        isSpinning={isLoading}
+                        type="submit"
+                    >
+                        Save identity
+                    </ButtonWithSpinner>
+                </ModalFooter>
+            </form>
+        </Modal>
+    );
+}
+
+function InformationBadge() {
+    return (
+        <div
+            className={classNames(
+                "bg-faded-info rounded-2 mt-3 align-items-center px-2 py-1 d-flex me-2 align-self-start"
+            )}
+        >
+            <Icon icon="info" size="md" color="info" />
+            <div className="word-break">
+                <p className="mb-0">
+                    The effective identity separator in configuration is: <strong>/</strong>
+                </p>
+                <p className="mb-0">
+                    The next document that will be created with prefix &quot;<strong>some_prefix|</strong>&quot; will
+                    have ID: &quot;<strong>some_prefix|2</strong>&quot;
+                </p>
+            </div>
+        </div>
+    );
+}
+
+interface FormFields extends Omit<ComponentPropsWithoutRef<typeof FormInput>, "control"> {
+    label: string;
+}
+
+interface DocumentIdentitiesAddModalFormProps {
+    control: Control<{ prefix?: string; value?: number }>;
+    isEditing?: boolean;
+}
+
+function DocumentIdentitiesAddModalForm({
+                                            control,
+                                            isEditing,
+                                        }: DocumentIdentitiesAddModalFormProps) {
+    const formFields: FormFields[] = useMemo(
+        () => [
+            {
+                type: "text",
+                name: "prefix",
+                label: "Prefix",
+                placeholder: "Enter the document id prefix",
+                disabled: isEditing,
+            },
+            {
+                type: "number",
+                label: "Value",
+                name: "value",
+                placeholder: "Enter identity value",
+            },
+        ],
+        []
+    );
+
+    return (
+        <>
+            {formFields.map(({ label, ...props }) => (
+                <InputGroup className="vstack my-1">
+                    <Label>{label}</Label>
+                    <FormInput control={control} {...props} />
+                </InputGroup>
+            ))}
+        </>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesAddModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesAddModal.tsx
@@ -20,11 +20,11 @@ interface DocumentIdentitiesAddModalProps extends ModalProps {
 }
 
 export default function DocumentIdentitiesAddModal({
-                                                       defaultValues,
-                                                       contentClassName,
-                                                       wrapClassName,
-                                                       ...props
-                                                   }: DocumentIdentitiesAddModalProps) {
+    defaultValues,
+    contentClassName,
+    wrapClassName,
+    ...props
+}: DocumentIdentitiesAddModalProps) {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const { databasesService } = useServices();
     const form = useForm<AddIdentitiesFormData>({
@@ -46,7 +46,7 @@ export default function DocumentIdentitiesAddModal({
         } finally {
             setIsLoading(false);
         }
-    }, []);
+    }, [databaseName, databasesService, form, props]);
 
     return (
         <Modal
@@ -121,10 +121,7 @@ interface DocumentIdentitiesAddModalFormProps {
     isEditing?: boolean;
 }
 
-function DocumentIdentitiesAddModalForm({
-                                            control,
-                                            isEditing,
-                                        }: DocumentIdentitiesAddModalFormProps) {
+function DocumentIdentitiesAddModalForm({ control, isEditing }: DocumentIdentitiesAddModalFormProps) {
     const formFields: FormFields[] = useMemo(
         () => [
             {
@@ -141,7 +138,7 @@ function DocumentIdentitiesAddModalForm({
                 placeholder: "Enter identity value",
             },
         ],
-        []
+        [isEditing]
     );
 
     return (

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesAddModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesAddModal.tsx
@@ -35,18 +35,21 @@ export default function DocumentIdentitiesAddModal({
     const isEditing = !!defaultValues;
 
     const formValues = useWatch({ control: form.control });
-    const onSubmit: SubmitHandler<AddIdentitiesFormData> = useCallback(async ({ prefix, value }) => {
-        setIsLoading(true);
-        try {
-            await databasesService.seedIdentity(databaseName, prefix, value);
-            form.reset();
-            props.toggleModal(false);
-        } catch (e) {
-            console.error(e);
-        } finally {
-            setIsLoading(false);
-        }
-    }, [databaseName, databasesService, form, props]);
+    const onSubmit: SubmitHandler<AddIdentitiesFormData> = useCallback(
+        async ({ prefix, value }) => {
+            setIsLoading(true);
+            try {
+                await databasesService.seedIdentity(databaseName, prefix, value);
+                form.reset();
+                props.toggleModal(false);
+            } catch (e) {
+                console.error(e);
+            } finally {
+                setIsLoading(false);
+            }
+        },
+        [databaseName, databasesService, form, props]
+    );
 
     return (
         <Modal

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesValidation.ts
@@ -1,12 +1,10 @@
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 
-
 const schema = yup.object({
     prefix: yup.string().required(),
     value: yup.number().required(),
 });
-
 
 export const addIdentitiesYupResolver = yupResolver(schema);
 export type AddIdentitiesFormData = yup.InferType<typeof schema>;

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/DocumentIdentitiesValidation.ts
@@ -1,0 +1,12 @@
+import * as yup from "yup";
+import { yupResolver } from "@hookform/resolvers/yup";
+
+
+const schema = yup.object({
+    prefix: yup.string().required(),
+    value: yup.number().required(),
+});
+
+
+export const addIdentitiesYupResolver = yupResolver(schema);
+export type AddIdentitiesFormData = yup.InferType<typeof schema>;

--- a/src/Raven.Studio/typescript/components/pages/database/documents/identities/useDocumentIdentitiesColumns.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/identities/useDocumentIdentitiesColumns.tsx
@@ -1,0 +1,71 @@
+import { useMemo, useState } from "react";
+import { CellContext, ColumnDef } from "@tanstack/react-table";
+import { CellValueWrapper } from "components/common/virtualTable/cells/CellValue";
+import { virtualTableUtils } from "components/common/virtualTable/utils/virtualTableUtils";
+import { Button } from "reactstrap";
+import { Icon } from "components/common/Icon";
+import DocumentIdentitiesAddModal from "components/pages/database/documents/identities/DocumentIdentitiesAddModal";
+import { useAppSelector } from "components/store";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
+
+type IdentitiesItem = {
+    prefix: string;
+    value: number;
+};
+
+export function useDocumentIdentitiesColumns(availableWidth: number) {
+    const databaseAccessWrite = useAppSelector(accessManagerSelectors.getHasDatabaseWriteAccess)();
+    const bodyWidth = virtualTableUtils.getTableBodyWidth(availableWidth);
+    const getSize = virtualTableUtils.getCellSizeProvider(bodyWidth);
+
+    const identitiesColumns: ColumnDef<IdentitiesItem>[] = useMemo(
+        () => [
+            {
+                header: "Document ID Prefix",
+                accessorKey: "prefix",
+                cell: CellValueWrapper,
+                size: getSize(22),
+            },
+            {
+                header: "Latest value",
+                accessorKey: "value",
+                cell: CellValueWrapper,
+                size: getSize(22),
+            },
+        ],
+        [getSize]
+    );
+
+    if (databaseAccessWrite) {
+        identitiesColumns.push({
+            id: "actions",
+            header: "Edit",
+            cell: CellValueButtonWrapper,
+            size: getSize(6),
+        });
+    }
+
+    return {
+        identitiesColumns,
+    };
+}
+
+function CellValueButtonWrapper(args: CellContext<IdentitiesItem, unknown>) {
+    const [isOpen, setIsOpen] = useState(false);
+    const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const toggleModal = (value: boolean) => setIsOpen(value);
+    return (
+        <>
+            <Button onClick={() => setIsOpen(!isOpen)}>
+                <Icon icon="edit" margin="me-0" />
+            </Button>
+            <DocumentIdentitiesAddModal
+                isOpen={isOpen}
+                defaultValues={args.row.original}
+                databaseName={databaseName}
+                toggleModal={toggleModal}
+            />
+        </>
+    );
+}

--- a/src/Raven.Studio/typescript/components/services/DatabasesService.ts
+++ b/src/Raven.Studio/typescript/components/services/DatabasesService.ts
@@ -71,6 +71,8 @@ import { restoreDatabaseFromBackupCommand } from "commands/resources/restoreData
 import distributeSecretCommand = require("commands/database/secrets/distributeSecretCommand");
 import saveCustomAnalyzerCommand from "commands/database/settings/saveCustomAnalyzerCommand";
 import getDocumentsPreviewCommand = require("commands/database/documents/getDocumentsPreviewCommand");
+import getIdentitiesCommand from "commands/database/identities/getIdentitiesCommand";
+import seedIdentityCommand from "commands/database/identities/seedIdentityCommand";
 
 export default class DatabasesService {
     async setLockMode(databaseNames: string[], newLockMode: DatabaseLockMode) {
@@ -350,5 +352,13 @@ export default class DatabasesService {
 
     async getDocumentsPreview(...args: ConstructorParameters<typeof getDocumentsPreviewCommand>) {
         return new getDocumentsPreviewCommand(...args).execute();
+    }
+
+    async getIdentities(...args: ConstructorParameters<typeof getIdentitiesCommand>) {
+        return new getIdentitiesCommand(...args).execute();
+    }
+
+    async seedIdentity(...args: ConstructorParameters<typeof seedIdentityCommand>) {
+        return new seedIdentityCommand(...args).execute();
     }
 }

--- a/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
+++ b/src/Raven.Studio/typescript/test/mocks/services/MockDatabasesService.ts
@@ -170,4 +170,12 @@ export default class MockDatabasesService extends AutoMockService<DatabasesServi
     withDatabaseStats(dto?: MockedValue<Raven.Client.Documents.Operations.DatabaseStatistics>) {
         return this.mockResolvedValue(this.mocks.getDatabaseStats, dto, DatabasesStubs.detailedStats());
     }
+
+    withSampleIdentities(dto?: MockedValue<Record<string, number>>) {
+        return this.mockResolvedValue(this.mocks.getIdentities, dto, DatabasesStubs.getIdentities(5));
+    }
+
+    withLargeAmountOfIdentities(dto?: MockedValue<Record<string, number>>) {
+        return this.mockResolvedValue(this.mocks.getIdentities, dto, DatabasesStubs.getIdentities(1000));
+    }
 }

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -776,4 +776,23 @@ return docs[0];`,
             ],
         };
     }
+
+    static getIdentities(length = 1): Record<string, number> {
+        const object: Record<string, number> = {};
+        for (let i = 0; i < length; i++) {
+            const randomIdentity = this.getRandomIdentities();
+            Object.assign(object, randomIdentity);
+        }
+        return object;
+    }
+
+    private static getRandomIdentities(): Record<string, number> {
+        const randomRecord: Record<string, number> = {};
+
+        const randomKey = `key${Math.floor(Math.random() * 100000)}`;
+        const randomValue = Math.floor(Math.random() * 100000);
+        randomRecord[randomKey] = randomValue;
+
+        return randomRecord;
+    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21764/Move-identities-to-react

### Additional description

Moved identities view from knockout to react.js with slightly updated layout.



### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
