### PR TITLE
RavenDB-23466 Corax: do not return the stored value from an index entry field when the field is a vector field.

### DIFF
--- a/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
+++ b/src/Raven.Server/Documents/Patch/BlittableObjectInstance.cs
@@ -171,6 +171,10 @@ namespace Raven.Server.Documents.Patch
              
                 while (reader.FindNextStored(fieldRootPage))
                 {
+                    // Even though the vector hash is stored, it is Corax's internal value and is not meant to be projected.
+                    if (reader.IsVectorHash)
+                        return false;
+                    
                     // check if stored value is an array and we haven't initialized it yet
                     if (reader.IsList)
                     {

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -641,6 +641,10 @@ namespace Raven.Server.Documents.Queries.Results
             bool found = false;
             while (reader.FindNextStored(fieldRootPage))
             {
+                // Even though the vector hash is stored, it is Corax's internal value and is not meant to be projected.
+                if (reader.IsVectorHash)
+                    return false;
+                
                 found = true;
                 if (reader.IsList && value is null)
                 {

--- a/test/SlowTests/Issues/RavenDB-23466.cs
+++ b/test/SlowTests/Issues/RavenDB-23466.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23466(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void ProjectionOfVectorFieldWillAlwaysResultInValueNotFound()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        string id;
+        using (var session = store.OpenSession())
+        {
+            var dto = new Dto { Vector = new[] { 1f, 2f, 3f } };
+            session.Store(dto);
+            session.SaveChanges();
+            id = dto.Id;
+        }
+        
+        new Index().Execute(store);
+        Indexes.WaitForIndexing(store);
+        using (var session = store.OpenSession())
+        {
+            var projection = session.Query<ProjectionDto, Index>().Select(x => new {x.Id, x.VectorStored}).ToList();
+            Assert.Equal(1, projection.Count);
+            Assert.Equal(id, projection[0].Id);
+            Assert.Equal(null, projection[0].VectorStored);
+
+            var exception = Assert.Throws<InvalidQueryException>(() => session.Query<ProjectionDto, Index>()
+                .Customize(c => c.Projection(ProjectionBehavior.FromIndexOrThrow))
+                .Select(x => new { Id = RavenQuery.Id(x), Test = x.VectorStored })
+                .ToList());
+            
+            Assert.Contains("Could not extract field 'VectorStored' from index 'Index', because index does not contain such", exception.Message);
+            var result = session.Query<ProjectionDto, Index>()
+                .Select(x => new { Id = RavenQuery.Id(x), Test = x.VectorStored })
+                .ToList();
+            Assert.Equal(1, result.Count);
+            Assert.Equal(id, result[0].Id);
+            Assert.Equal(null, result[0].Test);
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public object Vector { get; set; }
+    }
+
+    private class ProjectionDto
+    {
+        public string Id { get; set; }
+        public float[] VectorStored { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<Dto>
+    {
+        public Index()
+        {
+            Map = dtos => from dto in dtos
+                select new { VectorStored = CreateVector((IEnumerable<float>)dto.Vector) };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23466 

### Additional description
We store the vector hash in the `IndexEntry`; however, it is only meant for removal purposes.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
