### PR TITLE
RavenDB-22287 switch TimeoutManager to Task.Delay on low core instances

### DIFF
--- a/src/Sparrow/Utils/TimeoutManager.cs
+++ b/src/Sparrow/Utils/TimeoutManager.cs
@@ -134,6 +134,9 @@ namespace Sparrow.Utils
                 return Task.CompletedTask;
             }
 
+            if (duration == TimeSpan.MaxValue)
+                duration = Timeout.InfiniteTimeSpan;
+
             if (UseTaskDelay)
             {
                 return await Task.WhenAny(outer, Task.Delay(duration, token)).ConfigureAwait(false);
@@ -169,6 +172,9 @@ namespace Sparrow.Utils
             {
                 return;
             }
+
+            if (duration == TimeSpan.MaxValue)
+                duration = Timeout.InfiniteTimeSpan;
 
             if (UseTaskDelay)
             {

--- a/src/Sparrow/Utils/TimeoutManager.cs
+++ b/src/Sparrow/Utils/TimeoutManager.cs
@@ -20,13 +20,12 @@ namespace Sparrow.Utils
         private static readonly ConcurrentDictionary<uint, TimerTaskHolder> Values = new ConcurrentDictionary<uint, TimerTaskHolder>();
         private static readonly Task InfiniteTask = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously).Task;
 
-        private const bool ForceTaskDelay = true;
-
         private static readonly bool UseTaskDelay;
 
         static TimeoutManager()
         {
-            UseTaskDelay = Environment.ProcessorCount <= 2 || ForceTaskDelay;
+            if (bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_TIMEOUTMANAGER_USE_TASK_DELAY"), out var useTaskDelay))
+                UseTaskDelay = useTaskDelay;
         }
 
         private sealed class TimerTaskHolder : IDisposable

--- a/src/Sparrow/Utils/TimeoutManager.cs
+++ b/src/Sparrow/Utils/TimeoutManager.cs
@@ -6,6 +6,8 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,10 +16,20 @@ namespace Sparrow.Utils
 {
     internal static class TimeoutManager
     {
+        private static FrozenDictionary<uint, TimerTaskHolder> ValuesForRead = new Dictionary<uint, TimerTaskHolder>().ToFrozenDictionary();
         private static readonly ConcurrentDictionary<uint, TimerTaskHolder> Values = new ConcurrentDictionary<uint, TimerTaskHolder>();
         private static readonly Task InfiniteTask = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously).Task;
 
-        private sealed class TimerTaskHolder  : IDisposable
+        private const bool ForceTaskDelay = true;
+
+        private static readonly bool UseTaskDelay;
+
+        static TimeoutManager()
+        {
+            UseTaskDelay = Environment.ProcessorCount <= 2 || ForceTaskDelay;
+        }
+
+        private sealed class TimerTaskHolder : IDisposable
         {
             private TaskCompletionSource<object> _nextTimeout;
             private readonly Timer _timer;
@@ -59,7 +71,7 @@ namespace Sparrow.Utils
             }
         }
 
-        private static async Task WaitForInternal(TimeSpan time, CancellationToken token)
+        private static async Task WaitForInternal(TimeSpan time, bool canBeCanceled, CancellationToken token)
         {
             if (time.TotalMilliseconds < 0)
                 ThrowOutOfRange();
@@ -76,7 +88,7 @@ namespace Sparrow.Utils
 
             var value = GetHolderForDuration(duration);
 
-            using (token.Register(value.TimerCallback, null))
+            using (canBeCanceled ? (IDisposable)token.Register(value.TimerCallback, null) : null)
             {
                 var sp = Stopwatch.StartNew();
                 await value.NextTask.ConfigureAwait(false);
@@ -104,9 +116,10 @@ namespace Sparrow.Utils
 
         private static TimerTaskHolder GetHolderForDuration(uint duration)
         {
-            if (Values.TryGetValue(duration, out var value) == false)
+            if (ValuesForRead.TryGetValue(duration, out var value) == false)
             {
                 value = Values.GetOrAdd(duration, d => new TimerTaskHolder(d));
+                ValuesForRead = Values.ToFrozenDictionary();
             }
             return value;
         }
@@ -121,18 +134,25 @@ namespace Sparrow.Utils
                 return Task.CompletedTask;
             }
 
+            if (UseTaskDelay)
+            {
+                return await Task.WhenAny(outer, Task.Delay(duration, token)).ConfigureAwait(false);
+            }
+
+            var canBeCanceled = token != CancellationToken.None && token.CanBeCanceled;
+
             Task task;
             // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
             if (duration != Timeout.InfiniteTimeSpan)
-                task = WaitForInternal(duration, token);
+                task = WaitForInternal(duration, canBeCanceled, token);
             else
                 task = InfiniteTask;
-            
-            if (token == CancellationToken.None || token.CanBeCanceled == false)
+
+            if (canBeCanceled == false)
             {
                 return await Task.WhenAny(outer, task).ConfigureAwait(false);
             }
-            
+
             var onCancel = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             using (token.Register(tcs => onCancel.TrySetCanceled(), onCancel))
             {
@@ -150,14 +170,22 @@ namespace Sparrow.Utils
                 return;
             }
 
+            if (UseTaskDelay)
+            {
+                await Task.Delay(duration, token).ConfigureAwait(false);
+                return;
+            }
+
+            var canBeCanceled = token != CancellationToken.None && token.CanBeCanceled;
+
             Task task;
             // ReSharper disable once ConvertIfStatementToConditionalTernaryExpression
             if (duration != Timeout.InfiniteTimeSpan)
-                task = WaitForInternal(duration, token);
+                task = WaitForInternal(duration, canBeCanceled, token);
             else
                 task = InfiniteTask;
-            
-            if (token == CancellationToken.None || token.CanBeCanceled == false)
+
+            if (canBeCanceled == false)
             {
                 await task.ConfigureAwait(false);
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22287

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
