### PR TITLE
RavenDB-23314: skip high allocating tests on 32Bits

### DIFF
--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -189,11 +189,17 @@ namespace SlowTests.Cluster
             return new string(str);
         }
 
-        [Theory]
+        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
         [InlineData(1)]
+        public async Task CanPreformSeveralClusterTransactions(int numberOfNodes)
+        {
+            await CanPreformSeveralClusterTransactions_X64(1);
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi, RavenArchitecture.AllX64)]
         [InlineData(3)]
         [InlineData(5)]
-        public async Task CanPreformSeveralClusterTransactions(int numberOfNodes)
+        public async Task CanPreformSeveralClusterTransactions_X64(int numberOfNodes)
         {
             var numOfSessions = 10;
             var docsPerSession = 2;
@@ -2109,7 +2115,7 @@ select incl(c)"
             }
         }
 
-        [RavenTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi)]
+        [RavenMultiplatformTheory(RavenTestCategory.ClusterTransactions | RavenTestCategory.ClientApi, RavenArchitecture.AllX64)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public async Task ClusterWideTrx_WhenExecutedBatchExceedsSpaceLimit_ShouldStoreAllDocumentsSuccessfully(Options options)
         {

--- a/test/SlowTests/Cluster/CompareExchangeTests.cs
+++ b/test/SlowTests/Cluster/CompareExchangeTests.cs
@@ -22,7 +22,7 @@ public class CompareExchangeTests : RavenTestBase
     {
     }
     
-    [RavenFact(RavenTestCategory.CompareExchange)]
+    [RavenMultiplatformFact(RavenTestCategory.CompareExchange, RavenArchitecture.AllX64)]
     public async Task AddOrUpdateCompareExchangeCommand_WhenCommandSentTwice_SecondAttemptShouldNotReturnNull()
     {
         var leader = GetNewServer();

--- a/test/SlowTests/Tests/TestsInheritanceTests.cs
+++ b/test/SlowTests/Tests/TestsInheritanceTests.cs
@@ -88,7 +88,7 @@ namespace SlowTests.Tests
                         select method;
 
             var array = types.ToArray();
-            const int numberToTolerate = 6395;
+            const int numberToTolerate = 6394;
             if (array.Length == numberToTolerate)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23314

### Additional description

Skipped tests that were high allocating (~1GB) on 32bits

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
