### PR TITLE
RavenDB-23343 7.0 Admin Logs: Top-level dropdown Level should not allow to be set to Off

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/AdminLogs.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/AdminLogs.tsx
@@ -69,6 +69,8 @@ export default function AdminLogs() {
         await dispatch(adminLogsActions.fetchConfigs());
     };
 
+    const enabledLogLevelOptions = logLevelOptions.filter((x) => x.value !== "Off");
+
     return (
         <div className="content-padding vstack gap-3 h-100">
             <div className="hstack flex-wrap gap-1">
@@ -83,11 +85,11 @@ export default function AdminLogs() {
                                 <Icon icon="logs" addon="arrow-filled-up" />
                                 Min level:{" "}
                                 <Select
-                                    value={logLevelOptions.find(
+                                    value={enabledLogLevelOptions.find(
                                         (x) => x.value === configs?.adminLogsConfig?.AdminLogs?.CurrentMinLevel
                                     )}
                                     onChange={handlePageMinLevelChange}
-                                    options={logLevelOptions}
+                                    options={enabledLogLevelOptions}
                                     isLoading={configsLoadStatus === "loading"}
                                     isDisabled={configsLoadStatus !== "success"}
                                     className="ms-1"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23343/7.0-Admin-Logs-Top-level-dropdown-Level-should-not-allow-to-be-set-to-Off

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
