### PR TITLE
RavenDB-23065 - Don't use StreamWithTimeout for substreams

### DIFF
--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -115,7 +115,7 @@ namespace Raven.Server.Web
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected Stream GetBodyStream(MultipartSection section)
         {
-            Stream stream = new StreamWithTimeout(GetDecompressedStream(section.Body, section.Headers));
+            Stream stream = GetDecompressedStream(section.Body, section.Headers);
             _context.HttpContext.Response.RegisterForDispose(stream);
             return stream;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23065/StressTests.Client.Attachments.AttachmentsHugeFiles.BatchRequestWithLongMultiPartSectionssize-2684354560-hash

### Additional description

The issue arises from using `StreamWithTimeout` twice, with the second instance applied to a non-network stream. Specifically, we have an `HttpRequestStream` that is wrapped by a `MultipartReaderStream` for each section. The `MultipartReaderStream` is a substream that reads from the `HttpRequestStream` (see [MultipartReaderStream.cs](https://github.com/dotnet/aspnetcore/blob/main/src/Http/WebUtilities/src/MultipartReaderStream.cs)).

To resolve this, `StreamWithTimeout` should only be applied to the `HttpRequestStream` to handle timeout logic for the entire HTTP request. Applying it to the `MultipartReaderStream` introduces unnecessary redundancy and potential conflicts.

Full stack trace:
```
Raven.Client.dll!Raven.Client.Util.StreamWithTimeout.ReadAsyncWithTimeout(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) Line 204	C#
 	Raven.Client.dll!Raven.Client.Util.StreamWithTimeout.ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) Line 176	C#
 	System.Private.CoreLib.dll!System.IO.Stream.ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken)	Unknown
 	Microsoft.AspNetCore.WebUtilities.dll!Microsoft.AspNetCore.WebUtilities.BufferedReadStream.EnsureBufferedAsync(int minCount, System.Threading.CancellationToken cancellationToken)	Unknown
 	Microsoft.AspNetCore.WebUtilities.dll!Microsoft.AspNetCore.WebUtilities.MultipartReaderStream.ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken)	Unknown
 	Microsoft.AspNetCore.WebUtilities.dll!Microsoft.AspNetCore.WebUtilities.MultipartReaderStream.ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken)	Unknown
 	Raven.Client.dll!Raven.Client.Util.StreamWithTimeout.ReadAsyncWithTimeout(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) Line 207	C#
 	Raven.Client.dll!Raven.Client.Util.StreamWithTimeout.ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) Line 176	C#
 	System.Private.CoreLib.dll!System.IO.Stream.ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken)	Unknown
 	Raven.Server.dll!Raven.Server.Documents.AttachmentsStorageHelper.CopyStreamToFileAndCalculateHash(Raven.Server.ServerWide.Context.DocumentsOperationContext context, System.IO.Stream requestStream, System.IO.Stream file, System.Threading.CancellationToken cancellationToken) Line 26	C#
 	Raven.Server.dll!Raven.Server.Documents.Handlers.BatchHandler.ParseMultipart(Raven.Server.ServerWide.Context.DocumentsOperationContext context, Raven.Server.Documents.Handlers.BatchHandler.MergedBatchCommand command, System.Threading.CancellationToken token) Line 388	C#
 	Raven.Server.dll!Raven.Server.Documents.Handlers.BatchHandler.BulkDocs() Line 72	C#
 	Raven.Server.dll!Raven.Server.Routing.RequestRouter.HandlePath(Raven.Server.Web.RequestHandlerContext reqCtx) Line 418	C#
 	Raven.Server.dll!Raven.Server.RavenServerStartup.RequestHandler(Microsoft.AspNetCore.Http.HttpContext context) Line 184	C#
```

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
