### PR TITLE
RavenDB-17678 Fix support sharded export of query results

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/StreamOperation.cs
@@ -314,7 +314,7 @@ namespace Raven.Client.Documents.Session.Operations
         {
             public YieldStreamResults(InMemoryDocumentSessionOperations session, StreamResult response, bool isQueryStream, bool isTimeSeriesStream, bool isAsync, StreamQueryStatistics streamQueryStatistics, CancellationToken token = default)
             {
-                _response = response ?? throw new InvalidOperationException("The index does not exists, failed to stream results");
+                _response = response ?? throw new IndexDoesNotExistException("The index does not exists, failed to stream results");
                 _builderReturnContext = session.RequestExecutor.ContextPool.AllocateOperationContext(out _builderContext);
                 _peepingTomStream = new PeepingTomStream(_response.Stream, session.Context);
                 _inputContext = session.Context;
@@ -328,7 +328,7 @@ namespace Raven.Client.Documents.Session.Operations
 
             public YieldStreamResults(Func<(JsonOperationContext, IDisposable)> allocateJsonContext, StreamResult response, bool isQueryStream, bool isTimeSeriesStream, bool isAsync, StreamQueryStatistics streamQueryStatistics, CancellationToken token = default)
             {
-                _response = response ?? throw new InvalidOperationException("The index does not exists, failed to stream results");
+                _response = response ?? throw new IndexDoesNotExistException("The index does not exists, failed to stream results");
                 (_builderContext, _builderReturnContext) = allocateJsonContext();
                 (_inputContext, _inputReturnContext) = allocateJsonContext();
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Streaming/StreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Streaming/StreamingHandlerProcessorForGetStreamQuery.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.AspNetCore.Http;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Queries;
@@ -51,12 +49,10 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
             return RequestHandler.Database.QueryMetadataCache;
         }
 
-        protected override async ValueTask ExecuteAndWriteIndexQueryStreamEntriesAsync(DocumentsOperationContext context, IndexQueryServerSide query, string format, string _,
-            string[] propertiesArray, string fileNamePrefix, bool ignoreLimit, bool fromSharded, OperationCancelToken token)
+        protected override async ValueTask ExecuteAndWriteIndexQueryStreamEntriesAsync(DocumentsOperationContext context, IndexQueryServerSide query, string format,
+            string[] propertiesArray, string fileNamePrefix, bool ignoreLimit, OperationCancelToken token)
         {
-            //writes either csv or blittable documents if is shard
-            await using (var writer = GetBlittableQueryResultWriter(format, isDebug: true, context, HttpContext.Response, RequestHandler.ResponseBodyStream(),
-                             fromSharded, propertiesArray, fileNamePrefix))
+            await using (var writer = GetResultWriter<BlittableJsonReaderObject>(format, context, HttpContext.Response, RequestHandler.ResponseBodyStream(), propertiesArray, fileNamePrefix))
             {
                 try
                 {
@@ -66,19 +62,15 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                 catch (IndexDoesNotExistException)
                 {
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
-
-                    if (fromSharded)
-                        throw;
-
                     await writer.WriteErrorAsync($"Index {query.Metadata.IndexName} does not exist");
                 }
             }
         }
 
         protected override async ValueTask ExecuteAndWriteQueryStreamAsync(DocumentsOperationContext context, IndexQueryServerSide query, string format,
-            string[] propertiesArray, string fileNamePrefix, bool _, bool fromSharded, OperationCancelToken token)
+            string[] propertiesArray, string fileNamePrefix, OperationCancelToken token)
         {
-            await using (var writer = GetDocumentQueryResultWriter(format, HttpContext.Response, context, RequestHandler.ResponseBodyStream(), propertiesArray,
+            await using (var writer = GetResultWriter<Document>(format, context, HttpContext.Response, RequestHandler.ResponseBodyStream(), propertiesArray,
                              fileNamePrefix))
             {
                 try
@@ -88,10 +80,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
                 catch (IndexDoesNotExistException)
                 {
                     HttpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
-
-                    if (fromSharded)
-                        throw;
-
                     await writer.WriteErrorAsync($"Index {query.Metadata.IndexName} does not exist");
                 }
                 catch (Exception e)
@@ -113,55 +101,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Streaming
 
                     throw;
                 }
-            }
-        }
-
-        private IStreamQueryResultWriter<Document> GetDocumentQueryResultWriter(string format, HttpResponse response, JsonOperationContext context, Stream responseBodyStream,
-            string[] propertiesArray, string fileNamePrefix = null)
-        {
-            var queryFormat = GetQueryResultFormat(format);
-            switch (queryFormat)
-            {
-                case QueryResultFormat.Json:
-                    return new StreamJsonFileDocumentQueryResultWriter(response, responseBodyStream, context, propertiesArray, fileNamePrefix);
-                case QueryResultFormat.Csv:
-                    return new StreamCsvDocumentQueryResultWriter(response, responseBodyStream, propertiesArray, fileNamePrefix);
-            }
-
-            if (propertiesArray != null)
-            {
-                ThrowUnsupportedException("Using json output format with custom fields is not supported.");
-            }
-
-            switch (queryFormat)
-            {
-                case QueryResultFormat.Jsonl:
-                    return new StreamJsonlDocumentQueryResultWriter(responseBodyStream, context);
-                default:
-                    return new StreamJsonDocumentQueryResultWriter(responseBodyStream, context);
-            }
-        }
-
-        protected override IStreamQueryResultWriter<BlittableJsonReaderObject> GetBlittableQueryResultWriter(string format, bool isDebug, JsonOperationContext context, HttpResponse response, Stream responseBodyStream, bool fromSharded,
-            string[] propertiesArray, string fileNamePrefix = null)
-        {
-            if (fromSharded)
-            {
-                return new StreamBlittableDocumentQueryResultWriter(responseBodyStream, context);
-            }
-
-            var queryFormat = GetQueryResultFormat(format);
-            switch (queryFormat)
-            {
-                case QueryResultFormat.Json:
-                    //does not write query stats to stream
-                    return new StreamJsonFileBlittableQueryResultWriter(response, responseBodyStream, context, propertiesArray, fileNamePrefix);
-                case QueryResultFormat.Csv:
-                    //does not write query stats to stream
-                    return new StreamCsvBlittableQueryResultWriter(response, responseBodyStream, propertiesArray, fileNamePrefix);
-                default:
-                    ThrowUnsupportedException($"You have selected \"{format}\" file format, which is not supported.");
-                    return null;
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
@@ -33,6 +33,9 @@ namespace Raven.Server.Documents.Handlers
             Constants.Documents.Metadata.Id,
             Constants.Documents.Metadata.LastModified,
             Constants.Documents.Metadata.IndexScore,
+            Constants.Documents.Metadata.Sharding.Querying.OrderByFields,
+            Constants.Documents.Metadata.Sharding.Querying.ResultDataHash,
+            Constants.Documents.Metadata.Sharding.Querying.SuggestionsPopularityFields,
         };
 
         protected StreamCsvResultWriter(HttpResponse response, Stream stream, string[] properties = null, string csvFileNamePrefix = "export")
@@ -127,9 +130,6 @@ namespace Raven.Server.Documents.Handlers
             {
                 // skip reserved metadata properties
                 if (inMetadata && p.StartsWith('@') && MetadataPropertiesToSkip.Contains(p))
-                    continue;
-
-                if (p.StartsWith('@') && p.Equals(Constants.Documents.Metadata.Key) == false && propertyTuple.ParentPath.Equals(Constants.Documents.Metadata.Key) == false)
                     continue;
 
                 var path = string.IsNullOrEmpty(propertyTuple.ParentPath) ? BlittablePath.EscapeString(p) : $"{propertyTuple.ParentPath}.{BlittablePath.EscapeString(p)}";

--- a/src/Raven.Server/Documents/Handlers/StreamJsonFileBlittableQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamJsonFileBlittableQueryResultWriter.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
+using Raven.Client;
+using Raven.Client.Extensions;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers;
@@ -37,6 +40,16 @@ public class StreamJsonFileBlittableQueryResultWriter : AbstractStreamJsonFileBl
                     Writer.WriteComma();
                 else
                     innerFirst = false;
+
+                if (Constants.Documents.Metadata.Id == property)
+                {
+                    if (res.TryGetMetadata(out var metadata) && metadata.TryGetId(out var id))
+                    {
+                        Writer.WritePropertyName(Constants.Documents.Metadata.Id);
+                        Writer.WriteString(id.ToString(CultureInfo.InvariantCulture));
+                        continue;
+                    }
+                }
 
                 var propertyIndex = res.GetPropertyIndex(property);
                 if (propertyIndex == -1)

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3278,7 +3278,7 @@ namespace Raven.Server.Documents.Indexes
         public virtual async Task StreamIndexEntriesQuery(HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer,
             IndexQueryServerSide query, QueryOperationContext queryContext, bool ignoreLimit, OperationCancelToken token)
         {
-            var result = new StreamDocumentIndexEntriesQueryResult(response, writer, Definition.ClusterState.LastIndex, token);
+            var result = new StreamDocumentIndexQueryResult(response, writer, Definition.ClusterState.LastIndex, token);
             await IndexEntriesQueryInternal(result, query, queryContext, ignoreLimit, token);
             result.Flush();
 

--- a/src/Raven.Server/Documents/Queries/ShardedStreamQueryCsvResult.cs
+++ b/src/Raven.Server/Documents/Queries/ShardedStreamQueryCsvResult.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Raven.Client;
+using Raven.Client.Extensions;
+using Raven.Server.ServerWide;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Queries;
+
+public sealed class ShardedStreamQueryCsvResult : StreamQueryResult<BlittableJsonReaderObject>
+{
+    private readonly JsonOperationContext _context;
+    private readonly string _timeSeries;
+
+    public override async ValueTask AddResultAsync(BlittableJsonReaderObject result, CancellationToken token)
+    {
+        if (HasAnyWrites() == false)
+            StartResponseIfNeeded();
+
+        using (result)
+        {
+            var writer = GetWriter();
+            if (string.IsNullOrEmpty(_timeSeries) == false)
+            {
+                if (result.TryGet(_timeSeries, out BlittableJsonReaderArray arr))
+                {
+                    var djv = new DynamicJsonValue
+                    {
+                        [Constants.Documents.Metadata.Id] = result.GetMetadata().GetId()
+                    };
+                    var properties = result.GetPropertyNames();
+                    foreach (var property in properties)
+                    {
+                        if (_timeSeries == property)
+                            continue;
+
+                        djv[property] = result[property];
+                    }
+                    foreach (BlittableJsonReaderObject entry in arr)
+                    {
+                        foreach (var property in entry.GetPropertyNames())
+                        {
+                            djv[property] = entry[property];
+                        }
+
+                        await writer.AddResultAsync(_context.ReadObject(djv, "ts->csv"), token).ConfigureAwait(false);
+                    }
+                }
+            }
+            else
+            {
+                await writer.AddResultAsync(result, token).ConfigureAwait(false);
+            }
+        }
+
+        GetToken().Delay();
+    }
+
+    public ShardedStreamQueryCsvResult(JsonOperationContext context, HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer, IndexQueryServerSide query, OperationCancelToken token) : base(response, writer, indexDefinitionRaftIndex: null, token)
+    {
+        if (response.HasStarted)
+            throw new InvalidOperationException("You cannot start streaming because response has already started.");
+            
+        _context = context;
+
+        var tsField = query.Metadata.SelectFields?.SingleOrDefault(f => f.Function?.StartsWith(Constants.TimeSeries.QueryFunction) == true);
+        _timeSeries = tsField?.Alias ?? tsField?.Name.Value;
+    }
+}

--- a/src/Raven.Server/Documents/Queries/StreamDocumentIndexQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/StreamDocumentIndexQueryResult.cs
@@ -7,7 +7,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.Queries
 {
-    public sealed class StreamDocumentIndexEntriesQueryResult : StreamQueryResult<BlittableJsonReaderObject>
+    public sealed class StreamDocumentIndexQueryResult : StreamQueryResult<BlittableJsonReaderObject>
     {
         public override async ValueTask AddResultAsync(BlittableJsonReaderObject result, CancellationToken token)
         {
@@ -19,7 +19,7 @@ namespace Raven.Server.Documents.Queries
             GetToken().Delay();
         }
 
-        public StreamDocumentIndexEntriesQueryResult(HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer, long? indexDefinitionRaftIndex, OperationCancelToken token) : base(response, writer, indexDefinitionRaftIndex, token)
+        public StreamDocumentIndexQueryResult(HttpResponse response, IStreamQueryResultWriter<BlittableJsonReaderObject> writer, long? indexDefinitionRaftIndex, OperationCancelToken token) : base(response, writer, indexDefinitionRaftIndex, token)
         {
             if (response.HasStarted)
                 throw new InvalidOperationException("You cannot start streaming because response has already started.");

--- a/src/Raven.Server/Documents/Queries/StreamJsonlBlittableQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Queries/StreamJsonlBlittableQueryResultWriter.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Session;
+using Sparrow.Extensions;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Queries;
+
+public sealed class StreamJsonlBlittableQueryResultWriter : IStreamQueryResultWriter<BlittableJsonReaderObject>
+{
+    private readonly AsyncBlittableJsonTextWriter _writer;
+
+    public StreamJsonlBlittableQueryResultWriter(Stream stream, JsonOperationContext context)
+    {
+        _writer = new AsyncBlittableJsonTextWriter(context, stream);
+    }
+
+
+    public void StartResponse()
+    {
+    }
+
+    public void StartResults()
+    {
+    }
+
+    public void EndResults()
+    {
+    }
+
+    public ValueTask AddResultAsync(BlittableJsonReaderObject res, CancellationToken token)
+    {
+        _writer.WriteStartObject();
+        _writer.WritePropertyName("Item");
+        _writer.WriteObject(res);
+        _writer.WriteEndObject();
+
+        _writer.WriteNewLine();
+        return ValueTask.CompletedTask;
+    }
+
+    public void EndResponse()
+    {
+    }
+
+    public ValueTask WriteErrorAsync(Exception e)
+    {
+        _writer.WriteStartObject();
+        _writer.WritePropertyName("Error");
+        _writer.WriteString(e.ToString());
+        _writer.WriteEndObject();
+
+        _writer.WriteNewLine();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask WriteErrorAsync(string error)
+    {
+        _writer.WriteStartObject();
+        _writer.WritePropertyName("Error");
+        _writer.WriteString(error);
+        _writer.WriteEndObject();
+
+        _writer.WriteNewLine();
+        return ValueTask.CompletedTask;
+    }
+
+    public void WriteQueryStatistics(long resultEtag, bool isStale, string indexName, long totalResults, DateTime timestamp)
+    {
+        _writer.WriteStartObject();
+        _writer.WritePropertyName("Stats");
+        _writer.WriteStartObject();
+
+        _writer.WritePropertyName(nameof(StreamQueryStatistics.ResultEtag));
+        _writer.WriteInteger(resultEtag);
+        _writer.WriteComma();
+
+        _writer.WritePropertyName(nameof(StreamQueryStatistics.IsStale));
+        _writer.WriteBool(isStale);
+        _writer.WriteComma();
+
+        _writer.WritePropertyName(nameof(StreamQueryStatistics.IndexName));
+        _writer.WriteString(indexName);
+        _writer.WriteComma();
+
+        _writer.WritePropertyName(nameof(StreamQueryStatistics.TotalResults));
+        _writer.WriteInteger(totalResults);
+        _writer.WriteComma();
+
+        _writer.WritePropertyName(nameof(StreamQueryStatistics.IndexTimestamp));
+        _writer.WriteString(timestamp.GetDefaultRavenFormat(isUtc: true));
+
+        _writer.WriteEndObject();
+        _writer.WriteEndObject();
+
+        _writer.WriteNewLine();
+    }
+
+    public bool SupportStatistics => true;
+
+    public ValueTask DisposeAsync()
+    {
+        return _writer.DisposeAsync();
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryResultDocument.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryResultDocument.cs
@@ -55,7 +55,8 @@ public sealed class ShardedQueryResultDocument : Document
             TransactionMarker = doc.TransactionMarker,
             Id = doc.Id,
             LowerId = doc.LowerId,
-            Data = doc.Data
+            Data = doc.Data,
+            TimeSeriesStream = doc.TimeSeriesStream
         };
     }
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -7,6 +7,7 @@ using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Commands.Streaming;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Timings;
+using Raven.Server.Documents.Sharding.Comparers;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Streaming;
 using Raven.Server.ServerWide.Context;
@@ -47,8 +48,9 @@ namespace Raven.Server.Documents.Sharding.Queries
         public override Task<ShardedStreamQueryResult> ExecuteShardedOperations(QueryTimingsScope scope)
         {
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal, "Handle continuation token in streaming");
+            DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal, "Missing scope usage");
 
-            var documentsComparer = GetComparer(Query);
+            var documentsComparer = string.IsNullOrEmpty(_debug) ? GetComparer(Query) : ConstantComparer.Instance;
 
             var commands = GetOperationCommands(null);
 

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-            const int numberToTolerate = 4554;
+            const int numberToTolerate = 4553;
 
             if (array.Length == numberToTolerate)
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17678

### Additional description

- Fix support for sharded export to CSV, JSON, JSONL
- Fix support for sharded export of time-series
- Reorganize code path and abstraction of query streaming

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
