### PR TITLE
RavenDB-23467 - Add the GC mark time and size

### DIFF
--- a/src/Raven.Server/EventListener/EventListener.cs
+++ b/src/Raven.Server/EventListener/EventListener.cs
@@ -18,6 +18,7 @@ public class EventListener
                 public const string GCFinalizersEnd = "GCFinalizersEnd_V1";
                 public const string GCJoin = "GCJoin_V2";
                 public const string GCHeapStats = "GCHeapStats_V2";
+                public const string GCMarkWithType = "GCMarkWithType";
             }
 
             public class Allocations

--- a/test/FastTests/Server/DebugMemoryTests.cs
+++ b/test/FastTests/Server/DebugMemoryTests.cs
@@ -20,6 +20,9 @@ public class DebugMemoryTests : NoDisposalNeeded
         Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCEnd == "GCEnd_V1",
             "Check if GCEnd event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
 
+        Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCMarkWithType == "GCMarkWithType",
+            "Check if GCEnd event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
+
         Assert.True(Environment.Version.Major == 8 && EventListener.Constants.EventNames.GC.GCSuspendBegin == "GCSuspendEEBegin_V1",
             "Check if GCSuspendBegin event was updated: https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gcevents.h");
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23467/Add-the-GC-mark-time-and-size

### Additional description

Add the GC mark time and size to the event listener log.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
