### PR TITLE
RavenDB-23498 MoreLikeThis fails if json doc has null properties

### DIFF
--- a/src/Raven.Server/Documents/Queries/MoreLikeThis/MoreLikeThisBase.cs
+++ b/src/Raven.Server/Documents/Queries/MoreLikeThis/MoreLikeThisBase.cs
@@ -406,8 +406,9 @@ namespace Raven.Server.Documents.Queries.MoreLikeThis
 
         protected void RetrieveTerms(BlittableJsonReaderObject json, Dictionary<string, int> words)
         {
-            var prop = new BlittableJsonReaderObject.PropertyDetails();
+            if (json is null) return;
 
+            var prop = new BlittableJsonReaderObject.PropertyDetails();
             for (int i = 0; i < json.Count; i++)
             {
                 json.GetPropertyByIndex(i, ref prop);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23498 

### Additional description

Added a null check to prevent NRE

### Type of change

- [x] Bug fix

### How risky is the change?

- [x] Low 

### Backward compatibility

- [x] Non breaking change