### PR TITLE
RavenDB-17015 - SlowTests.Client.TimeSeries.Query.QueryFromMultipleTimeSeries.SameQueryResultForRawAndRollupForJuly

### DIFF
--- a/test/SlowTests/Client/TimeSeries/Query/QueryFromMultipleTimeSeries.cs
+++ b/test/SlowTests/Client/TimeSeries/Query/QueryFromMultipleTimeSeries.cs
@@ -1642,10 +1642,10 @@ select out()
                             {
                                 p1,
                                 p2,
-                                p3,
+                                p3
                             }
-                        },
-                    },
+                        }
+                    }
                 };
 
                 await AssertWaitForValueAsync(async () =>
@@ -1672,7 +1672,7 @@ select out()
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(config));
                 
                 await TimeSeries.WaitForPolicyRunnerAsync(database);
-                await TimeSeries.VerifyPolicyExecutionAsync(store, config.Collections["Users"],12);
+                await TimeSeries.VerifyPolicyExecutionAsync(store, config.Collections["Users"],12, timeout: 30000);
 
                 var rawAndRoll = GetSum(store, now);
                 Assert.Equal(raw, rawAndRoll);


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17015/SlowTests.Client.TimeSeries.Query.QueryFromMultipleTimeSeries.SameQueryResultForRawAndRollupForJulyday-8

### Additional description

* Added additional information to the failure message.
* Increased the timeout for the `VerifyPolicyExecutionAsync` method.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
