### PR TITLE
RavenDB-20832 - fix failing test

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -450,7 +450,7 @@ namespace FastTests
             }
         }
 
-        protected static async Task<T> WaitForValueAsync<T>(Func<T> act, T expectedVal, int timeout = 15000)
+        protected static async Task<T> WaitForValueAsync<T>(Func<T> act, T expectedVal, int timeout = 15000, int interval = 100)
         {
             if (Debugger.IsAttached)
                 timeout *= 100;
@@ -477,7 +477,7 @@ namespace FastTests
                         throw;
                     }
                 }
-                await Task.Delay(100);
+                await Task.Delay(interval);
             } while (true);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20832


### Additional description

This pull request includes several changes to the `test/SlowTests/Issues/RavenDB-17650.cs` file, primarily aimed at improving the robustness and reliability of the test by adding retry mechanisms and better handling of node revival. The most important changes include adding a new method for waiting and asserting node rehabilitation, modifying the subscription worker options, and updating the cancellation token source.

Improvements to node revival and rehabilitation:

* Added a new method `WaitForRehabAndAssert` to wait for node rehabilitation and assert the expected state, including logging details of the database topology.
* Updated the node revival process to run tasks concurrently and wait for all tasks to complete, followed by a call to the new `WaitForRehabAndAssert` method.

Enhancements to subscription worker configuration:

* Modified the `GetSubscriptionWorker` call to include a `TimeToWaitBeforeConnectionRetry` option set to 1 second, improving the test's resilience to connection issues.

Improved cancellation handling:

* Updated the `CancellationTokenSource` to use a timeout of 5 minutes, ensuring that the test does not hang indefinitely.

Minor improvements:

* Added a missing `using` directive for `Raven.Client.Documents` to ensure all necessary namespaces are included.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
