### PR TITLE
RavenDB-23427 Move AuditLog configuration keys back under Security.*

### DIFF
--- a/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SecurityConfiguration.cs
@@ -32,21 +32,21 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(128)]
         [MinValue(16)]
         [SizeUnit(SizeUnit.Megabytes)]
-        [ConfigurationEntry("Logs.AuditLog.ArchiveAboveSizeInMb", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("Security.AuditLog.ArchiveAboveSizeInMb", ConfigurationEntryScope.ServerWideOnly)]
         public Size AuditLogArchiveAboveSize { get; set; }
 
         [DefaultValue(3)]
-        [ConfigurationEntry("Logs.AuditLog.MaxArchiveDays", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("Security.AuditLog.MaxArchiveDays", ConfigurationEntryScope.ServerWideOnly)]
         public int? AuditLogMaxArchiveDays { get; set; }
 
         [DefaultValue(null)]
         [MinValue(0)]
-        [ConfigurationEntry("Logs.AuditLog.MaxArchiveFiles", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("Security.AuditLog.MaxArchiveFiles", ConfigurationEntryScope.ServerWideOnly)]
         public int? AuditLogMaxArchiveFiles { get; set; }
 
         [Description("Will determine whether to compress the audit log files.")]
         [DefaultValue(false)]
-        [ConfigurationEntry("Logs.AuditLog.EnableArchiveFileCompression", ConfigurationEntryScope.ServerWideOnly)]
+        [ConfigurationEntry("Security.AuditLog.EnableArchiveFileCompression", ConfigurationEntryScope.ServerWideOnly)]
         [ConfigurationEntry("Security.AuditLog.Compress", ConfigurationEntryScope.ServerWideOnly)]
         public bool AuditLogEnableArchiveFileCompression { get; set; }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23427/Inconsistency-in-AuditLog-configuration-keys

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
