### PR TITLE
RavenDB-23446 Support for converting an auto-index with a vector field into a static index.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-23446.cs
+++ b/test/SlowTests/Issues/RavenDB-23446.cs
@@ -1,0 +1,197 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Documents.Handlers.Processors.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23446(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Vector)]
+    public async Task CanConvertVectorFieldToStaticField()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.Query<Dto>()
+                .VectorSearch(x => x.WithField(p => p.Vector), v => v.ByEmbedding([1f, 2f]))
+                .ToListAsync();
+        }
+
+        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+        var autoIndex = record.AutoIndexes.Values.First();
+        var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex);
+        RavenTestHelper.AssertEqualRespectingNewLines(@"public class Index_Dtos_ByVector_search_Vector_ : Raven.Client.Documents.Indexes.AbstractIndexCreationTask<Dto>
+{
+    public Index_Dtos_ByVector_search_Vector_()
+    {
+        Map = items => from item in items
+                       select new
+                       {
+                           Vector = CreateVector(item.Vector)
+                       };
+
+        Vector(""Vector"", factory => factory.SourceEmbedding(VectorEmbeddingType.Single).DestinationEmbedding(VectorEmbeddingType.Single));
+    }
+}
+", result);
+        
+        var def = AutoToStaticIndexConverter.Instance.ConvertToIndexDefinition(autoIndex);
+
+        await store.Maintenance.SendAsync(new PutIndexesOperation(def));
+        await store.Maintenance.SendAsync(new DeleteIndexOperation(def.Name));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var command = new RavenDB_22498.ConvertAutoIndexCommand(autoIndex.Name);
+            await store.GetRequestExecutor().ExecuteAsync(command, session.Advanced.Context);
+
+            var def2 = command.Result;
+            
+            // We accept that fields are different (since vector objects in AutoIndexes and Static indexes have different configuration objects, so we will check it manually).
+            Assert.Equal(IndexDefinitionCompareDifferences.Fields, def.Compare(def2));
+            Assert.Equal(1, def.Fields.Count);
+            Assert.Equal(1, def2.Fields.Count);
+            var convertField = def.Fields.First().Value.Vector;
+            var autoField = def.Fields.First().Value.Vector;
+            Assert.Equal(autoField.SourceEmbeddingType, convertField.SourceEmbeddingType);
+            Assert.Equal(autoField.DestinationEmbeddingType, convertField.DestinationEmbeddingType);
+            Assert.Equal(null, convertField.Dimensions);
+            Assert.Equal(null, convertField.NumberOfEdges);
+            Assert.Equal(null, convertField.NumberOfCandidatesForIndexing);
+            Assert.Equal(null, autoField.Dimensions);
+            Assert.Equal(null, autoField.NumberOfEdges);
+            Assert.Equal(null, autoField.NumberOfCandidatesForIndexing);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Vector)]
+    public async Task CanConvertVectorFieldWithQuantizationToStaticField()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.Query<Dto>()
+                .VectorSearch(x => x.WithEmbedding(p => p.Vector).TargetQuantization(VectorEmbeddingType.Int8), v => v.ByEmbedding([1f, 2f]))
+                .ToListAsync();
+        }
+
+        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+        var autoIndex = record.AutoIndexes.Values.First();
+        var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex);
+        RavenTestHelper.AssertEqualRespectingNewLines(@"public class Index_Dtos_ByVector_search_embedding_f32_i8_Vector__ : Raven.Client.Documents.Indexes.AbstractIndexCreationTask<Dto>
+{
+    public Index_Dtos_ByVector_search_embedding_f32_i8_Vector__()
+    {
+        Map = items => from item in items
+                       select new
+                       {
+                           Vector = CreateVector(item.Vector)
+                       };
+
+        Vector(""Vector"", factory => factory.SourceEmbedding(VectorEmbeddingType.Single).DestinationEmbedding(VectorEmbeddingType.Int8));
+    }
+}
+", result);
+        
+        var def = AutoToStaticIndexConverter.Instance.ConvertToIndexDefinition(autoIndex);
+
+        await store.Maintenance.SendAsync(new PutIndexesOperation(def));
+        await store.Maintenance.SendAsync(new DeleteIndexOperation(def.Name));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var command = new RavenDB_22498.ConvertAutoIndexCommand(autoIndex.Name);
+            await store.GetRequestExecutor().ExecuteAsync(command, session.Advanced.Context);
+
+            var def2 = command.Result;
+            
+            // We accept that fields are different (since vector objects in AutoIndexes and Static indexes have different configuration objects, so we will check it manually).
+            Assert.Equal(IndexDefinitionCompareDifferences.Fields, def.Compare(def2));
+            Assert.Equal(1, def.Fields.Count);
+            Assert.Equal(1, def2.Fields.Count);
+            var convertField = def.Fields.First().Value.Vector;
+            var autoField = def.Fields.First().Value.Vector;
+            Assert.Equal(autoField.SourceEmbeddingType, convertField.SourceEmbeddingType);
+            Assert.Equal(autoField.DestinationEmbeddingType, convertField.DestinationEmbeddingType);
+            Assert.Equal(null, convertField.Dimensions);
+            Assert.Equal(null, convertField.NumberOfEdges);
+            Assert.Equal(null, convertField.NumberOfCandidatesForIndexing);
+            Assert.Equal(null, autoField.Dimensions);
+            Assert.Equal(null, autoField.NumberOfEdges);
+            Assert.Equal(null, autoField.NumberOfCandidatesForIndexing);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Vector)]
+    public async Task CanConvertTextualVectorFieldToStaticField()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.Query<Dto>()
+                .VectorSearch(x => x.WithText(p => p.Text), v => v.ByText("test"))
+                .ToListAsync();
+        }
+
+        var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+        var autoIndex = record.AutoIndexes.Values.First();
+        var result = AutoToStaticIndexConverter.Instance.ConvertToAbstractIndexCreationTask(autoIndex);
+        RavenTestHelper.AssertEqualRespectingNewLines(@"public class Index_Dtos_ByVector_search_embedding_text_Text__ : Raven.Client.Documents.Indexes.AbstractIndexCreationTask<Dto>
+{
+    public Index_Dtos_ByVector_search_embedding_text_Text__()
+    {
+        Map = items => from item in items
+                       select new
+                       {
+                           Vector = CreateVector(item.Text)
+                       };
+
+        Vector(""Vector"", factory => factory.SourceEmbedding(VectorEmbeddingType.Text).DestinationEmbedding(VectorEmbeddingType.Single));
+    }
+}
+", result);
+        
+        var def = AutoToStaticIndexConverter.Instance.ConvertToIndexDefinition(autoIndex);
+
+        await store.Maintenance.SendAsync(new PutIndexesOperation(def));
+        await store.Maintenance.SendAsync(new DeleteIndexOperation(def.Name));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var command = new RavenDB_22498.ConvertAutoIndexCommand(autoIndex.Name);
+            await store.GetRequestExecutor().ExecuteAsync(command, session.Advanced.Context);
+
+            var def2 = command.Result;
+            
+            // We accept that fields are different (since vector objects in AutoIndexes and Static indexes have different configuration objects, so we will check it manually).
+            Assert.Equal(IndexDefinitionCompareDifferences.Fields, def.Compare(def2));
+            Assert.Equal(1, def.Fields.Count);
+            Assert.Equal(1, def2.Fields.Count);
+            var convertField = def.Fields.First().Value.Vector;
+            var autoField = def.Fields.First().Value.Vector;
+            Assert.Equal(autoField.SourceEmbeddingType, convertField.SourceEmbeddingType);
+            Assert.Equal(autoField.DestinationEmbeddingType, convertField.DestinationEmbeddingType);
+            Assert.Equal(null, convertField.Dimensions);
+            Assert.Equal(null, convertField.NumberOfEdges);
+            Assert.Equal(null, convertField.NumberOfCandidatesForIndexing);
+            Assert.Equal(null, autoField.Dimensions);
+            Assert.Equal(null, autoField.NumberOfEdges);
+            Assert.Equal(null, autoField.NumberOfCandidatesForIndexing);
+        }
+    }
+
+    private class Dto
+    {
+        public string Text { get; set; }
+        public float[] Vector { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_22498.cs
+++ b/test/SlowTests/Issues/RavenDB_22498.cs
@@ -325,7 +325,7 @@ public class RavenDB_22498 : RavenTestBase
         }
     }
 
-    private class ConvertAutoIndexCommand : RavenCommand<IndexDefinition>
+    internal class ConvertAutoIndexCommand : RavenCommand<IndexDefinition>
     {
         private readonly string _name;
         public override bool IsReadRequest => false;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23446

### Additional description


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
