### PR TITLE
RavenDB-22794 - Add comments for operations that implements IMaintenanceOperation

### DIFF
--- a/src/Raven.Client/Documents/Operations/OngoingTasks/GetOngoingTaskInfoOperation.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/GetOngoingTaskInfoOperation.cs
@@ -7,12 +7,23 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.OngoingTasks
 {
+    /// <summary>
+    /// Operation to retrieve detailed information about a specific ongoing task.
+    /// Ongoing tasks include various types of tasks such as replication, ETL, backup, and subscriptions.
+    /// </summary>
     public sealed class GetOngoingTaskInfoOperation : IMaintenanceOperation<OngoingTask>
     {
         private readonly string _taskName;
         private readonly long _taskId;
         private readonly OngoingTaskType _type;
 
+        /// <inheritdoc cref="GetOngoingTaskInfoOperation"/>
+        /// <param name="taskId">The unique identifier of the ongoing task to retrieve information for.</param>
+        /// <param name="type">The type of the ongoing task, such as replication, ETL, or backup.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if the specified task type is <see cref="OngoingTaskType.PullReplicationAsHub"/>, which is not supported.
+        /// Use <see cref="GetPullReplicationTasksInfoOperation"/> for pull replication hub tasks instead.
+        /// </exception>
         public GetOngoingTaskInfoOperation(long taskId, OngoingTaskType type)
         {
             _taskId = taskId;
@@ -24,6 +35,9 @@ namespace Raven.Client.Documents.Operations.OngoingTasks
             }
         }
 
+        /// <inheritdoc cref="GetOngoingTaskInfoOperation"/>
+        /// <param name="taskName">The name of the ongoing task to retrieve information for.</param>
+        /// <param name="type">The type of the ongoing task, such as replication, ETL, or backup.</param>
         public GetOngoingTaskInfoOperation(string taskName, OngoingTaskType type)
         {
             _taskName = taskName;

--- a/src/Raven.Client/Documents/Operations/OngoingTasks/GetPullReplicationHubTasksInfoOperation.cs
+++ b/src/Raven.Client/Documents/Operations/OngoingTasks/GetPullReplicationHubTasksInfoOperation.cs
@@ -7,10 +7,18 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.OngoingTasks
 {
+    /// <summary>
+    /// Operation to retrieve information about a specific pull replication task.
+    /// The information includes the pull replication hub definition and the current connections associated with the task.
+    /// </summary>
     public sealed class GetPullReplicationTasksInfoOperation : IMaintenanceOperation<PullReplicationDefinitionAndCurrentConnections>
     {
         private readonly long _taskId;
 
+        /// <inheritdoc cref="GetPullReplicationTasksInfoOperation"/>
+        /// <param name="taskId">
+        /// The unique identifier of the pull replication task to retrieve information for.
+        /// </param>
         public GetPullReplicationTasksInfoOperation(long taskId)
         {
             _taskId = taskId;

--- a/src/Raven.Client/Documents/Operations/Refresh/ConfigureRefreshOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/ConfigureRefreshOperation.cs
@@ -9,10 +9,26 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Refresh
 {
+    /// <summary>
+    /// Operation to configure the refresh task.
+    /// By enabling and configuring refresh task, the database automatically refreshes documents
+    /// at a specified interval, based on the provided configuration parameters.
+    /// </summary>
     public sealed class ConfigureRefreshOperation : IMaintenanceOperation<ConfigureRefreshOperationResult>
     {
         private readonly RefreshConfiguration _configuration;
 
+        /// <inheritdoc cref="ConfigureRefreshOperation"/>
+        /// <param name="configuration">
+        /// The <see cref="RefreshConfiguration"/> object containing the refresh settings to apply.
+        /// This configuration includes:
+        /// <list type="bullet">
+        /// <item><description>The interval time for refreshing documents (<see cref="RefreshConfiguration.RefreshFrequencyInSec"/>).</description></item>
+        /// <item><description>The maximum number of documents to process during each refresh cycle (<see cref="RefreshConfiguration.MaxItemsToProcess"/>).</description></item>
+        /// <item><description>A flag indicating whether the refresh operation is enabled or disabled.</description></item>
+        /// </list>
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="configuration"/> is null.</exception>
         public ConfigureRefreshOperation(RefreshConfiguration configuration)
         {
             _configuration = configuration;

--- a/src/Raven.Client/Documents/Operations/Refresh/RefreshConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Refresh/RefreshConfiguration.cs
@@ -2,12 +2,28 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Refresh
 {
+    /// <summary>
+    /// The configuration settings for the refresh feature.
+    /// Refresh settings control the automatic update behavior of documents at specified intervals.
+    /// </summary>
     public sealed class RefreshConfiguration : IDynamicJson
     {
+        /// <summary>
+        /// A value indicating whether the refresh feature is disabled.
+        /// When <c>true</c>, the refresh operation will not process any documents.
+        /// </summary>
         public bool Disabled { get; set; }
 
+        /// <summary>
+        /// The frequency, in seconds, at which documents are refreshed.
+        /// If <c>null</c>, the default system refresh interval will be used.
+        /// </summary>
         public long? RefreshFrequencyInSec { get; set; }
 
+        /// <summary>
+        /// The maximum number of documents to process in a single refresh cycle.
+        /// If <c>null</c>, the system default maximum will be used.
+        /// </summary>
         public long? MaxItemsToProcess { get; set; }
 
         private bool Equals(RefreshConfiguration other)

--- a/src/Raven.Client/Documents/Operations/Replication/GetReplicationHubAccessOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/GetReplicationHubAccessOperation.cs
@@ -7,12 +7,21 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
+    /// <summary>
+    /// Operation to retrieve access details for a specific replication hub task.
+    /// This operation provides a paginated list of detailed access information, including the nodes or sinks
+    /// that are authorized to access the specified replication hub.
+    /// </summary>
     public sealed class GetReplicationHubAccessOperation : IMaintenanceOperation<DetailedReplicationHubAccess[]>
     {
         private readonly string _hubName;
         private readonly int _start;
         private readonly int _pageSize;
 
+        /// <inheritdoc cref="GetReplicationHubAccessOperation"/>
+        /// <param name="hubName">The name of the replication hub task for which access details are retrieved.</param>
+        /// <param name="start">The starting point for pagination (default is 0).</param>
+        /// <param name="pageSize">The maximum number of records to return per page (default is 25).</param>
         public GetReplicationHubAccessOperation(string hubName, int start = 0, int pageSize = 25)
         {
             _hubName = hubName;

--- a/src/Raven.Client/Documents/Operations/Replication/GetReplicationPerformanceStatisticsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/GetReplicationPerformanceStatisticsOperation.cs
@@ -6,6 +6,11 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
+    /// <summary>
+    /// Operation to retrieve replication performance statistics.
+    /// This operation provides detailed metrics and performance data about the replication processes,
+    /// which can help diagnose issues and monitor the replication behavior.
+    /// </summary>
     public sealed class GetReplicationPerformanceStatisticsOperation : IMaintenanceOperation<ReplicationPerformance>
     {
         public RavenCommand<ReplicationPerformance> GetCommand(DocumentConventions conventions, JsonOperationContext context)

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -5,24 +5,57 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
+    /// <summary>
+    /// Represents a pull replication task configured as a sink.
+    /// This configuration defines how data is replicated from a hub to the sink and optionally from the sink back to the hub.
+    /// </summary>
     public sealed class PullReplicationAsSink : ExternalReplicationBase
     {
+        /// <summary>
+        /// The replication mode, determining the direction of data flow between the hub and the sink.
+        /// Defaults to <see cref="PullReplicationMode.HubToSink"/>.
+        /// </summary>
         public PullReplicationMode Mode = PullReplicationMode.HubToSink;
 
+        /// <summary>
+        /// The paths allowed for data replication from the hub to the sink.
+        /// </summary>
         public string[] AllowedHubToSinkPaths;
+
+        /// <summary>
+        /// The paths allowed for data replication from the sink to the hub.
+        /// </summary>
         public string[] AllowedSinkToHubPaths;
 
+        /// <summary>
+        /// The certificate with a private key, encoded in Base64, used for secure communication.
+        /// </summary>
         public string CertificateWithPrivateKey; // base64
+
+        /// <summary>
+        /// The password for the certificate, if required.
+        /// </summary>
         public string CertificatePassword;
 
+        /// <summary>
+        /// The access name for the sink.
+        /// </summary>
         public string AccessName;
 
+        /// <summary>
+        /// The name of the hub task that this sink replicates from.
+        /// </summary>
         public string HubName;
 
+        /// <inheritdoc cref="PullReplicationAsSink"/>
         public PullReplicationAsSink()
         {
         }
 
+        /// <inheritdoc cref="PullReplicationAsSink"/>
+        /// <param name="database">The name of the target database.</param>
+        /// <param name="connectionStringName">The name of the connection string for the replication.</param>
+        /// <param name="hubName">The name of the hub task that this sink replicates from.</param>
         public PullReplicationAsSink(string database, string connectionStringName, string hubName) : base(database, connectionStringName)
         {
             HubName = hubName;

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
@@ -5,27 +5,67 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
+    /// <summary>
+    /// The definition of a pull replication task.
+    /// This defines the settings and behavior for pulling data between replication hubs and sinks.
+    /// </summary>
     public sealed class PullReplicationDefinition : IDynamicJsonValueConvertible
     {
+        /// <summary>
+        /// The delay duration for replication. Data will not be replicated until the specified delay has passed.
+        /// </summary>
         public TimeSpan DelayReplicationFor;
+
+        /// <summary>
+        /// A value indicating whether the pull replication task is disabled.
+        /// </summary>
         public bool Disabled;
 
+        /// <summary>
+        /// The mentor node responsible for the pull replication task.
+        /// </summary>
         public string MentorNode;
 
+        /// <summary>
+        /// A value indicating whether the pull replication task should remain pinned to the mentor node.
+        /// </summary>
         public bool PinToMentorNode;
 
+        /// <summary>
+        /// The mode of pull replication, determining the direction of data flow between hubs and sinks.
+        /// Defaults to <see cref="PullReplicationMode.HubToSink"/>.
+        /// </summary>
         public PullReplicationMode Mode = PullReplicationMode.HubToSink;
 
+        /// <summary>
+        /// The name of the pull replication task.
+        /// </summary>
         public string Name;
+
+        /// <summary>
+        /// The unique identifier of the pull replication task.
+        /// </summary>
         public long TaskId;
 
+        /// <summary>
+        /// A value indicating whether filtering is enabled for the pull replication task.
+        /// </summary>
         public bool WithFiltering;
+
+        /// <summary>
+        /// The mode to prevent deletions during replication.
+        /// </summary>
         public PreventDeletionsMode PreventDeletionsMode { get; set; }
 
+        /// <inheritdoc cref="PullReplicationDefinition"/>
         public PullReplicationDefinition()
         {
         }
 
+        /// <inheritdoc cref="PullReplicationDefinition"/>
+        /// <param name="name">The name of the pull replication task.</param>
+        /// <param name="delay">The delay duration for replication.</param>
+        /// <param name="mentor">The mentor node for the pull replication task. Optional.</param>
         public PullReplicationDefinition(string name, TimeSpan delay = default, string mentor = null)
         {
             Name = name;

--- a/src/Raven.Client/Documents/Operations/Replication/PutPullReplicationAsHubOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PutPullReplicationAsHubOperation.cs
@@ -10,10 +10,18 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
+    /// <summary>
+    /// Operation to create a pull replication task as a hub.
+    /// A pull replication hub allows data to be pulled by sink nodes in other clusters or databases.
+    /// Additionally, it can be configured to receive data from sink nodes.
+    /// </summary>
     public sealed class PutPullReplicationAsHubOperation : IMaintenanceOperation<ModifyOngoingTaskResult>
     {
         private readonly PullReplicationDefinition _pullReplicationDefinition;
 
+        /// <inheritdoc cref="PutPullReplicationAsHubOperation"/>
+        /// <param name="name">The name of the pull replication hub task.</param>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="name"/> is null or empty.</exception>
         public PutPullReplicationAsHubOperation(string name)
         {
             if (string.IsNullOrEmpty(name))
@@ -24,6 +32,9 @@ namespace Raven.Client.Documents.Operations.Replication
             _pullReplicationDefinition = new PullReplicationDefinition(name);
         }
 
+        /// <inheritdoc cref="PutPullReplicationAsHubOperation"/>
+        /// <param name="pullReplicationDefinition">The pull replication hub definition to apply.</param>
+        /// <exception cref="ArgumentException">Thrown if the <see cref="PullReplicationDefinition.Name"/> is null or empty.</exception>
         public PutPullReplicationAsHubOperation(PullReplicationDefinition pullReplicationDefinition)
         {
             if (string.IsNullOrEmpty(pullReplicationDefinition.Name))

--- a/src/Raven.Client/Documents/Operations/Replication/UpdateExternalReplicationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdateExternalReplicationOperation.cs
@@ -11,10 +11,19 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
+    /// <summary>
+    /// Operation to update the configuration of an external replication task.
+    /// External replication allows data to be replicated from the current database to another database in a different cluster.
+    /// </summary>
     public sealed class UpdateExternalReplicationOperation : IMaintenanceOperation<ModifyOngoingTaskResult>
     {
         private readonly ExternalReplication _newWatcher;
 
+        /// <inheritdoc cref="UpdateExternalReplicationOperation"/>
+        /// <param name="newWatcher">
+        /// The <see cref="ExternalReplication"/> object containing the updated configuration for the external replication task.
+        /// This includes details such as destination database, connection strings, and other replication settings.
+        /// </param>
         public UpdateExternalReplicationOperation(ExternalReplication newWatcher)
         {
             _newWatcher = newWatcher;

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -12,10 +12,23 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
+    /// <summary>
+    /// Operation to update the configuration of a pull replication task as a sink.
+    /// Pull replication as a sink allows a database to pull data from a source (hub) database in another cluster or server.
+    /// </summary>
     public sealed class UpdatePullReplicationAsSinkOperation : IMaintenanceOperation<ModifyOngoingTaskResult>
     {
         private readonly PullReplicationAsSink _pullReplication;
 
+        /// <inheritdoc cref="UpdatePullReplicationAsSinkOperation"/>
+        /// <param name="pullReplication">
+        /// The <see cref="PullReplicationAsSink"/> object containing the updated configuration for the pull replication sink task.
+        /// This configuration includes details such as the source database, connection strings, allowed paths for data flow 
+        /// between the sink and hub, and an optional private key for a certificate used in secure communication.
+        /// </param>
+        /// <exception cref="AuthorizationException">
+        /// Thrown if the provided certificate does not include a private key but is required for secure replication.
+        /// </exception>
         public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication)
         {
             _pullReplication = pullReplication;

--- a/src/Raven.Client/Documents/Operations/Revisions/ConfigureRevisionsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/ConfigureRevisionsOperation.cs
@@ -9,10 +9,19 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Revisions
 {
+    /// <summary>
+    /// Operation to configure document revision settings.
+    /// </summary>
     public sealed class ConfigureRevisionsOperation : IMaintenanceOperation<ConfigureRevisionsOperationResult>
     {
         private readonly RevisionsConfiguration _configuration;
 
+        /// <inheritdoc cref="ConfigureRevisionsOperation"/>
+        /// <param name="configuration">
+        /// The <see cref="RevisionsConfiguration"/> object containing the revision settings to apply.
+        /// This includes specific settings for individual collections or default settings for all collections
+        /// as defined in <see cref="RevisionsCollectionConfiguration"/>.
+        /// </param>
         public ConfigureRevisionsOperation(RevisionsConfiguration configuration)
         {
             _configuration = configuration;

--- a/src/Raven.Client/Documents/Operations/Revisions/RevisionsConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/RevisionsConfiguration.cs
@@ -12,10 +12,22 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Revisions
 {
+    /// <summary>
+    /// Represents the configuration for document revisions.
+    /// Revisions allow tracking and preserving historical versions of documents.
+    /// This configuration includes default revision settings and collection-specific configurations.
+    /// </summary>
     public sealed class RevisionsConfiguration : IFillFromBlittableJson
     {
+        /// <summary>
+        /// The default revisions configuration to be applied when no collection-specific configuration exists.
+        /// </summary>
         public RevisionsCollectionConfiguration Default { get; set; }
 
+        /// <summary>
+        /// The collection-specific revisions configurations.
+        /// Each key represents a collection name, and the value is its associated configuration.
+        /// </summary>
         public Dictionary<string, RevisionsCollectionConfiguration> Collections { get; set; }
 
         public bool Equals(RevisionsConfiguration other)

--- a/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesValueNamesOperation.cs
+++ b/src/Raven.Client/Documents/Operations/TimeSeries/ConfigureTimeSeriesValueNamesOperation.cs
@@ -10,10 +10,24 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.TimeSeries
 {
+    /// <summary>
+    /// Operation to configure value names for a time series in a specific collection.
+    /// </summary>
     public sealed class ConfigureTimeSeriesValueNamesOperation : IMaintenanceOperation<ConfigureTimeSeriesOperationResult>
     {
         private readonly Parameters _parameters;
 
+        /// <inheritdoc cref="ConfigureTimeSeriesValueNamesOperation"/>
+        /// <param name="parameters">
+        /// The parameters for configuring value names, including the collection name, time series name, 
+        /// and the new value names to set.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="parameters"/> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown if the provided parameters are invalid (e.g., missing required fields).
+        /// </exception>
         public ConfigureTimeSeriesValueNamesOperation(Parameters parameters)
         {
             _parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
@@ -65,11 +79,31 @@ namespace Raven.Client.Documents.Operations.TimeSeries
             public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
         }
 
+        /// <summary>
+        /// Encapsulates the parameters needed for configuring value names for a time series in a specific collection.
+        /// </summary>
         public sealed class Parameters : IDynamicJson
         {
+            /// <summary>
+            /// The name of the collection where the time series resides.
+            /// </summary>
             public string Collection;
+
+            /// <summary>
+            /// The name of the time series to configure.
+            /// </summary>
             public string TimeSeries;
+
+            /// <summary>
+            /// The list of value names to associate with the time series.
+            /// </summary>
             public string[] ValueNames;
+
+            /// <summary>
+            /// Indicates whether to update an existing configuration for the specified time series in the collection.
+            /// If set to <c>false</c> and a configuration already exists for this time series in the collection, 
+            /// an exception will be thrown.
+            /// </summary>
             public bool Update;
 
             internal void Validate()

--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -602,22 +602,48 @@ namespace Raven.Client.ServerWide
         HardDelete
     }
 
+    /// <summary>
+    /// Represents the configuration for compressing documents.
+    /// This configuration includes options for compressing specific collections, all collections, and document revisions.
+    /// </summary>
     public sealed class DocumentsCompressionConfiguration : IDynamicJson
     {
+        /// <summary>
+        /// The collections for which document compression is enabled.
+        /// </summary>
         public string[] Collections { get; set; }
+
+        /// <summary>
+        /// A value indicating whether all collections in the database should be compressed.
+        /// If <c>true</c>, the <see cref="Collections"/> property is ignored.
+        /// </summary>
         public bool CompressAllCollections { get; set; }
+
+        /// <summary>
+        /// A value indicating whether document revisions should be compressed.
+        /// </summary>
         public bool CompressRevisions { get; set; }
 
+        /// <inheritdoc cref="DocumentsCompressionConfiguration"/>
         public DocumentsCompressionConfiguration()
         {
         }
 
+        /// <inheritdoc cref="DocumentsCompressionConfiguration"/>
+        /// <param name="compressRevisions">Specifies whether document revisions should be compressed.</param>
+        /// <param name="collections">The collections for which compression should be enabled.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="collections"/> is null.</exception>
         public DocumentsCompressionConfiguration(bool compressRevisions, params string[] collections)
         {
             Collections = collections ?? throw new ArgumentNullException(nameof(collections));
             CompressRevisions = compressRevisions;
         }
 
+        /// <inheritdoc cref="DocumentsCompressionConfiguration"/>
+        /// <param name="compressRevisions">Specifies whether document revisions should be compressed.</param>
+        /// <param name="compressAllCollections">Specifies whether all collections should be compressed.</param>
+        /// <param name="collections">The collections for which compression should be enabled.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="collections"/> is null.</exception>
         public DocumentsCompressionConfiguration(bool compressRevisions, bool compressAllCollections, params string[] collections)
         {
             Collections = collections ?? throw new ArgumentNullException(nameof(collections));

--- a/src/Raven.Client/ServerWide/Operations/DocumentsCompression/UpdateDocumentsCompressionConfigurationOperation.cs
+++ b/src/Raven.Client/ServerWide/Operations/DocumentsCompression/UpdateDocumentsCompressionConfigurationOperation.cs
@@ -10,14 +10,23 @@ using Sparrow.Json;
 
 namespace Raven.Client.ServerWide.Operations.DocumentsCompression
 {
+    /// <summary>
+    /// Operation to update the documents compression configuration.
+    /// </summary>
     public sealed class UpdateDocumentsCompressionConfigurationOperation : IMaintenanceOperation<DocumentCompressionConfigurationResult>
     {
         private readonly DocumentsCompressionConfiguration _documentsCompressionConfiguration;
 
+        /// <inheritdoc cref="UpdateDocumentsCompressionConfigurationOperation"/>
+        /// <param name="configuration">
+        /// The <see cref="DocumentsCompressionConfiguration"/> object containing the new compression settings to apply.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration"/> is null.</exception>
         public UpdateDocumentsCompressionConfigurationOperation(DocumentsCompressionConfiguration configuration)
         {
             _documentsCompressionConfiguration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
+
         public RavenCommand<DocumentCompressionConfigurationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
         {
             return new UpdateDocumentCompressionConfigurationCommand(conventions, _documentsCompressionConfiguration);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22794/Add-comments-for-operations-that-implements-IMaintenanceOperationT

### Additional description

Operations in this PR:
* `ConfigureTimeSeriesValueNamesOperation (in Raven.Client.Documents.Operations.TimeSeries)`
* `UpdateDocumentsCompressionConfigurationOperation (in Raven.Client.ServerWide.Operations.DocumentsCompression)`
* `ConfigureRevisionsOperation (in Raven.Client.Documents.Operations.Revisions)`
* `UpdatePullReplicationAsSinkOperation (in Raven.Client.Documents.Operations.Replication)`
* `UpdateExternalReplicationOperation (in Raven.Client.Documents.Operations.Replication)`
* `PutPullReplicationAsHubOperation (in Raven.Client.Documents.Operations.Replication)`
* `GetReplicationHubAccessOperation (in Raven.Client.Documents.Operations.Replication)`
* `GetReplicationPerformanceStatisticsOperation (in Raven.Client.Documents.Operations.Replication)`
* `ConfigureRefreshOperation (in Raven.Client.Documents.Operations.Refresh)`
* `GetPullReplicationTasksInfoOperation (in Raven.Client.Documents.Operations.OngoingTasks)`
* `GetOngoingTaskInfoOperation (in Raven.Client.Documents.Operations.OngoingTasks)`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
