### PR TITLE
RavenDB-23351 - handle long paths in EmbeddedTestBase

### DIFF
--- a/test/EmbeddedTests/EmbeddedTestBase.cs
+++ b/test/EmbeddedTests/EmbeddedTestBase.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using EmbeddedTests.Platform;
 using Raven.Embedded;
 using Sparrow.Collections;
+using Sparrow.Platform;
+
+#pragma warning disable LOCAL0003
 
 namespace EmbeddedTests
 {
@@ -20,7 +25,7 @@ namespace EmbeddedTests
             if (PosixHelper.RunningOnPosix)
                 path = PosixHelper.FixLinuxPath(path);
 
-            path = Path.GetFullPath(path);
+            path = ToFullPath(Path.GetFullPath(path));
             _localPathsToDelete.Add(path);
 
             return path;
@@ -29,8 +34,8 @@ namespace EmbeddedTests
         protected (string ServerDirectory, string DataDirectory) CopyServer()
         {
             var baseDirectory = NewDataPath();
-            var serverDirectory = Path.Combine(baseDirectory, "RavenDBServer");
-            var dataDirectory = Path.Combine(baseDirectory, "RavenDB");
+            var serverDirectory = ToFullPath(Path.Combine(baseDirectory, "RavenDBServer"));
+            var dataDirectory = ToFullPath(Path.Combine(baseDirectory, "RavenDB"));
 
             if (Directory.Exists(serverDirectory) == false)
                 Directory.CreateDirectory(serverDirectory);
@@ -52,14 +57,14 @@ namespace EmbeddedTests
             if (runtimeConfigFileInfo.Exists == false)
                 throw new FileNotFoundException("Could not find runtime config", runtimeConfigPath);
 
-            File.Copy(runtimeConfigPath, Path.Combine(serverDirectory, runtimeConfigFileInfo.Name), true);
+            File.Copy(runtimeConfigPath, ToFullPath(Path.Combine(serverDirectory, runtimeConfigFileInfo.Name)), true);
 
             foreach (var extension in new[] { "*.dll", "*.so", "*.dylib", "*.deps.json" })
             {
-                foreach (var file in Directory.GetFiles(runtimeConfigFileInfo.DirectoryName, extension))
+                foreach (var file in Directory.GetFiles(runtimeConfigFileInfo.DirectoryName, extension).Select(x => ToFullPath(x)))
                 {
                     var fileInfo = new FileInfo(file);
-                    File.Copy(file, Path.Combine(serverDirectory, fileInfo.Name), true);
+                    File.Copy(file, ToFullPath(Path.Combine(serverDirectory, fileInfo.Name)), true);
                 }
             }
 
@@ -68,11 +73,11 @@ namespace EmbeddedTests
 
             foreach (string dirPath in Directory.GetDirectories(runtimesSource, "*",
                 SearchOption.AllDirectories))
-                Directory.CreateDirectory(dirPath.Replace(runtimesSource, runtimesDestination));
+                Directory.CreateDirectory(ToFullPath(dirPath.Replace(runtimesSource, runtimesDestination)));
 
             foreach (string newPath in Directory.GetFiles(runtimesSource, "*.*",
-                SearchOption.AllDirectories))
-                File.Copy(newPath, newPath.Replace(runtimesSource, runtimesDestination), true);
+                SearchOption.AllDirectories).Select(x => ToFullPath(x)))
+                File.Copy(newPath, ToFullPath(newPath.Replace(runtimesSource, runtimesDestination)), true);
 
             return (serverDirectory, dataDirectory);
         }
@@ -82,7 +87,7 @@ namespace EmbeddedTests
             var (severDirectory, dataDirectory) = CopyServer();
             return new ServerOptions { ServerDirectory = severDirectory, DataDirectory = dataDirectory, LogsPath = Path.Combine(severDirectory, "Logs") };
         }
-        
+
         public virtual void Dispose()
         {
             foreach (var path in _localPathsToDelete)
@@ -91,8 +96,53 @@ namespace EmbeddedTests
                 if (directoryInfo.Exists == false)
                     continue;
 
-                directoryInfo.Delete(recursive: true);
+                DeleteAllFilesAndSubfolders(directoryInfo);
             }
+        }
+
+        private void DeleteAllFilesAndSubfolders(DirectoryInfo directoryInfo)
+        {
+            // Delete all files in the current directory
+            foreach (var p in directoryInfo.GetFiles().Select(x => ToFullPath(x.FullName)))
+            {
+                File.Delete(p);
+            }
+
+            // Recursively delete all subdirectories
+            foreach (var subdirectory in directoryInfo.GetDirectories())
+            {
+                DeleteAllFilesAndSubfolders(subdirectory);
+                Directory.Delete(ToFullPath(subdirectory.FullName));
+            }
+        }
+
+        private static string ToFullPath(string inputPath, string baseDataDirFullPath = null)
+        {
+            var path = Environment.ExpandEnvironmentVariables(inputPath);
+
+            if (PlatformDetails.RunningOnPosix == false && path.StartsWith(@"\") == false ||
+                PlatformDetails.RunningOnPosix && path.StartsWith(@"/") == false) // if relative path
+                path = Path.Combine(baseDataDirFullPath ?? AppContext.BaseDirectory, path);
+
+            var result = Path.IsPathRooted(path)
+                ? path
+                : Path.Combine(baseDataDirFullPath ?? AppContext.BaseDirectory, path);
+
+            if (result.Length >= 260 &&
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                result.StartsWith(@"\\?\") == false)
+                result = @"\\?\" + result;
+
+            var resultRoot = Path.GetPathRoot(result);
+            if (resultRoot != result && (result.EndsWith(@"\") || result.EndsWith("/")))
+                result = result.TrimEnd('\\', '/');
+
+            if (PlatformDetails.RunningOnPosix)
+                result = PosixHelper.FixLinuxPath(result);
+
+            return result != string.Empty || resultRoot == null
+                ? Path.GetFullPath(result)
+                : Path.GetFullPath(resultRoot); // it will unify directory separators and sort out parent directories
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23351/EmbeddedTests.BasicTests.TestEmbedded

### Additional description

This pull request introduces several changes to the `EmbeddedTestBase` class in the `test/EmbeddedTests` directory, primarily focused on improving path handling and directory management. 

The most significant changes include the addition of a new `ToFullPath` method which handles path longer then 260 chars, updates to various methods to utilize this new method, and the creation of a helper method for deleting files and subdirectories recursively.

Improvements to path handling:

* Added `ToFullPath` method to standardize and expand paths, ensuring compatibility across different operating systems.
* Updated `NewDataPath` and `CopyServer` methods to use `ToFullPath` for generating full paths. [[1]](diffhunk://#diff-5c5d5b877211abd4bd34cdf00d803afc7fdfd012f13204e7f8e0545fbfa393c2L23-R28) [[2]](diffhunk://#diff-5c5d5b877211abd4bd34cdf00d803afc7fdfd012f13204e7f8e0545fbfa393c2L32-R38) [[3]](diffhunk://#diff-5c5d5b877211abd4bd34cdf00d803afc7fdfd012f13204e7f8e0545fbfa393c2L55-R67) [[4]](diffhunk://#diff-5c5d5b877211abd4bd34cdf00d803afc7fdfd012f13204e7f8e0545fbfa393c2L71-R80)

Directory and file management enhancements:

* Introduced `DeleteAllFilesAndSubfolders` method to recursively delete all files and subdirectories within a directory, improving the cleanup process in the `Dispose` method.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms. Only windows
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
