### PR TITLE
RavenDB-23348 - Increase wait for rehab timeout

### DIFF
--- a/test/SlowTests/Issues/RavenDB-17650.cs
+++ b/test/SlowTests/Issues/RavenDB-17650.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -10,13 +11,16 @@ using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Subscriptions;
+using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.ServerWide.Maintenance;
 using Sparrow.Extensions;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
@@ -96,12 +100,18 @@ namespace SlowTests.Issues
                 Server = leader
             });
             string id = "User/33-A";
+            string id2 = "User/333-A";
             using (var session = store.OpenAsyncSession())
             {
                 await session.StoreAsync(new User { Id = id, Name = "1" });
-                await session.StoreAsync(new User { Name = "2" });
+                await session.StoreAsync(new User { Id = id2, Name = "2" });
                 await session.SaveChangesAsync();
             }
+            // wait for replication
+            Assert.True(await WaitForDocumentInClusterAsync<Core.Utils.Entities.User>(new DatabaseTopology { Members = new List<string> { nodes.First().ServerStore.NodeTag, nodes.Last().ServerStore.NodeTag } }, store.Database, id, null,
+                timeout: TimeSpan.FromSeconds(60)), id);
+            Assert.True(await WaitForDocumentInClusterAsync<Core.Utils.Entities.User>(new DatabaseTopology { Members = new List<string> { nodes.First().ServerStore.NodeTag, nodes.Last().ServerStore.NodeTag } }, store.Database, id2, null,
+                timeout: TimeSpan.FromSeconds(60)), id2);
 
             await store.Subscriptions
                 .CreateAsync(new SubscriptionCreationOptions<User>
@@ -145,15 +155,46 @@ namespace SlowTests.Issues
             //revive node
             Assert.True(await failMre.WaitAsync(TimeSpan.FromSeconds(15)), "Subscription didn't fail as expected.");
             var revivedNodes = new List<RavenServer>();
-            var t = Task.Run(() => revivedNodes.Add(ReviveNode(result0.DataDirectory, result0.Url)), cts.Token);
-            var tt = Task.Run(() => revivedNodes.Add(ReviveNode(result1.DataDirectory, result1.Url)), cts.Token);
+            ConcurrentDictionary<string, List<string>> initLogs = new ConcurrentDictionary<string, List<string>>();
+
+            var loadMre1 = new AsyncManualResetEvent();
+            var loadMre2 = new AsyncManualResetEvent();
+
+            var t = Task.Run(() => revivedNodes.Add(ReviveNode(result0.DataDirectory, result0.Url, serverStore =>
+            {
+                serverStore.DatabasesLandlord.OnDatabaseLoaded += (name) =>
+                {
+                    if (serverStore.DatabasesLandlord.InitLog.TryGetValue(name, out ConcurrentQueue<string> q))
+                    {
+                        initLogs.TryAdd($"{name} @ {serverStore.NodeTag}", q.ToList());
+                    }
+
+                    loadMre1.Set();
+                };
+            })), cts.Token);
+            var tt = Task.Run(() => revivedNodes.Add(ReviveNode(result1.DataDirectory, result1.Url, serverStore =>
+            {
+                serverStore.DatabasesLandlord.OnDatabaseLoaded += (name) =>
+                {
+                    if (serverStore.DatabasesLandlord.InitLog.TryGetValue(name, out ConcurrentQueue<string> q))
+                    {
+                        initLogs.TryAdd($"{name} @ {serverStore.NodeTag}", q.ToList());
+                    }
+                    loadMre2.Set();
+                };
+            })), cts.Token);
             await Task.WhenAll(t, tt);
 
-            await WaitForRehabAndAssert(revivedNodes, store, subscriptionLog);
-           
-            if (await successMre.WaitAsync(TimeSpan.FromSeconds(15)) == false)
+            //Wait for DBs to load
+            Assert.True(await loadMre1.WaitAsync(cts.Token));
+            Assert.True(await loadMre2.WaitAsync(cts.Token));
+
+            var rehabsCount = await WaitForRehabCount(revivedNodes, store, subscriptionLog);
+            var mreWait = await successMre.WaitAsync(TimeSpan.FromSeconds(60));
+
+            if (rehabsCount != 0 || mreWait == false)
             {
-                subscriptionLog.Add((DateTime.UtcNow, $"Could not reconnect subscription on {result0.Url} & {result1.Url}"));
+                subscriptionLog.Add((DateTime.UtcNow, $"Could not reconnect subscription on {result0.Url} & {result1.Url}, {nameof(rehabsCount)}: {rehabsCount}, {nameof(mreWait)}: {mreWait}"));
 
                 foreach (var node in revivedNodes)
                 {
@@ -199,12 +240,27 @@ namespace SlowTests.Issues
                 }
 
                 subscriptionLog.Add((DateTime.UtcNow, sb.ToString()));
-                Assert.Fail(string.Join(Environment.NewLine, subscriptionLog.Select(x => $"#### {x.Item1.GetDefaultRavenFormat()}: {x.Item2}")));
+
+                var str = string.Join(Environment.NewLine, subscriptionLog.Select(x => $"#### {x.Item1.GetDefaultRavenFormat()}: {x.Item2}"));
+                str = str + Environment.NewLine + "#### InitLogs:" + Environment.NewLine;
+                foreach (var kvp in initLogs)
+                {
+                    str = str + Environment.NewLine + $"$$$$ Database: {kvp.Key}";
+                    foreach (var log in kvp.Value)
+                    {
+                        str = str + Environment.NewLine + log;
+                    }
+                    str += Environment.NewLine;
+                }
+
+                Assert.Fail(str);
             }
         }
 
-        private static async Task WaitForRehabAndAssert(List<RavenServer> revivedNodes, DocumentStore store, List<(DateTime, string)> subscriptionLog)
+        private static async Task<int> WaitForRehabCount(List<RavenServer> revivedNodes, DocumentStore store, List<(DateTime, string)> subscriptionLog)
         {
+            var rehabsCount = 0;
+
             foreach (var node in revivedNodes)
             {
                 var rehabs = await WaitForValueAsync(() =>
@@ -215,11 +271,7 @@ namespace SlowTests.Issues
                         try
                         {
                             var dbTopology = node.ServerStore.Cluster.ReadDatabaseTopology(context, store.Database);
-                            var json = dbTopology.ToJson();
-
-                            using var bjro = context.ReadObject(json, "ReadDatabaseTopology", BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-                            subscriptionLog.Add((DateTime.UtcNow,
-                                $"ReadDatabaseTopology in WaitForValueAsync for ['{node.ServerStore.NodeTag}', {node.WebUrl}]{Environment.NewLine}{bjro}"));
+                            LogTopologyToSubscriptionLog(subscriptionLog, context, store.Database, dbTopology.ToJson(), node);
                             return dbTopology.Rehabs.Count;
                         }
                         catch (Exception e)
@@ -229,13 +281,22 @@ namespace SlowTests.Issues
                             return int.MaxValue;
                         }
                     }
-                }, expectedVal: 0, interval: 322 * 2);
+                }, expectedVal: 0, timeout: 60_000, interval: 322 * 2);
 
-                Assert.Equal(0, rehabs);
+                rehabsCount += rehabs;
             }
+
+            return rehabsCount;
         }
 
-        private RavenServer ReviveNode(string nodeDataDirectory, string nodeUrl)
+        private static void LogTopologyToSubscriptionLog(List<(DateTime, string)> subscriptionLog, TransactionOperationContext context, string database, DynamicJsonValue json, RavenServer node)
+        {
+            using var bjro = context.ReadObject(json, $"ReadDatabaseTopology_{database}", BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+            subscriptionLog.Add((DateTime.UtcNow,
+                $"ReadDatabaseTopology in WaitForValueAsync for ['{database}' @ '{node.ServerStore.NodeTag}', {node.WebUrl}]{Environment.NewLine}{bjro}"));
+        }
+
+        private RavenServer ReviveNode(string nodeDataDirectory, string nodeUrl, Action<ServerStore> beforeDatabasesStartup = null)
         {
             var cs = new Dictionary<string, string>(DefaultClusterSettings);
             cs[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = nodeUrl;
@@ -244,7 +305,8 @@ namespace SlowTests.Issues
                 DeletePrevious = false,
                 RunInMemory = false,
                 DataDirectory = nodeDataDirectory,
-                CustomSettings = cs
+                CustomSettings = cs,
+                BeforeDatabasesStartup = beforeDatabasesStartup
             });
         }
 


### PR DESCRIPTION
### Issue link

https://github.com/ravendb/ravendb/pull/19812
https://issues.hibernatingrhinos.com/issue/RavenDB-23348

### Additional description

When we revive the nodes, we might hit exception in the replication loader, and it will take more time to reconnect, and move the modes back to members from rehab.

As well this pull request includes several changes to the `test/SlowTests/Issues/RavenDB-17650.cs` file to enhance the testing process for handling node failures and revivals in a RavenDB cluster. The changes involve adding new dependencies, modifying existing test logic, and improving logging mechanisms.

### Test Enhancements:
* Modified the `Should_Retry_When_AllTopologyNodesDownException_Was_Thrown` method to include additional document IDs and ensure replication across nodes.
* Enhanced the node revival process to include logging of database initialization and waiting for databases to load before proceeding with further assertions.

### Logging Improvements:
* Improved the logging mechanism to capture and display initialization logs for databases upon test failure, providing more detailed context for debugging.

### Refactoring:
* Refactored the `WaitForRehabAndAssert` method to return the count of rehabilitation nodes, allowing for more detailed assertions and logging. [[1]](diffhunk://#diff-b28fcf9abccdc3b4a90de62593cf48271ac2054004557bc1982a86ddb06f6e23L249-R313) [[2]](diffhunk://#diff-b28fcf9abccdc3b4a90de62593cf48271ac2054004557bc1982a86ddb06f6e23L284-R344)
* Updated the `ReviveNode` method to accept an optional `beforeDatabasesStartup` action, enabling custom actions during node revival. [[1]](diffhunk://#diff-b28fcf9abccdc3b4a90de62593cf48271ac2054004557bc1982a86ddb06f6e23L366-R422) [[2]](diffhunk://#diff-b28fcf9abccdc3b4a90de62593cf48271ac2054004557bc1982a86ddb06f6e23L375-R432)
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
