### PR TITLE
RavenDB-22287 switched to HashedWheelTimer

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2269,7 +2269,10 @@ namespace Raven.Server.Documents.Indexes
                 var timeLeft = timeToWaitInMilliseconds - sp.ElapsedMilliseconds;
                 // wait for sync
                 if (timeLeft > 0)
-                    Task.Delay((int)timeLeft, _indexingProcessCancellationTokenSource.Token).Wait();
+                {
+                    if (_indexingProcessCancellationTokenSource.Token.WaitHandle.WaitOne((int)timeLeft))
+                        return;
+                }
             }
             catch (OperationCanceledException)
             {

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -813,14 +813,7 @@ namespace Raven.Server
                     }
                 }
 
-                try
-                {
-                    Task.Delay(1000).Wait(ServerStore.ServerShutdown);
-                }
-                catch (OperationCanceledException)
-                {
-                    return;
-                }
+                ServerStore.ServerShutdown.WaitHandle.WaitOne(TimeSpan.FromSeconds(5));
             }
 
             void MaybeRaiseAlert(

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -469,7 +469,7 @@ namespace Raven.Server.ServerWide
 
         private int ReconnectionBackoff(int delay)
         {
-            TimeoutManager.WaitFor(TimeSpan.FromMilliseconds(delay), ServerShutdown).Wait(ServerShutdown);
+            ServerShutdown.WaitHandle.WaitOne(delay);
             return Math.Min(15_000, delay * 2);
         }
 

--- a/src/Sparrow.Server/AsyncManualResetEvent.cs
+++ b/src/Sparrow.Server/AsyncManualResetEvent.cs
@@ -101,7 +101,7 @@ namespace Sparrow.Server
                 if (_parent._token.IsCancellationRequested)
                     return false;
 
-                var result = await waitAsync.WaitFor(timeout, _parent._token).ConfigureAwait(false);
+                var result = await TimeoutManager.WaitFor(waitAsync, timeout, _parent._token).ConfigureAwait(false);
 
                 if (result.IsFaulted)
                     throw result.Exception;

--- a/src/Sparrow/Utils/HWT/HashedWheelBucket.cs
+++ b/src/Sparrow/Utils/HWT/HashedWheelBucket.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Sparrow.Utils.HWT
+{
+    internal sealed class HashedWheelBucket
+    {
+        // Used for the linked-list datastructure
+        private HashedWheelTimeout _head;
+        private HashedWheelTimeout _tail;
+
+        public void AddTimeout(HashedWheelTimeout timeout)
+        {
+            timeout._bucket = this;
+            if (_head == null)
+            {
+                _head = _tail = timeout;
+            }
+            else
+            {
+                _tail._next = timeout;
+                timeout._prev = _tail;
+                _tail = timeout;
+            }
+        }
+
+        /// <summary>
+        /// Expire all HashedWheelTimeout for the given deadline.
+        /// </summary>
+        /// <param name="deadline"></param>
+        internal void ExpireTimeouts(long deadline)
+        {
+            HashedWheelTimeout timeout = _head;
+
+            // process all timeouts
+            while (timeout != null)
+            {
+                HashedWheelTimeout next = timeout._next;
+                if (timeout._remainingRounds <= 0)
+                {
+                    next = Remove(timeout);
+                    if (timeout._deadline <= deadline)
+                    {
+                        timeout.Expire();
+                    }
+                    else
+                    {
+                        // The timeout was placed into a wrong slot. This should never happen.
+                        throw new InvalidOperationException($"timeout.deadline ({timeout._deadline}) > deadline ({deadline})");
+                    }
+                }
+                else if (timeout.Cancelled)
+                {
+                    next = Remove(timeout);
+                }
+                else
+                {
+                    timeout._remainingRounds--;
+                }
+                timeout = next;
+            }
+        }
+
+        internal HashedWheelTimeout Remove(HashedWheelTimeout timeout)
+        {
+            HashedWheelTimeout next = timeout._next;
+            // remove timeout that was either processed or cancelled by updating the linked-list
+            if (timeout._prev != null)
+            {
+                timeout._prev._next = next;
+            }
+            if (timeout._next != null)
+            {
+                timeout._next._prev = timeout._prev;
+            }
+
+            if (timeout == _head)
+            {
+                // if timeout is also the tail we need to adjust the entry too
+                if (timeout == _tail)
+                {
+                    _tail = null;
+                    _head = null;
+                }
+                else
+                {
+                    _head = next;
+                }
+            }
+            else if (timeout == _tail)
+            {
+                // if the timeout is the tail modify the tail to be the prev node.
+                _tail = timeout._prev;
+            }
+            // null out prev, next and bucket to allow for GC.
+            timeout._prev = null;
+            timeout._next = null;
+            timeout._bucket = null;
+            timeout._timer.DecreasePendingTimeouts();
+            return next;
+        }
+
+        internal void ClearTimeouts(ISet<Timeout> set)
+        {
+            for (; ; )
+            {
+                HashedWheelTimeout timeout = PollTimeout();
+                if (timeout == null)
+                {
+                    return;
+                }
+                if (timeout.Expired || timeout.Cancelled)
+                {
+                    continue;
+                }
+                set.Add(timeout);
+            }
+        }
+
+        private HashedWheelTimeout PollTimeout()
+        {
+            HashedWheelTimeout head = this._head;
+            if (head == null)
+            {
+                return null;
+            }
+            HashedWheelTimeout next = head._next;
+            if (next == null)
+            {
+                _tail = this._head = null;
+            }
+            else
+            {
+                this._head = next;
+                next._prev = null;
+            }
+
+            // null out prev and next to allow for GC.
+            head._next = null;
+            head._prev = null;
+            head._bucket = null;
+            return head;
+        }
+    }
+}

--- a/src/Sparrow/Utils/HWT/HashedWheelTimeout.cs
+++ b/src/Sparrow/Utils/HWT/HashedWheelTimeout.cs
@@ -1,0 +1,91 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sparrow.Utils.HWT
+{
+    internal sealed class HashedWheelTimeout : Timeout
+    {
+        internal const int ST_INIT = 0;
+        internal const int ST_CANCELLED = 1;
+        internal const int ST_EXPIRED = 2;
+
+        private volatile int _state = ST_INIT;
+        internal int State { get { return _state; } }
+
+        internal readonly HashedWheelTimer _timer;
+        private readonly TimerTask _task;
+        internal readonly long _deadline;
+
+        // remainingRounds will be calculated and set by Worker.transferTimeoutsToBuckets() before the
+        // HashedWheelTimeout will be added to the correct HashedWheelBucket.
+        internal long _remainingRounds;
+
+        internal HashedWheelTimeout _next;
+        internal HashedWheelTimeout _prev;
+
+        // The bucket to which the timeout was added
+        internal HashedWheelBucket _bucket;
+
+
+        internal HashedWheelTimeout(HashedWheelTimer timer, TimerTask task, long deadline)
+        {
+            this._timer = timer;
+            this._task = task;
+            this._deadline = deadline;
+        }
+
+
+        public Timer Timer { get { return _timer; } }
+
+        public TimerTask TimerTask { get { return _task; } }
+
+        public bool Expired { get { return _state == ST_EXPIRED; } }
+
+        public bool Cancelled { get { return _state == ST_CANCELLED; } }
+
+        bool CompareAndSetState(int expected, int state)
+        {
+            int originalState = Interlocked.CompareExchange(ref _state, state, expected);
+            return originalState == expected;
+        }
+
+        public bool Cancel()
+        {
+            // only update the state it will be removed from HashedWheelBucket on next tick.
+            if (!CompareAndSetState(ST_INIT, ST_CANCELLED))
+            {
+                return false;
+            }
+            // If a task should be canceled we put this to another queue which will be processed on each tick.
+            // So this means that we will have a GC latency of max. 1 tick duration which is good enough. This way
+            // we can make again use of our MpscLinkedQueue and so minimize the locking / overhead as much as possible.
+            _timer._cancelledTimeouts.Enqueue(this);
+            return true;
+        }
+
+        internal void Remove()
+        {
+            HashedWheelBucket bucket = _bucket;
+            if (bucket != null)
+            {
+                bucket.Remove(this);
+            }
+            else
+            {
+                _timer.DecreasePendingTimeouts();
+            }
+        }
+
+        public void Expire()
+        {
+            if (!CompareAndSetState(ST_INIT, ST_EXPIRED))
+            {
+                return;
+            }
+
+            Task.Run(() => {
+                _task.Run(this);
+            });
+        }
+    }
+}

--- a/src/Sparrow/Utils/HWT/HashedWheelTimer.cs
+++ b/src/Sparrow/Utils/HWT/HashedWheelTimer.cs
@@ -1,0 +1,386 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Sparrow.Utils.HWT
+{
+    /// <summary>
+    /// A Timer optimized for approximated I/O timeout scheduling.
+    /// 
+    /// ## Tick Duration ##
+    /// As described with 'approximated', this timer does not execute the scheduled TimerTask on time. HashedWheelTimer, 
+    /// on every tick, will check if there are any TimerTasks behind the schedule and execute them.
+    /// You can increase or decrease the accuracy of the execution timing by specifying smaller or larger tick duration 
+    /// in the constructor.In most network applications, I/O timeout does not need to be accurate. 
+    /// Therefore, the default tick duration is 100 milliseconds and you will not need to try different configurations in most cases.
+    /// 
+    /// ## Ticks per Wheel (Wheel Size) ##
+    /// 
+    /// HashedWheelTimer maintains a data structure called 'wheel'. 
+    /// To put simply, a wheel is a hash table of TimerTasks whose hash function is 'dead line of the task'. 
+    /// The default number of ticks per wheel (i.e. the size of the wheel) is 512. 
+    /// You could specify a larger value if you are going to schedule a lot of timeouts.
+    /// 
+    /// ## Do not create many instances. ##
+    /// 
+    /// HashedWheelTimer creates a new thread whenever it is instantiated and started. 
+    /// Therefore, you should make sure to create only one instance and share it across your application. 
+    /// One of the common mistakes, that makes your application unresponsive, is to create a new instance for every connection.
+    /// 
+    /// ## Implementation Details ##
+    /// HashedWheelTimer is based on George Varghese and Tony Lauck's paper, 
+    /// 'Hashed and Hierarchical Timing Wheels: data structures to efficiently implement a timer facility'. 
+    /// More comprehensive slides are located here http://www.cse.wustl.edu/~cdgill/courses/cs6874/TimingWheels.ppt.
+    /// </summary>
+    internal sealed class HashedWheelTimer : Timer
+    {
+        public const int WORKER_STATE_INIT = 0;
+        public const int WORKER_STATE_STARTED = 1;
+        public const int WORKER_STATE_SHUTDOWN = 2;
+
+        private volatile int _workerState; // 0 - init, 1 - started, 2 - shut down
+
+        private readonly long _tickDuration;
+        private readonly HashedWheelBucket[] _wheel;
+        private readonly int _mask;
+        private readonly ManualResetEvent _startTimeInitialized = new(false);
+        private readonly ConcurrentQueue<HashedWheelTimeout> _timeouts = new();
+        internal readonly ConcurrentQueue<HashedWheelTimeout> _cancelledTimeouts = new();
+        private readonly long _maxPendingTimeouts;
+        private readonly Thread _workerThread;
+
+        /// <summary>
+        /// There are 10,000 ticks in a millisecond
+        /// </summary>
+        private readonly long _base = DateTime.UtcNow.Ticks / 10000;
+
+
+        private /*volatile*/ long _startTime;
+        private long _pendingTimeouts = 0;
+
+        private long GetCurrentMs() { return DateTime.UtcNow.Ticks / 10000 - _base; }
+
+        internal long DecreasePendingTimeouts()
+        {
+            return Interlocked.Decrement(ref _pendingTimeouts);
+        }
+
+        /// <summary>
+        /// Creates a new timer with default tick duration 100 ms, and default number of ticks per wheel 512.
+        /// </summary>
+        public HashedWheelTimer() : this(TimeSpan.FromMilliseconds(100), 512, 0)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new timer.
+        /// </summary>
+        /// <param name="tickDuration">the duration between tick</param>
+        /// <param name="ticksPerWheel">the size of the wheel</param>
+        /// <param name="maxPendingTimeouts">The maximum number of pending timeouts after which call to NewTimeout will result in InvalidOperationException being thrown. No maximum pending timeouts limit is assumed if this value is 0 or negative.
+        /// </param>
+        public HashedWheelTimer(TimeSpan tickDuration, int ticksPerWheel, long maxPendingTimeouts)
+        {
+            if (tickDuration.TotalMilliseconds <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tickDuration), "must be greater than 0 ms");
+            }
+            if (ticksPerWheel <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ticksPerWheel), "must be greater than 0: ");
+            }
+
+            // Normalize ticksPerWheel to power of two and initialize the wheel.
+            _wheel = CreateWheel(ticksPerWheel);
+            _mask = _wheel.Length - 1;
+
+            // Convert tickDuration to ms.
+            _tickDuration = (long)tickDuration.TotalMilliseconds;
+
+            // Prevent overflow.
+            if (_tickDuration >= long.MaxValue / _wheel.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tickDuration)
+                    , $"{tickDuration} (expected: 0 < tickDuration in ms < {long.MaxValue / _wheel.Length}");
+            }
+            _workerThread = new Thread(Run)
+            {
+                IsBackground = true,
+                Name = "HW Timer"
+            };
+
+            _maxPendingTimeouts = maxPendingTimeouts;
+        }
+
+
+        private static HashedWheelBucket[] CreateWheel(int ticksPerWheel)
+        {
+            if (ticksPerWheel <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ticksPerWheel), "must be greater than 0");
+            }
+            if (ticksPerWheel > 1073741824)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ticksPerWheel), "may not be greater than 2^30");
+            }
+
+            ticksPerWheel = NormalizeTicksPerWheel(ticksPerWheel);
+            HashedWheelBucket[] wheel = new HashedWheelBucket[ticksPerWheel];
+            for (int i = 0; i < wheel.Length; i++)
+            {
+                wheel[i] = new HashedWheelBucket();
+            }
+            return wheel;
+        }
+
+        private static int NormalizeTicksPerWheel(int ticksPerWheel)
+        {
+            int normalizedTicksPerWheel = 1;
+            while (normalizedTicksPerWheel < ticksPerWheel)
+            {
+                normalizedTicksPerWheel <<= 1;
+            }
+            return normalizedTicksPerWheel;
+        }
+
+        /// <summary>
+        ///  Starts the background thread explicitly.  The background thread will start automatically on demand 
+        ///  even if you did not call this method.
+        /// </summary>
+        private void Start()
+        {
+            switch (_workerState)
+            {
+                case WORKER_STATE_INIT:
+                    int originalWorkerState = Interlocked.CompareExchange(ref _workerState, WORKER_STATE_STARTED, WORKER_STATE_INIT);
+                    if (originalWorkerState == WORKER_STATE_INIT)
+                    {
+                        _workerThread.Start();
+                    }
+                    break;
+                case WORKER_STATE_STARTED:
+                    break;
+                case WORKER_STATE_SHUTDOWN:
+                    return;
+                default:
+                    throw new InvalidOperationException("HashedWheelTimer.workerState is invalid");
+            }
+
+            // Wait until the startTime is initialized by the worker.
+            while (_startTime == 0)
+            {
+                try
+                {
+                    _startTimeInitialized.WaitOne(5000);
+                }
+                catch
+                {
+                    // Ignore - it will be ready very soon.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Schedules the specified TimerTask for one-time execution after the specified delay.
+        /// </summary>
+        /// <param name="task"></param>
+        /// <param name="span"></param>
+        /// <returns>a handle which is associated with the specified task</returns>
+        public Timeout NewTimeout(TimerTask task, TimeSpan span)
+        {
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            if (_workerState == WORKER_STATE_SHUTDOWN)
+                return null;
+
+            long pendingTimeoutsCount = Interlocked.Increment(ref _pendingTimeouts);
+
+            if (_maxPendingTimeouts > 0 && pendingTimeoutsCount > _maxPendingTimeouts)
+            {
+                Interlocked.Decrement(ref _pendingTimeouts);
+                throw new InvalidOperationException($"Number of pending timeouts ({pendingTimeoutsCount}) is greater than or equal to maximum allowed pending  timeouts ({_maxPendingTimeouts})");
+            }
+
+            Start();
+
+            // Add the timeout to the timeout queue which will be processed on the next tick.
+            // During processing all the queued HashedWheelTimeouts will be added to the correct HashedWheelBucket.
+            long deadline = GetCurrentMs() + (long)span.TotalMilliseconds - _startTime;
+
+            // Guard against overflow.
+            if (span.TotalMilliseconds > 0 && deadline < 0)
+            {
+                deadline = long.MaxValue;
+            }
+            HashedWheelTimeout timeout = new(this, task, deadline);
+            _timeouts.Enqueue(timeout);
+            return timeout;
+        }
+
+        /// <summary>
+        /// Releases all resources acquired by this Timer and cancels all tasks which were scheduled but not executed yet.
+        /// </summary>
+        /// <returns></returns>
+        public HashSet<Timeout> Stop()
+        {
+            int originalWorkerState = Interlocked.CompareExchange(ref _workerState, WORKER_STATE_SHUTDOWN, WORKER_STATE_STARTED);
+
+            if (originalWorkerState != WORKER_STATE_STARTED)
+            {
+                return new HashSet<Timeout>();
+            }
+
+            try
+            {
+                while (_workerThread.IsAlive)
+                {
+                    _workerThread.Join(1000);
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return _unprocessedTimeouts;
+        }
+
+
+
+        private readonly HashSet<Timeout> _unprocessedTimeouts = new();
+        private long _tick;
+
+        private void Run()
+        {
+            // Initialize the startTime.
+            _startTime = GetCurrentMs();
+            if (_startTime == 0)
+            {
+                // We use 0 as an indicator for the uninitialized value here, so make sure it's not 0 when initialized.
+                _startTime = 1;
+            }
+
+            // Notify the other threads waiting for the initialization at start().
+            _startTimeInitialized.Set();
+
+            do
+            {
+                long deadline = WaitForNextTick();
+                if (deadline > 0)
+                {
+                    int idx = (int)(_tick & _mask);
+                    ProcessCancelledTasks();
+                    HashedWheelBucket bucket = _wheel[idx];
+                    TransferTimeoutsToBuckets();
+                    bucket.ExpireTimeouts(deadline);
+                    _tick++;
+                }
+            } while (_workerState == WORKER_STATE_STARTED);
+
+            // Fill the unprocessedTimeouts so we can return them from stop() method.
+            foreach (HashedWheelBucket bucket in _wheel)
+            {
+                bucket.ClearTimeouts(_unprocessedTimeouts);
+            }
+            for (; ; )
+            {
+                if (!_timeouts.TryDequeue(out HashedWheelTimeout timeout) || timeout == null)
+                {
+                    break;
+                }
+                if (!timeout.Cancelled)
+                {
+                    _unprocessedTimeouts.Add(timeout);
+                }
+            }
+            ProcessCancelledTasks();
+        }
+
+        private void TransferTimeoutsToBuckets()
+        {
+            // transfer only max. 100000 timeouts per tick to prevent a thread to stale the workerThread when it just
+            // adds new timeouts in a loop.
+            for (int i = 0; i < 100000; i++)
+            {
+                if (!_timeouts.TryDequeue(out HashedWheelTimeout timeout) || timeout == null)
+                {
+                    // all processed
+                    break;
+                }
+                if (timeout.State == HashedWheelTimeout.ST_CANCELLED)
+                {
+                    // Was cancelled in the meantime.
+                    continue;
+                }
+
+                long calculated = timeout._deadline / _tickDuration;
+                timeout._remainingRounds = (calculated - _tick) / _wheel.Length;
+
+                long ticks = Math.Max(calculated, _tick); // Ensure we don't schedule for past.
+                int stopIndex = (int)(ticks & _mask);
+
+                HashedWheelBucket bucket = _wheel[stopIndex];
+                bucket.AddTimeout(timeout);
+            }
+        }
+
+
+
+        private void ProcessCancelledTasks()
+        {
+            for (; ; )
+            {
+                if (!_cancelledTimeouts.TryDequeue(out HashedWheelTimeout timeout) || timeout == null)
+                {
+                    // all processed
+                    break;
+                }
+                try
+                {
+                    timeout.Remove();
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+        }
+
+
+        private long WaitForNextTick()
+        {
+            long deadline = _tickDuration * (_tick + 1);
+
+            for (; ; )
+            {
+                long currentTime = GetCurrentMs() - _startTime;
+                int sleepTimeMs = (int)Math.Truncate(deadline - currentTime + 1M);
+
+                if (sleepTimeMs <= 0)
+                {
+                    if (currentTime == long.MaxValue)
+                    {
+                        return -long.MaxValue;
+                    }
+                    else
+                    {
+                        return currentTime;
+                    }
+                }
+
+                Thread.Sleep(sleepTimeMs);
+            }
+        }
+
+        public TimedAwaiter Delay(long milliseconds)
+        {
+            TimedAwaiter awaiter = new();
+            NewTimeout(awaiter, TimeSpan.FromMilliseconds(milliseconds));
+            return awaiter;
+        }
+    }
+}

--- a/src/Sparrow/Utils/HWT/TimedAwaiter.cs
+++ b/src/Sparrow/Utils/HWT/TimedAwaiter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Sparrow.Utils.HWT
+{
+    internal sealed class TimedAwaiter : INotifyCompletion, TimerTask
+    {
+        public bool IsCompleted { get; private set; }
+
+
+        private Action _continuation;
+
+        public void OnCompleted(Action continuation)
+        {
+            _continuation = continuation;
+            if (IsCompleted)
+                Interlocked.Exchange(ref _continuation, null)?.Invoke();
+        }
+
+        public void Run(Timeout timeout)
+        {
+            IsCompleted = true;
+            Interlocked.Exchange(ref _continuation, null)?.Invoke();
+        }
+
+        public TimedAwaiter GetAwaiter()
+        {
+            return this;
+        }
+
+        public object GetResult()
+        {
+            return null;
+        }
+    }
+}

--- a/src/Sparrow/Utils/HWT/Timeout.cs
+++ b/src/Sparrow/Utils/HWT/Timeout.cs
@@ -1,0 +1,38 @@
+﻿
+namespace Sparrow.Utils.HWT
+{
+    /// <summary>
+    /// A handle associated with a TimerTask that is returned by a Timer
+    /// </summary>
+    internal interface Timeout
+    {
+        /// <summary>
+        ///  Returns the Timer that created this handle.
+        /// </summary>
+        Timer Timer { get; }
+
+        /// <summary>
+        /// Returns the TimerTask which is associated with this handle.
+        /// </summary>
+        TimerTask TimerTask { get; }
+
+        /// <summary>
+        /// Returns true if and only if the TimerTask associated
+        /// with this handle has been expired
+        /// </summary>
+        bool Expired { get; }
+
+        /// <summary>
+        /// Returns true if and only if the TimerTask associated
+        /// with this handle has been cancelled
+        /// </summary>
+        bool Cancelled { get; }
+
+        /// <summary>
+        /// Attempts to cancel the {@link TimerTask} associated with this handle.
+        /// If the task has been executed or cancelled already, it will return with no side effect.
+        /// </summary>
+        /// <returns>True if the cancellation completed successfully, otherwise false</returns>
+        bool Cancel();
+    }
+}

--- a/src/Sparrow/Utils/HWT/Timer.cs
+++ b/src/Sparrow/Utils/HWT/Timer.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Sparrow.Utils.HWT
+{
+    internal interface Timer
+    {
+        /// <summary>
+        ///  Schedules the specified TimerTask for one-time execution after the specified delay.
+        /// </summary>
+        /// <param name="task"></param>
+        /// <param name="span"></param>
+        /// <returns> handle which is associated with the specified task</returns>
+        Timeout NewTimeout(TimerTask task, TimeSpan span);
+
+
+        /// <summary>
+        /// Releases all resources acquired by this Timer and cancels all
+        /// tasks which were scheduled but not executed yet.
+        /// </summary>
+        /// <returns>the handles associated with the tasks which were canceled by this method</returns>
+        HashSet<Timeout> Stop();
+    }
+}

--- a/src/Sparrow/Utils/HWT/TimerTask.cs
+++ b/src/Sparrow/Utils/HWT/TimerTask.cs
@@ -1,0 +1,15 @@
+﻿
+namespace Sparrow.Utils.HWT
+{
+    /// <summary>
+    /// A task which is executed after the delay specified with Timer.NewTimeout(TimerTask, long, TimeUnit).
+    /// </summary>
+    internal interface TimerTask
+    {
+        /// <summary>
+        /// Executed after the delay specified with Timer.NewTimeout(TimerTask, long, TimeUnit)
+        /// </summary>
+        /// <param name="timeout">timeout a handle which is associated with this task</param>
+        void Run(Timeout timeout);
+    }
+}

--- a/src/Sparrow/Utils/TimeoutManager.cs
+++ b/src/Sparrow/Utils/TimeoutManager.cs
@@ -5,66 +5,26 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Sparrow.Utils.HWT;
+using Timeout = System.Threading.Timeout;
 
 namespace Sparrow.Utils
 {
     internal static class TimeoutManager
     {
-        private static readonly ConcurrentDictionary<uint, TimerTaskHolder> Values = new ConcurrentDictionary<uint, TimerTaskHolder>();
+        private static readonly HashedWheelTimer Timer = new(tickDuration: TimeSpan.FromMilliseconds(50), ticksPerWheel: 512, maxPendingTimeouts: 0);
+
         private static readonly Task InfiniteTask = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously).Task;
 
-        private sealed class TimerTaskHolder  : IDisposable
-        {
-            private TaskCompletionSource<object> _nextTimeout;
-            private readonly Timer _timer;
-
-            public void TimerCallback(object state)
-            {
-                var old = Interlocked.Exchange(ref _nextTimeout, null);
-                old?.TrySetResult(null);
-            }
-
-            public Task NextTask
-            {
-                get
-                {
-                    while (true)
-                    {
-                        var tcs = _nextTimeout;
-                        if (tcs != null)
-                            return tcs.Task;
-
-                        tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
-                        if (Interlocked.CompareExchange(ref _nextTimeout, tcs, null) == null)
-                            return tcs.Task;
-                    }
-                }
-            }
-
-            public TimerTaskHolder(uint timeout)
-            {
-                if (timeout > uint.MaxValue - 1) // Timer cannot have an interval bigger than this value
-                    timeout = uint.MaxValue - 1;
-                var period = TimeSpan.FromMilliseconds(timeout);
-                _timer = new Timer(TimerCallback, null, period, period);
-            }
-
-            public void Dispose()
-            {
-                _timer?.Dispose();
-            }
-        }
-
-        private static async Task WaitForInternal(TimeSpan time, CancellationToken token)
+        private static async Task WaitForInternal(TimeSpan time, bool canBeCanceled, CancellationToken token)
         {
             if (time.TotalMilliseconds < 0)
                 ThrowOutOfRange();
 
-            var duration = (uint)Math.Min(time.TotalMilliseconds, uint.MaxValue - 45);
+            var duration = (int)Math.Min(time.TotalMilliseconds, uint.MaxValue - 45);
             if (duration == 0)
                 return;
 
@@ -74,41 +34,33 @@ namespace Sparrow.Utils
                 duration += 50 - mod;
             }
 
-            var value = GetHolderForDuration(duration);
-
-            using (token.Register(value.TimerCallback, null))
+            if (canBeCanceled == false)
             {
-                var sp = Stopwatch.StartNew();
-                await value.NextTask.ConfigureAwait(false);
+#pragma warning disable RDB0002
+                await Timer.Delay(duration);
+#pragma warning restore RDB0002
+                return;
+            }
+
+            var sp = Stopwatch.StartNew();
+
+            var step = duration / 8;
+
+            do
+            {
                 token.ThrowIfCancellationRequested();
 
-                var step = duration / 8;
+#pragma warning disable RDB0002
+                await Timer.Delay(step);
+#pragma warning restore RDB0002
+            } while (sp.ElapsedMilliseconds < duration);
 
-                if (sp.ElapsedMilliseconds >= (duration - step))
-                    return;
-
-                value = GetHolderForDuration(step);
-
-                do
-                {
-                    token.ThrowIfCancellationRequested();
-                    await value.NextTask.ConfigureAwait(false);
-                } while (sp.ElapsedMilliseconds < (duration - step));
-            }
+            token.ThrowIfCancellationRequested();
         }
 
         private static void ThrowOutOfRange()
         {
             throw new ArgumentOutOfRangeException("time");
-        }
-
-        private static TimerTaskHolder GetHolderForDuration(uint duration)
-        {
-            if (Values.TryGetValue(duration, out var value) == false)
-            {
-                value = Values.GetOrAdd(duration, d => new TimerTaskHolder(d));
-            }
-            return value;
         }
 
         public static async Task<Task> WaitFor(this Task outer, TimeSpan duration, CancellationToken token = default)
@@ -121,18 +73,20 @@ namespace Sparrow.Utils
                 return Task.CompletedTask;
             }
 
+            var canBeCanceled = token != CancellationToken.None && token.CanBeCanceled;
+
             Task task;
             // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
             if (duration != Timeout.InfiniteTimeSpan)
-                task = WaitForInternal(duration, token);
+                task = WaitForInternal(duration, canBeCanceled, token);
             else
                 task = InfiniteTask;
-            
-            if (token == CancellationToken.None || token.CanBeCanceled == false)
+
+            if (canBeCanceled == false)
             {
                 return await Task.WhenAny(outer, task).ConfigureAwait(false);
             }
-            
+
             var onCancel = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             using (token.Register(tcs => onCancel.TrySetCanceled(), onCancel))
             {
@@ -150,14 +104,16 @@ namespace Sparrow.Utils
                 return;
             }
 
+            var canBeCanceled = token != CancellationToken.None && token.CanBeCanceled;
+
             Task task;
             // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
             if (duration != Timeout.InfiniteTimeSpan)
-                task = WaitForInternal(duration, token);
+                task = WaitForInternal(duration, canBeCanceled, token);
             else
                 task = InfiniteTask;
-            
-            if (token == CancellationToken.None || token.CanBeCanceled == false)
+
+            if (canBeCanceled == false)
             {
                 await task.ConfigureAwait(false);
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22287

### Additional description

TimeoutManager works great if it has a finite number of values, at some point we started putting dynamic values there creating a wider spectrum of Timers that were working infinitely without anyone actually using them. 
- Switched all HashedWheelTimer
- avoiding registering on non-cancelable token

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
