### PR TITLE
RavenDB-23340 Adjust deb scripts for .Net 9, set default version

### DIFF
--- a/scripts/linux/pkg/deb/build-deb.ps1
+++ b/scripts/linux/pkg/deb/build-deb.ps1
@@ -67,7 +67,7 @@ if ($env:TARBALL_DIR)
 
 docker run --rm -t `
     --platform $env:DOCKER_BUILDPLATFORM `
-    -v "$($env:OUTPUT_DIR):/dist" `
+    -v "$($distroOutputDir):/dist" `
     -v "$($packageFileDir):/cache" `
     -e RAVENDB_VERSION=$ravenVersion  `
     -e "DOTNET_RUNTIME_VERSION=$env:DOTNET_RUNTIME_VERSION" `

--- a/scripts/linux/pkg/deb/set-raven-version-env.ps1
+++ b/scripts/linux/pkg/deb/set-raven-version-env.ps1
@@ -1,3 +1,3 @@
 if (-not $env:RAVENDB_VERSION) {
-    $env:RAVENDB_VERSION = "5.4.101"
+    $env:RAVENDB_VERSION = "7.0.0"
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23340

### Additional description

Adjust deb package creation scripts for .Net 9, set default raven version (for local testing)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
