### PR TITLE
RavenDB-23344 7.0 Admin Logs: Settings should have default levels set

### DIFF
--- a/src/Raven.Studio/typescript/components/common/ConditionalPopover.tsx
+++ b/src/Raven.Studio/typescript/components/common/ConditionalPopover.tsx
@@ -2,19 +2,21 @@ import React, { ReactNode, PropsWithChildren } from "react";
 import { PopoverBody, UncontrolledPopover } from "reactstrap";
 import useUniqueId from "components/hooks/useUniqueId";
 import { Placement } from "@popperjs/core";
+import { ClassNameProps } from "components/models/common";
+import classNames from "classnames";
 
 interface Condition {
     isActive: boolean;
     message?: ReactNode | ReactNode[];
 }
 
-interface ConditionalPopoverProps extends Required<PropsWithChildren> {
+interface ConditionalPopoverProps extends Required<PropsWithChildren>, ClassNameProps {
     conditions: Condition | Condition[];
     popoverPlacement?: Placement;
 }
 
 export function ConditionalPopover(props: ConditionalPopoverProps) {
-    const { children, popoverPlacement } = props;
+    const { children, popoverPlacement, className } = props;
 
     const containerId = useUniqueId("conditional-popover-");
 
@@ -23,7 +25,7 @@ export function ConditionalPopover(props: ConditionalPopoverProps) {
 
     return (
         <>
-            <div id={containerId} className="d-flex w-fit-content">
+            <div id={containerId} className={classNames("d-flex w-fit-content", className)}>
                 {children}
             </div>
 

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/bits/AdminLogsFilterField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/bits/AdminLogsFilterField.tsx
@@ -1,31 +1,80 @@
+import { ConditionalPopover } from "components/common/ConditionalPopover";
 import { FormSelect, FormInput } from "components/common/Form";
 import { Icon } from "components/common/Icon";
+import { SelectOption } from "components/common/select/Select";
 import { AdminLogsConfigLogsFormData } from "components/pages/resources/manageServer/adminLogs/disk/settings/AdminLogsConfigLogs";
 import { AdminLogsViewSettingsFormData } from "components/pages/resources/manageServer/adminLogs/view/AdminLogsViewSettingsModal";
-import { logLevelOptions, logFilterActionOptions } from "components/utils/common";
-import { Control } from "react-hook-form";
+import { logLevelOptions, logFilterActionOptions, logLevelRelevances } from "components/utils/common";
+import { Control, useWatch } from "react-hook-form";
+import { components, OptionProps } from "react-select";
 import { Row, Col, FormGroup, Label, Button, UncontrolledPopover, Card, InputGroup } from "reactstrap";
 
+type FormData = AdminLogsViewSettingsFormData | AdminLogsConfigLogsFormData;
+
+interface LevelOptionProps extends SelectOption {
+    isDisabled?: boolean;
+    level?: "max" | "min";
+}
+
 interface AdminLogsFilterFieldProps {
-    control: Control<AdminLogsViewSettingsFormData | AdminLogsConfigLogsFormData>;
+    control: Control<FormData>;
     idx: number;
     remove: () => void;
 }
 
 export default function AdminLogsFilterField({ control, idx, remove }: AdminLogsFilterFieldProps) {
+    const formValues = useWatch({ control });
+
+    const maxLevel = formValues.filters[idx].maxLevel;
+    const minLevel = formValues.filters[idx].minLevel;
+
+    const getMinLevelOptions = (): LevelOptionProps[] => {
+        if (maxLevel) {
+            return logLevelOptions.map((option) => ({
+                ...option,
+                level: "min",
+                isDisabled: logLevelRelevances[option.value] > logLevelRelevances[maxLevel],
+            }));
+        }
+
+        return logLevelOptions;
+    };
+
+    const getMaxLevelOptions = (): LevelOptionProps[] => {
+        if (minLevel) {
+            return logLevelOptions.map((option) => ({
+                ...option,
+                level: "max",
+                isDisabled: logLevelRelevances[option.value] < logLevelRelevances[minLevel],
+            }));
+        }
+
+        return logLevelOptions;
+    };
+
     return (
         <Card color="faded-info" className="p-3 rounded">
             <Row>
                 <Col md={4}>
                     <FormGroup className="flex-grow-1">
                         <Label>Minimum level</Label>
-                        <FormSelect control={control} name={`filters.${idx}.minLevel`} options={logLevelOptions} />
+                        <FormSelect
+                            control={control}
+                            name={`filters.${idx}.minLevel`}
+                            options={getMinLevelOptions()}
+                            components={{ Option: LevelOption }}
+                        />
                     </FormGroup>
                 </Col>
                 <Col md={4}>
                     <FormGroup className="flex-grow-1">
                         <Label>Maximum level</Label>
-                        <FormSelect control={control} name={`filters.${idx}.maxLevel`} options={logLevelOptions} />
+                        <FormSelect
+                            control={control}
+                            name={`filters.${idx}.maxLevel`}
+                            options={getMaxLevelOptions()}
+                            components={{ Option: LevelOption }}
+                        />
                     </FormGroup>
                 </Col>
                 <Col md={4}>
@@ -64,5 +113,34 @@ export default function AdminLogsFilterField({ control, idx, remove }: AdminLogs
                 </InputGroup>
             </div>
         </Card>
+    );
+}
+
+export function LevelOption(props: OptionProps<LevelOptionProps>) {
+    const { data } = props;
+
+    const getDisabledReason = (): string => {
+        if (!data.isDisabled) {
+            return null;
+        }
+        if (data.level === "min") {
+            return "The minimum level cannot be higher than the maximum level";
+        }
+        if (data.level === "max") {
+            return "The maximum level cannot be lower than the minimum level";
+        }
+    };
+
+    return (
+        <ConditionalPopover
+            conditions={{
+                isActive: data.isDisabled,
+                message: getDisabledReason(),
+            }}
+            popoverPlacement="top"
+            className="w-100"
+        >
+            <components.Option {...props}>{data.label}</components.Option>
+        </ConditionalPopover>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/common/adminLogsUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/common/adminLogsUtils.ts
@@ -1,0 +1,20 @@
+import * as yup from "yup";
+
+const filterSchema = yup.object({
+    minLevel: yup.string<Sparrow.Logging.LogLevel>().nullable().required(),
+    maxLevel: yup.string<Sparrow.Logging.LogLevel>().nullable().required(),
+    condition: yup.string().nullable().required(),
+    action: yup.string<Sparrow.Logging.LogFilterAction>().nullable().required(),
+});
+
+const initialFilter: yup.InferType<typeof filterSchema> = {
+    minLevel: "Trace",
+    maxLevel: "Fatal",
+    condition: null,
+    action: null,
+};
+
+export const adminLogsUtils = {
+    filtersSchema: yup.array().of(filterSchema),
+    initialFilter,
+};

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/disk/settings/AdminLogsConfigLogs.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/disk/settings/AdminLogsConfigLogs.tsx
@@ -28,6 +28,7 @@ import {
 import { useAppDispatch, useAppSelector } from "components/store";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
 import AdminLogsPersistInfoIcon from "components/pages/resources/manageServer/adminLogs/bits/AdminLogsPersistInfoIcon";
+import { adminLogsUtils } from "components/pages/resources/manageServer/adminLogs/common/adminLogsUtils";
 
 export default function AdminLogsConfigLogs({ targetId }: { targetId: string }) {
     const dispatch = useAppDispatch();
@@ -103,14 +104,7 @@ export default function AdminLogsConfigLogs({ targetId }: { targetId: string }) 
                             type="button"
                             color="info"
                             className="w-fit-content"
-                            onClick={() =>
-                                filterFieldArray.append({
-                                    minLevel: null,
-                                    maxLevel: null,
-                                    condition: null,
-                                    action: null,
-                                })
-                            }
+                            onClick={() => filterFieldArray.append(adminLogsUtils.initialFilter)}
                         >
                             <Icon icon="plus" />
                             Add Filter
@@ -179,14 +173,7 @@ const schema = yup.object({
     minLevel: yup.string<Sparrow.Logging.LogLevel>().nullable().required(),
     isPersist: yup.boolean(),
     logFilterDefaultAction: yup.string<Sparrow.Logging.LogFilterAction>().nullable().required(),
-    filters: yup.array().of(
-        yup.object({
-            minLevel: yup.string<Sparrow.Logging.LogLevel>().nullable().required(),
-            maxLevel: yup.string<Sparrow.Logging.LogLevel>().nullable().required(),
-            condition: yup.string().nullable().required(),
-            action: yup.string<Sparrow.Logging.LogFilterAction>().nullable().required(),
-        })
-    ),
+    filters: adminLogsUtils.filtersSchema,
 });
 
 export type AdminLogsConfigLogsFormData = yup.InferType<typeof schema>;

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/view/AdminLogsViewSettingsModal.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/view/AdminLogsViewSettingsModal.tsx
@@ -5,6 +5,7 @@ import { Icon } from "components/common/Icon";
 import { useDirtyFlag } from "components/hooks/useDirtyFlag";
 import { useServices } from "components/hooks/useServices";
 import AdminLogsFilterField from "components/pages/resources/manageServer/adminLogs/bits/AdminLogsFilterField";
+import { adminLogsUtils } from "components/pages/resources/manageServer/adminLogs/common/adminLogsUtils";
 import {
     adminLogsActions,
     adminLogsSelectors,
@@ -79,14 +80,7 @@ export default function AdminLogsViewSettingsModal() {
                             type="button"
                             color="info"
                             className="w-fit-content"
-                            onClick={() =>
-                                filterFieldArray.append({
-                                    minLevel: null,
-                                    maxLevel: null,
-                                    condition: null,
-                                    action: null,
-                                })
-                            }
+                            onClick={() => filterFieldArray.append(adminLogsUtils.initialFilter)}
                         >
                             <Icon icon="plus" />
                             Add Filter
@@ -115,14 +109,7 @@ export default function AdminLogsViewSettingsModal() {
 
 const schema = yup.object({
     logFilterDefaultAction: yup.string<Sparrow.Logging.LogFilterAction>().required(),
-    filters: yup.array().of(
-        yup.object({
-            minLevel: yup.string<Sparrow.Logging.LogLevel>().nullable().required(),
-            maxLevel: yup.string<Sparrow.Logging.LogLevel>().nullable().required(),
-            condition: yup.string().nullable().required(),
-            action: yup.string<Sparrow.Logging.LogFilterAction>().nullable().required(),
-        })
-    ),
+    filters: adminLogsUtils.filtersSchema,
 });
 
 export type AdminLogsViewSettingsFormData = yup.InferType<typeof schema>;

--- a/src/Raven.Studio/typescript/components/utils/common.ts
+++ b/src/Raven.Studio/typescript/components/utils/common.ts
@@ -137,6 +137,16 @@ export const allLogLevels = exhaustiveStringTuple<Sparrow.Logging.LogLevel>()(
     "Fatal"
 );
 
+export const logLevelRelevances: Record<Sparrow.Logging.LogLevel, number> = {
+    Off: 0,
+    Trace: 1,
+    Debug: 2,
+    Info: 3,
+    Warn: 4,
+    Error: 5,
+    Fatal: 6,
+};
+
 export const allLogFilterActions = exhaustiveStringTuple<Sparrow.Logging.LogFilterAction>()(
     "Ignore",
     "IgnoreFinal",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23344/7.0-Admin-Logs-Settings-should-have-default-levels-set

### Additional description

Sets default filter values for min/max level
Disable options depending on selected min/max level

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
