### PR TITLE
RavenDB-23190 Enable/disable ongoing task is visible only after hard refresh

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksReducer.ts
@@ -494,7 +494,8 @@ export const ongoingTasksReducer: Reducer<OngoingTasksState, OngoingTaskReducerA
                             );
 
                             if (draftNodeInfoIdx !== -1 && nodeInfoIdx !== -1) {
-                                draft.tasks[draftTaskIdx] = task;
+                                draft.tasks[draftTaskIdx].nodesInfo[draftNodeInfoIdx] = task.nodesInfo[nodeInfoIdx];
+                                draft.tasks[draftTaskIdx].shared = task.shared;
                             }
                         } else {
                             // The task is not in the state so we add it

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/OngoingTasksReducer.ts
@@ -494,8 +494,7 @@ export const ongoingTasksReducer: Reducer<OngoingTasksState, OngoingTaskReducerA
                             );
 
                             if (draftNodeInfoIdx !== -1 && nodeInfoIdx !== -1) {
-                                // The task is already in the state so we update the node info
-                                draft.tasks[draftTaskIdx].nodesInfo[draftNodeInfoIdx] = task.nodesInfo[nodeInfoIdx];
+                                draft.tasks[draftTaskIdx] = task;
                             }
                         } else {
                             // The task is not in the state so we add it


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23190

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
