### PR TITLE
RavenDB-23442 Implicit (configured) order by score when vector.search is involved.

### DIFF
--- a/src/Corax/Querying/IndexSearcher.VectorSearch.cs
+++ b/src/Corax/Querying/IndexSearcher.VectorSearch.cs
@@ -6,8 +6,8 @@ namespace Corax.Querying;
 
 public partial class IndexSearcher
 {
-    public VectorSearchMatch VectorSearch(in FieldMetadata metadata, in VectorValue vectorValue, float minimumMatch, in int numberOfCandidates, bool isExact)
+    public VectorSearchMatch VectorSearch(in FieldMetadata metadata, in VectorValue vectorValue, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch)
     {
-        return new VectorSearchMatch(this, metadata, vectorValue, minimumMatch, numberOfCandidates, isExact);
+        return new VectorSearchMatch(this, metadata, vectorValue, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch);
     }
 }

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
@@ -96,7 +96,7 @@ unsafe partial struct SortingMatch<TInner>
                 // We get the boosting tree and go to check every document. 
                 BoostDocuments(match, batchResults, readScores);
             }
-
+            
             // Note! readScores & indexes are aliased and same as batchTermIds
             var heapSize = Math.Min(match._take, batchResults.Length);
             heapSize = heapSize < 0 ? batchResults.Length : heapSize;

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -614,6 +614,12 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForQuerying", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public int CoraxVectorDefaultNumberOfCandidatesForQuerying { get; protected set; }
         
+        [Description("Order by score automatically when vector.search is inside query.")]
+        [DefaultValue(true)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
+        [ConfigurationEntry("Indexing.Corax.OrderByScoreAutomaticallyWhenVectorSearchIsUsed", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public bool OrderByScoreAutomaticallyWhenVectorSearchIsUsed { get; set; }
+        
         protected override void ValidateProperty(PropertyInfo property)
         {
             base.ValidateProperty(property);

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -617,8 +617,8 @@ namespace Raven.Server.Config.Categories
         [Description("Order by score automatically when vector.search is inside query.")]
         [DefaultValue(true)]
         [IndexUpdateType(IndexUpdateType.Refresh)]
-        [ConfigurationEntry("Indexing.Corax.OrderByScoreAutomaticallyWhenVectorSearchIsUsed", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
-        public bool OrderByScoreAutomaticallyWhenVectorSearchIsUsed { get; set; }
+        [ConfigurationEntry("Indexing.Corax.VectorSearch.OrderByScoreAutomatically", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public bool CoraxVectorSearchOrderByScoreAutomatically { get; set; }
         
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -1350,15 +1350,20 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             int read;
             long i = Skip();
             Page page = default;
-
+            var alreadySeenDocuments = new HashSet<long>();
+            
             while (true)
             {
                 token.ThrowIfCancellationRequested();
                 for (; docsToLoad != 0 && i < read; ++i, --docsToLoad)
                 {
+                    var coraxInternalEntryId = ids[i];
+                    if (alreadySeenDocuments.Add(coraxInternalEntryId) == false)
+                        continue;
+                    
                     token.ThrowIfCancellationRequested();
-                    var reader = IndexSearcher.GetEntryTermsReader(ids[i], ref page);
-                    var id = _documentIdReader.GetTermFor(ids[i]);
+                    var reader = IndexSearcher.GetEntryTermsReader(coraxInternalEntryId, ref page);
+                    var id = _documentIdReader.GetTermFor(coraxInternalEntryId);
                     yield return documentsContext.ReadObject(coraxEntryReader.GetDocument(ref reader), id);
                 }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -97,7 +97,7 @@ public static class CoraxQueryBuilder
             HasBoost = index.HasBoostedFields 
                        || query.Metadata.HasBoost 
                        || IsVectorSingleClause
-                       || (query.Metadata.HasVectorSearch && index.Configuration.OrderByScoreAutomaticallyWhenVectorSearchIsUsed)
+                       || (query.Metadata.HasVectorSearch && index.Configuration.CoraxVectorSearchOrderByScoreAutomatically)
                        || (index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved &&
                                                       HasBoostingAsOrderingType(query.Metadata.OrderBy));
             Allocator = allocator;
@@ -1496,7 +1496,7 @@ public static class CoraxQueryBuilder
         {
             if (builderParameters.HasBoost && (
                     index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved 
-                    || index.Configuration.OrderByScoreAutomaticallyWhenVectorSearchIsUsed))
+                    || index.Configuration.CoraxVectorSearchOrderByScoreAutomatically))
             {
                 // in case when we've single vector clause and we exose the score, we have to go through 
                 // order by primitive to retrieve them; however scores are detected as natively sorted

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
 
         public abstract long EntriesCount();
 
-        internal virtual void AssertCanOrderByScoreAutomaticallyWhenBoostingIsInvolved()
+        internal virtual void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved()
         {
         }
         

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -629,7 +629,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 if (index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved == false || query.Metadata.HasBoost == false && index.HasBoostedFields == false)
                     return null;
 
-                AssertCanOrderByScoreAutomaticallyWhenBoostingIsInvolved();
+                AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved();
                 sort = SortByFieldScore;
                 return null;
             }

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
@@ -176,5 +176,5 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
         return result;
     }
     
-    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled.");
+    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenVectorSearchIsUsed)}` enabled.");
 }

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
@@ -176,5 +176,5 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
         return result;
     }
     
-    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenVectorSearchIsUsed)}` enabled.");
+    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.CoraxVectorSearchOrderByScoreAutomatically)}` enabled.");
 }

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Lucene/ShardedLuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Lucene/ShardedLuceneIndexReadOperation.cs
@@ -89,5 +89,5 @@ public sealed class ShardedLuceneIndexReadOperation : LuceneIndexReadOperation
         return result;
     }
     
-    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenVectorSearchIsUsed)}` enabled.");
+    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.CoraxVectorSearchOrderByScoreAutomatically)}` enabled.");
 }

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Lucene/ShardedLuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Lucene/ShardedLuceneIndexReadOperation.cs
@@ -89,5 +89,5 @@ public sealed class ShardedLuceneIndexReadOperation : LuceneIndexReadOperation
         return result;
     }
     
-    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled.");
+    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenVectorSearchIsUsed)}` enabled.");
 }

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -49,7 +49,7 @@ class configurationItem {
         "Indexing.Corax.VectorSearch.DefaultNumberOfEdges",
         "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForIndexing",
         "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForQuerying",
-        "Indexing.Corax.OrderByScoreAutomaticallyWhenVectorSearchIsUsed"
+        "Indexing.Corax.VectorSearch.OrderByScoreAutomatically"
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -48,7 +48,8 @@ class configurationItem {
         "Indexing.Corax.VectorSearch.DefaultMinimumSimilarity",
         "Indexing.Corax.VectorSearch.DefaultNumberOfEdges",
         "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForIndexing",
-        "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForQuerying"
+        "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForQuerying",
+        "Indexing.Corax.OrderByScoreAutomaticallyWhenVectorSearchIsUsed"
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*
             Obsolete keys:

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.Numerics.Tensors;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using Sparrow;
 
 namespace Voron.Data.Graphs;
 
@@ -14,7 +16,7 @@ public partial class Hnsw
         CosineSimilarityI8 = 1,
         HammingDistance = 2,
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static float CosineSimilaritySingles(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
@@ -28,21 +30,21 @@ public partial class Hnsw
     {
         Debug.Assert(a.Length == b.Length, "a.Length == b.Length");
         var vectorLength = a.Length - sizeof(float);
-        
-        ref var aRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte,sbyte>(a[..vectorLength]));
+
+        ref var aRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, sbyte>(a[..vectorLength]));
         ref var bRef = ref MemoryMarshal.GetReference(MemoryMarshal.Cast<byte, sbyte>(b[..vectorLength]));
-        
+
         var magA = Unsafe.ReadUnaligned<float>(ref MemoryMarshal.GetReference(a[vectorLength..]));
         var magB = Unsafe.ReadUnaligned<float>(ref MemoryMarshal.GetReference(b[vectorLength..]));
-        
+
         var alpha1 = magA / 127f;
         var alpha2 = magB / 127f;
-        
+
         float dotProduct = alpha1 * alpha2 * vectorLength;
 
         float sq1 = 0;
         float sq2 = 0;
-        
+
         for (int i = 0; i < vectorLength; i++)
         {
             var aValue = Unsafe.Add(ref aRef, i);
@@ -50,11 +52,11 @@ public partial class Hnsw
             dotProduct += alpha1 * aValue;
             dotProduct += alpha2 * bValue;
             dotProduct += aValue * bValue;
-            
+
             sq1 += aValue * aValue;
             sq2 += bValue * bValue;
         }
-        
+
         sq1 = MathF.Sqrt(sq1);
         sq2 = MathF.Sqrt(sq2);
 
@@ -65,5 +67,103 @@ public partial class Hnsw
     private static float HammingDistance(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
         return TensorPrimitives.HammingBitDistance<byte>(a, b);
+    }
+    
+    internal static void DistanceToScoreHammingSimilarity(Span<float> scores, int vectorSizeInBytes)
+    {
+        var pos = 0;
+        ref float bufferRef = ref MemoryMarshal.GetReference(scores);
+        int N = 0;
+
+        if (AdvInstructionSet.IsAcceleratedVector512)
+        {
+            var divisor = Vector512.Create(8f * vectorSizeInBytes);
+            N = Vector512<float>.Count;
+            for (; pos + N < scores.Length; pos += N)
+            {
+                ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
+                var currentScores = Vector512.LoadUnsafe(ref currentPos);
+                var divide = Vector512.Divide(currentScores, divisor);
+                var result = Vector512.Subtract(Vector512.Create(1F), divide);
+                result.StoreUnsafe(ref currentPos);
+            }
+        }
+
+        if (AdvInstructionSet.IsAcceleratedVector256)
+        {
+            var divisor = Vector256.Create(8f * vectorSizeInBytes);
+            N = Vector256<float>.Count;
+            for (; pos + N < scores.Length; pos += N)
+            {
+                ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
+                var currentScores = Vector256.LoadUnsafe(ref currentPos);
+                var divide = Vector256.Divide(currentScores, divisor);
+                var result = Vector256.Subtract(Vector256.Create(1F), divide);
+                result.StoreUnsafe(ref currentPos);
+            }
+        }
+
+        if (AdvInstructionSet.IsAcceleratedVector128)
+        {
+            var divisor = Vector128.Create(8f * vectorSizeInBytes);
+            N = Vector128<float>.Count;
+            for (; pos + N < scores.Length; pos += N)
+            {
+                ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
+                var currentScores = Vector128.LoadUnsafe(ref currentPos);
+                var divide = Vector128.Divide(currentScores, divisor);
+                var result = Vector128.Subtract(Vector128.Create(1F), divide);
+                result.StoreUnsafe(ref currentPos);
+            }
+        }
+
+        for (; pos < scores.Length; pos++)
+            Unsafe.Add(ref bufferRef, pos) = 1f - (Unsafe.Add(ref bufferRef, pos) / (8f * vectorSizeInBytes));
+    }
+
+    internal static void DistanceToScoreCosineSimilarity(Span<float> scores)
+    {
+        var pos = 0;
+        ref float bufferRef = ref MemoryMarshal.GetReference(scores);
+        int N = 0;
+
+        if (AdvInstructionSet.IsAcceleratedVector512)
+        {
+            N = Vector512<float>.Count;
+            for (; pos + N < scores.Length; pos += N)
+            {
+                ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
+                var currentScores = Vector512.LoadUnsafe(ref currentPos);
+                var result = Vector512.Subtract(Vector512.Create(1F), currentScores);
+                result.StoreUnsafe(ref currentPos);
+            }
+        }
+
+        if (AdvInstructionSet.IsAcceleratedVector256)
+        {
+            N = Vector256<float>.Count;
+            for (; pos + N < scores.Length; pos += N)
+            {
+                ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
+                var currentScores = Vector256.LoadUnsafe(ref currentPos);
+                var result = Vector256.Subtract(Vector256.Create(1F), currentScores);
+                result.StoreUnsafe(ref currentPos);
+            }
+        }
+
+        if (AdvInstructionSet.IsAcceleratedVector128)
+        {
+            N = Vector128<float>.Count;
+            for (; pos + Vector128<float>.Count < scores.Length; pos += N)
+            {
+                ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
+                var currentScores = Vector128.LoadUnsafe(ref currentPos);
+                var result = Vector128.Subtract(Vector128.Create(1F), currentScores);
+                result.StoreUnsafe(ref currentPos);
+            }
+        }
+
+        for (; pos < scores.Length; pos++)
+            Unsafe.Add(ref bufferRef, pos) = 1 - Unsafe.Add(ref bufferRef, pos);
     }
 }

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -92,7 +92,7 @@ namespace FastTests.Issues
                 "Indexing.Corax.VectorSearch.DefaultNumberOfEdges",
                 "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForIndexing",
                 "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForQuerying",
-                "Indexing.Corax.OrderByScoreAutomaticallyWhenVectorSearchIsUsed",
+                "Indexing.Corax.VectorSearch.OrderByScoreAutomatically",
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",
                 "Indexing.Analyzers.NGram.MaxGram",

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -92,6 +92,7 @@ namespace FastTests.Issues
                 "Indexing.Corax.VectorSearch.DefaultNumberOfEdges",
                 "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForIndexing",
                 "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForQuerying",
+                "Indexing.Corax.OrderByScoreAutomaticallyWhenVectorSearchIsUsed",
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",
                 "Indexing.Analyzers.NGram.MaxGram",

--- a/test/SlowTests/Corax/RavenDB-23442.cs
+++ b/test/SlowTests/Corax/RavenDB-23442.cs
@@ -1,0 +1,132 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Intrinsics;
+using FastTests;
+using FastTests.Voron.FixedSize;
+using Raven.Client.Documents;
+using Raven.Server.Config;
+using Sparrow;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Voron.Data.Graphs;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_23442(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private static IEnumerable<object[]> Theory()
+    {
+        foreach (var sortVectorSearchByScoreAutomatically in new[] { false, true })
+        {
+            foreach (var includeScores in new[] { false, true })
+            {
+                yield return [sortVectorSearchByScoreAutomatically, includeScores];
+            }
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [MemberData(nameof(Theory))]
+    public void SingleVectorSearchWillAlwaysBeSortedByDistance(bool sortVectorSearchByScoreAutomatically, bool includeScore)
+    {
+        using var store = GetDocumentStoreWithDocuments(sortVectorSearchByScoreAutomatically, includeScore);
+        using var session = store.OpenSession();
+
+        var results = session.Query<Product>()
+            .Customize(c => c.WaitForNonStaleResults())
+            .VectorSearch(f => f.WithText(p => p.Name),
+                v => v.ByText("vehicle"), minimumSimilarity: 0.1f)
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("car", results[0].Name);
+        Assert.Equal("banana", results[1].Name);
+    }
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [MemberData(nameof(Theory))]
+    public void VectorSearchWillAlwaysBeSortedByDistance(bool sortVectorSearchByScoreAutomatically, bool includeScore)
+    {
+        using var store = GetDocumentStoreWithDocuments(sortVectorSearchByScoreAutomatically, includeScore);
+        using var session = store.OpenSession();
+
+        var results = session.Advanced.DocumentQuery<Product>()
+            .WaitForNonStaleResults()
+            .WhereEquals(x => x.Discontinued, true)
+            .AndAlso()
+            .VectorSearch(f => f.WithText(p => p.Name),
+                v => v.ByText("vehicle"), minimumSimilarity: 0.1f)
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        if (sortVectorSearchByScoreAutomatically)
+        {
+            Assert.Equal("car", results[0].Name);
+            Assert.Equal("banana", results[1].Name);
+        }
+        else
+        {
+            Assert.Equal("banana", results[0].Name);
+            Assert.Equal("car", results[1].Name);
+        }
+    }
+
+    private IDocumentStore GetDocumentStoreWithDocuments(bool sortVectorSearchByScoreAutomatically, bool coraxIncludeDocumentScore)
+    {
+        var sourceOptions = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
+        sourceOptions.ModifyDatabaseRecord += record =>
+        {
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.OrderByScoreAutomaticallyWhenVectorSearchIsUsed)] = sortVectorSearchByScoreAutomatically.ToString();
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = coraxIncludeDocumentScore.ToString();
+        };
+
+        var store = GetDocumentStore(sourceOptions);
+        using var session = store.OpenSession();
+        session.Store(new Product() { Name = "banana", Discontinued = true });
+        session.Store(new Product() { Name = "car", Discontinued = true });
+        session.SaveChanges();
+        return store;
+    }
+
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed]
+    public void SimdCosineSimilarityToScore(int seed)
+    {
+        var size = GetSizeForSimdTest();
+        var random = new System.Random(seed);
+        var originalArray = Enumerable.Range(0, size).Select(x => random.NextSingle()).ToArray();
+        var clonedArray = originalArray.ToArray();
+
+        Hnsw.DistanceToScoreCosineSimilarity(clonedArray);
+        for (int i = 0; i < originalArray.Length; i++)
+            Assert.Equal(1f - originalArray[i], clonedArray[i], float.Epsilon);
+    }
+
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed]
+    public void SimdHammingSimilarityToScore(int seed)
+    {
+        var size = GetSizeForSimdTest();
+        var random = new System.Random(seed);
+        var originalArray = Enumerable.Range(0, size).Select(x => (float)random.Next(0, 64)).ToArray();
+        var clonedArray = originalArray.ToArray();
+
+        Hnsw.DistanceToScoreHammingSimilarity(clonedArray, 8);
+        for (int i = 0; i < originalArray.Length; i++)
+            Assert.Equal(1f - (originalArray[i] / 64f), clonedArray[i], float.Epsilon);
+    }
+
+    private static int GetSizeForSimdTest()
+    {
+        var size = 1;
+        if (AdvInstructionSet.IsAcceleratedVector512)
+            size += Vector512<float>.Count;
+        if (AdvInstructionSet.IsAcceleratedVector256)
+            size += Vector256<float>.Count;
+        if (AdvInstructionSet.IsAcceleratedVector128)
+            size += Vector128<float>.Count;
+        return size;
+    }
+}

--- a/test/SlowTests/Corax/RavenDB-23442.cs
+++ b/test/SlowTests/Corax/RavenDB-23442.cs
@@ -78,7 +78,7 @@ public class RavenDB_23442(ITestOutputHelper output) : RavenTestBase(output)
         var sourceOptions = Options.ForSearchEngine(RavenSearchEngineMode.Corax);
         sourceOptions.ModifyDatabaseRecord += record =>
         {
-            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.OrderByScoreAutomaticallyWhenVectorSearchIsUsed)] = sortVectorSearchByScoreAutomatically.ToString();
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.CoraxVectorSearchOrderByScoreAutomatically)] = sortVectorSearchByScoreAutomatically.ToString();
             record.Settings[RavenConfiguration.GetKey(x => x.Indexing.CoraxIncludeDocumentScore)] = coraxIncludeDocumentScore.ToString();
         };
 

--- a/test/SlowTests/Issues/RavenDB-23457.cs
+++ b/test/SlowTests/Issues/RavenDB-23457.cs
@@ -19,7 +19,7 @@ public class RavenDB_23457 : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Indexes)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public void Test(Options options)
+    public void CanShowIndexRawEntryWhenVectorSearchIsInsideWhereClause(Options options)
     {
         using (var store = GetDocumentStore(options))
         {

--- a/test/SlowTests/Tests/Indexes/BoostingDuringIndexing.cs
+++ b/test/SlowTests/Tests/Indexes/BoostingDuringIndexing.cs
@@ -155,8 +155,7 @@ namespace SlowTests.Tests.Indexes
             Indexes.WaitForIndexing(store);
 
             var ex = Assert.Throws<NotSupportedInShardingException>(() => session.Query<User, UsersByName>().ToList());
-            Assert.Contains(
-                $"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled.",
+            Assert.Contains($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenVectorSearchIsUsed)}` enabled.",
                 ex.Message);
         }
     }

--- a/test/SlowTests/Tests/Indexes/BoostingDuringIndexing.cs
+++ b/test/SlowTests/Tests/Indexes/BoostingDuringIndexing.cs
@@ -155,7 +155,7 @@ namespace SlowTests.Tests.Indexes
             Indexes.WaitForIndexing(store);
 
             var ex = Assert.Throws<NotSupportedInShardingException>(() => session.Query<User, UsersByName>().ToList());
-            Assert.Contains($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenVectorSearchIsUsed)}` enabled.",
+            Assert.Contains($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.CoraxVectorSearchOrderByScoreAutomatically)}` enabled.",
                 ex.Message);
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23442

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
