### PR TITLE
RavenDB-22689 fix test

### DIFF
--- a/test/SlowTests/Issues/RavenDB-16659.cs
+++ b/test/SlowTests/Issues/RavenDB-16659.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Exceptions;
+using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using SlowTests.Core.Utils.Entities;
 using Sparrow.Server;
@@ -25,6 +25,7 @@ namespace SlowTests.Issues
         {
             DoNotReuseServer();
             var mre = new AsyncManualResetEvent();
+            var mre2 = new ManualResetEvent(false);
             var backupPath = NewDataPath();
             
             using (var store = GetDocumentStore())
@@ -52,13 +53,23 @@ namespace SlowTests.Issues
                     RestoreBackupOperation restoreOperation =
                         new RestoreBackupOperation(new RestoreBackupConfiguration
                             {BackupLocation = Path.Combine(backupPath, result.LocalBackup.BackupDirectory), DatabaseName = databaseName });
-                    Server.ServerStore.ForTestingPurposesOnly().RestoreDatabaseAfterSavingDatabaseRecord += () => mre.Set();
-                    
+                    Server.ServerStore.ForTestingPurposesOnly().RestoreDatabaseAfterSavingDatabaseRecord += () => {
+                        mre.Set();
+                        mre2.WaitOne(); // Wait to ensure the restore process doesn't finish until we intentionally cancel it.
+                    };
+
                     var op  = await store.Maintenance.Server.SendAsync(restoreOperation);
                     var res = await mre.WaitAsync(TimeSpan.FromSeconds(30));
                     Assert.True(res);
+
+                    var val = await WaitForValueAsync(async () => await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName)) != null, true, 30_000);
+                    Assert.True(val);
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(databaseName));
+                    Assert.Equal(DatabaseStateStatus.RestoreInProgress, record.DatabaseState);
+
                     var e = Assert.Throws<RavenException>(() => store.Maintenance.Server.Send(new DeleteDatabasesOperation(databaseName, hardDelete: true)));
                     Assert.Contains($"Can't delete database '{databaseName}' while the restore process is in progress.", e.Message);
+                    mre2.Set();
                     await op.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
                 }
                 finally


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22689

### Additional description
Wasn't able to reproduce the failure.

* Added a wait for the database record to check DatabaseStateStatus is RestoreInProgress.
* Added a ManualResetEvent to ensure the restore process does not finish before the check.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
