### PR TITLE
RavenDB-23464 Validate during index compilation that the index is using Corax as the search engine when the map contains `CreateVector`.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -629,6 +629,7 @@ namespace Raven.Server.Documents.Indexes
         }
 
         public virtual bool HasBoostedFields => false;
+        public virtual bool HasVectorFields => false;
 
         public virtual bool IsMultiMap => false;
 

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompilationCache.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompilationCache.cs
@@ -156,7 +156,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
             if (index.HasVectorFields && singleConfig.StaticIndexingEngineType != SearchEngineType.Corax)
             {
-                throw new NotSupportedException($"Vector fields are supported only by the Corax search engine. This deployment requested '{singleConfig.StaticIndexingEngineType}' search engine.");
+                throw new NotSupportedException($"Vector fields are supported only by the Corax search engine. This deployment requested '{singleConfig.StaticIndexingEngineType}' search engine. Read more at https://ravendb.net/l/Y4B762/7.0");
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -582,6 +582,9 @@ namespace Raven.Server.Documents.Indexes.Static
             if (methods.HasBoost)
                 statements.Add(RoslynHelper.This(nameof(AbstractStaticIndexBase.HasBoostedFields)).Assign(SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)).AsExpressionStatement());
 
+            if (methods.HasCreateVector)
+                statements.Add(RoslynHelper.This(nameof(AbstractStaticIndexBase.HasVectorFields)).Assign(SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)).AsExpressionStatement());
+            
             var ctor = RoslynHelper.PublicCtor(name)
                 .AddBodyStatements(statements.ToArray());
 
@@ -1000,6 +1003,8 @@ namespace Raven.Server.Documents.Indexes.Static
 
             public bool HasCreateField { get; set; }
 
+            public bool HasCreateVector { get; set; }
+            
             public bool HasBoost { get; set; }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -296,6 +296,7 @@ function map(name, lambda) {
 
                         HasDynamicFields |= operation.HasDynamicReturns;
                         HasBoostedFields |= operation.HasBoostedFields;
+                        HasVectorFields |= operation.HasVectorFields;
 
                         fields.UnionWith(operation.Fields);
                         foreach (var (k, v) in operation.FieldOptions)

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -52,6 +52,7 @@ namespace Raven.Server.Documents.Indexes.Static
         }
 
         public override bool HasBoostedFields => _compiled.HasBoostedFields;
+        public override bool HasVectorFields => _compiled.HasVectorFields;
 
         public override bool IsMultiMap => _compiled.Maps.Count > 1 || _compiled.Maps.Any(x => x.Value.Count > 1 || x.Value.Any(y => y.Value.Count > 1));
 

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/MethodDetectorRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/MethodDetectorRewriter.cs
@@ -46,6 +46,10 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
                 case "CreateField":
                     Methods.HasCreateField = true;
                     break;
+                case "this.CreateVector":
+                case "CreateVector":
+                    Methods.HasCreateVector = true;
+                    break;
             }
 
             var memberAccessExpression = node.Expression as MemberAccessExpressionSyntax;

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -203,6 +203,8 @@ namespace Raven.Server.Documents.Indexes.Static
         public bool HasDynamicFields { get; set; }
 
         public bool HasBoostedFields { get; set; }
+        
+        public bool HasVectorFields { get; set; }
 
         public string Source;
 

--- a/test/SlowTests/Issues/RavenDB-23464.cs
+++ b/test/SlowTests/Issues/RavenDB-23464.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Orders;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Counters;
+using Raven.Client.Documents.Indexes.TimeSeries;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23464(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanDeployCoraxCsharpMapIndexWithVectorField(Options options)
+    {
+        options ??= Options.ForSearchEngine(RavenSearchEngineMode.Lucene);
+        using var store = GetDocumentStore(options);
+        new CsharpIndexBaseCorax().Execute(store);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanDeployCoraxJsMapIndexWithVectorField(Options options)
+    {
+        options ??= Options.ForSearchEngine(RavenSearchEngineMode.Lucene);
+        using var store = GetDocumentStore(options);
+        new JsIndexCorax().Execute(store);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanDeployCoraxCsharpCounterIndexWithVectorField(Options options)
+    {
+        options ??= Options.ForSearchEngine(RavenSearchEngineMode.Lucene);
+        using var store = GetDocumentStore(options);
+        new CounterIndexCorax().Execute(store);
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanDeployCoraxCsharpTimeSeriesIndexWithVectorField(Options options)
+    {
+        options ??= Options.ForSearchEngine(RavenSearchEngineMode.Lucene);
+        using var store = GetDocumentStore(options);
+        new TimeSeriesIndexCorax().Execute(store);
+    }
+    
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpCounterIndexBase() =>
+        ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpCounterTestBase<CounterIndexBase>();
+    
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpCounterIndexExplicitLucene(Options options) =>
+        ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpCounterTestBase<CounterIndexLucene>(options);
+    
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpTimeSeriesIndexBase() =>
+        ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpTimeSeriesTestBase<TimeSeriesIndexBase>();
+    
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpTimeSeriesIndexExplicitLucene() =>
+        ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpTimeSeriesTestBase<TimeSeriesIndexLucene>();
+    
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpMapIndexBase() => ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxBase<CsharpIndexBase>();
+    
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpMapIndexExplicitLucene(Options options) => ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxBase<CsharpIndexBaseLucene>(options);
+    
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxJavaScriptBase() => ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxBase<JsIndexBase>();
+    
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxJavaScriptLucene(Options options) => ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxBase<JsIndexLucene>(options);
+    
+    private void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxBase<TIndex>(Options options = null) where TIndex : AbstractIndexCreationTask, new()
+    {
+        options ??= Options.ForSearchEngine(RavenSearchEngineMode.Lucene);
+        using var store = GetDocumentStore(options);
+        AssertExceptionOfVectorFieldInIndex(() => new TIndex().Execute(store));
+    }
+    
+    private void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpCounterTestBase<TIndex>(Options options = null)
+        where TIndex : AbstractCountersIndexCreationTask, new()
+    {
+        options ??= Options.ForSearchEngine(RavenSearchEngineMode.Lucene);
+        using var store = GetDocumentStore(options);
+        AssertExceptionOfVectorFieldInIndex(() => new TIndex().Execute(store));
+    }
+    
+    private void ThrowOnIndexCreationWithVectorFieldWhenSearchEngineIsNotCoraxCsharpTimeSeriesTestBase<TIndex>(Options options = null)
+        where TIndex : AbstractTimeSeriesIndexCreationTask, new()
+    {
+        options ??= Options.ForSearchEngine(RavenSearchEngineMode.Lucene);
+        using var store = GetDocumentStore(options);
+        AssertExceptionOfVectorFieldInIndex(() => new TIndex().Execute(store));
+    }
+
+    private static void AssertExceptionOfVectorFieldInIndex(Action indexDeployment)
+    {
+        var ravenException = Assert.Throws<RavenException>(indexDeployment);
+        Assert.IsType<NotSupportedException>(ravenException.InnerException);
+        Assert.Contains("Vector fields are supported only by the Corax search engine. This deployment requested 'Lucene' search engine.", ravenException.InnerException.Message);
+    }
+
+    private class Dto
+    {
+        public string Text { get; set; }
+    }
+
+    private class CsharpIndexBaseCorax : CsharpIndexBase
+    {
+        public CsharpIndexBaseCorax() : base()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+    
+    private class CsharpIndexBaseLucene : CsharpIndexBase
+    {
+        public CsharpIndexBaseLucene() : base()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Lucene;
+        }
+    }
+    
+    private class CsharpIndexBase : AbstractIndexCreationTask<Dto>
+    {
+        public CsharpIndexBase()
+        {
+            Map = dtos => dtos.Select(d => new { Vector = CreateVector(d.Text) });
+        }
+    }
+
+    private class JsIndexCorax : JsIndexBase
+    {
+        public JsIndexCorax()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+    
+    private class JsIndexLucene : JsIndexBase
+    {
+        public JsIndexLucene()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Lucene;
+        }
+    }
+    
+    private class JsIndexBase : AbstractJavaScriptIndexCreationTask
+    {
+        public JsIndexBase()
+        {
+            Maps = [@$"map('Dtos', function (e) {{
+    return {{ 
+        Name: e.Name,
+        Vector: createVector(e.Text)
+    }};
+}})"];
+        }
+    }
+
+    private class CounterIndexCorax : CounterIndexBase
+    {
+        public CounterIndexCorax()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+    
+    private class CounterIndexLucene : CounterIndexBase
+    {
+        public CounterIndexLucene()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Lucene;
+        }
+    }
+    
+    private class CounterIndexBase : AbstractCountersIndexCreationTask<Company>
+    {
+        public CounterIndexBase()
+        {
+            AddMapForAll(counters => from counter in counters
+                select new
+                {
+                    HeartBeat = counter.Value,
+                    Name = counter.Name,
+                    User = counter.DocumentId,
+                    Vector = CreateVector(counter.Name)
+                });
+        }
+    }
+
+    private class TimeSeriesIndexCorax : TimeSeriesIndexBase
+    {
+        public TimeSeriesIndexCorax()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+    
+    private class TimeSeriesIndexLucene : TimeSeriesIndexBase
+    {
+        public TimeSeriesIndexLucene()
+        {
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Lucene;
+        }
+    }
+    
+    private class TimeSeriesIndexBase : AbstractTimeSeriesIndexCreationTask<Company>
+    {
+        public TimeSeriesIndexBase()
+        {
+            AddMap(
+                "HeartRate",
+                timeSeries => from ts in timeSeries
+                    from entry in ts.Entries
+                    select new
+                    {
+                        HeartBeat = entry.Values[0],
+                        entry.Timestamp.Date,
+                        User = ts.DocumentId,
+                        Vector = CreateVector(ts.DocumentId)
+                    });
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23464

### Additional description


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
