### PR TITLE
RavenDB-23271 - Related ID copies escaped value

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocumentConnectedDocuments.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocumentConnectedDocuments.ts
@@ -264,7 +264,7 @@ class connectedDocuments {
                         onValue(timeSeriesItem.numberOfEntries.toLocaleString());
                     } else {
                         const value = column.getCellValue(item);
-                        onValue(genUtils.escapeHtml(value));
+                        onValue(genUtils.escapeHtml(value), value);
                     }
                 }
             });

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
@@ -7,9 +7,16 @@ import moment = require("moment");
 
 
 class copyFeature implements columnPreviewFeature {
+    decodeHtml(html: string): string {
+        const txt = document.createElement("textarea");
+        txt.innerHTML = html;
+        return txt.value;
+    }
+
     install($tooltip: JQuery, valueProvider: () => any, elementProvider: () => any) {
         $tooltip.on("click", ".copy", () => {
-            copyToClipboard.copy(valueProvider(), "Item has been copied to clipboard");
+            const isEncoded = valueProvider() !== this.decodeHtml(valueProvider());
+            copyToClipboard.copy(isEncoded ? this.decodeHtml(valueProvider()) : valueProvider(), "Item has been copied to clipboard");
 
             $(".copy", $tooltip).addClass("btn-success");
             $(".copy span", $tooltip)

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
@@ -9,8 +9,7 @@ import moment = require("moment");
 class copyFeature implements columnPreviewFeature {
     install($tooltip: JQuery, valueProvider: () => any, elementProvider: () => any) {
         $tooltip.on("click", ".copy", () => {
-            const isEncoded = valueProvider() !== generalUtils.unescapeHtml(valueProvider());
-            copyToClipboard.copy(isEncoded ? generalUtils.unescapeHtml(valueProvider()) : valueProvider(), "Item has been copied to clipboard");
+            copyToClipboard.copy(valueProvider(), "Item has been copied to clipboard");
 
             $(".copy", $tooltip).addClass("btn-success");
             $(".copy span", $tooltip)

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
@@ -7,16 +7,10 @@ import moment = require("moment");
 
 
 class copyFeature implements columnPreviewFeature {
-    decodeHtml(html: string): string {
-        const txt = document.createElement("textarea");
-        txt.innerHTML = html;
-        return txt.value;
-    }
-
     install($tooltip: JQuery, valueProvider: () => any, elementProvider: () => any) {
         $tooltip.on("click", ".copy", () => {
-            const isEncoded = valueProvider() !== this.decodeHtml(valueProvider());
-            copyToClipboard.copy(isEncoded ? this.decodeHtml(valueProvider()) : valueProvider(), "Item has been copied to clipboard");
+            const isEncoded = valueProvider() !== generalUtils.unescapeHtml(valueProvider());
+            copyToClipboard.copy(isEncoded ? generalUtils.unescapeHtml(valueProvider()) : valueProvider(), "Item has been copied to clipboard");
 
             $(".copy", $tooltip).addClass("btn-success");
             $(".copy span", $tooltip)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23271/Related-ID-copies-escaped-value

### Additional description

fixed escaping values on copy by adding decodeHtml function

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
