### PR TITLE
RavenDB-23207 fix test LastSetStateDetermineTheStateAutoMapIndex

### DIFF
--- a/test/SlowTests/Issues/RavenDB-20922.cs
+++ b/test/SlowTests/Issues/RavenDB-20922.cs
@@ -161,32 +161,46 @@ namespace SlowTests.Issues
             {
                 documentDatabase = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
                 IndexDefinition[] index = await CreateAutoMapIndex(store);
+                string name;
+                if (index == null)
+                {
+                    await WaitForValueAsync(async () =>
+                    {
+                        documentDatabase = await leader.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
+                        return documentDatabase.IndexStore.GetIndexes().Count() ;
+                    }, 1);
+
+                    var indexes = documentDatabase.IndexStore.GetIndexes();
+                    Assert.Equal(1, indexes.Count());
+                    name = indexes.First().Name;
+                }
+                else
+                {
+                    name = index.First().Name;
+                }
 
                 //Check index is enabled and running
                 foreach (var server in Servers)
                 {
-                    await CheckIndexStateInTheCluster(database, index[0].Name, IndexState.Normal);
+                    await CheckIndexStateInTheCluster(database, name, IndexState.Normal);
                     await WaitForValueAsync(async () =>
                     {
                         documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
-                        return documentDatabase.IndexStore.GetIndex(index[0].Name).Status;
+                        return documentDatabase.IndexStore.GetIndex(name).Status;
                     }, IndexRunningStatus.Running);
-                    Assert.Equal(IndexRunningStatus.Running, documentDatabase.IndexStore.GetIndex(index[0].Name).Status);
+                    Assert.Equal(IndexRunningStatus.Running, documentDatabase.IndexStore.GetIndex(name).Status);
                 }
-
-                documentDatabase = await Servers[0].ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
-                var autoIndex = documentDatabase.IndexStore.GetIndex(index[0].Name);
 
                 var count = 0;
                 string info = "";
 
-                await ActionWithLeader((l) => l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(index[0].Name, IndexState.Disabled, database, Guid.NewGuid().ToString())),
+                await ActionWithLeader((l) => l.ServerStore.Engine.SendToLeaderAsync(new SetIndexStateCommand(name, IndexState.Disabled, database, Guid.NewGuid().ToString())),
                     Servers);
                 //Check index is disabled
-                await CheckIndexStateInTheCluster(database, index[0].Name, IndexState.Disabled);
+                await CheckIndexStateInTheCluster(database, name, IndexState.Disabled);
 
                 //Set index to normal
-                autoIndex = documentDatabase.IndexStore.GetIndex(index[0].Name);
+                var autoIndex = documentDatabase.IndexStore.GetIndex(name);
                 autoIndex.SetState(IndexState.Normal);
 
                 count = 0;
@@ -198,7 +212,7 @@ namespace SlowTests.Issues
                     foreach (var server in Servers)
                     {
                         documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
-                        var index2 = documentDatabase.IndexStore.GetIndex(index[0].Name);
+                        var index2 = documentDatabase.IndexStore.GetIndex(name);
                         var state = index2.State;
                         info += $"Index state for node {server.ServerStore.NodeTag} is {state} in definition {index2.Definition.State}.  ";
                         foreach (var error in index2.GetErrors())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23207

### Additional description

Could not reproduce the failure. Made some changes to the test that may address the issue.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
