### PR TITLE
RavenDB-23336 Propagate the `RequestedByUser` flag when creating statistics to ensure proper results count in Corax.

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -4049,7 +4049,8 @@ The recommended method is to use full text search (mark the field as Analyzed an
             var finalQuery = ((DocumentQuery<T>)DocumentQuery).CreateDocumentQueryInternal<TProjection>(
                 new QueryData(fields, projections, FromAlias, _declareTokens, _loadTokens, _declareTokens != null || _jsSelectBody != null)
                 {
-                    IsProjectInto = _isProjectInto
+                    IsProjectInto = _isProjectInto,
+                    QueryStatistics =  _queryStatistics
                 });
 
             var executeQuery = GetQueryResult(finalQuery);

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -1112,9 +1112,12 @@ namespace Raven.Client.Documents.Session
         public IRavenQueryable<T> ToQueryable()
         {
             var type = typeof(T);
-            var queryStatistics = new QueryStatistics();
+            var queryStatistics = new QueryStatistics()
+            {
+                RequestedByUser = QueryStats.RequestedByUser
+            };
             var highlightings = new LinqQueryHighlightings();
-
+            
             var ravenQueryInspector = new RavenQueryInspector<T>();
             var ravenQueryProvider = new RavenQueryProvider<T>(
                 CreateDocumentQueryInternal<T>(), // clone

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -1099,7 +1099,10 @@ namespace Raven.Client.Documents.Session
         {
             var type = typeof(T);
 
-            var queryStatistics = new QueryStatistics();
+            var queryStatistics = new QueryStatistics()
+            {
+                RequestedByUser = QueryStats.RequestedByUser
+            };
             var highlightings = new LinqQueryHighlightings();
 
             var ravenQueryInspector = new RavenQueryInspector<T>();

--- a/test/SlowTests/Issues/RavenDB_23336.cs
+++ b/test/SlowTests/Issues/RavenDB_23336.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23336(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task TotalResultsShouldBeEqualWithAndWithoutSortingAsync(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        await store.ExecuteIndexAsync(new TestIndex());
+        await using (var bulk = store.BulkInsert())
+            foreach (var testDoc in Enumerable.Range(1, 20)
+                         .Select(x => new TestDoc { Created = DateTime.UtcNow }))
+                await bulk.StoreAsync(testDoc);
+        await Indexes.WaitForIndexingAsync(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // First query - without sorting
+            var queryWithoutSorting = session
+                .Advanced
+                .AsyncDocumentQuery<TestIndex.Result, TestIndex>()
+                .Statistics(out var statsWithoutSorting)
+                .Take(10);
+
+            var itemsWithoutSorting = await queryWithoutSorting.ToQueryable().As<TestDoc>().ToListAsync();
+
+            var totalResultsWithoutSorting = statsWithoutSorting.TotalResults;
+            var countWithoutSorting = itemsWithoutSorting.Count;
+
+            // Second query - with sorting
+            var queryWithSorting = session
+                .Advanced
+                .AsyncDocumentQuery<TestIndex.Result, TestIndex>()
+                .Statistics(out var statsWithSorting)
+                .Take(10)
+                .OrderByDescending(sample => sample.Requested);
+
+            var itemsWithSorting = await queryWithSorting.ToQueryable().As<TestDoc>().ToListAsync();
+
+            var totalResultsWithSorting = statsWithSorting.TotalResults;
+            var countWithSorting = itemsWithSorting.Count;
+
+            Assert.Equal(totalResultsWithoutSorting, totalResultsWithSorting);
+            Assert.Equal(countWithoutSorting, countWithSorting);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TotalResultsShouldBeEqualWithAndWithoutSortingSync(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        store.ExecuteIndex(new TestIndex());
+        using (var bulk = store.BulkInsert())
+        {
+            foreach (var testDoc in Enumerable.Range(1, 20).Select(x => new TestDoc { Created = DateTime.UtcNow }))
+            {
+                bulk.Store(testDoc);
+            }
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            // First query - without sorting
+            var queryWithoutSorting = session
+                .Advanced
+                .DocumentQuery<TestIndex.Result, TestIndex>()
+                .Statistics(out var statsWithoutSorting)
+                .Take(10);
+
+            var itemsWithoutSorting = queryWithoutSorting.ToQueryable().As<TestDoc>().ToList();
+
+            var totalResultsWithoutSorting = statsWithoutSorting.TotalResults;
+            var countWithoutSorting = itemsWithoutSorting.Count;
+
+            // Second query - with sorting
+            var queryWithSorting = session
+                .Advanced
+                .DocumentQuery<TestIndex.Result, TestIndex>()
+                .Statistics(out var statsWithSorting)
+                .Take(10)
+                .OrderByDescending(sample => sample.Requested);
+
+            var itemsWithSorting = queryWithSorting.ToQueryable().As<TestDoc>().ToList();
+
+            var totalResultsWithSorting = statsWithSorting.TotalResults;
+            var countWithSorting = itemsWithSorting.Count;
+
+            Assert.Equal(totalResultsWithoutSorting, totalResultsWithSorting);
+            Assert.Equal(countWithoutSorting, countWithSorting);
+        }
+    }
+
+    private class TestIndex : AbstractIndexCreationTask<TestDoc, TestIndex.Result>
+    {
+        public TestIndex()
+        {
+            Map = testDocs =>
+                from testDoc in testDocs
+                select new Result { Requested = testDoc.Created, };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+
+        public class Result
+        {
+            public DateTime Requested { get; set; }
+        }
+    }
+
+    private class TestDoc
+    {
+        public DateTime Created { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23336

### Additional description
When the  `order by` clause is optimized via a streaming operation in Corax's primitives, we additionally stop when we reach the page size. However, if the user has requested statistics, we must process all results and count them.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
