### PR TITLE
RavenDB-23353 allow to load any certificate in the UpdatePullReplicationAsSinkOperation, we are performing the validation ourselves

### DIFF
--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -36,7 +36,7 @@ namespace Raven.Client.Documents.Operations.Replication
             if (pullReplication.CertificateWithPrivateKey != null)
             {
                 var certBytes = Convert.FromBase64String(pullReplication.CertificateWithPrivateKey);
-                using (var certificate = CertificateLoaderUtil.CreateCertificateFromPfx(certBytes,
+                using (var certificate = CertificateLoaderUtil.CreateCertificateFromAny(certBytes,
                     pullReplication.CertificatePassword,
                     CertificateLoaderUtil.FlagsForExport))
                 {

--- a/test/StressTests/Issues/RavenDB-15145.cs
+++ b/test/StressTests/Issues/RavenDB-15145.cs
@@ -37,7 +37,7 @@ namespace StressTests.Issues
             var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = sinkSettings, RegisterForDisposal = true });
 
             var dummy = Certificates.GenerateAndSaveSelfSignedCertificate(createNew: true);
-            var pullReplicationCertificate = CertificateHelper.CreateCertificateFromPfx(dummy.ServerCertificatePath, (string)null, X509KeyStorageFlags.MachineKeySet | CertificateLoaderUtil.FlagsForExport);
+            var pullReplicationCertificate = CertificateHelper.CreateCertificateFromPfx(dummy.ServerCertificatePath, (string)null, X509KeyStorageFlags.UserKeySet | CertificateLoaderUtil.FlagsForExport);
             Assert.True(pullReplicationCertificate.HasPrivateKey);
 
             using (var hubStore = GetDocumentStore(new Options


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23353

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
