### PR TITLE
RavenDB-23448 Persist the implicit embedding source type of a vector field on disk for proper querying.

### DIFF
--- a/test/SlowTests/Issues/RavenDB_23448.cs
+++ b/test/SlowTests/Issues/RavenDB_23448.cs
@@ -1,0 +1,116 @@
+﻿using System.Linq;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23448(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void CanQueryTextualValuesInVectorSearchWhenFieldConfigurationIsNotExplicitlySet()
+    {
+        using var store = GetDocumentStore(new Options() { RunInMemory = false, DeleteDatabaseOnDispose = true, Path = NewDataPath() });
+        new Index().Execute(store);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Product { Name = "Product 1" });
+            session.SaveChanges();
+            Indexes.WaitForIndexing(store);
+
+            var result = session.Advanced.DocumentQuery<Product, Index>()
+                .VectorSearch(p => p.WithField("Vector"),
+                    v => v.ByText("Product 1"))
+                .FirstOrDefault();
+
+            Assert.NotNull(result);
+        }
+
+        var status = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, true));
+        Assert.Equal(true, status.Disabled);
+        status = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, false));
+        Assert.Equal(false, status.Disabled);
+
+        using (var session = store.OpenSession())
+        {
+            var result = session.Advanced.DocumentQuery<Product, Index>()
+                .VectorSearch(p => p.WithField("Vector"),
+                    v => v.ByText("Product 1"))
+                .FirstOrDefault();
+
+            Assert.NotNull(result);
+
+            result = session.Advanced.RawQuery<Product>(@"from index Index where vector.search(Vector, $p0)")
+                .AddParameter("$p0", "Product 1")
+                .FirstOrDefault();
+
+            Assert.NotNull(result);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void CanQueryNumericalValuesInVectorSearchWhenFieldConfigurationIsNotExplicitlySet()
+    {
+        float[] vec = [0.1f, 0.2f, 0.3f];
+        using var store = GetDocumentStore(new Options() { RunInMemory = false, DeleteDatabaseOnDispose = true, Path = NewDataPath() });
+        new IndexWithEmbedding().Execute(store);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new ProductEmbedding() { Vector = vec });
+            session.SaveChanges();
+            Indexes.WaitForIndexing(store);
+
+            var result = session.Advanced.DocumentQuery<ProductEmbedding, IndexWithEmbedding>()
+                .VectorSearch(p => p.WithField(x => x.Vector),
+                    v => v.ByEmbedding(vec))
+                .FirstOrDefault();
+
+            Assert.NotNull(result);
+        }
+
+        var status = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, true));
+        Assert.Equal(true, status.Disabled);
+        status = store.Maintenance.Server.Send(new ToggleDatabasesStateOperation(store.Database, false));
+        Assert.Equal(false, status.Disabled);
+
+        using (var session = store.OpenSession())
+        {
+            var result = session.Advanced.DocumentQuery<ProductEmbedding, IndexWithEmbedding>()
+                .VectorSearch(p => p.WithField(x => x.Vector),
+                    v => v.ByEmbedding(vec))
+                .FirstOrDefault();
+
+            Assert.NotNull(result);
+        }
+    }
+
+    private class Index : AbstractIndexCreationTask<Product>
+    {
+        public Index()
+        {
+            Map = products => from p in products
+                select new { Vector = CreateVector(p.Name) };
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class IndexWithEmbedding : AbstractIndexCreationTask<ProductEmbedding>
+    {
+        public IndexWithEmbedding()
+        {
+            Map = products => from p in products
+                select new { Vector = CreateVector(p.Vector) };
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class ProductEmbedding
+    {
+        public float[] Vector { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23448

### Additional description

When the user does not provide explicit vector index field configuration, we determine it during indexing time.

> When the value being indexed in the first document is a numeric array, we treat the field as `Single`.
> When the value is textual, we generate the embedding from it.

During a cold start (when we do not have information in runtime about previously indexed data), we do not know how to handle the input during querying (since the user may send an array converted to base64).

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
