### PR TITLE
RavenDB-23438

### DIFF
--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -1589,12 +1589,25 @@ namespace Raven.Client.Documents.Conventions
             if (ForTestingPurposes != null)
                 return ForTestingPurposes;
 
-            return ForTestingPurposes = new TestingStuff();
+            return ForTestingPurposes = new TestingStuff(this);
         }
 
         internal class TestingStuff
         {
+            private readonly DocumentConventions _conventions;
+
+            public TestingStuff(DocumentConventions conventions)
+            {
+                _conventions = conventions;
+            }
+
             internal Action<RequestExecutor> OnBeforeTopologyUpdate;
+
+            internal HttpCompressionAlgorithm HttpCompressionAlgorithm
+            {
+                get => _conventions._httpCompressionAlgorithm;
+                set => _conventions._httpCompressionAlgorithm = value;
+            }
         }
     }
 }

--- a/test/InterversionTests/MixedClusterTestBase.cs
+++ b/test/InterversionTests/MixedClusterTestBase.cs
@@ -42,13 +42,12 @@ namespace InterversionTests
             return base.GetNewServer(options, caller);
         }
 
-        protected async Task<List<ProcessNode>> CreateCluster(string[] peers, X509Certificate2 certificate = null
-            , bool watcherCluster = false)
+        protected async Task<List<ProcessNode>> CreateCluster(string[] peers, InterversionTestOptions options = null, X509Certificate2 certificate = null, bool watcherCluster = false)
         {
             var processes = new List<ProcessNode>();
             foreach (var peer in peers)
             {
-                processes.Add(await GetServerAsync(peer));
+                processes.Add(await GetServerAsync(peer, options));
             }
 
             var leader = processes[0];

--- a/test/InterversionTests/MixedClusterTests.cs
+++ b/test/InterversionTests/MixedClusterTests.cs
@@ -1054,7 +1054,25 @@ namespace InterversionTests
             {
                 await CreateDatabase(stores, database, nodes.Count);
             }
+        }
 
+        [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Cluster, RavenPlatform.Windows | RavenPlatform.Linux)]
+        public async Task ClusterTcpCompressionTest_70()
+        {
+            DebuggerAttachedTimeout.DisableLongTimespan = true;
+
+            var nodes = await CreateCluster(new[] { "5.4.0", "5.4.0", "5.4.0" });
+            await UpgradeServerAsync("7.0.0-nightly-20250103-0446", nodes[0], new Dictionary<string, string>
+            {
+                ["RAVEN_HTTP_COMPRESSION_ALGORITHM"] = "gzip"
+            });
+
+            var database = GetDatabaseName();
+            var (disposable, stores) = await GetStores(database, nodes);
+            using (disposable)
+            {
+                await CreateDatabase(stores, database, nodes.Count);
+            }
         }
 
         [RavenMultiplatformFact(RavenTestCategory.Interversion | RavenTestCategory.Counters, RavenPlatform.Windows, Skip = "WIP")]

--- a/test/Tests.Infrastructure/InterversionTest/ConfigurableRavenServerLocator.cs
+++ b/test/Tests.Infrastructure/InterversionTest/ConfigurableRavenServerLocator.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using Sparrow.Platform;
 
@@ -13,11 +14,12 @@ namespace Tests.Infrastructure.InterversionTest
         private static int _port = 8080;
         private static int Port => Interlocked.Increment(ref _port) - 1;
 
-        public ConfigurableRavenServerLocator(string serverDirPath, string version, string dataDir = null, string url = null)
+        public ConfigurableRavenServerLocator(string serverDirPath, string version, string dataDir = null, string url = null, Dictionary<string, string> environmentVariables = null)
         {
             _serverDirPath = serverDirPath;
             _dataDir = dataDir;
             _serverUrl = url;
+            EnvironmentVariables = environmentVariables;
             if (version.StartsWith("4."))
             {
                 _commandsArg = "--Http.UseLibuv=true";
@@ -29,6 +31,7 @@ namespace Tests.Infrastructure.InterversionTest
         }
 
         public override string CommandArguments => _commandsArg;
+        public override Dictionary<string, string> EnvironmentVariables { get; }
 
         public override string ServerPath => Path.Combine(
             _serverDirPath,

--- a/test/Tests.Infrastructure/InterversionTest/RavenServerLocator.cs
+++ b/test/Tests.Infrastructure/InterversionTest/RavenServerLocator.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Tests.Infrastructure.InterversionTest
 {
     public abstract class RavenServerLocator
@@ -9,5 +11,7 @@ namespace Tests.Infrastructure.InterversionTest
         public virtual string Command => ServerPath;
 
         public virtual string CommandArguments => string.Empty;
+
+        public abstract Dictionary<string, string> EnvironmentVariables { get; }
     }
 }

--- a/test/Tests.Infrastructure/InterversionTest/RavenServerRunner.cs
+++ b/test/Tests.Infrastructure/InterversionTest/RavenServerRunner.cs
@@ -67,7 +67,7 @@ namespace Tests.Infrastructure.InterversionTest
                 };
 
                 var argumentsString = string.Join(" ", commandArguments);
-                return new ProcessStartInfo
+                var processStartInfo = new ProcessStartInfo
                 {
                     FileName = locator.Command,
                     Arguments = argumentsString,
@@ -77,6 +77,14 @@ namespace Tests.Infrastructure.InterversionTest
                     RedirectStandardInput = true,
                     UseShellExecute = false,
                 };
+
+                if (locator.EnvironmentVariables is { Count: > 0 })
+                {
+                    foreach (var kvp in locator.EnvironmentVariables)
+                        processStartInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+                }
+
+                return processStartInfo;
             }
         }
 


### PR DESCRIPTION
- forcing to use Gzip by default in the interversion tests
- added a dedicated test that does migration from 5.4 to 7.0 with the ability to override the http compression algorithm via env variable

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23438

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
