### PR TITLE
RavenDB-23182 - Fixed copy text feature

### DIFF
--- a/src/Raven.Studio/typescript/common/copyToClipboard.ts
+++ b/src/Raven.Studio/typescript/common/copyToClipboard.ts
@@ -1,12 +1,29 @@
 ﻿import messagePublisher = require("common/messagePublisher");
 
 class copyToClipboard {
-    static async copy(toCopy: string, successMessage?: string) {
+    static copy(toCopy: string, successMessage?: string, container: Element = document.body) {
+        const dummy = document.createElement("textarea");
+        // Add it to the document
+        container.appendChild(dummy);
         try {
-            await navigator.clipboard.writeText(toCopy);
-            messagePublisher.reportSuccess(successMessage);
+            dummy.value = toCopy;
+            // Select it
+            dummy.select();
+            // Copy its contents
+            const success = document.execCommand("copy");
+
+            if (success) {
+                if (successMessage) {
+                    messagePublisher.reportSuccess(successMessage);
+                }
+            } else {
+                messagePublisher.reportWarning("Unable to copy to clipboard");
+            }
         } catch (err) {
             messagePublisher.reportWarning("Unable to copy to clipboard", err);
+        } finally {
+            // Remove it as its not needed anymore
+            container.removeChild(dummy);
         }
     }
 }

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/etlTransformOrLoadErrorDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/etlTransformOrLoadErrorDetails.ts
@@ -82,7 +82,7 @@ class etlTransformOrLoadErrorDetails extends abstractAlertDetails {
     }
     
     copyToClipboard(item: Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo) {
-        copyToClipboard.copy(item.Error, "Error has been copied to clipboard");
+        copyToClipboard.copy(item.Error, "Error has been copied to clipboard", document.getElementById("js-etl-error-details"));
     }
 
     private fetcher(): JQueryPromise<pagedResult<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>> {

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/recentErrorDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/recentErrorDetails.ts
@@ -27,7 +27,7 @@ class recentErrorDetails extends dialogViewModelBase {
 
     copyErrorDetails(): void {
         const errorDetails = this.recentError.details();
-        copyToClipboard.copy(errorDetails, "Error has been copied to clipboard");
+        copyToClipboard.copy(errorDetails, "Error has been copied to clipboard", document.getElementById("bootstrapModal"));
     }
 
     static supportsDetailsFor(notification: abstractNotification) {

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/additionalAssemblySyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/additionalAssemblySyntax.ts
@@ -17,7 +17,7 @@ class additionalAssemblySyntax extends dialogViewModelBase {
 
     copySample(sampleTitle: string) {
         const sampleText = additionalAssemblySyntax.csharpSamples.find(x => x.title === sampleTitle).text;
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly additionalSourceCsharpText =

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/additionalSourceSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/additionalSourceSyntax.ts
@@ -19,7 +19,7 @@ class additionalSourceSyntax extends dialogViewModelBase {
         const sampleText = [...additionalSourceSyntax.csharpSamples, ...additionalSourceSyntax.javascriptSamples]
             .find(x => x.title === sampleTitle).text;
 
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly additionalSourceCsharpText =

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/mapIndexSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/mapIndexSyntax.ts
@@ -15,7 +15,7 @@ class mapIndexSyntax extends dialogViewModelBase {
 
     copySample(sampleTitle: string) {
         const sampleText = mapIndexSyntax.samples.find(x => x.title === sampleTitle).text;
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly samples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/mapReduceIndexSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/mapReduceIndexSyntax.ts
@@ -17,7 +17,7 @@ class mapReduceIndexSyntax extends dialogViewModelBase {
         const sampleText = [...mapReduceIndexSyntax.linqSamples, ...mapReduceIndexSyntax.javascriptSamples]
             .find(x => x.title === sampleTitle).text;
         
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly linqSamples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/database/patch/patchSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/patch/patchSyntax.ts
@@ -17,7 +17,7 @@ class patchSyntax extends dialogViewModelBase {
 
     copySample(sampleTitle: string) {
         const sampleText = patchSyntax.samples.find(x => x.title === sampleTitle).text;
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly samples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/database/query/querySyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/query/querySyntax.ts
@@ -17,7 +17,7 @@ class querySyntax extends dialogViewModelBase {
 
     copySample(sampleTitle: string) {
         const sampleText = querySyntax.samples.find(x => x.title === sampleTitle).text;
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly samples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/database/settings/conflictResolutionScriptSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/settings/conflictResolutionScriptSyntax.ts
@@ -29,7 +29,7 @@ return docs[0];
     }
 
     copySample() {
-        copyToClipboard.copy(conflictResolutionScriptSyntax.sampleScript, "Sample has been copied to clipboard");
+        copyToClipboard.copy(conflictResolutionScriptSyntax.sampleScript, "Sample has been copied to clipboard", this.dialogContainer);
     }
     
     scriptHtml = ko.pureComputed(() => {

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/subscriptionRqlSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/subscriptionRqlSyntax.ts
@@ -15,7 +15,7 @@ class subscriptionRqlSyntax extends dialogViewModelBase {
 
     copySample(sampleTitle: string) {
         const sampleText = subscriptionRqlSyntax.samples.find(x => x.title === sampleTitle).text;
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly samples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/transformationScriptSyntax.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/transformationScriptSyntax.ts
@@ -63,7 +63,7 @@ class transformationScriptSyntax extends dialogViewModelBase {
                 genUtils.assertUnreachable(type, "Unknown studioEtlType: " + type);
         }
         
-        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard");
+        copyToClipboard.copy(sampleText, "Sample has been copied to clipboard", this.dialogContainer);
     }
 
     static readonly ravenEtlSamples: Array<sampleCode> = [

--- a/src/Raven.Studio/typescript/viewmodels/manage/threadStackTrace.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/threadStackTrace.ts
@@ -66,7 +66,7 @@ class threadStackTrace extends dialogViewModelBase {
     }
     
     copyStackTrace(): void {
-        copyToClipboard.copy(this.stackTrace().toString(), "Stack trace has been copied to clipboard");
+        copyToClipboard.copy(this.stackTrace().toString(), "Stack trace has been copied to clipboard", this.dialogContainer);
     }
 
     isUserCode(line: string): boolean {

--- a/src/Raven.Studio/typescript/viewmodels/resources/setupEncryptionKey.ts
+++ b/src/Raven.Studio/typescript/viewmodels/resources/setupEncryptionKey.ts
@@ -89,7 +89,8 @@ abstract class setupEncryptionKey {
     abstract keyDataText(): string;
     
     copyEncryptionKeyToClipboard() {
-        copyToClipboard.copy(this.keyDataText(), "Encryption key data was copied to clipboard");
+        const container = this.getContainer();
+        copyToClipboard.copy(this.keyDataText(), "Encryption key data was copied to clipboard", container);
     }
 
     downloadEncryptionKey() {

--- a/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
+++ b/src/Raven.Studio/typescript/widgets/virtualGrid/columnPreviewPlugin.ts
@@ -7,9 +7,9 @@ import moment = require("moment");
 
 
 class copyFeature implements columnPreviewFeature {
-    install($tooltip: JQuery, valueProvider: () => any, elementProvider: () => any) {
+    install($tooltip: JQuery, valueProvider: () => any, elementProvider: () => any, containerSelector: string) {
         $tooltip.on("click", ".copy", () => {
-            copyToClipboard.copy(valueProvider(), "Item has been copied to clipboard");
+            copyToClipboard.copy(valueProvider(), "Item has been copied to clipboard", document.querySelector(containerSelector));
 
             $(".copy", $tooltip).addClass("btn-success");
             $(".copy span", $tooltip)

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
@@ -105,8 +105,7 @@
             </div>
             <div class="clearfix" data-bind="visible: !operationFailed()">
                 <div class="pull-right margin-top">
-                    <button class="btn btn-default btn-sm" data-bind="click: toggleDetails">
-                        <i class="icon-logs"></i><span data-bind="text: detailsVisible() ? 'Hide details':'Show details', clickBubble: false"></span>
+                    <button class="btn btn-default btn-sm" data-bind="click: toggleDetails, text: detailsVisible() ? 'Hide details':'Show details', clickBubble: false">
                     </button>
                 </div>
             </div>

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/operations/smugglerDatabaseDetails.html
@@ -105,7 +105,8 @@
             </div>
             <div class="clearfix" data-bind="visible: !operationFailed()">
                 <div class="pull-right margin-top">
-                    <button class="btn btn-default btn-sm" data-bind="click: toggleDetails, text: detailsVisible() ? 'Hide details':'Show details', clickBubble: false">
+                    <button class="btn btn-default btn-sm" data-bind="click: toggleDetails">
+                        <i class="icon-logs"></i><span data-bind="text: detailsVisible() ? 'Hide details':'Show details', clickBubble: false"></span>
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23182/Copy-text-feature-doesnt-work

### Additional description

fix additionally revert [commit](https://github.com/ravendb/ravendb/commit/8f2892f4688a1b8101c97e492624c3d6e98b304a) which was uploaded on v6.2+, but not on v5.4

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
