### PR TITLE
RavenDB-23143 Fixing ocassionally failing RavenDB_22534.BackwardCompatibilityComplexFields test

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
@@ -215,9 +215,13 @@ public partial class RavenTestBase
             }
         }
 
-        public IndexErrors[] WaitForIndexingErrors(IDocumentStore store, string[] indexNames = null, TimeSpan? timeout = null, string nodeTag = null, bool? errorsShouldExists = null)
+        public IndexErrors[] WaitForIndexingErrors(IDocumentStore store, string[] indexNames = null, TimeSpan? timeout = null, string nodeTag = null,
+            bool? errorsShouldExists = null)
         {
-            var databaseName = store.Database;
+            return WaitForIndexingErrors(store, store.Database, indexNames, timeout, nodeTag, errorsShouldExists);
+        }
+        public IndexErrors[] WaitForIndexingErrors(IDocumentStore store, string databaseName, string[] indexNames = null, TimeSpan? timeout = null, string nodeTag = null, bool? errorsShouldExists = null)
+        {
             var admin = store.Maintenance.ForDatabase(databaseName);
             var databaseRecord = admin.Server.Send(new GetDatabaseRecordOperation(databaseName));
 
@@ -279,7 +283,7 @@ public partial class RavenTestBase
                     }
                     else
                     {
-                        var indexes = store.Maintenance.Send(new GetIndexErrorsOperation(indexNames, nodeTag));
+                        var indexes = store.Maintenance.ForDatabase(databaseName).Send(new GetIndexErrorsOperation(indexNames, nodeTag));
                         foreach (var index in indexes)
                         {
                             if (index.Errors.Length > 0)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23143

### Additional description

There was a race between WaitForIndexing and getting index errors. Since indexing errors are written in separate tx it could not be available yet.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test fix

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
