### PR TITLE
RavenDB-17678 Support export time series query results to CSV

### DIFF
--- a/src/Raven.Server/Documents/Handlers/StreamCsvBlittableQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvBlittableQueryResultWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -9,6 +10,9 @@ namespace Raven.Server.Documents.Handlers
 {
     public class StreamCsvBlittableQueryResultWriter : StreamCsvResultWriter<BlittableJsonReaderObject>
     {
+        protected override (string, string)[] GetProperties(BlittableJsonReaderObject entity, bool writeIds) => 
+            GetPropertiesRecursive((string.Empty, string.Empty), entity, writeIds).ToArray();
+
         public override async ValueTask AddResultAsync(BlittableJsonReaderObject res, CancellationToken token)
         {
             WriteCsvHeaderIfNeeded(res, false);

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesCsvWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesCsvWriter.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers;
+
+public class TimeSeriesCsvWriter : IDisposable
+{
+    public const string TimeSeriesPathPrefix = "$TS";
+    private readonly IEnumerator<DynamicJsonValue> _it;
+
+    public TimeSeriesCsvWriter(TimeSeriesStream tStream)
+    {
+        if (tStream == null)
+        {
+            // no time-series here
+            return;
+        }
+
+        _it = tStream.TimeSeries.GetEnumerator();
+        _it.MoveNext();
+    }
+
+    public bool MoveNext()
+    {
+        if (_it == null)
+            return false; // no time-series here
+
+        return _it.MoveNext();
+    }
+
+    public IEnumerable<(string Property, string Path)> GetProperties()
+    {
+        if (_it == null)
+            return Enumerable.Empty<(string Property, string Path)>();
+
+        using (var ctx = JsonOperationContext.ShortTermSingleUse())
+        {
+            var blittable = ctx.ReadObject(_it.Current, "ts-headers");
+            return StreamCsvDocumentQueryResultWriter.GetPropertiesRecursive((string.Empty, TimeSeriesPathPrefix), blittable, addId: false).ToArray();
+        }
+    }
+
+    public string GetValue(string key)
+    {
+        var p = _it?.Current[key];
+
+        switch (p)
+        {
+            case DynamicJsonArray dja:
+                var sb = new StringBuilder();
+                sb.Append("[");
+                for (int i = 0; i < dja.Items.Count; i++)
+                {
+                    object item = dja.Items[i];
+                    sb.Append(item);
+                    if (i < dja.Items.Count - 1)
+                    {
+                        sb.Append(",");
+                    }
+                }
+                sb.Append("]");
+                return sb.ToString();
+            case DateTime dt:
+                return dt.ToString("O");
+            default:
+                return p?.ToString();
+        }
+    }
+    public void Dispose()
+    {
+        using (_it)
+        {
+                    
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -355,7 +355,7 @@ namespace Raven.Server.Documents.Queries.Results
         protected (Document Document, List<Document> List) AddProjectionToResult(Document doc, Lucene.Net.Search.ScoreDoc scoreDoc, FieldsToFetch fieldsToFetch, DynamicJsonValue result, string key, object fieldVal)
         {
             if (_query.IsStream &&
-                key.StartsWith(Constants.TimeSeries.QueryFunction))
+                (key.StartsWith(Constants.TimeSeries.QueryFunction) || fieldsToFetch.AnyTimeSeries))
             {
                 doc.TimeSeriesStream ??= new TimeSeriesStream();
                 var value = (TimeSeriesRetriever.TimeSeriesStreamingRetrieverResult)fieldVal;

--- a/test/SlowTests/Issues/RavenDB_17678.cs
+++ b/test/SlowTests/Issues/RavenDB_17678.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.HashFunction.Core.Utilities;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.Configuration.Attributes;
+using CsvHelper.TypeConversion;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Smuggler;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_17678 : RavenTestBase
+{
+    public RavenDB_17678(ITestOutputHelper output) : base(output)
+    {
+    }
+
+
+    [RavenTheory(RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanExportToCsvTimeSeriesQuery(Options options)
+    {
+        var q1 = @"from 'Companies'
+            where Address.Country ='USA'
+            select timeseries(
+                from 'StockPrices'
+            between '2019-06-01T00:00:00.000Z'
+            and '2020-02-01T00:00:00.000Z'
+                )";
+
+        var q2 = @"from 'Companies'
+            where Address.Country ='USA'
+            select timeseries(
+                from 'StockPrices'
+            between '2019-06-01T00:00:00.000Z'
+            and '2020-02-01T00:00:00.000Z'
+            select first(), avg()
+                ) as t";
+
+        using (var store = GetDocumentStore(options))
+        {
+            await store.Maintenance.SendAsync(new CreateSampleDataOperation(DatabaseItemType.Documents | DatabaseItemType.TimeSeries));
+
+            await AssertRawTimeSeriesQuery(store, q1);
+            await AssertAggregatedTimeSeriesQuery(store, q2);
+        }
+    }
+
+    private static async Task AssertAggregatedTimeSeriesQuery(DocumentStore store, string q2)
+    {
+        var httpClient = store.GetRequestExecutor().HttpClient;
+        await using var stream = await httpClient.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?query={q2}&format=csv");
+
+        using var csvReader = new CsvReader(new StreamReader(stream), new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = ",", });
+
+        var hasValues = false;
+        await foreach (var r in csvReader.GetRecordsAsync<ExportedAggregatedTimeSeries>())
+        {
+            Assert.StartsWith("companies/", r.Id);
+            Assert.True(r.From > DateTime.MinValue);
+            Assert.True(r.To > DateTime.MinValue);
+            Assert.Equal(5, r.Average.Length);
+            Assert.Equal(5, r.Count.Length);
+            Assert.Equal(5, r.First.Length);
+            Assert.True(r.Average.Sum(Math.Abs) > 0);
+            Assert.True(r.Count.Sum(Math.Abs) > 0);
+            Assert.True(r.First.Sum(Math.Abs) > 0);
+            hasValues = true;
+        }
+        Assert.True(hasValues);
+    }
+
+    private static async Task AssertRawTimeSeriesQuery(DocumentStore store, string q1)
+    {
+        var httpClient = store.GetRequestExecutor().HttpClient;
+        await using var stream = await httpClient.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?query={q1}&format=csv");
+
+        using var csvReader = new CsvReader(new StreamReader(stream), new CsvConfiguration(CultureInfo.InvariantCulture) { Delimiter = ",", });
+        
+        var hasValues = false;
+        await foreach (var r in csvReader.GetRecordsAsync<ExportedRawTimeSeries>())
+        {
+            Assert.StartsWith("companies/", r.Id);
+            Assert.StartsWith("employees/", r.Tag);
+            Assert.True(r.Timestamp > DateTime.MinValue);
+            Assert.Equal(5, r.Values.Length);
+            Assert.True(r.Values.Sum(Math.Abs) > 0);
+            Assert.False(r.IsRollup);
+            hasValues = true;
+        }
+        Assert.True(hasValues);
+    }
+
+    private class ExportedAggregatedTimeSeries
+    {
+        [Name("@id")]
+        public string Id { get; set; }
+        public DateTime From { get; set; }
+        public DateTime To { get; set; }
+        [TypeConverter(typeof(TimeSeriesValuesConverter))]
+        public double[] Count { get; set; }
+        [TypeConverter(typeof(TimeSeriesValuesConverter))]
+        public double[] First { get; set; }
+        [TypeConverter(typeof(TimeSeriesValuesConverter))]
+        public double[] Average { get; set; }
+    }
+
+    private class ExportedRawTimeSeries
+    {
+        [Name("@id")]
+        public string Id { get; set; }
+        public string Tag { get; set; }
+        public DateTime Timestamp { get; set; }
+        [TypeConverter(typeof(TimeSeriesValuesConverter))]
+        public double[] Values { get; set; }
+        public bool IsRollup { get; set; }
+    }
+
+    private class TimeSeriesValuesConverter : DefaultTypeConverter
+    {
+        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+        {
+            if (string.IsNullOrEmpty(text))
+                return null;
+
+            var result = new List<double>();
+            var size = 0;
+            Span<byte> buffer = stackalloc byte[64];
+            var input = text.AsSpan();
+
+            for (int i = 0; i < input.Length; i++)
+            {
+                var b = input[i];
+                if (b == '[' || b == '"')
+                    continue;
+
+                if (b == ']')
+                {
+                    if (size > 0)
+                    {
+                        result.Add(double.Parse(buffer[..size]));
+                    }
+                }
+
+                if (b == ',')
+                {
+                    result.Add(double.Parse(buffer[..size]));
+                    size = 0;
+                    continue;
+                }
+
+                buffer[size++] = (byte)b;
+            }
+
+            return result.ToArray();
+        }
+
+        public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData) => throw new NotImplementedException();
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_9519.cs
+++ b/test/SlowTests/Issues/RavenDB_9519.cs
@@ -42,8 +42,8 @@ namespace SlowTests.Issues
                     cv = session.Advanced.GetChangeVectorFor(_testCompany);
                 }
 
-                var client = new HttpClient();
-                var stream = await client.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?query={query}&format=csv");
+                var client = store.GetRequestExecutor().HttpClient;
+                await using var stream = await client.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?query={query}&format=csv");
 
                 using (var commands = store.Commands())
                 {
@@ -100,8 +100,8 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var client = new HttpClient();
-                var stream = await client.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?fromDocument=queries%2F1&format=csv");
+                var client = store.GetRequestExecutor().HttpClient;
+                await using var stream = await client.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?fromDocument=queries%2F1&format=csv");
 
                 using (var commands = store.Commands())
                 {
@@ -137,8 +137,8 @@ namespace SlowTests.Issues
                     session.SaveChanges();
                 }
 
-                var client = new HttpClient();
-                var stream = await client.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?fromDocument=queries%2F1&format=csv");
+                var client = store.GetRequestExecutor().HttpClient;
+                await using var stream = await client.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?fromDocument=queries%2F1&format=csv");
 
                 using (var commands = store.Commands())
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17678

### Additional description

It seems that we missed to implement the functionality of exporting time-series query to CSV.

We do not export it from the studio directly, but we generate the file from the `/databases/*/streams/queries` EP, so it hit different EPs for querying in the studio and exporting the results.

Now query like 
```
from 'Companies'
where Address.Country ='USA'
select timeseries(
    from 'StockPrices'
    between '2019-06-01T00:00:00.000Z'
    and '2020-02-01T00:00:00.000Z'
)
``` 
will be exported to the following format
```
@id,@metadata.@projection,Tag,Timestamp,Values,IsRollup
companies/32-A,True,employees/9-A,2019-12-17T00:00:00.0000000Z,"[10.04,10.02,10.075,9.92,430051]",False
companies/32-A,True,employees/4-A,2019-12-18T00:00:00.0000000Z,"[10.11,10.06,10.205,10.05,510593]",False
companies/32-A,True,employees/7-A,2019-12-19T00:00:00.0000000Z,"[10.15,10.09,10.17,10.045,520568]",False
companies/32-A,True,employees/9-A,2019-12-20T00:00:00.0000000Z,"[10.16,10.2,10.21,10.055,1393751]",False
...
```

and aggregated queries like
```
from 'Companies'
where Address.Country ='USA'
select timeseries(
    from 'StockPrices'
    between '2019-06-01T00:00:00.000Z'
    and '2020-02-01T00:00:00.000Z'
    group by 1month
    select avg()
)
```
will have the format
```
@id,@metadata.@projection,From,To,Key,Count,Average
companies/32-A,True,2019-12-01T00:00:00.0000000Z,2020-01-01T00:00:00.0000000Z,,"[10,10,10,10,10]","[10.196000000000002,10.115,10.241000000000001,10.064499999999999,460425.2]"
companies/36-A,True,2019-12-01T00:00:00.0000000Z,2020-01-01T00:00:00.0000000Z,,"[10,10,10,10,10]","[32.947,32.849000000000004,33.11381000000001,32.675,108250.5]"
companies/36-A,True,2020-01-01T00:00:00.0000000Z,2020-02-01T00:00:00.0000000Z,,"[21,21,21,21,21]","[34.701904761904764,34.76857142857142,34.98555714285715,34.49751428571428,98042.90476190476]"
companies/43-A,True,2019-12-01T00:00:00.0000000Z,2020-01-01T00:00:00.0000000Z,,"[10,10,10,10,10]","[45.678000000000004,45.76800000000001,46.070499999999996,45.319069999999996,134405.7]"
companies/43-A,True,2020-01-01T00:00:00.0000000Z,2020-02-01T00:00:00.0000000Z,,"[21,21,21,21,21]","[44.392380952380954,44.31809523809524,44.84190476190476,43.736261904761896,88382.28571428571]"
...
```


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
