### PR TITLE
RavenDB-23076: Backport of support classes from the v7.1 branch. 

### DIFF
--- a/src/Sparrow/Collections/FastList.cs
+++ b/src/Sparrow/Collections/FastList.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 
@@ -8,10 +9,10 @@ namespace Sparrow.Collections
 {
     public sealed class FastList<T> : IList<T>
     {
-        private uint _version = 0;
-        private uint _size = 0;
+        private uint _version;
+        private uint _size;
 
-        private static readonly T[] EmptyArray = new T[0];
+        private static readonly T[] EmptyArray = Array.Empty<T>();
 
         private T[] _items;
 
@@ -112,14 +113,13 @@ namespace Sparrow.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Add(T item)
         {
-            if (_size == _items.Length)
-                goto Unlikely;
+            if (_size != _items.Length)
+            {
+                _items[_size++] = item;
+                _version++;
+                return;
+            }
 
-            _items[_size++] = item;
-            _version++;
-            return;
-
-            Unlikely:
             AddUnlikely(item, (int)_size + 1);
         }
 
@@ -127,14 +127,13 @@ namespace Sparrow.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AddByRef(in T item)
         {
-            if (_size == _items.Length)
-                goto Unlikely;
+            if (_size != _items.Length)
+            {
+                _items[_size++] = item;
+                _version++;
+                return;
+            }
 
-            _items[_size++] = item;
-            _version++;
-            return;
-
-            Unlikely:
             AddUnlikely(item, (int)_size + 1);
         }
 
@@ -145,7 +144,7 @@ namespace Sparrow.Collections
                 dest.Capacity = size;
 
             dest._size = (uint)size;
-            Array.Copy( _items, dest._items, size);
+            Array.Copy(_items, dest._items, size);
             dest._version++;
         }
 
@@ -181,26 +180,33 @@ namespace Sparrow.Collections
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        /// <summary>
+        /// Removes all objects from the Stack but clearing the backing array unless the type is native.
+        /// </summary>
         public void Clear()
         {
-            // PERF: We are using this to avoid the Array.Clear cost when using structs. 
-            //       When RuntimeHelpers.IsReferenceOrContainsReferences<T>() becomes available, we can use Clear instead. 
             if (typeof(T) == typeof(int) || typeof(T) == typeof(uint) || typeof(T) == typeof(byte) ||
-                typeof(T) == typeof(short) || typeof(T) == typeof(long) || typeof(T) == typeof(ulong))
+                typeof(T) == typeof(short) || typeof(T) == typeof(long) || typeof(T) == typeof(ulong) ||
+                typeof(T) == typeof(nint) || typeof(T) == typeof(IntPtr))
             {
                 _size = 0;
                 _version++;
-            }
-            else
-            {
-                int size = (int)_size;
 
-                _size = 0;
-                _version++;
-                if (size > 0)
-                    Array.Clear(_items, 0, size); // Clear the elements so that the gc can reclaim the references.
+                return;
             }
+
+            int size = (int)_size;
+
+            _size = 0;
+            _version++;
+
+#if NET6_0_OR_GREATER
+            // PERF: We are using this to avoid the Array.Clear cost when using structs. 
+            if (size <= 0 || RuntimeHelpers.IsReferenceOrContainsReferences<T>() == false)
+                return;
+#endif
+
+            Array.Clear(_items, 0, size); // Clear the elements so that the gc can reclaim the references.
         }
 
         public void Trim(int size)
@@ -262,7 +268,7 @@ namespace Sparrow.Collections
         {
             throw new NotSupportedException();
         }
-    
+
         public bool Remove(T item)
         {
             int index = IndexOf(item);
@@ -292,37 +298,34 @@ namespace Sparrow.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void RemoveAt(int index)
         {
-            if ((uint) index >= _size)
-                goto ERROR;
+            if ((uint)index >= _size)
+                ThrowWhenIndexIsOutOfRange(index);
 
             _size--;
             _version++;
 
             if (index < _size)
                 Array.Copy(_items, index + 1, _items, index, (int)_size - index);
-            return;
-
-            ERROR:
-            ThrowWhenIndexIsOutOfRange(index);
         }
 
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
         public void ThrowWhenIndexIsOutOfRange(int index)
         {
             throw new ArgumentOutOfRangeException(nameof(index));
         }
 
         // Removes a range of elements from this list.
-        // 
         public void RemoveRange(int index, int count)
         {
-            uint uindex = (uint)index;
-            if (uindex >= _size || (int)_size - index < count)
-                goto ERROR;
+            if ((uint)index >= _size || (int)_size - index < count)
+                ThrowWhenIndexIsOutOfRange(index);
 
             if (count <= 0)
                 return;
 
-            _size -= (uint) count;
+            _size -= (uint)count;
             if (index < _size)
             {
                 Array.Copy(_items, index + count, _items, index, (int)_size - index);
@@ -330,16 +333,17 @@ namespace Sparrow.Collections
 
             _version++;
 
-            if (typeof(T) != typeof(int) && typeof(T) != typeof(uint) && typeof(T) != typeof(byte) &&
-                typeof(T) != typeof(short) && typeof(T) != typeof(long) && typeof(T) != typeof(ulong))
-            {
-                Array.Clear(_items, (int) _size, count);
-            }
+            if (typeof(T) == typeof(int) || typeof(T) == typeof(uint) || typeof(T) == typeof(byte) ||
+                typeof(T) == typeof(short) || typeof(T) == typeof(long) || typeof(T) == typeof(ulong) ||
+                typeof(T) == typeof(nint) || typeof(T) == typeof(nuint) || typeof(T) == typeof(IntPtr))
+                return;
 
-            return;            
+#if NET6_0_OR_GREATER
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>() == false)
+                return;
+#endif
 
-            ERROR:
-            ThrowWhenIndexIsOutOfRange(index);
+            Array.Clear(_items, (int)_size, count);
         }
 
         public Span<T> AsUnsafeSpan()
@@ -360,13 +364,13 @@ namespace Sparrow.Collections
         IEnumerator<T> IEnumerable<T>.GetEnumerator()
         {
             return new Enumerator(this);
-        }        
+        }
 
         public struct Enumerator : IEnumerator<T>
         {
             private readonly FastList<T> _list;
             private readonly uint _version;
-            private uint _index;            
+            private uint _index;
             private T _current;
 
             internal Enumerator(FastList<T> list)
@@ -406,7 +410,7 @@ namespace Sparrow.Collections
 
             public T Current => _current;
 
-            Object IEnumerator.Current
+            object IEnumerator.Current
             {
                 get
                 {

--- a/src/Sparrow/DisposableExceptions.cs
+++ b/src/Sparrow/DisposableExceptions.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Diagnostics;
+
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+#endif
+
+namespace Sparrow;
+
+internal static class DisposableExceptions
+{
+    [Conditional("DEBUG")]
+    public static void ThrowIfDisposedOnDebug<T>(
+        T disposable, string message = "The object has already been disposed.",
+#if NET6_0_OR_GREATER
+        [CallerArgumentExpression(nameof(disposable))]
+#endif
+        string paramName = null) where T : IDisposableQueryable
+    {
+        ThrowIfDisposed(disposable, message, paramName);
+    }
+
+
+    public static void ThrowIfDisposed<T>(
+        T disposable, string message = "The object has already been disposed.",
+#if NET6_0_OR_GREATER        
+        [CallerArgumentExpression(nameof(disposable))]
+#endif
+        string paramName = null) where T : IDisposableQueryable
+    {
+        if (disposable?.IsDisposed ?? false)
+        {
+#if !NET6_0_OR_GREATER
+            paramName ??= disposable.GetType().Name;
+#endif
+            Throw(paramName, message);
+        }
+    }
+
+#if NET6_0_OR_GREATER
+    [DoesNotReturn]
+#endif
+    public static void Throw<T>(
+        T disposable, string message = "The object has already been disposed.",
+#if NET6_0_OR_GREATER
+        [CallerArgumentExpression(nameof(disposable))]
+#endif
+        string paramName = null) where T : IDisposableQueryable
+    {
+#if !NET6_0_OR_GREATER
+        paramName ??= disposable.GetType().Name;
+#endif
+        Throw(paramName, message);
+    }
+
+#if NET6_0_OR_GREATER
+    [DoesNotReturn]
+#endif
+    private static void Throw(string paramName, string message) => throw new ObjectDisposedException(paramName, message);
+}

--- a/src/Sparrow/IDisposableQueryable.cs
+++ b/src/Sparrow/IDisposableQueryable.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Sparrow
+{
+    internal interface IDisposableQueryable
+    {
+        bool IsDisposed { get; }
+    }
+}

--- a/src/Voron/VoronConfiguration.cs
+++ b/src/Voron/VoronConfiguration.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Voron
+{
+    internal static class VoronConfiguration
+    {
+        // PERF: Because all those values are static readonly booleans that are defined during the process of loading the type,
+        // the JIT will detect them as such and will use the values instead. 
+        // https://alexandrnikitin.github.io/blog/jit-optimization-static-readonly-to-const/
+
+        public static readonly bool FailFastForStability;
+
+        static VoronConfiguration()
+        {
+#if DEBUG
+            FailFastForStability = true;
+#else
+            if (Environment.GetEnvironmentVariable("RAVENDB_Voron_FailFast")?.ToLowerInvariant() == "true")
+            {
+                // We are enabling Voron fail-fast in release mode, this is useful to analyze corruptions even in
+                // release mode. 
+                FailFastForStability = true;
+            }
+#endif
+        }
+    }
+}

--- a/src/Voron/VoronExceptions.cs
+++ b/src/Voron/VoronExceptions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Voron.Impl;
+
+namespace Voron
+{
+    public static class VoronExceptions
+    {
+        public static void ThrowIfReadOnly(LowLevelTransaction tx, string message = "A write transaction is required for this operation")
+        {
+            if (tx.Flags == TransactionFlags.Read)
+                throw new InvalidOperationException(message);
+        }
+
+        public static void ThrowIfReadOnly(Transaction tx, string message = "A write transaction is required for this operation")
+        {
+            if (tx.LowLevelTransaction.Flags == TransactionFlags.Read)
+                throw new InvalidOperationException(message);
+        }
+
+        public static void ThrowIfNull(Slice argument, [CallerArgumentExpression(nameof(argument))] string paramName = null)
+        {
+            if (argument.HasValue == false)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23076

### Additional description
Backport of support classes from the v7.1 branch. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
