### PR TITLE
RavenDB-23231 - Changed from blocking the thread to using await for asynchronous execution

### DIFF
--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -413,7 +413,10 @@ namespace Raven.Server.Commercial
                 if (TryValidateLicenseExpirationDate(deserializedLicense, out var deserializedLicenseExpirationDate))
                 {
                     ValidateLicenseVersionOrThrow(deserializedLicense, serverStore, contextPool);
-                    serverStore.LicenseManager.OnBeforeInitialize += () => serverStore.LicenseManager.TryActivateLicenseAsync(throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).Wait(serverStore.ServerShutdown);
+
+                    serverStore.LicenseManager.OnBeforeInitialize += () => AsyncHelpers.RunSync(() => serverStore.LicenseManager.TryActivateLicenseAsync
+                        (throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).WaitAsync(TimeSpan.FromSeconds(30)));
+
                     return true;
                 }
 

--- a/src/Raven.Server/Commercial/LicenseHelper.cs
+++ b/src/Raven.Server/Commercial/LicenseHelper.cs
@@ -415,7 +415,7 @@ namespace Raven.Server.Commercial
                     ValidateLicenseVersionOrThrow(deserializedLicense, serverStore, contextPool);
 
                     serverStore.LicenseManager.OnBeforeInitialize += () => AsyncHelpers.RunSync(() => serverStore.LicenseManager.TryActivateLicenseAsync
-                        (throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).WaitAsync(TimeSpan.FromSeconds(30)));
+                        (throwOnActivationFailure: serverStore.Server.ThrowOnLicenseActivationFailure).WaitAsync(serverStore.ServerShutdown));
 
                     return true;
                 }

--- a/test/BenchmarkTests/BenchmarkTestBase.cs
+++ b/test/BenchmarkTests/BenchmarkTestBase.cs
@@ -170,13 +170,13 @@ namespace BenchmarkTests
             throw new TimeoutException($"The index '{indexName}' stayed stale for more than {timeout.Value}.");
         }
 
-        protected DatabaseRecord CreateDatabaseRecord(string databaseName)
+        protected async Task <DatabaseRecord> CreateDatabaseRecord(string databaseName)
         {
             var databaseRecord = new DatabaseRecord(databaseName);
 
             if (Encrypted)
             {
-                Encryption.PutSecretKeyForDatabaseInServerStore(databaseName, Server);
+                await Encryption.PutSecretKeyForDatabaseInServerStoreAsync(databaseName, Server);
                 databaseRecord.Encrypted = true;
             }
 

--- a/test/BenchmarkTests/Indexing/Index.cs
+++ b/test/BenchmarkTests/Indexing/Index.cs
@@ -191,8 +191,8 @@ namespace BenchmarkTests.Indexing
 
         public override async Task InitAsync(DocumentStore store)
         {
-            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(CreateDatabaseRecord(IndexDatabaseName)));
-            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(CreateDatabaseRecord(ReIndexDatabaseName)));
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(await CreateDatabaseRecord(IndexDatabaseName)));
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(await CreateDatabaseRecord(ReIndexDatabaseName)));
 
             await new Simple_Map_Index().ExecuteAsync(store, database: ReIndexDatabaseName);
             await new Simple_MapReduce_Index().ExecuteAsync(store, database: ReIndexDatabaseName);

--- a/test/BenchmarkTests/Patching/Patch.cs
+++ b/test/BenchmarkTests/Patching/Patch.cs
@@ -105,9 +105,9 @@ update
 
         public override async Task InitAsync(DocumentStore store)
         {
-            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(CreateDatabaseRecord("1M_Companies_Patch")));
-            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(CreateDatabaseRecord("1M_Companies_Patch_Put")));
-            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(CreateDatabaseRecord("1M_Companies_Patch_Delete")));
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(await CreateDatabaseRecord("1M_Companies_Patch")));
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(await CreateDatabaseRecord("1M_Companies_Patch_Put")));
+            await store.Maintenance.Server.SendAsync(new CreateDatabaseOperation(await CreateDatabaseRecord("1M_Companies_Patch_Delete")));
 
             using (var bulkInsert1 = store.BulkInsert("1M_Companies_Patch"))
             using (var bulkInsert2 = store.BulkInsert("1M_Companies_Patch_Put"))

--- a/test/SlowTests/Client/Attachments/AttachmentsBigFiles.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsBigFiles.cs
@@ -24,9 +24,8 @@ namespace SlowTests.Client.Attachments
             X509Certificate2 adminCert = null;
             if (encrypted)
             {
-                var backupPath = NewDataPath(suffix: "BackupFolder");
-                var key = Encryption.EncryptedServer(out var certificates, out dbName);
-                adminCert = certificates.ServerCertificate.Value;
+                var result = await Encryption.EncryptedServerAsync();
+                adminCert = result.Certificates.ServerCertificate.Value;
             }
             else
             {
@@ -85,9 +84,8 @@ namespace SlowTests.Client.Attachments
             X509Certificate2 adminCert = null;
             if (encrypted)
             {
-                var backupPath = NewDataPath(suffix: "BackupFolder");
-                var key = Encryption.EncryptedServer(out var certificates, out dbName);
-                adminCert = certificates.ServerCertificate.Value;
+                var result = await Encryption.EncryptedServerAsync();
+                adminCert = result.Certificates.ServerCertificate.Value;
             }
             else
             {

--- a/test/SlowTests/Client/Attachments/AttachmentsBigFiles.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsBigFiles.cs
@@ -20,11 +20,12 @@ namespace SlowTests.Client.Attachments
         [InlineData(10, "i1enlqXQfLBMwWFN/CrLP3PtxxLX9DNhnKO75muxX0k=", true)]
         public async Task BatchRequestWithLongMultiPartSections(long size, string hash, bool encrypted)
         {
-            string dbName = null;
+            string dbName;
             X509Certificate2 adminCert = null;
             if (encrypted)
             {
                 var result = await Encryption.EncryptedServerAsync();
+                dbName = result.DatabaseName;
                 adminCert = result.Certificates.ServerCertificate.Value;
             }
             else
@@ -44,23 +45,21 @@ namespace SlowTests.Client.Attachments
                 var dbId1 = new Guid("00000000-48c4-421e-9466-000000000000");
                 await Databases.SetDatabaseId(store, dbId1);
 
-                using (var session = store.OpenSession())
-                using (var stream = new BigDummyStream(size))
+                using (var session = store.OpenAsyncSession())
+                await using (var stream = new BigDummyStream(size))
                 {
                     var user = new User { Name = "Fitzchak" };
-                    session.Store(user, "users/1");
-
+                    await session.StoreAsync(user, "users/1");
                     session.Advanced.Attachments.Store(user, "big-file", stream);
-
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    var user = session.Load<User>("users/1");
+                    var user = await session.LoadAsync<User>("users/1");
 
-                    using (var bigStream = new BigDummyStream(size))
-                    using (var attachment = session.Advanced.Attachments.Get(user, "big-file"))
+                    await using (var bigStream = new BigDummyStream(size))
+                    using (var attachment = await session.Advanced.Attachments.GetAsync(user, "big-file"))
                     {
                         Assert.Contains("A:2", attachment.Details.ChangeVector);
                         Assert.Equal("big-file", attachment.Details.Name);
@@ -68,7 +67,7 @@ namespace SlowTests.Client.Attachments
                         Assert.Equal(size, attachment.Details.Size);
                         Assert.Equal("", attachment.Details.ContentType);
 
-                        attachment.Stream.CopyTo(bigStream);
+                        await attachment.Stream.CopyToAsync(bigStream);
                         Assert.Equal(size, bigStream.Position);
                     }
                 }
@@ -80,11 +79,12 @@ namespace SlowTests.Client.Attachments
         [InlineData(10, "i1enlqXQfLBMwWFN/CrLP3PtxxLX9DNhnKO75muxX0k=", true)]
         public async Task SupportHugeAttachment(long size, string hash, bool encrypted)
         {
-            string dbName = null;
+            string dbName;
             X509Certificate2 adminCert = null;
             if (encrypted)
             {
                 var result = await Encryption.EncryptedServerAsync();
+                dbName = result.DatabaseName;
                 adminCert = result.Certificates.ServerCertificate.Value;
             }
             else
@@ -104,15 +104,15 @@ namespace SlowTests.Client.Attachments
                 var dbId1 = new Guid("00000000-48c4-421e-9466-000000000000");
                 await Databases.SetDatabaseId(store, dbId1);
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new User { Name = "Fitzchak" }, "users/1");
-                    session.SaveChanges();
+                    await session.StoreAsync(new User { Name = "Fitzchak" }, "users/1");
+                    await session.SaveChangesAsync();
                 }
 
-                using (var bigStream = new BigDummyStream(size))
+                await using (var bigStream = new BigDummyStream(size))
                 {
-                    var result = store.Operations.Send(new PutAttachmentOperation("users/1", "huge-file", bigStream));
+                    var result = await store.Operations.SendAsync(new PutAttachmentOperation("users/1", "huge-file", bigStream));
                     Assert.Contains("A:2", result.ChangeVector);
                     Assert.Equal("huge-file", result.Name);
                     Assert.Equal("users/1", result.DocumentId);
@@ -122,14 +122,14 @@ namespace SlowTests.Client.Attachments
                     Assert.Equal(size, bigStream.Position);
                 }
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    var user = session.Load<User>("users/1");
+                    var user = await session.LoadAsync<User>("users/1");
 
-                    using (var bigStream = new BigDummyStream(size))
-                    using (var attachment = session.Advanced.Attachments.Get(user, "huge-file"))
+                    await using (var bigStream = new BigDummyStream(size))
+                    using (var attachment = await session.Advanced.Attachments.GetAsync(user, "huge-file"))
                     {
-                        attachment.Stream.CopyTo(bigStream);
+                        await attachment.Stream.CopyToAsync(bigStream);
                         Assert.Contains("A:2", attachment.Details.ChangeVector);
                         Assert.Equal("huge-file", attachment.Details.Name);
                         Assert.Equal(hash, attachment.Details.Hash);

--- a/test/SlowTests/Client/Subscriptions/RavenDB_3491.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB_3491.cs
@@ -298,7 +298,7 @@ namespace SlowTests.Client.Subscriptions
                     }
                 }
 
-                Assert.True(Task.WaitAll(new[] { subscriptionReleasedAwaiter }, 250));
+                await subscriptionReleasedAwaiter.WaitAsync(TimeSpan.FromMilliseconds(250));
 
                 using (var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(subscriptionName)
                 {

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -30,8 +30,7 @@ namespace SlowTests.Issues
         {
             DebuggerAttachedTimeout.DisableLongTimespan = true;
             var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(3, watcherCluster: true);
-
-            Encryption.EncryptedCluster(nodes, certificates, out var databaseName);
+            var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
             var options = new Options
             {
@@ -74,8 +73,7 @@ namespace SlowTests.Issues
         {
             DebuggerAttachedTimeout.DisableLongTimespan = true;
             var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(3, watcherCluster: true);
-
-            Encryption.EncryptedCluster(nodes, certificates, out var databaseName);
+            var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
             var options = new Options
             {
@@ -141,8 +139,7 @@ namespace SlowTests.Issues
         public async Task AddingNodeToEncryptedDatabaseGroupShouldThrow()
         {
             var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(3);
-
-            Encryption.EncryptedCluster(nodes, certificates, out var databaseName);
+            var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
             var options = new Options
             {
@@ -172,7 +169,7 @@ namespace SlowTests.Issues
                 }))
                 {
                     await Assert.ThrowsAsync<DatabaseLoadFailureException>(async () => await TrySavingDocument(notInDbGroupStore));
-                    Encryption.PutSecretKeyForDatabaseInServerStore(databaseName, notInDbGroupServer);
+                    await Encryption.PutSecretKeyForDatabaseInServerStoreAsync(databaseName, notInDbGroupServer);
                     await notInDbGroupServer.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName, ignoreDisabledDatabase: true);
                     await TrySavingDocument(notInDbGroupStore);
                 }
@@ -194,13 +191,13 @@ namespace SlowTests.Issues
         [Fact]
         public async Task DeletingMasterKeyForExistedEncryptedDatabaseShouldFail()
         {
-            Encryption.EncryptedServer(out var certificates, out var databaseName);
+            var result = await Encryption.EncryptedServerAsync();
 
             var options = new Options
             {
-                ModifyDatabaseName = _ => databaseName,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                ModifyDatabaseName = _ => result.DatabaseName,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
                 Encrypted = true
             };
 
@@ -227,8 +224,7 @@ namespace SlowTests.Issues
         public async Task DeletingEncryptedDatabaseFromDatabaseGroup()
         {
             var (nodes, server, certificates) = await CreateRaftClusterWithSsl(3);
-
-            Encryption.EncryptedCluster(nodes, certificates, out var databaseName);
+            var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
             var options = new Options
             {

--- a/test/SlowTests/Issues/RavenDB-15807.cs
+++ b/test/SlowTests/Issues/RavenDB-15807.cs
@@ -102,7 +102,7 @@ namespace SlowTests.Issues
                 {
                     BlittableJsonReaderObject reader = ctx.Sync.ReadForMemory(new MemoryStream(Encoding.UTF8.GetBytes(json)), "users/1");
                     
-                    var task = await sinkServer.ServerStore.UpdatePullReplicationAsSink(sinkStore.Database, reader, Guid.NewGuid().ToString(), out PullReplicationAsSink pullReplication);
+                    await sinkServer.ServerStore.UpdatePullReplicationAsSink(sinkStore.Database, reader, Guid.NewGuid().ToString(), out PullReplicationAsSink pullReplication);
                     Assert.Null(pullReplication.CertificateWithPrivateKey);
                 }
 

--- a/test/SlowTests/Issues/RavenDB-15807.cs
+++ b/test/SlowTests/Issues/RavenDB-15807.cs
@@ -82,8 +82,8 @@ namespace SlowTests.Issues
                 {
                     BlittableJsonReaderObject reader = ctx.Sync.ReadForMemory(new MemoryStream(Encoding.UTF8.GetBytes(json)), "users/1");
                     
-                    var task = await sinkServer.ServerStore.UpdatePullReplicationAsSink(sinkStore.Database, reader, Guid.NewGuid().ToString(), out PullReplicationAsSink pullReplication);
-                    taskId = task.Index;
+                    var result = await sinkServer.ServerStore.UpdatePullReplicationAsSink(sinkStore.Database, reader, Guid.NewGuid().ToString(), out PullReplicationAsSink pullReplication);
+                    taskId = result.Index;
                     Assert.NotNull(pullReplication.CertificateWithPrivateKey);
                 }
 

--- a/test/SlowTests/Issues/RavenDB-19625.cs
+++ b/test/SlowTests/Issues/RavenDB-19625.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
@@ -19,27 +20,27 @@ public class RavenDB_19625 : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Indexes)]
-    public void CanQueryIndexFilteredByDateTime()
+    public async Task CanQueryIndexFilteredByDateTime()
     {
         using (var store = GetDocumentStore())
         {
-            store.ExecuteIndex(new QueryDateTime_Index());
+            await store.ExecuteIndexAsync(new QueryDateTime_Index());
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new Post {Id = "posts/1", Date = new DateTime(2023, 1, 1, 12, 11, 10)});
+                await session.StoreAsync(new Post { Id = "posts/1", Date = new DateTime(2023, 1, 1, 12, 11, 10) });
 
-                session.SaveChanges();
+                await session.SaveChangesAsync();
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
-                var res = session.Query<QueryDateTime_Index.Result, QueryDateTime_Index>()
+                var res = await session.Query<QueryDateTime_Index.Result, QueryDateTime_Index>()
                     .Where(x => x.Date < DateTime.UtcNow)
                     .ProjectInto<QueryDateTime_Index.Result>()
-                    .ToList();
+                    .ToListAsync();
 
                 Assert.NotEmpty(res);
-                var hasTimeValues = GetDatabase(store.Database).Result.IndexStore.GetIndex(new QueryDateTime_Index().IndexName).IndexFieldsPersistence
+                var hasTimeValues = (await GetDatabase(store.Database)).IndexStore.GetIndex(new QueryDateTime_Index().IndexName).IndexFieldsPersistence
                     .HasTimeValues(nameof(QueryDateTime_Index.Result.Date));
                 Assert.True(hasTimeValues);
             }
@@ -49,7 +50,7 @@ public class RavenDB_19625 : RavenTestBase
     [RavenTheory(RavenTestCategory.Indexes)]
     [InlineData("SlowTests.Data.RavenDB_21957.js_index_with_dates_54112.ravendb-snapshot")]
     [InlineData("SlowTests.Data.RavenDB_21957.js_index_with_dates_601.ravendb-snapshot")]
-    public void IndexBuiltBeforeJsDateIntroductionWillNotInsertTicks(string snapshotResourcePath)
+    public async Task IndexBuiltBeforeJsDateIntroductionWillNotInsertTicks(string snapshotResourcePath)
     {
         var backupPath = NewDataPath(forceCreateDir: true);
         var fullBackupPath = Path.Combine(backupPath, "backup.ravendb-snapshot");
@@ -57,38 +58,37 @@ public class RavenDB_19625 : RavenTestBase
         using (var file = File.Create(fullBackupPath))
         using (var stream = typeof(RavenDB_19625).Assembly.GetManifestResourceStream(snapshotResourcePath))
         {
-            stream.CopyTo(file);
+            await stream.CopyToAsync(file);
         }
 
         using var store = GetDocumentStore();
         var databaseName = GetDatabaseName();
         using var _ = Backup.RestoreDatabase(store, new RestoreBackupConfiguration {BackupLocation = backupPath, DatabaseName = databaseName});
 
-        using (var session = store.OpenSession(databaseName))
+        using (var session = store.OpenAsyncSession(databaseName))
         {
-            var results = session.Query<QueryDateTime_Index.Result, QueryDateTime_Index>()
+            var results = await session.Query<QueryDateTime_Index.Result, QueryDateTime_Index>()
                 .Where(x => x.Date < new DateTime(2024, 1, 1))
                 .ProjectInto<QueryDateTime_Index.Result>()
-                .ToList();
+                .ToListAsync();
             Assert.Equal(1, results.Count);
             Assert.Equal("posts/1", results[0].Id);
-            var hasTimeValues = GetDatabase(databaseName).Result.IndexStore.GetIndex(new QueryDateTime_Index().IndexName).IndexFieldsPersistence
+            var hasTimeValues = (await GetDatabase(databaseName)).IndexStore.GetIndex(new QueryDateTime_Index().IndexName).IndexFieldsPersistence
                 .HasTimeValues(nameof(QueryDateTime_Index.Result.Date));
             Assert.False(hasTimeValues);
             
+            await session.StoreAsync(new Post {Id = "posts/2", Date = new DateTime(2023, 1, 2, 12, 11, 12)});
+            await session.SaveChangesAsync();
+            await Indexes.WaitForIndexingAsync(store, databaseName);
             
-            session.Store(new Post {Id = "posts/2", Date = new DateTime(2023, 1, 2, 12, 11, 12)});
-            session.SaveChanges();
-            Indexes.WaitForIndexing(store, databaseName);
-            
-            results = session.Query<QueryDateTime_Index.Result, QueryDateTime_Index>()
+            results = await session.Query<QueryDateTime_Index.Result, QueryDateTime_Index>()
                 .Where(x => x.Date < new DateTime(2024, 1, 1))
                 .ProjectInto<QueryDateTime_Index.Result>()
-                .ToList();
+                .ToListAsync();
             
             Assert.Equal(2, results.Count);
 
-            hasTimeValues = GetDatabase(databaseName).Result.IndexStore.GetIndex(new QueryDateTime_Index().IndexName).IndexFieldsPersistence
+            hasTimeValues = (await GetDatabase(databaseName)).IndexStore.GetIndex(new QueryDateTime_Index().IndexName).IndexFieldsPersistence
                 .HasTimeValues(nameof(QueryDateTime_Index.Result.Date));
             Assert.False(hasTimeValues);
         }

--- a/test/SlowTests/Issues/RavenDB-20136.cs
+++ b/test/SlowTests/Issues/RavenDB-20136.cs
@@ -37,59 +37,59 @@ namespace SlowTests.Issues
                 var loadDone2 = Etl.WaitForEtlToComplete(src, (_, statistics) => statistics.LoadSuccesses == 2);
                 var deleteDone = Etl.WaitForEtlToComplete(src, (_, statistics) => statistics.LoadSuccesses == 3);
 
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
-                    session.Store(new User { Name = "Bob" }, "users/1");
-                    session.SaveChanges();
+                    await session.StoreAsync(new User { Name = "Bob" }, "users/1");
+                    await session.SaveChangesAsync();
                 }
 
                 if (loadDone1.Wait(TimeSpan.FromSeconds(30)) == false)
                 {
-                    Etl.TryGetLoadError(src.Database, configuration, out var loadError);
-                    Etl.TryGetTransformationError(src.Database, configuration, out var transformationError);
+                    var loadError = await Etl.TryGetLoadErrorAsync(src.Database, configuration);
+                    var transformationError = await Etl.TryGetTransformationErrorAsync(src.Database, configuration);
 
                     Assert.Fail($"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
                 }
 
-                using (var session = dst.OpenSession())
+                using (var session = dst.OpenAsyncSession())
                 {
-                    var user = session.Load<User>("users/1");
+                    var user = await session.LoadAsync<User>("users/1");
                     Assert.Equal("Bob", user.Name);
                 }
 
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
-                    var user = session.Load<User>("users/1");
+                    var user = await session.LoadAsync<User>("users/1");
                     user.Name = "Gracjan";
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 if (loadDone2.Wait(TimeSpan.FromSeconds(30)) == false)
                 {
-                    Etl.TryGetLoadError(src.Database, configuration, out var loadError);
-                    Etl.TryGetTransformationError(src.Database, configuration, out var transformationError);
+                    var loadError = await Etl.TryGetLoadErrorAsync(src.Database, configuration);
+                    var transformationError = await Etl.TryGetTransformationErrorAsync(src.Database, configuration);
 
                     Assert.Fail($"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
                 }
 
-                using (var session = dst.OpenSession())
+                using (var session = dst.OpenAsyncSession())
                 {
-                    var user = session.Load<User>("users/1");
+                    var user = await session.LoadAsync<User>("users/1");
                     Assert.NotNull(user);
                     Assert.Equal("Gracjan", user.Name);
                 }
 
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
                     session.Delete("users/1");
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 Assert.True(deleteDone.Wait(TimeSpan.FromSeconds(30)));
 
-                using (var session = dst.OpenSession())
+                using (var session = dst.OpenAsyncSession())
                 {
-                    var user = session.Load<User>("users/1");
+                    var user = await session.LoadAsync<User>("users/1");
                     Assert.Null(user);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-20979.cs
+++ b/test/SlowTests/Issues/RavenDB-20979.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using FastTests;
 using FastTests.Client;
 using Raven.Client.Documents.Operations.Indexes;
@@ -18,15 +19,16 @@ public class RavenDB_20979 : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Indexes)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void CanUsePulsedEnumeratorInDictionaryTrainingPhase(Options parameters)
+    public async Task CanUsePulsedEnumeratorInDictionaryTrainingPhase(Options parameters)
     {
-        Encryption.EncryptedServer(out var certificates, out string dbName);
+        var result = await Encryption.EncryptedServerAsync();
+
         using var store = GetDocumentStore(new Options
         {
             Encrypted = true,
-            AdminCertificate = certificates.ServerCertificate.Value,
-            ClientCertificate = certificates.ServerCertificate.Value,
-            ModifyDatabaseName = s => dbName,
+            AdminCertificate = result.Certificates.ServerCertificate.Value,
+            ClientCertificate = result.Certificates.ServerCertificate.Value,
+            ModifyDatabaseName = s => result.DatabaseName,
             ModifyDatabaseRecord = record =>
             {
                 parameters.ModifyDatabaseRecord(record);

--- a/test/SlowTests/Issues/RavenDB_12725_Raven.cs
+++ b/test/SlowTests/Issues/RavenDB_12725_Raven.cs
@@ -35,7 +35,7 @@ namespace SlowTests.Issues
             }))
             {
                 db = await GetDatabase(store.Database);
-                store.Maintenance.Send(new CreateSampleDataOperation());
+                await store.Maintenance.SendAsync(new CreateSampleDataOperation());
             }
 
             db.Dispose();

--- a/test/SlowTests/Issues/RavenDB_13291.cs
+++ b/test/SlowTests/Issues/RavenDB_13291.cs
@@ -34,24 +34,24 @@ namespace SlowTests.Issues
                     DatabaseName = databaseName
                 }))
                 {
-                    var stats = store.Maintenance.ForDatabase(databaseName).Send(new GetStatisticsOperation());
+                    var stats = await store.Maintenance.ForDatabase(databaseName).SendAsync(new GetStatisticsOperation());
 
                     Assert.Equal(2, stats.CountOfDocuments);
                     Assert.Equal(1, stats.CountOfCounterEntries);
 
-                    using (var session = store.OpenSession(databaseName))
+                    using (var session = store.OpenAsyncSession(databaseName))
                     {
-                        var o = session.Load<object>("LoginCounters/1");
+                        var o = await session.LoadAsync<object>("LoginCounters/1");
 
                         Assert.NotNull(o);
 
-                        var d = session.Load<object>("downloads/1");
+                        var d = await session.LoadAsync<object>("downloads/1");
 
                         Assert.NotNull(d);
 
-                        var details = store.Operations
+                        var details = await store.Operations
                             .ForDatabase(databaseName)
-                            .Send(new GetCountersOperation("downloads/1", returnFullResults: true));
+                            .SendAsync(new GetCountersOperation("downloads/1", returnFullResults: true));
 
                         Assert.Equal(1, details.Counters.Count);
                         Assert.Equal("NumberOfDownloads", details.Counters[0].CounterName);

--- a/test/SlowTests/Issues/RavenDB_13972.cs
+++ b/test/SlowTests/Issues/RavenDB_13972.cs
@@ -240,29 +240,29 @@ namespace SlowTests.Issues
             }
         }
 
-        protected void CanStreamQueryWithPulsatingReadTransaction_ActualTest(int numberOfUsers, DocumentStore store)
+        protected async Task CanStreamQueryWithPulsatingReadTransaction_ActualTestAsync(int numberOfUsers, DocumentStore store)
         {
-            using (var bulk = store.BulkInsert())
+            await using (var bulk = store.BulkInsert())
             {
                 for (int i = 0; i < numberOfUsers; i++)
                 {
-                    bulk.Store(new User(), "users/" + i);
+                    await bulk.StoreAsync(new User(), "users/" + i);
                 }
             }
 
-            new Users_ByName().Execute(store);
+            await new Users_ByName().ExecuteAsync(store);
 
             Indexes.WaitForIndexing(store);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 var query = session.Query<User, Users_ByName>();
 
-                var enumerator = session.Advanced.Stream<User>(query);
+                var enumerator = await session.Advanced.StreamAsync<User>(query);
 
                 var count = 0;
 
-                while (enumerator.MoveNext())
+                while (await enumerator.MoveNextAsync())
                 {
                     count++;
                 }
@@ -271,30 +271,30 @@ namespace SlowTests.Issues
             }
         }
 
-        protected static void CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTest(int numberOfUsers, DocumentStore store)
+        protected static async Task CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTestAsync(int numberOfUsers, DocumentStore store)
         {
             var uniqueUserNames = _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10;
 
-            using (var bulk = store.BulkInsert())
+            await using (var bulk = store.BulkInsert())
             {
                 for (int i = 0; i < numberOfUsers; i++)
                 {
-                    bulk.Store(new User()
-                        {
-                            Name = "users-" + (i % uniqueUserNames)
-                        }, "users/" + i);
+                    await bulk.StoreAsync(new User()
+                    {
+                        Name = "users-" + (i % uniqueUserNames)
+                    }, "users/" + i);
                 }
             }
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 var query = session.Query<User>();
 
-                var enumerator = session.Advanced.Stream<User>(query);
+                var enumerator = await session.Advanced.StreamAsync<User>(query);
 
                 var count = 0;
 
-                while (enumerator.MoveNext())
+                while (await enumerator.MoveNextAsync())
                 {
                     count++;
                 }
@@ -304,18 +304,18 @@ namespace SlowTests.Issues
 
             // distinct
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 var query = session.Query<User>().Select(x => new User
                 {
                     Name = x.Name
                 }).Distinct();
 
-                var enumerator = session.Advanced.Stream(query);
+                var enumerator = await session.Advanced.StreamAsync(query);
 
                 var count = 0;
 
-                while (enumerator.MoveNext())
+                while (await enumerator.MoveNextAsync())
                 {
                     count++;
                 }
@@ -325,18 +325,18 @@ namespace SlowTests.Issues
 
             // paging
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 var skip = 100;
                 var take = _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10;
 
                 var query = session.Query<User>().Skip(skip).Take(take);
 
-                var enumerator = session.Advanced.Stream<User>(query);
+                var enumerator = await session.Advanced.StreamAsync<User>(query);
 
                 var count = 0;
 
-                while (enumerator.MoveNext())
+                while (await enumerator.MoveNextAsync())
                 {
                     count++;
                 }

--- a/test/SlowTests/Issues/RavenDB_13972_32_bits.cs
+++ b/test/SlowTests/Issues/RavenDB_13972_32_bits.cs
@@ -86,7 +86,7 @@ namespace SlowTests.Issues
         [Theory]
         [InlineData(2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3)]
-        public void CanStreamQueryWithPulsatingReadTransaction(int numberOfUsers)
+        public async Task CanStreamQueryWithPulsatingReadTransaction(int numberOfUsers)
         {
             using (var server = GetNewServer(new ServerCreationOptions
             {
@@ -105,14 +105,14 @@ namespace SlowTests.Issues
                 }
             }))
             {
-                CanStreamQueryWithPulsatingReadTransaction_ActualTest(numberOfUsers, store);
+                await CanStreamQueryWithPulsatingReadTransaction_ActualTestAsync(numberOfUsers, store);
             }
         }
 
         [Theory]
         [InlineData(2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3)]
-        public void CanStreamCollectionQueryWithPulsatingReadTransaction(int numberOfUsers)
+        public async Task CanStreamCollectionQueryWithPulsatingReadTransaction(int numberOfUsers)
         {
             using (var server = GetNewServer(new ServerCreationOptions
             {
@@ -130,7 +130,7 @@ namespace SlowTests.Issues
                 }
             }))
             {
-                CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTest(numberOfUsers, store);
+                await CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTestAsync(numberOfUsers, store);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_13972_encrypted.cs
+++ b/test/SlowTests/Issues/RavenDB_13972_encrypted.cs
@@ -24,14 +24,13 @@ namespace SlowTests.Issues
         {
             var file = GetTempFileName();
             var fileAfterDeletions = GetTempFileName();
-
-            Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var storeToExport = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
                     record.Settings[RavenConfiguration.GetKey(x => x.Databases.PulseReadTransactionLimit)] = "0";
@@ -57,15 +56,15 @@ namespace SlowTests.Issues
         [InlineData(2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10, 2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10, 3)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3, 0, 3)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3, 4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3, 2)]
-        public void CanStreamDocumentsWithPulsatingReadTransaction(int numberOfUsers, int numberOfOrders, int deleteUserFactor)
+        public async Task CanStreamDocumentsWithPulsatingReadTransaction(int numberOfUsers, int numberOfOrders, int deleteUserFactor)
         {
-            Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
                     record.Settings[RavenConfiguration.GetKey(x => x.Databases.PulseReadTransactionLimit)] = "0";
@@ -81,15 +80,15 @@ namespace SlowTests.Issues
         [InlineData(2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3)]
         [InlineData(10 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3)]
-        public void CanStreamQueryWithPulsatingReadTransaction(int numberOfUsers)
+        public async Task CanStreamQueryWithPulsatingReadTransaction(int numberOfUsers)
         {
-            Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
                     record.Settings[RavenConfiguration.GetKey(x => x.Databases.PulseReadTransactionLimit)] = "0";
@@ -97,22 +96,22 @@ namespace SlowTests.Issues
                 }
             }))
             {
-                CanStreamQueryWithPulsatingReadTransaction_ActualTest(numberOfUsers, store);
+                await CanStreamQueryWithPulsatingReadTransaction_ActualTestAsync(numberOfUsers, store);
             }
         }
 
         [Theory]
         [InlineData(2 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10)]
         [InlineData(4 * _numberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 3)]
-        public void CanStreamCollectionQueryWithPulsatingReadTransaction(int numberOfUsers)
+        public async Task CanStreamCollectionQueryWithPulsatingReadTransaction(int numberOfUsers)
         {
-            Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record =>
                 {
                     record.Settings[RavenConfiguration.GetKey(x => x.Databases.PulseReadTransactionLimit)] = "0";
@@ -120,7 +119,7 @@ namespace SlowTests.Issues
                 }
             }))
             {
-                CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTest(numberOfUsers, store);
+                await CanStreamCollectionQueryWithPulsatingReadTransaction_ActualTestAsync(numberOfUsers, store);
             }
         }
     }

--- a/test/SlowTests/Issues/RavenDB_15163.cs
+++ b/test/SlowTests/Issues/RavenDB_15163.cs
@@ -25,16 +25,16 @@ namespace SlowTests.Issues
             {
                 var database = await GetDatabase(store.Database);
 
-                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                await store.Maintenance.SendAsync(new PutIndexesOperation(new IndexDefinition
                 {
                     Maps = { "from user in docs.Users select new { user.FirstName }" },
                     Type = IndexType.Map,
                     Name = "Users/ByName"
                 }));
 
-                store.Maintenance.Send(new StopIndexingOperation());
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
 
-                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                await store.Maintenance.SendAsync(new PutIndexesOperation(new IndexDefinition
                 {
                     Maps = { "from user in docs.Users select new { user.LastName }" },
                     Type = IndexType.Map,
@@ -66,7 +66,7 @@ namespace SlowTests.Issues
                 Assert.Equal("Users/ByName", indexes[0].Name);
                 Assert.Same(replacementIndexInstance, indexes[0]);
 
-                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                await store.Maintenance.SendAsync(new PutIndexesOperation(new IndexDefinition
                 {
                     Maps = { "from user in docs.Users select new { user.LastName2 }" },
                     Type = IndexType.Map,
@@ -101,7 +101,7 @@ namespace SlowTests.Issues
 
                 database = await GetDatabase(store.Database);
 
-                Indexes.WaitForIndexing(store); // old index could be opened as well, so we wait until replacement is done and switches the index
+                await Indexes.WaitForIndexingAsync(store); // old index could be opened as well, so we wait until replacement is done and switches the index
 
                 indexes = database.IndexStore.GetIndexes().ToList();
 

--- a/test/SlowTests/Issues/RavenDB_16303.cs
+++ b/test/SlowTests/Issues/RavenDB_16303.cs
@@ -3,6 +3,7 @@ using System.Data.Common;
 using Microsoft.Data.SqlClient;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 using Npgsql;
 using Oracle.ManagedDataAccess.Client;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -27,7 +28,7 @@ namespace SlowTests.Issues
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
-        public void CanCreateSqlEtlTransformScriptWithGuidWhenTableTypeGuid(MigrationProvider provider)
+        public async Task CanCreateSqlEtlTransformScriptWithGuidWhenTableTypeGuid(MigrationProvider provider)
         {
             using (var store = GetDocumentStore())
             {
@@ -45,7 +46,7 @@ namespace SlowTests.Issues
                         ConnectionString = connectionString
                     });
 
-                    store.Maintenance.Send(operation);
+                    await store.Maintenance.SendAsync(operation);
 
                     var etlDone = new ManualResetEventSlim();
                     var configuration = new SqlEtlConfiguration
@@ -70,8 +71,8 @@ loadToTestGuidEtls(item);"
                         }
                     };
 
-                    store.Maintenance.Send(new AddEtlOperation<SqlConnectionString>(configuration));
-                    var database = GetDatabase(store.Database).Result;
+                    await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(configuration));
+                    var database = await GetDatabase(store.Database);
                     var errors = 0;
                     database.EtlLoader.BatchCompleted += x =>
                     {
@@ -85,10 +86,10 @@ loadToTestGuidEtls(item);"
                         }
                     };
                     var guid = Guid.NewGuid();
-                    using (var session = store.OpenSession())
+                    using (var session = store.OpenAsyncSession())
                     {
-                        session.Store(new TestGuidEtl() { Guid = guid });
-                        session.SaveChanges();
+                        await session.StoreAsync(new TestGuidEtl() { Guid = guid });
+                        await session.SaveChangesAsync();
                     }
 
                     etlDone.Wait(TimeSpan.FromMinutes(5));
@@ -105,7 +106,7 @@ loadToTestGuidEtls(item);"
         [RequiresMySqlInlineData]
         [RequiresNpgSqlInlineData]
         [RequiresOracleSqlInlineData]
-        public void CanCreateSqlEtlTransformScriptWithGuidWhenTableTypeVarchar(MigrationProvider provider)
+        public async Task CanCreateSqlEtlTransformScriptWithGuidWhenTableTypeVarchar(MigrationProvider provider)
         {
             using (var store = GetDocumentStore())
             {
@@ -123,7 +124,7 @@ loadToTestGuidEtls(item);"
                         ConnectionString = connectionString
                     });
 
-                    store.Maintenance.Send(operation);
+                    await store.Maintenance.SendAsync(operation);
 
                     var etlDone = new ManualResetEventSlim();
                     var configuration = new SqlEtlConfiguration
@@ -148,8 +149,8 @@ loadToTestGuidEtls(item);"
                         }
                     };
 
-                    store.Maintenance.Send(new AddEtlOperation<SqlConnectionString>(configuration));
-                    var database = GetDatabase(store.Database).Result;
+                    await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(configuration));
+                    var database = await GetDatabase(store.Database);
                     var errors = 0;
                     database.EtlLoader.BatchCompleted += x =>
                     {

--- a/test/SlowTests/Issues/RavenDB_16656.cs
+++ b/test/SlowTests/Issues/RavenDB_16656.cs
@@ -20,31 +20,30 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 var index = new Products_ByCategory();
-                index.Execute(store);
+                await index.ExecuteAsync(store);
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new Category { Id = "categories/0", Name = "foo"});
-                    session.Store(new Category { Id = "categories/1", Name = "bar"});
+                    await session.StoreAsync(new Category { Id = "categories/0", Name = "foo"});
+                    await session.StoreAsync(new Category { Id = "categories/1", Name = "bar"});
 
                     for (int i = 0; i < 200; i++)
                     {
-                        session.Store(new Product { Category = $"categories/{i % 2}"});
+                        await session.StoreAsync(new Product { Category = $"categories/{i % 2}"});
                     }
 
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new Category { Id = "categories/1", Name = "baz" });
-
-                    session.SaveChanges();
+                    await session.StoreAsync(new Category { Id = "categories/1", Name = "baz" });
+                    await session.SaveChangesAsync();
                 }
 
-                Indexes.WaitForIndexing(store);
+                await Indexes.WaitForIndexingAsync(store);
 
                 var indexInstance = (await GetDatabase(store.Database)).IndexStore.GetIndex(index.IndexName);
 

--- a/test/SlowTests/Issues/RavenDB_18496.cs
+++ b/test/SlowTests/Issues/RavenDB_18496.cs
@@ -19,16 +19,16 @@ namespace SlowTests.Issues
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task ReplicationShouldNotGetStuckWhenEncryptionBufferSizeIsGreaterThanMaxSizeToSend(Options options)
         {
-            Encryption.EncryptedServer(out var certificates, out var databaseName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var encryptedStore = GetDocumentStore(new Options(options)
             {
-                ModifyDatabaseName = _ => databaseName,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                AdminCertificate = certificates.ServerCertificate.Value,
+                ModifyDatabaseName = _ => result.DatabaseName,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
                 Encrypted = true
             }))
-            using (var store2 = GetDocumentStore(new Options(options) { ClientCertificate = certificates.ServerCertificate.Value }))
+            using (var store2 = GetDocumentStore(new Options(options) { ClientCertificate = result.Certificates.ServerCertificate.Value }))
             {
                 const string docId = "users/1";
 

--- a/test/SlowTests/Issues/RavenDB_20237.cs
+++ b/test/SlowTests/Issues/RavenDB_20237.cs
@@ -18,20 +18,20 @@ public class RavenDB_20237 : RavenTestBase
     [RavenFact(RavenTestCategory.Encryption)]
     public async Task MustProvideEncryptionKeyToAllDbStorages()
     {
-        Encryption.EncryptedServer(out var certificates, out var databaseName);
+        var result = await Encryption.EncryptedServerAsync();
 
         using (var store = GetDocumentStore(new Options
                {
-                   ModifyDatabaseName = _ => databaseName,
-                   ClientCertificate = certificates.ServerCertificate.Value,
-                   AdminCertificate = certificates.ServerCertificate.Value,
+                   ModifyDatabaseName = _ => result.DatabaseName,
+                   ClientCertificate = result.Certificates.ServerCertificate.Value,
+                   AdminCertificate = result.Certificates.ServerCertificate.Value,
                    Encrypted = true
                }))
         {
             Index index = new Index();
             await index.ExecuteAsync(store);
 
-            var database = await GetDatabase(databaseName);
+            var database = await GetDatabase(result.DatabaseName);
 
             Assert.NotNull(database.MasterKey);
 

--- a/test/SlowTests/Issues/RavenDB_8847.cs
+++ b/test/SlowTests/Issues/RavenDB_8847.cs
@@ -47,11 +47,12 @@ namespace SlowTests.Issues
                         Name = "B"
                     });
 
+                    var batchCompleted = await Indexes.WaitForIndexBatchCompletedAsync(store, x => x.DidWork);
+
                     await session.SaveChangesAsync();
 
                     await session.Query<User>().Customize(x => x.WaitForNonStaleResults()).Where(x => x.Name != "ema").ToListAsync();
-
-                    var batchCompleted = await Indexes.WaitForIndexBatchCompletedAsync(store, x => x.DidWork);
+                    
                     using (var tcs = new CancellationTokenSource(TimeSpan.FromSeconds(2)))
                         await batchCompleted.WaitAsync(tcs.Token);
 
@@ -85,7 +86,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    session.Query<User>(usersByName).Customize(x => x.WaitForNonStaleResults()).ToList();
+                    await session.Query<User>(usersByName).Customize(x => x.WaitForNonStaleResults()).ToListAsync();
 
                     Assert.True(index._firstBatchTimeout.HasValue);
                 }
@@ -99,11 +100,12 @@ namespace SlowTests.Issues
                         Name = "B"
                     });
 
+                    var batchCompleted = await Indexes.WaitForIndexBatchCompletedAsync(store, x => x.DidWork);
+
                     await session.SaveChangesAsync();
 
                     await session.Query<User>(usersByName).Customize(x => x.WaitForNonStaleResults()).Where(x => x.Name != "ema").ToListAsync();
 
-                    var batchCompleted = await Indexes.WaitForIndexBatchCompletedAsync(store, x => x.DidWork);
                     using (var tcs = new CancellationTokenSource(TimeSpan.FromSeconds(2)))
                         await batchCompleted.WaitAsync(tcs.Token);
 

--- a/test/SlowTests/Issues/RavenDB_8847.cs
+++ b/test/SlowTests/Issues/RavenDB_8847.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Tests.Core.Utils.Entities;
@@ -27,9 +28,9 @@ namespace SlowTests.Issues
 
                 Raven.Server.Documents.Indexes.Index index;
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Query<User>().Statistics(out var stats).Where(x => x.Name != "joe").ToList();
+                    await session.Query<User>().Statistics(out var stats).Where(x => x.Name != "joe").ToListAsync();
 
                     index = database.IndexStore.GetIndex(stats.IndexName);
 
@@ -38,16 +39,16 @@ namespace SlowTests.Issues
 
                 database.IndexStore.StartIndexing();
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new User()
+                    await session.StoreAsync(new User()
                     {
                         Name = "B"
                     });
 
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
 
-                    session.Query<User>().Customize(x => x.WaitForNonStaleResults()).Where(x => x.Name != "ema").ToList();
+                    await session.Query<User>().Customize(x => x.WaitForNonStaleResults()).Where(x => x.Name != "ema").ToListAsync();
 
                     Indexes.WaitForIndexBatchCompleted(store, x => x.DidWork).Wait(TimeSpan.FromSeconds(2));
 
@@ -64,11 +65,11 @@ namespace SlowTests.Issues
             {
                 var database = await GetDatabase(store.Database);
 
-                var usersByname = "users/byname";
+                var usersByName = "users/byname";
 
                 store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition()
                 {
-                    Name = usersByname,
+                    Name = usersByName,
                     Maps =
                     {
                         "from user in docs.Users select new { user.Name }"
@@ -77,27 +78,27 @@ namespace SlowTests.Issues
 
                 database.IndexStore.StopIndexing();
 
-                var index = database.IndexStore.GetIndex(usersByname);
+                var index = database.IndexStore.GetIndex(usersByName);
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Query<User>(usersByname).Customize(x => x.WaitForNonStaleResults()).ToList();
+                    session.Query<User>(usersByName).Customize(x => x.WaitForNonStaleResults()).ToList();
 
                     Assert.True(index._firstBatchTimeout.HasValue);
                 }
 
                 database.IndexStore.StartIndexing();
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new User()
+                    await session.StoreAsync(new User()
                     {
                         Name = "B"
                     });
 
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
 
-                    session.Query<User>(usersByname).Customize(x => x.WaitForNonStaleResults()).Where(x => x.Name != "ema").ToList();
+                    await session.Query<User>(usersByName).Customize(x => x.WaitForNonStaleResults()).Where(x => x.Name != "ema").ToListAsync();
 
                     Indexes.WaitForIndexBatchCompleted(store, x => x.DidWork).Wait(TimeSpan.FromSeconds(2));
 

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -140,12 +140,12 @@ loadToOrders" + IndexSuffix + @"(orderData);";
             }
         }
 
-        protected void AssertEtlDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, ElasticSearchEtlConfiguration config)
+        protected async Task AssertEtlDoneAsync(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, ElasticSearchEtlConfiguration config)
         {
             if (etlDone.Wait(timeout) == false)
             {
-                Etl.TryGetLoadError(databaseName, config, out var loadError);
-                Etl.TryGetTransformationError(databaseName, config, out var transformationError);
+                var loadError = await Etl.TryGetLoadErrorAsync(databaseName, config);
+                var transformationError = await Etl.TryGetTransformationErrorAsync(databaseName, config);
 
                 Assert.Fail($"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
             }

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17476.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_17476.cs
@@ -53,9 +53,9 @@ loadTo" + OrdersIndexName + @"(orderData);
 
                 var etlDone = Etl.WaitForEtlToComplete(store);
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new Order
+                    await session.StoreAsync(new Order
                     {
                         Lines = new List<OrderLine>
                         {
@@ -63,10 +63,10 @@ loadTo" + OrdersIndexName + @"(orderData);
                             new OrderLine { PricePerUnit = 4, Product = "Bear", Quantity = 2 },
                         }
                     });
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
-                AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+                await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
                 var ordersCount = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
                 var orderLinesCount = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));
@@ -79,14 +79,14 @@ loadTo" + OrdersIndexName + @"(orderData);
 
                 etlDone.Reset();
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
                     session.Delete("orders/1-A");
 
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
-                AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+                await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
                 var ordersCountAfterDelete = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrdersIndexName)));
                 var orderLinesCountAfterDelete = await client.CountAsync<object>(c => c.Indices(Indices.Index(OrderLinesIndexName)));

--- a/test/SlowTests/Server/Documents/ETL/Queue/QueueEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/QueueEtlTestBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Xunit;
@@ -13,12 +14,12 @@ public abstract class QueueEtlTestBase : RavenTestBase
     {
     }
 
-    protected void AssertEtlDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, QueueEtlConfiguration config)
+    protected async Task AssertEtlDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, QueueEtlConfiguration config)
     {
         if (etlDone.Wait(timeout) == false)
         {
-            Etl.TryGetLoadError(databaseName, config, out var loadError);
-            Etl.TryGetTransformationError(databaseName, config, out var transformationError);
+            var loadError = await Etl.TryGetLoadErrorAsync(databaseName, config);
+            var transformationError = await Etl.TryGetTransformationErrorAsync(databaseName, config);
 
             Assert.Fail($"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
         }

--- a/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
@@ -27,16 +27,16 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void SimpleScript()
+    public async Task SimpleScript()
     {
         using (var store = GetDocumentStore())
         {
             var config = SetupQueueEtlToRabbitMq(store, DefaultScript, DefaultCollections);
             var etlDone = Etl.WaitForEtlToComplete(store);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new Order
+                await session.StoreAsync(new Order
                 {
                     Id = "orders/1-A",
                     OrderLines = new List<OrderLine>
@@ -45,10 +45,10 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
                         new OrderLine { Cost = 4, Product = "Bear", Quantity = 1 },
                     }
                 });
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);
@@ -85,7 +85,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void CanUseRoutingKeyWithAutomaticDeclarations()
+    public async Task CanUseRoutingKeyWithAutomaticDeclarations()
     {
         using var store = GetDocumentStore();
 
@@ -95,14 +95,14 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
 
         var etlDone = Etl.WaitForEtlToComplete(store);
 
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession())
         {
-            session.Store(new User { Name = "Joe Doe" }, "users/1");
-            session.Store(new Person { Name = "James Smith" }, "people/1");
-            session.SaveChanges();
+            await session.StoreAsync(new User { Name = "Joe Doe" }, "users/1");
+            await session.StoreAsync(new Person { Name = "James Smith" }, "people/1");
+            await session.SaveChangesAsync();
         }
         
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -133,7 +133,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void CanUseRoutingKeyWithCustomDeclarations()
+    public async Task CanUseRoutingKeyWithCustomDeclarations()
     {
         using var store = GetDocumentStore();
 
@@ -156,14 +156,14 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
 
         var etlDone = Etl.WaitForEtlToComplete(store);
 
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession())
         {
-            session.Store(new User { Name = "Joe Doe" }, "users/1");
-            session.Store(new Person { Name = "James Smith" }, "people/1");
-            session.SaveChanges();
+            await session.StoreAsync(new User { Name = "Joe Doe" }, "users/1");
+            await session.StoreAsync(new Person { Name = "James Smith" }, "people/1");
+            await session.SaveChangesAsync();
         }
 
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         channel.BasicConsume(queue: queueName, autoAck: true, consumer: consumer);
 
@@ -192,7 +192,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
 
 
     [RequiresRabbitMqRetryFact]
-    public void CanPushDirectlyToTheQueue()
+    public async Task CanPushDirectlyToTheQueue()
     {
         using var store = GetDocumentStore();
 
@@ -202,13 +202,13 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
 
         var etlDone = Etl.WaitForEtlToComplete(store);
 
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession())
         {
-            session.Store(new User { Name = "Joe Doe" }, "users/1");
-            session.SaveChanges();
+            await session.StoreAsync(new User { Name = "Joe Doe" }, "users/1");
+            await session.SaveChangesAsync();
         }
 
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -228,16 +228,16 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void TestAreHeadersPresent()
+    public async Task TestAreHeadersPresent()
     {
         using (var store = GetDocumentStore())
         {
             var config = SetupQueueEtlToRabbitMq(store, DefaultScript, DefaultCollections);
             var etlDone = Etl.WaitForEtlToComplete(store);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new Order
+                await session.StoreAsync(new Order
                 {
                     Id = "orders/1-A",
                     OrderLines = new List<OrderLine>
@@ -246,10 +246,10 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
                         new OrderLine { Cost = 4, Product = "Bear", Quantity = 1 },
                     }
                 });
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using var channel = CreateRabbitMqChannel();
 
@@ -272,7 +272,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void SimpleScriptWithManyDocuments()
+    public async Task SimpleScriptWithManyDocuments()
     {
         using var store = GetDocumentStore();
 
@@ -284,7 +284,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
 
         for (int i = 0; i < numberOfOrders; i++)
         {
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
                 Order order = new Order { OrderLines = new List<OrderLine>() };
 
@@ -293,13 +293,13 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
                     order.OrderLines.Add(new OrderLine { Cost = j + 1, Product = "foos/" + j, Quantity = (i * j) % 10 });
                 }
 
-                session.Store(order, "orders/" + i);
+                await session.StoreAsync(order, "orders/" + i);
 
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
         }
 
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
         
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -323,7 +323,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void Docs_from_two_collections_loaded_to_single_one()
+    public async Task Docs_from_two_collections_loaded_to_single_one()
     {
         using var store = GetDocumentStore();
 
@@ -332,14 +332,14 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
             new[] { "Users", "People" });
         var etlDone = Etl.WaitForEtlToComplete(store);
 
-        using (var session = store.OpenSession())
+        using (var session = store.OpenAsyncSession())
         {
-            session.Store(new User { Name = "Joe Doe" }, "users/1");
-            session.Store(new Person { Name = "James Smith" }, "people/1");
-            session.SaveChanges();
+            await session.StoreAsync(new User { Name = "Joe Doe" }, "users/1");
+            await session.StoreAsync(new Person { Name = "James Smith" }, "people/1");
+            await session.SaveChangesAsync();
         }
 
-        AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
         
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -513,7 +513,7 @@ output('test output')"
     }
 
     [RequiresRabbitMqRetryFact]
-    public void CanPassAttributesToLoadToMethod()
+    public async Task CanPassAttributesToLoadToMethod()
     {
         using (var store = GetDocumentStore())
         {
@@ -527,13 +527,13 @@ output('test output')"
 
             var etlDone = Etl.WaitForEtlToComplete(store);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new User { Name = "Arek" }, "users/1");
-                session.SaveChanges();
+                await session.StoreAsync(new User { Name = "Arek" }, "users/1");
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
             
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);
@@ -560,7 +560,7 @@ output('test output')"
     }
 
     [RequiresRabbitMqRetryFact]
-    public void ShouldDeleteDocumentsAfterProcessing()
+    public async Task ShouldDeleteDocumentsAfterProcessing()
     {
         using (var store = GetDocumentStore())
         {
@@ -570,13 +570,13 @@ output('test output')"
 
             var etlDone = Etl.WaitForEtlToComplete(store);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new User { Id = "users/1", Name = "Arek" });
-                session.SaveChanges();
+                await session.StoreAsync(new User { Id = "users/1", Name = "Arek" });
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
             
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);
@@ -593,9 +593,9 @@ output('test output')"
             Assert.NotNull(user);
             Assert.Equal(user.Name, "Arek");
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                var entity = session.Load<User>("users/1");
+                var entity = await session.LoadAsync<User>("users/1");
                 Assert.Null(entity);
             }
         }

--- a/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_Kafka.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_Kafka.cs
@@ -1,6 +1,7 @@
 ﻿using Confluent.Kafka;
 using System;
 using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -16,7 +17,7 @@ public class RavenDB_21659_Kafka : KafkaEtlTestBase
     }
 
     [RequiresKafkaRetryFact]
-    public void CanPassOptionalAttributesToLoadToMethod()
+    public async Task CanPassOptionalAttributesToLoadToMethod()
     {
         using (var store = GetDocumentStore())
         {
@@ -29,16 +30,16 @@ public class RavenDB_21659_Kafka : KafkaEtlTestBase
 
             var etlDone = Etl.WaitForEtlToComplete(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new User
+                await session.StoreAsync(new User
                 {
                     Name = "Arek"
                 });
-                session.SaveChanges();
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(new[] { $"Users{TopicSuffix}" });
 

--- a/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_RabbitMq.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_RabbitMq.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using RabbitMQ.Client;
 using Raven.Tests.Core.Utils.Entities;
@@ -17,7 +18,7 @@ public class RavenDB_21659_RabbitMq : RabbitMqEtlTestBase
     }
 
     [RequiresRabbitMqRetryFact]
-    public void CanPassOptionalAttributesToLoadToMethod()
+    public async Task CanPassOptionalAttributesToLoadToMethod()
     {
         using (var store = GetDocumentStore())
         {
@@ -30,13 +31,13 @@ public class RavenDB_21659_RabbitMq : RabbitMqEtlTestBase
 
             var etlDone = Etl.WaitForEtlToComplete(store, (n, statistics) => statistics.LoadSuccesses != 0);
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                session.Store(new User { Name = "Arek" }, "users/1");
-                session.SaveChanges();
+                await session.StoreAsync(new User { Name = "Arek" }, "users/1");
+                await session.SaveChangesAsync();
             }
 
-            AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_13220.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_13220.cs
@@ -56,7 +56,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
             using (var src = GetDocumentStore(options))
             using (var dstServer = GetNewServer())
-            using (var dest = GetDocumentStore(new Options()
+            using (var dest = GetDocumentStore(new Options
             {
                 Server = dstServer
             }))
@@ -67,7 +67,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     Name = "myFirstEtl",
                     Transforms =
                     {
-                        new Transformation()
+                        new Transformation
                         {
                             Collections =
                             {
@@ -78,7 +78,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                         }
                     },
                     AllowEtlOnNonEncryptedChannel = true
-                }, new RavenConnectionString()
+                }, new RavenConnectionString
                 {
                     Name = "test",
                     TopologyDiscoveryUrls = dest.Urls,
@@ -92,21 +92,21 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 var etlDone = Etl.WaitForEtlToComplete(src);
 
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
-                    session.Store(new User()
+                    await session.StoreAsync(new User
                     {
                         Name = "Joe Doe"
                     }, docId);
 
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                using (var session = dest.OpenSession())
+                using (var session = dest.OpenAsyncSession())
                 {
-                    var user = session.Load<User>(docId);
+                    var user = await session.LoadAsync<User>(docId);
 
                     Assert.NotNull(user);
                     Assert.Equal("Joe Doe", user.Name);
@@ -162,7 +162,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                 ModifyDatabaseName = s => dstDbName,
             }))
             {
-                Etl.AddEtl(src, new RavenEtlConfiguration()
+                Etl.AddEtl(src, new RavenEtlConfiguration
                 {
                     ConnectionStringName = "test",
                     Name = "myFirstEtl",
@@ -193,21 +193,21 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 var etlDone = Etl.WaitForEtlToComplete(src);
 
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
-                    session.Store(new User()
+                    await session.StoreAsync(new User
                     {
                         Name = "Joe Doe"
                     }, docId);
 
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                using (var session = dest.OpenSession())
+                using (var session = dest.OpenAsyncSession())
                 {
-                    var user = session.Load<User>(docId);
+                    var user = await session.LoadAsync<User>(docId);
 
                     Assert.NotNull(user);
                     Assert.Equal("Joe Doe", user.Name);

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_6257.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_6257.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client;
 using Raven.Server.Documents;
@@ -19,7 +20,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
         }
 
         [RavenFact(RavenTestCategory.Etl)]
-        public void Collection_specific_etl_process_is_aware_of_processed_tombstones()
+        public async Task Collection_specific_etl_process_is_aware_of_processed_tombstones()
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -28,30 +29,27 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 var etlDone = Etl.WaitForEtlToComplete(src);
 
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
-                    session.Store(new User());
-
-                    session.Store(new Order());
-
-                    session.SaveChanges();
+                    await session.StoreAsync(new User());
+                    await session.StoreAsync(new Order());
+                    await session.SaveChangesAsync();
                 }
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
                 etlDone.Reset();
 
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
                     session.Delete("users/1-A");
                     session.Delete("orders/1-A");
-
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                var db = GetDatabase(src.Database).Result;
+                var db = await GetDatabase(src.Database);
 
                 var etlProcess = db.EtlLoader;
 
@@ -68,7 +66,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
         }
 
         [RavenFact(RavenTestCategory.Etl)]
-        public void All_docs_etl_process_is_aware_of_processed_tombstones()
+        public async Task All_docs_etl_process_is_aware_of_processed_tombstones()
         {
             using (var src = GetDocumentStore())
             using (var dest = GetDocumentStore())
@@ -77,29 +75,27 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 var etlDone = Etl.WaitForEtlToComplete(src, (n, s) => s.LoadSuccesses >= 4); // 2 docs and 2 HiLos
 
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
-                    session.Store(new User());
-                    session.Store(new Order());
-
-                    session.SaveChanges();
+                    await session.StoreAsync(new User());
+                    await session.StoreAsync(new Order());
+                    await session.SaveChangesAsync();
                 }
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
                 etlDone = Etl.WaitForEtlToComplete(src, (n, s) => s.LoadSuccesses >= 6);
 
-                using (var session = src.OpenSession())
+                using (var session = src.OpenAsyncSession())
                 {
                     session.Delete("users/1-A");
                     session.Delete("orders/1-A");
-
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));
 
-                var db = GetDatabase(src.Database).Result;
+                var db = await GetDatabase(src.Database);
 
                 var etlProcess = db.EtlLoader;
 

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_10674.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_10674.cs
@@ -20,11 +20,10 @@ namespace SlowTests.Server.Documents.ETL
         {
             using (var src = GetDocumentStore())
             {
-                using (var store = src.OpenSession())
+                using (var store = src.OpenAsyncSession())
                 {
-                    store.Store(new User());
-
-                    store.SaveChanges();
+                    await store.StoreAsync(new User());
+                    await store.SaveChangesAsync();
                 }
 
                 var configuration = new RavenEtlConfiguration()
@@ -33,7 +32,7 @@ namespace SlowTests.Server.Documents.ETL
                     Name = "aaa",
                     Transforms =
                     {
-                        new Transformation()
+                        new Transformation
                         {
                             Collections = {"Users"},
                             Name = "test"

--- a/test/SlowTests/Server/Documents/ETL/RavenDB_12809.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB_12809.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.ServerWide.Operations.Certificates;
@@ -18,7 +19,7 @@ namespace SlowTests.Server.Documents.ETL
         }
 
         [RavenFact(RavenTestCategory.Etl)]
-        public void Can_setup_etl_from_encrypted_to_non_encrypted_db()
+        public async Task Can_setup_etl_from_encrypted_to_non_encrypted_db()
         {
             var certificates = Certificates.SetupServerAuthentication();
             var dbName = GetDatabaseName();
@@ -54,13 +55,13 @@ namespace SlowTests.Server.Documents.ETL
                 ModifyDatabaseName = s => dbName,
             }))
             {
-                Etl.AddEtl(src, new RavenEtlConfiguration()
+                Etl.AddEtl(src, new RavenEtlConfiguration
                 {
                     ConnectionStringName = "test",
                     Name = "myFirstEtl",
                     Transforms =
                     {
-                        new Transformation()
+                        new Transformation
                         {
                             Collections =
                             {
@@ -78,7 +79,7 @@ namespace SlowTests.Server.Documents.ETL
                     Database = "Northwind",
                 });
 
-                var db = GetDatabase(src.Database).Result;
+                var db = await GetDatabase(src.Database);
 
                 Assert.Equal(1, db.EtlLoader.Processes.Length);
             }

--- a/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_19518.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_19518.cs
@@ -132,7 +132,7 @@ for (var i = 0; i < this.OrderLines.length; i++) {
 }";
     
     [RequiresNpgSqlFact]
-    public void CanReplicateToArraysInPostgresSQL()
+    public async Task CanReplicateToArraysInPostgresSQL()
     {
         MigrationProvider provider = MigrationProvider.NpgSQL;
         using (var store = GetDocumentStore())
@@ -170,7 +170,7 @@ for (var i = 0; i < this.OrderLines.length; i++) {
                 };
 
                 store.Maintenance.Send(new AddEtlOperation<SqlConnectionString>(configuration));
-                var database = GetDatabase(store.Database).Result;
+                var database = await GetDatabase(store.Database);
                 var errors = 0;
                 database.EtlLoader.BatchCompleted += x =>
                 {
@@ -184,9 +184,9 @@ for (var i = 0; i < this.OrderLines.length; i++) {
                     }
                 };
 
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    session.Store(new Order
+                    await session.StoreAsync(new Order
                     {
                         OrderLines = new List<OrderLine>
                         {
@@ -194,7 +194,7 @@ for (var i = 0; i < this.OrderLines.length; i++) {
                             new OrderLine{Cost = 4, Product = "Bear", Quantity = 2},
                         }
                     });
-                    session.SaveChanges();
+                    await session.SaveChangesAsync();
                 }
 
                 etlDone.Wait(TimeSpan.FromMinutes(1));

--- a/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/EncryptedBackupTest.cs
@@ -29,13 +29,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_encrypted_backup_use_db_key_1()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -50,7 +50,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 }
 
                 var config = Backup.CreateBackupConfiguration(backupPath);
-                var backupTaskId = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
+                await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
 
                 var databaseName = $"restored_database-{Guid.NewGuid()}";
 
@@ -61,7 +61,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseProvidedKey,
-                        Key = key
+                        Key = result.Key
                     }
                 }))
                 {
@@ -79,13 +79,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_encrypted_backup_use_db_key_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -114,7 +114,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseProvidedKey,
-                        Key = key
+                        Key = result.Key
                     }
                 }))
                 {
@@ -132,13 +132,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_encrypted_backup_use_new_key()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 ModifyDocumentStore = s => s.Conventions.DisposeCertificate = false,
                 Path = NewDataPath()
@@ -186,13 +186,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_encrypted_backup_use_db_key_1()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -219,7 +219,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseProvidedKey,
-                        Key = key
+                        Key = result.Key
                     }
                 }))
                 {
@@ -237,13 +237,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_encrypted_backup_use_db_key_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -273,7 +273,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseProvidedKey,
-                        Key = key
+                        Key = result.Key
                     }
                 }))
                 {
@@ -291,13 +291,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_encrypted_backup_use_new_key()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -344,13 +344,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_not_encrypted_DB_with_unencrypted_backup()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -392,13 +392,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_and_restore_to_encrypted_DB_with_unencrypted_backup()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -442,13 +442,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
 
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -470,7 +470,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     BackupLocation = Directory.GetDirectories(backupPath).First(),
                     DatabaseName = databaseName,
-                    EncryptionKey = key,
+                    EncryptionKey = result.Key,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseDatabaseKey
@@ -490,13 +490,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task snapshot_encrypted_db_and_restore_to_encrypted_DB_2()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -522,7 +522,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     BackupLocation = Directory.GetDirectories(backupPath).First(),
                     DatabaseName = databaseName,
-                    EncryptionKey = key,
+                    EncryptionKey = result.Key,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseDatabaseKey
@@ -543,15 +543,15 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
 
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             const string key1 = "users/1";
             const string key2 = "users/2";
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -584,7 +584,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     BackupLocation = Directory.GetDirectories(backupPath).First(),
                     DatabaseName = databaseName,
-                    EncryptionKey = key,
+                    EncryptionKey = result.Key,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseDatabaseKey
@@ -1046,13 +1046,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task snapshot_encrypted_db_with_new_key_fail()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -1195,13 +1195,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task backup_encrypted_db_without_backup_encryption_configuration(BackupType backupType, string expectedExtension)
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -1231,7 +1231,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     BackupLocation = folderPath,
                     DatabaseName = databaseName,
-                    EncryptionKey = key,
+                    EncryptionKey = result.Key,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseDatabaseKey

--- a/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/Restore/RestoreFromS3.cs
@@ -190,14 +190,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
         protected async Task incremental_and_full_backup_encrypted_db_and_restore_to_encrypted_DB_with_database_key_internal(BackupUploadMode backupUploadMode)
         {
             var s3Settings = GetS3Settings();
-
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -239,7 +238,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
                     DatabaseName = databaseName,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
-                        Key = key,
+                        Key = result.Key,
                         EncryptionMode = EncryptionMode.UseProvidedKey
                     }
                 }))
@@ -326,13 +325,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
         protected async Task incremental_and_full_backup_encrypted_db_and_restore_to_encrypted_DB_with_provided_key_internal()
         {
             var s3Settings = GetS3Settings();
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -393,14 +392,14 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
 
         protected async Task snapshot_encrypted_db_and_restore_to_encrypted_DB_internal(BackupUploadMode backupUploadMode)
         {
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             var s3Settings = GetS3Settings();
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true
             }))
             {
@@ -424,7 +423,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup.Restore
                 {
                     Settings = s3Settings,
                     DatabaseName = databaseName,
-                    EncryptionKey = key,
+                    EncryptionKey = result.Key,
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseDatabaseKey

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ServerWideBackup.cs
@@ -551,13 +551,13 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         public async Task ServerWideBackupShouldBeEncryptedForEncryptedDatabase(EncryptionMode encryptionMode)
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
-            var key = Encryption.EncryptedServer(out var certificates, out string dbName);
+            var result = await Encryption.EncryptedServerAsync();
 
             using (var store = GetDocumentStore(new Options
             {
-                AdminCertificate = certificates.ServerCertificate.Value,
-                ClientCertificate = certificates.ServerCertificate.Value,
-                ModifyDatabaseName = s => dbName,
+                AdminCertificate = result.Certificates.ServerCertificate.Value,
+                ClientCertificate = result.Certificates.ServerCertificate.Value,
+                ModifyDatabaseName = s => result.DatabaseName,
                 ModifyDatabaseRecord = record => record.Encrypted = true,
                 Path = NewDataPath()
             }))
@@ -628,7 +628,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     BackupEncryptionSettings = new BackupEncryptionSettings
                     {
                         EncryptionMode = EncryptionMode.UseProvidedKey,
-                        Key = key
+                        Key = result.Key
                     }
                 }))
                 {

--- a/test/StressTests/Issues/RavenDB_12151.cs
+++ b/test/StressTests/Issues/RavenDB_12151.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using FastTests;
 using Orders;
 using Raven.Client.Documents;
@@ -21,7 +22,7 @@ namespace StressTests.Issues
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
-        public void IndexingWhenTransactionSizeLimitExceeded()
+        public async Task IndexingWhenTransactionSizeLimitExceeded()
         {
             using (var store = GetDocumentStore(new Options()
             {
@@ -31,12 +32,12 @@ namespace StressTests.Issues
                 }
             }))
             {
-                RunTest(store, "Reached transaction size limit");
+                await RunTest(store, "Reached transaction size limit");
             }
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
-        public void IndexingWhenScratchSpaceLimitExceeded()
+        public async Task IndexingWhenScratchSpaceLimitExceeded()
         {
             using (var store = GetDocumentStore(new Options()
             {
@@ -48,12 +49,12 @@ namespace StressTests.Issues
                 }
             }))
             {
-                RunTest(store, "Reached scratch space limit");
+                await RunTest(store, "Reached scratch space limit");
             }
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
-        public void IndexingWhenGlobalScratchSpaceLimitExceeded()
+        public async Task IndexingWhenGlobalScratchSpaceLimitExceeded()
         {
             UseNewLocalServer(new Dictionary<string, string>
             {
@@ -66,12 +67,12 @@ namespace StressTests.Issues
                 ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Storage.MaxScratchBufferSize)] = "2"
             }))
             {
-                RunTest(store, "Reached global scratch space limit");
+                await RunTest(store, "Reached global scratch space limit");
             }
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenArchitecture.AllX86)]
-        public void IndexingWhenTransactionSizeLimitExceeded32()
+        public async Task IndexingWhenTransactionSizeLimitExceeded32()
         {
             using (var store = GetDocumentStore(new Options()
             {
@@ -81,12 +82,12 @@ namespace StressTests.Issues
                 }
             }))
             {
-                RunTest32(store, "Reached transaction size limit");
+                await RunTest32(store, "Reached transaction size limit");
             }
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenArchitecture.AllX86)]
-        public void IndexingWhenScratchSpaceLimitExceeded32()
+        public async Task IndexingWhenScratchSpaceLimitExceeded32()
         {
             using (var store = GetDocumentStore(new Options()
             {
@@ -98,12 +99,12 @@ namespace StressTests.Issues
                 }
             }))
             {
-                RunTest32(store, "Reached scratch space limit");
+                await RunTest32(store, "Reached scratch space limit");
             }
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenArchitecture.AllX86)]
-        public void IndexingWhenGlobalScratchSpaceLimitExceeded32()
+        public async Task IndexingWhenGlobalScratchSpaceLimitExceeded32()
         {
             UseNewLocalServer(new Dictionary<string, string>
             {
@@ -116,12 +117,12 @@ namespace StressTests.Issues
                 ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Storage.MaxScratchBufferSize)] = "2"
             }))
             {
-                RunTest32(store, "Reached global scratch space limit");
+                await RunTest32(store, "Reached global scratch space limit");
             }
         }
 
         [Fact]
-        public void IndexingWhenEncryptedTransactionSizeLimitLimitExceeded()
+        public async Task IndexingWhenEncryptedTransactionSizeLimitLimitExceeded()
         {
             string dbName = Encryption.SetupEncryptedDatabase(out var certificates, out var _);
 
@@ -138,21 +139,21 @@ namespace StressTests.Issues
                 }
             }))
             {
-                RunTest(store, "Reached transaction size limit");
+                await RunTest(store, "Reached transaction size limit");
             }
         }
 
-        private void RunTest(DocumentStore store, string endOfPatchReason)
+        private async Task RunTest(DocumentStore store, string endOfPatchReason)
         {
-            using (var bulk = store.BulkInsert())
+            await using (var bulk = store.BulkInsert())
             {
                 for (int i = 0; i < 2000; i++)
                 {
-                    bulk.Store(new Order()
+                    await bulk.StoreAsync(new Order
                     {
                         Company = $"companies/{i}",
                         Employee = $"employee/{i}",
-                        Lines = new List<OrderLine>()
+                        Lines = new List<OrderLine>
                         {
                             new OrderLine()
                             {
@@ -171,9 +172,9 @@ namespace StressTests.Issues
 
             SimpleIndex index = new SimpleIndex();
 
-            index.Execute(store);
+            await index.ExecuteAsync(store);
 
-            var indexInstance = GetDatabase(store.Database).Result.IndexStore.GetIndex(index.IndexName);
+            var indexInstance = (await GetDatabase(store.Database)).IndexStore.GetIndex(index.IndexName);
 
             indexInstance._indexStorage.Environment().Options.MaxNumberOfPagesInJournalBeforeFlush = 4;
 
@@ -181,9 +182,9 @@ namespace StressTests.Issues
 
             try
             {
-                using (var session = store.OpenSession())
+                using (var session = store.OpenAsyncSession())
                 {
-                    var count = session.Query<Order, SimpleIndex>().Customize(x => x.WaitForNonStaleResults(TimeSpan.FromMinutes(5))).Count();
+                    var count = await session.Query<Order, SimpleIndex>().Customize(x => x.WaitForNonStaleResults(TimeSpan.FromMinutes(5))).CountAsync();
 
                     Assert.Equal(4000, count);
                 }
@@ -198,7 +199,7 @@ namespace StressTests.Issues
 
                 try
                 {
-                    Indexes.WaitForIndexing(store);
+                    await Indexes.WaitForIndexingAsync(store);
                 }
                 catch
                 {
@@ -230,25 +231,25 @@ namespace StressTests.Issues
             Assert.True(mapRunDetails.Any(x => x.BatchCompleteReason.Contains(endOfPatchReason)));
         }
 
-        private void RunTest32(DocumentStore store, string endOfPatchReason)
+        private async Task RunTest32(DocumentStore store, string endOfPatchReason)
         {
             const int docsCount = 2500;
-            using (var bulk = store.BulkInsert())
+            await using (var bulk = store.BulkInsert())
             {
                 for (int i = 0; i < docsCount; i++)
                 {
-                    bulk.Store(new Order()
+                    await bulk.StoreAsync(new Order
                     {
                         Company = $"companies/{i}",
                         Employee = $"employee/{i}",
-                        Lines = new List<OrderLine>()
+                        Lines = new List<OrderLine>
                         {
-                            new OrderLine()
+                            new OrderLine
                             {
                                 Product = $"products/{i}",
                                 ProductName = new string((char)i, i)
                             },
-                            new OrderLine()
+                            new OrderLine
                             {
                                 Product = $"products/{i}",
                                 ProductName = new string((char)i, i)
@@ -260,15 +261,15 @@ namespace StressTests.Issues
 
             var index = new SimpleIndex32();
 
-            index.Execute(store);
+            await index.ExecuteAsync(store);
 
-            var indexInstance = GetDatabase(store.Database).Result.IndexStore.GetIndex(index.IndexName);
+            var indexInstance = (await GetDatabase(store.Database)).IndexStore.GetIndex(index.IndexName);
 
             indexInstance._indexStorage.Environment().Options.MaxNumberOfPagesInJournalBeforeFlush = 4;
 
-            using (var session = store.OpenSession())
+            using (var session = store.OpenAsyncSession())
             {
-                var count = session.Query<Order, SimpleIndex32>().Customize(x => x.WaitForNonStaleResults(TimeSpan.FromMinutes(2))).Count();
+                var count = await session.Query<Order, SimpleIndex32>().Customize(x => x.WaitForNonStaleResults(TimeSpan.FromMinutes(2))).CountAsync();
 
                 Assert.Equal(docsCount, count);
             }

--- a/test/StressTests/Server/Encryption/EncryptionStressTests.cs
+++ b/test/StressTests/Server/Encryption/EncryptionStressTests.cs
@@ -34,8 +34,7 @@ namespace StressTests.Server.Encryption
             {
                 DebuggerAttachedTimeout.DisableLongTimespan = true;
                 var (nodes, leader, certificates) = await CreateRaftClusterWithSsl(7, watcherCluster: true);
-
-                Encryption.EncryptedCluster(nodes, certificates, out var databaseName);
+                var databaseName = await Encryption.EncryptedClusterAsync(nodes, certificates);
 
                 var options = new Options
                 {

--- a/test/Tests.Infrastructure/RavenTestBase.Encryption.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Encryption.cs
@@ -4,10 +4,10 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server;
 using Sparrow.Platform;
-using Xunit;
 
 namespace FastTests;
 
@@ -26,10 +26,11 @@ public partial class RavenTestBase
             _parent = parent ?? throw new ArgumentNullException(nameof(parent));
         }
 
-        public string EncryptedServer(out TestCertificatesHolder certificates, out string databaseName)
+        public async Task<EncryptServerResult> EncryptedServerAsync()
         {
-            certificates = _parent.Certificates.SetupServerAuthentication();
-            databaseName = _parent.GetDatabaseName();
+            var certificates = _parent.Certificates.SetupServerAuthentication();
+            var databaseName = _parent.GetDatabaseName();
+
             _parent.Certificates.RegisterClientCertificate(certificates, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
 
             var base64Key = CreateMasterKey(out var buffer);
@@ -54,16 +55,23 @@ public partial class RavenTestBase
             if (canUseProtect == false) // fall back to a file
                 _parent.Server.ServerStore.Configuration.Security.MasterKeyPath = _parent.GetTempFileName();
 
-            Assert.True(_parent.Server.ServerStore.EnsureNotPassiveAsync().Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
-            Assert.True(_parent.Server.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
+            // activate license so we can insert the secret key
+            await _parent.Server.ServerStore.EnsureNotPassiveAsync().WaitAsync(TimeSpan.FromSeconds(30));
+            await _parent.Server.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).WaitAsync(TimeSpan.FromSeconds(30));
+
             _parent.Server.ServerStore.PutSecretKey(base64Key, databaseName, overwrite: true);
 
-            return Convert.ToBase64String(buffer);
+            return new EncryptServerResult
+            {
+                Certificates = certificates,
+                DatabaseName = databaseName,
+                Key = Convert.ToBase64String(buffer)
+            };
         }
 
-        public void EncryptedCluster(List<RavenServer> nodes, TestCertificatesHolder certificates, out string databaseName)
+        public async Task<string> EncryptedClusterAsync(List<RavenServer> nodes, TestCertificatesHolder certificates)
         {
-            databaseName = _parent.GetDatabaseName();
+            var databaseName = _parent.GetDatabaseName();
 
             foreach (var node in nodes)
             {
@@ -73,22 +81,26 @@ public partial class RavenTestBase
 
                 EnsureServerMasterKeyIsSetup(node);
 
-                Assert.True(node.ServerStore.EnsureNotPassiveAsync().Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
-                Assert.True(node.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
+                // activate license so we can insert the secret key
+                await _parent.Server.ServerStore.EnsureNotPassiveAsync().WaitAsync(TimeSpan.FromSeconds(30));
+                await _parent.Server.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).WaitAsync(TimeSpan.FromSeconds(30));
 
                 node.ServerStore.PutSecretKey(base64Key, databaseName, overwrite: true);
             }
+
+            return databaseName;
         }
 
-        public void PutSecretKeyForDatabaseInServerStore(string databaseName, RavenServer server)
+        public async Task PutSecretKeyForDatabaseInServerStoreAsync(string databaseName, RavenServer server)
         {
             var base64key = CreateMasterKey(out _);
             var base64KeyClone = new string(base64key.ToCharArray());
 
             EnsureServerMasterKeyIsSetup(server);
 
-            Assert.True(server.ServerStore.EnsureNotPassiveAsync().Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
-            Assert.True(server.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).Wait(TimeSpan.FromSeconds(30))); // activate license so we can insert the secret key
+            // activate license so we can insert the secret key
+            await _parent.Server.ServerStore.EnsureNotPassiveAsync().WaitAsync(TimeSpan.FromSeconds(30));
+            await _parent.Server.ServerStore.LicenseManager.TryActivateLicenseAsync(_parent.Server.ThrowOnLicenseActivationFailure).WaitAsync(TimeSpan.FromSeconds(30));
 
             server.ServerStore.PutSecretKey(base64key, databaseName, overwrite: true);
 
@@ -183,6 +195,15 @@ public partial class RavenTestBase
 
             var base64Key = Convert.ToBase64String(buffer);
             return base64Key;
+        }
+
+        public class EncryptServerResult
+        {
+            public TestCertificatesHolder Certificates { get; set; }
+
+            public string DatabaseName { get; set; }
+
+            public string Key { get; set; }
         }
     }
 }

--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -234,9 +234,9 @@ namespace FastTests
                 });
             }
 
-            public bool TryGetLoadError<T>(string databaseName, EtlConfiguration<T> config, out EtlErrorInfo error) where T : ConnectionString
+            public async Task<EtlErrorInfo> TryGetLoadErrorAsync<T>(string databaseName, EtlConfiguration<T> config) where T : ConnectionString
             {
-                var database = _parent.GetDatabase(databaseName).Result;
+                var database = await _parent.GetDatabase(databaseName);
 
                 string tag;
 
@@ -256,27 +256,16 @@ namespace FastTests
                 var loadAlert = database.NotificationCenter.EtlNotifications.GetAlert<EtlErrorsDetails>(tag, $"{config.Name}/{config.Transforms.First().Name}", AlertType.Etl_LoadError);
 
                 if (loadAlert is null)
-                {
-                    error = null;
-                    return false;
-                }
+                    return null;
 
                 var details = (EtlErrorsDetails)loadAlert.Details;
 
-                if (details.Errors.Count != 0)
-                {
-                    error = details.Errors.First();
-
-                    return true;
-                }
-
-                error = null;
-                return false;
+                return details.Errors.Count != 0 ? details.Errors.First() : null;
             }
 
-            public bool TryGetTransformationError<T>(string databaseName, EtlConfiguration<T> config, out EtlErrorInfo error) where T : ConnectionString
+            public async Task<EtlErrorInfo> TryGetTransformationErrorAsync<T>(string databaseName, EtlConfiguration<T> config) where T : ConnectionString
             {
-                var database = _parent.GetDatabase(databaseName).Result;
+                var database = await _parent.GetDatabase(databaseName);
 
                 string tag;
 
@@ -296,22 +285,11 @@ namespace FastTests
                 var loadAlert = database.NotificationCenter.EtlNotifications.GetAlert<EtlErrorsDetails>(tag, $"{config.Name}/{config.Transforms.First().Name}", AlertType.Etl_TransformationError);
                 
                 if (loadAlert is null)
-                {
-                    error = null;
-                    return false;
-                }
+                    return null;
 
                 var details = (EtlErrorsDetails)loadAlert.Details;
 
-                if (details.Errors.Count != 0)
-                {
-                    error = details.Errors.First();
-
-                    return true;
-                }
-
-                error = null;
-                return false;
+                return details.Errors.Count != 0 ? details.Errors.First() : null;
             }
 
             public async Task<DocumentDatabase> GetDatabaseFor(IDocumentStore store, string docId)

--- a/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Indexes.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Runtime.Internal.Util;
+using Nito.AsyncEx;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
@@ -340,11 +341,11 @@ public partial class RavenTestBase
             return entriesCount;
         }
 
-        public ManualResetEventSlim WaitForIndexBatchCompleted(IDocumentStore store, Func<(string IndexName, bool DidWork), bool> predicate)
+        public async Task<AsyncManualResetEvent> WaitForIndexBatchCompletedAsync(IDocumentStore store, Func<(string IndexName, bool DidWork), bool> predicate)
         {
-            var database = _parent.GetDatabase(store.Database).Result;
+            var database = await _parent.GetDatabase(store.Database);
 
-            var mre = new ManualResetEventSlim();
+            var mre = new AsyncManualResetEvent();
 
             database.IndexStore.IndexBatchCompleted += x =>
             {

--- a/test/Tryouts/Program.cs
+++ b/test/Tryouts/Program.cs
@@ -8,6 +8,7 @@ using SlowTests.Corax;
 using SlowTests.Sharding.Cluster;
 using Xunit;
 using FastTests.Voron.Util;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Tryouts;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23231/Hanged-test-suite

### Additional description

Port of 2 PRs:
https://github.com/ravendb/ravendb/pull/19679
https://github.com/ravendb/ravendb/pull/19702

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
