### PR TITLE
RavenDB-23473 Vector fields without explicit configuration will be indexed as dynamic fields to avoid overriding field definitions at runtime.

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -92,6 +92,8 @@ namespace Corax
             public const int FrequencyTermFreeSpace = 0b1111_1111;
             public const int MaxSizeOfTermVectorList = int.MaxValue >> 1;
 
+            internal const long UninitializedFieldRootPage = -1L;
+
             public static class Hnsw
             {
                 public const int TreeExists = -1;

--- a/src/Corax/Indexing/IndexedField.cs
+++ b/src/Corax/Indexing/IndexedField.cs
@@ -74,7 +74,7 @@ internal sealed class IndexedField
     }
 
     private IndexedField(int id, Slice name, Slice nameLong, Slice nameDouble, Slice nameTotalLengthOfTerms, Analyzer analyzer,
-        FieldIndexingMode fieldIndexingMode, bool hasSuggestions, bool shouldStore, in SupportedFeatures supportedFeatures, string nameForStatistics, long fieldRootPage, long termsVectorFieldRootPage, FastList<EntriesModifications> storage, Dictionary<Slice, int> textual, Dictionary<long, int> longs, Dictionary<double, int> doubles, IndexedField parent)
+        FieldIndexingMode fieldIndexingMode, bool hasSuggestions, bool shouldStore, in SupportedFeatures supportedFeatures, string nameForStatistics, long fieldRootPage, long termsVectorFieldRootPage, FastList<EntriesModifications> storage, Dictionary<Slice, int> textual, Dictionary<long, int> longs, Dictionary<double, int> doubles, VectorOptions vectorOptions, IndexedField parent)
     {
         _parent = parent;
         Name = name;
@@ -96,7 +96,7 @@ internal sealed class IndexedField
         ShouldIndex = supportedFeatures.StoreOnly == false || fieldIndexingMode != FieldIndexingMode.No;
         NameForStatistics = nameForStatistics ?? $"Field_{Name}";
         VectorIndexer = _parent.VectorIndexer;
-        
+        _vectorOptions = vectorOptions;
         IsVirtual = true;
         if (fieldIndexingMode is FieldIndexingMode.Search && _parent.EntryToTerms.IsValid == false)
             EntryToTerms = new();
@@ -145,9 +145,9 @@ internal sealed class IndexedField
                 break;
         }
         
-        return new IndexedField(Constants.IndexWriter.DynamicField, Name, NameLong, NameDouble,
-            NameTotalLengthOfTerms, analyzer, fieldIndexingMode, dynamicField.HasSuggestions, dynamicField.ShouldStore,
-            _supportedFeatures, dynamicField.FieldNameForStatistics, FieldRootPage, TermsVectorFieldRootPage, Storage, Textual, Longs, Doubles, this);
+        return new IndexedField(Constants.IndexWriter.DynamicField, dynamicField.FieldName, dynamicField.FieldNameLong, dynamicField.FieldNameDouble,
+            dynamicField.FieldTermTotalSumField, analyzer, fieldIndexingMode, dynamicField.HasSuggestions, dynamicField.ShouldStore,
+            _supportedFeatures, dynamicField.FieldNameForStatistics, FieldRootPage, TermsVectorFieldRootPage, Storage, Textual, Longs, Doubles, dynamicField.VectorOptions, this);
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Corax/Indexing/IndexedField.cs
+++ b/src/Corax/Indexing/IndexedField.cs
@@ -171,8 +171,8 @@ internal sealed class IndexedField
                 break;
         }
         
-        return new IndexedField(Constants.IndexWriter.DynamicField, dynamicField.FieldName, dynamicField.FieldNameLong, dynamicField.FieldNameDouble,
-            dynamicField.FieldTermTotalSumField, analyzer, fieldIndexingMode, dynamicField.HasSuggestions, dynamicField.ShouldStore,
+        return new IndexedField(Constants.IndexWriter.DynamicField, Name, NameLong, NameDouble,
+            NameTotalLengthOfTerms, analyzer, fieldIndexingMode, dynamicField.HasSuggestions, dynamicField.ShouldStore,
             _supportedFeatures, dynamicField.FieldNameForStatistics, FieldRootPage, TermsVectorFieldRootPage, Storage, Textual, Longs, Doubles, dynamicField.VectorOptions, this);
     }
     

--- a/src/Corax/Mappings/IndexFieldsMappingBuilder.cs
+++ b/src/Corax/Mappings/IndexFieldsMappingBuilder.cs
@@ -51,14 +51,14 @@ public sealed class IndexFieldsMappingBuilder : IDisposable
     }
 
     public IndexFieldsMappingBuilder AddBindingToEnd(Slice fieldName, Analyzer analyzer = null, bool hasSuggestion = false,
-        FieldIndexingMode fieldIndexingMode = FieldIndexingMode.Normal, bool shouldStore = false,  bool hasSpatial = false) =>
-        AddBinding(_fields.Count, fieldName, analyzer, hasSuggestion, fieldIndexingMode, shouldStore,  hasSpatial);
+        FieldIndexingMode fieldIndexingMode = FieldIndexingMode.Normal, bool shouldStore = false,  bool hasSpatial = false, VectorOptions vectorOptions = null) =>
+        AddBinding(_fields.Count, fieldName, analyzer, hasSuggestion, fieldIndexingMode, shouldStore,  hasSpatial, vectorOptions);
 
-    public IndexFieldsMappingBuilder AddDynamicBinding(Slice fieldName, FieldIndexingMode mode, bool shouldStore)
+    public IndexFieldsMappingBuilder AddDynamicBinding(Slice fieldName, FieldIndexingMode mode, bool shouldStore, VectorOptions vectorOptions = null)
     {
         if (_fields.TryGetValue(fieldName, out var storedBinding) == false)
         {
-            AddBindingToEnd(fieldName, GetAnalyzer(), fieldIndexingMode: mode, shouldStore: shouldStore);
+            AddBindingToEnd(fieldName, GetAnalyzer(), fieldIndexingMode: mode, shouldStore: shouldStore, hasSpatial: false, vectorOptions: vectorOptions);
         }
 
         Analyzer GetAnalyzer() => mode switch

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -5242,20 +5242,13 @@ namespace Raven.Server.Documents.Indexes
         {
             return _vectorFields.GetOrAdd(name, _ =>
             {
-                if (Definition.MapFields.TryGetValue(name, out var field) == false)
+                if (Definition.MapFields.TryGetValue(name, out var field) == false || field is IndexField { Vector: null })
                 {
                     var isTextual = IsFieldTextualAndPersistConfigurationOnDisk();
                     return IndexField.Create(name, new IndexFieldOptions()
                         {
                             Vector = CreateVectorOptionsBasedOnConfiguration(isTextual)
                         }, null, Corax.Constants.IndexWriter.DynamicField);
-                }
-
-                // When field doesn't contain vector options we've to create it manually by default values.
-                if (field is IndexField { Vector: null } indexField)
-                {
-                    var isTextual = IsFieldTextualAndPersistConfigurationOnDisk();
-                    indexField.Vector = CreateVectorOptionsBasedOnConfiguration(isTextual);
                 }
                 
                 return field switch

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexWriteOperation.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Corax;
 using Corax.Mappings;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
 using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Exceptions;
 using Raven.Server.Utils;
@@ -17,6 +18,7 @@ using Voron;
 using Voron.Impl;
 using Constants = Raven.Client.Constants;
 using IndexWriter = Corax.Indexing.IndexWriter;
+using VectorOptions = Corax.Mappings.VectorOptions;
 
 namespace Raven.Server.Documents.Indexes.Persistence.Corax
 {
@@ -135,7 +137,25 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             foreach (var (fieldName, fieldIndexing) in _indexingScope.DynamicFields)
             {
                 using var _ = Slice.From(_allocator, fieldName, out var slice);
-                _dynamicFieldsBuilder.AddDynamicBinding(slice, FieldIndexingIntoFieldIndexingMode(fieldIndexing.Indexing), fieldIndexing.Storage== FieldStorage.Yes);
+                VectorOptions vectorOptions = null;
+                if (fieldIndexing.Vector != null)
+                {
+                    vectorOptions = new()
+                    {
+                        NumberOfCandidates = fieldIndexing.Vector.NumberOfCandidatesForIndexing!.Value,
+                        NumberOfEdges = fieldIndexing.Vector.NumberOfEdges!.Value,
+                        VectorEmbeddingType = fieldIndexing.Vector.DestinationEmbeddingType switch
+                        {
+                            VectorEmbeddingType.Binary => Voron.Data.Graphs.VectorEmbeddingType.Binary,
+                            VectorEmbeddingType.Int8 => Voron.Data.Graphs.VectorEmbeddingType.Int8,
+                            VectorEmbeddingType.Single => Voron.Data.Graphs.VectorEmbeddingType.Single,
+                            _ => throw new ArgumentOutOfRangeException(nameof(fieldIndexing.Vector.DestinationEmbeddingType),
+                                fieldIndexing.Vector.DestinationEmbeddingType, null)
+                        }
+                    };
+                }
+                
+                _dynamicFieldsBuilder.AddDynamicBinding(slice, FieldIndexingIntoFieldIndexingMode(fieldIndexing.Indexing), fieldIndexing.Storage== FieldStorage.Yes, vectorOptions);
             }
 
             _dynamicFields = _dynamicFieldsBuilder.Build();

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -655,6 +655,8 @@ public unsafe partial class Hnsw
         private readonly long _globalVectorsContainerId;
         private PostingList _largePostingListSet;
 
+        public int AmountOfModifiedVectorsInTransaction => _vectorHashCache.Count;
+        
         public Registration(LowLevelTransaction llt, Slice name, Random random = null)
         {
             Random = random ?? Random.Shared;

--- a/test/FastTests/Corax/Vectors/VectorSimilarityScoreTests.cs
+++ b/test/FastTests/Corax/Vectors/VectorSimilarityScoreTests.cs
@@ -70,6 +70,8 @@ public class VectorSimilarityScoreTests(ITestOutputHelper output) : RavenTestBas
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]
+    [InlineData(1253422244)]
+    [InlineData(1351777189)]
     public void TestInt8Similarity(int seed)
     {
         var random = new Random(seed);

--- a/test/SlowTests/Issues/RavenDB-23473.cs
+++ b/test/SlowTests/Issues/RavenDB-23473.cs
@@ -143,8 +143,8 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
     
     private class Embedding
     {
-        public string Id;
-        public List<float> Vector;
+        public string Id { get; set; }
+        public List<float> Vector { get; set; }
     }
 
     private class Question

--- a/test/SlowTests/Issues/RavenDB-23473.cs
+++ b/test/SlowTests/Issues/RavenDB-23473.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Subscriptions;
+using SmartComponents.LocalEmbeddings;
+using Sparrow;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
+{
+    public static LocalEmbedder LocalEmbedder = new LocalEmbedder();
+
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public void IndexVectorWhenPreviousElementsAreNullWithoutExplicitVectorFieldConfiguration()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        string id;
+        using (var session = store.OpenSession())
+        {
+            var dto = new Dto() { };
+            session.Store(dto);
+            session.SaveChanges();
+            id = dto.Id;
+        }
+
+        new DtoIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var dto = session.Load<Dto>(id);
+            dto.Vector = [.1f, .2f, .3f];
+            session.Store(dto);
+            session.SaveChanges();
+        }
+
+        var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
+        Assert.Null(errors);
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public float[] Vector { get; set; }
+    }
+
+    private class DtoIndex : AbstractIndexCreationTask<Dto>
+    {
+        public DtoIndex()
+        {
+            Map = dtos => from dto in dtos select new { Vector = CreateVector(dto.Vector) };
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23473.cs
+++ b/test/SlowTests/Issues/RavenDB-23473.cs
@@ -1,9 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Subscriptions;
 using SmartComponents.LocalEmbeddings;
 using Sparrow;
@@ -16,17 +17,14 @@ namespace SlowTests.Issues;
 
 public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
 {
-    public static LocalEmbedder LocalEmbedder = new LocalEmbedder();
-
-
     [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
-    public void IndexVectorWhenPreviousElementsAreNullWithoutExplicitVectorFieldConfiguration()
+    public void CanIndexVectorWhenPreviousElementsAreNullWithoutExplicitVectorFieldConfiguration()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
         string id;
         using (var session = store.OpenSession())
         {
-            var dto = new Dto() { };
+            var dto = new Embedding() { };
             session.Store(dto);
             session.SaveChanges();
             id = dto.Id;
@@ -37,7 +35,7 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
 
         using (var session = store.OpenSession())
         {
-            var dto = session.Load<Dto>(id);
+            var dto = session.Load<Embedding>(id);
             dto.Vector = [.1f, .2f, .3f];
             session.Store(dto);
             session.SaveChanges();
@@ -46,18 +44,112 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
         var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
         Assert.Null(errors);
     }
-
-    private class Dto
+    
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public async Task CanUpdateNoExplicitlyConfiguredVectorFieldViaSubscriptionWithLoadDocument()
     {
-        public string Id { get; set; }
-        public float[] Vector { get; set; }
+        using (LocalEmbedder localEmbedder = new())
+        using (var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax)))
+        {
+            await store.ExecuteIndexAsync(new VectorIndex());
+
+            var sub = await store.Subscriptions.CreateAsync<Question>(new SubscriptionCreationOptions<Question>());
+            var worker = store.Subscriptions.GetSubscriptionWorker<Question>(sub);
+            var mre = new AsyncManualResetEvent();
+            List<float> vector = [];
+            var t = worker.Run(async x =>
+            {
+                using var session = x.OpenAsyncSession();
+                foreach (var item in x.Items)
+                {
+                    var q = item.Result;
+                    var hash = Hashing.XXHash64.Calculate(Encodings.Utf8.GetBytes(q.Body));
+                    var embeddingId = $"embeddings/{hash}";
+
+                    var localEmbedding = await session.LoadAsync<Embedding>(embeddingId);
+                    if (localEmbedding == null)
+                    {
+                        // ReSharper disable once AccessToDisposedClosure
+                        var embedding = localEmbedder.Embed(q.Body);
+                        vector = embedding.Values.ToArray().ToList();
+                        localEmbedding = new Embedding { Vector = vector };
+                        await session.StoreAsync(localEmbedding, embeddingId);
+                    }
+
+                    q.EmbeddingId = localEmbedding.Id;
+                }
+
+                await session.SaveChangesAsync();
+                mre.Set();
+            });
+
+            for (int i = 0; i < 5; i++)
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Question { Body = "this is a test" });
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            await mre.WaitAsync();
+
+            await Indexes.WaitForIndexingAsync(store);
+            var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
+            Assert.Null(errors);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var results = await session.Query<Question, VectorIndex>()
+                    .VectorSearch(
+                        f => f.WithField("Vector"),
+                        v => v.ByEmbedding(vector))
+                    .ToListAsync();
+                Assert.Equal(5, results.Count);
+            }
+            
+            var deleteByQueryOp = await store.Operations.SendAsync(new DeleteByQueryOperation("from 'embeddings'"));
+            await deleteByQueryOp.WaitForCompletionAsync();
+            await Indexes.WaitForIndexingAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var result = await session.Advanced.AsyncDocumentQuery<Question, VectorIndex>().WhereEquals("Vector", null).ToListAsync();
+                Assert.Equal(5, result.Count);
+            }            
+        }
     }
 
-    private class DtoIndex : AbstractIndexCreationTask<Dto>
+    private class VectorIndex : AbstractIndexCreationTask<Question>
+    {
+        public VectorIndex()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+
+            Map = questions =>
+                from q in questions
+                let embedding = LoadDocument<Embedding>(q.EmbeddingId)
+                select new { Vector = CreateVector(embedding.Vector) };
+        }
+    }
+    
+    private class DtoIndex : AbstractIndexCreationTask<Embedding>
     {
         public DtoIndex()
         {
             Map = dtos => from dto in dtos select new { Vector = CreateVector(dto.Vector) };
         }
+    }
+    
+    private class Embedding
+    {
+        public string Id;
+        public List<float> Vector;
+    }
+
+    private class Question
+    {
+        public string Body { get; set; }
+        public string EmbeddingId { get; set; }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23473 
### Additional description

Vector fields without explicit configuration will be indexed as dynamic fields to avoid overriding fields definition in runtime.

This fixes the situation where the first document has a `null` value instead of a numerical or textual value. On update, we replace the `null` value with the actual value and update the definition. Since Corax field mappings persist as long as the indexing thread, after the first batch, we are no longer able to change the underlying configuration of the field, so we have to insert non-explicitly configured fields as dynamic.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
