### PR TITLE
RavenDB-23227 - Report last cluster wide transaction raft index

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -401,6 +401,8 @@ namespace Raven.Server.ServerWide.Maintenance
 
                     previous.LastSentEtag = dbReport.LastSentEtag;
                     previous.LastCompareExchangeIndex = dbReport.LastCompareExchangeIndex;
+                    previous.LastClusterWideTransactionRaftIndex = dbReport.LastClusterWideTransactionRaftIndex;
+
                     previous.UpTime = dbReport.UpTime;
                     nodeReport.Report[dbName] = previous;
                 }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceSupervisor.cs
@@ -402,6 +402,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     previous.LastSentEtag = dbReport.LastSentEtag;
                     previous.LastCompareExchangeIndex = dbReport.LastCompareExchangeIndex;
                     previous.LastClusterWideTransactionRaftIndex = dbReport.LastClusterWideTransactionRaftIndex;
+                    previous.LastCompletedClusterTransaction = dbReport.LastCompletedClusterTransaction;
 
                     previous.UpTime = dbReport.UpTime;
                     nodeReport.Report[dbName] = previous;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterMaintenanceWorker.cs
@@ -250,6 +250,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 {
                     var now = dbInstance.Time.GetUtcNow();
                     FillReplicationInfo(dbInstance, report);
+                    report.LastClusterWideTransactionRaftIndex = dbInstance.ClusterWideTransactionIndexWaiter.LastIndex;
 
                     prevReport.TryGetValue(dbName, out var prevDatabaseReport);
                     if (SupportedFeatures.Heartbeats.SendChangesOnly &&
@@ -263,8 +264,7 @@ namespace Raven.Server.ServerWide.Maintenance
                     using (var context = QueryOperationContext.Allocate(dbInstance, needsServerContext: true))
                     {
                         FillDocumentsInfo(prevDatabaseReport, dbInstance, report, context.Documents, documentsStorage);
-                        FillClusterTransactionInfo(report, dbInstance);
-
+                        
                         if (indexStorage != null)
                         {
                             foreach (var index in indexStorage.GetIndexes())
@@ -294,13 +294,6 @@ namespace Raven.Server.ServerWide.Maintenance
             }
 
             return result;
-        }
-
-        private static void FillClusterTransactionInfo(DatabaseStatusReport report, DocumentDatabase dbInstance)
-        {
-            report.LastTransactionId = dbInstance.LastTransactionId;
-            report.LastCompletedClusterTransaction = dbInstance.LastCompletedClusterTransaction;
-            report.LastClusterWideTransactionRaftIndex = dbInstance.ClusterWideTransactionIndexWaiter.LastIndex;
         }
 
         private static void FillIndexInfo(Index index, QueryOperationContext context, DateTime now, DatabaseStatusReport report)
@@ -353,6 +346,8 @@ namespace Raven.Server.ServerWide.Maintenance
                     report.DatabaseChangeVector = DocumentsStorage.GetDatabaseChangeVector(context);
                 }
             }
+            report.LastTransactionId = dbInstance.LastTransactionId;
+            report.LastCompletedClusterTransaction = dbInstance.LastCompletedClusterTransaction;
         }
 
         private static void FillReplicationInfo(DocumentDatabase dbInstance, DatabaseStatusReport report)

--- a/test/SlowTests/Cluster/CompareExchangeTests.cs
+++ b/test/SlowTests/Cluster/CompareExchangeTests.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.Util;
+using Raven.Server.Config;
 using Raven.Server.ServerWide.Commands;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -60,5 +64,30 @@ public class CompareExchangeTests : RavenTestBase
         })).ToArray();
 
         await Task.WhenAll(longCommandTasks);
+    }
+    
+    [RavenTheory(RavenTestCategory.ClusterTransactions)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task DeletingCompareExchangeCommand_WhenNoModificationsOnTheDatabase_ShouldDeleteTombstone(Options options)
+    {
+        var settings = new Dictionary<string, string>
+        {
+            { RavenConfiguration.GetKey(x => x.Cluster.MaxClusterTransactionCompareExchangeTombstoneCheckInterval), "0" },
+            { RavenConfiguration.GetKey(x => x.Cluster.CompareExchangeTombstonesCleanupInterval), "0" },
+        };
+        var server = GetNewServer(new ServerCreationOptions{CustomSettings = settings});
+            
+        options.Server = server;
+        using (var store = GetDocumentStore(options))
+        {
+            var saveResult = store.Operations.Send(new PutCompareExchangeValueOperation<string>("key", "value", 0));
+            store.Operations.Send(new DeleteCompareExchangeValueOperation<string>("key", saveResult.Index));
+
+            await WaitForValueAsync(async () =>
+            {
+                var stats = await store.Maintenance.SendAsync(new GetDetailedStatisticsOperation());
+                return stats.CountOfCompareExchangeTombstones;
+            }, 0, timeout: 15 * 1000);
+        }
     }
 }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23227

### Additional description
If the storage hasn't changed, we don't send the last cluster-wide transaction index.
This PR moves that information out of the report section that isn't sent.
Once this information is sent, the compare-exchange tombstone cleaner removes the tombstones.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
