### PR TITLE
RavenDB-23215 Always show 'All revisions' and 'Revisions bin' menu items

### DIFF
--- a/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
+++ b/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
@@ -41,20 +41,15 @@ class collectionsTracker {
     }
 
     async configureRevisions(db: database) {
-        if (db.hasRevisionsConfiguration()) {
-            const revisionsPreview = await new getRevisionsPreviewCommand({
-                databaseName: db.name,
-                start: 0,
-                pageSize: 0,
-                type: "All",
-            }).execute();
+        const revisionsPreview = await new getRevisionsPreviewCommand({
+            databaseName: db.name,
+            start: 0,
+            pageSize: 0,
+            type: "All",
+        }).execute();
 
-            this.allRevisions(new collection(collection.allRevisionsCollectionName, revisionsPreview.totalResultCount));
-            this.revisionsBin(new collection(collection.revisionsBinCollectionName));
-        } else {
-            this.allRevisions(null);
-            this.revisionsBin(null);
-        }
+        this.allRevisions(new collection(collection.allRevisionsCollectionName, revisionsPreview.totalResultCount));
+        this.revisionsBin(new collection(collection.revisionsBinCollectionName));
     }
 
     private collectionsLoaded(collectionsStats: collectionsStats) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23215/Always-show-all-revisions-view-revisions-bin-view-when-we-have-revisions

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
