### PR TITLE
RavenDB-23370: Update benchmarks to .Net 9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,7 +46,7 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageVersion Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.553101" />
-    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.77" />
+    <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.18" />
     <PackageVersion Include="Microsoft.DotNet.xunit.performance" Version="1.0.0-alpha-build0041" />
     <PackageVersion Include="Microsoft.DotNet.xunit.performance.runner.cli" Version="1.0.0-alpha-build0041" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />

--- a/bench/Micro.Benchmark/Benchmarks/BatchedIntegerEncoding.cs
+++ b/bench/Micro.Benchmark/Benchmarks/BatchedIntegerEncoding.cs
@@ -25,7 +25,7 @@ namespace Micro.Benchmark.Benchmarks
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core50,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit,
                     },

--- a/bench/Micro.Benchmark/Benchmarks/Dictionary.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Dictionary.cs
@@ -25,7 +25,7 @@ namespace Micro.Benchmark.Benchmarks
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core70,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit,
                     },

--- a/bench/Micro.Benchmark/Benchmarks/Hardware/Compare.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Hardware/Compare.cs
@@ -30,7 +30,7 @@ namespace Micro.Benchmark.Benchmarks.Hardware
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core80,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit
                     }

--- a/bench/Micro.Benchmark/Benchmarks/Hardware/Diff.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Hardware/Diff.cs
@@ -32,7 +32,7 @@ namespace Micro.Benchmark.Benchmarks.Hardware
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core22,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit
                     }

--- a/bench/Micro.Benchmark/Benchmarks/Hardware/Prefetch.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Hardware/Prefetch.cs
@@ -27,7 +27,7 @@ namespace Micro.Benchmark.Benchmarks.Hardware
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core22,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit
                     }

--- a/bench/Micro.Benchmark/Benchmarks/Hardware/Prefetch2.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Hardware/Prefetch2.cs
@@ -27,7 +27,7 @@ namespace Micro.Benchmark.Benchmarks.Hardware
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core22,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit
                     }

--- a/bench/Micro.Benchmark/Benchmarks/Hardware/Search.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Hardware/Search.cs
@@ -29,7 +29,7 @@ namespace Micro.Benchmark.Benchmarks.Hardware
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core22,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit
                     }

--- a/bench/Micro.Benchmark/Benchmarks/Hashing.XXHash32.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Hashing.XXHash32.cs
@@ -27,7 +27,7 @@ namespace Micro.Benchmark.Benchmarks
             {
                 AddJob(new Job
                 {
-                    Environment = { Runtime = CoreRuntime.Core70, Platform = Platform.X64, Jit = Jit.RyuJit, },
+                    Environment = { Runtime = CoreRuntime.Core90, Platform = Platform.X64, Jit = Jit.RyuJit, },
                     Run =
                     {
                         // TODO: Next line is just for testing. Fine tune parameters.

--- a/bench/Micro.Benchmark/Benchmarks/Hashing.XXHash64.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Hashing.XXHash64.cs
@@ -27,7 +27,7 @@ namespace Micro.Benchmark.Benchmarks
             {
                 AddJob(new Job
                 {
-                    Environment = { Runtime = CoreRuntime.Core70, Platform = Platform.X64, Jit = Jit.RyuJit, },
+                    Environment = { Runtime = CoreRuntime.Core90, Platform = Platform.X64, Jit = Jit.RyuJit, },
                     Run =
                     {
                         // TODO: Next line is just for testing. Fine tune parameters.

--- a/bench/Micro.Benchmark/Benchmarks/HopeEncoder.cs
+++ b/bench/Micro.Benchmark/Benchmarks/HopeEncoder.cs
@@ -24,7 +24,7 @@ namespace Micro.Benchmark.Benchmarks
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core50,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit,
                     },

--- a/bench/Micro.Benchmark/Benchmarks/IntegerEncoding.cs
+++ b/bench/Micro.Benchmark/Benchmarks/IntegerEncoding.cs
@@ -25,7 +25,7 @@ namespace Micro.Benchmark.Benchmarks
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core70,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.Default,
                     },

--- a/bench/Micro.Benchmark/Benchmarks/LZ4/LZ4Benchmark.cs
+++ b/bench/Micro.Benchmark/Benchmarks/LZ4/LZ4Benchmark.cs
@@ -23,11 +23,11 @@ namespace Micro.Benchmark.Benchmarks.LZ4
         {
             public Config()
             {
-                AddJob(new Job(RunMode.Dry)
+                AddJob(new Job
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core22,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit
                     }

--- a/bench/Micro.Benchmark/Benchmarks/PageLocator/PlRandomRead.cs
+++ b/bench/Micro.Benchmark/Benchmarks/PageLocator/PlRandomRead.cs
@@ -24,7 +24,7 @@ namespace Micro.Benchmark.Benchmarks.PageLocator
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core22,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit
                     },

--- a/bench/Micro.Benchmark/Benchmarks/PageLocator/PlRandomWrite.cs
+++ b/bench/Micro.Benchmark/Benchmarks/PageLocator/PlRandomWrite.cs
@@ -23,7 +23,7 @@ namespace Micro.Benchmark.Benchmarks.PageLocator
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core22,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit
                     },

--- a/bench/Micro.Benchmark/Benchmarks/PointerBenchmarks.cs
+++ b/bench/Micro.Benchmark/Benchmarks/PointerBenchmarks.cs
@@ -22,7 +22,7 @@ namespace Micro.Benchmark.Benchmarks
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core70,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.Default,
                     },

--- a/bench/Micro.Benchmark/Benchmarks/Sorting/Sorting.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Sorting/Sorting.cs
@@ -24,7 +24,7 @@ namespace Micro.Benchmark.Benchmarks.Sorting
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core70,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit,
                     },

--- a/bench/Micro.Benchmark/Benchmarks/TypeCache.cs
+++ b/bench/Micro.Benchmark/Benchmarks/TypeCache.cs
@@ -13,6 +13,7 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Validators;
 using Sparrow.Binary;
 using Sparrow.Collections;
+using Sparrow.Utils;
 
 namespace Micro.Benchmark.Benchmarks
 {
@@ -27,7 +28,7 @@ namespace Micro.Benchmark.Benchmarks
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core70,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit,
                     },
@@ -52,6 +53,7 @@ namespace Micro.Benchmark.Benchmarks
 
         private Type[] _typesToCheck;
 
+        private readonly TypeCache<int> _ravenDb60TypeCache = new(128);
         private readonly RavenDb50TypeCache<int> _ravenDb50TypeCache = new(128);
         private readonly UnsafeAddressTypeCache<int> _compareExchangeThreadSafe = new(128);
         private readonly HashFastTypeCache<int> _hashCompareExchangeThreadSafe = new(128);
@@ -77,20 +79,33 @@ namespace Micro.Benchmark.Benchmarks
             foreach (var type in typesToCheck)
             {
                 _ravenDb50TypeCache.Put(type, 0);
+                _ravenDb60TypeCache.Put(type, 0);
                 _compareExchangeThreadSafe.Put(type, 0);
                 _hashCompareExchangeThreadSafe.Set(type, 0);
                 _dictionary.Add(type, 0);
             }
         }
 
-
-        [Benchmark(Baseline = true)]
-        public int CurrentThreadUnsafe()
+        [Benchmark]
+        public int RavenDB50ThreadUnsafe()
         {
             int result = 0;
             foreach (var type in _typesToCheck)
             {
                 _ravenDb50TypeCache.TryGet(type, out var r);
+                result += r;
+            }
+
+            return result;
+        }
+
+        [Benchmark(Baseline = true)]
+        public int RavenDB60ThreadUnsafe()
+        {
+            int result = 0;
+            foreach (var type in _typesToCheck)
+            {
+                _ravenDb60TypeCache.TryGet(type, out var r);
                 result += r;
             }
 

--- a/bench/Micro.Benchmark/Benchmarks/Zstd/ZstdBenchmark.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Zstd/ZstdBenchmark.cs
@@ -27,7 +27,7 @@ namespace Micro.Benchmark.Benchmarks.LZ4
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core70,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit
                     }

--- a/bench/Micro.Benchmark/Benchmarks/Zstd/ZstdPageBenchmark.cs
+++ b/bench/Micro.Benchmark/Benchmarks/Zstd/ZstdPageBenchmark.cs
@@ -27,7 +27,7 @@ namespace Micro.Benchmark.Benchmarks.LZ4
                 {
                     Environment =
                     {
-                        Runtime = CoreRuntime.Core70,
+                        Runtime = CoreRuntime.Core90,
                         Platform = Platform.X64,
                         Jit = Jit.RyuJit
                     }

--- a/bench/Micro.Benchmark/Program.cs
+++ b/bench/Micro.Benchmark/Program.cs
@@ -17,10 +17,6 @@ namespace Micro.Benchmark
             Console.WriteLine($"{nameof(Avx)} support: {Avx.IsSupported}");
             Console.WriteLine($"{nameof(Avx2)} support: {Avx2.IsSupported}");
 
-            var test = new ZstdPageBenchmark();
-            test.Setup();
-            test.Zstd();
-
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }
     }

--- a/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMerger.Benchmark.csproj
+++ b/bench/ServerStoreTxMerger.Benchmark/ServerStoreTxMerger.Benchmark.csproj
@@ -8,8 +8,8 @@
     <CodeAnalysisRuleSet>..\..\RavenDB.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" VersionOverride="3.1.17" />
+    <PackageReference Include="BenchmarkDotNet" />    
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />

--- a/tools/Raven.Debug/Raven.Debug.csproj
+++ b/tools/Raven.Debug/Raven.Debug.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" VersionOverride="2.0.77" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23370

### Additional description

Updated and fix nuget references to work under .Net 9.0 for the benchmarks projects.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
