### PR TITLE
RavenDB-19410 Using GUID instead of Random to create the key for test

### DIFF
--- a/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
+++ b/test/SlowTests/Cluster/CompareExchangeExpirationTest.cs
@@ -28,6 +28,8 @@ using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+using System.Text.Json;
+using Raven.Client.Exceptions;
 
 namespace SlowTests.Cluster
 {
@@ -66,14 +68,13 @@ namespace SlowTests.Cluster
                     server.ServerStore.Observer.Time.UtcDateTime = () => DateTime.UtcNow;
                     var local = server.ServerStore.Observer._lastExpiredCompareExchangeCleanupTimeInTicks = DateTime.UtcNow.Ticks;
 
-                    var rnd = new Random(DateTime.Now.Millisecond);
-                    var user = new User { Name = new string(Enumerable.Repeat(_chars, 10).Select(s => s[rnd.Next(s.Length)]).ToArray()) };
+                    var user = new User { Name = Guid.NewGuid().ToString() };
                     var expiry = DateTime.Now.AddMinutes(2);
 
                     if (dateTimeFormat.Value == DateTimeKind.Utc)
                         expiry = expiry.ToUniversalTime();
 
-                    var key = new string(Enumerable.Repeat(_chars, 10).Select(s => s[rnd.Next(s.Length)]).ToArray());
+                    var key = Guid.NewGuid().ToString();
                     using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                     {
                         var result = session.Advanced.ClusterTransaction.CreateCompareExchangeValue(key, user);
@@ -544,28 +545,48 @@ namespace SlowTests.Cluster
                     var expirationDate = res.Metadata.GetString(Constants.Documents.Metadata.Expires);
                     Assert.NotNull(expirationDate);
                     var dateTime = DateTime.ParseExact(expirationDate, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-                    Assert.Equal(expiry.Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffffff"), expirationDate);
+                    Assert.Equal(expiry.Value, dateTime);
                 }
             }
         }
 
         private static async Task AddCompareExchangesWithExpire(int count, Dictionary<string, User> compareExchanges, DocumentStore store, DateTime? expiry = null)
         {
-            for (int i = 0; i < count; i++)
+            try
             {
-                var rnd = new Random(DateTime.Now.Millisecond);
-                var user = new User { Name = new string(Enumerable.Repeat(_chars, 10).Select(s => s[rnd.Next(s.Length)]).ToArray()) };
-                var key = $"{new string(Enumerable.Repeat(_chars, 10).Select(s => s[rnd.Next(s.Length)]).ToArray())}{i}";
-                compareExchanges[key] = user;
-                using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                for (int i = 0; i < count; i++)
                 {
-                    var result = session.Advanced.ClusterTransaction.CreateCompareExchangeValue(key, user);
-                    if (expiry != null)
+                    var key = $"user{Guid.NewGuid()}{i}";
+                    var user = new User { Name = key };
+                    compareExchanges[key] = user;
+                    using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
                     {
-                        result.Metadata[Constants.Documents.Metadata.Expires] = expiry;
+                        var result = session.Advanced.ClusterTransaction.CreateCompareExchangeValue(key, user);
+                        if (expiry != null)
+                        {
+                            result.Metadata[Constants.Documents.Metadata.Expires] = expiry?.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                        }
+                        await session.SaveChangesAsync();
                     }
-                    await session.SaveChangesAsync();
                 }
+            }
+            catch (ClusterTransactionConcurrencyException e)
+            {
+                Exception toThrow;
+                try
+                {
+                    using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+                    {
+                        var result = await session.Advanced.ClusterTransaction.GetCompareExchangeValuesAsync<User>("user", pageSize:1000);
+                        toThrow = new AggregateException($"Compare exchange values : [{string.Join(",", result.Values.Select(x => JsonSerializer.Serialize(x)))}]", e);
+                    }
+                }
+                catch (Exception ie)
+                {
+                    toThrow = new AggregateException(e, ie);
+                }
+
+                throw toThrow;
             }
         }
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-19410

### Additional description
I couldn’t reproduce the issue, but the code potentially allows the same key to be generated, which will lead to a concurrency exception.
This requires a combination of the same milliseconds in `DateTime.Now` and the same iteration number (the same value for i).
While this scenario is extremely rare, I updated the key generation logic to rule out that possibility.

While this "fix" is also relevant for version 5.4, I created the PR against this version. 
Additionally, I added more logging to provide better insights if the issue occurs again in the future.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Test fix and invastigation

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed
- [x] Not relevant

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
