### PR TITLE
RavenDB-23457 Fetching vector options from index definition instead of query for index entries access

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -632,7 +632,7 @@ public static class CoraxQueryBuilder
             builderParameters.FieldsToFetch, builderParameters.HasDynamics, builderParameters.DynamicFields, hasBoost: builderParameters.HasBoost);
 
         VectorOptions vectorOptions = null;
-        if (builderParameters.FieldsToFetch.IndexFields.TryGetValue(fieldName, out var indexField))
+        if (builderParameters.FieldsToFetch != null && builderParameters.FieldsToFetch.IndexFields.TryGetValue(fieldName, out var indexField))
         {
             // VectorOptions can be null when a user does not specify the configuration.
             // In such cases, we will choose the input depending on the value type (similar to how we handle it during indexing).
@@ -650,6 +650,8 @@ public static class CoraxQueryBuilder
             }
             
         }
+        else if (builderParameters.Index.Definition.IndexFields.TryGetValue(fieldName, out indexField))
+            vectorOptions = indexField.Vector;
         else
             PortableExceptions.Throw<InvalidDataException>($"Cannot find `{fieldName}` field in the index.");
         

--- a/test/SlowTests/Issues/RavenDB-23457.cs
+++ b/test/SlowTests/Issues/RavenDB-23457.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Commands;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23457 : RavenTestBase
+{
+    public RavenDB_23457(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void Test(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto1 = new Dto() 
+                { 
+                    Text = "Cat has brown eyes.", 
+                    Text2 = "Car has brown eyes.", 
+                    Text3 = null, 
+                    TextArr = 
+                    [
+                        "Cat has brown eyes.",
+                        "Car has brown eyes."
+                    ]
+                };
+                
+                var dto2 = new Dto()
+                {
+                    Text = "Apple usually is red.",
+                    Text2 = "Mouse usually is red.",
+                    Text3 = null,
+                    TextArr =
+                    [
+                        "Apple usually is red.",
+                        "Mouse usually is red."
+                    ]
+                };
+                
+                session.Store(dto1);
+                session.Store(dto2);
+                
+                session.SaveChanges();
+                
+                var index = new DummyIndex();
+                
+                index.Execute(store);
+                
+                Indexes.WaitForIndexing(store);
+                
+                QueryCommand queryCommand = new QueryCommand((InMemoryDocumentSessionOperations)session, new IndexQuery
+                {
+                    Query = "from index 'DummyIndex' where vector.search(Vector, 'ddd', 0.1)"
+                }, metadataOnly: false, indexEntriesOnly: true);
+                
+                session.Advanced.RequestExecutor.Execute(queryCommand, session.Advanced.Context, session.Advanced.SessionInfo);
+                
+                QueryResult result = queryCommand.Result;
+                
+                Assert.Equal(2, result.Results.Length);
+            }
+        }        
+    }
+    
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Text { get; set; }
+        public string Text2 { get; set; }
+        public string Text3 { get; set; }
+        public string[] TextArr { get; set; }
+    }
+
+    private class DummyIndex : AbstractIndexCreationTask<Dto>
+    {
+        public DummyIndex()
+        {
+            Map = dtos => from dto in dtos
+                let x = new List<string> { dto.Text, dto.Text2 }
+                select new
+                {
+                    Id = dto.Id,
+                    Vector = CreateVector(x.Concat(dto.TextArr)),
+                    Vector2 = CreateVector(dto.TextArr.Append(dto.Text2)),
+                    Vector3 = CreateVector(dto.TextArr)
+                };
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23457.cs
+++ b/test/SlowTests/Issues/RavenDB-23457.cs
@@ -18,7 +18,7 @@ public class RavenDB_23457 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void Test(Options options)
     {
         using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23457/System.NullReferenceException-in-vector-index

### Additional description

When accessing raw index entries, `FieldsToFetch` of query are `null`, which means we can't get vector options from them. Instead, we should use data from the index definition. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
