### PR TITLE
RavenDB-23362 Add isRoundedPill to Select component

### DIFF
--- a/src/Raven.Studio/typescript/components/common/select/Select.stories.tsx
+++ b/src/Raven.Studio/typescript/components/common/select/Select.stories.tsx
@@ -1,0 +1,110 @@
+import { Meta } from "@storybook/react/*";
+import Select, {
+    OptionWithIcon,
+    OptionWithIconAndSeparator,
+    OptionWithWarning,
+    SelectOption,
+    SelectOptionWithIcon,
+    SelectOptionWithIconAndSeparator,
+    SelectOptionWithWarning,
+    SingleValueWithIcon,
+} from "components/common/select/Select";
+import SelectCreatable from "components/common/select/SelectCreatable";
+import { withStorybookContexts, withBootstrap5 } from "test/storybookTestUtils";
+
+export default {
+    title: "Bits/Select",
+    component: Select,
+    decorators: [withStorybookContexts, withBootstrap5],
+} as Meta;
+
+export const Variants = {
+    render: () => {
+        return (
+            <div style={{ width: 300 }} className="vstack gap-2">
+                <div>
+                    <span className="small-label">Default</span>
+                    <Select options={options} />
+                </div>
+                <div>
+                    <span className="small-label">Clearable</span>
+                    <Select options={options} isClearable value={options[0]} />
+                </div>
+                <div>
+                    <span className="small-label">Rounded pill</span>
+                    <Select options={options} isRoundedPill value={options[0]} />
+                </div>
+                <div>
+                    <span className="small-label">Disabled</span>
+                    <Select options={options} isDisabled />
+                </div>
+                <div>
+                    <span className="small-label">Loading</span>
+                    <Select options={options} isLoading />
+                </div>
+                <div>
+                    <span className="small-label">Multi</span>
+                    <Select options={options} isMulti value={options} />
+                </div>
+                <div>
+                    <span className="small-label">Creatable</span>
+                    <SelectCreatable options={options} />
+                </div>
+                <div>
+                    <span className="small-label">With icon</span>
+                    <Select
+                        options={optionsWithIcon}
+                        components={{
+                            SingleValue: SingleValueWithIcon,
+                            Option: OptionWithIcon,
+                        }}
+                        value={optionsWithIcon[0]}
+                    />
+                </div>
+                <div>
+                    <span className="small-label">With icon and separator</span>
+                    <Select
+                        options={optionsWithIconAndSeparator}
+                        components={{
+                            SingleValue: SingleValueWithIcon,
+                            Option: OptionWithIconAndSeparator,
+                        }}
+                    />
+                </div>
+                <div>
+                    <span className="small-label">With warning</span>
+                    <Select
+                        options={optionsWithWarning}
+                        components={{
+                            Option: OptionWithWarning,
+                        }}
+                    />
+                </div>
+            </div>
+        );
+    },
+};
+
+const options: SelectOption[] = [
+    { value: "one", label: "One" },
+    { value: "two", label: "Two" },
+    { value: "three", label: "Three" },
+];
+
+const optionsWithIcon: SelectOptionWithIcon[] = [
+    { value: "one", label: "One", icon: "access-admin" },
+    { value: "two", label: "Two", icon: "access-read" },
+    { value: "three", label: "Three", icon: "access-read-write" },
+];
+
+const optionsWithIconAndSeparator: SelectOptionWithIconAndSeparator[] = [
+    { value: "one", label: "One", icon: "access-admin", horizontalSeparatorLine: true },
+    { value: "two", label: "Two", icon: "access-read", horizontalSeparatorLine: true },
+    { value: "three", label: "Three", icon: "access-read-write" },
+];
+
+const optionsWithWarning: SelectOptionWithWarning[] = [
+    { value: "one", label: "One", isWarning: true },
+    { value: "two", label: "Two", isWarning: true },
+    { value: "three", label: "Three" },
+];

--- a/src/Raven.Studio/typescript/components/common/select/Select.tsx
+++ b/src/Raven.Studio/typescript/components/common/select/Select.tsx
@@ -6,6 +6,7 @@ import ReactSelect, {
     components,
     MultiValueProps,
     InputProps,
+    StylesConfig,
 } from "react-select";
 import { Icon } from "../Icon";
 import "./Select.scss";
@@ -38,12 +39,28 @@ export type SelectOptionWithWarning<T extends SelectValue = string> = SelectOpti
 export type SelectOptionWithIconAndSeparator<T extends SelectValue = string> = SelectOptionWithIcon<T> &
     SelectOptionSeparator;
 
+interface SelectProps<Option, IsMulti extends boolean = false, Group extends GroupBase<Option> = GroupBase<Option>>
+    extends ComponentProps<typeof ReactSelect<Option, IsMulti, Group>> {
+    isRoundedPill?: boolean;
+}
+
 export default function Select<
     Option,
     IsMulti extends boolean = false,
     Group extends GroupBase<Option> = GroupBase<Option>,
->(props: ComponentProps<typeof ReactSelect<Option, IsMulti, Group>>) {
-    return <ReactSelect {...props} className="bs5 react-select-container" classNamePrefix="react-select" />;
+>({ isRoundedPill, className, styles = {}, ...rest }: SelectProps<Option, IsMulti, Group>) {
+    if (isRoundedPill) {
+        applyRoundedPillStyle(styles);
+    }
+
+    return (
+        <ReactSelect
+            styles={styles}
+            {...rest}
+            classNamePrefix="react-select"
+            className={classNames("bs5 react-select-container", { "rounded-pill": isRoundedPill }, className)}
+        />
+    );
 }
 
 export function OptionWithIcon(props: OptionProps<SelectOptionWithIcon>) {
@@ -107,4 +124,11 @@ export function MultiValueLabelWithIcon({ children, ...props }: MultiValueProps<
 // https://github.com/JedWatson/react-select/issues/3068
 export function InputNotHidden({ ...props }: InputProps) {
     return <components.Input {...props} isHidden={false} />;
+}
+
+export function applyRoundedPillStyle(styles: StylesConfig) {
+    styles.control = (base) => ({
+        ...base,
+        borderRadius: "50rem",
+    });
 }

--- a/src/Raven.Studio/typescript/components/common/select/SelectCreatable.tsx
+++ b/src/Raven.Studio/typescript/components/common/select/SelectCreatable.tsx
@@ -1,19 +1,34 @@
-import React, { ComponentProps } from "react";
+import { ComponentProps } from "react";
 import ReactSelectCreatable from "react-select/creatable";
 import { GroupBase } from "react-select";
 import "./Select.scss";
+import classNames from "classnames";
+import { applyRoundedPillStyle } from "components/common/select/Select";
+
+interface SelectCreatableProps<
+    Option,
+    IsMulti extends boolean = false,
+    Group extends GroupBase<Option> = GroupBase<Option>,
+> extends ComponentProps<typeof ReactSelectCreatable<Option, IsMulti, Group>> {
+    isRoundedPill?: boolean;
+}
 
 export default function SelectCreatable<
     Option,
     IsMulti extends boolean = false,
     Group extends GroupBase<Option> = GroupBase<Option>,
->(props: ComponentProps<typeof ReactSelectCreatable<Option, IsMulti, Group>>) {
+>({ isRoundedPill, className, styles = {}, ...rest }: SelectCreatableProps<Option, IsMulti, Group>) {
+    if (isRoundedPill) {
+        applyRoundedPillStyle(styles);
+    }
+
     return (
         <ReactSelectCreatable
-            {...props}
-            className="bs5 react-select-container"
-            classNamePrefix="react-select"
+            styles={styles}
             formatCreateLabel={(value) => value}
+            {...rest}
+            classNamePrefix="react-select"
+            className={classNames("bs5 react-select-container", { "rounded-pill": isRoundedPill }, className)}
         />
     );
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23362/Add-isRoundedPill-to-Select-component

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
