### PR TITLE
RavenDB-23254 Default search analyzer not shown in UI

### DIFF
--- a/src/Raven.Studio/typescript/common/typeUtils.spec.ts
+++ b/src/Raven.Studio/typescript/common/typeUtils.spec.ts
@@ -56,18 +56,20 @@ describe("typeUtils", () => {
         it("should return true for empty values", () => {
             expect(isEmpty(undefined)).toBe(true);
             expect(isEmpty(null)).toBe(true);
-            expect(isEmpty('')).toBe(true);
-            expect(isEmpty(' ')).toBe(true);
+            expect(isEmpty("")).toBe(true);
             expect(isEmpty([])).toBe(true);
             expect(isEmpty({})).toBe(true);
+            expect(isEmpty(0)).toBe(true);
+            expect(isEmpty(false)).toBe(true);
+            expect(isEmpty(true)).toBe(true);
         });
         
         it("should return false for non-empty values", () => {
-            expect(isEmpty('hello')).toBe(false);
-            expect(isEmpty(0)).toBe(false);
-            expect(isEmpty(false)).toBe(false);
-            expect(isEmpty([0, false])).toBe(false);
-            expect(isEmpty({ key: 'value' })).toBe(false);
+            expect(isEmpty("hello")).toBe(false);
+            expect(isEmpty(" ")).toBe(false);
+            expect(isEmpty(15)).toBe(false);
+            expect(isEmpty([0, false, "test"])).toBe(false);
+            expect(isEmpty({ key: "value" })).toBe(false);
         });
-    })
+    });
 });

--- a/src/Raven.Studio/typescript/common/typeUtils.spec.ts
+++ b/src/Raven.Studio/typescript/common/typeUtils.spec.ts
@@ -67,7 +67,6 @@ describe("typeUtils", () => {
         it("should return false for non-empty values", () => {
             expect(isEmpty("hello")).toBe(false);
             expect(isEmpty(" ")).toBe(false);
-            expect(isEmpty(15)).toBe(false);
             expect(isEmpty([0, false, "test"])).toBe(false);
             expect(isEmpty({ key: "value" })).toBe(false);
         });

--- a/src/Raven.Studio/typescript/common/typeUtils.spec.ts
+++ b/src/Raven.Studio/typescript/common/typeUtils.spec.ts
@@ -1,4 +1,4 @@
-import { compareSets, isBoolean, range } from "./typeUtils";
+import { compareSets, isBoolean, range, isEmpty } from "./typeUtils";
 
 describe("typeUtils", () => {
     describe("isBoolean", () => {
@@ -51,4 +51,23 @@ describe("typeUtils", () => {
             expect(compareSets([1, 2, 3], [1, 2])).toBe(false);
         });
     });
+    
+    describe("isEmpty", () => {
+        it("should return true for empty values", () => {
+            expect(isEmpty(undefined)).toBe(true);
+            expect(isEmpty(null)).toBe(true);
+            expect(isEmpty('')).toBe(true);
+            expect(isEmpty(' ')).toBe(true);
+            expect(isEmpty([])).toBe(true);
+            expect(isEmpty({})).toBe(true);
+        });
+        
+        it("should return false for non-empty values", () => {
+            expect(isEmpty('hello')).toBe(false);
+            expect(isEmpty(0)).toBe(false);
+            expect(isEmpty(false)).toBe(false);
+            expect(isEmpty([0, false])).toBe(false);
+            expect(isEmpty({ key: 'value' })).toBe(false);
+        });
+    })
 });

--- a/src/Raven.Studio/typescript/common/typeUtils.ts
+++ b/src/Raven.Studio/typescript/common/typeUtils.ts
@@ -66,19 +66,18 @@ export function compareSets<T extends string | number>(set1: T[], set2: T[]): bo
     return true;
 }
 
-export function isEmpty<T>(value: T | undefined) {
-    const type = typeof value;
-    
-    if ((value !== null && type === "object") || type === "function") {
-        const propsKeys = Object.keys(value);
-        if (propsKeys.length === 0) {
-            return true;
-        }
+export function isEmpty(obj: any): boolean {
+    if (obj?.length || obj?.size) {
+        return false;
     }
-    
-    if (type === "boolean") {
+    if (typeof obj !== "object") {
         return true;
     }
-    
-    return !value;
-}
+    for (const key in obj) {
+        // eslint-disable-next-line no-prototype-builtins
+        if (obj.hasOwnProperty(key)) {
+            return false;
+        }
+    }
+    return true;
+};

--- a/src/Raven.Studio/typescript/common/typeUtils.ts
+++ b/src/Raven.Studio/typescript/common/typeUtils.ts
@@ -66,22 +66,19 @@ export function compareSets<T extends string | number>(set1: T[], set2: T[]): bo
     return true;
 }
 
-export const isEmpty = <T>(value: T | undefined): value is undefined => {
-    if (value === undefined || value === null) {
+export function isEmpty<T>(value: T | undefined) {
+    const type = typeof value;
+    
+    if ((value !== null && type === "object") || type === "function") {
+        const propsKeys = Object.keys(value);
+        if (propsKeys.length === 0) {
+            return true;
+        }
+    }
+    
+    if (type === "boolean") {
         return true;
     }
     
-    if (typeof value === 'string' && value.trim() === '') {
-        return true;
-    }
-    
-    if (Array.isArray(value)) {
-        return value.length === 0;
-    }
-    
-    if (value instanceof Object) {
-        return Object.keys(value).length === 0;
-    }
-    
-    return false;
-};
+    return !value;
+}

--- a/src/Raven.Studio/typescript/common/typeUtils.ts
+++ b/src/Raven.Studio/typescript/common/typeUtils.ts
@@ -65,3 +65,23 @@ export function compareSets<T extends string | number>(set1: T[], set2: T[]): bo
     }
     return true;
 }
+
+export const isEmpty = <T>(value: T | undefined): value is undefined => {
+    if (value === undefined || value === null) {
+        return true;
+    }
+    
+    if (typeof value === 'string' && value.trim() === '') {
+        return true;
+    }
+    
+    if (Array.isArray(value)) {
+        return value.length === 0;
+    }
+    
+    if (value instanceof Object) {
+        return Object.keys(value).length === 0;
+    }
+    
+    return false;
+};

--- a/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
@@ -30,7 +30,6 @@ class mapItem {
     }
 }
 
-
 class indexDefinition {
    
     name = ko.observable<string>();

--- a/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
@@ -6,7 +6,7 @@ import configurationItem = require("models/database/index/configurationItem");
 import validateNameCommand = require("commands/resources/validateNameCommand");
 import generalUtils = require("common/generalUtils");
 import compoundField = require("models/database/index/compoundField");
-import { IndexingDatabaseSettingsType } from "models/database/index/types";
+import indexingDatabaseSettingsTypes = require("models/database/index/types")
 
 class mapItem {
     map = ko.observable<string>();
@@ -73,9 +73,9 @@ class indexDefinition {
     searchEngine = ko.observable<Raven.Client.Documents.Indexes.SearchEngineType>();
 
     validationGroup: KnockoutValidationGroup;
-    indexingDatabaseSettings = ko.observable<IndexingDatabaseSettingsType>();
+    indexingDatabaseSettings = ko.observable<indexingDatabaseSettingsTypes.IndexingDatabaseSettingsType>();
 
-    constructor(dto: Raven.Client.Documents.Indexes.IndexDefinition, indexingDatabaseSettings?: IndexingDatabaseSettingsType) {
+    constructor(dto: Raven.Client.Documents.Indexes.IndexDefinition, indexingDatabaseSettings?: indexingDatabaseSettingsTypes.IndexingDatabaseSettingsType) {
         this.isAutoIndex(dto.Type.startsWith("Auto"));
 
         this.name(dto.Name);
@@ -400,7 +400,7 @@ class indexDefinition {
         }
     }
     
-    static createDefaultIndexDefinition(indexingDatabaseSettings?: IndexingDatabaseSettingsType): indexDefinition {
+    static createDefaultIndexDefinition(indexingDatabaseSettings?: indexingDatabaseSettingsTypes.IndexingDatabaseSettingsType): indexDefinition {
         return new indexDefinition({
             Fields: {},
             Maps: [""],

--- a/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
@@ -6,7 +6,7 @@ import configurationItem = require("models/database/index/configurationItem");
 import validateNameCommand = require("commands/resources/validateNameCommand");
 import generalUtils = require("common/generalUtils");
 import compoundField = require("models/database/index/compoundField");
-import models = require("models/database/settings/databaseSettingsModels");
+import { IndexingDatabaseSettingsType } from "models/database/index/types";
 
 class mapItem {
     map = ko.observable<string>();
@@ -29,12 +29,6 @@ class mapItem {
         });
     }
 }
-
-
-type indexingDatabaseSettings =
-  "Indexing.Analyzers.Default"
-  | "Indexing.Analyzers.Exact.Default"
-  | "Indexing.Analyzers.Search.Default"
 
 
 class indexDefinition {
@@ -80,9 +74,9 @@ class indexDefinition {
     searchEngine = ko.observable<Raven.Client.Documents.Indexes.SearchEngineType>();
 
     validationGroup: KnockoutValidationGroup;
-    indexingDatabaseSettings = ko.observable<Record<indexingDatabaseSettings[number], models.serverWideOnlyEntry | models.databaseEntry<string | number>>>();
+    indexingDatabaseSettings = ko.observable<IndexingDatabaseSettingsType>();
 
-    constructor(dto: Raven.Client.Documents.Indexes.IndexDefinition, indexingDatabaseSettings?: Record<indexingDatabaseSettings[number], models.serverWideOnlyEntry | models.databaseEntry<string | number>>) {
+    constructor(dto: Raven.Client.Documents.Indexes.IndexDefinition, indexingDatabaseSettings?: IndexingDatabaseSettingsType) {
         this.isAutoIndex(dto.Type.startsWith("Auto"));
 
         this.name(dto.Name);
@@ -407,7 +401,7 @@ class indexDefinition {
         }
     }
     
-    static empty(indexingDatabaseSettings?: Record<indexingDatabaseSettings[number], models.serverWideOnlyEntry | models.databaseEntry<string | number>>): indexDefinition {
+    static createDefaultIndexDefinition(indexingDatabaseSettings?: IndexingDatabaseSettingsType): indexDefinition {
         return new indexDefinition({
             Fields: {},
             Maps: [""],

--- a/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
@@ -452,11 +452,7 @@ class indexFieldOptions {
         const isAnalyzerNameInDictionary = this.analyzersNamesDictionary().some((analyzerItem) => analyzerItem.serverName === configuration);
 
 
-        const currentAnalyzerStudioName = localAnalyzerConfiguration
-            ? this.analyzersNamesDictionary().find((item) => item.serverName === localAnalyzerConfiguration)?.studioName ??
-            localAnalyzerConfiguration
-            : this.analyzersNamesDictionary().find((item) => item.serverName === databaseAnalyzerSetting?.effectiveValue())?.studioName ??
-            databaseAnalyzerSetting?.effectiveValue();
+        const currentAnalyzerStudioName = this.analyzersNamesDictionary().find((item) => item.serverName === configuration)?.studioName ?? configuration;
         
         const parentAnalyzerStudioName = this.analyzersNamesDictionary().find((item) => item.serverName === parentAnalyzer)?.studioName ?? parentAnalyzer;
         

--- a/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
@@ -613,7 +613,7 @@ class indexFieldOptions {
                           databaseIndexConfiguration?: databaseIndexConfigurationType) {
         const defaultDto: Raven.Client.Documents.Indexes.IndexFieldOptions = {
             Storage: null,
-            Indexing: null,
+            Indexing: "Default",
             Analyzer: null,
             Suggestions: null,
             Spatial: null as Raven.Client.Documents.Indexes.Spatial.SpatialOptions,

--- a/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
@@ -437,7 +437,9 @@ class indexFieldOptions {
         const parentAnalyzer = this.parent() ? this.parent()?.analyzer() : null;
 
         const analyzerConfigurationKey = `Indexing.Analyzers.${thisIndexing === "Default" || thisIndexing === null ? `Default` : `${thisIndexing}.Default`}`;
+        
         const databaseAnalyzerSetting = this.databaseIndexConfiguration?.[analyzerConfigurationKey];
+        
         const localAnalyzerConfiguration: string | undefined = this.indexLocalConfiguration?.[analyzerConfigurationKey];
 
         const hasDatabaseDefaultChanged =
@@ -464,7 +466,6 @@ class indexFieldOptions {
             this.analyzer(null);
         }
         
-        console.log("@@TEST", thisIndexing, parentIndexing, this.analyzer(), "@@DB", this.databaseIndexConfiguration, this.indexLocalConfiguration, this.parent()?.analyzer());
         this.disabledAnalyzerText("");
         const helpMsg = "To set a different analyzer, select the 'Indexing.Search' option first.";
         
@@ -597,7 +598,7 @@ class indexFieldOptions {
         };
         
         if (databaseIndexConfiguration && isEmpty(indexConfiguration)) {
-            defaultDto.Analyzer = databaseIndexConfiguration?.[`Indexing.Analyzers.Default`].effectiveValue();
+            defaultDto.Analyzer = databaseIndexConfiguration?.[`Indexing.Analyzers.Default`]?.effectiveValue();
         }
         
         if (!isEmpty(indexConfiguration)) {
@@ -615,16 +616,16 @@ class indexFieldOptions {
     private static getDefaultDto(indexConfiguration?: Raven.Client.Documents.Indexes.IndexConfiguration,
                           databaseIndexConfiguration?: Record<string, models.serverWideOnlyEntry | models.databaseEntry<string | number>>) {
         const defaultDto: Raven.Client.Documents.Indexes.IndexFieldOptions = {
-            Storage: "No",
-            Indexing: "Default",
-            Analyzer: "RavenStandardAnalyzer",
-            Suggestions: false,
+            Storage: null,
+            Indexing: null,
+            Analyzer: null,
+            Suggestions: null,
             Spatial: null as Raven.Client.Documents.Indexes.Spatial.SpatialOptions,
-            TermVector: "No"
-        };
+            TermVector: null
+        }
         
         if (databaseIndexConfiguration && isEmpty(indexConfiguration)) {
-            defaultDto.Analyzer = databaseIndexConfiguration?.[`Indexing.Analyzers.Default`].effectiveValue();
+            defaultDto.Analyzer = databaseIndexConfiguration?.[`Indexing.Analyzers.Default`]?.effectiveValue();
         }
         
         if (!isEmpty(indexConfiguration)) {

--- a/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
@@ -467,7 +467,7 @@ class indexFieldOptions {
         
         if (thisIndexing === "Exact" || (!thisIndexing && parentIndexing === "Exact")) {
             if ((localAnalyzerConfiguration || hasDatabaseDefaultChanged) && isAnalyzerNameInDictionary) {
-                this.analyzer(defaultFieldAnalyzer);
+                this.analyzer(null);
                 placeHolder = defaultFieldAnalyzer;
                 this.disabledAnalyzerText(`${defaultFieldAnalyzer} is used when selecting Indexing.Exact. ` + helpMsg);
             } else {
@@ -480,7 +480,7 @@ class indexFieldOptions {
         if (thisIndexing === "Default" || (!thisIndexing && (parentIndexing === "Default" || !parentIndexing))) {
             if ((localAnalyzerConfiguration || hasDatabaseDefaultChanged) && isAnalyzerNameInDictionary) {
                 placeHolder = defaultFieldAnalyzer;
-                this.analyzer(defaultFieldAnalyzer);
+                this.analyzer(null);
                 this.disabledAnalyzerText(`${defaultFieldAnalyzer} is used when selecting Indexing.Default. ` + helpMsg);
             } else {
                 this.analyzer(null);
@@ -495,7 +495,7 @@ class indexFieldOptions {
 
         if (!thisIndexing && parentIndexing === "Search") {
             if ((localAnalyzerConfiguration || hasDatabaseDefaultChanged) && isAnalyzerNameInDictionary) {
-                this.analyzer(defaultFieldAnalyzer);
+                this.analyzer(null);
                 placeHolder = defaultFieldAnalyzer;
             } else {
                 this.analyzer(null);
@@ -505,7 +505,7 @@ class indexFieldOptions {
 
         if (thisIndexing === "Search") {
             if ((localAnalyzerConfiguration || hasDatabaseDefaultChanged) && isAnalyzerNameInDictionary) {
-                this.analyzer(defaultFieldAnalyzer);
+                this.analyzer(null);
                 placeHolder = defaultFieldAnalyzer;
             } else {
                 placeHolder = "Raven Standard Analyzer";

--- a/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
@@ -2,7 +2,7 @@
 import spatialOptions = require("models/database/index/spatialOptions");
 import jsonUtil = require("common/jsonUtil");
 import models = require("models/database/settings/databaseSettingsModels");
-import { isEmpty } from "lodash";
+import typeUtils = require("common/typeUtils")
 
 function labelMatcher<T>(labels: Array<valueAndLabelItem<T, string>>): (arg: T) => string {
     return(arg) => labels.find(x => x.value === arg).label;
@@ -22,7 +22,7 @@ interface analyzerName {
     serverName: string;
 }
 
-type databaseIndexConfigurationType = Record<string, models.serverWideOnlyEntry | models.databaseEntry<string | number>>
+type databaseIndexConfigurationType = Record<string, models.serverWideOnlyEntry | models.databaseEntry<string | number>>;
 
 class indexFieldOptions {
     analyzersNamesDictionary = ko.observableArray<analyzerName>([
@@ -166,7 +166,7 @@ class indexFieldOptions {
         this.indexLocalConfiguration = indexLocalConfiguration;
         this.databaseIndexConfiguration = databaseIndexConfiguration;
         
-        if (!isEmpty(databaseIndexConfiguration)) {
+        if (!typeUtils.isEmpty(databaseIndexConfiguration)) {
             Object.values(databaseIndexConfiguration).forEach((databaseIndexConfigurationElement) => {
                 if (!this.analyzersNamesDictionary().some(x => x.serverName === databaseIndexConfigurationElement.effectiveValue())) {
                     this.analyzersNamesDictionary.push({
@@ -177,7 +177,7 @@ class indexFieldOptions {
             });
         }
         
-        if (!isEmpty(indexLocalConfiguration)) {
+        if (!typeUtils.isEmpty(indexLocalConfiguration)) {
             Object.values(indexLocalConfiguration).forEach((indexConfigurationElement) => {
                 if (!this.analyzersNamesDictionary().some(x => x.serverName === indexConfigurationElement)) {
                     this.analyzersNamesDictionary.push({
@@ -593,11 +593,11 @@ class indexFieldOptions {
             TermVector: "No"
         };
         
-        if (databaseIndexConfiguration && isEmpty(indexConfiguration)) {
+        if (databaseIndexConfiguration && typeUtils.isEmpty(indexConfiguration)) {
             defaultDto.Analyzer = databaseIndexConfiguration?.[`Indexing.Analyzers.Default`]?.effectiveValue();
         }
         
-        if (!isEmpty(indexConfiguration)) {
+        if (!typeUtils.isEmpty(indexConfiguration)) {
             defaultDto.Analyzer = indexConfiguration?.[`Indexing.Analyzers.Default`];
         }
         
@@ -620,11 +620,11 @@ class indexFieldOptions {
             TermVector: null
         }
         
-        if (databaseIndexConfiguration && isEmpty(indexConfiguration)) {
+        if (databaseIndexConfiguration && typeUtils.isEmpty(indexConfiguration)) {
             defaultDto.Analyzer = databaseIndexConfiguration?.[`Indexing.Analyzers.Default`]?.effectiveValue();
         }
         
-        if (!isEmpty(indexConfiguration)) {
+        if (!typeUtils.isEmpty(indexConfiguration)) {
             defaultDto.Analyzer = indexConfiguration?.[`Indexing.Analyzers.Default`];
         }
         

--- a/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexFieldOptions.ts
@@ -438,7 +438,8 @@ class indexFieldOptions {
         const parentIndexing = this.parent() ? this.parent().indexing() : null;
         const parentAnalyzer = this.parent() ? this.parent()?.analyzer() : null;
 
-        const analyzerConfigurationKey = `Indexing.Analyzers.${thisIndexing === "Default" || thisIndexing === null ? `Default` : `${thisIndexing}.Default`}`;
+        const indexingAnalyzerKey = !thisIndexing && parentIndexing ? parentIndexing : thisIndexing
+        const analyzerConfigurationKey = `Indexing.Analyzers.${indexingAnalyzerKey === "Default" || indexingAnalyzerKey === null ? `Default` : `${indexingAnalyzerKey}.Default`}`;
         
         const databaseAnalyzerSetting = this.databaseIndexConfiguration?.[analyzerConfigurationKey];
         

--- a/src/Raven.Studio/typescript/models/database/index/types.ts
+++ b/src/Raven.Studio/typescript/models/database/index/types.ts
@@ -1,0 +1,5 @@
+import { serverWideOnlyEntry, databaseEntry } from "models/database/settings/databaseSettingsModels"
+
+export type IndexingDatabaseSetting = "Indexing.Analyzers.Default" | "Indexing.Analyzers.Exact.Default" | "Indexing.Analyzers.Search.Default"
+
+export type IndexingDatabaseSettingsType = Record<IndexingDatabaseSetting, serverWideOnlyEntry | databaseEntry<string | number>>

--- a/src/Raven.Studio/typescript/models/database/index/types.ts
+++ b/src/Raven.Studio/typescript/models/database/index/types.ts
@@ -1,5 +1,5 @@
-import { serverWideOnlyEntry, databaseEntry } from "models/database/settings/databaseSettingsModels"
+import models = require("models/database/settings/databaseSettingsModels");
 
 export type IndexingDatabaseSetting = "Indexing.Analyzers.Default" | "Indexing.Analyzers.Exact.Default" | "Indexing.Analyzers.Search.Default"
 
-export type IndexingDatabaseSettingsType = Record<IndexingDatabaseSetting, serverWideOnlyEntry | databaseEntry<string | number>>
+export type IndexingDatabaseSettingsType = Record<IndexingDatabaseSetting, models.serverWideOnlyEntry | models.databaseEntry<string | number>>

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -356,7 +356,8 @@ class editIndex extends shardViewModelBase {
         this.fetchDatabaseSettings();
         
         return $.when<any>(super.canActivate(indexToEditName))
-            .then(() => {
+            .then(async () => {
+                await this.fetchDatabaseSettings();
                 const db = this.db;
 
                 if (indexToEditName) {

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -59,13 +59,10 @@ import licenseLimitsUtils = require("components/utils/licenseLimitsUtils");
 import getClusterLicenseLimitsUsage = require("commands/licensing/getClusterLicenseLimitsUsage");
 import convertToStaticDialog = require("viewmodels/database/indexes/convertToStaticDialog");
 import convertedIndexesToStaticStorage = require("common/storage/convertedIndexesToStaticStorage");
-import getDatabaseSettingsCommand from "commands/database/settings/getDatabaseSettingsCommand";
+import getDatabaseSettingsCommand = require("commands/database/settings/getDatabaseSettingsCommand");
 import models = require("models/database/settings/databaseSettingsModels");
-import {
-    IndexingDatabaseSetting,
-    IndexingDatabaseSettingsType
-} from "models/database/index/types";
-import genUtils from "common/generalUtils";
+import indexingDatabaseSettingsTypes = require("models/database/index/types")
+import genUtils = require("common/generalUtils");
 
 class editIndex extends shardViewModelBase {
     
@@ -149,7 +146,7 @@ class editIndex extends shardViewModelBase {
 
     infoHubView: ReactInKnockout<typeof EditIndexInfoHub.EditIndexInfoHub>;
     isAddingNewIndex = ko.observable<boolean>(true);
-    indexingAnalyzerSettings = ko.observable<IndexingDatabaseSettingsType>();
+    indexingAnalyzerSettings = ko.observable<indexingDatabaseSettingsTypes.IndexingDatabaseSettingsType>();
 
     constructor(db: database) {
         super(db);
@@ -353,7 +350,6 @@ class editIndex extends shardViewModelBase {
     
     canActivate(indexToEdit: string): JQueryPromise<canActivateResultDto> {
         const indexToEditName = indexToEdit || undefined;
-        this.fetchDatabaseSettings();
         
         return $.when<any>(super.canActivate(indexToEditName))
             .then(async () => {
@@ -555,12 +551,10 @@ class editIndex extends shardViewModelBase {
     }
 
     private fetchDatabaseSettings() {
-        eventsCollector.default.reportEvent("database-settings", "get");
-        
         return new getDatabaseSettingsCommand(this.db)
           .execute()
           .done((result: Raven.Server.Config.SettingsResult) => {
-              const indexingAnalyzersDefaultsDatabaseSettingsKeys = genUtils.exhaustiveStringTuple<IndexingDatabaseSetting>()(
+              const indexingAnalyzersDefaultsDatabaseSettingsKeys = genUtils.exhaustiveStringTuple<indexingDatabaseSettingsTypes.IndexingDatabaseSetting>()(
                   "Indexing.Analyzers.Default", "Indexing.Analyzers.Exact.Default", "Indexing.Analyzers.Search.Default"
               )
               const settingsEntries = result.Settings.map(x => {
@@ -574,7 +568,7 @@ class editIndex extends shardViewModelBase {
                       key,
                       settingsEntries.find(entry => entry.keyName() === key)
                   ])
-              ) as IndexingDatabaseSettingsType
+              ) as indexingDatabaseSettingsTypes.IndexingDatabaseSettingsType
               this.indexingAnalyzerSettings(indexingAnalyzerSettings);
           });
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23254

Changed standard Analyzer to Raven Standard Analyzer, added autocomplete on choosing index, if database settings have changed values like Indexing.Analyzers...

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
