### PR TITLE
RavenDB-23298 : fix failing test

### DIFF
--- a/test/SlowTests/Issues/RavenDB_22835.cs
+++ b/test/SlowTests/Issues/RavenDB_22835.cs
@@ -857,12 +857,16 @@ namespace SlowTests.Issues
             });
 
             var db = await GetDatabase(store.Database);
-            using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-            using (context.OpenReadTransaction())
+
+            Assert.True(await WaitForValueAsync(() =>
             {
-                var lastCounterFixed = DocumentsStorage.ReadLastFixedCounterKey(context.Transaction.InnerTransaction);
-                Assert.Equal(CountersRepairTask.Completed, lastCounterFixed);
-            }
+                using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var lastCounterFixed = DocumentsStorage.ReadLastFixedCounterKey(context.Transaction.InnerTransaction);
+                    return lastCounterFixed == CountersRepairTask.Completed;
+                }
+            }, expectedVal: true));
 
             await ReloadDatabase(store);
             db = await GetDatabase(store.Database);


### PR DESCRIPTION
 wait for counters repair task to complete instead of asserting the value of FixCountersLastKeySlice immediately

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23298

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Tests stabilization

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant
