### PR TITLE
RavenDB-23261 InvalidQueryException in RQL Query on Sharded Database

### DIFF
--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -98,7 +98,7 @@ namespace Raven.Client.Documents.Session
 
         protected readonly IEnumerable<DeclareToken> DeclareTokens;
 
-        protected readonly List<LoadToken> LoadTokens;
+        protected List<LoadToken> LoadTokens;
 
         public FieldsToFetchToken FieldsToFetchToken { get; set; }
 

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1145,5 +1145,11 @@ namespace Raven.Client.Documents.Session
         {
             throw new NotSupportedException("Cannot create an async LINQ query from DocumentQuery, you need to use AsyncDocumentQuery for that");
         }
+
+        internal void Load(List<LoadToken> list)
+        {
+            LoadTokens ??= new List<LoadToken>();
+            LoadTokens.AddRange(list);
+        }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -159,7 +159,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         else
             queryTemplate = Query.ToJson(Context);
 
-        if (Query.Metadata.IsCollectionQuery && Query.Metadata.DeclaredFunctions is null or { Count: 0 })
+        if (Query.Metadata.IsCollectionQuery && Query.Metadata.DeclaredFunctions is null or { Count: 0 } && Query.Metadata.HasIncludeOrLoad == false)
         {
             // * For collection queries that specify ids, we can turn that into a set of loads that 
             //   will hit the known servers

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.Loaders;
+using Raven.Client.Documents.Session.Tokens;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Extensions;
@@ -159,7 +160,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         else
             queryTemplate = Query.ToJson(Context);
 
-        if (Query.Metadata.IsCollectionQuery && Query.Metadata.DeclaredFunctions is null or { Count: 0 } && Query.Metadata.HasIncludeOrLoad == false)
+        if (Query.Metadata.IsCollectionQuery && Query.Metadata.DeclaredFunctions is null or { Count: 0 })
         {
             // * For collection queries that specify ids, we can turn that into a set of loads that 
             //   will hit the known servers
@@ -638,6 +639,21 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         var queryData = Query.Metadata.QueryData;
         if (queryData != null)
             documentQuery.SelectFields<dynamic>(queryData);
+
+        if (Query.Metadata.Query.Load is { Count: > 0 })
+        {
+            var loadTokens = new List<LoadToken>();
+            foreach (var loadItem in Query.Metadata.Query.Load)
+            {
+                if (loadItem.Expression == null || !loadItem.Alias.HasValue)
+                    continue;
+
+                var argument = loadItem.Expression.GetTextWithAlias(null);
+                var alias = loadItem.Alias.Value.Value;
+                loadTokens.Add(LoadToken.Create(argument, alias));
+            }
+            documentQuery.Load(loadTokens);
+        }
 
         var queryText = documentQuery.ToString();
 

--- a/test/FastTests/Issues/RavenDB-23261.cs
+++ b/test/FastTests/Issues/RavenDB-23261.cs
@@ -1,0 +1,56 @@
+﻿using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_23261 : RavenTestBase
+    {
+        public RavenDB_23261(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Sharding)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void CanRunCustomRQLQueryWithLoadAndSelect(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company { Name = "Acme Inc." }, "companies/1-A");
+
+                    session.Store(new Order
+                    {
+                        Id = "orders/830-A",
+                        Employee = "John Doe",
+                        Company = "companies/1-A"
+                    });
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Advanced.RawQuery<dynamic>(@"
+                    from 'Orders' as o
+                    where id() == 'orders/830-A'
+                    load o.Company as c
+                    select {
+                        Handled: o.Employee,
+                        CompName: c.Name
+                    }
+                ");
+                    WaitForUserToContinueTheTest(store);
+                    var result = query.FirstOrDefault();
+
+                    // Assert
+                    Assert.NotNull(result);
+                    Assert.Equal("John Doe", result.Handled.ToString());
+                }
+            }
+        }
+    }
+}

--- a/test/FastTests/Issues/RavenDB-23261.cs
+++ b/test/FastTests/Issues/RavenDB-23261.cs
@@ -12,22 +12,17 @@ namespace FastTests.Issues
         {
         }
 
-        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Sharding)]
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void CanRunCustomRQLQueryWithLoadAndSelect(Options options)
+        public void CanRunCustomRqlQueryWithLoadAndSelect(Options options)
         {
             using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
-                    session.Store(new Company { Name = "Acme Inc." }, "companies/1-A");
+                    session.Store(new Order { Id = "orders/830-A", Employee = "John Doe", Company = "companies/1-A" }, "orders/830-A");
 
-                    session.Store(new Order
-                    {
-                        Id = "orders/830-A",
-                        Employee = "John Doe",
-                        Company = "companies/1-A"
-                    });
+                    session.Store(new Company { Name = "Acme Inc." }, "companies/1-A");
 
                     session.SaveChanges();
                 }
@@ -35,20 +30,60 @@ namespace FastTests.Issues
                 using (var session = store.OpenSession())
                 {
                     var query = session.Advanced.RawQuery<dynamic>(@"
-                    from 'Orders' as o
-                    where id() == 'orders/830-A'
-                    load o.Company as c
-                    select {
+                        from 'Orders' as o
+                       where id() == 'orders/830-A'
+                       load o.Company as c
+                       select {
                         Handled: o.Employee,
                         CompName: c.Name
-                    }
-                ");
-                    WaitForUserToContinueTheTest(store);
+                    }");
+
                     var result = query.FirstOrDefault();
 
                     // Assert
                     Assert.NotNull(result);
                     Assert.Equal("John Doe", result.Handled.ToString());
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        public void CanRunCustomRqlQueryWithLoadAndSelectSameShard(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order
+                    {
+                        Id = "orders/830-A",
+                        Employee = "John Doe",
+                        Company = "companies/1-A$orders/830-A"
+                    }, "orders/830-A");
+
+                    session.Store(new Company { Name = "Acme Inc." }, "companies/1-A$orders/830-A");
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                        var query = session.Advanced.RawQuery<dynamic>(@"
+                        from 'Orders' as o
+                       where id() == 'orders/830-A'
+                       load o.Company as c
+                       select {
+                        Handled: o.Employee,
+                        CompName: c.Name
+                    }");
+
+                    var result = query.FirstOrDefault();
+
+                    // Assert
+                    Assert.NotNull(result);
+                    Assert.Equal("John Doe", result.Handled.ToString());
+                    Assert.Equal("Acme Inc.", result.CompName.ToString());
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23261

### Additional description

We have an optimization that directs queries for a specific ID to the correct shard. Previously, when using this optimization, load operations were being skipped. Now, we have adjusted the behavior so that the optimization also performs the load operation on the same shard. If the load target is on the same shard, the information will be included; otherwise, it will return null.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
