### PR TITLE
RavenDB-23368 Run Snowflake tests only on one platform

### DIFF
--- a/test/SlowTests/Authentication/AuthenticationBasicTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationBasicTests.cs
@@ -1229,7 +1229,7 @@ namespace SlowTests.Authentication
             }
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Certificates, RavenArchitecture.AllX64, NightlyBuildOnly = true)]
+        [RavenMultiplatformFact(RavenTestCategory.Certificates, RavenArchitecture.AllX64, NightlyBuildRequired = true)]
         public async Task Routes_ClusterAdmin()
         {
             var certificates = Certificates.SetupServerAuthentication();

--- a/test/SlowTests/Monitoring/DiskStatsGetterTest.cs
+++ b/test/SlowTests/Monitoring/DiskStatsGetterTest.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Monitoring
         {
         }
 
-        [RavenMultiplatformFact(RavenTestCategory.Linux, RavenPlatform.Linux, NightlyBuildOnly = true)]
+        [RavenMultiplatformFact(RavenTestCategory.Linux, RavenPlatform.Linux, NightlyBuildRequired = true)]
         public async Task LinuxDiskStats_WhenGetInParallel_ShouldTakeTheSameAsSequential()
         {
 #pragma warning disable CA1416

--- a/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
@@ -65,13 +65,14 @@ loadToRegions({
     Territories: {Type: 'Array', Value: this.Territories}
 });
 ";
-    
+
+    private const string SnowflakeRoleForTestsName = "RAVENDB_TEST_ADMIN";
     
     private static DisposableAction WithSnowflakeDatabase(out string connectionString, out string databaseName, out string schemaName)
     {
         databaseName = "snowflake_test_" + Guid.NewGuid();
         schemaName = "snowflake_test_" + Guid.NewGuid();
-        var rawConnectionString = TestSnowflakeConnectionString.Instance.VerifiedConnectionString.Value;
+        var rawConnectionString = $"{TestSnowflakeConnectionString.Instance.VerifiedConnectionString.Value}ROLE={SnowflakeRoleForTestsName};"; 
         
         if(string.IsNullOrEmpty(rawConnectionString))
             throw new InvalidOperationException("The connection string for Snowflake db is null");

--- a/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Snowflake/SnowflakeEtlTests.cs
@@ -210,7 +210,7 @@ loadToRegions({
         CreateSnowflakeTable(connectionString, "create or replace TABLE ORDERS (\n\tID STRING,\n\tNAME STRING,\n\tPIC BINARY\n);");
     }
     
-    [RavenRetryFact(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     public async Task CanUseSnowflakeEtl()
     {
         using (var store = GetDocumentStore())
@@ -256,7 +256,7 @@ loadToRegions({
         }
     }
     
-    [RavenRetryFact(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     public async Task CanUseSnowflakeEtlForArrayData()
     {
         using (var store = GetDocumentStore())
@@ -282,7 +282,7 @@ loadToRegions({
     }
     
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task ShouldHandleCaseMismatchBetweenTableDefinitionAndLoadTo(RavenDatabaseMode databaseMode)
@@ -333,7 +333,7 @@ loadToOrDerS(orderData); // note 'OrDerS' here vs 'Orders' defined in the config
     }
     
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task NullPropagation(RavenDatabaseMode databaseMode)
@@ -377,7 +377,7 @@ loadToOrders(orderData);");
         }
     }
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task NullPropagation_WithExplicitNull(RavenDatabaseMode databaseMode)
@@ -429,7 +429,7 @@ loadToOrders(orderData);");
         }
     }
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task RavenDB_3341(RavenDatabaseMode databaseMode)
@@ -468,7 +468,7 @@ loadToOrders(orderData);");
         }
     }
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task CanUpdateToBeNoItemsInChildTable(RavenDatabaseMode databaseMode)
@@ -515,7 +515,7 @@ loadToOrders(orderData);");
     }
     
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task RavenDB_3172(RavenDatabaseMode databaseMode)
@@ -562,7 +562,7 @@ loadToOrders(orderData);");
         }
     }
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task WillLog(RavenDatabaseMode databaseMode)
@@ -635,7 +635,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
     }
     
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single, true)]
     [InlineData(RavenDatabaseMode.Single, false)]
     [InlineData(RavenDatabaseMode.Sharded, true)]
@@ -720,7 +720,7 @@ var nameArr = this.StepName.split('.'); loadToOrders({});");
     }
     
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task VarcharAndNVarcharFunctionsArentAvailable(RavenDatabaseMode databaseMode)
@@ -814,7 +814,7 @@ output(result);
         }
     }
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single, true)]
     [InlineData(RavenDatabaseMode.Single, false)]
     [InlineData(RavenDatabaseMode.Sharded, true)]
@@ -893,7 +893,7 @@ output(result);
         }
     }
 
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task Should_not_error_if_attachment_doesnt_exist(RavenDatabaseMode databaseMode)
@@ -962,7 +962,7 @@ loadToOrders(orderData);
         }
     }
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task LoadingMultipleAttachments(RavenDatabaseMode databaseMode)
@@ -1033,7 +1033,7 @@ for (var i = 0; i < attachments.length; i++)
     }
 
 
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task CanSkipSettingFieldIfAttachmentDoesntExist(RavenDatabaseMode databaseMode)
@@ -1086,7 +1086,7 @@ loadToOrders(orderData);
         }
     }
     
-    [RavenRetryTheory(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     [InlineData(RavenDatabaseMode.Single)]
     [InlineData(RavenDatabaseMode.Sharded)]
     public async Task LoadingFromMultipleCollections(RavenDatabaseMode databaseMode)
@@ -1135,7 +1135,7 @@ loadToOrders(orderData);
         }
     }
     
-    [RavenRetryFact(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     public void Should_stop_batch_if_size_limit_exceeded_RavenDB_12800()
     {
         using (var store = GetDocumentStore(new Options { ModifyDatabaseRecord = x => x.Settings[RavenConfiguration.GetKey(c => c.Etl.MaxBatchSize)] = "5" }))
@@ -1192,7 +1192,7 @@ loadToOrders(orderData);
         }
     }
     
-    [RavenRetryFact(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     public async Task CanLoadSingleAttachment()
     {
         using (var store = GetDocumentStore())
@@ -1247,7 +1247,7 @@ loadToOrders(orderData);
     }
 
 
-    [RavenRetryFact(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     public async Task CanDelete()
     {
         using (var store = GetDocumentStore(Options.ForMode(RavenDatabaseMode.Single)))
@@ -1288,7 +1288,7 @@ loadToOrders(orderData);
         }
     }
     
-    [RavenRetryFact(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     public async Task ShouldImportTask()
     {
         using (var srcStore = GetDocumentStore())
@@ -1325,7 +1325,7 @@ loadToOrders(orderData);
         }
     }
 
-    [RavenRetryFact(RavenTestCategory.Etl, delayBetweenRetriesMs: 1000, SnowflakeRequired = true, NightlyBuildRequired = true)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl, RavenPlatform.Windows, RavenArchitecture.X64,  SnowflakeRequired = true, NightlyBuildRequired = true)]
     public void SnowflakeConnectionStringAuditJsonShouldnNotContainCredentials()
     {
         SnowflakeConnectionString cs = new() { ConnectionString = "secret", Name = "Test" };

--- a/test/Tests.Infrastructure/NightlyBuildMultiplatformFactAttribute.cs
+++ b/test/Tests.Infrastructure/NightlyBuildMultiplatformFactAttribute.cs
@@ -48,7 +48,7 @@ namespace Tests.Infrastructure
                 if (skip != null)
                     return skip;
 
-                return RavenMultiplatformFactAttribute.ShouldSkip(_platform, _architecture, _intrinsics, LicenseRequired, NightlyBuildOnly);
+                return RavenMultiplatformFactAttribute.ShouldSkip(_platform, _architecture, _intrinsics, LicenseRequired, NightlyBuildOnly, false);
             }
             set => _skip = value;
         }

--- a/test/Tests.Infrastructure/NightlyBuildMultiplatformTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/NightlyBuildMultiplatformTheoryAttribute.cs
@@ -38,7 +38,7 @@
                 if (skip != null)
                     return skip;
 
-                return RavenMultiplatformFactAttribute.ShouldSkip(_platform, _architecture, _intrinsics, LicenseRequired, nightlyBuildOnly: true);
+                return RavenMultiplatformFactAttribute.ShouldSkip(_platform, _architecture, _intrinsics, LicenseRequired, nightlyBuildOnly: true, snowflakeRequired: false);
             }
         }
     }

--- a/test/Tests.Infrastructure/RavenMultiplatformFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenMultiplatformFactAttribute.cs
@@ -84,8 +84,6 @@ public class RavenMultiplatformFactAttribute : RavenFactAttribute
         _intrinsics = intrinsics;
     }
 
-    public bool NightlyBuildOnly { get; set; }
-
     public override string Skip
     {
         get
@@ -94,18 +92,21 @@ public class RavenMultiplatformFactAttribute : RavenFactAttribute
             if (skip != null)
                 return skip;
 
-            return ShouldSkip(_platform, _architecture, _intrinsics, LicenseRequired, NightlyBuildOnly);
+            return ShouldSkip(_platform, _architecture, _intrinsics, LicenseRequired, NightlyBuildRequired, SnowflakeRequired);
         }
         set => _skip = value;
     }
 
-    internal static string ShouldSkip(RavenPlatform platform, RavenArchitecture architecture, RavenIntrinsics intrinsics, bool licenseRequired, bool nightlyBuildOnly)
+    internal static string ShouldSkip(RavenPlatform platform, RavenArchitecture architecture, RavenIntrinsics intrinsics, bool licenseRequired, bool nightlyBuildOnly, bool snowflakeRequired)
     {
         if (licenseRequired && LicenseRequiredFactAttribute.ShouldSkip())
             return LicenseRequiredFactAttribute.SkipMessage;
 
         if (nightlyBuildOnly && NightlyBuildTheoryAttribute.IsNightlyBuild == false)
             return NightlyBuildTheoryAttribute.SkipMessage;
+        
+        if (snowflakeRequired && SnowflakeHelper.ShouldSkip(out string skip))
+            return skip;
 
         var matchesPlatform = Match(platform);
         var matchesArchitecture = Match(architecture);

--- a/test/Tests.Infrastructure/RavenMultiplatformTheoryAttribute.cs
+++ b/test/Tests.Infrastructure/RavenMultiplatformTheoryAttribute.cs
@@ -42,8 +42,6 @@ public class RavenMultiplatformTheoryAttribute : RavenTheoryAttribute
         _intrinsics = intrinsics;
     }
 
-    public bool NightlyBuildOnly { get; set; }
-
     public override string Skip
     {
         get
@@ -52,7 +50,7 @@ public class RavenMultiplatformTheoryAttribute : RavenTheoryAttribute
             if (skip != null)
                 return skip;
 
-            return RavenMultiplatformFactAttribute.ShouldSkip(_platform, _architecture, _intrinsics, LicenseRequired, NightlyBuildOnly);
+            return RavenMultiplatformFactAttribute.ShouldSkip(_platform, _architecture, _intrinsics, LicenseRequired, NightlyBuildRequired, SnowflakeRequired);
         }
         set => _skip = value;
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23368/Run-Snowflake-tests-only-on-one-platform

### Additional description

Improvement of  https://issues.hibernatingrhinos.com/issue/RavenDB-23279/Run-Snowflake-tests-only-nightly (https://github.com/ravendb/ravendb/pull/19772). Let's run Snowflake tests not only nightly, but also on single platform. 
Also, fixed Snowflake RBAC issues.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
