### PR TITLE
RavenDB-23484 Admin Logs: "Off" level is confusing

### DIFF
--- a/src/Raven.Studio/typescript/components/utils/common.ts
+++ b/src/Raven.Studio/typescript/components/utils/common.ts
@@ -128,23 +128,23 @@ export type OmitIndexSignature<T> = {
 export type StringWithAutocomplete<T> = T | (string & NonNullable<unknown>);
 
 export const allLogLevels = exhaustiveStringTuple<Sparrow.Logging.LogLevel>()(
-    "Off",
     "Trace",
     "Debug",
     "Info",
     "Warn",
     "Error",
-    "Fatal"
+    "Fatal",
+    "Off"
 );
 
 export const logLevelRelevances: Record<Sparrow.Logging.LogLevel, number> = {
-    Off: 0,
-    Trace: 1,
-    Debug: 2,
-    Info: 3,
-    Warn: 4,
-    Error: 5,
-    Fatal: 6,
+    Trace: 0,
+    Debug: 1,
+    Info: 2,
+    Warn: 3,
+    Error: 4,
+    Fatal: 5,
+    Off: 6,
 };
 
 export const allLogFilterActions = exhaustiveStringTuple<Sparrow.Logging.LogFilterAction>()(


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23484/Admin-Logs-Off-level-is-confusing

### Additional description

Fixes log levels order

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
