### PR TITLE
RavenDB-23391 switched default http compression algorithm to zstd and enabled bulk insert compression by default

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -144,7 +144,7 @@ namespace Raven.Client.Documents.BulkInsert
             if (string.IsNullOrWhiteSpace(database))
                 ThrowNoDatabase();
 
-            CompressionLevel = options?.CompressionLevel ?? CompressionLevel.NoCompression;
+            CompressionLevel = options?.CompressionLevel ?? BulkInsertOptions.DefaultCompressionLevel;
             _options = options ?? new BulkInsertOptions();
             _database = database;
             _token = token;

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOptions.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOptions.cs
@@ -5,7 +5,9 @@ namespace Raven.Client.Documents.BulkInsert
 {
     public sealed class BulkInsertOptions
     {
-        public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.NoCompression;
+        internal static readonly CompressionLevel DefaultCompressionLevel = CompressionLevel.Fastest;
+
+        public CompressionLevel CompressionLevel { get; set; } = DefaultCompressionLevel;
 
         /// <summary>
         /// Determines whether we should skip overwriting a document when it is updated by exactly the same document (by comparing the content and the metadata)

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -47,7 +47,11 @@ namespace Raven.Client.Documents.Conventions
         internal static TimeSpan? DefaultHttpPooledConnectionIdleTimeout;
 #endif
 
+#if FEATURE_ZSTD_SUPPORT
+        internal static HttpCompressionAlgorithm DefaultHttpCompressionAlgorithm = HttpCompressionAlgorithm.Zstd;
+#else
         internal static HttpCompressionAlgorithm DefaultHttpCompressionAlgorithm = HttpCompressionAlgorithm.Gzip;
+#endif
 
         internal static readonly DocumentConventions Default = new();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23391

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
