### PR TITLE
RavenDB-29492 Fix issue for message batch id and test connection

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestAmazonSqsConnection.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestAmazonSqsConnection.cs
@@ -46,7 +46,7 @@ internal sealed class
                     context.Write(writer, result);
                 }
             }
-            catch (AmazonSQSException ex) when (ex.ErrorCode.Contains("AWS.SimpleQueueService.NonExistentQueue"))
+            catch (AmazonSQSException ex) when (ex.ErrorCode.Contains("NonExistentQueue"))
             {
                 // In this case, it means the connection is valid but the queue is not accessible
                 DynamicJsonValue result = new() { [nameof(NodeConnectionTestResult.Success)] = true };

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestAmazonSqsConnection.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestAmazonSqsConnection.cs
@@ -46,7 +46,7 @@ internal sealed class
                     context.Write(writer, result);
                 }
             }
-            catch (AmazonSQSException ex) when (ex.ErrorCode == "AWS.SimpleQueueService.NonExistentQueue")
+            catch (AmazonSQSException ex) when (ex.ErrorCode.Contains("AWS.SimpleQueueService.NonExistentQueue"))
             {
                 // In this case, it means the connection is valid but the queue is not accessible
                 DynamicJsonValue result = new() { [nameof(NodeConnectionTestResult.Success)] = true };

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestAmazonSqsConnection.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Handlers/Processors/QueueEtlHandlerProcessorForTestAmazonSqsConnection.cs
@@ -46,7 +46,7 @@ internal sealed class
                     context.Write(writer, result);
                 }
             }
-            catch (AmazonSQSException ex) when (ex.ErrorCode == "QueueDoesNotExist")
+            catch (AmazonSQSException ex) when (ex.ErrorCode == "AWS.SimpleQueueService.NonExistentQueue")
             {
                 // In this case, it means the connection is valid but the queue is not accessible
                 DynamicJsonValue result = new() { [nameof(NodeConnectionTestResult.Success)] = true };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22429/ETL-to-AWS-SQS

### Additional description

Fix issue with test connection string and sending messages in a batch

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
