### PR TITLE
RavenDB-23188 Fix Non-Consistent noCaching Behavior

### DIFF
--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -59,7 +59,7 @@ namespace Raven.Client.Http
         public RavenCommandResponseType ResponseType { get; protected set; }
 
         public TimeSpan? Timeout { get; protected internal set; }
-        public bool CanCache { get; protected set; }
+        public bool CanCache { get; protected internal set; }
         public bool CanCacheAggressively { get; protected set; }
         public string SelectedNodeTag { get; protected set; }
         public int NumberOfAttempts { get; internal set; }
@@ -154,7 +154,7 @@ namespace Raven.Client.Http
                     using (var stream = new StreamWithTimeout(responseStream))
                     {
                         var json = await context.ReadForMemoryAsync(stream, "response/object").ConfigureAwait(false);
-                        if (cache != null) //precaution
+                        if (cache != null && CanCache)
                         {
                             CacheResponse(cache, url, response, json);
                         }

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -904,9 +904,8 @@ namespace Raven.Client.Http
             if (request == null)
                 return;
 
-            var noCaching = sessionInfo?.NoCaching ?? false;
-
-            using (var cachedItem = GetFromCache(context, command, !noCaching, url, out string cachedChangeVector, out BlittableJsonReaderObject cachedValue))
+            
+            using (var cachedItem = GetFromCache(context, command, sessionInfo, url, out string cachedChangeVector, out BlittableJsonReaderObject cachedValue))
             {
                 if (cachedChangeVector != null)
                 {
@@ -1387,9 +1386,12 @@ namespace Raven.Client.Http
             throw new InvalidOperationException($"Maximum request timeout is set to '{GlobalHttpClientTimeout}' but was '{timeout}'.");
         }
 
-        private HttpCache.ReleaseCacheItem GetFromCache<TResult>(JsonOperationContext context, RavenCommand<TResult> command, bool useCache, string url, out string cachedChangeVector, out BlittableJsonReaderObject cachedValue)
+        private HttpCache.ReleaseCacheItem GetFromCache<TResult>(JsonOperationContext context, RavenCommand<TResult> command, SessionInfo sessionInfo, string url, out string cachedChangeVector, out BlittableJsonReaderObject cachedValue)
         {
-            if (useCache && command.CanCache && command.IsReadRequest && command.ResponseType == RavenCommandResponseType.Object)
+            if (sessionInfo?.NoCaching == true)
+                command.CanCache = false;
+
+            if (command.CanCache && command.IsReadRequest && command.ResponseType == RavenCommandResponseType.Object)
             {
                 return Cache.Get(context, url, out cachedChangeVector, out cachedValue);
             }

--- a/test/SlowTests/Issues/RavenDB-23188.cs
+++ b/test/SlowTests/Issues/RavenDB-23188.cs
@@ -1,0 +1,67 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_23188 : RavenTestBase
+    {
+        public RavenDB_23188(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void OnSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+
+                var session = store.OpenSession(new SessionOptions()
+                {
+                    NoCaching = true
+                });
+
+                session.Query<Product>().ToList();
+
+                Assert.Equal(0, session.Advanced.RequestExecutor.Cache.NumberOfItems);
+            }
+
+            using (var store = GetDocumentStore())
+            {
+
+                var session = store.OpenSession(new SessionOptions());
+
+                session.Query<Product>().ToList();
+
+                Assert.Equal(1, session.Advanced.RequestExecutor.Cache.NumberOfItems);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void OnQuery()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.DocumentQuery<Product>()
+                        .NoCaching().ToList();
+
+                    Assert.Equal(0, session.Advanced.RequestExecutor.Cache.NumberOfItems);
+                }
+
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.DocumentQuery<Product>().ToList();
+
+                    Assert.Equal(1, session.Advanced.RequestExecutor.Cache.NumberOfItems);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23188

### Additional description

This PR resolves the inconsistent NoCaching behavior observed when using SessionOptions.NoCaching in RavenDB.

Problem:
When NoCaching = true was set at the session level (SessionOptions), data was still being added to the cache, although it was not read back from the cache.
Command-level NoCaching() worked correctly by skipping both adding to and reading from the cache.

Solution:
Added a NoCaching property in RavenCommand.
Updated the RequestExecutor and ProcessResponse methods to properly respect the NoCaching setting when handling requests and responses.

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [X] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [X] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [X] No documentation update is needed 

### Testing by Contributor

- [X] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [X] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [X] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [X] No UI work is needed
