### PR TITLE
RavenDB-23186 & RavenDB-22223 minor client API breaking changes

### DIFF
--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -19,9 +19,10 @@ namespace Raven.Client.Documents.Commands.Batches
         public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
 
         public ClusterWideBatchCommand(DocumentConventions conventions, IList<ICommandData> commands, BatchOptions options = null, bool? disableAtomicDocumentsWrites = null) :
-            base(conventions, context: null, commands, options, TransactionMode.ClusterWide)
+            base(conventions, context: null, commands, options)
         {
             DisableAtomicDocumentWrites = disableAtomicDocumentsWrites;
+            Mode = TransactionMode.ClusterWide;
         }
 
         protected override void AppendOptions(StringBuilder sb)
@@ -43,14 +44,14 @@ namespace Raven.Client.Documents.Commands.Batches
         private readonly DocumentConventions _conventions;
         private readonly IList<ICommandData> _commands;
         private readonly BatchOptions _options;
-        private readonly TransactionMode _mode;
+        protected TransactionMode Mode;
 
-        public SingleNodeBatchCommand(DocumentConventions conventions, JsonOperationContext context, IList<ICommandData> commands, BatchOptions options = null, TransactionMode mode = TransactionMode.SingleNode)
+        public SingleNodeBatchCommand(DocumentConventions conventions, JsonOperationContext context, IList<ICommandData> commands, BatchOptions options = null)
         {
             _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
             _commands = commands ?? throw new ArgumentNullException(nameof(commands));
             _options = options;
-            _mode = mode;
+            Mode = TransactionMode.SingleNode;
 
             _commandsAsJson = new BlittableJsonReaderObject[_commands.Count];
             foreach (var command in commands)
@@ -102,7 +103,7 @@ namespace Raven.Client.Documents.Commands.Batches
                     {
                         writer.WriteStartObject();
                         writer.WriteArray("Commands", _commandsAsJson);
-                        if (_mode == TransactionMode.ClusterWide)
+                        if (Mode == TransactionMode.ClusterWide)
                         {
                             writer.WriteComma();
                             writer.WritePropertyName(nameof(TransactionMode));

--- a/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
+++ b/src/Raven.Client/Documents/Operations/Counters/CounterBatch.cs
@@ -28,7 +28,7 @@ namespace Raven.Client.Documents.Operations.Counters
         /// Gets or sets a value indicating whether the batch originated from an ETL process.
         /// This is used internally to identify and manage counter operations triggered by ETL pipelines.
         /// </summary>
-        public bool FromEtl;
+        internal bool FromEtl;
     }
 
     /// <summary>

--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -55,7 +55,7 @@ namespace Raven.Client.Documents.Session.Operations
                     _session.DisableAtomicDocumentWritesInClusterWideTransaction);
             }
 
-            return new SingleNodeBatchCommand(_session.Conventions, _session.Context, result.SessionCommands, result.Options);
+            return new SingleNodeBatchCommand(_session.Conventions, result.SessionCommands, result.Options);
         }
 
         public void SetResult(BatchCommandResult result)

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -171,7 +171,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                 };
             }
 
-            using (var batchCommand = new SingleNodeBatchCommand(DocumentConventions.DefaultForServer, context, commands, options))
+            using (var batchCommand = new SingleNodeBatchCommand(DocumentConventions.DefaultForServer, commands, options))
             {
                 var duration = Stopwatch.StartNew();
 

--- a/test/FastTests/Client/BatchCommandWithNoReplyFlagTest.cs
+++ b/test/FastTests/Client/BatchCommandWithNoReplyFlagTest.cs
@@ -39,7 +39,7 @@ public class BatchCommandWithNoReplyFlagTest : RavenTestBase
             var patchRequest = new PatchRequest{Script = "this.Name = args.val_0;", Values = new Dictionary<string, object>{{"val_0", user1Value}}};
             result.SessionCommands.Add(new PatchCommandData(user1Id, null, patchRequest));
             
-            var sbc = new TestSingleNodeBatchCommand(DocumentConventions.Default, context, result.SessionCommands, result.Options);
+            var sbc = new TestSingleNodeBatchCommand(DocumentConventions.Default, result.SessionCommands, result.Options);
             
             await requestExecutor.ExecuteAsync(sbc, context);
         }
@@ -70,7 +70,7 @@ public class BatchCommandWithNoReplyFlagTest : RavenTestBase
             var jpd = new JsonPatchDocument();
             jpd.Add("/Name", user2Value);
             result.SessionCommands.Add(new JsonPatchCommandData(user2Id, jpd));
-            var sbc = new TestSingleNodeBatchCommand(DocumentConventions.Default, context, result.SessionCommands, result.Options);
+            var sbc = new TestSingleNodeBatchCommand(DocumentConventions.Default, result.SessionCommands, result.Options);
             
             await requestExecutor.ExecuteAsync(sbc, context);
         }
@@ -90,7 +90,8 @@ public class BatchCommandWithNoReplyFlagTest : RavenTestBase
     
     private class TestSingleNodeBatchCommand : SingleNodeBatchCommand
     {
-        public TestSingleNodeBatchCommand(DocumentConventions conventions, JsonOperationContext context, IList<ICommandData> commands, BatchOptions options = null) : base(conventions, context, commands, options)
+        public TestSingleNodeBatchCommand(DocumentConventions conventions, IList<ICommandData> commands, BatchOptions options = null) 
+            : base(conventions, commands, options)
         {
         }
 

--- a/test/FastTests/Client/BatchCommandWithNoReplyFlagTest.cs
+++ b/test/FastTests/Client/BatchCommandWithNoReplyFlagTest.cs
@@ -90,7 +90,7 @@ public class BatchCommandWithNoReplyFlagTest : RavenTestBase
     
     private class TestSingleNodeBatchCommand : SingleNodeBatchCommand
     {
-        public TestSingleNodeBatchCommand(DocumentConventions conventions, JsonOperationContext context, IList<ICommandData> commands, BatchOptions options = null, TransactionMode mode = TransactionMode.SingleNode) : base(conventions, context, commands, options, mode)
+        public TestSingleNodeBatchCommand(DocumentConventions conventions, JsonOperationContext context, IList<ICommandData> commands, BatchOptions options = null) : base(conventions, context, commands, options)
         {
         }
 

--- a/test/SlowTests/Issues/RavenDB_13890.cs
+++ b/test/SlowTests/Issues/RavenDB_13890.cs
@@ -30,7 +30,7 @@ namespace SlowTests.Issues
                         Url = "http://dummy:1234"
                     };
 
-                    var batchCommand = new SingleNodeBatchCommand(store.Conventions, context,new List<ICommandData>());
+                    var batchCommand = new SingleNodeBatchCommand(store.Conventions, new List<ICommandData>());
                     var uri = requestExecutor.CreateRequest(context, dummy, batchCommand, out _);
                     Assert.DoesNotContain("raft", uri.RequestUri.ToString());
 

--- a/test/SlowTests/RavenDB-15796.cs
+++ b/test/SlowTests/RavenDB-15796.cs
@@ -80,7 +80,7 @@ namespace SlowTests
                         {
                             var result = new InMemoryDocumentSessionOperations.SaveChangesData((InMemoryDocumentSessionOperations)session2);
                             result.SessionCommands.Add(new PutCommandDataWithBlittableJson("users/1", null, null, blittableJson));
-                            var sbc = new SingleNodeBatchCommand(DocumentConventions.Default, context, result.SessionCommands, result.Options);
+                            var sbc = new SingleNodeBatchCommand(DocumentConventions.Default, result.SessionCommands, result.Options);
                             await requestExecutor.ExecuteAsync(sbc, context);
                         }
                     }

--- a/test/Tests.Infrastructure/DocumentStoreExtensions.cs
+++ b/test/Tests.Infrastructure/DocumentStoreExtensions.cs
@@ -270,7 +270,7 @@ namespace FastTests
 
             public async Task BatchAsync(List<ICommandData> commands)
             {
-                var command = new SingleNodeBatchCommand(_store.Conventions, Context, commands);
+                var command = new SingleNodeBatchCommand(_store.Conventions, commands);
 
                 await RequestExecutor.ExecuteAsync(command, Context);
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23186
https://issues.hibernatingrhinos.com/issue/RavenDB-22223

### Additional description

- Remove Transaction mode param in SingleNodeBatchCommand
- Make FromEtl internal in CounterBatch class

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
