### PR TITLE
RavenDB-23111 Added managed heap sizes after last GC to /admin/debug/memory/stats endpoint

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/MemoryDebugHandler.cs
@@ -293,6 +293,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             var memInfo = MemoryInformation.GetMemoryInformationUsingOneTimeSmapsReader();
             long managedMemoryInBytes = AbstractLowMemoryMonitor.GetManagedMemoryInBytes();
+            var gcInfo = GC.GetGCMemoryInfo(GCKind.Any);
             long totalUnmanagedAllocations = NativeMemory.TotalAllocatedMemory;
             var encryptionBuffers = EncryptionBuffersPool.Instance.GetStats();
             var dirtyMemoryState = MemoryInformation.GetDirtyMemoryState();
@@ -324,6 +325,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 [nameof(MemoryInfo.PhysicalMemory)] = memInfo.TotalPhysicalMemory.ToString(),
                 [nameof(MemoryInfo.WorkingSet)] = memInfo.WorkingSet.ToString(),
                 [nameof(MemoryInfo.ManagedAllocations)] = Size.Humane(managedMemoryInBytes),
+                [nameof(MemoryInfo.ManagedHeapsAfterLastGC)] = ManagedHeapsInfo(gcInfo),
                 [nameof(MemoryInfo.UnmanagedAllocations)] = Size.Humane(totalUnmanagedAllocations),
                 [nameof(MemoryInfo.LuceneManagedAllocationsForTermCache)] = Size.Humane(NativeMemory.TotalLuceneManagedAllocationsForTermCache),
                 [nameof(MemoryInfo.LuceneUnmanagedAllocationsForSorting)] = Size.Humane(NativeMemory.TotalLuceneUnmanagedAllocationsForSorting),
@@ -357,6 +359,48 @@ namespace Raven.Server.Documents.Handlers.Debugging
             writer.WriteEndArray();
 
             writer.WriteEndObject();
+
+            static DynamicJsonValue ManagedHeapsInfo(GCMemoryInfo info)
+            {
+                if (info.Index == 0)
+                    return null;
+
+                var gen0 = info.GenerationInfo[0];
+                var gen1 = info.GenerationInfo[1];
+                var gen2 = info.GenerationInfo[2];
+                var loh = info.GenerationInfo[3];
+                var poh = info.GenerationInfo[4];
+
+                return new DynamicJsonValue()
+                {
+                    ["TotalSize"] = Size.Humane(info.HeapSizeBytes),
+                    ["Gen0"] = new DynamicJsonValue()
+                    {
+                        ["Size"] = Size.Humane(gen0.SizeAfterBytes),
+                        ["Fragmentation"] = Size.Humane(gen0.FragmentationAfterBytes),
+                    },
+                    ["Gen1"] = new DynamicJsonValue()
+                    {
+                        ["Size"] = Size.Humane(gen1.SizeAfterBytes),
+                        ["Fragmentation"] = Size.Humane(gen1.FragmentationAfterBytes),
+                    },
+                    ["Gen2"] = new DynamicJsonValue()
+                    {
+                        ["Size"] = Size.Humane(gen2.SizeAfterBytes),
+                        ["Fragmentation"] = Size.Humane(gen2.FragmentationAfterBytes),
+                    },
+                    ["LOH"] = new DynamicJsonValue()
+                    {
+                        ["Size"] = Size.Humane(loh.SizeAfterBytes),
+                        ["Fragmentation"] = Size.Humane(loh.FragmentationAfterBytes),
+                    },
+                    ["POH"] = new DynamicJsonValue()
+                    {
+                        ["Size"] = Size.Humane(poh.SizeAfterBytes),
+                        ["Fragmentation"] = Size.Humane(poh.FragmentationAfterBytes),
+                    },
+                };
+            }
         }
 
         private static void WriteThreads(bool includeThreads, AsyncBlittableJsonTextWriter writer, JsonOperationContext context)
@@ -529,6 +573,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             
             public string Remarks { get; set; }
             public string ManagedAllocations { get; set; }
+            public DynamicJsonValue ManagedHeapsAfterLastGC { get; set; }
             public string UnmanagedAllocations { get; set; }
             public string LuceneManagedAllocationsForTermCache { get; set; }
             public string LuceneUnmanagedAllocationsForSorting { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23111/Add-managed-heap-sizes-after-last-GC-to-admin-debug-memory-stats-endpoint

### Additional description

Useful for debugging / support purposes.

```
"ManagedAllocations": "141.56 MBytes",
"ManagedHeapsAfterLastGC": {
	"TotalSize": "59.79 MBytes",
	"Gen0": {
		"Size": "3.87 MBytes",
		"Fragmentation": "3.86 MBytes"
	},
	"Gen1": {
		"Size": "50.78 MBytes",
		"Fragmentation": "659.11 KBytes"
	},
	"Gen2": {
		"Size": "0 Bytes",
		"Fragmentation": "0 Bytes"
	},
	"LOH": {
		"Size": "4.72 MBytes",
		"Fragmentation": "352 Bytes"
	},
	"POH": {
		"Size": "436.14 KBytes",
		"Fragmentation": "0 Bytes"
	}
},
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
