### PR TITLE
RavenDB-23477 Add info about All Revisions view in the Document Revisions view

### DIFF
--- a/src/Raven.Studio/typescript/common/appUrl.ts
+++ b/src/Raven.Studio/typescript/common/appUrl.ts
@@ -455,7 +455,7 @@ class appUrl {
         return "#databases/documents?" + collectionPart + appUrl.getEncodedDbPart(db);
     }
 
-    static forAllRevisions(db: database): string {
+    static forAllRevisions(db: database | string): string {
         const databasePart = appUrl.getEncodedDbPart(db);
         return "#databases/documents/revisions/all?" + databasePart;
     }

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -66,6 +66,9 @@ export default function DocumentRevisions() {
         licenseSelectors.statusValue("MaxNumberOfRevisionAgeToKeepInDays")
     );
 
+    const { appUrl } = useAppUrls();
+    const activeDatabaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+
     const featureAvailability = useLimitedFeatureAvailability({
         defaultFeatureAvailability,
         overwrites: [
@@ -371,7 +374,10 @@ export default function DocumentRevisions() {
                                 <div>
                                     A document revision will be created when:
                                     <ul>
-                                        <li>Revisions are defined and enabled for the document&apos;s collection.</li>
+                                        <li>
+                                            Revisions configuration is defined and enabled for the document&apos;s
+                                            collection.
+                                        </li>
                                         <li>The document has been modified.</li>
                                     </ul>
                                 </div>
@@ -405,6 +411,14 @@ export default function DocumentRevisions() {
                                             per collection.
                                         </li>
                                     </ul>
+                                </div>
+                                <div>
+                                    All document revisions that are created are listed in the{" "}
+                                    <a href={appUrl.forAllRevisions(activeDatabaseName)} target="_blank">
+                                        {" "}
+                                        All Revisions{" "}
+                                    </a>{" "}
+                                    view.
                                 </div>
                                 <hr />
                                 <div className="small-label mb-2">useful links</div>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
@@ -25,6 +25,8 @@ import { licenseSelectors } from "components/common/shell/licenseSlice";
 import moment from "moment";
 import RichAlert from "components/common/RichAlert";
 import useEditRevisionFormSideEffects from "components/pages/database/settings/documentRevisions/useEditRevisionFormSideEffects";
+import { useAppUrls } from "hooks/useAppUrls";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 
 const revisionsDelta = 100;
 const revisionsByAgeDelta = 604800; // 7 days
@@ -106,6 +108,9 @@ export default function EditRevision(props: EditRevisionProps) {
         !isDefaultConflicts &&
         ((revisionsAgeInDaysLimit > 0 && minimumRevisionAgeToKeepDays > revisionsAgeInDaysLimit) ||
             (revisionsToKeepLimit > 0 && formValues.minimumRevisionsToKeep > revisionsToKeepLimit));
+
+    const { appUrl } = useAppUrls();
+    const activeDatabaseName = useAppSelector(databaseSelectors.activeDatabaseName);
 
     return (
         <Modal isOpen toggle={toggle} wrapClassName="bs5" contentClassName="modal-border bulge-info" centered>
@@ -201,13 +206,20 @@ export default function EditRevision(props: EditRevisionProps) {
                     <RichAlert variant="primary" title="Summary" className="mt-2">
                         <ul className="m-0 ps-2 vstack gap-1">
                             <li>
-                                A revision will be created anytime a document is modified
+                                A revision will be created anytime a document is created, modified,
                                 {!formValues.isPurgeOnDeleteEnabled && <span> or deleted</span>}.
                             </li>
                             {formValues.isPurgeOnDeleteEnabled ? (
                                 <li>When a document is deleted all its revisions will be removed.</li>
                             ) : (
-                                <li>Revisions of a deleted document can be accessed in the Revisions Bin view.</li>
+                                <li>
+                                    Revisions of a deleted document can be accessed in the{" "}
+                                    <a href={appUrl.forRevisionsBin(activeDatabaseName)} target="_blank">
+                                        {" "}
+                                        Revisions Bin{" "}
+                                    </a>{" "}
+                                    view.
+                                </li>
                             )}
                             {formValues.minimumRevisionsToKeep > 0 && (
                                 <>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23477/Add-info-about-All-Revisions-view-in-the-Document-Revisions-view

### Additional description
Add info in the "About this view" + inner links

### Type of change
- [x] Bug fix - Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
