### PR TITLE
RavenDB-23268 Disabled side-by-side reset of map-reduce indexes with output reduce to collection

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -1525,10 +1525,14 @@ namespace Raven.Server.Documents.Indexes
             if (index.Type.IsAuto())
                 throw new NotSupportedException("Side by side index reset is not supported for auto indexes.");
             
+            var definition = index.GetIndexDefinition();
+            
+            if (index.Type.IsMapReduce() && definition.OutputReduceToCollection != null)
+                throw new NotSupportedException("Side by side index reset is not supported for map-reduce indexes with output reduce to collection.");
+            
             try
             {
                 var definitionClone = new IndexDefinition();
-                var definition = index.GetIndexDefinition();
                 definition.CopyTo(definitionClone);
 
                 var sideBySideIndex = GetIndex(Constants.Documents.Indexing.SideBySideIndexNamePrefix + index.Name);

--- a/test/SlowTests/Issues/RavenDB-23268.cs
+++ b/test/SlowTests/Issues/RavenDB-23268.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23268 : RavenTestBase
+{
+    public RavenDB_23268(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public void TestCase()
+    {
+        const int count = 1;
+        
+        using (var store = GetDocumentStore())
+        {
+            var testIndex = new TestIndex();
+            
+            testIndex.Execute(store);
+            
+            using (var bulk = store.BulkInsert())
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    var guid = Guid.NewGuid().ToString();
+                    var testOjb = new TestOjb { Id = guid, Prop = guid };
+                    bulk.Store(testOjb);
+                }
+            }
+            
+            Indexes.WaitForIndexing(store);
+            
+            var resetIndexOperation = new ResetIndexOperation(testIndex.IndexName, IndexResetMode.SideBySide);
+            
+            var exception = Assert.Throws<RavenException>(() => store.Maintenance.Send(resetIndexOperation));
+
+            Assert.Contains("Side by side index reset is not supported for map-reduce indexes with output reduce to collection.", exception.Message);
+            Assert.Equal(typeof(NotSupportedException), exception.InnerException?.GetType());
+        }
+    }
+    
+    private class TestOjb
+    {
+        public string Id { get; set; }
+        public string Prop { get; set; }
+    }
+    
+    private class TestIndex : AbstractIndexCreationTask<TestOjb, TestIndex.Result>
+    {
+        public class Result
+        {
+            public string IndexProp { get; set; }
+            public int Count { get; set; }
+        }
+        public TestIndex()
+        {
+            Map = users => from user in users
+                select new Result 
+                {
+                    IndexProp = user.Prop,
+                    Count = 1
+                };
+
+            Reduce = objs => 
+                from obj in objs 
+                group obj by obj.IndexProp 
+                into g 
+                select new Result
+                {
+                    IndexProp = g.Key, 
+                    Count = g.Sum(x => x.Count)
+                };
+            
+            OutputReduceToCollection = "OutputCollection";
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23268/Side-by-side-reset-of-an-index-removes-the-output-collection

### Additional description

The reason for disabling this kind of side-by-side reset is that we'd have to create documents using modified `ReduceOutputIndex`, which would break consistency between the nodes. Using the same `ReduceOutputIndex` means we either 
* Don't delete documents at all
* First delete the existing ones, then create new ones using the same index

The first approach means the reset won't fix problems with output documents themselves, the second one means the reset is not done in a side-by-side manner

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
