### PR TITLE
RavenDB-23154 make cluster test more stable

### DIFF
--- a/test/RachisTests/AddNodeToClusterTests.cs
+++ b/test/RachisTests/AddNodeToClusterTests.cs
@@ -41,6 +41,7 @@ namespace RachisTests
     {
         public AddNodeToClusterTests(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [Fact]

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -39,6 +39,7 @@ namespace RachisTests.DatabaseCluster
     {
         public ClusterDatabaseMaintenance(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         private class User

--- a/test/RachisTests/DatabaseCluster/EtlFailover.cs
+++ b/test/RachisTests/DatabaseCluster/EtlFailover.cs
@@ -23,6 +23,7 @@ namespace RachisTests.DatabaseCluster
     {
         public EtlFailover(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [Fact]

--- a/test/RachisTests/SubscriptionsFailover.cs
+++ b/test/RachisTests/SubscriptionsFailover.cs
@@ -36,6 +36,7 @@ namespace RachisTests
     {
         public SubscriptionsFailover(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         private class SubscriptionProggress

--- a/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsReplication.cs
@@ -35,6 +35,7 @@ namespace SlowTests.Client.Attachments
     {
         public AttachmentsReplication(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [RavenTheory(RavenTestCategory.Attachments | RavenTestCategory.Replication)]

--- a/test/SlowTests/Client/ChangesApiFailover.cs
+++ b/test/SlowTests/Client/ChangesApiFailover.cs
@@ -30,6 +30,7 @@ namespace SlowTests.Client
     {
         public ChangesApiFailover(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [RavenTheory(RavenTestCategory.ChangesApi | RavenTestCategory.Cluster)]

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -29,6 +29,7 @@ namespace SlowTests.Client.Subscriptions
     {
         public ConcurrentSubscriptionsTests(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromSeconds(60);

--- a/test/SlowTests/Cluster/ClusterOperationTests.cs
+++ b/test/SlowTests/Cluster/ClusterOperationTests.cs
@@ -28,6 +28,7 @@ namespace SlowTests.Cluster
     {
         public ClusterOperationTests(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [Fact]

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -42,6 +42,7 @@ namespace SlowTests.Cluster
     {
         public ClusterTransactionTests(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         protected override RavenServer GetNewServer(ServerCreationOptions options = null, [CallerMemberName] string caller = null)

--- a/test/SlowTests/Issues/RavenDB-15535.cs
+++ b/test/SlowTests/Issues/RavenDB-15535.cs
@@ -26,6 +26,7 @@ namespace SlowTests.Issues
     {
         public RavenDB_15535(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [Fact]

--- a/test/SlowTests/Issues/RavenDB-17347.cs
+++ b/test/SlowTests/Issues/RavenDB-17347.cs
@@ -20,6 +20,7 @@ namespace SlowTests.Issues
     {
         public RavenDB_17347(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [Fact]

--- a/test/SlowTests/Issues/RavenDB-17650.cs
+++ b/test/SlowTests/Issues/RavenDB-17650.cs
@@ -30,6 +30,7 @@ namespace SlowTests.Issues
     {
         public RavenDB_17650(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [RavenTheory(RavenTestCategory.Subscriptions)]

--- a/test/SlowTests/Issues/RavenDB-19379.cs
+++ b/test/SlowTests/Issues/RavenDB-19379.cs
@@ -19,6 +19,7 @@ namespace SlowTests.Issues
     {
         public RavenDB_19379(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [Fact]

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -30,6 +30,7 @@ namespace SlowTests.Server.Replication
     {
         public PullReplicationTests(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [RavenTheory(RavenTestCategory.Replication)]

--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -33,6 +33,7 @@ namespace SlowTests.Server.Replication
     {
         public ReplicationCleanTombstones(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [RavenMultiplatformTheory(RavenTestCategory.Replication, RavenArchitecture.X64)]

--- a/test/SlowTests/Sharding/Cluster/ShardedClusterObserverTests.cs
+++ b/test/SlowTests/Sharding/Cluster/ShardedClusterObserverTests.cs
@@ -29,6 +29,7 @@ namespace SlowTests.Sharding.Cluster
     {
         public ShardedClusterObserverTests(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
         
         [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]

--- a/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
+++ b/test/SlowTests/Sharding/Cluster/SubscriptionsWithReshardingTests.cs
@@ -33,6 +33,7 @@ namespace SlowTests.Sharding.Cluster
     {
         public SubscriptionsWithReshardingTests(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         [RavenFact(RavenTestCategory.Sharding)]

--- a/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionClusterTests.cs
+++ b/test/SlowTests/Sharding/Subscriptions/ShardedSubscriptionClusterTests.cs
@@ -20,6 +20,7 @@ namespace SlowTests.Sharding.Subscriptions
     {
         public ShardedSubscriptionClusterTests(ITestOutputHelper output) : base(output)
         {
+            EnableFastMoveToRehabResponse();
         }
 
         private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromSeconds(60);

--- a/test/Tests.Infrastructure/ClusterTestBase.cs
+++ b/test/Tests.Infrastructure/ClusterTestBase.cs
@@ -691,12 +691,14 @@ namespace Tests.Infrastructure
             Servers.Remove(serverToDispose);
         }
 
-        protected Dictionary<string, string> DefaultClusterSettings = new Dictionary<string, string>
+        protected Dictionary<string, string> DefaultClusterSettings = new Dictionary<string, string>();
+
+        protected void EnableFastMoveToRehabResponse()
         {
-            [RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "1",
-            [RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1",
-            [RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1",
-        };
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Cluster.MoveToRehabGraceTime)] = "1";
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Cluster.AddReplicaTimeout)] = "1";
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Cluster.StabilizationTime)] = "1";
+        }
 
         protected async Task<(List<RavenServer> Nodes, RavenServer Leader)> CreateRaftCluster(
             int numberOfNodes,


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23154

### Additional description

set lower config values for moving into rehab only for tests that actually require it

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
