### PR TITLE
RavenDB-19445 Fixing concurrency issue in RavenDB_16942.ByteStringContext_Should_Reuse_When_Large_Allocations_Are_Requested test

### DIFF
--- a/test/FastTests/Issues/RavenDB_16942.cs
+++ b/test/FastTests/Issues/RavenDB_16942.cs
@@ -20,9 +20,23 @@ namespace FastTests.Issues
                 // internalCurrent and externalCurrent might be larger than requested 4096 because
                 // ByteStringMemoryCache uses a static pool so other tests might affect the actual size here
                 var initialTotalAllocated = allocator._totalAllocated;
-                var previousTotalAllocated = initialTotalAllocated;
+
+                // We may have concurrency, such as the following line:
+                // which adds to the cache a large segment
+                //using (var concurrent = new ByteStringContext(SharedMultipleUseFlag.None))
+                //{
+                //    concurrent.Allocate(1024 * 512 - 10, out var buffer);
+                //}
 
                 var size = 128 * 1024;
+                // allocate once, to "capture" a segment, and then we should be static 
+                // in term of allocations
+                using (allocator.Allocate(size, out var buffer))
+                {
+                    Assert.Equal(allocator._currentlyAllocated, buffer.Size);
+                }
+                var previousTotalAllocated = allocator._totalAllocated;
+
                 for (var i = 0; i < 100; i++)
                 {
                     using (allocator.Allocate(size, out var buffer))
@@ -31,16 +45,10 @@ namespace FastTests.Issues
                     }
 
                     Assert.Equal(0, allocator._currentlyAllocated);
-                    Assert.True(allocator._totalAllocated > 0);
-
-                    if (previousTotalAllocated != allocator._totalAllocated)
-                        Output.WriteLine($"{nameof(ByteStringContext_Should_Reuse_When_Large_Allocations_Are_Requested)} {i}: P: {previousTotalAllocated}: C: {allocator._totalAllocated}");
-
-                    previousTotalAllocated = allocator._totalAllocated;
+                    Assert.Equal(previousTotalAllocated, allocator._totalAllocated);
                 }
 
                 Assert.True(allocator._totalAllocated - initialTotalAllocated > 0);
-                Assert.True(allocator._totalAllocated - initialTotalAllocated < 1024 * 1024, $"{allocator._totalAllocated} < 1024 * 1024");
             }
         }
     }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-19445/FastTests.Issues.RavenDB16942.ByteStringContextShouldReuseWhenLargeAllocationsAreRequested

### Additional description

Reapplying fix from https://github.com/ravendb/ravendb/pull/19633/commits/88cef28baebd1b3b3676f4f0bfe1829310525066

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test fix

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
