### PR TITLE
RavenDB-23061: StressTests.Server.Documents.PeriodicBackup.ServerWideBackupStress.ServerWideBackupShouldBackupIdleDatabaseStressNightly(rounds: 5) (fix)

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1201,7 +1201,7 @@ namespace Raven.Server.Documents
             if (SkipShouldContinueDisposeCheck)
                 return true;
 
-            // if we have a small value or even a negative one, simply don't dispose the database.
+            // if we have a small value, simply don't dispose the database.
             return idleDatabaseActivity.DueTime > TimeSpan.FromMinutes(5).TotalMilliseconds;
         }
 
@@ -1288,7 +1288,7 @@ namespace Raven.Server.Documents
         public DateTime? DateTime { get; internal set; }
         public long TaskId { get; }
         public int DueTime => DateTime.HasValue
-            ? (int)Math.Min(int.MaxValue, (DateTime.Value - System.DateTime.UtcNow).TotalMilliseconds)
+            ? (int)Math.Min(int.MaxValue, Math.Max(0, (DateTime.Value - System.DateTime.UtcNow).TotalMilliseconds))
             : 0;
 
         public IdleDatabaseActivity(IdleDatabaseActivityType type)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23061

### Additional description

When handling very precise timing events, we could accidentally try to set a new `Timer` with a `dueTime` argument less than `-1` (which would throw an exception from the `Timer` constructor) or even exactly `-1` (which equals infinity - meaning it would never run).  Regarding bringing the database out of idle state, we should not have a scenario where a timer is created without a callback time. Therefore, any negative `dueTime` value should be treated as an immediate execution of the callback method.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
