### PR TITLE
RavenDB-23059 fix test CannotDeleteDatabaseWhenRestoreCancelledOnNonR…

### DIFF
--- a/test/SlowTests/Issues/RavenDB-22659.cs
+++ b/test/SlowTests/Issues/RavenDB-22659.cs
@@ -124,7 +124,7 @@ namespace SlowTests.Issues
             var backupPath = NewDataPath();
             var db = "NewDatabase";
             //Cluster with 2 nodes
-            var (nodes, leader) = await CreateRaftCluster(2);
+            var (nodes, leader) = await CreateRaftCluster(2, shouldRunInMemory: false);
             await CreateDatabaseInCluster(db, 2, leader.WebUrl);
             using (var store = new DocumentStore
             {
@@ -171,11 +171,9 @@ namespace SlowTests.Issues
 
                 var res = mre.WaitOne(TimeSpan.FromSeconds(30)); // Wait to ensure the database record is written before disposing of one node.
                 Assert.True(res);
-
                 var disposedNode = await DisposeServerAndWaitForFinishOfDisposalAsync(nodeToTakeDown);
                 await restoreTask.KillAsync();
                 mre2.Set();
-
                 var database = await GetDatabase(remainingNode, store.Database);
                 WaitForValue(() =>
                 {


### PR DESCRIPTION
…esponsibleNode

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23059

### Additional description

fixing the test. needed to add : shouldRunInMemory: false

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
