### PR TITLE
RavenDB-22076 & RavenDB-23076: Vector search - RavenVector and Blittable Vector

### DIFF
--- a/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
@@ -218,6 +218,16 @@ public interface IVectorEmbeddingFieldValueFactory
     /// </summary>
     /// <param name="base64Embedding">Embedding encoded as base64 string.</param>
     public void ByBase64(string base64Embedding);
+    
+    /// <summary>
+    /// Defines queried embedding.
+    /// </summary>
+    /// <param name="embedding">RavenVector containing embedding values.</param>
+    public void ByEmbedding<T>(RavenVector<T> embedding) where T : unmanaged
+#if NET7_0_OR_GREATER
+        , INumber<T>
+#endif
+    ;
 }
 
 public interface IVectorFieldValueFactory : IVectorEmbeddingTextFieldValueFactory, IVectorEmbeddingFieldValueFactory
@@ -263,4 +273,10 @@ internal class VectorFieldValueFactory : IVectorFieldValueFactory
     {
         Text = text;
     }
+    
+    void IVectorEmbeddingFieldValueFactory.ByEmbedding<T>(RavenVector<T> embedding)
+    {
+        Embedding = embedding;
+    }
+
 }

--- a/src/Raven.Client/Documents/RavenVector.cs
+++ b/src/Raven.Client/Documents/RavenVector.cs
@@ -7,7 +7,7 @@ using System.Numerics;
 
 namespace Raven.Client.Documents;
 
-public class RavenVector<T> : IEnumerable
+public class RavenVector<T> : IEnumerable, IEnumerable<T>
     where T : unmanaged
 #if NET7_0_OR_GREATER
     , INumber<T>
@@ -43,6 +43,11 @@ public class RavenVector<T> : IEnumerable
         if (isKnownType == false)
             throw new InvalidDataException($"The type of embedding must be numeric. Supported types are: float, double, decimal, sbyte, byte, int, uint, long, ulong. Received: {typeof(T).FullName}.");
 #endif
+    }
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    {
+        return Embedding.AsEnumerable().GetEnumerator();
     }
 
     public IEnumerator GetEnumerator()

--- a/src/Raven.Client/Documents/RavenVector.cs
+++ b/src/Raven.Client/Documents/RavenVector.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+
+namespace Raven.Client.Documents;
+
+public class RavenVector<T> where T : unmanaged
+#if NET7_0_OR_GREATER
+    , INumber<T>
+#endif
+{
+    public T[] Embedding { get; set; }
+    
+    public RavenVector(IEnumerable<T> embedding)
+    {
+        AssertEmbeddingType();
+        Embedding = embedding.ToArray(); //todo
+    }
+
+    public RavenVector(T[] embedding)
+    {
+        AssertEmbeddingType();
+        Embedding = embedding;
+    }
+
+    public static implicit operator RavenVector<T>(T[] array)
+    {
+        return new RavenVector<T>(array);
+    }
+    
+    private static void AssertEmbeddingType()
+    {
+#if !NET7_0_OR_GREATER
+        // For >=NET7, INumber<T> is the guardian.
+        var isKnownType = typeof(T) == typeof(float) || typeof(T) == typeof(double) || typeof(T) == typeof(decimal) || typeof(T) == typeof(sbyte) || typeof(T) == typeof(byte) || typeof(T) == typeof(int) || typeof(T) == typeof(uint) || typeof(T) == typeof(long) || typeof(T) == typeof(ulong);
+        
+        if (isKnownType == false)
+            throw new InvalidDataException($"The type of embedding must be numeric. Supported types are: float, double, decimal, sbyte, byte, int, uint, long, ulong. Received: {typeof(T).FullName}.");
+#endif
+    }
+}

--- a/src/Raven.Client/Documents/RavenVector.cs
+++ b/src/Raven.Client/Documents/RavenVector.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -5,7 +7,8 @@ using System.Numerics;
 
 namespace Raven.Client.Documents;
 
-public class RavenVector<T> where T : unmanaged
+public class RavenVector<T> : IEnumerable
+    where T : unmanaged
 #if NET7_0_OR_GREATER
     , INumber<T>
 #endif
@@ -15,7 +18,7 @@ public class RavenVector<T> where T : unmanaged
     public RavenVector(IEnumerable<T> embedding)
     {
         AssertEmbeddingType();
-        Embedding = embedding.ToArray(); //todo
+        Embedding = embedding.ToArray();
     }
 
     public RavenVector(T[] embedding)
@@ -29,6 +32,8 @@ public class RavenVector<T> where T : unmanaged
         return new RavenVector<T>(array);
     }
     
+    internal Type GetEmbeddingType() => typeof(T);
+    
     private static void AssertEmbeddingType()
     {
 #if !NET7_0_OR_GREATER
@@ -38,5 +43,10 @@ public class RavenVector<T> where T : unmanaged
         if (isKnownType == false)
             throw new InvalidDataException($"The type of embedding must be numeric. Supported types are: float, double, decimal, sbyte, byte, int, uint, long, ulong. Received: {typeof(T).FullName}.");
 #endif
+    }
+
+    public IEnumerator GetEnumerator()
+    {
+        return Embedding.GetEnumerator();
     }
 }

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonReader.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonReader.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Numerics;
 using Newtonsoft.Json;
 using Sparrow;
 using Sparrow.Json;
@@ -211,6 +212,9 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                     return true;
                 case BlittableJsonToken.Null:
                     SetToken(JsonToken.Null);
+                    return true;
+                case BlittableJsonToken.Vector:
+                    SetToken(JsonToken.None, value);
                     return true;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonWriter.cs
@@ -672,6 +672,11 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
             else
                 _manualBlittableJsonDocumentBuilder.WriteValueNull();
         }
+        
+        public void WriteVector<T>(ReadOnlySpan<T> value) where T : unmanaged
+        {
+            _manualBlittableJsonDocumentBuilder.WriteVector(value);
+        }
 
         public override void WriteValue(object value)
         {

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/VectorConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/VectorConverter.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.IO;
 using System.Numerics;
 using Newtonsoft.Json;
 using Raven.Client.Documents;
@@ -9,6 +11,44 @@ internal sealed class VectorConverter : JsonConverter
 {
     public static readonly VectorConverter Instance = new();
     
+    private static bool TryWriteVectorArray<T>(JsonWriter writer, RavenVector<T> vector)
+    where T : unmanaged
+#if NET7_0_OR_GREATER
+    , INumber<T>
+#endif
+    {
+        foreach (T element in vector.Embedding)
+            WriteValue(element);
+        
+        return true;
+        
+        void WriteValue(in T value)
+        {    
+            if (typeof(T) == typeof(float))
+                writer.WriteValue((float)(object)value); 
+            else if (typeof(T) == typeof(double))
+                writer.WriteValue((double)(object)value); 
+            else if (typeof(T) == typeof(byte))
+                writer.WriteValue((byte)(object)value); 
+            else if (typeof(T) == typeof(ushort))
+                writer.WriteValue((ushort)(object)value); 
+            else if (typeof(T) == typeof(uint))
+                writer.WriteValue((uint)(object)value); 
+            else if (typeof(T) == typeof(ulong))
+                writer.WriteValue((ulong)(object)value); 
+            else if (typeof(T) == typeof(sbyte))
+                writer.WriteValue((sbyte)(object)value);  
+            else if (typeof(T) == typeof(short))
+                writer.WriteValue((short)(object)value); 
+            else if (typeof(T) == typeof(int))
+                writer.WriteValue((int)(object)value);  
+            else if (typeof(T) == typeof(long))
+                writer.WriteValue((long)(object)value);
+            else
+                writer.WriteValue(value);
+        }
+    }
+    
     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
     {
         if (value == null)
@@ -18,16 +58,34 @@ internal sealed class VectorConverter : JsonConverter
         }
         
         writer.WriteStartObject();
-        
         writer.WritePropertyName("@vector");
-        
-        // todo
-        var vector = (RavenVector<float>)value;
-        
         writer.WriteStartArray();
 
-        foreach (var element in vector.Embedding)
-            writer.WriteValue(element);
+        // For known types we can cast vector, otherwise we will use reflection
+        var writtenKnownType = value switch
+        {
+            RavenVector<byte> v => TryWriteVectorArray(writer, v),
+            RavenVector<ushort> v => TryWriteVectorArray(writer, v),
+            RavenVector<uint> v => TryWriteVectorArray(writer, v),
+            RavenVector<ulong> v => TryWriteVectorArray(writer, v),
+            RavenVector<sbyte> v => TryWriteVectorArray(writer, v),
+            RavenVector<short> v => TryWriteVectorArray(writer, v),
+            RavenVector<int> v => TryWriteVectorArray(writer, v),
+            RavenVector<long> v => TryWriteVectorArray(writer, v),
+            RavenVector<decimal> v => TryWriteVectorArray(writer, v),
+            _ => false
+        };
+
+        if (writtenKnownType)
+        {
+            IEnumerable enumerable = value as IEnumerable;
+            
+            if (enumerable is null)
+                throw new InvalidDataException($"Expected IEnumerable, but got {enumerable} instead.");
+            
+            foreach (var element in enumerable)
+                writer.WriteValue(element);
+        }
         
         writer.WriteEndArray();
         

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/VectorConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/VectorConverter.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections;
 using System.Diagnostics;
-using System.IO;
 using System.Numerics;
-using System.Reflection;
-using System.Reflection.Emit;
 using Newtonsoft.Json;
 using Raven.Client.Documents;
 using Sparrow.Json;
@@ -15,45 +12,57 @@ internal sealed class VectorConverter : JsonConverter
 {
     public static readonly VectorConverter Instance = new();
     
-    private static bool TryWriteVectorArray<T>(JsonWriter writer, RavenVector<T> vector)
-    where T : unmanaged
-#if NET7_0_OR_GREATER
+    /// <summary>
+    /// When the writer is a BlittableJsonWriter, we can simply use the native blittable Vector writer.
+    /// Otherwise, we need to construct a JSON array of numerical values.
+    /// </summary>
+    private static bool CanWriteVectorInNativeForm(JsonWriter writer) => writer is BlittableJsonWriter;
+    
+    private static void WriteVectorArray<T>(JsonWriter writer, RavenVector<T> vector, bool writeInNativeForm) where T : unmanaged
+    #if NET7_0_OR_GREATER
     , INumber<T>
-#endif
+    #endif
     {
-        foreach (T element in vector.Embedding)
-            WriteValue(element);
-        
-        return true;
-        
-        void WriteValue(in T value)
-        {    
-            if (typeof(T) == typeof(float))
-                writer.WriteValue((float)(object)value); 
-            else if (typeof(T) == typeof(double))
-                writer.WriteValue((double)(object)value); 
-            else if (typeof(T) == typeof(decimal))
-                writer.WriteValue((decimal)(object)value);
+        if (writeInNativeForm)
+        {
+            ((BlittableJsonWriter)writer).WriteVector<T>(vector.Embedding);
+        }
+        else
+        {
+            // very unlikely, rollback for the default serializer
+            foreach (T value in vector.Embedding)
+            {
+                if (typeof(T) == typeof(float))
+                    writer.WriteValue((float)(object)value); 
+                else if (typeof(T) == typeof(double))
+                    writer.WriteValue((double)(object)value); 
+                else if (typeof(T) == typeof(decimal))
+                    writer.WriteValue((decimal)(object)value);
+#if NET6_0_OR_GREATER
+                else if (typeof(T) == typeof(Half))
+                    writer.WriteValue((Half)(object)value);
+#endif
+                
+                else if (typeof(T) == typeof(byte))
+                    writer.WriteValue((byte)(object)value); 
+                else if (typeof(T) == typeof(ushort))
+                    writer.WriteValue((ushort)(object)value); 
+                else if (typeof(T) == typeof(uint))
+                    writer.WriteValue((uint)(object)value); 
+                else if (typeof(T) == typeof(ulong))
+                    writer.WriteValue((ulong)(object)value); 
             
-            else if (typeof(T) == typeof(byte))
-                writer.WriteValue((byte)(object)value); 
-            else if (typeof(T) == typeof(ushort))
-                writer.WriteValue((ushort)(object)value); 
-            else if (typeof(T) == typeof(uint))
-                writer.WriteValue((uint)(object)value); 
-            else if (typeof(T) == typeof(ulong))
-                writer.WriteValue((ulong)(object)value); 
-            
-            else if (typeof(T) == typeof(sbyte))
-                writer.WriteValue((sbyte)(object)value);  
-            else if (typeof(T) == typeof(short))
-                writer.WriteValue((short)(object)value); 
-            else if (typeof(T) == typeof(int))
-                writer.WriteValue((int)(object)value);  
-            else if (typeof(T) == typeof(long))
-                writer.WriteValue((long)(object)value);
-            else
-                writer.WriteValue(value);
+                else if (typeof(T) == typeof(sbyte))
+                    writer.WriteValue((sbyte)(object)value);  
+                else if (typeof(T) == typeof(short))
+                    writer.WriteValue((short)(object)value); 
+                else if (typeof(T) == typeof(int))
+                    writer.WriteValue((int)(object)value);  
+                else if (typeof(T) == typeof(long))
+                    writer.WriteValue((long)(object)value);
+                else
+                    writer.WriteValue(value);
+            }
         }
     }
     
@@ -67,39 +76,66 @@ internal sealed class VectorConverter : JsonConverter
         
         writer.WriteStartObject();
         writer.WritePropertyName(Sparrow.Global.Constants.Naming.VectorPropertyName);
-        writer.WriteStartArray();
+        
+        bool canWriteInNativeForm = CanWriteVectorInNativeForm(writer);
+        
+        if (canWriteInNativeForm == false)
+            writer.WriteStartArray();
 
         // For known types we can cast vector, otherwise we will use reflection
-        var writtenKnownType = value switch
+        switch (value)
         {
-            RavenVector<float> v => TryWriteVectorArray(writer, v),
-            RavenVector<double> v => TryWriteVectorArray(writer, v),
-            RavenVector<decimal> v => TryWriteVectorArray(writer, v),
+            case RavenVector<float> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+            case RavenVector<double> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+            case RavenVector<decimal> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
             
-            RavenVector<byte> v => TryWriteVectorArray(writer, v),
-            RavenVector<ushort> v => TryWriteVectorArray(writer, v),
-            RavenVector<uint> v => TryWriteVectorArray(writer, v),
-            RavenVector<ulong> v => TryWriteVectorArray(writer, v),
-            
-            RavenVector<sbyte> v => TryWriteVectorArray(writer, v),
-            RavenVector<short> v => TryWriteVectorArray(writer, v),
-            RavenVector<int> v => TryWriteVectorArray(writer, v),
-            RavenVector<long> v => TryWriteVectorArray(writer, v),
-            _ => false
-        };
-
-        if (writtenKnownType == false)
-        {
-            IEnumerable enumerable = value as IEnumerable;
-            
-            if (enumerable is null)
-                throw new InvalidDataException($"Expected IEnumerable, but got {value} instead.");
-            
-            foreach (var element in enumerable)
-                writer.WriteValue(element);
+            case RavenVector<byte> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+            case RavenVector<ushort> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+            case RavenVector<uint> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+            case RavenVector<ulong> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+            case RavenVector<sbyte> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+            case RavenVector<short> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+            case RavenVector<int> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+            case RavenVector<long> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+#if NET6_0_OR_GREATER
+            case RavenVector<Half> v:
+                WriteVectorArray(writer, v, canWriteInNativeForm);
+                break;
+#endif
+            default:
+                if (canWriteInNativeForm)
+                    writer.WriteStartArray();
+                canWriteInNativeForm = false;
+                foreach (var element in (IEnumerable)value)
+                    writer.WriteValue(element);
+                break;
+                
         }
         
-        writer.WriteEndArray();
+        if (canWriteInNativeForm == false)
+            writer.WriteEndArray();
         
         writer.WriteEndObject();
     }
@@ -111,21 +147,18 @@ internal sealed class VectorConverter : JsonConverter
         
         Debug.Assert(reader.TokenType == JsonToken.StartObject, "reader.TokenType == JsonToken.StartArray");
         
+        // Reading the "@vector" property
         reader.Read();
         Debug.Assert(reader.TokenType == JsonToken.PropertyName, "reader.TokenType == JsonToken.PropertyName");
-        
         Debug.Assert(reader.Value?.ToString() == Sparrow.Global.Constants.Naming.VectorPropertyName, "propertyName == VectorPropertyName");
-
-        // Read vector value
+        
+        // Read array
         reader.Read();
-
         Debug.Assert(objectType.GenericTypeArguments.Length == 1);
-        
         var embeddingType = objectType.GenericTypeArguments[0];
-        
         var blittableJsonReaderVector = (BlittableJsonReaderVector)reader.Value;
-
-        reader.Read();
+        
+        reader.Read(); //end object
         Debug.Assert(reader.TokenType == JsonToken.EndObject, "reader.TokenType == JsonToken.EndObject");
         
         if (embeddingType == typeof(float))
@@ -134,6 +167,10 @@ internal sealed class VectorConverter : JsonConverter
             return CreateRavenVector<double>(blittableJsonReaderVector);
         if (embeddingType == typeof(decimal))
             return CreateRavenVector<double>(blittableJsonReaderVector);
+#if NET6_0_OR_GREATER
+        if (embeddingType == typeof(Half))
+            return CreateRavenVector<Half>(blittableJsonReaderVector);
+#endif
         
         if (embeddingType == typeof(byte))
             return CreateRavenVector<byte>(blittableJsonReaderVector);
@@ -161,8 +198,18 @@ internal sealed class VectorConverter : JsonConverter
         , INumber<T>
 #endif
     {
-        var vectorSpan = bjrv.ReadArray<T>();
-        return new RavenVector<T>(vectorSpan.ToArray());
+        if (bjrv.TryReadArray<T>(out var vectorSpan))
+            return new RavenVector<T>(vectorSpan.ToArray());
+
+        //when we compressed the type internally, we've to fallback and read one-by-one
+        var enumerator = bjrv.ReadAs<T>();
+        var vector = new T[enumerator.Count];
+        var idX = 0;
+        while (enumerator.MoveNext())
+            vector[idX++] = enumerator.Current;
+        
+        Debug.Assert(idX == vector.Length);
+        return new RavenVector<T>(vector);
     }
 
     public override bool CanConvert(Type objectType)

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/VectorConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/VectorConverter.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections;
 using System.Diagnostics;
+using System.IO;
 using System.Numerics;
 using Newtonsoft.Json;
 using Raven.Client.Documents;
+using Sparrow;
 using Sparrow.Json;
 
 namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal.Converters;
@@ -124,14 +126,16 @@ internal sealed class VectorConverter : JsonConverter
                 WriteVectorArray(writer, v, canWriteInNativeForm);
                 break;
 #endif
-            default:
+            case IEnumerable v:
                 if (canWriteInNativeForm)
                     writer.WriteStartArray();
                 canWriteInNativeForm = false;
-                foreach (var element in (IEnumerable)value)
+                foreach (var element in v)
                     writer.WriteValue(element);
                 break;
-                
+            default:
+                PortableExceptions.Throw<InvalidDataException>($"Cannot create 'RavenVector' from type '{value.GetType().FullName}'.");
+                break;
         }
         
         if (canWriteInNativeForm == false)

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/VectorConverter.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/Converters/VectorConverter.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Numerics;
+using Newtonsoft.Json;
+using Raven.Client.Documents;
+
+namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal.Converters;
+
+internal sealed class VectorConverter : JsonConverter
+{
+    public static readonly VectorConverter Instance = new();
+    
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        if (value == null)
+        {
+            writer.WriteNull();
+            return;
+        }
+        
+        writer.WriteStartObject();
+        
+        writer.WritePropertyName("@vector");
+        
+        // todo
+        var vector = (RavenVector<float>)value;
+        
+        writer.WriteStartArray();
+
+        foreach (var element in vector.Embedding)
+            writer.WriteValue(element);
+        
+        writer.WriteEndArray();
+        
+        writer.WriteEndObject();
+    }
+    
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.Null)
+            return null;
+        
+        if (reader.TokenType != JsonToken.PropertyName)
+            throw new InvalidOperationException();
+        
+        reader.Read();
+        
+        return reader.Value;
+    }
+
+    public override bool CanConvert(Type objectType)
+    {
+        if (objectType.IsGenericType == false)
+            return false;
+
+        return objectType.GetGenericTypeDefinition() == typeof(RavenVector<>);
+    }
+}

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/NewtonsoftJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/NewtonsoftJsonSerializationConventions.cs
@@ -201,6 +201,7 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson
             jsonSerializer.Converters.Add(DateOnlyConverter.Instance);
             jsonSerializer.Converters.Add(TimeOnlyConverter.Instance);
 #endif
+            jsonSerializer.Converters.Add(VectorConverter.Instance);
 
             jsonSerializer.Converters.Add(_jsonEnumerableConverter);
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -657,7 +657,9 @@ public static class CoraxQueryBuilder
         }
         else if (value is BlittableJsonReaderObject json)
         {
-            json.TryGetMember(Sparrow.Global.Constants.Naming.VectorPropertyName, out var vectorObject);
+            var vectorObjectFound = json.TryGetMember(Sparrow.Global.Constants.Naming.VectorPropertyName, out var vectorObject);
+            PortableExceptions.ThrowIfNot<InvalidDataException>(vectorObjectFound, "Cannot find vector property in the object.");
+            
             var vectorReader = (BlittableJsonReaderVector)vectorObject;
             var bytesUsed = vectorReader.Length * vectorReader.ElementSize;
             var memoryScope = builderParameters.Allocator.Allocate(bytesUsed, out Memory<byte> vectorBytes);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -655,6 +655,16 @@ public static class CoraxQueryBuilder
         {
             transformedEmbedding = GenerateEmbeddings.FromBase64Array(vectorOptions, allocator: builderParameters.Allocator, stringSegment.ToString());
         }
+        else if (value is BlittableJsonReaderObject json)
+        {
+            json.TryGetMember(Sparrow.Global.Constants.Naming.VectorPropertyName, out var vectorObject);
+            var vectorReader = (BlittableJsonReaderVector)vectorObject;
+            var bytesUsed = vectorReader.Length * vectorReader.ElementSize;
+            var memoryScope = builderParameters.Allocator.Allocate(bytesUsed, out Memory<byte> vectorBytes);
+            
+            vectorReader.ReadUnderlyingMemory().CopyTo(vectorBytes.Span);
+            transformedEmbedding = GenerateEmbeddings.FromArray(builderParameters.Allocator, memoryScope, vectorBytes, vectorOptions, bytesUsed);
+        }
         else
         {
             var underlyingEnumerable = (BlittableJsonReaderArray)value;

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -426,8 +426,9 @@ namespace Raven.Server.Documents.Indexes.Static
                 return HandleBlittableJsonReaderArray(bjra);
             }
 
-            if (value is BlittableJsonReaderObject bjro)
+            if (value is BlittableJsonReaderObject or DynamicBlittableJson)
             {
+                var bjro = value as BlittableJsonReaderObject ?? ((DynamicBlittableJson)value).BlittableJson;
                 if (bjro.TryGetMember(Sparrow.Global.Constants.Naming.VectorPropertyName, out var vector) && vector is BlittableJsonReaderVector bjrv)
                 {
                     return HandleBlittableJsonReaderVector(bjrv);

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -428,7 +428,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
             if (value is BlittableJsonReaderObject bjro)
             {
-                if (bjro.TryGetMember("@vector", out var vector) && vector is BlittableJsonReaderVector bjrv)
+                if (bjro.TryGetMember(Sparrow.Global.Constants.Naming.VectorPropertyName, out var vector) && vector is BlittableJsonReaderVector bjrv)
                 {
                     return HandleBlittableJsonReaderVector(bjrv);
                 }

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -426,6 +426,16 @@ namespace Raven.Server.Documents.Indexes.Static
                 return HandleBlittableJsonReaderArray(bjra);
             }
 
+            if (value is BlittableJsonReaderObject bjro)
+            {
+                if (bjro.TryGetMember("@vector", out var vector) && vector is BlittableJsonReaderVector bjrv)
+                {
+                    return HandleBlittableJsonReaderVector(bjrv);
+                }
+
+                throw new ArgumentException($"Expected BlittableJsonReaderVector, but got {value.GetType().FullName}");
+            }
+
             if (value is JsArray js)
                 return HandleJsArray(js);
 
@@ -438,13 +448,14 @@ namespace Raven.Server.Documents.Indexes.Static
             }
             object HandleBlittableJsonReaderArray(BlittableJsonReaderArray data)
             {
+                var dataLength = data.Length;
                 var first = data[0];
                 
                 //Array of base64s
                 if (IsBase64(first))
                 {
-                    var values = new object[data.Length];
-                    for (var i = 0; i < data.Length; i++)
+                    var values = new object[dataLength];
+                    for (var i = 0; i < dataLength; i++)
                         values[i] = Base64ToVector(data[i].ToString());
 
                     return values;
@@ -453,15 +464,14 @@ namespace Raven.Server.Documents.Indexes.Static
                 //Array of arrays
                 if (first is BlittableJsonReaderArray)
                 {
-                    var values = new object[data.Length];
-                    for (var i = 0; i < data.Length; i++)
+                    var values = new object[dataLength];
+                    for (var i = 0; i < dataLength; i++)
                         values[i] = HandleBlittableJsonReaderArray((BlittableJsonReaderArray)data[i]);
 
                     return values;
                 }
-
-                var len = data.Length;
-                var bufferSize = data.Length * (vectorOptions.SourceEmbeddingType) switch
+                
+                var bufferSize = dataLength * (vectorOptions.SourceEmbeddingType) switch
                 {
                     VectorEmbeddingType.Single => sizeof(float),
                     _ => sizeof(byte)
@@ -472,7 +482,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 ref var sbyteRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, sbyte>(mem.Span));
                 ref var byteRef = ref MemoryMarshal.GetReference(mem.Span);
                 
-                for (int i = 0; i < len; ++i)
+                for (int i = 0; i < dataLength; ++i)
                 {
                     switch (vectorOptions.SourceEmbeddingType)
                     {
@@ -488,6 +498,37 @@ namespace Raven.Server.Documents.Indexes.Static
                     }
                 }
 
+                return GenerateEmbeddings.FromArray(allocator, memScope, mem, vectorOptions, bufferSize);
+            }
+
+            object HandleBlittableJsonReaderVector(BlittableJsonReaderVector bjrv)
+            {
+                var type = bjrv[0].GetType();
+
+                if (type == typeof(float))
+                    return HandleBjrvInternal(bjrv.ReadArray<float>());
+                if (type == typeof(double))
+                    return HandleBjrvInternal(bjrv.ReadArray<double>());
+                if (type == typeof(byte))
+                    return HandleBjrvInternal(bjrv.ReadArray<byte>());
+                if (type == typeof(sbyte))
+                    return HandleBjrvInternal(bjrv.ReadArray<sbyte>());
+                
+                throw new NotSupportedException($"Embeddings of type {type.FullName} are not supported.");
+            }
+
+            object HandleBjrvInternal<T>(ReadOnlySpan<T> embedding) where T : unmanaged
+            {
+                var bufferSize = embedding.Length * (vectorOptions.SourceEmbeddingType) switch
+                {
+                    VectorEmbeddingType.Single => sizeof(float),
+                    _ => sizeof(byte)
+                };
+                
+                var memScope = allocator.Allocate(bufferSize, out Memory<byte> mem);
+                
+                MemoryMarshal.Cast<T, byte>(embedding).CopyTo(mem.Span);
+                
                 return GenerateEmbeddings.FromArray(allocator, memScope, mem, vectorOptions, bufferSize);
             }
 

--- a/src/Raven.Server/Documents/Queries/MoreLikeThis/MoreLikeThisBase.cs
+++ b/src/Raven.Server/Documents/Queries/MoreLikeThis/MoreLikeThisBase.cs
@@ -391,7 +391,7 @@ namespace Raven.Server.Documents.Queries.MoreLikeThis
                    !token.HasFlag(BlittableJsonToken.String) &&
                    !token.HasFlag(BlittableJsonToken.Boolean) &&
                    !token.HasFlag(BlittableJsonToken.EmbeddedBlittable) &&
-                   !token.HasFlag(BlittableJsonToken.Reserved2) &&
+                   !token.HasFlag(BlittableJsonToken.Reserved3) &&
                    !token.HasFlag(BlittableJsonToken.Reserved4) &&
                    !token.HasFlag(BlittableJsonToken.Reserved6);
         }

--- a/src/Sparrow/Collections/FastList.cs
+++ b/src/Sparrow/Collections/FastList.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
@@ -8,10 +9,10 @@ namespace Sparrow.Collections
 {
     public sealed class FastList<T> : IList<T>
     {
-        private uint _version = 0;
-        private uint _size = 0;
+        private uint _version;
+        private uint _size;
 
-        private static readonly T[] EmptyArray = new T[0];
+        private static readonly T[] EmptyArray = Array.Empty<T>();
 
         private T[] _items;
 
@@ -112,14 +113,13 @@ namespace Sparrow.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Add(T item)
         {
-            if (_size == _items.Length)
-                goto Unlikely;
+            if (_size != _items.Length)
+            {
+                _items[_size++] = item;
+                _version++;
+                return;
+            }
 
-            _items[_size++] = item;
-            _version++;
-            return;
-
-            Unlikely:
             AddUnlikely(item, (int)_size + 1);
         }
 
@@ -127,14 +127,13 @@ namespace Sparrow.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AddByRef(in T item)
         {
-            if (_size == _items.Length)
-                goto Unlikely;
+            if (_size != _items.Length)
+            {
+                _items[_size++] = item;
+                _version++;
+                return;
+            }
 
-            _items[_size++] = item;
-            _version++;
-            return;
-
-            Unlikely:
             AddUnlikely(item, (int)_size + 1);
         }
 
@@ -145,7 +144,7 @@ namespace Sparrow.Collections
                 dest.Capacity = size;
 
             dest._size = (uint)size;
-            Array.Copy( _items, dest._items, size);
+            Array.Copy(_items, dest._items, size);
             dest._version++;
         }
 
@@ -181,26 +180,33 @@ namespace Sparrow.Collections
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        /// <summary>
+        /// Removes all objects from the Stack but clearing the backing array unless the type is native.
+        /// </summary>
         public void Clear()
         {
-            // PERF: We are using this to avoid the Array.Clear cost when using structs. 
-            //       When RuntimeHelpers.IsReferenceOrContainsReferences<T>() becomes available, we can use Clear instead. 
             if (typeof(T) == typeof(int) || typeof(T) == typeof(uint) || typeof(T) == typeof(byte) ||
-                typeof(T) == typeof(short) || typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
+                typeof(T) == typeof(short) || typeof(T) == typeof(long) || typeof(T) == typeof(ulong) ||
+                typeof(T) == typeof(nint) || typeof(T) == typeof(IntPtr))
             {
                 _size = 0;
                 _version++;
-            }
-            else
-            {
-                int size = (int)_size;
 
-                _size = 0;
-                _version++;
-                if (size > 0)
-                    Array.Clear(_items, 0, size); // Clear the elements so that the gc can reclaim the references.
+                return;
             }
+
+            int size = (int)_size;
+
+            _size = 0;
+            _version++;
+
+#if NET6_0_OR_GREATER
+            // PERF: We are using this to avoid the Array.Clear cost when using structs. 
+            if (size <= 0 || RuntimeHelpers.IsReferenceOrContainsReferences<T>() == false)
+                return;
+#endif
+
+            Array.Clear(_items, 0, size); // Clear the elements so that the gc can reclaim the references.
         }
 
         public void Trim(int size)
@@ -262,7 +268,7 @@ namespace Sparrow.Collections
         {
             throw new NotSupportedException();
         }
-    
+
         public bool Remove(T item)
         {
             int index = IndexOf(item);
@@ -292,37 +298,34 @@ namespace Sparrow.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RemoveAt(int index)
         {
-            if ((uint) index >= _size)
-                goto ERROR;
+            if ((uint)index >= _size)
+                ThrowWhenIndexIsOutOfRange(index);
 
             _size--;
             _version++;
 
             if (index < _size)
                 Array.Copy(_items, index + 1, _items, index, (int)_size - index);
-            return;
-
-            ERROR:
-            ThrowWhenIndexIsOutOfRange(index);
         }
 
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
         public void ThrowWhenIndexIsOutOfRange(int index)
         {
             throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         // Removes a range of elements from this list.
-        // 
         public void RemoveRange(int index, int count)
         {
-            uint uindex = (uint)index;
-            if (uindex >= _size || (int)_size - index < count)
-                goto ERROR;
+            if ((uint)index >= _size || (int)_size - index < count)
+                ThrowWhenIndexIsOutOfRange(index);
 
             if (count <= 0)
                 return;
 
-            _size -= (uint) count;
+            _size -= (uint)count;
             if (index < _size)
             {
                 Array.Copy(_items, index + count, _items, index, (int)_size - index);
@@ -330,16 +333,17 @@ namespace Sparrow.Collections
 
             _version++;
 
-            if (typeof(T) != typeof(int) && typeof(T) != typeof(uint) && typeof(T) != typeof(byte) &&
-                typeof(T) != typeof(short) && typeof(T) != typeof(long) && typeof(T) != typeof(ulong))
-            {
-                Array.Clear(_items, (int) _size, count);
-            }
+            if (typeof(T) == typeof(int) || typeof(T) == typeof(uint) || typeof(T) == typeof(byte) ||
+                typeof(T) == typeof(short) || typeof(T) == typeof(long) || typeof(T) == typeof(ulong) ||
+                typeof(T) == typeof(nint) || typeof(T) == typeof(nuint) || typeof(T) == typeof(IntPtr))
+                return;
 
-            return;            
+#if NET6_0_OR_GREATER
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>() == false)
+                return;
+#endif
 
-            ERROR:
-            ThrowWhenIndexIsOutOfRange(index);
+            Array.Clear(_items, (int)_size, count);
         }
 
         public Span<T> AsUnsafeSpan()
@@ -360,13 +364,13 @@ namespace Sparrow.Collections
         IEnumerator<T> IEnumerable<T>.GetEnumerator()
         {
             return new Enumerator(this);
-        }        
+        }
 
         public struct Enumerator : IEnumerator<T>
         {
             private readonly FastList<T> _list;
             private readonly uint _version;
-            private uint _index;            
+            private uint _index;
             private T _current;
 
             internal Enumerator(FastList<T> list)
@@ -406,7 +410,7 @@ namespace Sparrow.Collections
 
             public T Current => _current;
 
-            Object IEnumerator.Current
+            object IEnumerator.Current
             {
                 get
                 {

--- a/src/Sparrow/Constants.cs
+++ b/src/Sparrow/Constants.cs
@@ -60,6 +60,7 @@ namespace Sparrow.Global
         internal static class Naming
         {
             public const string VectorPropertyName = "@vector";
+            
             public static ReadOnlySpan<byte> VectorPropertyNameAsSpan => "@vector"u8;
         }
     }

--- a/src/Sparrow/Constants.cs
+++ b/src/Sparrow/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace Sparrow.Global
+﻿using System;
+
+namespace Sparrow.Global
 {
     internal static class Constants
     {
@@ -53,6 +55,12 @@
 
                 internal const string DefaultAuditRuleName = "Raven_Default_Audit";
             }
+        }
+
+        internal static class Naming
+        {
+            public const string VectorPropertyName = "@vector";
+            public static ReadOnlySpan<byte> VectorPropertyNameAsSpan => "@vector"u8;
         }
     }
 }

--- a/src/Sparrow/DisposableExceptions.cs
+++ b/src/Sparrow/DisposableExceptions.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Diagnostics;
+
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+#endif
+
+namespace Sparrow;
+
+internal static class DisposableExceptions
+{
+    [Conditional("DEBUG")]
+    public static void ThrowIfDisposedOnDebug<T>(
+        T disposable, string message = "The object has already been disposed.",
+#if NET6_0_OR_GREATER
+        [CallerArgumentExpression(nameof(disposable))]
+#endif
+        string paramName = null) where T : IDisposableQueryable
+    {
+        ThrowIfDisposed(disposable, message, paramName);
+    }
+
+
+    public static void ThrowIfDisposed<T>(
+        T disposable, string message = "The object has already been disposed.",
+#if NET6_0_OR_GREATER        
+        [CallerArgumentExpression(nameof(disposable))]
+#endif
+        string paramName = null) where T : IDisposableQueryable
+    {
+        if (disposable?.IsDisposed ?? false)
+        {
+#if !NET6_0_OR_GREATER
+            paramName ??= disposable.GetType().Name;
+#endif
+            Throw(paramName, message);
+        }
+    }
+
+#if NET6_0_OR_GREATER
+    [DoesNotReturn]
+#endif
+    public static void Throw<T>(
+        T disposable, string message = "The object has already been disposed.",
+#if NET6_0_OR_GREATER
+        [CallerArgumentExpression(nameof(disposable))]
+#endif
+        string paramName = null) where T : IDisposableQueryable
+    {
+#if !NET6_0_OR_GREATER
+        paramName ??= disposable.GetType().Name;
+#endif
+        Throw(paramName, message);
+    }
+
+#if NET6_0_OR_GREATER
+    [DoesNotReturn]
+#endif
+    private static void Throw(string paramName, string message) => throw new ObjectDisposedException(paramName, message);
+}

--- a/src/Sparrow/DisposableExceptions.cs
+++ b/src/Sparrow/DisposableExceptions.cs
@@ -21,7 +21,6 @@ internal static class DisposableExceptions
         ThrowIfDisposed(disposable, message, paramName);
     }
 
-
     public static void ThrowIfDisposed<T>(
         T disposable, string message = "The object has already been disposed.",
 #if NET6_0_OR_GREATER        

--- a/src/Sparrow/IDisposableQueryable.cs
+++ b/src/Sparrow/IDisposableQueryable.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Sparrow
+{
+    internal interface IDisposableQueryable
+    {
+        bool IsDisposed { get; }
+    }
+}

--- a/src/Sparrow/IDisposableQueryable.cs
+++ b/src/Sparrow/IDisposableQueryable.cs
@@ -2,7 +2,7 @@
 
 namespace Sparrow
 {
-    internal interface IDisposableQueryable
+    public interface IDisposableQueryable
     {
         bool IsDisposed { get; }
     }

--- a/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Sparrow.Collections;
@@ -67,44 +67,44 @@ namespace Sparrow.Json
                 throw new ObjectDisposedException(GetType().Name);
         }
 
-        protected struct BuildingState
+        protected struct BuildingState(ContinuationState state, bool partialRead = false)
         {
-            public ContinuationState State;
+            public ContinuationState State = state;
             public int MaxPropertyId;
             public CachedProperties.PropertyName CurrentProperty;
             public FastList<PropertyTag> Properties;
             public FastList<BlittableJsonToken> Types;
             public FastList<int> Positions;
             public long FirstWrite;
-            internal bool PartialRead;
 
-            public BuildingState(ContinuationState state)
-            {
-                State = state;
-                MaxPropertyId = 0;
-                CurrentProperty = null;
-                Properties = null;
-                Types = null;
-                Positions = null;
-                FirstWrite = 0;
-                PartialRead = false;
-            }
+            internal bool PartialRead = partialRead;
         }
 
-        protected enum ContinuationState
+        protected const int AllowedAllStates = 0xFF;
+        protected const int DisallowBufferedStates = 0x7F;
+        protected const int Buffered = 0x80;
+
+        protected enum ContinuationState : int
         {
-            ReadPropertyName,
-            ReadPropertyValue,
-            ReadArray,
-            ReadArrayValue,
-            ReadObject,
-            ReadValue,
-            CompleteReadingPropertyValue,
-            ReadObjectDocument,
-            ReadArrayDocument,
-            CompleteDocumentArray,
-            CompleteArray,
-            CompleteArrayValue
+            ReadObject = 0x01,
+            ReadArray = 0x02,
+            ReadObjectDocument = 0x03,
+            ReadArrayDocument = 0x04,
+            ReadPropertyName = 0x05,
+            ReadPropertyValue = 0x06,
+            CompleteDocumentArray = 0x07,
+            CompleteReadingPropertyValue = 0x08,
+
+            ReadArrayValue = 0x09,
+            ReadValue = 0x0A,
+            CompleteArray = 0x0B,
+            CompleteArrayValue = 0x0C,
+
+            // Support for vector type.
+            ReadBufferedArrayValue = ReadArrayValue | Buffered,
+            ReadBufferedValue = ReadValue | Buffered,
+            CompleteBufferedArray = CompleteArray | Buffered,
+            CompleteBufferedArrayValue = CompleteArrayValue | Buffered,
         }
 
         public struct PropertyTag

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -197,9 +197,119 @@ namespace Sparrow.Json
                     WriteRawString(blob.Address, blob.Length);
                     break;
 
+                case BlittableJsonToken.Vector:
+                    WriteVectorToStream((BlittableJsonReaderVector)val);
+                    break;
+                
                 default:
                     throw new DataMisalignedException($"Unidentified Type {token}");
             }
+        }
+
+        private void WriteVectorToStream(BlittableJsonReaderVector vectorReader)
+        {
+
+            void WriteValues<T>(ReadOnlySpan<T> values) 
+                where T : unmanaged
+            {
+                for (var i = 0; i < values.Length; i++)
+                {
+                    if (i != 0)
+                    {
+                        WriteComma();
+                    }
+
+                    if (typeof(T) == typeof(float))
+                    {
+                        WriteDouble((float)(object)values[i]);
+                    }
+                    else if (typeof(T) == typeof(double))
+                    {
+                        WriteDouble((double)(object)values[i]);
+                    }
+#if NET6_0_OR_GREATER
+                    else if (typeof(T) == typeof(Half))
+                    {
+                        WriteDouble((double)(object)values[i]);
+                    }
+#endif
+                    else if (typeof(T) == typeof(sbyte))
+                    {
+                        WriteInteger((sbyte)(object)values[i]);
+                    }
+                    else if (typeof(T) == typeof(byte))
+                    {
+                        WriteInteger((byte)(object)values[i]);
+                    }
+                    else if (typeof(T) == typeof(short))
+                    {
+                        WriteInteger((short)(object)values[i]);
+                    }
+                    else if (typeof(T) == typeof(int))
+                    {
+                        WriteInteger((int)(object)values[i]);
+                    }
+                    else if (typeof(T) == typeof(ushort))
+                    {
+                        WriteInteger((ushort)(object)values[i]);
+                    }
+                    else if (typeof(T) == typeof(uint))
+                    {
+                        WriteInteger((uint)(object)values[i]);
+                    }
+                    else if (typeof(T) == typeof(ulong))
+                    {
+                        WriteInteger((ulong)(object)values[i]);
+                    }
+                    else
+                    {
+                        WriteInteger((long)(object)values[i]);
+                    }
+                }
+            }
+
+
+            WriteStartArray();
+
+            switch (vectorReader.Type)
+            {
+                case BlittableVectorType.SByte:
+                    WriteValues(vectorReader.ReadArray<sbyte>());
+                    break;
+                case BlittableVectorType.Int16:
+                    WriteValues(vectorReader.ReadArray<short>());
+                    break;
+                case BlittableVectorType.Int32:
+                    WriteValues(vectorReader.ReadArray<int>());
+                    break;
+                case BlittableVectorType.Int64:
+                    WriteValues(vectorReader.ReadArray<long>());
+                    break;
+                case BlittableVectorType.Byte:
+                    WriteValues(vectorReader.ReadArray<byte>());
+                    break;
+                case BlittableVectorType.UInt16:
+                    WriteValues(vectorReader.ReadArray<ushort>());
+                    break;
+                case BlittableVectorType.UInt32:
+                    WriteValues(vectorReader.ReadArray<uint>());
+                    break;
+                case BlittableVectorType.UInt64:
+                    WriteValues(vectorReader.ReadArray<ulong>());
+                    break;
+#if NET6_0_OR_GREATER
+                case BlittableVectorType.Half:
+                    WriteValues(vectorReader.ReadArray<Half>()); break;
+#endif
+                case BlittableVectorType.Float:
+                    WriteValues(vectorReader.ReadArray<float>());
+                    break;
+                case BlittableVectorType.Double:
+                    WriteValues(vectorReader.ReadArray<double>());
+                    break;
+            }
+
+            WriteEndArray();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -767,6 +767,40 @@ namespace Sparrow.Json
             _pos = auxPos;
         }
 
+        public void WriteInteger(ulong val)
+        {
+            if (val == 0)
+            {
+                EnsureBuffer(1);
+                Unsafe.WriteUnaligned(_buffer + _pos, (byte)'0');
+                _pos++;
+
+                return;
+            }
+
+            var localBuffer = stackalloc byte[32];
+
+            int idx = 0;
+
+            do
+            {
+                var v = val % 10;
+                localBuffer[idx++] = (byte)('0' + v);
+                val /= 10;
+            } while (val != 0);
+
+            EnsureBuffer(idx);
+
+            var buffer = _buffer;
+            int auxPos = _pos;
+
+            do
+                buffer[auxPos++] = localBuffer[--idx];
+            while (idx > 0);
+
+            _pos = auxPos;
+        }
+        
         public void WriteDouble(LazyNumberValue val)
         {
             if (val.IsNaN())

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -371,11 +371,12 @@ namespace Sparrow.Json
 
                                     _state.AddBuffered(decimal.ToDouble(value));
                                 }
-#else
-                                throw new NotSupportedException("Vector representations are only supported for .Net versions greater than 6.0");
-#endif
                                 processed = true;
                                 break;
+
+#else
+                                throw new NotSupportedException("Vector representations are only supported for .NET versions greater than 7.0");
+#endif
                         }
 
                         if (processed)

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -16,7 +16,7 @@ namespace Sparrow.Json
         private readonly JsonOperationContext _context;
         private UsageMode _mode;
         private readonly IJsonParser _reader;
-        private bool _isVector;
+
         public IBlittableDocumentModifier _modifier;
         private readonly BlittableWriter<UnmanagedWriteBuffer> _writer;
         private readonly JsonParserState _state;
@@ -26,6 +26,8 @@ namespace Sparrow.Json
 
         private WriteToken _writeToken;
         private string _debugTag;
+
+        private bool _isVectorProperty;
 
         public BlittableJsonDocumentBuilder(JsonOperationContext context, JsonParserState state, IJsonParser reader,
             BlittableWriter<UnmanagedWriteBuffer> writer = null,
@@ -203,13 +205,13 @@ namespace Sparrow.Json
                         currentState.Positions = _positionsCache.Allocate();
 
                         // todo check property name here instead in ReadPropertyName
-                        if (_isVector == false)
+                        if (_isVectorProperty == false)
                         {
                             currentState.State = ContinuationState.ReadArrayValue;
                             goto case ContinuationState.ReadArrayValue;
                         }
 
-                        _isVector = false;
+                        _isVectorProperty = false;
                         currentState.State = ContinuationState.ReadBufferedArrayValue;
                         goto case ContinuationState.ReadBufferedArrayValue;
 
@@ -273,7 +275,7 @@ namespace Sparrow.Json
                         currentState.CurrentProperty = _context.CachedProperties.GetProperty(property);
 
                         if (currentState.CurrentProperty.Comparer.ToString() == "@vector")
-                            _isVector = true;
+                            _isVectorProperty = true;
 
                         currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
                         currentState.State = ContinuationState.ReadPropertyValue;

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -203,8 +203,7 @@ namespace Sparrow.Json
 
                         currentState.Types = _tokensCache.Allocate();
                         currentState.Positions = _positionsCache.Allocate();
-
-                        // todo check property name here instead in ReadPropertyName
+                        
                         if (_isVectorProperty == false)
                         {
                             currentState.State = ContinuationState.ReadArrayValue;

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -273,7 +273,7 @@ namespace Sparrow.Json
                         var property = CreateLazyStringValueFromParserState();
                         currentState.CurrentProperty = _context.CachedProperties.GetProperty(property);
 
-                        if (currentState.CurrentProperty.Comparer.ToString() == "@vector")
+                        if (currentState.CurrentProperty.ComparePropertyNameToBytes(Global.Constants.Naming.VectorPropertyNameAsSpan) == 0)
                             _isVectorProperty = true;
 
                         currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);

--- a/src/Sparrow/Json/BlittableJsonReaderBase.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderBase.cs
@@ -90,12 +90,13 @@ namespace Sparrow.Json
                 BlittableJsonToken.StartArray |
                 BlittableJsonToken.StartObject |
                 BlittableJsonToken.String |
-                BlittableJsonToken.CompressedString;
+                BlittableJsonToken.CompressedString | 
+                BlittableJsonToken.Vector;
         
         public static BlittableJsonToken ProcessTokenTypeFlags(BlittableJsonToken currentType)
         {
             var token = currentType & TypesMask;
-            if (token is >= BlittableJsonToken.StartObject and <= BlittableJsonToken.RawBlob)
+            if (token is >= BlittableJsonToken.StartObject and < BlittableJsonToken.Reserved3)
                 return currentType & TypesMask;
 
             ThrowInvalidType(currentType);

--- a/src/Sparrow/Json/BlittableJsonReaderVector.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderVector.cs
@@ -1,0 +1,338 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Sparrow.Json.Parsing;
+using static Sparrow.PortableExceptions;
+
+namespace Sparrow.Json
+{
+    public enum BlittableVectorType : byte
+    {
+        SByte = 0b0000_0001,  // 1 byte
+        Int16 = 0b0000_0010,  // 2 bytes
+        Int32 = 0b0000_0100,  // 4 bytes
+        Int64 = 0b0000_1000,  // 8 bytes
+
+        Byte = 0b1000_0001,  // 1 byte
+        UInt16 = 0b1000_0010,  // 2 bytes
+        UInt32 = 0b1000_0100,  // 4 bytes
+        UInt64 = 0b1000_1000,  // 8 bytes
+        
+        Half =   0b1100_0010, // 2 bytes
+        Float =  0b1100_0100, // 4 bytes
+        Double = 0b1100_1000, // 8 bytes
+    }
+
+
+    [StructLayout(LayoutKind.Explicit, Size = 8)]
+    internal struct BlittableVectorHeader
+    {
+        private const byte TypeMask = 0b0011_1111;
+        private const byte FloatFlag = 0b0100_0000;
+        private const byte UnsignedFlag = 0b1000_0000;
+
+        [FieldOffset(0)]
+        private BlittableVectorType _type;
+
+        [FieldOffset(1)]
+        public byte AlignmentOffset;
+
+        [FieldOffset(2)]
+        public int Count;
+
+        public BlittableVectorHeader(BlittableVectorType type, int count)
+        {
+            _type = type;
+            Count = count;
+        }
+
+        public BlittableVectorType Type => _type;
+
+        public bool IsFloatingPoint => (BlittableVectorType)((byte)_type & FloatFlag) != 0;
+
+        public bool IsUnsigned => (BlittableVectorType)((byte)_type & UnsignedFlag) != 0;
+
+        public int ElementSize => ((byte)Type) & TypeMask;
+        
+        
+    }
+    
+    public sealed unsafe class BlittableJsonReaderVector : BlittableJsonReaderBase, IEnumerable
+    {
+        private readonly BlittableVectorHeader* _header;
+        private readonly byte* _dataStart;
+
+        public int Length => _header->Count;
+
+        public BlittableVectorType Type => _header->Type;
+
+        public BlittableJsonReaderVector(byte* mem, int bufferSize, JsonOperationContext context)
+            : base(context)
+        {
+            //otherwise SetupPropertiesAccess will throw because of the memory garbage
+            //(or won't throw, but this is actually worse!)
+            ThrowIf<ArgumentException>(bufferSize == 0, $"{nameof(BlittableJsonReaderObject)} does not support objects with zero size");
+
+            _mem = mem;
+            _header = (BlittableVectorHeader*)mem; // +1 to skip the token byte
+            _dataStart = mem + sizeof(BlittableVectorHeader) + _header->AlignmentOffset;
+        }
+
+        public object this[int i]
+        {
+            get
+            {
+                switch (_header->Type)
+                {
+                    case BlittableVectorType.SByte:
+                        return *((sbyte*)_dataStart + i);
+                    case BlittableVectorType.Int16:
+                        return *((short*)_dataStart + i);
+                    case BlittableVectorType.Int32:
+                        return *((int*)_dataStart + i);
+                    case BlittableVectorType.Int64:
+                        return *((long*)_dataStart + i);
+                    case BlittableVectorType.Byte:
+                        return *((byte*)_dataStart + i);
+                    case BlittableVectorType.UInt16:
+                        return *((ushort*)_dataStart + i);
+                    case BlittableVectorType.UInt32:
+                        return *((uint*)_dataStart + i);
+                    case BlittableVectorType.UInt64:
+                        return *((ulong*)_dataStart + i);
+#if NET6_0_OR_GREATER
+                    case BlittableVectorType.Half:
+                        return *((Half*)_dataStart + i);
+#endif
+                    case BlittableVectorType.Float:
+                        return *((float*)_dataStart + i);
+                    case BlittableVectorType.Double:
+                        return *((double*)_dataStart + i);
+                }
+
+                throw new InvalidOperationException($"Vector is not of any known type {_header->Type}");
+            }
+        }
+
+        public bool IsOfType<T>()
+        {
+            var type = typeof(T);
+            switch (_header->Type)
+            {
+                case BlittableVectorType.SByte:
+                    return type == typeof(sbyte);
+                case BlittableVectorType.Int16:
+                    return type == typeof(short);
+                case BlittableVectorType.Int32:
+                    return type == typeof(int);
+                case BlittableVectorType.Int64:
+                    return type == typeof(long);
+                case BlittableVectorType.Byte:
+                    return type == typeof(byte);
+                case BlittableVectorType.UInt16:
+                    return type == typeof(ushort);
+                case BlittableVectorType.UInt32:
+                    return type == typeof(uint);
+                case BlittableVectorType.UInt64:
+                    return type == typeof(ulong);
+#if NET6_0_OR_GREATER
+                case BlittableVectorType.Half:
+                    return type == typeof(Half);
+#endif
+                case BlittableVectorType.Float:
+                    return type == typeof(float);
+                case BlittableVectorType.Double:
+                    return type == typeof(double);
+                default:
+                    return false;
+            }
+        }
+
+        public ReadOnlySpan<T> ReadArray<T>()
+            where T : unmanaged
+        {
+            if (!IsOfType<T>())
+                throw new InvalidOperationException($"Vector is not of type {typeof(T).Name}");
+
+            return new ReadOnlySpan<T>(_dataStart, _header->Count);
+        }
+
+        private struct EnumerateAsLong<T> : IEnumerator<long> where T : unmanaged
+        {
+            private readonly byte* _dataStart;
+            private readonly int _dataLength;
+            private int _position;
+
+            public EnumerateAsLong(byte* dataStart, int dataLength)
+            {
+                _dataStart = dataStart;
+                _dataLength = dataLength;
+            }
+
+            public bool MoveNext()
+            {
+                _position++;
+                return _position < _dataLength;
+            }
+
+            public void Reset()
+            {
+                _position = 0;
+            }
+
+            public long Current
+            {
+                get
+                {
+                    if (typeof(T) == typeof(sbyte))
+                        return *((sbyte*)_dataStart + _position);
+                    if (typeof(T) == typeof(byte))
+                        return *((byte*)_dataStart + _position);
+
+                    if (typeof(T) == typeof(short))
+                        return *((short*)_dataStart + _position);
+                    if (typeof(T) == typeof(ushort))
+                        return *((ushort*)_dataStart + _position);
+
+                    if (typeof(T) == typeof(int))
+                        return *((int*)_dataStart + _position);
+                    if (typeof(T) == typeof(uint))
+                        return *((uint*)_dataStart + _position);
+
+                    if (typeof(T) == typeof(ulong))
+                        return (long)*((ulong*)_dataStart + _position);
+
+                    return *((long*)_dataStart + _position);
+                }
+            }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() { }
+        }
+
+        private struct EnumerateAsULong<T> : IEnumerator<ulong> where T : unmanaged
+        {
+            private readonly byte* _dataStart;
+            private readonly int _dataLength;
+            private int _position;
+
+            public EnumerateAsULong(byte* dataStart, int dataLength)
+            {
+                _dataStart = dataStart;
+                _dataLength = dataLength;
+            }
+
+            public bool MoveNext()
+            {
+                _position++;
+                return _position < _dataLength;
+            }
+
+            public void Reset()
+            {
+                _position = 0;
+            }
+
+            public ulong Current
+            {
+                get
+                {
+                    if (typeof(T) == typeof(byte))
+                        return *((byte*)_dataStart + _position);
+                    if (typeof(T) == typeof(ushort))
+                        return *((ushort*)_dataStart + _position);
+                    if (typeof(T) == typeof(uint))
+                        return *((uint*)_dataStart + _position);
+
+                    return *((ulong*)_dataStart + _position);
+                }
+            }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() { }
+        }
+
+        private struct EnumerateAsDouble<T> : IEnumerator<double> where T : unmanaged
+        {
+            private readonly byte* _dataStart;
+            private readonly int _dataLength;
+            private int _position;
+
+            public EnumerateAsDouble(byte* dataStart, int dataLength)
+            {
+                _dataStart = dataStart;
+                _dataLength = dataLength;
+            }
+
+            public bool MoveNext()
+            {
+                _position++;
+                return _position < _dataLength;
+            }
+
+            public void Reset()
+            {
+                _position = 0;
+            }
+
+            public double Current
+            {
+                get
+                {
+#if NET6_0_OR_GREATER                    
+                    if (typeof(T) == typeof(Half))
+                        return (double)*((Half*)_dataStart + _position);
+#endif
+                    if (typeof(T) == typeof(float))
+                        return *((float*)_dataStart + _position);
+                    return *((double*)_dataStart + _position);
+                }
+            }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() { }
+        }
+
+        public IEnumerator GetEnumerator()
+        {
+            switch (_header->Type)
+            {
+                case BlittableVectorType.SByte:
+                    return new EnumerateAsLong<sbyte>(_dataStart, _header->Count);
+                case BlittableVectorType.Int16:
+                    return new EnumerateAsLong<short>(_dataStart, _header->Count);
+                case BlittableVectorType.Int32:
+                    return new EnumerateAsLong<int>(_dataStart, _header->Count);
+                case BlittableVectorType.Int64:
+                    return new EnumerateAsLong<long>(_dataStart, _header->Count);
+                case BlittableVectorType.Byte:
+                    return new EnumerateAsLong<byte>(_dataStart, _header->Count);
+                case BlittableVectorType.UInt16:
+                    return new EnumerateAsLong<ushort>(_dataStart, _header->Count);
+                case BlittableVectorType.UInt32:
+                    return new EnumerateAsLong<uint>(_dataStart, _header->Count);
+                case BlittableVectorType.UInt64:
+                    return new EnumerateAsULong<ulong>(_dataStart, _header->Count);
+#if NET6_0_OR_GREATER
+                case BlittableVectorType.Half:
+                    return new EnumerateAsDouble<Half>(_dataStart, _header->Count);
+#endif
+                case BlittableVectorType.Float:
+                    return new EnumerateAsDouble<float>(_dataStart, _header->Count);
+                case BlittableVectorType.Double:
+                    return new EnumerateAsDouble<double>(_dataStart, _header->Count);
+            }
+
+            throw new NotSupportedException("The type is not supported.");
+        }
+    }
+}

--- a/src/Sparrow/Json/BlittableJsonReaderVector.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderVector.cs
@@ -217,7 +217,6 @@ namespace Sparrow.Json
         public struct EnumerableAs<TOut> : IEnumerator<TOut>
             where TOut : unmanaged
         {
-            private readonly BlittableVectorType _type;
             public int Count => _dataLength / _elementSize;
             private int _position = -1;
             private readonly byte* _dataStart;
@@ -408,8 +407,6 @@ namespace Sparrow.Json
                 if (typeof(TOut) == typeof(Half))
                     return (TOut)(object)(Half)Convert.ToSingle(value);
 #endif
-                
-                return (TOut)(object)value;
                 
                 return (TOut)(object)value;
             }

--- a/src/Sparrow/Json/BlittableJsonReaderVector.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderVector.cs
@@ -127,9 +127,9 @@ namespace Sparrow.Json
                 BlittableVectorType.Int16 => type == typeof(short) || type == typeof(ushort),
                 BlittableVectorType.Int32 => type == typeof(int) || type == typeof(uint),
                 BlittableVectorType.Int64 => type == typeof(long) || type == typeof(ulong),
-                BlittableVectorType.UInt16 => type == typeof(ushort) || type == typeof(byte),
-                BlittableVectorType.UInt32 => type == typeof(uint) || type == typeof(byte),
-                BlittableVectorType.UInt64 => type == typeof(ulong) || type == typeof(byte),
+                BlittableVectorType.UInt16 => type == typeof(ushort) || type == typeof(short),
+                BlittableVectorType.UInt32 => type == typeof(uint) || type == typeof(int),
+                BlittableVectorType.UInt64 => type == typeof(ulong) || type == typeof(long),
                 BlittableVectorType.Float => type == typeof(float),
                 BlittableVectorType.Double => type == typeof(double),
                 #if NET6_0_OR_GREATER
@@ -231,6 +231,7 @@ namespace Sparrow.Json
                 _dataLength = dataLength;
                 _elementSize = elementSize;
                 
+                // This might be expensive; however, the method should not be used extensively.
                 _getElement = type switch
                 {
                     BlittableVectorType.SByte => &SbyteConverter,

--- a/src/Sparrow/Json/BlittableJsonReaderVector.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderVector.cs
@@ -69,6 +69,8 @@ namespace Sparrow.Json
         public int Length => _header->Count;
 
         public BlittableVectorType Type => _header->Type;
+
+        public int ElementSize => _header->ElementSize;
         
         public DynamicJsonArray Modifications;
 
@@ -152,6 +154,15 @@ namespace Sparrow.Json
                 default:
                     return false;
             }
+        }
+
+        /// <summary>
+        /// Useful when we've to copy memory without known type. 
+        /// </summary>
+        /// <returns>Span of underlying memory</returns>
+        public ReadOnlySpan<byte> ReadUnderlyingMemory()
+        {
+            return new ReadOnlySpan<byte>(_dataStart, _header->Count * _header->ElementSize);
         }
 
         public ReadOnlySpan<T> ReadArray<T>()

--- a/src/Sparrow/Json/BlittableJsonReaderVector.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderVector.cs
@@ -59,8 +59,6 @@ namespace Sparrow.Json
         public bool IsUnsigned => (BlittableVectorType)((byte)_type & UnsignedFlag) != 0;
 
         public int ElementSize => ((byte)Type) & TypeMask;
-        
-        
     }
     
     public sealed unsafe class BlittableJsonReaderVector : BlittableJsonReaderBase, IEnumerable
@@ -71,6 +69,8 @@ namespace Sparrow.Json
         public int Length => _header->Count;
 
         public BlittableVectorType Type => _header->Type;
+        
+        public DynamicJsonArray Modifications;
 
         public BlittableJsonReaderVector(byte* mem, int bufferSize, JsonOperationContext context)
             : base(context)

--- a/src/Sparrow/Json/BlittableJsonToken.cs
+++ b/src/Sparrow/Json/BlittableJsonToken.cs
@@ -8,34 +8,35 @@ namespace Sparrow.Json
     [Flags]
     public enum BlittableJsonToken : byte
     {
-        StartObject = 1,
-        StartArray = 2,
-        Integer = 3,
-        LazyNumber = 4,
-        String = 5,
-        CompressedString = 6,
-        Boolean = 7,
-        Null = 8,
-        EmbeddedBlittable = 9,
-        RawBlob = 10,
+        StartObject = 0x01,
+        StartArray = 0x02,
+        Integer = 0x03,
+        LazyNumber = 0x04,
+        String = 0x05,
+        CompressedString = 0x06,
+        Boolean = 0x07,
+        Null = 0x08,
+        EmbeddedBlittable = 0x09,
+        RawBlob = 0x0A,
+        Vector = 0x0B,
 
-        Reserved2 = 11,
-        Reserved3 = 12,
-        Reserved4 = 13,
-        Reserved5 = 14,
-        Reserved6 = 15,
+        Reserved3 = 0x0C,
+        Reserved4 = 0x0D,
+        Reserved5 = 0x0E,
+        Reserved6 = 0x0F,
 
         // Position sizes 
-        OffsetSizeByte = 16,
-        OffsetSizeShort = 32,
-        OffsetSizeInt = 48,
+        OffsetSizeByte = 0b0001_0000,
+        OffsetSizeShort = 0b0010_0000,
+        OffsetSizeInt =   0b0011_0000,
 
         // PropertyId sizes
-        PropertyIdSizeByte = 64,
-        PropertyIdSizeShort = 128,
-        PropertyIdSizeInt = 192,
+        PropertyIdSizeByte =  0b0100_0000,
+        PropertyIdSizeShort = 0b1000_0000,
+        PropertyIdSizeInt = 0b1100_0000,
 
-        PositionMask = OffsetSizeByte | OffsetSizeShort | OffsetSizeInt,        
-        PropertyIdMask = PropertyIdSizeByte | PropertyIdSizeShort | PropertyIdSizeInt,
+        TypesMask = OffsetSizeByte - 1, // 0b0000_1111
+        PositionMask = OffsetSizeByte | OffsetSizeShort | OffsetSizeInt, // 0b0011_0000       
+        PropertyIdMask = PropertyIdSizeByte | PropertyIdSizeShort | PropertyIdSizeInt,  // 0b1100_0000    
     }
 }

--- a/src/Sparrow/Json/BlittableWriter.cs
+++ b/src/Sparrow/Json/BlittableWriter.cs
@@ -729,6 +729,11 @@ namespace Sparrow.Json
                     return BlittableVectorType.Float;
                 if (type == typeof(double))
                     return BlittableVectorType.Double;
+#if NET6_0_OR_GREATER
+                if (type == typeof(Half))
+                    return BlittableVectorType.Half;
+#endif
+                
                 throw new NotSupportedException($"Type {type.Name} is not supported in vectors.");
             }
             

--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -107,11 +107,11 @@ namespace Sparrow.Json
                 return Comparer.CompareTo(other.Comparer);
             }
 
-            public int ComparePropertyNameToBytes(ReadOnlySpan<byte> other)
+            public bool EqualsPropertyNameToBytes(ReadOnlySpan<byte> other)
             {
-                return Comparer.AsReadOnlySpan().SequenceCompareTo(other);
+                return Comparer.AsReadOnlySpan().SequenceEqual(other);
             }
-
+            
             public override string ToString()
             {
                 return $"Value: {Comparer}, GlobalSortOrder: {GlobalSortOrder}, PropertyId: {PropertyId}";

--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -107,6 +107,11 @@ namespace Sparrow.Json
                 return Comparer.CompareTo(other.Comparer);
             }
 
+            public int ComparePropertyNameToBytes(ReadOnlySpan<byte> other)
+            {
+                return Comparer.AsReadOnlySpan().SequenceCompareTo(other);
+            }
+
             public override string ToString()
             {
                 return $"Value: {Comparer}, GlobalSortOrder: {GlobalSortOrder}, PropertyId: {PropertyId}";

--- a/src/Sparrow/Json/ManualBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/ManualBlittableJsonDocumentBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Numerics;
 using static Sparrow.Json.BlittableJsonDocumentBuilder;
 
 namespace Sparrow.Json
@@ -283,7 +284,7 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
@@ -351,7 +352,7 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
@@ -368,7 +369,7 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
@@ -385,7 +386,7 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
@@ -402,7 +403,7 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
@@ -419,7 +420,7 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
@@ -436,7 +437,7 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
@@ -453,15 +454,14 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
         public void WriteValue(string value)
         {
             var currentState = _continuationState.Pop();
-            BlittableJsonToken stringToken;
-            var valuePos = _writer.WriteValue(value, out stringToken, _mode);
+            var valuePos = _writer.WriteValue(value, out BlittableJsonToken stringToken, _mode);
             _writeToken = new WriteToken
             {
                 ValuePos = valuePos,
@@ -471,16 +471,15 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
         public void WriteValue(LazyStringValue value)
         {
             var currentState = _continuationState.Pop();
-            BlittableJsonToken stringToken;
 
-            var valuePos = _writer.WriteValue(value, out stringToken, UsageMode.None, null);
+            var valuePos = _writer.WriteValue(value, out BlittableJsonToken stringToken, UsageMode.None, null);
             _writeToken = new WriteToken
             {
                 ValuePos = valuePos,
@@ -490,18 +489,17 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
         public void WriteValue(LazyCompressedStringValue value)
         {
             var currentState = _continuationState.Pop();
-            BlittableJsonToken stringToken;
 
             //public unsafe int WriteValue(byte* buffer, int size, out BlittableJsonToken token, UsageMode mode, int? initialCompressedSize)
             //var valuePos = _writer.WriteValue(value, out stringToken, UsageMode.None, null);
-            var valuePos = _writer.WriteValue(value, out stringToken, UsageMode.None);
+            var valuePos = _writer.WriteValue(value, out BlittableJsonToken stringToken, UsageMode.None);
             _writeToken = new WriteToken
             {
                 ValuePos = valuePos,
@@ -511,7 +509,7 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
@@ -533,7 +531,7 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
@@ -550,11 +548,24 @@ namespace Sparrow.Json
             if (currentState.FirstWrite == -1)
                 currentState.FirstWrite = valuePos;
 
-            currentState = FinishWritingScalarValue(currentState);
+            FinishWritingScalarValue(ref currentState);
             _continuationState.Push(currentState);
         }
 
-        private BuildingState FinishWritingScalarValue(BuildingState currentState)
+        public void WriteVector<T>(ReadOnlySpan<T> array) where T : unmanaged
+        {
+            var valuePos = _writer.WriteVector(array);
+            _writeToken = new WriteToken(position: valuePos, token: BlittableJsonToken.Vector);
+
+            // Update the state accordingly
+            ref var currentState = ref _continuationState.TopByRef();
+            if (currentState.FirstWrite == -1)
+                currentState.FirstWrite = valuePos;
+
+            FinishWritingScalarValue(ref currentState);
+        }
+
+        private void FinishWritingScalarValue(ref BuildingState currentState)
         {
             switch (currentState.State)
             {
@@ -578,7 +589,6 @@ namespace Sparrow.Json
                     ThrowIllegalStateException(currentState.State, "ReadValue");
                     break;
             }
-            return currentState;
         }
 
         public void FinalizeDocument()
@@ -621,5 +631,6 @@ namespace Sparrow.Json
             _writer.Dispose();
             base.Dispose();
         }
+
     }
 }

--- a/src/Sparrow/Json/ManualBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/ManualBlittableJsonDocumentBuilder.cs
@@ -371,6 +371,11 @@ namespace Sparrow.Json
                         case BlittableVectorType.Double:
                             WriteVector(vector.ReadArray<double>());
                             break;
+#if NET6_0_OR_GREATER
+                        case BlittableVectorType.Half:
+                            WriteVector(vector.ReadArray<Half>());
+                            break;
+#endif
                         default:
                             throw new ArgumentOutOfRangeException(nameof(vector.Type), vector.Type, $"Cannot write vector of {vector.Type}.");
                     }

--- a/src/Sparrow/Json/Parsing/JsonParserState.cs
+++ b/src/Sparrow/Json/Parsing/JsonParserState.cs
@@ -226,7 +226,7 @@ namespace Sparrow.Json.Parsing
         }
 
         internal FastList<(JsonParserToken, long)> _bufferedSequence;
-        private long _maxLongMagnitude;
+        private decimal _maxLongMagnitude;
         private double _maxDoubleMagnitude;
         private bool _hasNegativeValue;
 
@@ -247,8 +247,8 @@ namespace Sparrow.Json.Parsing
             {
                 // We need to check both because we can convert longs to doubles, but not the other
                 // way around. 
-                double maxValue = Math.Max(_maxDoubleMagnitude, _maxLongMagnitude);
-                
+                var maxValue = Math.Max(decimal.ToDouble(_maxLongMagnitude), _maxDoubleMagnitude);
+
                 // If handling floating-point values, use a simple check first.
                 return Math.Abs(maxValue) switch
                 {

--- a/src/Sparrow/Json/Parsing/JsonParserState.cs
+++ b/src/Sparrow/Json/Parsing/JsonParserState.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
 using Sparrow.Collections;
 using InvalidOperationException = System.InvalidOperationException;
@@ -273,7 +273,8 @@ namespace Sparrow.Json.Parsing
                 (>= uint.MinValue, <= uint.MaxValue) => BlittableVectorType.UInt32,
                 
                 (>= long.MinValue, <= long.MaxValue) => BlittableVectorType.Int64,
-                (>= ulong.MinValue, _) => BlittableVectorType.Int64, // Fallback for unsigned long
+                (>= ulong.MinValue, _) => BlittableVectorType.UInt64, // Fallback for unsigned long
+                (_, _) => throw new InvalidDataException("Unable to determine a type for values ranging between {_minLong} and {_maxLong}.")
             };
         }
 

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -549,7 +549,15 @@ namespace Sparrow.Json.Parsing
                     _state.CurrentTokenType = JsonParserToken.Float;
                     return true;
                 }
-
+#if NET6_0_OR_GREATER
+                if (current is Half h)
+                {
+                    var s = EnsureDecimalPlace((double)h, h.ToString("R", CultureInfo.InvariantCulture));
+                    SetStringBuffer(s);
+                    _state.CurrentTokenType = JsonParserToken.Float;
+                    return true;              
+                }
+#endif
                 if (current is DateTime dateTime1)
                 {
                     var s = dateTime1.GetDefaultRavenFormat();

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -395,6 +395,38 @@ namespace Sparrow.Json.Parsing
                     current = modifications;
                     continue;
                 }
+                
+                if (current is BlittableJsonReaderVector bjrv)
+                {
+                    if (bjrv.Modifications == null)
+                        bjrv.Modifications = new DynamicJsonArray();
+                    
+                    if (_seenValues.Add(bjrv.Modifications))
+                    {
+                        _elements.Push(bjrv);
+                        bjrv.Modifications.SourceIndex = bjrv.Modifications.SkipOriginalArray ? bjrv.Length : -1;
+                        bjrv.Modifications.ModificationsIndex = 0;
+                        _state.CurrentTokenType = JsonParserToken.StartArray;
+                        return true;
+                    }
+                    
+                    var modifications = bjrv.Modifications;
+                    modifications.SourceIndex++;
+                    if (modifications.SourceIndex < bjrv.Length)
+                    {
+                        if (modifications.Removals != null && modifications.Removals.Contains(modifications.SourceIndex))
+                        {
+                            continue;
+                        }
+
+                        current = bjrv[modifications.SourceIndex];
+                        _elements.Push(bjrv);
+                        continue;
+                    }
+                    
+                    current = modifications;
+                    continue;
+                }
 
                 if (current is IBlittableJsonContainer dbj)
                 {

--- a/src/Voron/VoronConfiguration.cs
+++ b/src/Voron/VoronConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Voron
+{
+    internal static class VoronConfiguration
+    {
+        // PERF: Because all those values are static readonly booleans that are defined during the process of loading the type,
+        // the JIT will detect them as such and will use the values instead. 
+        // https://alexandrnikitin.github.io/blog/jit-optimization-static-readonly-to-const/
+
+        public static readonly bool FailFastForStability;
+
+        static VoronConfiguration()
+        {
+#if DEBUG
+            FailFastForStability = true;
+#else
+            if (Environment.GetEnvironmentVariable("RAVENDB_Voron_FailFast")?.ToLowerInvariant() == "true")
+            {
+                // We are enabling Voron fail-fast in release mode, this is useful to analyze corruptions even in
+                // release mode. 
+                FailFastForStability = true;
+            }
+#endif
+        }
+    }
+}

--- a/src/Voron/VoronExceptions.cs
+++ b/src/Voron/VoronExceptions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Voron.Impl;
+
+namespace Voron
+{
+    public static class VoronExceptions
+    {
+        public static void ThrowIfReadOnly(LowLevelTransaction tx, string message = "A write transaction is required for this operation")
+        {
+            if (tx.Flags == TransactionFlags.Read)
+                throw new InvalidOperationException(message);
+        }
+
+        public static void ThrowIfReadOnly(Transaction tx, string message = "A write transaction is required for this operation")
+        {
+            if (tx.LowLevelTransaction.Flags == TransactionFlags.Read)
+                throw new InvalidOperationException(message);
+        }
+
+        public static void ThrowIfNull(Slice argument, [CallerArgumentExpression(nameof(argument))] string paramName = null)
+        {
+            if (argument.HasValue == false)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+        }
+    }
+}

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/FunctionalityTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/FunctionalityTests.cs
@@ -13,6 +13,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
 using Sparrow.Utils;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -117,7 +118,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             NativeMemory.Free(encodeOutput, maximumOutputLength);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Core)]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
@@ -662,6 +662,19 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             VectorTestBase(array);
         }
         
+        [RavenTheory(RavenTestCategory.Vector)]
+        [InlineDataWithRandomSeed(1)]
+        [InlineDataWithRandomSeed(2)]
+        [InlineDataWithRandomSeed(4)]
+        [InlineDataWithRandomSeed(256)]
+        [InlineDataWithRandomSeed(4000)]
+        public void VectorDoubleTest(int size, int seed)
+        {
+            var random = new Random(seed);
+            var array = Enumerable.Range(0, size).Select(x => random.NextSingle() * double.MaxValue).ToArray();
+            VectorTestBase(array);
+        }
+        
         private static void VectorTestBase<T>(T[] array) where T : unmanaged, INumber<T>
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
@@ -509,7 +509,7 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
             }
         }
 
-        [Fact]
+        [RavenFact(RavenTestCategory.Core | RavenTestCategory.Vector)]
         public void ObjectWithNestedIntVectorTest()
         {
             using (var context = new JsonOperationContext(1024, 1024 * 4, 32 * 1024, SharedMultipleUseFlag.None))

--- a/test/FastTests/Corax/Vectors/BlittableVectorIntegrationTests.cs
+++ b/test/FastTests/Corax/Vectors/BlittableVectorIntegrationTests.cs
@@ -54,11 +54,10 @@ public class BlittableVectorIntegrationTests(ITestOutputHelper output) : RavenTe
     }
     
     [RavenTheory(RavenTestCategory.Vector)]
-    // [InlineDataWithRandomSeed(8)]
-    // [InlineDataWithRandomSeed(500)]
-    // [InlineDataWithRandomSeed(1024)]
-    // [InlineDataWithRandomSeed(2048)]
-    [InlineData(1024, 12312412)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
     public async Task CanReadGenericValuesULong(int size, int seed)
     {
         var random = new Random(seed);
@@ -124,6 +123,19 @@ public class BlittableVectorIntegrationTests(ITestOutputHelper output) : RavenTe
     [InlineDataWithRandomSeed(500)]
     [InlineDataWithRandomSeed(1024)]
     [InlineDataWithRandomSeed(2048)]
+    public async Task CanReadGenericValuesHalf(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => (Half)random.NextSingle() * Half.MaxValue).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => (Half)random.NextSingle()).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
     public async Task CanReadGenericValuesFloat(int size, int seed)
     {
         var random = new Random(seed);
@@ -143,6 +155,126 @@ public class BlittableVectorIntegrationTests(ITestOutputHelper output) : RavenTe
         var array1 = Enumerable.Range(0, size).Select(_ => random.NextSingle() * double.MaxValue).ToArray();
         var array2 = Enumerable.Range(0, size).Select(_ => random.NextSingle() * double.MaxValue).ToArray();
         await CanReadGenericValuesBase(array1, array2);
+    }
+
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineData(1.0d, 8)]
+    [InlineData(1.0d, 500)]
+    [InlineData(1.0d, 1024)]
+    [InlineData(1.0d, 2048)]
+    [InlineData(1.1d, 8)]
+    [InlineData(1.1d, 500)]
+    [InlineData(1.1d, 1024)]
+    [InlineData(1.1d, 2048)]
+    public async Task CanReadFloatingValuesAsAllTypes(double repeatedValue, int size)
+    {
+        var array1 = Enumerable.Repeat(1d, size).ToArray();
+        using var store = GetDocumentStore();
+        string id;
+        using (var session = store.OpenAsyncSession(new SessionOptions(){NoCaching = true}))
+        {
+            var vectorDto = new GenericUser<double>(){Vector = array1};
+            await session.StoreAsync(vectorDto);
+            await session.SaveChangesAsync();
+            id = vectorDto.Id;
+        }
+        
+        //Double
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<double>>(id);
+            Assert.Equal(array1.Select(x => (double)x), storedUser.Vector.Embedding);
+        }
+        
+        //Float
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<float>>(id);
+            Assert.Equal(array1.Select(x => (float)x), storedUser.Vector.Embedding);
+        }
+        
+        //Half
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<Half>>(id);
+            Assert.Equal(array1.Select(x => (Half)x), storedUser.Vector.Embedding);
+        }
+        
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineData(8)]
+    [InlineData(500)]
+    [InlineData(1024)]
+    [InlineData(2048)]
+    public async Task CanReadNumericValuesAsAllTypes(int size)
+    {
+        var array1 = Enumerable.Repeat(1, size).ToArray();
+        using var store = GetDocumentStore();
+        string id;
+        using (var session = store.OpenAsyncSession(new SessionOptions(){NoCaching = true}))
+        {
+            var vectorDto = new GenericUser<int>(){Vector = array1};
+            await session.StoreAsync(vectorDto);
+            await session.SaveChangesAsync();
+            id = vectorDto.Id;
+        }
+        
+        //SByte
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<sbyte>>(id);
+            Assert.Equal(array1.Select(x => (sbyte)x), storedUser.Vector.Embedding);
+        }
+        
+        //Short
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<short>>(id);
+            Assert.Equal(array1.Select(x => (short)x), storedUser.Vector.Embedding);
+        }
+        
+        //Int
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<int>>(id);
+            Assert.Equal(array1.Select(x => (int)x), storedUser.Vector.Embedding);
+        }
+        
+        //Long
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<long>>(id);
+            Assert.Equal(array1.Select(x => (long)x), storedUser.Vector.Embedding);
+        }
+        
+        //SByte
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<byte>>(id);
+            Assert.Equal(array1.Select(x => (byte)x), storedUser.Vector.Embedding);
+        }
+        
+        //UShort
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<ushort>>(id);
+            Assert.Equal(array1.Select(x => (ushort)x), storedUser.Vector.Embedding);
+        }
+        
+        //UInt
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<uint>>(id);
+            Assert.Equal(array1.Select(x => (uint)x), storedUser.Vector.Embedding);
+        }
+        
+        //ULong
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var storedUser = await session.LoadAsync<GenericUser<ulong>>(id);
+            Assert.Equal(array1.Select(x => (ulong)x), storedUser.Vector.Embedding);
+        }
     }
     
     private async Task CanReadGenericValuesBase<T>(T[] array1, T[] array2) where T : unmanaged, INumber<T>

--- a/test/FastTests/Corax/Vectors/BlittableVectorIntegrationTests.cs
+++ b/test/FastTests/Corax/Vectors/BlittableVectorIntegrationTests.cs
@@ -1,5 +1,11 @@
-﻿using Raven.Client.Documents;
+﻿using System;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using FastTests.Voron.FixedSize;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -8,27 +14,217 @@ namespace FastTests.Corax.Vectors;
 
 public class BlittableVectorIntegrationTests(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.JavaScript | RavenTestCategory.Patching)]
-    public void CanPatchWithBlittableVector()
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
+    public async Task CanReadGenericValuesByte(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => (byte)random.Next(byte.MinValue, byte.MaxValue + 1)).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => (byte)random.Next(byte.MinValue, byte.MaxValue + 1)).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
+    public async Task CanReadGenericValuesUshort(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => (ushort)random.Next(ushort.MinValue, ushort.MaxValue + 1)).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => (ushort)random.Next(ushort.MinValue, ushort.MaxValue + 1)).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
+    public async Task CanReadGenericValuesUInt(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => (uint)random.NextInt64(uint.MinValue, (long)uint.MaxValue + 1)).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => (uint)random.NextInt64(uint.MinValue, (long)uint.MaxValue + 1)).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    // [InlineDataWithRandomSeed(8)]
+    // [InlineDataWithRandomSeed(500)]
+    // [InlineDataWithRandomSeed(1024)]
+    // [InlineDataWithRandomSeed(2048)]
+    [InlineData(1024, 12312412)]
+    public async Task CanReadGenericValuesULong(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => (ulong)~random.NextInt64(long.MinValue, long.MaxValue)).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => (ulong)~random.NextInt64(long.MinValue, long.MaxValue)).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
+    public async Task CanReadGenericValuesSByte(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => (sbyte)random.Next(sbyte.MinValue, sbyte.MaxValue + 1)).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => (sbyte)random.Next(sbyte.MinValue, sbyte.MaxValue + 1)).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
+    public async Task CanReadGenericValuesShort(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => (short)random.Next(short.MinValue, short.MaxValue + 1)).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => (short)random.Next(short.MinValue, short.MaxValue + 1)).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
+    public async Task CanReadGenericValuesInt(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => (int)random.NextInt64(int.MinValue, (long)int.MaxValue + 1)).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => (int)random.NextInt64(int.MinValue, (long)int.MaxValue + 1)).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
+    public async Task CanReadGenericValuesLong(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => random.NextInt64(long.MinValue, long.MaxValue)).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => random.NextInt64(long.MinValue, long.MaxValue)).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
+    public async Task CanReadGenericValuesFloat(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => random.NextSingle()).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => random.NextSingle()).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(8)]
+    [InlineDataWithRandomSeed(500)]
+    [InlineDataWithRandomSeed(1024)]
+    [InlineDataWithRandomSeed(2048)]
+    public async Task CanReadGenericValuesDouble(int size, int seed)
+    {
+        var random = new Random(seed);
+        var array1 = Enumerable.Range(0, size).Select(_ => random.NextSingle() * double.MaxValue).ToArray();
+        var array2 = Enumerable.Range(0, size).Select(_ => random.NextSingle() * double.MaxValue).ToArray();
+        await CanReadGenericValuesBase(array1, array2);
+    }
+    
+    private async Task CanReadGenericValuesBase<T>(T[] array1, T[] array2) where T : unmanaged, INumber<T>
     {
         using var store = GetDocumentStore();
-        var vectorDto = new User(new[] { 0.1f, 0.1f, 0.1f, 0.1f });
-        using (var session = store.OpenSession())
+        string id;
+        using (var session = store.OpenAsyncSession(new SessionOptions(){NoCaching = true}))
         {
-            session.Store(vectorDto);
-            session.SaveChanges();
+            var vectorDto = new GenericUser<T>(){Vector = array1, Vector2 = array2};
+            await session.StoreAsync(vectorDto);
+            await session.SaveChangesAsync();
+            id = vectorDto.Id;
         }
         
-        var operation = store.Operations.Send(new PatchByQueryOperation("from Users update { this.NewVec = this.Vector; }"));
-        operation.WaitForCompletion();
-
-        WaitForUserToContinueTheTest(store);
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
         {
-            var valueFromServer = session.Load<User>(vectorDto.Id);
-            Assert.Equal(vectorDto.Vector.Embedding, valueFromServer.NewVec.Embedding);
+            var storedUser = await session.LoadAsync<GenericUser<T>>(id);
+            Assert.Equal(array1, storedUser.Vector.Embedding);
+            Assert.Equal(array2, storedUser.Vector2.Embedding);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.JavaScript)]
+    public async Task CanReadBlittableVector()
+    {
+        using var store = GetDocumentStore();
+        string id;
+        var array = new[] { 0.1f, 0.1f, 0.1f, 0.1f };
+        var array2 = array.Select(x => x * 2f).ToArray();
+        using (var session = store.OpenAsyncSession(new SessionOptions(){NoCaching = true}))
+        {
+            var vectorDto = new User(){Vector = array, CopiedVector = array2};
+            await session.StoreAsync(vectorDto);
+            await session.SaveChangesAsync();
+            id = vectorDto.Id;
+        }
+
+        using (var session = store.OpenAsyncSession(new SessionOptions() { NoCaching = true }))
+        {
+            var valueFromServer = await session.LoadAsync<User>(id);
+            Assert.Equal(array, valueFromServer.Vector.Embedding);
+            Assert.Equal(array2, valueFromServer.CopiedVector.Embedding);
+        }        
+    }
+
+    
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.JavaScript | RavenTestCategory.Patching)]
+    public async Task CanPatchWithBlittableVector()
+    {
+        using var store = GetDocumentStore();
+        string id;
+        var array = new[] { 0.1f, 0.1f, 0.1f, 0.1f };
+        using (var session = store.OpenAsyncSession(new SessionOptions(){NoCaching = true}))
+        {
+            var vectorDto = new User(){Vector = array};
+            await session.StoreAsync(vectorDto);
+            await session.SaveChangesAsync();
+            id = vectorDto.Id;
+        }
+        
+        var operation = await store.Operations.SendAsync(new PatchByQueryOperation("from Users update { this.CopiedVector = this.Vector; }"));
+        await operation.WaitForCompletionAsync();
+
+        using (var session = store.OpenAsyncSession(new SessionOptions(){NoCaching = true, NoTracking = true}))
+        {
+            await Task.Delay(TimeSpan.FromSeconds(0.5));
+            var valueFromServer = await session.LoadAsync<User>(id);
+            Assert.Equal(array, valueFromServer.CopiedVector.Embedding);
         }
     }
 
-    private record User(RavenVector<float> Vector, RavenVector<float> NewVec = null, string Id = null);
+    private class User
+    {
+        public RavenVector<float> Vector { get; set; }
+        public RavenVector<float> CopiedVector { get; set; }
+        public string Id { get; set; }
+    }
+    
+    private class GenericUser<T> where T : unmanaged, INumber<T>
+    {
+        public RavenVector<T> Vector { get; set; }
+        public RavenVector<T> Vector2 { get; set; }
+        public string Id { get; set; }
+    }
 }

--- a/test/FastTests/Corax/Vectors/BlittableVectorIntegrationTests.cs
+++ b/test/FastTests/Corax/Vectors/BlittableVectorIntegrationTests.cs
@@ -1,0 +1,34 @@
+﻿using Raven.Client.Documents;
+using Raven.Client.Documents.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Vectors;
+
+public class BlittableVectorIntegrationTests(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.JavaScript | RavenTestCategory.Patching)]
+    public void CanPatchWithBlittableVector()
+    {
+        using var store = GetDocumentStore();
+        var vectorDto = new User(new[] { 0.1f, 0.1f, 0.1f, 0.1f });
+        using (var session = store.OpenSession())
+        {
+            session.Store(vectorDto);
+            session.SaveChanges();
+        }
+        
+        var operation = store.Operations.Send(new PatchByQueryOperation("from Users update { this.NewVec = this.Vector; }"));
+        operation.WaitForCompletion();
+
+        WaitForUserToContinueTheTest(store);
+        using (var session = store.OpenSession())
+        {
+            var valueFromServer = session.Load<User>(vectorDto.Id);
+            Assert.Equal(vectorDto.Vector.Embedding, valueFromServer.NewVec.Embedding);
+        }
+    }
+
+    private record User(RavenVector<float> Vector, RavenVector<float> NewVec = null, string Id = null);
+}

--- a/test/FastTests/Corax/Vectors/VectorAutoIndexClientApi.cs
+++ b/test/FastTests/Corax/Vectors/VectorAutoIndexClientApi.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes.Vector;
@@ -14,87 +15,110 @@ namespace FastTests.Corax.Vectors;
 
 public class VectorAutoIndexClientApi(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenTheory(RavenTestCategory.Vector)]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void SinglesToSinglesTest(bool isExact) => AutoIndexingTestingBase(
-        autoIndexName: "Auto/AutoVecDocs/ByVector.search(Singles)",
-        fieldRqlSelector: "vector.search(Singles, $p0)",
-        vectorWhere: docs => docs.
-            VectorSearch(field => field.WithEmbedding(f => f.Singles), 
-                value => value.ByEmbedding([0.1f, 0.1f]), isExact: isExact), isExact);
-    
-    [RavenTheory(RavenTestCategory.Vector)]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void SinglesToInt8Test(bool isExact) => AutoIndexingTestingBase(
-        autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.f32_i8(Singles))",
-        fieldRqlSelector: "vector.search(embedding.f32_i8(Singles), $p0)",
-        vectorWhere: docs => docs.
-            VectorSearch(field => field.WithEmbedding(f => f.Singles).TargetQuantization(VectorEmbeddingType.Int8), 
-                value => value.ByEmbedding([0.1f, 0.1f]), isExact: isExact), isExact);
-    
-    [RavenTheory(RavenTestCategory.Vector)]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void SinglesToBinaryTest(bool isExact) => AutoIndexingTestingBase(
-        autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.f32_i1(Singles))",
-        fieldRqlSelector: "vector.search(embedding.f32_i1(Singles), $p0)",
-        vectorWhere: docs => docs.
-            VectorSearch(field => field.WithEmbedding(f => f.Singles).TargetQuantization(VectorEmbeddingType.Binary), 
-                value => value.ByEmbedding([0.1f, 0.1f]), isExact: isExact), isExact);
+    public static IEnumerable<object[]> GenerateScenarios()
+    {
+        bool[] exactConfig = [ false];
+        bool[] isNativeVector = [ false];
+        Func<object, Action<IVectorEmbeddingFieldValueFactory>> primitiveValueFunc = (data =>
+        {
+            return data switch
+            {
+                float[] fArray => factory => factory.ByEmbedding(fArray),
+                sbyte[] i8Array => factory => factory.ByEmbedding(i8Array),
+                byte[] i1Array => factory => factory.ByEmbedding(i1Array),
+                _ => throw new ArgumentException("Invalid data type")
+            };
+        });
+
+
+        Func<object, Action<IVectorEmbeddingFieldValueFactory>> ravenVectorValueFunc = (data =>
+        {
+            return data switch
+            {
+                float[] fArray => factory => factory.ByEmbedding(new RavenVector<float>(fArray)),
+                sbyte[] i8Array => factory => factory.ByEmbedding(new RavenVector<sbyte>(i8Array)),
+                byte[] i1Array => factory => factory.ByEmbedding(new RavenVector<byte>(i1Array)),
+                _ => throw new ArgumentException("Invalid data type")
+            };
+        });
+
+        foreach (var isExact in exactConfig)
+        {
+            foreach (var isNative in isNativeVector)
+            {
+                yield return [isExact, isNative, isNative ? primitiveValueFunc : ravenVectorValueFunc];
+            }
+        }
+    }
 
     [RavenTheory(RavenTestCategory.Vector)]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void Int8Test(bool isExact) => AutoIndexingTestingBase(
+    [MemberData(nameof(GenerateScenarios))]
+    public void SinglesToSinglesTest(bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
+        autoIndexName: "Auto/AutoVecDocs/ByVector.search(Singles)",
+        fieldRqlSelector: "vector.search(Singles, $p0)",
+        vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Singles),
+            embedding(new float[] {0.1f, 0.1f}), isExact: isExact), isExact);
+
+    [RavenTheory(RavenTestCategory.Vector)]
+    [MemberData(nameof(GenerateScenarios))]
+    public void SinglesToInt8Test(bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
+        autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.f32_i8(Singles))",
+        fieldRqlSelector: "vector.search(embedding.f32_i8(Singles), $p0)",
+        vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Singles).TargetQuantization(VectorEmbeddingType.Int8), embedding(new float[] { 0.1f, 0.1f }), isExact: isExact), isExact);
+
+    [RavenTheory(RavenTestCategory.Vector)]
+    [MemberData(nameof(GenerateScenarios))]
+    public void SinglesToBinaryTest(bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
+        autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.f32_i1(Singles))",
+        fieldRqlSelector: "vector.search(embedding.f32_i1(Singles), $p0)",
+        vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Singles).TargetQuantization(VectorEmbeddingType.Binary), embedding(new float[]{ 0.1f, 0.1f }), isExact: isExact), isExact);
+
+    [RavenTheory(RavenTestCategory.Vector)]
+    [MemberData(nameof(GenerateScenarios))]
+    public void Int8Test(bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.i8(Int8))",
         fieldRqlSelector: "vector.search(embedding.i8(Int8), $p0)",
         vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Int8, VectorEmbeddingType.Int8),
-            value => value.ByEmbedding(VectorQuantizer.ToInt8([-1f, 1f])), isExact: isExact), isExact);
-    
-    
+            embedding(VectorQuantizer.ToInt8([-1f, 1f])), isExact: isExact), isExact);
+
+
     [RavenTheory(RavenTestCategory.Vector)]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void Int1Test(bool isExact) => AutoIndexingTestingBase(
+    [MemberData(nameof(GenerateScenarios))]
+    public void Int1Test(bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.i1(Binary))",
         fieldRqlSelector: "vector.search(embedding.i1(Binary), $p0)",
-        vectorWhere: docs => docs.
-            VectorSearch(field => field.WithEmbedding(f => f.Binary, VectorEmbeddingType.Binary), 
-                value => value.ByEmbedding(VectorQuantizer.ToInt1([1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0])), isExact: isExact), isExact);
-    
+        vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Binary, VectorEmbeddingType.Binary),
+            embedding(VectorQuantizer.ToInt1([1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0])), isExact: isExact), isExact);
+
     [RavenTheory(RavenTestCategory.Vector)]
     [InlineData(true)]
     [InlineData(false)]
     public void TextToSinglesTest(bool isExact) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.text(Text))",
         fieldRqlSelector: "vector.search(embedding.text(Text), $p0)",
-        vectorWhere: docs => docs.
-            VectorSearch(field => field.WithText(x => x.Text), 
-                value => value.ByText("test"), isExact: isExact), isExact);
-    
+        vectorWhere: docs => docs.VectorSearch(field => field.WithText(x => x.Text),
+            value => value.ByText("test"), isExact: isExact), isExact);
+
     [RavenTheory(RavenTestCategory.Vector)]
     [InlineData(true)]
     [InlineData(false)]
     public void TextToInt8Test(bool isExact) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.text_i8(Text))",
         fieldRqlSelector: "vector.search(embedding.text_i8(Text), $p0)",
-        vectorWhere: docs => docs.
-            VectorSearch(field => field.WithText(x => x.Text).TargetQuantization(VectorEmbeddingType.Int8), 
-                value => value.ByText("test"), isExact: isExact), isExact);
-    
+        vectorWhere: docs => docs.VectorSearch(field => field.WithText(x => x.Text).TargetQuantization(VectorEmbeddingType.Int8),
+            value => value.ByText("test"), isExact: isExact), isExact);
+
     [RavenTheory(RavenTestCategory.Vector)]
     [InlineData(true)]
     [InlineData(false)]
     public void TextToInt1Test(bool isExact) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.text_i1(Text))",
         fieldRqlSelector: "vector.search(embedding.text_i1(Text), $p0)",
-        vectorWhere: docs => docs.
-            VectorSearch(field => field.WithText(x => x.Text).TargetQuantization(VectorEmbeddingType.Binary), 
-                value => value.ByText("test"), isExact: isExact), isExact);
-    
-    private void AutoIndexingTestingBase(string autoIndexName, string fieldRqlSelector, Func<IRavenQueryable<AutoVecDoc>, IRavenQueryable<AutoVecDoc>> vectorWhere, bool isExact)
+        vectorWhere: docs => docs.VectorSearch(field => field.WithText(x => x.Text).TargetQuantization(VectorEmbeddingType.Binary),
+            value => value.ByText("test"), isExact: isExact), isExact);
+
+    private void AutoIndexingTestingBase(string autoIndexName, string fieldRqlSelector, Func<IRavenQueryable<AutoVecDoc>, IRavenQueryable<AutoVecDoc>> vectorWhere,
+        bool isExact)
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
         using var session = store.OpenSession();
@@ -128,9 +152,9 @@ public class VectorAutoIndexClientApi(ITestOutputHelper output) : RavenTestBase(
             .VectorSearch(f => f.WithText("NonExistingField"), v => v.ByText("---"))
             .Statistics(out stats)
             .ToList();
-        
+
         WaitForUserToContinueTheTest(store);
     }
-    
+
     private record AutoVecDoc(string Text, float[] Singles, sbyte[] Int8, byte[] Binary, string Id = null);
 }

--- a/test/FastTests/Corax/Vectors/VectorSimilarityScoreTests.cs
+++ b/test/FastTests/Corax/Vectors/VectorSimilarityScoreTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using System.Numerics.Tensors;
 using System.Runtime.InteropServices;
 using FastTests.Voron.FixedSize;
@@ -9,10 +8,8 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Queries.Vector;
 using Raven.Server.Config;
-using Sparrow.Server.Platform.Posix.macOS;
 using Tests.Infrastructure;
 using Voron.Data.Graphs;
 using Xunit;
@@ -84,12 +81,8 @@ public class VectorSimilarityScoreTests(ITestOutputHelper output) : RavenTestBas
 
         var queryVector = VectorQuantizer.ToInt8(Enumerable.Range(0, dimensions).Select(_ => random.NextSingle()).ToArray());
 
-        var query = session.Query<Dto, Index>() 
-            .VectorSearch(f => f.WithEmbedding("fieldName", VectorEmbeddingType.Single).TargetQuantization(VectorEmbeddingType.Int8)
-                , v => v.ByEmbedding([1f, 2f])
-                ,minimumSimilarity: 0.1f, 
-                numberOfCandidates: 12, 
-                isExact: true)
+        var query = session.Query<Dto, Index>()
+            .VectorSearch(f => f.WithField(d => d.Int8), v => v.ByEmbedding(queryVector), 0.1f)
             .OrderByScore();
 
 
@@ -178,14 +171,8 @@ public class VectorSimilarityScoreTests(ITestOutputHelper output) : RavenTestBas
         public Index()
         {
             Map = dtos => from doc in dtos
-                select new
-                {
-                    Singles = CreateVector(doc.Singles),
-                    Int8 = CreateVector(doc.Int8), 
-                    Binary = CreateVector(doc.Binary)
-                };
+                select new { Singles = CreateVector(doc.Singles), Int8 = CreateVector(doc.Int8), Binary = CreateVector(doc.Binary) };
 
-            Vector(f => f.Singles, i => i.SourceEmbedding(VectorEmbeddingType.Single).DestinationEmbedding(VectorEmbeddingType.Int8).Dimensions(2));
             Vector(f => f.Int8, i => i.SourceEmbedding(VectorEmbeddingType.Int8));
             Vector(f => f.Binary, i => i.SourceEmbedding(VectorEmbeddingType.Binary));
         }

--- a/test/SlowTests/Issues/RavenDB-23076.cs
+++ b/test/SlowTests/Issues/RavenDB-23076.cs
@@ -1,0 +1,33 @@
+using FastTests;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23076 : RavenTestBase
+{
+    public RavenDB_23076(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.None)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void Test(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var sampleObject = new
+                {
+                    Vector = new RavenVector<float>(new []{ 0.1f, 0.2f }),
+                };
+                
+                session.Store(sampleObject);
+                
+                session.SaveChanges();
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23076.cs
+++ b/test/SlowTests/Issues/RavenDB-23076.cs
@@ -71,7 +71,7 @@ public class RavenDB_23076 : RavenTestBase
         public IndexWithServerSideType()
         {
             Map = dtos => from dto in dtos
-                select new IndexEntry() { UnderlyingArrayType = ((Raven.Server.Documents.Indexes.Static.DynamicBlittableJson)(object)dto.Vector)["@vector"].GetType().FullName };
+                select new IndexEntry() { UnderlyingArrayType = ((Raven.Server.Documents.Indexes.Static.DynamicBlittableJson)(object)dto.Vector)[Sparrow.Global.Constants.Naming.VectorPropertyName].GetType().FullName };
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-23076.cs
+++ b/test/SlowTests/Issues/RavenDB-23076.cs
@@ -21,7 +21,7 @@ public class RavenDB_23076 : RavenTestBase
             {
                 var sampleObject = new
                 {
-                    Vector = new RavenVector<float>(new []{ 0.1f, 0.2f }),
+                    Vector = new RavenVector<float>(new []{ 0.1f, 0.2f })
                 };
                 
                 session.Store(sampleObject);

--- a/test/SlowTests/Issues/RavenDB-23076.cs
+++ b/test/SlowTests/Issues/RavenDB-23076.cs
@@ -1,6 +1,10 @@
+using System.Linq;
 using FastTests;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Sparrow.Json;
 using Tests.Infrastructure;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues;
@@ -13,21 +17,61 @@ public class RavenDB_23076 : RavenTestBase
 
     [RavenTheory(RavenTestCategory.None)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void Test(Options options)
+    public void TestRavenVectorStorageAndLoad(Options options)
     {
         using (var store = GetDocumentStore(options))
         {
+            var vectorToStore = new RavenVector<float>(new[] { 0.1f, 0.2f });
+            
             using (var session = store.OpenSession())
             {
-                var sampleObject = new
+                var dto = new Dto()
                 {
-                    Vector = new RavenVector<float>(new []{ 0.1f, 0.2f })
+                    Id = "Dtos/1",
+                    Vector = vectorToStore
                 };
                 
-                session.Store(sampleObject);
+                session.Store(dto);
                 
                 session.SaveChanges();
+
+                var index = new IndexWithServerSideType();
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                var entries = session.Query<IndexWithServerSideType.IndexEntry, IndexWithServerSideType>().Where(x => x.UnderlyingArrayType == "Sparrow.Json.BlittableJsonReaderVector").ProjectInto<Dto>().ToList();
+
+                Assert.Equal(1, entries.Count);
             }
+            
+            using (var session = store.OpenSession())
+            {
+                var loadedDto = session.Load<Dto>("Dtos/1");
+
+                Assert.Equal(loadedDto.Vector, vectorToStore);
+            }
+        }
+    }
+
+    public class Dto
+    {
+        public string Id { get; set; }
+        public RavenVector<float> Vector { get; set; }
+    }
+
+    public class IndexWithServerSideType : AbstractIndexCreationTask<Dto>
+    {
+        public class IndexEntry
+        {
+            public string UnderlyingArrayType { get; set; }
+        }
+        
+        public IndexWithServerSideType()
+        {
+            Map = dtos => from dto in dtos
+                select new IndexEntry() { UnderlyingArrayType = ((Raven.Server.Documents.Indexes.Static.DynamicBlittableJson)(object)dto.Vector)["@vector"].GetType().FullName };
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-23076.cs
+++ b/test/SlowTests/Issues/RavenDB-23076.cs
@@ -15,7 +15,7 @@ public class RavenDB_23076 : RavenTestBase
     {
     }
 
-    [RavenTheory(RavenTestCategory.None)]
+    [RavenTheory(RavenTestCategory.Vector)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void TestRavenVectorStorageAndLoad(Options options)
     {
@@ -55,13 +55,13 @@ public class RavenDB_23076 : RavenTestBase
         }
     }
 
-    public class Dto
+    private class Dto
     {
         public string Id { get; set; }
         public RavenVector<float> Vector { get; set; }
     }
 
-    public class IndexWithServerSideType : AbstractIndexCreationTask<Dto>
+    private class IndexWithServerSideType : AbstractIndexCreationTask<Dto>
     {
         public class IndexEntry
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22076 
https://issues.hibernatingrhinos.com/issue/RavenDB-23076

### Additional description

This PR contains support for `BlittableJsonVector` and `RavenVector<>`, which gives possibility for more efficient vector storage.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
