### PR TITLE
RavenDB-23363 Lucene StandardAnalyzer is treated as known instead of custom in search method with wildcards.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -11,6 +11,7 @@ using Corax.Querying.Matches.Meta;
 using Corax.Querying.Matches.SortingMatches.Meta;
 using Corax.Utils;
 using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.Standard;
 using NetTopologySuite.Utilities;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Corax;
@@ -1225,7 +1226,7 @@ public static class CoraxQueryBuilder
                     KeywordAnalyzer keywordAnalyzer => builderParameters.IndexFieldsMapping.ExactAnalyzer(original.FieldName.ToString()),
                     // here we force a lower case keyword analyzer to ensure proper behavior
                     // https://ayende.com/blog/191841-B/understanding-query-processing-and-wildcards-in-ravendb
-                    RavenStandardAnalyzer or NGramAnalyzer => builderParameters.IndexFieldsMapping.DefaultAnalyzer,
+                    RavenStandardAnalyzer or NGramAnalyzer or StandardAnalyzer => builderParameters.IndexFieldsMapping.DefaultAnalyzer,
                     LowerCaseKeywordAnalyzer or CollationAnalyzer => builderParameters.IndexFieldsMapping.DefaultAnalyzer,
                     // if the user has a custom analyzer, we'll use that, and they can deal with any surprises
                     // in wildcard queries

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1226,7 +1226,8 @@ public static class CoraxQueryBuilder
                     KeywordAnalyzer keywordAnalyzer => builderParameters.IndexFieldsMapping.ExactAnalyzer(original.FieldName.ToString()),
                     // here we force a lower case keyword analyzer to ensure proper behavior
                     // https://ayende.com/blog/191841-B/understanding-query-processing-and-wildcards-in-ravendb
-                    RavenStandardAnalyzer or NGramAnalyzer or StandardAnalyzer => builderParameters.IndexFieldsMapping.DefaultAnalyzer,
+                    RavenStandardAnalyzer or NGramAnalyzer => builderParameters.IndexFieldsMapping.DefaultAnalyzer,
+                    StandardAnalyzer when laa.Analyzer.GetType() == typeof(StandardAnalyzer) => builderParameters.IndexFieldsMapping.DefaultAnalyzer,
                     LowerCaseKeywordAnalyzer or CollationAnalyzer => builderParameters.IndexFieldsMapping.DefaultAnalyzer,
                     // if the user has a custom analyzer, we'll use that, and they can deal with any surprises
                     // in wildcard queries

--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Lucene.Net.Analysis;
+using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Analysis.Tokenattributes;
 using Lucene.Net.Index;
 using Lucene.Net.Search;
@@ -189,7 +190,7 @@ namespace Raven.Server.Documents.Queries
                     KeywordAnalyzer keywordAnalyzer => keywordAnalyzer,
                     // here we force a lower case keyword analyzer to ensure proper behavior
                     // https://ayende.com/blog/191841-B/understanding-query-processing-and-wildcards-in-ravendb
-                    RavenStandardAnalyzer or NGramAnalyzer => WildcardAnalyzer.Value,
+                    RavenStandardAnalyzer or NGramAnalyzer or StandardAnalyzer => WildcardAnalyzer.Value,
                     LowerCaseKeywordAnalyzer or CollationAnalyzer => analyzer,
                     // if the user has a custom analyzer, we'll use that, and they can deal with any surprises
                     // in wildcard queries

--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -190,7 +190,8 @@ namespace Raven.Server.Documents.Queries
                     KeywordAnalyzer keywordAnalyzer => keywordAnalyzer,
                     // here we force a lower case keyword analyzer to ensure proper behavior
                     // https://ayende.com/blog/191841-B/understanding-query-processing-and-wildcards-in-ravendb
-                    RavenStandardAnalyzer or NGramAnalyzer or StandardAnalyzer => WildcardAnalyzer.Value,
+                    RavenStandardAnalyzer or NGramAnalyzer => WildcardAnalyzer.Value,
+                    StandardAnalyzer when analyzerToUse.GetType() == typeof(StandardAnalyzer) => WildcardAnalyzer.Value,
                     LowerCaseKeywordAnalyzer or CollationAnalyzer => analyzer,
                     // if the user has a custom analyzer, we'll use that, and they can deal with any surprises
                     // in wildcard queries

--- a/test/SlowTests/Issues/RavenDB-23363.cs
+++ b/test/SlowTests/Issues/RavenDB-23363.cs
@@ -1,0 +1,49 @@
+﻿using System.Linq;
+using FastTests;
+using Lucene.Net.Analysis.Standard;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23363(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void LuceneStandardAnalyzerIsTreatedAsKnownInsteadOfCustomInSearchMethodWithWildcards(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Store(new Document(){Name = "qwerty"});
+        session.Store(new Document(){Name = "qwertz"});
+        session.SaveChanges();
+        new Index().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        var results = session.Query<Document, Index>().Search(x => x.Name, "qwert*").ToList();
+        Assert.Equal(2, results.Count);
+
+        results = session.Query<Document, Index>().Search(x => x.Name, "*z").ToList();
+        Assert.Equal(1, results.Count);
+
+        results = session.Query<Document, Index>().Search(x => x.Name, "*wer*").ToList();
+        Assert.Equal(2, results.Count);
+    }
+
+    private class Index : AbstractIndexCreationTask<Document>
+    {
+        public Index()
+        {
+            Map = documents => documents.Select(d => new { d.Name });
+            Analyze(x => x.Name, nameof(StandardAnalyzer));
+        }
+    }
+
+    private class Document
+    {
+        public string Name { get; set; }
+    }
+}

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -91,7 +91,7 @@ namespace SlowTests.Tests
 
             var array = types.ToArray();
 
-            const int numberToTolerate = 4544;
+            const int numberToTolerate = 4539;
 
             if (array.Length == numberToTolerate)
                 return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23363

### Additional description

This PR adds Lucene StandardAnalyzer as known and allows performing wildcard queries, adjusting the changes made in: https://github.com/ravendb/ravendb/pull/17288

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
