### PR TITLE
RavenDB-23124: SlowTests.Issues.RavenDB_22659.CannotDeleteDatabaseWhenRestoreCancelledOnNonResponsibleNode (fix)

### DIFF
--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -926,7 +926,7 @@ namespace Raven.Server.Web.System
             if (state != DatabaseStateStatus.RestoreInProgress)
                 return;
 
-            var restoredOnNode = topology.Members.First(); // we restore only on one node
+            var restoredOnNode = topology.AllNodes.First(); // we restore only on one node
             if (ServerStore.NodeTag != restoredOnNode)
                 throw new InvalidOperationException($"Can't delete database '{databaseName}' while the restore " +
                                                     $"process is in progress. In order to delete the database, " +


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23124

### Additional description

Sometimes in tests, the node where restore occurred doesn't have `Member` status. For assertion purposes and marking a database for deletion, any node type works fine, not just member.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
