### PR TITLE
RavenDB-23319 double the default WorkerSamplePeriod & SupervisorSamplePeriod values

### DIFF
--- a/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/ClusterConfiguration.cs
@@ -15,13 +15,13 @@ namespace Raven.Server.Config.Categories
         public TimeSetting ElectionTimeout { get; set; }
 
         [Description("How frequently we sample the information about the databases and send it to the maintenance supervisor.")]
-        [DefaultValue(250)]
+        [DefaultValue(500)]
         [TimeUnit(TimeUnit.Milliseconds)]
         [ConfigurationEntry("Cluster.WorkerSamplePeriodInMs", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting WorkerSamplePeriod { get; set; }
 
         [Description("As the maintenance supervisor, how frequent we sample the information received from the nodes.")]
-        [DefaultValue(500)]
+        [DefaultValue(1000)]
         [TimeUnit(TimeUnit.Milliseconds)]
         [ConfigurationEntry("Cluster.SupervisorSamplePeriodInMs", ConfigurationEntryScope.ServerWideOnly)]
         public TimeSetting SupervisorSamplePeriod { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23319

### Additional description

We burn much of the CPU / Network on collecting, sending and analyzing the database reports by the cluster observer.

In the real world it doesn't have to be so intensive and we can relax the interval in which are doing this.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
