### PR TITLE
RavenDB-23100 - Use the correct item ID casing to align with the storage state

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Workers/Counters/HandleCompareExchangeCountersReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Counters/HandleCompareExchangeCountersReferences.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Indexes.Persistence;
-using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Server.Utils;
 using Voron;
@@ -31,6 +30,11 @@ namespace Raven.Server.Documents.Indexes.Workers.Counters
                 return null;
 
             return new CounterIndexItem(counter.LuceneKey, counter.DocumentId, counter.Etag, counter.CounterName, counter.Size, counter);
+        }
+
+        protected override string GetNextItemId(IndexItem indexItem)
+        {
+            return indexItem.LowerSourceDocumentId;
         }
 
         public override void HandleDelete(Tombstone tombstone, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)

--- a/src/Raven.Server/Documents/Indexes/Workers/Counters/HandleCountersReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/Counters/HandleCountersReferences.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Persistence;
-using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Server.Utils;
 using Voron;
@@ -27,6 +26,11 @@ namespace Raven.Server.Documents.Indexes.Workers.Counters
                 return null;
 
             return new CounterIndexItem(counter.LuceneKey, counter.DocumentId, counter.Etag, counter.CounterName, counter.Size, counter);
+        }
+
+        protected override string GetNextItemId(IndexItem indexItem)
+        {
+            return indexItem.LowerSourceDocumentId;
         }
 
         public override void HandleDelete(Tombstone tombstone, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleNotNormalizedCompareExchangeReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleNotNormalizedCompareExchangeReferences.cs
@@ -16,6 +16,11 @@ public class HandleNotNormalizedCompareExchangeReferences : HandleCompareExchang
         return HandleNotNormalizedDocumentReferences.GetNonNormalizedDocumentItem(databaseContext, key);
     }
 
+    protected override string GetNextItemId(IndexItem indexItem)
+    {
+        return indexItem.Id;
+    }
+
     protected override void DeleteReferences(string collection, IndexingStatsScope stats, DocumentsOperationContext databaseContext, TransactionOperationContext indexContext)
     {
         HandleNotNormalizedDocumentReferences.DeleteReferences(collection, stats, _referencesStorage, databaseContext, indexContext);

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleNotNormalizedDocumentReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleNotNormalizedDocumentReferences.cs
@@ -22,6 +22,11 @@ public class HandleNotNormalizedDocumentReferences : HandleDocumentReferences
         return GetNonNormalizedDocumentItem(databaseContext, key);
     }
 
+    protected override string GetNextItemId(IndexItem indexItem)
+    {
+        return indexItem.Id;
+    }
+
     public static unsafe IndexItem GetNonNormalizedDocumentItem(DocumentsOperationContext databaseContext, Slice key)
     {
         using (DocumentIdWorker.GetLower(databaseContext.Allocator, key.Content.Ptr, key.Size, out var loweredKey))

--- a/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/HandleReferences.cs
@@ -33,6 +33,11 @@ namespace Raven.Server.Documents.Indexes.Workers
             return GetDocumentItem(databaseContext, key);
         }
 
+        protected override string GetNextItemId(IndexItem indexItem)
+        {
+            return indexItem.LowerId;
+        }
+
         public static IndexItem GetDocumentItem(DocumentsOperationContext databaseContext, Slice key)
         {
             // when there is conflict, we need to apply same behavior as if the document would not exist
@@ -242,7 +247,7 @@ namespace Raven.Server.Documents.Indexes.Workers
                                                 if (CanContinueReferenceBatch() == false)
                                                 {
                                                     // updating the last reference state in order to continue from the place we left off
-                                                    referenceState = new ReferencesState.ReferenceState(referencedItem.Key, referencedItem.Etag, current.LowerSourceDocumentId ?? current.Id, lastIndexedParentEtag);
+                                                    referenceState = new ReferencesState.ReferenceState(referencedItem.Key, referencedItem.Etag, GetNextItemId(current), lastIndexedParentEtag);
 
                                                     if (batchContinuationResult != Index.CanContinueBatchResult.RenewTransaction)
                                                     {
@@ -469,6 +474,8 @@ namespace Raven.Server.Documents.Indexes.Workers
         }
 
         protected abstract IndexItem GetItem(DocumentsOperationContext databaseContext, Slice key);
+
+        protected abstract string GetNextItemId(IndexItem indexItem);
 
         protected virtual void DeleteReferences(string collection, IndexingStatsScope stats, DocumentsOperationContext databaseContext, TransactionOperationContext indexContext)
         {

--- a/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleCompareExchangeTimeSeriesReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleCompareExchangeTimeSeriesReferences.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Indexes.Persistence;
-using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Server.Utils;
@@ -31,6 +30,11 @@ namespace Raven.Server.Documents.Indexes.Workers.TimeSeries
                 return null;
 
             return new TimeSeriesIndexItem(timeSeries.LuceneKey, timeSeries.DocId, timeSeries.Etag, default, timeSeries.Name, timeSeries.SegmentSize, timeSeries);
+        }
+
+        protected override string GetNextItemId(IndexItem indexItem)
+        {
+            return indexItem.LowerSourceDocumentId;
         }
 
         public override void HandleDelete(Tombstone tombstone, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)

--- a/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleTimeSeriesReferences.cs
+++ b/src/Raven.Server/Documents/Indexes/Workers/TimeSeries/HandleTimeSeriesReferences.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Persistence;
-using Raven.Server.Documents.Indexes.Persistence.Lucene;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Server.Utils;
@@ -27,6 +26,11 @@ namespace Raven.Server.Documents.Indexes.Workers.TimeSeries
                 return null;
 
             return new TimeSeriesIndexItem(timeSeries.LuceneKey, timeSeries.DocId, timeSeries.Etag, default, timeSeries.Name, timeSeries.SegmentSize, timeSeries);
+        }
+
+        protected override string GetNextItemId(IndexItem indexItem)
+        {
+            return indexItem.LowerSourceDocumentId;
         }
 
         public override void HandleDelete(Tombstone tombstone, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)

--- a/test/SlowTests/Issues/RavenDB-15754.cs
+++ b/test/SlowTests/Issues/RavenDB-15754.cs
@@ -52,11 +52,15 @@ namespace SlowTests.Issues
 
                     using (var bulk = store.BulkInsert())
                     {
+                        var baseDate = new DateTime(2024, 9, 1);
                         for (var i = 0; i < _employeesCount; i++)
                         {
+                            var date = baseDate.AddDays(i);
+                            var dateString = date.ToString("yyyy-MM-dd");
                             await bulk.StoreAsync(new Employee
                             {
-                                CompanyId = company.Id
+                                CompanyId = company.Id,
+                                Id = $"Employees/Accounts/937-A/{dateString}"
                             });
                         }
                     }
@@ -378,11 +382,15 @@ namespace SlowTests.Issues
 
                 using (var bulk = store.BulkInsert())
                 {
+                    var baseDate = new DateTime(2024, 9, 1);
                     for (var i = 0; i < _employeesCount; i++)
                     {
+                        var date = baseDate.AddDays(i);
+                        var dateString = date.ToString("yyyy-MM-dd");
                         await bulk.StoreAsync(new Employee
                         {
-                            CompanyId = _commonName
+                            CompanyId = _commonName,
+                            Id = $"Employees/Accounts/937-A/{dateString}"
                         });
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23100/Map-reduce-index-with-references-with-a-very-long-running-batch

### Additional description

Since we now use the lower-cased version for handling references (fixed here: [PR #19612](https://github.com/ravendb/ravendb/pull/19612)), we should also use it when saving the item ID in the in-memory state.

The `LowerSourceDocumentId` is consistently used for `Counters` and `Time Series` indexes.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
