### PR TITLE
RavenDB-23445 Fixed indexing of null values for vector search

### DIFF
--- a/src/Corax/Utils/VectorValue.cs
+++ b/src/Corax/Utils/VectorValue.cs
@@ -10,6 +10,9 @@ public struct VectorValue : IDisposable
     private readonly Memory<byte> _memory;
     private int _length;
     public int Length => _length;
+    
+    public readonly bool IsNull;
+    public static readonly VectorValue Null = new(true);
 
     public ReadOnlySpan<byte> GetEmbedding()
     {
@@ -18,6 +21,11 @@ public struct VectorValue : IDisposable
 
     public VectorValue()
     {
+    }
+    
+    private VectorValue(bool isNull)
+    {
+        IsNull = isNull;
     }
 
     public VectorValue(IDisposable memoryScope, Memory<byte> embedding, int? length = null)
@@ -28,10 +36,9 @@ public struct VectorValue : IDisposable
     }
 
     public void OverrideLength(int len) => _length = len;
-
-
+    
     public void Dispose()
     {
-        _memoryScope.Dispose();
+        _memoryScope?.Dispose();
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverterBase.cs
@@ -310,6 +310,12 @@ public abstract class CoraxDocumentConverterBase : ConverterBase
             case ValueType.Vector:
                 using (var vectorField = (VectorValue)value)
                 {
+                    if (vectorField.IsNull)
+                    {
+                        builder.WriteNull(fieldId, path);
+                        break;
+                    }
+                    
                     var embedding = vectorField.GetEmbedding();
                     var destinationEmbeddingType = field.Vector.DestinationEmbeddingType;
                     

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -659,7 +659,10 @@ namespace Raven.Server.Documents.Indexes.Static
             {
                 var vectorList = new List<VectorValue>();
                 foreach (var item in enumerable)
+                {
                     vectorList.Add(CreateVectorValue(item));
+                }
+                
                 embedding = vectorList;
             }
 
@@ -679,7 +682,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 };
 
                 if (str == null)
-                    throw new InvalidDataException($"Unsupported vector value type: {valueToProcess?.GetType().FullName}");
+                    return VectorValue.Null;
 
                 return GenerateEmbeddings.FromText(allocator, indexField.Vector, str);
             }

--- a/test/SlowTests/Issues/RavenDB-23445.cs
+++ b/test/SlowTests/Issues/RavenDB-23445.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -40,6 +42,67 @@ public class RavenDB_23445 : RavenTestBase
                 Assert.Equal(1, results.Count);
             }
         }
+    }
+    
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineData(VectorEmbeddingType.Binary, 0.65f)]
+    [InlineData(VectorEmbeddingType.Int8, 0.80f)]
+    [InlineData(VectorEmbeddingType.Single, 0.80f)]
+    public void CanCreateVectorIndexFromCSharp(VectorEmbeddingType vectorEmbeddingType, float similarity)
+    {
+        var options = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document() { Text = null, Text2 = string.Empty, TextArr = ["Cat has brown eyes.", "Car has brown eyes."] });
+                session.Store(new Document() { Text2 = "Cat has brown eyes.", TextArr = ["Cat has brown eyes.", "Car has brown eyes."] });
+                
+                session.SaveChanges();
+                
+                new TextVectorIndex(vectorEmbeddingType).Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                var res = session.Query<Document, TextVectorIndex>().VectorSearch(x => x.WithField(f => f.Vector), f => f.ByText("animal color"), similarity);
+                
+                var results = res.ToList();
+
+                Assert.Equal(1, results.Count);
+                Assert.Contains("Cat", results[0].Text2);
+            }
+        }
+    }
+
+    private class TextVectorIndex : AbstractIndexCreationTask<Document>
+    {
+        public TextVectorIndex()
+        {
+            //querying
+        }
+
+        public TextVectorIndex(VectorEmbeddingType vectorEmbeddingType)
+        {
+            Map = docs => from doc in docs
+                          select new { Id = doc.Id, Vector = CreateVector(new List<string> { doc.Text, doc.Text2 }) };
+            
+            VectorIndexes.Add(x => x.Vector,
+                new VectorOptions()
+                {
+                    SourceEmbeddingType = VectorEmbeddingType.Text,
+                    DestinationEmbeddingType = vectorEmbeddingType
+                });
+        }
+    }
+
+    private class Document
+    {
+        public string Id { get; set; }
+        public string Text { get; set; }
+        public string Text2 { get; set; }
+        public string[] TextArr { get; set; }
+        public float[] Vector { get; set; }
     }
 
     private class Dto

--- a/test/SlowTests/Issues/RavenDB-23445.cs
+++ b/test/SlowTests/Issues/RavenDB-23445.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23445 : RavenTestBase
+{
+    public RavenDB_23445(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void TestIndexingOfNulls(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var territory1 = new Territory() { Name = "New York" };
+                var territory2 = new Territory() { Name = null };
+                
+                var dto1 = new Dto() { Territories = new List<Territory>() { territory1, territory2 } };
+                var dto2 = new Dto() { Territories = new List<Territory>() { territory2, null } };
+                
+                session.Store(dto1);
+                session.Store(dto2);
+                
+                session.SaveChanges();
+                
+                var results = session.Advanced.RawQuery<Dto>("from \"Dtos\" where vector.search(embedding.text(Territories[].Name), \"New York\")").ToList();
+                
+                Indexes.WaitForIndexing(store);
+                
+                Assert.Equal(1, results.Count);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public List<Territory> Territories { get; set; }
+    }
+
+    private class Territory
+    {
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23445/Vector-Search-null-handling-for-string

### Additional description

Fixed indexing of null values for textual vector search

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
