### PR TITLE
RavenDB-23415: Optimize the memory allocation and pooling

### DIFF
--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -146,7 +146,7 @@ namespace Corax.Querying.Matches
                 _itBuffer = (long*)bs.Ptr;
                 _containerItemsScope = _allocator.Allocate(BufferSize * sizeof(UnmanagedSpan), out bs);
                 _containerItems = (UnmanagedSpan*)bs.Ptr;
-                _pageLocator = new PageLocator();
+                _pageLocator = searcher.Transaction.LowLevelTransaction.AllocatePageLocator();
             }
 
             public void Reset(ref MultiTermMatch<TTermProvider> match)
@@ -295,6 +295,7 @@ namespace Corax.Querying.Matches
                 _smallPostListIds.Dispose();
                 _containerItemsScope.Dispose();
                 _itBufferScope.Dispose();
+                _searcher.Transaction.LowLevelTransaction.FreePageLocator(_pageLocator);
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -161,8 +161,6 @@ namespace Raven.Server.Documents.Indexes
 
         internal PoolOfThreads.LongRunningWork _indexingThread;
 
-        private bool CalledUnderIndexingThread => _indexingThread?.ManagedThreadId == Thread.CurrentThread.ManagedThreadId;
-
         private bool _initialized;
 
         internal UnmanagedBuffersPoolWithLowMemoryHandling _unmanagedBuffersPool;
@@ -2177,11 +2175,6 @@ namespace Raven.Server.Documents.Indexes
 
                 DocumentDatabase.DocumentsStorage.ContextPool.Clean();
                 _contextPool.Clean();
-
-                if (CalledUnderIndexingThread)
-                {
-                    ByteStringMemoryCache.CleanForCurrentThread();
-                }
 
                 IndexPersistence.Clean(mode);
                 environment?.Cleanup();

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -472,14 +472,17 @@ namespace Sparrow.Server
 
     public sealed unsafe class UnmanagedGlobalSegment : PooledItem
     {
-        public byte* Segment;
+        private byte* _segment;
+        public byte* Segment => _segment;
+
         public readonly int Size;
+
         private readonly NativeMemory.ThreadStats _thread;
 
         public UnmanagedGlobalSegment(int size)
         {
             Size = size;
-            Segment = NativeMemory.AllocateMemory(size, out _thread);
+            _segment = NativeMemory.AllocateMemory(size, out _thread);
             InUse.Raise();
         }
 
@@ -487,10 +490,12 @@ namespace Sparrow.Server
         {
             try
             {
-                if (Segment == null)
+                var segment = _segment;
+                if (segment == null)
                     return;
-                NativeMemory.Free(Segment, Size, _thread);
-                Segment = null;
+                _segment = null;
+
+                NativeMemory.Free(segment, Size, _thread);
             }
             catch (ObjectDisposedException)
             {
@@ -500,17 +505,13 @@ namespace Sparrow.Server
 
         public override void Dispose()
         {
-            if (Segment == null)
+            var segment = _segment;
+            if (segment == null)
                 return;
+            _segment = null;
+            GC.SuppressFinalize(this);
 
-            lock (this)
-            {
-                if (Segment == null)
-                    return;
-                NativeMemory.Free(Segment, Size, _thread);
-                Segment = null;
-                GC.SuppressFinalize(this);
-            }
+            NativeMemory.Free(segment, Size, _thread);
         }
 
     }
@@ -539,11 +540,11 @@ namespace Sparrow.Server
 
     public struct ByteStringMemoryCache : IByteStringAllocator
     {
-        private static readonly LightWeightThreadLocal<StackHeader<UnmanagedGlobalSegment>> SegmentsPool;
+        private static readonly LockFreeRingBuffer<UnmanagedGlobalSegment> SegmentsPool;
         private static readonly SharedMultipleUseFlag LowMemoryFlag;
         private static readonly LowMemoryHandler LowMemoryHandlerInstance = new LowMemoryHandler();
 
-        public static readonly NativeMemoryCleaner<StackHeader<UnmanagedGlobalSegment>, UnmanagedGlobalSegment> Cleaner;
+        public static readonly NativeMemoryCleaner<UnmanagedGlobalSegment> Cleaner;
 
         private sealed class LowMemoryHandler : ILowMemoryHandler
         {
@@ -553,7 +554,7 @@ namespace Sparrow.Server
                     return;
 
                 if (LowMemoryFlag.Raise())
-                    Cleaner.CleanNativeMemory(null);
+                    Cleaner.PurgeStaleOrExcessItems();
             }
 
             public void LowMemoryOver()
@@ -562,93 +563,105 @@ namespace Sparrow.Server
             }
         }
 
+        private static readonly int SegmentPoolSize = IntPtr.Size == 4 ? 64 : 1024;
+
         static ByteStringMemoryCache()
         {
-            SegmentsPool = new LightWeightThreadLocal<StackHeader<UnmanagedGlobalSegment>>(() => new StackHeader<UnmanagedGlobalSegment>());
+            SegmentsPool = new(SegmentPoolSize);
             LowMemoryFlag = new SharedMultipleUseFlag();
-            Cleaner = new NativeMemoryCleaner<StackHeader<UnmanagedGlobalSegment>, UnmanagedGlobalSegment>(typeof(ByteStringMemoryCache), _ => SegmentsPool.Values, LowMemoryFlag, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
-
-            ThreadLocalCleanup.ReleaseThreadLocalState += CleanForCurrentThread;
+            Cleaner = new NativeMemoryCleaner<UnmanagedGlobalSegment>(SegmentsPool, LowMemoryFlag, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
 
             LowMemoryNotification.Instance.RegisterLowMemoryHandler(LowMemoryHandlerInstance);
         }
 
-        [ThreadStatic]
-        private static int _minSize;
-
         public UnmanagedGlobalSegment Allocate(int size)
         {
-            if (_minSize < size)
-                _minSize = size;
+            var pool = SegmentsPool;
+            if (pool.TryDequeue(out var segment) == false)
+                goto ALLOCATE;
 
-            var stack = SegmentsPool.Value;
+            Debug.Assert(segment != null, "The segment cannot be null.");
 
-            while (true)
+            if (segment.Size >= size)
             {
-                var current = stack.Head;
-                if (current == null)
-                    break;
+                if (segment.InUse.Raise() == false)
+                    goto ALLOCATE;
 
-                if (Interlocked.CompareExchange(ref stack.Head, current.Next, current) != current)
-                    continue;
-
-                var segment = current.Value;
-                if (segment == null)
-                    continue;
-
-                if (segment.Size >= size)
-                {
-                    if (!segment.InUse.Raise())
-                        continue;
-
-                    return segment;
-                }
-
-                // not big enough, so we'll discard it and create a bigger instance
-                // it will go into the pool afterward and be available for future use
-                segment.Dispose();
+                return segment;
             }
-
+            
+            // not big enough, so if the pool is half full we'll discard it and create a bigger instance
+            // it will go into the pool afterward and be available for future use.
+            // The idea is that we will get rid of small segments if half full is that we want the
+            // pool to only be half full on average. 
+            if (pool.Count >= SegmentPoolSize / 2 || pool.TryEnqueue(segment) == false)
+                segment.Dispose();
+                        
+            ALLOCATE:
+            // have to allocate it directly
             return new UnmanagedGlobalSegment(size);
         }
 
+        /// <summary>
+        /// Returns an UnmanagedGlobalSegment to the pool. If the segment is no longer in use and the pool is not full, 
+        /// it is added back for future reuse. 
+        /// 
+        /// If the pool is full, we attempt a fallback strategy:
+        /// 1. Dequeue another segment from the pool to compare sizes.
+        /// 2. Keep the larger segment (to better accommodate future allocations) and dispose of the smaller one.
+        /// 3. If re-enqueueing the chosen segment still fails, we dispose it to prevent memory leaks.
+        ///
+        /// This ensures that we maintain a healthy set of segments in the pool while also preventing indefinite growth or 
+        /// memory leaks if the pool cannot accept more segments.
+        /// </summary>
         public unsafe void Free(UnmanagedGlobalSegment memory)
         {
             ThrowIfNull<InvalidOperationException>(memory.Segment, "Attempt to return a memory segment that has already been disposed");
 
-            if (_minSize > memory.Size)
-            {
-                memory.Dispose();
-                return;
-            }
+            if (memory.InUse.Lower() == false)
+                ThrowSegmentStillInUse();
 
-            memory.InUse.Lower();
             memory.InPoolSince = DateTime.UtcNow;
 
-            var stack = SegmentsPool.Value;
+            var pool = SegmentsPool;
 
-            while (true)
+            // Attempt to return the segment to the pool.
+            if (pool.IsFull || pool.TryEnqueue(memory) == false)
             {
-                var current = stack.Head;
-                var newHead = new StackNode<UnmanagedGlobalSegment> { Value = memory, Next = current };
-                if (Interlocked.CompareExchange(ref stack.Head, newHead, current) == current)
-                    return;
+                // Pool is full; attempt to swap an existing segment with the current one
+                if (pool.TryDequeue(out var comparable))
+                {
+                    // Compare the sizes of the two segments.
+                    var (toAdd, toRemove) = comparable.Size < memory.Size
+                        ? (memory, comparable) // Keep the larger segment for reuse.
+                        : (comparable, memory); // Keep the existing segment if it's better.
+
+                    // Try to re-enqueue the chosen segment.
+                    if (pool.TryEnqueue(toAdd) == false)
+                        toAdd.Dispose(); // If enqueue fails, dispose to prevent leaks.
+
+                    // Dispose of the other segment.
+                    toRemove.Dispose();
+                }
+                else
+                {
+                    // If we fail to dequeue, just dispose the memory.
+                    // While very unlikely this will ever execute, it prevents leaks if it happens.
+                    memory.Dispose();
+                }
             }
         }
 
-        public static void CleanForCurrentThread()
+        [DoesNotReturn]
+        private static void ThrowInvalidMemorySegment()
         {
-            if (SegmentsPool.IsValueCreated == false)
-                return; // nothing to do
+            throw new InvalidOperationException("Attempt to return a memory segment that has already been disposed");
+        }
 
-            var stack = SegmentsPool.Value;
-            _minSize = 0;
-            var current = Interlocked.Exchange(ref stack.Head, null);
-            while (current != null)
-            {
-                current.Value?.Dispose();
-                current = current.Next;
-            }
+        [DoesNotReturn]
+        private static void ThrowSegmentStillInUse()
+        {
+            throw new InvalidOperationException("Attempt to return a memory segment that it is still in use");
         }
     }
 
@@ -658,7 +671,7 @@ namespace Sparrow.Server
         internal static readonly int ExternalAlignedSize;
 
         public const int MinBlockSizeInBytes = 4 * 1024; // If this is changed, we need to change also LogMinBlockSize.
-        public const int MaxAllocationBlockSizeInBytes = 256 * MinBlockSizeInBytes;
+        public const int MaxAllocationBlockSizeInBytes = 4 * 256 * MinBlockSizeInBytes;
         public const int DefaultAllocationBlockSizeInBytes = 1 * MinBlockSizeInBytes;
         public const int MinReusableBlockSizeInBytes = 8;
         public const int MaxSegmentSizeInBytes = 2 * Sparrow.Global.Constants.Size.Megabyte;

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -488,16 +488,17 @@ namespace Sparrow.Server
 
         ~UnmanagedGlobalSegment()
         {
+            var segment = _segment;
+            if (segment == null)
+                return;
+            
+            _segment = null;
+
             try
             {
-                var segment = _segment;
-                if (segment == null)
-                    return;
-                _segment = null;
-
                 NativeMemory.Free(segment, Size, _thread);
             }
-            catch (ObjectDisposedException)
+            catch 
             {
                 // nothing that can be done here
             }
@@ -508,6 +509,7 @@ namespace Sparrow.Server
             var segment = _segment;
             if (segment == null)
                 return;
+
             _segment = null;
             GC.SuppressFinalize(this);
 
@@ -636,12 +638,12 @@ namespace Sparrow.Server
                         ? (memory, comparable) // Keep the larger segment for reuse.
                         : (comparable, memory); // Keep the existing segment if it's better.
 
-                    // Try to re-enqueue the chosen segment.
-                    if (pool.TryEnqueue(toAdd) == false)
-                        toAdd.Dispose(); // If enqueue fails, dispose to prevent leaks.
-
-                    // Dispose of the other segment.
-                    toRemove.Dispose();
+                    using (toRemove)
+                    {
+                        // Try to re-enqueue the chosen segment.
+                        if (pool.TryEnqueue(toAdd) == false)
+                            toAdd.Dispose(); // If enqueue fails, dispose to prevent leaks.
+                    }
                 }
                 else
                 {

--- a/src/Sparrow/Collections/LockFreeRingBuffer.cs
+++ b/src/Sparrow/Collections/LockFreeRingBuffer.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Sparrow.Binary;
+
+namespace Sparrow.Collections
+{
+    internal sealed class LockFreeRingBuffer<T>
+    {
+        // Explicit layout to control the exact memory layout
+        [StructLayout(LayoutKind.Sequential, Size = 128)]
+        internal unsafe struct Cell
+        {
+            // Sequence number at offset 0
+            internal long _sequence;
+
+            private fixed byte _sequencePadding[64 - sizeof(long)];
+
+            // Value at offset 64 to ensure it's on a different cache line
+            internal T _value;
+
+            public long Sequence
+            {
+                get => Volatile.Read(ref _sequence);
+                set => Volatile.Write(ref _sequence, value);
+            }
+
+            public T Value
+            {
+                get => _value;
+                set => _value = value;
+            }
+        }
+
+        private readonly int _bufferMask;
+        private readonly Cell[] _buffer;
+
+        private long _enqueuePos;
+        private long _dequeuePos;
+
+        public LockFreeRingBuffer(int capacity = 64)
+        {
+            if (capacity < 8)
+                throw new ArgumentException("Capacity must be at least 8", nameof(capacity));
+
+            // Ensure capacity is a power of two
+            if ((capacity & (capacity - 1)) != 0)
+                capacity = Bits.PowerOf2(capacity);
+            
+            _bufferMask = capacity - 1;
+
+            // Initialize the cells and the sequence numbers.
+            _buffer = new Cell[capacity];
+            for (long i = 0; i < capacity; i++)
+                _buffer[i].Sequence = i;
+        }
+
+
+        /// <summary>
+        /// Attempts to enqueue an item into the ring buffer.
+        /// Returns true if successful, false if the buffer is full.
+        /// </summary>
+        public bool TryEnqueue(in T item)
+        {
+            long pos = Volatile.Read(ref _enqueuePos);
+            ref Cell cell = ref _buffer[pos & _bufferMask];
+
+            while (true)
+            {
+                // This will perform a Volatile.Read on the sequence number.
+                long dif = cell.Sequence - pos;
+
+                if (dif == 0)
+                {
+                    if (Interlocked.CompareExchange(ref _enqueuePos, pos + 1, pos) == pos)
+                        break;
+                }
+                else if (dif < 0)
+                {
+                    // Buffer is full
+                    return false;
+                }
+
+                pos = Volatile.Read(ref _enqueuePos);
+                cell = ref _buffer[pos & _bufferMask];
+            }
+
+            cell.Value = item;
+            cell.Sequence = pos + 1; // This will perform a Volatile.Write on the sequence number.
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to dequeue an item from the ring buffer.
+        /// Returns true if successful, false if the buffer is empty.
+        /// </summary>
+        public bool TryDequeue(out T item)
+        {
+            long pos = Volatile.Read(ref _dequeuePos);
+            ref Cell cell = ref _buffer[pos & _bufferMask];
+
+            while (true)
+            {
+                // This will perform a Volatile.Read on the sequence number.
+                long dif = cell.Sequence - (pos + 1);
+
+                if (dif == 0)
+                {
+                    if (Interlocked.CompareExchange(ref _dequeuePos, pos + 1, pos) == pos)
+                        break;
+                }
+                else if (dif < 0)
+                {
+                    // Buffer is empty
+                    Unsafe.SkipInit(out item);
+                    return false;
+                }
+
+                pos = Volatile.Read(ref _dequeuePos);
+                cell = ref _buffer[pos & _bufferMask];
+            }
+
+            item = cell.Value;
+            cell.Sequence = pos + _buffer.Length; // This will perform a Volatile.Write on the sequence number.
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if the ring buffer is empty.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                long currentEnqueuePos = Volatile.Read(ref _enqueuePos);
+                Cell enqueueCell = _buffer[currentEnqueuePos & _bufferMask];
+
+                long currentDequeuePos = Volatile.Read(ref _dequeuePos);
+                Cell dequeueCell = _buffer[currentDequeuePos & _bufferMask];
+
+                return (int) (enqueueCell.Sequence - dequeueCell.Sequence);
+            }
+        }
+
+        /// <summary>
+        /// Checks if the ring buffer is empty.
+        /// </summary>
+        public bool IsEmpty
+        {
+            get
+            {
+                long currentDequeuePos = Volatile.Read(ref _dequeuePos);
+                Cell cell = _buffer[currentDequeuePos & _bufferMask];
+                return (cell.Sequence - (currentDequeuePos + 1)) < 0;
+            }
+        }
+
+        /// <summary>
+        /// Checks if the ring buffer is full.
+        /// </summary>
+        public bool IsFull
+        {
+            get
+            {
+                long currentEnqueuePos = Volatile.Read(ref _enqueuePos);
+                Cell cell = _buffer[currentEnqueuePos & _bufferMask];
+                return (cell.Sequence - currentEnqueuePos) < 0;
+            }
+        }
+    }
+}

--- a/src/Sparrow/Collections/LockFreeRingBuffer.cs
+++ b/src/Sparrow/Collections/LockFreeRingBuffer.cs
@@ -8,29 +8,19 @@ namespace Sparrow.Collections
 {
     public sealed class LockFreeRingBuffer<T>
     {
+        private const int CacheLine = 64;
+
         // Explicit layout to control the exact memory layout
-        [StructLayout(LayoutKind.Sequential, Size = 128)]
+        [StructLayout(LayoutKind.Sequential, Size = 2 * CacheLine)]
         internal unsafe struct Cell
         {
             // Sequence number at offset 0
-            internal long _sequence;
+            internal long Sequence;
 
             private fixed byte _sequencePadding[64 - sizeof(long)];
 
             // Value at offset 64 to ensure it's on a different cache line
-            internal T _value;
-
-            public long Sequence
-            {
-                get => Volatile.Read(ref _sequence);
-                set => Volatile.Write(ref _sequence, value);
-            }
-
-            public T Value
-            {
-                get => _value;
-                set => _value = value;
-            }
+            internal T Value;
         }
 
         private readonly int _bufferMask;
@@ -39,7 +29,19 @@ namespace Sparrow.Collections
         private long _enqueuePos;
         private long _dequeuePos;
 
-        public LockFreeRingBuffer(int capacity = 64)
+        static LockFreeRingBuffer()
+        {
+            // Fast + generic + big‐value‑friendly – pick any two; with a lock‑free ring buffer
+            // the missing one has to be paid for explicitly. We chose fast and generic.
+            if (Unsafe.SizeOf<T>() > CacheLine)
+                throw new NotSupportedException(
+                    $"Type {typeof(T)} is {Unsafe.SizeOf<T>()} B. " +
+                    "The ring‑buffer layout guarantees wait‑free behaviour only when the payload " +
+                    $"fits in the second cache line (≤ {CacheLine} B). " +
+                    "Use a reference or split metadata/payload for larger structs.");
+        }
+
+        public LockFreeRingBuffer(int capacity = CacheLine)
         {
             if (capacity < 8)
                 throw new ArgumentException("Capacity must be at least 8", nameof(capacity));
@@ -53,7 +55,7 @@ namespace Sparrow.Collections
             // Initialize the cells and the sequence numbers.
             _buffer = new Cell[capacity];
             for (long i = 0; i < capacity; i++)
-                _buffer[i].Sequence = i;
+                Volatile.Write(ref _buffer[i].Sequence, i);
         }
 
 
@@ -69,7 +71,7 @@ namespace Sparrow.Collections
             while (true)
             {
                 // This will perform a Volatile.Read on the sequence number.
-                long dif = cell.Sequence - pos;
+                long dif = Volatile.Read(ref cell.Sequence) - pos;
 
                 if (dif == 0)
                 {
@@ -87,7 +89,7 @@ namespace Sparrow.Collections
             }
 
             cell.Value = item;
-            cell.Sequence = pos + 1; // This will perform a Volatile.Write on the sequence number.
+            Volatile.Write(ref cell.Sequence, pos + 1); // This will perform a Volatile.Write on the sequence number.
             return true;
         }
 
@@ -103,7 +105,7 @@ namespace Sparrow.Collections
             while (true)
             {
                 // This will perform a Volatile.Read on the sequence number.
-                long dif = cell.Sequence - (pos + 1);
+                long dif = Volatile.Read(ref cell.Sequence) - (pos + 1);
 
                 if (dif == 0)
                 {
@@ -122,7 +124,7 @@ namespace Sparrow.Collections
             }
 
             item = cell.Value;
-            cell.Sequence = pos + _buffer.Length; // This will perform a Volatile.Write on the sequence number.
+            Volatile.Write(ref cell.Sequence, pos + _buffer.Length); // This will perform a Volatile.Write on the sequence number.
             return true;
         }
 
@@ -139,7 +141,7 @@ namespace Sparrow.Collections
                 long currentDequeuePos = Volatile.Read(ref _dequeuePos);
                 Cell dequeueCell = _buffer[currentDequeuePos & _bufferMask];
 
-                return (int) (enqueueCell.Sequence - dequeueCell.Sequence);
+                return (int) (Volatile.Read(ref enqueueCell.Sequence) - Volatile.Read(ref dequeueCell.Sequence));
             }
         }
 
@@ -152,7 +154,7 @@ namespace Sparrow.Collections
             {
                 long currentDequeuePos = Volatile.Read(ref _dequeuePos);
                 Cell cell = _buffer[currentDequeuePos & _bufferMask];
-                return (cell.Sequence - (currentDequeuePos + 1)) < 0;
+                return (Volatile.Read(ref cell.Sequence) - (currentDequeuePos + 1)) < 0;
             }
         }
 
@@ -165,7 +167,7 @@ namespace Sparrow.Collections
             {
                 long currentEnqueuePos = Volatile.Read(ref _enqueuePos);
                 Cell cell = _buffer[currentEnqueuePos & _bufferMask];
-                return (cell.Sequence - currentEnqueuePos) < 0;
+                return (Volatile.Read(ref cell.Sequence) - currentEnqueuePos) < 0;
             }
         }
     }

--- a/src/Sparrow/Collections/LockFreeRingBuffer.cs
+++ b/src/Sparrow/Collections/LockFreeRingBuffer.cs
@@ -6,7 +6,7 @@ using Sparrow.Binary;
 
 namespace Sparrow.Collections
 {
-    internal sealed class LockFreeRingBuffer<T>
+    public sealed class LockFreeRingBuffer<T>
     {
         // Explicit layout to control the exact memory layout
         [StructLayout(LayoutKind.Sequential, Size = 128)]

--- a/src/Sparrow/ObjectPool.cs
+++ b/src/Sparrow/ObjectPool.cs
@@ -141,7 +141,7 @@ namespace Sparrow
         {
             Debug.Assert(size >= 1);
             _factory = factory;
-            _ringBuffer = new LockFreeRingBuffer<T>(size);
+            _ringBuffer = new LockFreeRingBuffer<T>(Math.Max(8, size));
         }
 
         private T CreateInstance()

--- a/src/Sparrow/ObjectPool.cs
+++ b/src/Sparrow/ObjectPool.cs
@@ -6,12 +6,13 @@
 // 
 //#define TRACE_LEAKS
 
-// define DETECT_LEAKS to detect possible leaks
+//#define DETECT_LEAKS to detect possible leaks
 //#if DEBUG
 //    #define DETECT_LEAKS  //for now always enable DETECT_LEAKS in debug.
 //#endif
 
 
+using Sparrow.Collections;
 using Sparrow.Utils;
 
 namespace Sparrow
@@ -75,11 +76,6 @@ namespace Sparrow
     {
         private static readonly TResetBehavior Behavior = new TResetBehavior();
 
-        private struct Element
-        {
-            internal T Value;
-        }
-
         /// <remarks>
         /// Not using System.Func{T} because this file is linked into the (debugger) Formatter,
         /// which does not have that type (since it compiles against .NET 2.0).
@@ -89,7 +85,7 @@ namespace Sparrow
         // Storage for the pool objects. The first item is stored in a dedicated field because we
         // expect to be able to satisfy most requests from it.
         private T _firstItem;
-        private readonly Element[] _items;
+        private readonly LockFreeRingBuffer<T> _ringBuffer;
 
         // factory is stored for the lifetime of the pool. We will call this only when pool needs to
         // expand. compared to "new T()", Func gives more flexibility to implementers and faster
@@ -145,7 +141,7 @@ namespace Sparrow
         {
             Debug.Assert(size >= 1);
             _factory = factory;
-            _items = new Element[size - 1];
+            _ringBuffer = new LockFreeRingBuffer<T>(size);
         }
 
         private T CreateInstance()
@@ -178,7 +174,8 @@ namespace Sparrow
             T inst = _firstItem;
             if (inst == null || inst != Interlocked.CompareExchange(ref _firstItem, null, inst))
             {
-                inst = AllocateSlow();
+                if (_ringBuffer.TryDequeue(out inst) == false)
+                    inst = CreateInstance();
             }
 
 #if DETECT_LEAKS
@@ -192,28 +189,6 @@ namespace Sparrow
 #endif
             return inst;
         }  
-
-        private T AllocateSlow()
-        {
-            var items = _items;
-
-            for (int i = 0; i < items.Length; i++)
-            {
-                // Note that the initial read is optimistically not synchronized. That is intentional. 
-                // We will interlock only when we have a candidate. in a worst case we may miss some
-                // recently returned objects. Not a big deal.
-                T inst = items[i].Value;
-                if (inst != null)
-                {
-                    if (inst == Interlocked.CompareExchange(ref items[i].Value, null, inst))
-                    {
-                        return inst;
-                    }
-                }
-            }
-
-            return CreateInstance();
-        }
 
         /// <summary>
         /// Returns objects to the pool.
@@ -231,33 +206,11 @@ namespace Sparrow
 
             Behavior.Reset(obj);
 
-            if (_firstItem == null)
-            {
-                // Intentionally not using interlocked here. 
-                // In a worst case scenario two objects may be stored into same slot.
-                // It is very unlikely to happen and will only mean that one of the objects will get collected.
-                _firstItem = obj;
-            }
-            else
-            {
-                FreeSlow(obj);
-            }
-        }
+            T inst = _firstItem;
+            if (inst == null && Interlocked.CompareExchange(ref _firstItem, obj, null) == null)
+                return; // Successfully stored in _firstItem; no further action required.
 
-        private void FreeSlow(T obj)
-        {
-            var items = _items;
-            for (int i = 0; i < items.Length; i++)
-            {
-                if (items[i].Value == null)
-                {
-                    // Intentionally not using interlocked here. 
-                    // In a worst case scenario two objects may be stored into same slot.
-                    // It is very unlikely to happen and will only mean that one of the objects will get collected.
-                    items[i].Value = obj;
-                    break;
-                }
-            }
+            _ringBuffer.TryEnqueue(obj);
         }
 
         /// <summary>
@@ -303,20 +256,18 @@ namespace Sparrow
 
         [Conditional("DEBUG")]
         [Conditional("DETECT_LEAKS")]
-        private void Validate(object obj)
+        private void Validate(T obj)
         {
             Debug.Assert(obj != null, "freeing null?");
 
-            var items = _items;
-            for (int i = 0; i < items.Length; i++)
+            int count = _ringBuffer.Count;
+            for (int i = 0; i < count; i++)
             {
-                var value = items[i].Value;
-                if (value == null)
+                if (_ringBuffer.TryDequeue(out var item))
                 {
-                    return;
+                    Debug.Assert(item != obj, "freeing twice?");
+                    _ringBuffer.TryEnqueue(item);
                 }
-
-                Debug.Assert(value != obj, "freeing twice?");
             }
         }
     }

--- a/src/Sparrow/Utils/NativeMemoryCleaner.cs
+++ b/src/Sparrow/Utils/NativeMemoryCleaner.cs
@@ -95,8 +95,15 @@ namespace Sparrow.Utils
                         // Item is still valid, and we are not under memory pressure, attempt to return it back to the pool
                         if (_ringBuffer.TryEnqueue(item) == false)
                         {
-                            // Fallback: if the pool is full, dispose to prevent memory growth.
-                            item.Dispose();
+                            try
+                            {
+                                // Fallback: if the pool is full, dispose to prevent memory growth.
+                                item.Dispose();
+                            }
+                            catch (ObjectDisposedException)
+                            {
+                                // Item was already disposed elsewhere; ignore and continue.
+                            }
                         }
 
                         // If the pool now has too few items, stop cleaning.

--- a/src/Sparrow/Utils/NativeMemoryCleaner.cs
+++ b/src/Sparrow/Utils/NativeMemoryCleaner.cs
@@ -1,100 +1,125 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Sparrow.Collections;
 using Sparrow.Logging;
 using Sparrow.Threading;
 
 namespace Sparrow.Utils
 {
-    public sealed class NativeMemoryCleaner<TStack, TPooledItem> : IDisposable where TPooledItem : PooledItem where TStack : StackHeader<TPooledItem>
-    {
-        private static readonly IRavenLogger Logger = RavenLogManager.Instance.GetLoggerForSparrow(typeof(NativeMemoryCleaner<TStack, TPooledItem>));
 
-        private readonly object _lock = new object();
-        private readonly Func<object, ICollection<TStack>> _getContextsFromCleanupTarget;
+    /// <summary>
+    /// The NativeMemoryCleaner is responsible for periodically scanning a lock-free ring buffer of pooled items and
+    /// disposing of items that are either no longer needed or were allocated under low memory pressure.
+    /// 
+    /// It uses a SharedMultipleUseFlag (_lowMemoryFlag) and an idle time threshold (_idleTime) to decide which items
+    /// should be disposed. Items are dequeued from the buffer and checked:
+    /// - If we are under low memory conditions (LowMemoryFlag is raised) or the item has been idle longer than _idleTime, 
+    ///   the item is disposed.
+    /// - Otherwise, we attempt to return the item to the pool.
+    /// 
+    /// Because the LockFreeRingBuffer is thread-safe, we do not use a global lock. Instead, we optimistically dequeue items 
+    /// and handle them. If the queue is nearly empty (less than MinimumRetainedItemsInQueue), we stop cleaning to ensure some items
+    /// remain available for immediate allocation.
+    /// 
+    /// This approach reduces contention and overhead, improving throughput in memory-intensive operations.
+    /// </summary>
+    /// <param name="lowMemoryFlag">
+    /// A flag that indicates whether the system is under low memory pressure.
+    /// When raised, the cleaner becomes more aggressive in disposing of items.
+    /// </param>
+    /// <param name="idleTime">
+    /// The maximum duration an item can remain idle in the pool before it is considered for disposal.
+    /// </param>
+    public sealed class NativeMemoryCleaner<TPooledItem> : IDisposable
+        where TPooledItem : PooledItem
+    {
+        private static readonly IRavenLogger Logger = RavenLogManager.Instance.GetLoggerForSparrow(typeof(NativeMemoryCleaner<TPooledItem>));
+
+        private readonly LockFreeRingBuffer<TPooledItem> _ringBuffer;
         private readonly SharedMultipleUseFlag _lowMemoryFlag;
         private readonly TimeSpan _idleTime;
         private readonly Timer _timer;
-        private WeakReference _cleanupTargetWeakRef;
 
-        public NativeMemoryCleaner(object cleanupTarget, Func<object, ICollection<TStack>> getContexts, SharedMultipleUseFlag lowMemoryFlag, TimeSpan period, TimeSpan idleTime)
+        private bool _disposed;
+
+        public NativeMemoryCleaner(LockFreeRingBuffer<TPooledItem> ringBuffer, SharedMultipleUseFlag lowMemoryFlag, TimeSpan period, TimeSpan idleTime)
         {
-            _cleanupTargetWeakRef = new WeakReference(cleanupTarget);
-            _getContextsFromCleanupTarget = getContexts;
-
-            _lowMemoryFlag = lowMemoryFlag;
+            _ringBuffer = ringBuffer ?? throw new ArgumentNullException(nameof(ringBuffer));
+            _lowMemoryFlag = lowMemoryFlag ?? throw new ArgumentNullException(nameof(lowMemoryFlag));
             _idleTime = idleTime;
-            _timer = new Timer(CleanNativeMemory, null, period, period);
+            _timer = new Timer(x => PurgeStaleOrExcessItems(), null, period, period);
         }
 
-        private ICollection<TStack> GetContexts()
-        {
-            object cleanupTarget = _cleanupTargetWeakRef.Target;
-            return cleanupTarget == null ? Array.Empty<TStack>() : _getContextsFromCleanupTarget(cleanupTarget);
-        }
+        private const int MinimumRetainedItemsInQueue = 2;
 
-        public void CleanNativeMemory(object state)
+        /// <summary>
+        /// Called periodically by the timer to clean up old or unneeded items.
+        /// This method no longer takes a global lock, as the ring buffer is thread-safe.
+        /// We aggressively and optimistically dequeue items, check their conditions, and either dispose or re-enqueue them.
+        /// </summary>
+        public void PurgeStaleOrExcessItems()
         {
-            var lockTaken = false;
+            if (_disposed)
+                return;
+
+            // Errors during purging (e.g., ObjectDisposedException) are expected and ignored,
+            // ensuring the cleaner does not disrupt the main allocation flow.
+
             try
             {
-                Monitor.TryEnter(_lock, ref lockTaken);
-                if (lockTaken == false)
-                    return;
+                int maxIterations = _ringBuffer.Count;
 
-                var now = DateTime.UtcNow;
-                ICollection<TStack> values;
-                try
-                {
-                    values = GetContexts();
-                }
-                catch (OutOfMemoryException)
-                {
-                    return; // trying to allocate the list?
-                }
-                catch (ObjectDisposedException)
-                {
-                    return; // already disposed
-                }
-                foreach (var header in values)
-                {
-                    if (header == null)
-                        continue;
+                // Exit early if the pool has too few items to justify cleanup.
+                if (maxIterations <= MinimumRetainedItemsInQueue)
+                    return; 
 
-                    var current = header.Head;
-                    while (current != null)
+                DateTime now = DateTime.UtcNow;
+                for (int i = 0; i < maxIterations; i++)
+                {
+                    if (_ringBuffer.TryDequeue(out var item) == false)
+                        break; // Failed to dequeue, move on.
+
+                    if (item == null)
+                        continue; // Null items shouldn't happen, but we guard against it.
+
+                    Debug.Assert(item.InUse.IsRaised() == false, "Item should not be in use when in the pool.");
+                    
+                    // Check if the item has been idle for too long or if we are under memory pressure.
+                    var timeInPool = now - item.InPoolSince;
+                    bool shouldDispose = _lowMemoryFlag.IsRaised() || timeInPool >= _idleTime;
+                    if (shouldDispose == false)
                     {
-                        var item = current.Value;
-                        var parent = current;
-                        current = current.Next;
-
-                        if (item == null)
-                            continue;
-
-                        if (_lowMemoryFlag == false)
+                        // Item is still valid, and we are not under memory pressure, attempt to return it back to the pool
+                        if (_ringBuffer.TryEnqueue(item) == false)
                         {
-                            var timeInPool = now - item.InPoolSince;
-                            if (timeInPool < _idleTime)
-                                continue;
-                        } // else dispose context on low mem stress
-
-                        // it is too old, we can dispose it, but need to protect from races
-                        // if the owner thread will just pick it up
-
-                        if (!item.InUse.Raise())
-                            continue;
-
-                        try
-                        {
+                            // Fallback: if the pool is full, dispose to prevent memory growth.
                             item.Dispose();
                         }
-                        catch (ObjectDisposedException)
-                        {
-                            // it is possible that this has already been disposed
-                        }
 
-                        parent.Value = null;
+                        // If the pool now has too few items, stop cleaning.
+                        if (_ringBuffer.Count <= MinimumRetainedItemsInQueue)
+                            break;
+
+                        continue; // Move on to the next item.
+                    }
+
+                    // Dispose of the item because it is stale or memory pressure is high.
+
+                    // Ensure no other thread is using it and skip if we cannot safely raise InUse.
+                    // This shouldn't happen, but we guard against it.
+                    if (item.InUse.Raise() == false)
+                        continue; 
+
+                    try
+                    {
+                        item.Dispose();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // Item was already disposed elsewhere; ignore and continue.
                     }
                 }
             }
@@ -104,11 +129,6 @@ namespace Sparrow.Utils
                 if (Logger.IsErrorEnabled)
                     Logger.Error("Error during cleanup.", e);
             }
-            finally
-            {
-                if (lockTaken)
-                    Monitor.Exit(_lock);
-            }
         }
 
         public void Dispose()
@@ -116,6 +136,7 @@ namespace Sparrow.Utils
 #if !NETSTANDARD1_3
             using (var waitHandle = new ManualResetEvent(false))
             {
+                _disposed = true;
                 if (_timer.Dispose(waitHandle))
                 {
                     waitHandle.WaitOne();

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Sparrow;
 using Sparrow.Platform;
 using Sparrow.Server;
+using Sparrow.Server.Collections;
 using Sparrow.Threading;
 using Sparrow.Utils;
 using Sparrow.Server.Utils;
@@ -195,9 +196,21 @@ namespace Voron.Impl
 
             Flags = TransactionFlags.Read;
 
-            _pageLocator = transactionPersistentContext.AllocatePageLocator();
+            _pageLocator = AllocatePageLocator();
 
             InitializeRoots();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public PageLocator AllocatePageLocator()
+        {
+            return PersistentContext.AllocatePageLocator();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void FreePageLocator(PageLocator locator)
+        {
+            PersistentContext.FreePageLocator(locator);
         }
 
         private LowLevelTransaction(LowLevelTransaction previous, TransactionPersistentContext persistentContext, long txId)
@@ -256,7 +269,8 @@ namespace Voron.Impl
             _transactionPages = new HashSet<PageFromScratchBuffer>(PageFromScratchBufferEqualityComparer.Instance);
             _pagesToFreeOnCommit = new Stack<long>();
 
-            _pageLocator = PersistentContext.AllocatePageLocator();
+            _pageLocator = AllocatePageLocator();
+
             InitializeRoots();
             InitTransactionHeader();
         }
@@ -310,6 +324,7 @@ namespace Voron.Impl
             _scratchPagesInUse = _env.WriteTransactionPool.ScratchPagesInUse;
             _transactionPages = new HashSet<PageFromScratchBuffer>(PageFromScratchBufferEqualityComparer.Instance);
             _pagesToFreeOnCommit = new Stack<long>();
+            _pageLocator = AllocatePageLocator();
 
             InitializeRoots();
             InitTransactionHeader();
@@ -798,7 +813,7 @@ namespace Voron.Impl
 
                 _txStatus |= TxStatus.Disposed;
 
-                PersistentContext.FreePageLocator(_pageLocator);
+                FreePageLocator(_pageLocator);
             }
             finally
             {

--- a/src/Voron/Impl/SliceSmallSet.cs
+++ b/src/Voron/Impl/SliceSmallSet.cs
@@ -11,13 +11,28 @@ using Sparrow.Collections;
 
 namespace Voron.Impl
 {
-    // The concept of the small set is about a normal dictionary optimized for accessing recently accessed items. 
-    // In a sense it behaves like an LRU cache over a dictionary, however, it will not use the backing dictionary unless it has to.
-    // It is specially designed to deal with sequence values stored in byte pointers. The main difference with a
-    // dictionary is that the small set will calculate the hash ONLY if there are strong candidates that match already. 
+    // Represents a specialized, small, and partially LRU-like set optimized for frequently accessed items.
+    // Unlike a standard dictionary, this structure attempts to keep recently accessed items in a fast-access cache 
+    // (the "small set"). When needed, it falls back to a larger backing dictionary. This design is particularly
+    // suited for scenarios involving sequence values stored in unmanaged memory, and it defers expensive hash
+    // computations unless necessary. Effectively, it works as an LRU cache over a dictionary without always relying 
+    // on the dictionary for lookups.
     public sealed class SliceSmallSet<TValue> : IDisposable
     {
         private static readonly LockFreeRingBuffer<ArrayPool<SetItem>> PerCoreArrayPools = new(128);
+
+        static SliceSmallSet()
+        {
+            // We preallocate several array pools and store them in a lock-free ring buffer.
+            // By doing so, we reduce memory allocation overhead and better distribute the load across 
+            // multiple processors. This approach helps handle bursty workloads more evenly.
+            int processors = Math.Min(Environment.ProcessorCount / 2, PerCoreArrayPools.Count);
+            while (PerCoreArrayPools.Count < processors)
+            {
+                PerCoreArrayPools.TryEnqueue(ArrayPool<SetItem>.Create());
+            }
+        }
+
         private readonly ArrayPool<SetItem> _perCorePools;
 
         private const int Invalid = -1;
@@ -32,13 +47,25 @@ namespace Voron.Impl
 
         private readonly int _length;
         private readonly SetItem[] _items;
+
+        // If we exceed the capacity of _items, we use a dictionary as an overflow storage.
+        // Once we switch to this overflow mode, we consider the "small set" no longer fully reliable.
         private Dictionary<Slice, TValue> _overflowStorage;
+
+        // _currentIdx tracks the last used position in _items. 
+        // If _currentIdx < _length, we rely mainly on _items; 
+        // otherwise, we rely on _overflowStorage.
         private int _currentIdx;
 
         public SliceSmallSet(int size = 0)
         {
             _length = size > Vector<long>.Count ? (size - size % Vector<long>.Count) : Vector<long>.Count;
 
+            // RavenDB-23148: We will dequeue, rent and then return it immediately after use. The idea is that
+            // when we got it, rent, and then return it so someone else can use it; effectively behaving
+            // as a critical section. While it may happen that multiple threads will be returning arrays at the same time
+            // the expectation is that the distribution is time will be more even than trying to allocate 1000s of
+            // queries that come as a bundle. 
             if (PerCoreArrayPools.TryDequeue(out _perCorePools) == false)
             {
                 _perCorePools = ArrayPool<SetItem>.Create();
@@ -48,6 +75,8 @@ namespace Voron.Impl
 
             _overflowStorage = null;
             _currentIdx = Invalid;
+
+            PerCoreArrayPools.TryEnqueue(_perCorePools);
         }
 
         public IEnumerable<TValue> Values => ReturnValues();
@@ -78,11 +107,12 @@ namespace Voron.Impl
 
         public unsafe void Add(Slice key, TValue value)
         {
+            // We attempt to find the key among the recently accessed items (LRU section).
             int idx = FindKey(key);
             if (idx != Invalid)
                 goto Done;
 
-            // side effect, overflow if needed
+            // we request a writable bucket in the small set. If the small set is full, we switch to overflow storage.
             idx = RequestWritableBucket();
             if (idx == Invalid || _currentIdx >= _length)
             {
@@ -103,6 +133,7 @@ namespace Voron.Impl
         {
             Debug.Assert(key.HasValue, "The key is invalid.");
 
+            // If the small set is empty, return immediately.
             if (_currentIdx == Invalid)
                 return Invalid;
 
@@ -225,8 +256,6 @@ namespace Voron.Impl
             }
 
             _perCorePools.Return(_items);
-
-            PerCoreArrayPools.TryEnqueue(_perCorePools);
         }
 
         public void Remove(Slice name)

--- a/src/Voron/Impl/SliceSmallSet.cs
+++ b/src/Voron/Impl/SliceSmallSet.cs
@@ -1,12 +1,12 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Sparrow;
-using Sparrow.Json;
-using Sparrow.Server;
+using Sparrow.Collections;
+
 // ReSharper disable StaticMemberInGenericType
 
 namespace Voron.Impl
@@ -25,7 +25,7 @@ namespace Voron.Impl
             public readonly ArrayPool<TValue> ValuesPool = ArrayPool<TValue>.Create();
         }
 
-        private static readonly PerCoreContainer<ArrayPoolContainer> PerCoreArrayPools = new();
+        private static readonly LockFreeRingBuffer<ArrayPoolContainer> PerCoreArrayPools = new(128);
         private readonly ArrayPoolContainer _perCorePools;
 
         private const int Invalid = -1;
@@ -42,9 +42,12 @@ namespace Voron.Impl
         {
             _length = size > Vector<long>.Count ? (size - size % Vector<long>.Count) : Vector<long>.Count;
 
-            if (PerCoreArrayPools.TryPull(out _perCorePools) == false)
+            if (PerCoreArrayPools.TryDequeue(out _perCorePools) == false)
+            {
                 _perCorePools = new ArrayPoolContainer();
 
+            }
+            
             _keySizes = _perCorePools.KeySizesPool.Rent(_length);
             _keyHashes = _perCorePools.KeyHashesPool.Rent(_length);
             _keys = _perCorePools.KeysPool.Rent(_length);
@@ -232,7 +235,7 @@ namespace Voron.Impl
             }
             _perCorePools.ValuesPool.Return(_values);
 
-            PerCoreArrayPools.TryPush(_perCorePools);
+            PerCoreArrayPools.TryEnqueue(_perCorePools);
         }
 
         public void Remove(Slice name)

--- a/src/Voron/Impl/SliceSmallSet.cs
+++ b/src/Voron/Impl/SliceSmallSet.cs
@@ -12,29 +12,26 @@ using Sparrow.Collections;
 namespace Voron.Impl
 {
     // The concept of the small set is about a normal dictionary optimized for accessing recently accessed items. 
-    // In a sense it behaves like a LRU cache over a dictionary, however, it will not use the backing dictionary unless it has to.
+    // In a sense it behaves like an LRU cache over a dictionary, however, it will not use the backing dictionary unless it has to.
     // It is specially designed to deal with sequence values stored in byte pointers. The main difference with a
     // dictionary is that the small set will calculate the hash ONLY if there are strong candidates that match already. 
     public sealed class SliceSmallSet<TValue> : IDisposable
     {
-        private sealed class ArrayPoolContainer
-        {
-            public readonly ArrayPool<int> KeySizesPool = ArrayPool<int>.Create();
-            public readonly ArrayPool<ulong> KeyHashesPool = ArrayPool<ulong>.Create();
-            public readonly ArrayPool<Slice> KeysPool = ArrayPool<Slice>.Create();
-            public readonly ArrayPool<TValue> ValuesPool = ArrayPool<TValue>.Create();
-        }
-
-        private static readonly LockFreeRingBuffer<ArrayPoolContainer> PerCoreArrayPools = new(128);
-        private readonly ArrayPoolContainer _perCorePools;
+        private static readonly LockFreeRingBuffer<ArrayPool<SetItem>> PerCoreArrayPools = new(128);
+        private readonly ArrayPool<SetItem> _perCorePools;
 
         private const int Invalid = -1;
 
+        private struct SetItem
+        {
+            public int Size;
+            public ulong Hash;
+            public Slice Key;
+            public TValue Value;
+        }
+
         private readonly int _length;
-        private readonly int[] _keySizes;
-        private readonly ulong[] _keyHashes;
-        private readonly Slice[] _keys;
-        private readonly TValue[] _values;
+        private readonly SetItem[] _items;
         private Dictionary<Slice, TValue> _overflowStorage;
         private int _currentIdx;
 
@@ -44,14 +41,11 @@ namespace Voron.Impl
 
             if (PerCoreArrayPools.TryDequeue(out _perCorePools) == false)
             {
-                _perCorePools = new ArrayPoolContainer();
-
+                _perCorePools = ArrayPool<SetItem>.Create();
             }
-            
-            _keySizes = _perCorePools.KeySizesPool.Rent(_length);
-            _keyHashes = _perCorePools.KeyHashesPool.Rent(_length);
-            _keys = _perCorePools.KeysPool.Rent(_length);
-            _values = _perCorePools.ValuesPool.Rent(_length);
+
+            _items = _perCorePools.Rent(_length);
+
             _overflowStorage = null;
             _currentIdx = Invalid;
         }
@@ -69,8 +63,9 @@ namespace Voron.Impl
                     // RavenDB-20947: This may be the case of the "Cannot add a value in a read only transaction on $Root in Read"
                     // If we don't check for 'HasValue' or that the key size is bigger than zero, we may be returning a removed
                     // value. 
-                    if (_keySizes[i] != 0)
-                        yield return _values[i];
+                    ref var item = ref _items[i];
+                    if (item.Size != 0)
+                        yield return item.Value;
                 }
             }
             else
@@ -96,10 +91,11 @@ namespace Voron.Impl
             }
 
             Done:
-            _keys[idx] = key;
-            _keySizes[idx] = key.Size;
-            _keyHashes[idx] = Hashing.XXHash64.CalculateInline(key.Content.Ptr, (ulong)key.Size);
-            _values[idx] = value;
+            ref var item = ref _items[idx];
+            item.Key = key;
+            item.Size = key.Size;
+            item.Hash = Hashing.XXHash64.CalculateInline(key.Content.Ptr, (ulong)key.Size);
+            item.Value = value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -115,12 +111,9 @@ namespace Voron.Impl
 
             ulong keyHash = 0;
 
-            Slice[] keys = _keys;
-            int[] keySizes = _keySizes;
-            ulong[] keyHashes = _keyHashes;
             byte* keyPtr = key.Content.Ptr;
 
-            // PERF: It may seems strange to increase the size to decrement it as the first
+            // PERF: It may seem strange to increase the size to decrement it as the first
             // loop operation. The reason behind this is to be able to just jump back immediately
             // to the top of the loop as soon as we know the item is not the item we are looking
             // for. 
@@ -130,8 +123,10 @@ namespace Voron.Impl
                 var currentIdx = elementIdx;
                 elementIdx--;
 
+                ref var item = ref _items[currentIdx];
+
                 // First check, we are not going to look into any string that is not of the correct size
-                if (keySizes[currentIdx] != keyLength)
+                if (item.Size != keyLength)
                     continue;
 
                 // PERF: Assuming a uniformly random symbol distribution, the chance that first two symbols match
@@ -139,7 +134,7 @@ namespace Voron.Impl
                 // match(i.e.that S1[1] = S2[1] and S1[2] = S2[2]) is equal to 1/σ^2, etc. More generally,
                 // the probability that there is a match between all characters up to a 1 - indexed position i
                 // is equal to 1 / σ^i. We are using that knowledge to quickly get rid of elements.
-                ref var candidateKey = ref keys[currentIdx];
+                ref var candidateKey = ref item.Key;
 
                 Debug.Assert(candidateKey.HasValue, "If there is no way candidate key not have a value since then key size stored would be inconsistent.");
 
@@ -153,7 +148,7 @@ namespace Voron.Impl
                 if (keyHash == 0)
                     keyHash = Hashing.XXHash64.CalculateInline(keyPtr, (ulong)key.Size);
 
-                if (keyHashes[currentIdx] != keyHash)
+                if (item.Hash != keyHash)
                     continue;
 
                 // We now know that we have an almost sure hit. We will do a final verification at this time.
@@ -177,11 +172,13 @@ namespace Voron.Impl
 
                 for (int i = 0; i < _length; i++)
                 {
+                    ref var item = ref _items[i];
+
                     // If the key size is 0 then there are no keys in there.
-                    if (_keySizes[i] == 0)
+                    if (item.Size == 0)
                         continue;
 
-                    storage[_keys[i]] = _values[i];
+                    storage[item.Key] = item.Value;
                 }
 
                 _overflowStorage = storage;
@@ -196,7 +193,8 @@ namespace Voron.Impl
             int idx = FindKey(key);
             if (idx != Invalid)
             {
-                value = _values[idx];
+                ref var item = ref _items[idx];
+                value = item.Value;
                 return true;
             }
 
@@ -211,29 +209,22 @@ namespace Voron.Impl
 
         public void Clear()
         {
-            Array.Fill(_keySizes, 0);
-            Array.Fill(_keyHashes, 0ul);
-            Array.Fill(_keys, default);
-            Array.Fill(_values, default);
+            Array.Fill(_items, default);
+
             _overflowStorage?.Clear();
             _currentIdx = Invalid;
         }
 
         public void Dispose()
         {
-            _perCorePools.KeySizesPool.Return(_keySizes);
-            _perCorePools.KeyHashesPool.Return(_keyHashes);
-            _perCorePools.KeysPool.Return(_keys);
-
             // If we are holding references, then we will clear the portion of the values array
             // that it is in use.
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
             {
-                int valuesLength = Math.Min(_currentIdx, _length - 1) + 1;
-                if (valuesLength >= 0)
-                    _values.AsSpan(0, valuesLength).Clear();
+                Array.Fill(_items, default);
             }
-            _perCorePools.ValuesPool.Return(_values);
+
+            _perCorePools.Return(_items);
 
             PerCoreArrayPools.TryEnqueue(_perCorePools);
         }
@@ -248,10 +239,7 @@ namespace Voron.Impl
                 return;
 
             // If we have found it, we are retiring it from the cache.
-            _keys[idx] = default;
-            _keySizes[idx] = 0;
-            _keyHashes[idx] = 0ul;
-            _values[idx] = default;
+            _items[idx] = default;
         }
     }
 }

--- a/src/Voron/PageLocator.cs
+++ b/src/Voron/PageLocator.cs
@@ -89,7 +89,7 @@ namespace Voron
 
             ref var node = ref Unsafe.Add(ref _cache[0], (int)bucket);
 
-            if (node.PageNumber != pageNumber)
+            if (node.PageNumber != pageNumber || node.Generation != _generation)
             {
                 node.PageNumber = pageNumber;
                 node.Page = page;
@@ -108,7 +108,7 @@ namespace Voron
 
             ref var node = ref Unsafe.Add(ref _cache[0], (int)bucket);
 
-            if (node.PageNumber != pageNumber || node.IsWritable == false)
+            if (node.PageNumber != pageNumber || node.Generation != _generation || node.IsWritable == false )
             {
                 node.PageNumber = pageNumber;
                 node.Page = page;

--- a/src/Voron/TransactionPersistentContext.cs
+++ b/src/Voron/TransactionPersistentContext.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Voron.Impl;
@@ -29,12 +29,11 @@ namespace Voron
             return locator;
         }
 
-        public void FreePageLocator(PageLocator locator)
+        internal void FreePageLocator(PageLocator locator)
         {
             Debug.Assert(locator != null);
             if (_pageLocators.Count < 1024)
                 _pageLocators.Push(locator);
         }
-
     }
 }

--- a/test/FastTests/Sparrow/LockFreeRingBuffer.cs
+++ b/test/FastTests/Sparrow/LockFreeRingBuffer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Voron;
@@ -13,6 +14,19 @@ namespace FastTests.Sparrow
 {
     public class LockFreeRingBufferTests(ITestOutputHelper output) : StorageTest(output)
     {
+        [RavenFact(RavenTestCategory.Core)]
+        public unsafe void EnsureStructuralProperties()
+        {
+            LockFreeRingBuffer<long>.Cell[] cells = new LockFreeRingBuffer<long>.Cell[2];
+            long seqMemoryLocation = (long)Unsafe.AsPointer(ref cells[0].Sequence);
+            long valueMemoryLocation = (long)Unsafe.AsPointer(ref cells[0].Value);
+            long nextSeqMemoryLocation = (long)Unsafe.AsPointer(ref cells[1].Sequence);
+
+            Assert.Equal(64, valueMemoryLocation - seqMemoryLocation);
+            Assert.Equal(0, Unsafe.SizeOf<LockFreeRingBuffer<long>.Cell>() % 64);
+            Assert.Equal(0, (nextSeqMemoryLocation - seqMemoryLocation) % 64);
+        }
+
         [RavenFact(RavenTestCategory.Core)]
         public void Enqueue_Dequeue_SingleItem()
         {

--- a/test/FastTests/Sparrow/LockFreeRingBuffer.cs
+++ b/test/FastTests/Sparrow/LockFreeRingBuffer.cs
@@ -1,0 +1,384 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests.Voron;
+using Sparrow.Collections;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Sparrow
+{
+    public class LockFreeRingBufferTests(ITestOutputHelper output) : StorageTest(output)
+    {
+        [RavenFact(RavenTestCategory.Core)]
+        public void Enqueue_Dequeue_SingleItem()
+        {
+            var ringBuffer = new LockFreeRingBuffer<int>(8);
+
+            int item = 42;
+            bool enqueueResult = ringBuffer.TryEnqueue(item);
+            bool dequeueResult = ringBuffer.TryDequeue(out int dequeuedItem);
+
+            Assert.True(enqueueResult);
+            Assert.True(dequeueResult);
+            Assert.Equal(item, dequeuedItem);
+            Assert.True(ringBuffer.IsEmpty);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void Enqueue_Dequeue_MultipleItems()
+        {
+            var ringBuffer = new LockFreeRingBuffer<int>(8);
+
+            int[] items = { 1, 2, 3, 4, 5 };
+            foreach (var item in items)
+            {
+                bool enqueueResult = ringBuffer.TryEnqueue(item);
+                Assert.True(enqueueResult, $"Enqueue should succeed for item {item}.");
+            }
+
+            foreach (var expectedItem in items)
+            {
+                bool dequeueResult = ringBuffer.TryDequeue(out int dequeuedItem);
+                Assert.True(dequeueResult);
+                Assert.Equal(expectedItem, dequeuedItem);
+            }
+
+            Assert.True(ringBuffer.IsEmpty);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void Enqueue_BufferFull()
+        {
+            var ringBuffer = new LockFreeRingBuffer<int>(8);
+
+            int capacity = 8;
+
+            // Enqueue 'capacity' items
+            for (int i = 0; i < capacity; i++)
+            {
+                bool enqueueResult = ringBuffer.TryEnqueue(i);
+                Assert.True(enqueueResult, $"Enqueue should succeed for item {i}.");
+            }
+
+            // Attempt to enqueue one more item, which should fail
+            bool finalEnqueueResult = ringBuffer.TryEnqueue(999);
+
+            Assert.False(finalEnqueueResult);
+            Assert.True(ringBuffer.IsFull);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void Dequeue_BufferEmpty()
+        {
+            var ringBuffer = new LockFreeRingBuffer<int>(8);
+
+            // Act
+            bool dequeueResult = ringBuffer.TryDequeue(out int dequeuedItem);
+
+            // Assert
+            Assert.False(dequeueResult);
+            Assert.Equal(default(int), dequeuedItem);
+            Assert.True(ringBuffer.IsEmpty);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void Enqueue_Dequeue_WrapAround()
+        {
+            var ringBuffer = new LockFreeRingBuffer<int>(8);
+
+            int capacity = 8;
+            int halfCapacity = capacity / 2 + 1;
+            int[] firstBatch = new int[halfCapacity];
+            int[] secondBatch = new int[halfCapacity];
+
+            for (int i = 0; i < halfCapacity; i++)
+            {
+                firstBatch[i] = i;
+                bool enqueueResult = ringBuffer.TryEnqueue(firstBatch[i]);
+                Assert.True(enqueueResult, $"Enqueue should succeed for item {firstBatch[i]}.");
+            }
+
+            for (int i = 0; i < halfCapacity; i++)
+            {
+                bool dequeueResult = ringBuffer.TryDequeue(out int dequeuedItem);
+                Assert.True(dequeueResult, $"Dequeue should succeed for each enqueued item {i}.");
+                Assert.Equal(firstBatch[i], dequeuedItem);
+            }
+
+            for (int i = 0; i < halfCapacity; i++)
+            {
+                secondBatch[i] = i + 100;
+                bool enqueueResult = ringBuffer.TryEnqueue(secondBatch[i]);
+                Assert.True(enqueueResult, $"Enqueue should succeed for item {secondBatch[i]}.");
+            }
+
+            for (int i = 0; i < halfCapacity; i++)
+            {
+                bool dequeueResult = ringBuffer.TryDequeue(out int dequeuedItem);
+                Assert.True(dequeueResult, $"Dequeue should succeed for each enqueued item {i}.");
+                Assert.Equal(secondBatch[i], dequeuedItem);
+            }
+
+            Assert.True(ringBuffer.IsEmpty);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void Enqueue_Dequeue_MixedOperations()
+        {
+            var ringBuffer = new LockFreeRingBuffer<int>(8);
+
+            int[] items = [10, 20, 30, 40, 50, 60, 70, 80];
+
+            // Act & Assert
+            foreach (var item in items)
+            {
+                bool enqueueResult = ringBuffer.TryEnqueue(item);
+                Assert.True(enqueueResult, $"Enqueue should succeed for item {item}.");
+            }
+
+            // Buffer should be full now
+            Assert.True(ringBuffer.IsFull);
+
+            // Dequeue first four items
+            for (int i = 0; i < 4; i++)
+            {
+                bool dequeueResult = ringBuffer.TryDequeue(out int dequeuedItem);
+                Assert.True(dequeueResult, $"Dequeue should succeed for each enqueued item {i}.");
+                Assert.Equal(items[i], dequeuedItem);
+            }
+
+            // Buffer should not be full yet
+            Assert.False(ringBuffer.IsFull);
+
+            // Enqueue four more items
+            int[] additionalItems = { 90, 100, 110, 120 };
+            foreach (var item in additionalItems)
+            {
+                bool enqueueResult = ringBuffer.TryEnqueue(item);
+                Assert.True(enqueueResult, $"Enqueue should succeed for item {item}.");
+            }
+
+            // Buffer should be full again
+            Assert.True(ringBuffer.IsFull);
+
+            // Dequeue all remaining items
+            for (int i = 4; i < items.Length; i++)
+            {
+                bool dequeueResult = ringBuffer.TryDequeue(out int dequeuedItem);
+                Assert.True(dequeueResult, $"Dequeue should succeed for each enqueued item {i}.");
+                Assert.Equal(items[i], dequeuedItem);
+            }
+
+            foreach (var item in additionalItems)
+            {
+                bool dequeueResult = ringBuffer.TryDequeue(out int dequeuedItem);
+                Assert.True(dequeueResult, "Dequeue should succeed for each enqueued item.");
+                Assert.Equal(item, dequeuedItem);
+            }
+
+            // Assert buffer is empty after all dequeues
+            Assert.True(ringBuffer.IsEmpty, "Ring buffer should be empty after all dequeues.");
+        }
+
+        public static IEnumerable<object[]> Configuration =>
+            new List<object[]>
+            {
+                // With this number we ensure hitting full and empty conditions, bigger than that probability
+                // will ensure or the other are more common. 
+                new object[] { 10000, Random.Shared.Next(), 8 },
+                new object[] { 1000, Random.Shared.Next(), 8 },
+                new object[] { 100, Random.Shared.Next(), 8 },
+            };
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [MemberData(nameof(Configuration))]
+        public void Enqueue_Dequeue_RandomSequences_FuzzingTest(int totalOperations = 1000, int seed = 1337, int bufferCapacity = 8)
+        {
+            const double enqueueProbability = 0.5; // 50% chance to enqueue
+
+            // Initialize the lock-free ring buffer with the specified capacity
+            var ringBuffer = new LockFreeRingBuffer<int>(bufferCapacity);
+            // Initialize a reference queue to track expected behavior
+            var referenceQueue = new Queue<int>();
+            // Initialize a random number generator
+            var random = new Random(seed);
+
+            for (int operation = 0; operation < totalOperations; operation++)
+            {
+                bool shouldEnqueue;
+
+                // Determine whether to enqueue or dequeue based on current state
+                if (referenceQueue.Count == 0)
+                {
+                    // If the reference queue is empty, we must enqueue
+                    shouldEnqueue = true;
+                }
+                else if (referenceQueue.Count >= bufferCapacity)
+                {
+                    // If the reference queue is full, we must dequeue
+                    shouldEnqueue = false;
+                }
+                else
+                {
+                    // Otherwise, decide randomly
+                    shouldEnqueue = random.NextDouble() < enqueueProbability;
+                }
+
+                if (shouldEnqueue)
+                {
+                    // Generate a unique item to enqueue
+                    int item = operation;
+
+                    // Attempt to enqueue the item into the ring buffer
+                    bool enqueueResult = ringBuffer.TryEnqueue(item);
+                    // Determine the expected result based on the reference queue's state
+                    bool expectedEnqueueResult = referenceQueue.Count < bufferCapacity;
+
+                    // Assert that the enqueue result matches the expectation
+                    Assert.Equal(expectedEnqueueResult, enqueueResult);
+
+                    if (enqueueResult)
+                    {
+                        // If enqueue succeeded, enqueue the item into the reference queue
+                        referenceQueue.Enqueue(item);
+                    }
+                }
+                else
+                {
+                    // Attempt to dequeue an item from the ring buffer
+                    bool dequeueResult = ringBuffer.TryDequeue(out int dequeuedItem);
+                    // Determine the expected result based on the reference queue's state
+                    bool expectedDequeueResult = referenceQueue.Count > 0;
+
+                    // Assert that the dequeue result matches the expectation
+                    Assert.Equal(expectedDequeueResult, dequeueResult);
+
+                    if (dequeueResult)
+                    {
+                        // If dequeue succeeded, dequeue the item from the reference queue
+                        int expectedItem = referenceQueue.Dequeue();
+                        // Assert that the dequeued item matches the expected item
+                        Assert.Equal(expectedItem, dequeuedItem);
+                    }
+                }
+            }
+
+            // After all operations, ensure that the ring buffer and reference queue are consistent
+            while (referenceQueue.Count > 0)
+            {
+                bool dequeueResult = ringBuffer.TryDequeue(out int dequeuedItem);
+                Assert.True(dequeueResult, "Should be able to dequeue remaining items.");
+                int expectedItem = referenceQueue.Dequeue();
+                Assert.Equal(expectedItem, dequeuedItem);
+            }
+
+            // Finally, assert that the ring buffer is empty
+            Assert.True(ringBuffer.IsEmpty, "Ring buffer should be empty after all dequeues.");
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void Enqueue_Dequeue_MultithreadedOperations()
+        {
+            var ringBuffer = new LockFreeRingBuffer<int>(2048);
+
+            const int producerCount = 64; // Number of producer tasks
+            const int consumerCount = 64; // Number of consumer tasks
+            const int itemsPerProducer = 250_00; // Number of items each producer will enqueue
+
+            const int totalItems = producerCount * itemsPerProducer;
+
+            // Thread-safe collections to track enqueued and dequeued items
+            var enqueuedItems = new ConcurrentBag<int>();
+            var dequeuedItems = new ConcurrentBag<int>();
+
+            // Atomic counter for unique item generation
+            int itemCounter = -1;
+
+            // CancellationTokenSource to handle potential timeouts
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120)); // 30-second timeout
+
+            // Parallel Options
+            var parallelOptions = new ParallelOptions
+            {
+                MaxDegreeOfParallelism = producerCount + consumerCount,
+                CancellationToken = cts.Token
+            };
+
+
+            Parallel.For(0, producerCount + consumerCount, parallelOptions, (i, state) =>
+            {
+                if (i < producerCount)
+                {
+                    // Producer Task
+                    for (int j = 0; j < itemsPerProducer; j++)
+                    {
+                        // Generate a unique item
+                        int item = Interlocked.Increment(ref itemCounter);
+
+                        // Attempt to enqueue the item with retry logic
+                        while (ringBuffer.TryEnqueue(item) == false)
+                        {
+                            // Buffer is full, wait and retry
+                            Thread.Sleep(1);
+
+                            // Check for cancellation
+                            if (cts.Token.IsCancellationRequested)
+                            {
+                                state.Stop();
+                                return;
+                            }
+                        }
+
+                        // Track the enqueued item
+                        enqueuedItems.Add(item);
+                    }
+                }
+                else
+                {
+                    // Consumer Task
+                    while (dequeuedItems.Count < totalItems)
+                    {
+                        if (ringBuffer.TryDequeue(out int item))
+                        {
+                            // Track the dequeued item
+                            dequeuedItems.Add(item);
+                        }
+                        else
+                        {
+                            // Buffer is empty, wait and retry
+                            Thread.Sleep(1);
+                        }
+
+                        // Check for cancellation
+                        if (cts.Token.IsCancellationRequested)
+                        {
+                            state.Stop();
+                            return;
+                        }
+                    }
+                }
+            });
+
+
+            // Total items enqueued should match total items dequeued
+            Assert.Equal(totalItems, enqueuedItems.Count);
+            Assert.Equal(totalItems, dequeuedItems.Count);
+
+            // All enqueued items are present in dequeued items
+            var enqueuedSet = new HashSet<int>(enqueuedItems);
+            var dequeuedSet = new HashSet<int>(dequeuedItems);
+
+            Assert.True(enqueuedSet.SetEquals(dequeuedSet), "Enqueued and dequeued items do not match.");
+
+            // No duplicates in dequeued items
+            Assert.Equal(dequeuedItems.Count, dequeuedSet.Count);
+
+            // Ring buffer should be empty after all operations
+            Assert.True(ringBuffer.IsEmpty, "Ring buffer has to be empty after all dequeues.");
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23415

### Additional description

Implements a high-performance multi-writer and multi-reader lock free ring-buffer. Implement many of the current contention object and memory shared primitives in term of shared pools using the ring buffer. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
