### PR TITLE
RavenDB-23463 removed ios, android, tvos native libs

### DIFF
--- a/scripts/nuget.ps1
+++ b/scripts/nuget.ps1
@@ -83,6 +83,14 @@ function BuildEmbeddedNuget ($projectDir, $outDir, $serverSrcDir, $studioZipPath
     write-host "Copying Studio $studioZipPath -> $serverDir"
     Copy-Item "$studioZipPath" -Destination $serverDir
     
+    $directoriesToRemove = @("$serverDir\runtimes\ios*", "$serverDir\runtimes\android*", "$serverDir\runtimes\tvos*")
+    foreach ($dir in $directoriesToRemove) {
+        if (Test-Path $dir) {
+            Remove-Item -Path $dir -Recurse -Force
+            Write-Output "Removed: $dir"
+        }
+    }
+    
     $targetsSrc = [io.path]::combine($EMBEDDED_SRC_DIR, "RavenDB.Embedded.targets")
     $targetsDst = [io.path]::combine($EMBEDDED_BUILD_OUT_DIR, "RavenDB.Embedded.targets")
     Copy-Item "$targetsSrc" -Destination "$targetsDst"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23463

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
