### PR TITLE
RavenDB-17015 - SlowTests.Client.TimeSeries.Query.QueryFromMultipleTimeSeries.SameQueryResultForRawAndRollupForJuly

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.TimeSeries.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.TimeSeries.cs
@@ -28,41 +28,41 @@ namespace FastTests
                 var raw = configuration.RawPolicy;
                 configuration.ValidateAndInitialize();
 
-                await WaitForValueAsync(() =>
+                using (var session = store.OpenAsyncSession())
                 {
-                    using (var session = store.OpenSession())
+                    var ts = (await session.TimeSeriesFor("users/karmel", rawName)
+                        .GetAsync())?
+                        .ToList();
+
+                    Assert.NotNull(ts);
+                    if (raw != null)
+                        Assert.Equal(((TimeSpan)raw.RetentionTime).TotalMinutes, ts.Count);
+                    var policiesList = policies ?? configuration.Policies;
+                    foreach (var policy in policiesList)
                     {
-                        var ts = session.TimeSeriesFor("users/karmel", rawName)
-                            .Get()?
+                        ts = (await session.TimeSeriesFor("users/karmel", policy.GetTimeSeriesName(rawName))
+                            .GetAsync())?
                             .ToList();
 
-                        Assert.NotNull(ts);
-                        if (raw != null)
-                            Assert.Equal(((TimeSpan)raw.RetentionTime).TotalMinutes, ts.Count);
-                        var policiesList = policies ?? configuration.Policies;
-                        foreach (var policy in policiesList)
+                        TimeValue retentionTime = policy.RetentionTime;
+                        if (retentionTime == TimeValue.MaxValue)
                         {
-                            ts = session.TimeSeriesFor("users/karmel", policy.GetTimeSeriesName(rawName))
-                                .Get()?
-                                .ToList();
+                            var seconds = TimeSpan.FromDays(retentionNumberOfDays).TotalSeconds;
+                            var x = Math.Ceiling(seconds / policy.AggregationTime.Value);
+                            var max = Math.Max(x * policy.AggregationTime.Value, seconds);
+                            retentionTime = TimeSpan.FromSeconds(max);
+                        }
 
-                            TimeValue retentionTime = policy.RetentionTime;
-                            if (retentionTime == TimeValue.MaxValue)
-                            {
-                                var seconds = TimeSpan.FromDays(retentionNumberOfDays).TotalSeconds;
-                                var x = Math.Ceiling(seconds / policy.AggregationTime.Value);
-                                var max = Math.Max(x * policy.AggregationTime.Value, seconds);
-                                retentionTime = TimeSpan.FromSeconds(max);
-                            }
-
-                            Assert.NotNull(ts);
-                            var expected = ((TimeSpan)retentionTime).TotalMinutes / ((TimeSpan)policy.AggregationTime).TotalMinutes;
-                            if ((int)expected != ts.Count && Math.Ceiling(expected) != ts.Count)
-                                Assert.False(true, $"Expected {expected}, but got {ts.Count}");
+                        Assert.NotNull(ts);
+                        var expected = ((TimeSpan)retentionTime).TotalMinutes / ((TimeSpan)policy.AggregationTime).TotalMinutes;
+                        if ((int)expected != ts.Count && Math.Ceiling(expected) != ts.Count)
+                        {
+                            Assert.False(true, $"Policy '{policy.Name}' failed. Expected {expected}, but got {ts.Count} " +
+                                               $"(Math.Ceiling(expected) result: {Math.Ceiling(expected)}).{Environment.NewLine}" +
+                                               $"Existing timestamps: {string.Join(", ", ts.Select(t => t.Timestamp))}.");
                         }
                     }
-                    return true;
-                }, true);
+                }
             }
 
             public async Task WaitForPolicyRunnerAsync(DocumentDatabase database)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17015/SlowTests.Client.TimeSeries.Query.QueryFromMultipleTimeSeries.SameQueryResultForRawAndRollupForJulyday-8

### Additional description

Remove redundant `WaitForValue` in `VerifyPolicyExecutionAsync` & add more info.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
