### PR TITLE
RavenDB-21964 - add debug info

### DIFF
--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ using Raven.Server.Documents.Subscriptions;
 using Raven.Server.ServerWide.Commands.Subscriptions;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Server;
 using Tests.Infrastructure;
@@ -1180,6 +1182,7 @@ where predicate.call(doc)"
 
                 var docs = new HashSet<string>();
                 var workers = new List<SubscriptionWorker<User>>();
+                var subscriptionLog = new List<(string WorkerId, DateTime Date, string Message)>();
                 try
                 {
                     for (int i = 0; i < 10; i++)
@@ -1212,6 +1215,20 @@ where predicate.call(doc)"
                             Strategy = SubscriptionOpeningStrategy.Concurrent,
                             MaxDocsPerBatch = 1
                         });
+
+                        w.OnSubscriptionConnectionRetry += e =>
+                        {
+                            subscriptionLog.Add((w.WorkerId, DateTime.UtcNow, $"OnSubscriptionConnectionRetry: {e}"));
+                  
+                        };
+                        w.OnEstablishedSubscriptionConnection += () =>
+                        {
+                            subscriptionLog.Add((w.WorkerId, DateTime.UtcNow, $"OnEstablishedSubscriptionConnection: {((IPEndPoint)w?._tcpClient?.Client?.RemoteEndPoint)?.Address.ToString()}"));
+                        };
+                        w.OnUnexpectedSubscriptionError += ex =>
+                        {
+                            subscriptionLog.Add((w.WorkerId, DateTime.UtcNow, $"OnUnexpectedSubscriptionError: {ex}"));
+                        };
                         workers.Add(w);
 
                         var t2 = w.Run(x =>
@@ -1223,7 +1240,18 @@ where predicate.call(doc)"
                             }
                         });
 
-                        await AssertWaitForTrueAsync(() => Task.FromResult(docs.Count == i + 1), Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        var res = await WaitForValueAsync(() => Task.FromResult(docs.Count), i + 1, Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        if (res != i+1)
+                        {
+                            subscriptionLog.Add((w.WorkerId, DateTime.UtcNow, $"Expected to have 'docs.Count': {docs.Count} but processed 'i + 1':{i + 1}"));
+
+                            Assert.Fail(string.Join(Environment.NewLine, subscriptionLog.Select(x => $"#### {x.WorkerId}: {x.Date.GetDefaultRavenFormat()}: {x.Message}")));
+                        }
+                        else
+                        {
+                            subscriptionLog.Add((w.WorkerId, DateTime.UtcNow, $"Processed {i + 1}/{docs.Count} docs."));
+                        }
+
                         await AssertNoLeftovers(store, id);
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21964

### Additional description

This pull request includes changes to enhance the `ConcurrentSubscriptionsTests` in the `test/SlowTests/Client/Subscriptions` directory by adding logging functionality and improving the test assertions. The most important changes include the addition of logging for subscription events and modifications to the test's assertions to provide better error messages.

Enhancements to logging:

* Added a `subscriptionLog` list to store log entries for subscription events. (`test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs`)
* Added event handlers for `OnSubscriptionConnectionRetry`, `OnEstablishedSubscriptionConnection`, and `OnUnexpectedSubscriptionError` to log relevant messages. (`test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs`)

Improvements to test assertions:

* Modified the assertion to use `WaitForValueAsync` and log detailed error messages when the expected document count is not met. (`test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs`)

Additional changes:

* Imported `System.Net` and `Sparrow.Extensions` namespaces. (`test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs`) [[1]](diffhunk://#diff-c83a16c5348319c85b353161df766646989e88c38301d1540c10caf5e97a04e7R5) [[2]](diffhunk://#diff-c83a16c5348319c85b353161df766646989e88c38301d1540c10caf5e97a04e7R20)
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
