### PR TITLE
RavenDB-23340 Update docker to Ubuntu 24.04, update deb package dependencies

### DIFF
--- a/docker/build-ubuntu.ps1
+++ b/docker/build-ubuntu.ps1
@@ -61,8 +61,11 @@ function SetupDebBuildEnvironment($arch, $ubuntuVersion){
         "jammy" {
             . "..\scripts\linux\pkg\deb\set-ubuntu-jammy.ps1"
         }
+        "noble" {
+            . "..\scripts\linux\pkg\deb\set-ubuntu-noble.ps1"
+        }
         Default {
-            throw "ERROR: Unsupported Ubuntu version $($ubuntuVersion). Supported version: bionic, focal, jammy."
+            throw "ERROR: Unsupported Ubuntu version $($ubuntuVersion). Supported version: bionic, focal, jammy, noble."
             exit 1
         }
     }

--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -38,7 +38,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
 #                "$($repo):ubuntu-latest",
 #                "$($repo):ubuntu-latest-lts",
                 "$($repo):7.0-ubuntu-latest",
-                "$($repo):$($version)-ubuntu.22.04-x64"
+                "$($repo):$($version)-ubuntu.24.04-x64"
             )
             break;
         }
@@ -47,7 +47,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
 #                "$($repo):ubuntu-arm32v7-latest",
 #                "$($repo):ubuntu-arm32v7-latest-lts",
                 "$($repo):7.0-ubuntu-arm32v7-latest",
-                "$($repo):$($version)-ubuntu.22.04-arm32v7"
+                "$($repo):$($version)-ubuntu.24.04-arm32v7"
             )
             break;
         }
@@ -56,7 +56,7 @@ function GetUbuntuImageTags($repo, $version, $arch) {
 #                "$($repo):ubuntu-arm64v8-latest",
 #                "$($repo):ubuntu-arm64v8-latest-lts",
                 "$($repo):7.0-ubuntu-arm64v8-latest",
-                "$($repo):$($version)-ubuntu.22.04-arm64v8"
+                "$($repo):$($version)-ubuntu.24.04-arm64v8"
                 )
                 break;
         }

--- a/docker/ravendb-ubuntu/Dockerfile.arm32v7
+++ b/docker/ravendb-ubuntu/Dockerfile.arm32v7
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-jammy-arm32v7
+FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-noble-arm32v7
 
 ARG PATH_TO_DEB RAVEN_USER_ID RAVEN_GROUP_ID
 

--- a/docker/ravendb-ubuntu/Dockerfile.arm64v8
+++ b/docker/ravendb-ubuntu/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-jammy-arm64v8
+FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-noble-arm64v8
 
 ARG PATH_TO_DEB RAVEN_USER_ID RAVEN_GROUP_ID
 

--- a/docker/ravendb-ubuntu/Dockerfile.x64
+++ b/docker/ravendb-ubuntu/Dockerfile.x64
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-jammy
+FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-noble
 
 ARG PATH_TO_DEB RAVEN_USER_ID RAVEN_GROUP_ID
 

--- a/scripts/linux/pkg/deb/assets/build.sh
+++ b/scripts/linux/pkg/deb/assets/build.sh
@@ -64,7 +64,7 @@ else
 fi
 
 
-export DEB_DEPS="${DOTNET_RUNTIME_DEPS}, libc6-dev (>= 2.27)"
+export DEB_DEPS="${DOTNET_RUNTIME_DEPS}, libc6-dev (>= 2.27), adduser (>=3.0)"
 
 echo ".NET Runtime: $DOTNET_FULL_VERSION"
 echo "Package dependencies: $DEB_DEPS"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23340

### Additional description

https://github.com/dotnet/dotnet-docker/issues/6112#issuecomment-2541522997
.Net 9 runtime dependencies image is available only for ubuntu 24.04. Added dependency on `adduser` for ubuntu package.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
