### PR TITLE
RavenDB-23266 enhancements to the punch holing

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -158,5 +158,10 @@ namespace Raven.Server.Config.Categories
         [MinValue(0)]
         [ConfigurationEntry("Storage.MaxNumberOfRecyclableJournals", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public int MaxNumberOfRecyclableJournals { get; set; }
+
+        [Description("Disable further usage of sparse regions for the FS to reclaim free pages. In order to clear existing sparse regions you need to do that manually.")]
+        [DefaultValue(false)]
+        [ConfigurationEntry("Storage.DisableSparseRegions", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public bool DisableSparseRegions { get; set; }
     }
 }

--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -161,7 +161,7 @@ namespace Raven.Server.Config.Categories
 
         [Description("Disable further usage of sparse regions for the FS to reclaim free pages. In order to clear existing sparse regions you need to do that manually.")]
         [DefaultValue(false)]
-        [ConfigurationEntry("Storage.DisableSparseRegions", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        [ConfigurationEntry("Storage.DisableSparseRegions", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool DisableSparseRegions { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -70,7 +70,7 @@ namespace Raven.Server.Documents
             options.SkipChecksumValidationOnDatabaseLoading = _db.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = _db.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
             options.MaxNumberOfRecyclableJournals = _db.Configuration.Storage.MaxNumberOfRecyclableJournals;
-
+            options.DisableSparseRegions = _db.Configuration.Storage.DisableSparseRegions;
             try
             {
                 DirectoryExecUtils.SubscribeToOnDirectoryInitializeExec(options, _db.Configuration.Storage, _db.Name, DirectoryExecUtils.EnvironmentType.Configuration, _logger);

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -199,6 +199,7 @@ namespace Raven.Server.Documents
             options.SkipChecksumValidationOnDatabaseLoading = DocumentDatabase.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = DocumentDatabase.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
             options.MaxNumberOfRecyclableJournals = DocumentDatabase.Configuration.Storage.MaxNumberOfRecyclableJournals;
+            options.DisableSparseRegions = DocumentDatabase.Configuration.Storage.DisableSparseRegions;
 
             try
             {

--- a/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/StorageHandler.cs
@@ -344,10 +344,8 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 var freeSpaceHandling = storage.Environment.FreeSpaceHandling;
                 await using (var write = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, ResponseBodyStream()))
                 {
-                    context.Write(write, new DynamicJsonValue()
-                    {
-                        ["FreePages"] = freeSpaceHandling.FreeSpaceSnapshot(context.Transaction.InnerTransaction.LowLevelTransaction, hex)
-                    });
+                    var json = freeSpaceHandling.FreeSpaceSnapshot(context.Transaction.InnerTransaction.LowLevelTransaction, hex);
+                    context.Write(write, json);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -740,6 +740,7 @@ namespace Raven.Server.Documents.Indexes
             options.SkipChecksumValidationOnDatabaseLoading = documentDatabase.Configuration.Storage.SkipChecksumValidationOnDatabaseLoading;
             options.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions = documentDatabase.Configuration.Storage.IgnoreDataIntegrityErrorsOfAlreadySyncedTransactions;
             options.MaxNumberOfRecyclableJournals = documentDatabase.Configuration.Storage.MaxNumberOfRecyclableJournals;
+            options.DisableSparseRegions = documentDatabase.Configuration.Storage.DisableSparseRegions;
 
             if (documentDatabase.ServerStore.GlobalIndexingScratchSpaceMonitor != null)
                 options.ScratchSpaceUsage.AddMonitor(documentDatabase.ServerStore.GlobalIndexingScratchSpaceMonitor);

--- a/src/Voron/Debugging/DetailedStorageReport.cs
+++ b/src/Voron/Debugging/DetailedStorageReport.cs
@@ -47,9 +47,10 @@ namespace Voron.Debugging
             return $"{nameof(AllocatedSpaceInBytes)}: {new Size(AllocatedSpaceInBytes,SizeUnit.Bytes)}, {nameof(UsedSpaceInBytes)}: {new Size(UsedSpaceInBytes,SizeUnit.Bytes)}, {nameof(FreeSpaceInBytes)}: {new Size(FreeSpaceInBytes, SizeUnit.Bytes)}";
         }
 
-        public long AllocatedSpaceInBytes { get; set; }
-        public long UsedSpaceInBytes { get; set; }
-        public long FreeSpaceInBytes { get; set; }
+        public required long AllocatedSpaceInBytes { get; set; }
+        public required long ActualSpaceInBytes { get; set; }
+        public required long UsedSpaceInBytes { get; set; }
+        public required long FreeSpaceInBytes { get; set; }
     }
 
     public sealed class JournalsReport

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -28,11 +28,13 @@ using Voron.Util.Settings;
 
 namespace Voron.Debugging
 {
-    public sealed class ReportInput
+    public class ReportInput
     {
+
         public List<JournalFile> Journals;
         public JournalFile[] FlushedJournals { get; set; }
 
+        public required long ActualSizeInBytes { get; set; }
         public long NumberOfAllocatedPages { get; set; }
         public int NumberOfFreePages { get; set; }
         public long NextPageNumber { get; set; }
@@ -48,15 +50,10 @@ namespace Voron.Debugging
         public VoronPathSetting JournalPath { get; set; }
     }
 
-    public sealed class DetailedReportInput
+    public sealed class DetailedReportInput : ReportInput
     {
-        public long NumberOfAllocatedPages;
-        public long NumberOfFreePages;
-        public long NextPageNumber;
         public List<Tree> Trees;
         public List<FixedSizeTree> FixedSizeTrees;
-        public List<JournalFile> Journals;
-        public JournalFile[] FlushedJournals { get; set; }
         public List<Table> Tables;
         public Dictionary<Slice, long> Containers;
         public List<PostingList> PostingLists;
@@ -64,8 +61,6 @@ namespace Voron.Debugging
         public List<Lookup<Int64LookupKey>> NumericLookups;
         public List<Lookup<CompactTree.CompactKeyLookup>> TextualLookups;
         public bool IncludeDetails { get; set; }
-        public VoronPathSetting TempPath { get; set; }
-        public VoronPathSetting JournalPath { get; set; }
         public long LastFlushedTransactionId { get; set; }
         public long LastFlushedJournalId { get; set; }
         public long TotalWrittenButUnsyncedBytes { get; set; }
@@ -87,7 +82,7 @@ namespace Voron.Debugging
 
         public StorageReport Generate(ReportInput input)
         {
-            var dataFile = GenerateDataFileReport(input.NumberOfAllocatedPages, input.NumberOfFreePages, input.NextPageNumber);
+            var dataFile = GenerateDataFileReport(input.NumberOfAllocatedPages, input.NumberOfFreePages, input.NextPageNumber, input.ActualSizeInBytes);
 
             var journals = GenerateJournalsReport(input.Journals, input.FlushedJournals);
 
@@ -107,7 +102,7 @@ namespace Voron.Debugging
 
         public unsafe DetailedStorageReport Generate(DetailedReportInput input)
         {
-            var dataFile = GenerateDataFileReport(input.NumberOfAllocatedPages, input.NumberOfFreePages, input.NextPageNumber);
+            var dataFile = GenerateDataFileReport(input.NumberOfAllocatedPages, input.NumberOfFreePages, input.NextPageNumber, input.ActualSizeInBytes);
 
             long streamsAllocatedSpaceInBytes = 0;
             long treesAllocatedSpaceInBytes = 0;
@@ -278,12 +273,13 @@ namespace Voron.Debugging
             };
         }
 
-        private DataFileReport GenerateDataFileReport(long numberOfAllocatedPages, long numberOfFreePages, long nextPageNumber)
+        private DataFileReport GenerateDataFileReport(long numberOfAllocatedPages, long numberOfFreePages, long nextPageNumber, long actualSizeInBytes)
         {
             var unallocatedPagesAtEndOfFile = numberOfAllocatedPages - (nextPageNumber - 1);
 
             return new DataFileReport
             {
+                ActualSpaceInBytes = actualSizeInBytes,
                 AllocatedSpaceInBytes = PagesToBytes(numberOfAllocatedPages),
                 UsedSpaceInBytes = PagesToBytes((nextPageNumber - 1) - numberOfFreePages),
                 FreeSpaceInBytes = PagesToBytes(numberOfFreePages + unallocatedPagesAtEndOfFile)

--- a/src/Voron/EnvironmentStateRecord.cs
+++ b/src/Voron/EnvironmentStateRecord.cs
@@ -16,8 +16,12 @@ public record EnvironmentStateRecord(
     TreeRootHeader Root,
     long NextPageNumber,
     (JournalFile Current, long Last4KWritePosition) Journal,
-    object ClientState,
-    List<long> SparsePageRanges);
+    object ClientState);
+
+public record SparseRegionsRecord(
+    long TransactionId,
+    List<(long Start, long Count)> Regions
+);
 
 internal sealed class EnvironmentStateRecordHolder
 {

--- a/src/Voron/Impl/ApplyTosToDataFileState.cs
+++ b/src/Voron/Impl/ApplyTosToDataFileState.cs
@@ -5,5 +5,10 @@ namespace Voron.Impl;
 
 record ApplyLogsToDataFileState(
     List<PageFromScratchBuffer> Buffers,
-    List<long> SparseRegions,
-    EnvironmentStateRecord Record);
+    EnvironmentStateRecord Record)
+{
+    public override string ToString()
+    {
+        return Record.DataPagerState.Pager.FileName;
+    }
+}

--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -6,6 +6,7 @@ using Sparrow;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron.Data.Fixed;
+using Voron.Global;
 
 namespace Voron.Impl.FreeSpace
 {
@@ -344,7 +345,7 @@ namespace Voron.Impl.FreeSpace
             var json = new DynamicJsonValue();
             var freePages = new List<DynamicJsonValue>();
             long totalNumberFreePages = 0;
-            var load = new Dictionary<int, int>();
+            var load = new Dictionary<long, long>();
             using (var it = freeSpaceTree.Iterate())
             {
                 if (it.Seek(0))
@@ -362,12 +363,12 @@ namespace Voron.Impl.FreeSpace
                 }
 
                 json["FreePagesCount"] = totalNumberFreePages;
-                json["FreeSpaceSizeHumane"] = new Size(totalNumberFreePages * 8, SizeUnit.Kilobytes).ToString();
-                json["FreeSpaceSizeInKB"] = totalNumberFreePages * 8;
+                json["FreeSpaceSizeHumane"] = new Size(totalNumberFreePages * Constants.Storage.PageSize, SizeUnit.Bytes).ToString();
+                json["FreeSpaceSize"] = totalNumberFreePages * Constants.Storage.PageSize;
                 long sparseSize = load.Where(x => x.Key >= NumberOfFreePagesForSparseConsideration)
-                    .Sum(x => x.Value * x.Key) * 8;
-                json["ExpectedSparseSizeHumane"] = new Size(sparseSize, SizeUnit.Kilobytes).ToString();
-                json["ExpectedSparseSizeInKB"] = sparseSize;
+                    .Sum(x => x.Value * x.Key) * Constants.Storage.PageSize;
+                json["ExpectedSparseSizeHumane"] = new Size(sparseSize, SizeUnit.Bytes).ToString();
+                json["ExpectedSparseSize"] = sparseSize;
                 json["FreeSections"] = load.OrderByDescending(x => x.Value)
                     .Select(x => new DynamicJsonValue
                     {

--- a/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/FreeSpaceHandling.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Sparrow;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Voron.Data.Fixed;
@@ -8,11 +11,13 @@ namespace Voron.Impl.FreeSpace
 {
     public sealed unsafe class FreeSpaceHandling : IFreeSpaceHandling
     {
+        private readonly bool _disableSparseRegions;
         private static readonly Slice FreeSpaceKey;
 
         private readonly FreeSpaceHandlingDisabler _disableStatus = new FreeSpaceHandlingDisabler();
 
         private readonly FreeSpaceRecursiveCallGuard _guard;
+        private const int NumberOfFreePagesForSparseConsideration = NumberOfPagesInSection/4;
 
         static FreeSpaceHandling()
         {
@@ -22,8 +27,9 @@ namespace Voron.Impl.FreeSpace
             }
         }
 
-        public FreeSpaceHandling()
+        public FreeSpaceHandling(bool disableSparseRegions)
         {
+            _disableSparseRegions = disableSparseRegions;
             _guard = new FreeSpaceRecursiveCallGuard(this);
         }
 
@@ -332,27 +338,44 @@ namespace Voron.Impl.FreeSpace
                 return freePages;
             }
         }
-        public List<DynamicJsonValue> FreeSpaceSnapshot(LowLevelTransaction tx, bool hex)
+        public DynamicJsonValue FreeSpaceSnapshot(LowLevelTransaction tx, bool hex)
         {
             var freeSpaceTree = GetFreeSpaceTree(tx);
-            if (freeSpaceTree.NumberOfEntries == 0)
-                return new List<DynamicJsonValue>();
-
+            var json = new DynamicJsonValue();
+            var freePages = new List<DynamicJsonValue>();
+            long totalNumberFreePages = 0;
+            var load = new Dictionary<int, int>();
             using (var it = freeSpaceTree.Iterate())
             {
-                if (it.Seek(0) == false)
-                    return new List<DynamicJsonValue>();
-
-                var freeSpace = new List<DynamicJsonValue>();
-
-                do
+                if (it.Seek(0))
                 {
-                    var stream = it.CreateReaderForCurrent();
-                    var current = new StreamBitArray(stream.Base);
-                    freeSpace.Add(current.ToJson(it.CurrentKey, hex));
-                } while (it.MoveNext());
+                    do
+                    {
+                        var stream = it.CreateReaderForCurrent();
+                        var current = new StreamBitArray(stream.Base);
+                        totalNumberFreePages += current.SetCount;
+                        freePages.Add(current.ToJson(it.CurrentKey, hex));
 
-                return freeSpace;
+                        CollectionsMarshal.GetValueRefOrAddDefault(load, current.SetCount, out _)++;
+
+                    } while (it.MoveNext());
+                }
+
+                json["FreePagesCount"] = totalNumberFreePages;
+                json["FreeSpaceSizeHumane"] = new Size(totalNumberFreePages * 8, SizeUnit.Kilobytes).ToString();
+                json["FreeSpaceSizeInKB"] = totalNumberFreePages * 8;
+                long sparseSize = load.Where(x => x.Key >= NumberOfFreePagesForSparseConsideration)
+                    .Sum(x => x.Value * x.Key) * 8;
+                json["ExpectedSparseSizeHumane"] = new Size(sparseSize, SizeUnit.Kilobytes).ToString();
+                json["ExpectedSparseSizeInKB"] = sparseSize;
+                json["FreeSections"] = load.OrderByDescending(x => x.Value)
+                    .Select(x => new DynamicJsonValue
+                    {
+                        ["NumberOfFreePages"] = x.Key,
+                        ["NumberOfSections"] = x.Value
+                    }).ToList();
+                json["FreePages"] = freePages;
+                return json;
             }
         }
 
@@ -381,7 +404,7 @@ namespace Voron.Impl.FreeSpace
             }
         }
 
-        public IEnumerable<long> GetAllFullyEmptySegments(LowLevelTransaction tx)
+        public IEnumerable<long> GetCandidatesForSparseRegions(LowLevelTransaction tx)
         {
             var freeSpaceTree = GetFreeSpaceTree(tx);
             using (var it = freeSpaceTree.Iterate())
@@ -392,9 +415,9 @@ namespace Voron.Impl.FreeSpace
                 do
                 {
                     int freePagesInSegment = it.CreateReaderForCurrent().Read<int>();
-                    if (freePagesInSegment == NumberOfPagesInSection)
+                    if (freePagesInSegment >= NumberOfFreePagesForSparseConsideration)
                     {
-                        yield return it.CurrentKey * NumberOfPagesInSection;
+                        yield return it.CurrentKey;
                     }
                 } while (it.MoveNext());
             }
@@ -417,9 +440,10 @@ namespace Voron.Impl.FreeSpace
                     sba = !result.HasValue ? new StreamBitArray() : new StreamBitArray(result.CreateReader().Base);
                 }
                 sba.Set((int)(pageNumber % NumberOfPagesInSection), true);
-                if (sba.SetCount == NumberOfPagesInSection)
+                
+                if (_disableSparseRegions == false && sba.SetCount > NumberOfFreePagesForSparseConsideration)
                 {
-                    tx.RecordSparseRange(section * NumberOfPagesInSection);
+                    tx.RecordSparseRangeCandidate(section);
                 }
 
                 sba.Write(freeSpaceTree, section);
@@ -447,6 +471,48 @@ namespace Voron.Impl.FreeSpace
         {
             _disableStatus.DisableCount++;
             return _disableStatus;
+        }
+
+        public List<(long Start, long Count)> GetSparseRegions(LowLevelTransaction tx ,HashSet<long> sparseRangeCandidate)
+        {
+            var freeSpaceTree = GetFreeSpaceTree(tx);
+            var results = new List<(long Start, long Count)>();
+            
+            foreach (long sectionId in sparseRangeCandidate)
+            {
+                using (freeSpaceTree.Read(sectionId, out Slice result))
+                {
+                    if(result.HasValue is false)
+                        continue;
+
+                    var section = new StreamBitArray(result.CreateReader().Base);
+                    if(section .SetCount < NumberOfFreePagesForSparseConsideration)
+                        continue;
+
+                    var start = -1;
+                    while (start < NumberOfPagesInSection)
+                    {
+                        start = section.FirstSetBit(start + 1);
+                        if (start == -1)
+                            break;
+
+                        int nextUnsetBit = section.NextUnsetBits(start + 1);
+                        if (nextUnsetBit == -1)
+                            nextUnsetBit = NumberOfPagesInSection;
+
+                        var freeRange = nextUnsetBit  - start;
+
+                        if (freeRange >= 128)
+                        {
+                            results.Add(((sectionId * NumberOfPagesInSection) + start, freeRange));
+                        }
+
+                        start = nextUnsetBit;
+                    }
+                }
+            }
+
+            return results;
         }
 
         private static FixedSizeTree GetFreeSpaceTree(LowLevelTransaction tx)

--- a/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
+++ b/src/Voron/Impl/FreeSpace/IFreeSpaceHandling.cs
@@ -8,11 +8,12 @@ namespace Voron.Impl.FreeSpace
         long? TryAllocateFromFreeSpace(LowLevelTransaction tx, int num);
         List<long> AllPages(LowLevelTransaction tx);
         int GetFreePagesCount(LowLevelTransaction txLowLevelTransaction);
-        List<DynamicJsonValue> FreeSpaceSnapshot(LowLevelTransaction tx, bool hex);
-        IEnumerable<long> GetAllFullyEmptySegments(LowLevelTransaction tx);
+        DynamicJsonValue FreeSpaceSnapshot(LowLevelTransaction tx, bool hex);
+        IEnumerable<long> GetCandidatesForSparseRegions(LowLevelTransaction tx);
         void FreePage(LowLevelTransaction tx, long pageNumber);
         long GetFreePagesOverhead(LowLevelTransaction tx);
         IEnumerable<long> GetFreePagesOverheadPages(LowLevelTransaction tx);
         FreeSpaceHandlingDisabler Disable();
+        List<(long Start, long Count)> GetSparseRegions(LowLevelTransaction tx, HashSet<long> sparseRangeCandidate);
     }
 }

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -644,6 +644,17 @@ namespace Voron.Impl.Journal
                     }
 
                     _forTestingPurposes?.OnApplyLogsToDataFileUnderFlushingLock?.Invoke();
+                    _waj._env.ActiveTransactions.ForceRecheckingOldestTransactionByFlusherThread();
+                    long uptoTxIdExclusive = _waj._env.ActiveTransactions.OldestTransaction;
+
+                    var sparseRegionsToFlush = _waj._env.TryGetLatestSparseRegionsToFlush(uptoTxIdExclusive);
+                    if (sparseRegionsToFlush != null)
+                    {
+                        // This needs to happen _before_ we actually write to the disk
+                        // because we _first_ zero a range and then we may write data to that range (filling some of it up).
+                        // That is fine, and means that we don't need to track re-uses. 
+                        MarkSparseRegionsInDataFile(sparseRegionsToFlush);
+                    }
 
                     if (_applyLogsToDataFileStateFromPreviousFailedAttempt != null)
                     {
@@ -654,9 +665,8 @@ namespace Voron.Impl.Journal
                     else
                     {
                         // RavenDB-13302: we need to force a re-check this before we make decisions here
-                        _waj._env.ActiveTransactions.ForceRecheckingOldestTransactionByFlusherThread();
                         _applyLogsToDataFileStateFromPreviousFailedAttempt = _waj._env.TryGetLatestEnvironmentStateToFlush(
-                            uptoTxIdExclusive: _waj._env.ActiveTransactions.OldestTransaction);
+                            uptoTxIdExclusive: uptoTxIdExclusive);
                         if (_applyLogsToDataFileStateFromPreviousFailedAttempt == null)
                             return; // nothing to do
                     }
@@ -1307,15 +1317,10 @@ namespace Voron.Impl.Journal
                     Pager.PagerTransactionState txState = default;
                     try
                     {
-                        if (state.SparseRegions?.Count > 0)
-                        {
-                            // This needs to happen _before_ we actually write to the disk
-                            // because we _first_ zero a range and then we may write data to that range (filling some of it up).
-                            // That is fine, and means that we don't need to track re-uses. 
-                            MarkSparseRegionsInDataFile(dataPagerState,CollectionsMarshal.AsSpan(state.SparseRegions));
-                        }
-                        
                         Span<Page> pages = GetSortedPages(ref txState, record, pagesBuffer);
+
+                        if (pages.IsEmpty)
+                            return dataPagerState;
 
                         Page lastPage = pages[^1];
                         dataPager.EnsureContinuous(ref dataPagerState, lastPage.PageNumber, lastPage.GetNumberOfPages());
@@ -1324,11 +1329,10 @@ namespace Voron.Impl.Journal
                         {
                             PalHelper.ThrowLastError(rc, errorCode, $"Failed to get file handle for {dataPager.FileName}");
                         }
-
-                        (dataPagerState.TotalFileSize, dataPagerState.TotalDiskSpace) = dataPager.GetFileSize(dataPagerState);
                         
                         using (fileHandle)
                         {
+                            (dataPagerState.TotalFileSize, dataPagerState.TotalDiskSpace) = dataPager.GetFileSize(dataPagerState);
                             for (int i = 0; i < pages.Length; i++)
                             {
                                 int numberOfPages = pages[i].GetNumberOfPages();
@@ -1361,6 +1365,20 @@ namespace Voron.Impl.Journal
                 Interlocked.Add(ref _totalWrittenButUnsyncedBytes, written);
 
                 return dataPagerState;
+            }
+
+            private void MarkSparseRegionsInDataFile(Span<(long Start, long Count)> sparseRegions)
+            {
+                var currentStateRecord = _waj._env.CurrentStateRecord;
+                var dataPagerState = currentStateRecord.DataPagerState;
+             
+                foreach (var (start, count) in sparseRegions)
+                {
+                    _waj._env.DataPager.SetSparseRange(dataPagerState,
+                        start * Constants.Storage.PageSize,
+                        count * Constants.Storage.PageSize
+                    );
+                }
             }
 
             private void MarkSparseRegionsInDataFile(Pager.State dataPagerState, Span<long> sparseRegions)

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -48,7 +48,7 @@ namespace Voron.Impl
         private readonly bool _isValidationEnabled;
         private ImmutableDictionary<long,PageFromScratchBuffer>.Builder _scratchPagesInUse;
         private readonly ImmutableDictionary<long,PageFromScratchBuffer> _scratchPagesForReads;
-        private List<long> _sparsePageRanges;
+        private HashSet<long> _sparsePageRanges;
         private readonly GetPageMethod _getPageMethod;
         private readonly long _id;
         
@@ -75,6 +75,7 @@ namespace Voron.Impl
         public Pager.PagerTransactionState PagerTransactionState;
         private readonly WriteAheadJournal _journal;
         public ImmutableDictionary<long, PageFromScratchBuffer> ModifiedPagesInTransaction;
+        private SparseRegionsRecord _sparseRangesInTransaction;
         private ImmutableDictionary<long, PageFromScratchBuffer> _scratchBuffersSnapshotToRollbackTo;
         internal sealed class WriteTransactionPool
         {
@@ -1137,7 +1138,15 @@ namespace Voron.Impl
             _env.Journal.Applicator.OnTransactionCommitted(this);
 
             ModifiedPagesInTransaction = _scratchPagesInUse.ToImmutable();
+
+            if (_sparsePageRanges != null && _sparsePageRanges.Count != 0)
+            {
+                var regions = _freeSpaceHandling.GetSparseRegions(this, _sparsePageRanges);
+                _sparseRangesInTransaction = new SparseRegionsRecord(Id, regions);
+            }
         }
+
+        public SparseRegionsRecord SparseRegionsRecord => _sparseRangesInTransaction;
 
         [DoesNotReturn]
         private static void ThrowNextPageNumberCannotBeSmallerOrEqualThanOne([CallerMemberName] string caller = null)
@@ -1513,12 +1522,10 @@ namespace Voron.Impl
             _scratchPagesInUse.Remove(value.PageNumberInDataFile);
         }
 
-        public void RecordSparseRange(long sectionPageNumber)
+        public void RecordSparseRangeCandidate(long sectionPageNumber)
         {
             _sparsePageRanges ??= new();
             _sparsePageRanges.Add(sectionPageNumber);
         }
-
-        public List<long> GetSparsePageRanges() => _sparsePageRanges;
     }
 }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1674,13 +1674,13 @@ namespace Voron
             };
 
             var ranges = tx.SparseRegionsRecord;
-            if (ranges != null)
+            if (ranges?.Regions.Count > 0)
             {
                 _sparseRegionsToFlush.Enqueue(ranges);
-                Interlocked.Exchange(ref _currentSparseRegionsRecord, ranges);
             }
 
             // we don't _have_ to make it using interlocked, but let's publish it immediately
+            Interlocked.Exchange(ref _currentSparseRegionsRecord, ranges);
             Interlocked.Exchange(ref _currentStateRecord, updatedState);
 
             // We only want to flush to data pager transactions that have been flushed to the journal.

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -118,9 +118,12 @@ namespace Voron
 
         internal TestingStuff _forTestingPurposes;
         private EnvironmentStateRecord _currentStateRecord;
+        private SparseRegionsRecord _currentSparseRegionsRecord;
         private readonly ConcurrentQueue<EnvironmentStateRecordHolder> _transactionsToFlush = new();
+        private readonly ConcurrentQueue<SparseRegionsRecord> _sparseRegionsToFlush = new();
 
         internal EnvironmentStateRecord CurrentStateRecord => _currentStateRecord;
+        internal SparseRegionsRecord CurrentSparseRegions => _currentSparseRegionsRecord;
 
         public DateTime LastWorkTime;
 
@@ -147,7 +150,7 @@ namespace Voron
                 _log = RavenLogManager.Instance.GetLoggerForVoron<StorageEnvironment>(options, options.BasePath.FullPath);
                 _options = options;
                 (_dataPager, var dataPagerState) = options.InitializeDataPager();
-                _freeSpaceHandling = new FreeSpaceHandling();
+                _freeSpaceHandling = new FreeSpaceHandling(options.DisableSparseRegions);
                 _headerAccessor = new HeaderAccessor(this);
                 TimeToSyncAfterFlushInSec = options.TimeToSyncAfterFlushInSec;
 
@@ -159,7 +162,6 @@ namespace Voron
                     default(TreeRootHeader), 
                     -1,
                     (null, -1),
-                    null, 
                     null);
                 
                 _lastValidPageAfterLoad = dataPagerState.NumberOfAllocatedPages;
@@ -364,9 +366,12 @@ namespace Voron
                     metadataTree?.Add("db-id", DbId.ToByteArray());
                 }
 
-                foreach (long freeSegment in _freeSpaceHandling.GetAllFullyEmptySegments(tx))
+                if (_options.DisableSparseRegions == false)
                 {
-                    tx.RecordSparseRange(freeSegment);
+                    foreach (long freeSegment in _freeSpaceHandling.GetCandidatesForSparseRegions(tx))
+                    {
+                        tx.RecordSparseRangeCandidate(freeSegment);
+                    }
                 }
 
                 tx.Commit();
@@ -924,7 +929,7 @@ namespace Voron
 
             return new SizeReport
             {
-                DataFileInBytes = StorageReportGenerator.PagesToBytes(numberOfAllocatedPages),
+                DataFileInBytes = _currentStateRecord.DataPagerState.TotalDiskSpace,
                 JournalsInBytes = journalsSize,
                 TempBuffersInBytes = tempBuffers,
                 TempRecyclableJournalsInBytes = tempRecyclableJournals
@@ -987,6 +992,7 @@ namespace Voron
 
             return generator.Generate(new ReportInput
             {
+                ActualSizeInBytes = tx.LowLevelTransaction.CurrentStateRecord.DataPagerState.TotalDiskSpace,
                 NumberOfAllocatedPages = numberOfAllocatedPages,
                 NumberOfFreePages = numberOfFreePages,
                 NextPageNumber = NextPageNumber,
@@ -1232,6 +1238,7 @@ namespace Voron
 
             var detailedReportInput = new DetailedReportInput
             {
+                ActualSizeInBytes = tx.LowLevelTransaction.CurrentStateRecord.DataPagerState.TotalDiskSpace,
                 NumberOfAllocatedPages = numberOfAllocatedPages,
                 NumberOfFreePages = numberOfFreePages,
                 NextPageNumber = NextPageNumber,
@@ -1664,8 +1671,14 @@ namespace Voron
                 NextPageNumber = tx.GetNextPageNumber(),
                 Root = tx.RootObjects.ReadHeader(),
                 DataPagerState = tx.DataPagerState,
-                SparsePageRanges = tx.GetSparsePageRanges()
             };
+
+            var ranges = tx.SparseRegionsRecord;
+            if (ranges != null)
+            {
+                _sparseRegionsToFlush.Enqueue(ranges);
+                Interlocked.Exchange(ref _currentSparseRegionsRecord, ranges);
+            }
 
             // we don't _have_ to make it using interlocked, but let's publish it immediately
             Interlocked.Exchange(ref _currentStateRecord, updatedState);
@@ -1679,7 +1692,6 @@ namespace Voron
         }
 
         private readonly List<PageFromScratchBuffer> _cachedScratchBuffers = [];
-        private readonly List<long> _cachedSparseRegionsList = [];
 
         internal ApplyLogsToDataFileState TryGetLatestEnvironmentStateToFlush(long uptoTxIdExclusive)
         {
@@ -1688,8 +1700,6 @@ namespace Voron
 
             var scratchBuffers = _cachedScratchBuffers;
             scratchBuffers.Clear();
-            var sparseRegions = _cachedSparseRegionsList;
-            sparseRegions.Clear();
             bool found = false;
             EnvironmentStateRecord record = null;
             while (true)
@@ -1700,7 +1710,7 @@ namespace Voron
                     if (found == false)
                         return null;
                     Debug.Assert(record is not null);
-                    return new ApplyLogsToDataFileState(scratchBuffers, sparseRegions, record);
+                    return new ApplyLogsToDataFileState(scratchBuffers,  record);
                 }
 
                 if (_transactionsToFlush.TryDequeue(out EnvironmentStateRecordHolder recordHolder) == false)
@@ -1713,10 +1723,7 @@ namespace Voron
 
                 recordHolder.EnvStateRecord = null; // this way we ensure that _transactionsToFlush won't hold reference in its internal slots preventing GC on EnvironmentStateRecord.ClientState object
 
-                if (record.SparsePageRanges != null)
-                {
-                    sparseRegions.AddRange(record.SparsePageRanges);
-                }
+
                 foreach (var (_, pageFromScratch) in record.ScratchPagesTable)
                 {
                     if (pageFromScratch.AllocatedInTransaction != record.TransactionId)
@@ -1726,6 +1733,75 @@ namespace Voron
 
                 found = true;
             }
+        }
+
+        private SparseRegionsRecord _lastPeek;
+        internal Span<(long Start, long Count)> TryGetLatestSparseRegionsToFlush(long uptoTxIdExclusive)
+        {
+            if (uptoTxIdExclusive == 0)
+                uptoTxIdExclusive = long.MaxValue;
+
+            bool found = false;
+            SparseRegionsRecord record = null;
+            var allRegions = new List<(long Start, long Count)>();
+            while (true)
+            {
+                if (_lastPeek is null)
+                {
+                    _sparseRegionsToFlush.TryPeek(out _lastPeek);
+                }
+
+                if (_lastPeek is null || _lastPeek.TransactionId >= uptoTxIdExclusive)
+                {
+                    if (found == false)
+                        return null;
+
+                    Debug.Assert(record is not null);
+                    break;
+                }
+
+                if (_sparseRegionsToFlush.TryDequeue(out record) == false)
+                    throw new InvalidOperationException("Failed to get transaction to flush after already peeked successfully");
+
+                // single thread is reading from this, so we can be sure that peek + take gets the same value
+                Debug.Assert(ReferenceEquals(record, _lastPeek));
+
+                _lastPeek = null;
+
+                allRegions.AddRange(record.Regions);
+
+                found = true;
+            }
+
+            Debug.Assert(allRegions.Count > 0, "allRegions.Count == 0");
+
+            // This sorts first by the start, then by the count, so 
+            allRegions.Sort();
+            int used = 0;
+            var span = CollectionsMarshal.AsSpan(allRegions);
+            ref var prev = ref span[0];
+            for (int i = 1; i < allRegions.Count; i++)
+            {
+                ref var inUsed = ref span[used];
+                ref var cur = ref span[i];
+                if (prev.Start == cur.Start)
+                {
+                    inUsed.Count = cur.Count;
+                }
+                else if (prev.Start + prev.Count >= cur.Start)
+                {
+                    inUsed.Count = Math.Max(prev.Start + prev.Count, cur.Start + cur.Count) - prev.Start;
+                }
+                else
+                {
+                    used++;
+                    prev = ref cur;
+                    span[used] = prev;
+                }
+            }
+
+            return span.Slice(0, used + 1);
+
         }
 
         internal void UpdateJournal(JournalFile file, long last4KWrite)

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -1202,7 +1202,8 @@ namespace Voron
 
         public int MaxNumberOfRecyclableJournals { get; set; } = 32;
         public bool DiscardVirtualMemory { get; set; } = true;
-        
+        public bool DisableSparseRegions { get; set; }
+
         private readonly RavenLogger _log;
 
         private readonly SortedList<long, string> _journalsForReuse = new SortedList<long, string>();

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -88,6 +88,8 @@ namespace FastTests.Issues
                 "Indexing.Corax.MaxMemoizationSizeInMb",
                 "Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb",
                 "Indexing.Corax.Static.ComplexFieldIndexingBehavior",
+                
+                "Storage.DisableSparseRegions",
 
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",

--- a/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
+++ b/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
@@ -55,7 +55,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
 
             wtx.Commit();
         }
-        Assert.Equal([2048], Env.CurrentStateRecord.SparsePageRanges);
+        Assert.Equal([(2048, 2048), (4096, 1026)], Env.CurrentSparseRegions.Regions);
 
         using (var wtx = Env.WriteTransaction())
         {
@@ -71,7 +71,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
             wtx.Commit();
         }
         // proof that we can release regions released across multiple transactions
-        Assert.Equal([4096], Env.CurrentStateRecord.SparsePageRanges);
+        Assert.Equal([(4096, 2048), (6144, 514)], Env.CurrentSparseRegions.Regions);
         (_, long beforePhysicalSize) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);
 
         Env.FlushLogToDataFile();
@@ -83,11 +83,11 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
         // storing sectors using 512 bytes. So if we aren't aligned on 4KB on the disk, hole punching may not actually
         // clear all the blocks. We give ourselves a maximum of 8KB spare for this reason
         Assert.Equal(allocatedSize, Env.CurrentStateRecord.DataPagerState.TotalAllocatedSize);
-        const long amountOfSpaceSaved = (32 * 1024 * 1024);
+        const long amountOfSpaceSaved = (36 * 1024 * 1024);
         if (PlatformDetails.RunningOnMacOsx is false)
         {
             long expectedSize = allocatedSize - amountOfSpaceSaved;
-            Assert.True(Math.Abs(expectedSize - physicalSize) <= 4096 * 2,
+            Assert.True(Math.Abs(expectedSize - physicalSize) <= 8192 * 2,
             $"Expected size: {new Size(expectedSize, SizeUnit.Bytes)}, actual size: {new Size(physicalSize, SizeUnit.Bytes)}");
         }
         else
@@ -104,6 +104,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
         RequireFileBasedPager();
         Options.ManualFlushing = true;
         var pages = new List<long>();
+
         using (var wtx = Env.WriteTransaction())
         {
             for (int i = 0; i < 32; i++)
@@ -123,9 +124,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
             }
             wtx.Commit();
         }
-
         RestartDatabase();
-
-        Assert.Equal([2048, 4096, 6144], Env.CurrentStateRecord.SparsePageRanges);
+        Assert.Equal([(2, 2046), (2048, 2048), (4096, 2048), (6144, 2048)], Env.CurrentSparseRegions.Regions);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23266
https://issues.hibernatingrhinos.com/issue/RavenDB-23265

### Additional description

 * Punch hole in a granularity of 1MB instead of 16MB
 * Separate sparse regions state from the pager state. mainly because on start up we might have no pages to write, but we do have sparse regions.
 * Add option to disable the punch holing
 * Add actual size to reports

In my scenario, we didn't had a lot of free sections (16MB) and many sections looked like this (`databases/*/debug/storage/environment/free-space-snapshot` EP)
```
"Data": [
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"FFF00000",
"FFFFFFFF",
"FFFFFFFF",
"FFFFFFFF",
"FFFFFFFF",
"FFFFFFFF",
"FFFFFFFF",
"F",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0",
"0"
]
```

So we didn't do the hole punching, since we moved to 1MB granularity we were able to reduce the disk size by ~90% of the actual free space.

we had a database with 70GB and 11GB free, so now we report the database as 60GB of size.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
