### PR TITLE
RavenDB-20131 add Ipv6 support in Setup

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/RavenDnsRecordHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/RavenDnsRecordHelper.cs
@@ -169,62 +169,180 @@ public static class RavenDnsRecordHelper
 
     public static async Task AssertDnsUpdatedSuccessfully(string serverUrl, IPEndPoint[] expectedAddresses, CancellationToken token)
     {
-        // First we'll try to resolve the hostname through google's public dns api
+        var hostname = new Uri(serverUrl).Host;
+        
         using (var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
         using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token, cancellationTokenSource.Token))
         {
-            var expectedIps = expectedAddresses.Select(address => address.Address.ToString()).ToHashSet();
-
-            var hostname = new Uri(serverUrl).Host;
-
-            using (var client = new RavenHttpClient { BaseAddress = new Uri(GoogleDnsApi) })
+            if (OnlyIpv4Addresses(expectedAddresses))
             {
-                var response = await client.GetAsync($"/resolve?name={hostname}", cts.Token);
-
-                var responseString = await response.Content.ReadAsStringWithZstdSupportAsync(cts.Token).ConfigureAwait(false);
-                if (response.IsSuccessStatusCode == false)
-                    throw new InvalidOperationException($"Tried to resolve '{hostname}' using Google's api ({GoogleDnsApi}).{Environment.NewLine}" +
-                                                               $"Request failed with status {response.StatusCode}.{Environment.NewLine}{responseString}");
-
-                dynamic dnsResult = JsonConvert.DeserializeObject(responseString);
-
-                // DNS response format: https://developers.google.com/speed/public-dns/docs/dns-over-https
-
-                if (dnsResult?.Status != 0)
-                    throw new InvalidOperationException($"Tried to resolve '{hostname}' using Google's api ({GoogleDnsApi}).{Environment.NewLine}" +
-                                                               $"Got a DNS failure response:{Environment.NewLine}{responseString}" +
-                                                               Environment.NewLine +
-                                                               "Please wait a while until DNS propagation is finished and try again. If you are trying to update existing DNS records, it might take hours to update because of DNS caching. If the issue persists, contact RavenDB's support.");
-
-                JArray answers = dnsResult.Answer;
-                var googleIps = answers.Select(answer => answer["data"].ToString()).ToHashSet();
-
-                if (googleIps.SetEquals(expectedIps) == false)
-                    throw new InvalidOperationException($"Tried to resolve '{hostname}' using Google's api ({GoogleDnsApi}).{Environment.NewLine}" +
-                                                               $"Expected to get these ips: {string.Join(", ", expectedIps)} while Google's actual result was: {string.Join(", ", googleIps)}" +
-                                                               Environment.NewLine +
-                                                               "Please wait a while until DNS propagation is finished and try again. If you are trying to update existing DNS records, it might take hours to update because of DNS caching. If the issue persists, contact RavenDB's support.");
+                await AssertIpv4DnsUpdated(cts);
+                return;
+            }
+            
+            if (OnlyIpv6Addresses(expectedAddresses))
+            {
+                await AssertIpv6DnsUpdated(cts);
+                return;
+            }
+            
+            if (BothIpv4AndIpv6Addresses(expectedAddresses))
+            {
+                await AssertIpv4AndIpv6DnsUpdated(cts);
+                return;
             }
 
-            // Resolving through google worked, now let's check locally
-            HashSet<string> actualIps;
+            var unsupportedAddresses = expectedAddresses
+                .Where(x => x.AddressFamily is not (AddressFamily.InterNetwork or AddressFamily.InterNetworkV6))
+                .Select(x => x.AddressFamily.ToString())
+                .ToList();
+            
+            throw new InvalidOperationException($"Tried to resolve hostname {hostname}, but encountered unsupported address types: {string.Join(", ", unsupportedAddresses)}.");
+        }
+        
+        
+        bool OnlyIpv4Addresses(IPEndPoint[] addresses) => addresses.All(x => x.AddressFamily == AddressFamily.InterNetwork);
+        bool OnlyIpv6Addresses(IPEndPoint[] addresses) => addresses.All(x => x.AddressFamily == AddressFamily.InterNetworkV6);
+
+        bool BothIpv4AndIpv6Addresses(IPEndPoint[] addresses)
+        {
+            var iPv4OrIpv6 = addresses.All(x => x.AddressFamily is AddressFamily.InterNetwork or AddressFamily.InterNetworkV6);
+            var containsIpv4 = addresses.Any(x => x.AddressFamily == AddressFamily.InterNetwork);
+            var containsIpv6 = addresses.Any(x => x.AddressFamily == AddressFamily.InterNetworkV6);
+            
+            return iPv4OrIpv6 && containsIpv4 && containsIpv6;
+        }
+        
+        async Task AssertIpv4DnsUpdated(CancellationTokenSource cts)
+        {
+            var googleDnsIps = await GetGoogleDnsResult(DnsRecordType.A, cts.Token);
+            AssertExpectedIpsEqualGoogleIps(googleDnsIps);
+            
+            var localDnsIps = await GetLocalDnsResult(AddressFamily.InterNetwork, cts.Token);
+            AssertExpectedIpsEqualLocalIps(localDnsIps);
+        }
+
+        async Task AssertIpv6DnsUpdated(CancellationTokenSource cts)
+        {
+            var googleDnsIps = await GetGoogleDnsResult(DnsRecordType.AAAA, cts.Token);
+            AssertExpectedIpsEqualGoogleIps(googleDnsIps);
+            
+            var localDnsIps = await GetLocalDnsResult(AddressFamily.InterNetworkV6, cts.Token);
+            AssertExpectedIpsEqualLocalIps(localDnsIps);
+        }
+
+        async Task AssertIpv4AndIpv6DnsUpdated(CancellationTokenSource cts)
+        {
+            HashSet<string> allGoogleIps;
             try
             {
-                actualIps = (await Dns.GetHostAddressesAsync(hostname, AddressFamily.InterNetwork, cts.Token)).Select(address => address.ToString()).ToHashSet();
+                var task1 = GetGoogleDnsResult(DnsRecordType.A, cts.Token);
+                var task2 = GetGoogleDnsResult(DnsRecordType.AAAA, cts.Token);
+            
+                var result = await Task.WhenAll(task1,task2);
+                allGoogleIps = result[0].Concat(result[1]).ToHashSet();
+            }
+            catch
+            {
+                await cts.CancelAsync();
+                throw;
+            }
+            
+            AssertExpectedIpsEqualGoogleIps(allGoogleIps);
+            
+            HashSet<string> allLocalIps;
+            try
+            {
+                var task1 = GetLocalDnsResult(AddressFamily.InterNetwork, cts.Token);
+                var task2 = GetLocalDnsResult(AddressFamily.InterNetworkV6, cts.Token);
+                var result = await Task.WhenAll(task1, task2);
+                allLocalIps = result[0].Concat(result[1]).ToHashSet();
+            }
+            catch
+            {
+               await cts.CancelAsync();
+               throw;
+            }
+
+            AssertExpectedIpsEqualLocalIps(allLocalIps);
+        }
+
+        void AssertExpectedIpsEqualGoogleIps(HashSet<string> actualGoogleIps)
+        {
+            var allExpectedIps = GetAllExpectedIps();
+            
+            if (actualGoogleIps.SetEquals(allExpectedIps) == false)
+                throw new InvalidOperationException($"Tried to resolve '{hostname}' using Google's api ({GoogleDnsApi}).{Environment.NewLine}" +
+                                                    $"Expected to get these ips: {string.Join(", ", allExpectedIps)} while Google's actual result was: {string.Join(", ", actualGoogleIps)}" +
+                                                    Environment.NewLine +
+                                                    "Please wait a while until DNS propagation is finished and try again. If you are trying to update existing DNS records, it might take hours to update because of DNS caching. If the issue persists, contact RavenDB's support.");
+        }
+
+        void AssertExpectedIpsEqualLocalIps(HashSet<string> actualLocalIps)
+        {
+            var allExpectedIps = GetAllExpectedIps();
+            
+            if (allExpectedIps.SetEquals(actualLocalIps) == false)
+                throw new InvalidOperationException($"Tried to resolve '{hostname}' locally but got an outdated result." +
+                                                    Environment.NewLine + $"Expected to get these ips: {string.Join(", ", allExpectedIps)} while the actual result was: {string.Join(", ", actualLocalIps)}" +
+                                                    Environment.NewLine + $"If we try resolving through Google's api ({GoogleDnsApi}), it works well." +
+                                                    Environment.NewLine + "Try to clear your local/network DNS cache or wait a few minutes and try again." +
+                                                    Environment.NewLine + "Another temporary solution is to configure your local network connection to use Google's DNS server (8.8.8.8).");
+        }
+        
+        HashSet<string> GetAllExpectedIps()
+        {
+            var expectedIpsV4 = expectedAddresses
+                .Where(x => x.Address.AddressFamily == AddressFamily.InterNetwork)
+                .Select(address => address.Address.ToString())
+                .ToHashSet();
+            var expectedIpsV6 = expectedAddresses
+                .Where(x => x.Address.AddressFamily == AddressFamily.InterNetworkV6)
+                .Select(address => address.Address.ToString())
+                .ToHashSet();
+            
+            return expectedIpsV4.Concat(expectedIpsV6).ToHashSet();
+        }
+
+        async Task<HashSet<string>> GetGoogleDnsResult(DnsRecordType recordType, CancellationToken ct)
+        {
+            using (var client = new RavenHttpClient { BaseAddress = new Uri(GoogleDnsApi) })
+            {
+                var response = await client.GetAsync($"/resolve?name={hostname}&type={recordType}", ct);
+                var responseString = await response.Content.ReadAsStringWithZstdSupportAsync(ct).ConfigureAwait(false);
+                
+                if (response.IsSuccessStatusCode == false)
+                    throw new InvalidOperationException($"Tried to resolve '{hostname}' using Google's api ({GoogleDnsApi}).{Environment.NewLine}" +
+                                                        $"Request failed with status {response.StatusCode}.{Environment.NewLine}{responseString}");
+                
+                dynamic dnsResult = JsonConvert.DeserializeObject(responseString);
+                
+                // DNS response format: https://developers.google.com/speed/public-dns/docs/dns-over-https
+                
+                if (dnsResult?.Status != 0)
+                    throw new InvalidOperationException($"Tried to resolve '{hostname}' using Google's api ({GoogleDnsApi}).{Environment.NewLine}" +
+                                                        $"Got a DNS failure response:{Environment.NewLine}{responseString}" +
+                                                        Environment.NewLine +
+                                                        "Please wait a while until DNS propagation is finished and try again. If you are trying to update existing DNS records, it might take hours to update because of DNS caching. If the issue persists, contact RavenDB's support.");
+                
+                JArray answers = dnsResult.Answer;
+                return answers.Select(answer => answer["data"].ToString()).ToHashSet();
+            }
+        }
+
+        async Task<HashSet<string>> GetLocalDnsResult(AddressFamily addressFamily, CancellationToken ct)
+        {
+            try
+            {
+                var result = (await Dns.GetHostAddressesAsync(hostname, addressFamily, ct)).Select(address => address.ToString()).ToHashSet();
+                return result;
             }
             catch (Exception e)
             {
                 throw new InvalidOperationException($"Cannot resolve '{hostname}' locally but succeeded resolving the address using Google's api ({GoogleDnsApi})." +
-                                                           Environment.NewLine + "Try to clear your local/network DNS cache or wait a few minutes and try again." +
-                                                           Environment.NewLine + "Another temporary solution is to configure your local network connection to use Google's DNS server (8.8.8.8).", e);
-            }
-
-            if (expectedIps.SetEquals(actualIps) == false)
-                throw new InvalidOperationException($"Tried to resolve '{hostname}' locally but got an outdated result." +
-                                                    Environment.NewLine + $"Expected to get these ips: {string.Join(", ", expectedIps)} while the actual result was: {string.Join(", ", actualIps)}" +
-                                                    Environment.NewLine + $"If we try resolving through Google's api ({GoogleDnsApi}), it works well." +
                                                     Environment.NewLine + "Try to clear your local/network DNS cache or wait a few minutes and try again." +
-                                                    Environment.NewLine + "Another temporary solution is to configure your local network connection to use Google's DNS server (8.8.8.8).");
+                                                    Environment.NewLine + "Another temporary solution is to configure your local network connection to use Google's DNS server (8.8.8.8).", e);
+            }       
         }
     }
 
@@ -325,5 +443,11 @@ public static class RavenDnsRecordHelper
                 throw new TimeoutException("Request failed due to a timeout error", e);
             }
         }
+    }
+
+    private enum DnsRecordType
+    {
+        A = 1,
+        AAAA = 28
     }
 }

--- a/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
@@ -2,6 +2,8 @@
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -692,7 +694,10 @@ public static class SettingsZipFileHelper
 
     internal static string IpAddressToUrl(string address, int port, string scheme)
     {
-        var url = scheme + "://" + address;
+        var parsed = IPAddress.Parse(address);
+        var ip = parsed.AddressFamily == AddressFamily.InterNetworkV6 ? $"[{address}]" : address; 
+        
+        var url = scheme + "://" + ip;
         if ((scheme == "http" && port != 80) || (scheme == "tcp" && port != 0) || (scheme == "https" && port != 443))
             url += ":" + port;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20131/IPv6-support-in-Setup

### Additional description

The update allows setting up a cluster using Ipv4 and Ipv6 addresses. The `api.ravendb.net` service has already been adjusted in this respect. This means users can claim a domain being resolved to both A and AAAA record types.   

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes 
- [x] No

### UI work

- [x] It requires further work in the Studio. See https://issues.hibernatingrhinos.com/issue/RavenDB-23316
- [ ] No UI work is needed