### PR TITLE
RavenDB-23482 Admin Logs: Indicate that filters have been defined

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/AdminLogs.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/AdminLogs.tsx
@@ -23,6 +23,7 @@ import { StylesConfig } from "react-select";
 import { Button, Card, CardBody, CardHeader, Input } from "reactstrap";
 import { Switch } from "components/common/Checkbox";
 import { FlexGrow } from "components/common/FlexGrow";
+import AdminLogsFilterState from "components/pages/resources/manageServer/adminLogs/bits/AdminLogsFilterState";
 
 export default function AdminLogs() {
     const dispatch = useAppDispatch();
@@ -84,6 +85,9 @@ export default function AdminLogs() {
                                 Logs on this view
                             </h4>
                             <div className="d-flex align-items-center lh-base">
+                                <AdminLogsFilterState
+                                    isActive={configs?.adminLogsConfig?.AdminLogs?.CurrentFilters?.length > 0}
+                                />
                                 <Icon icon="logs" addon="arrow-filled-up" />
                                 <span className="lh-1">
                                     <strong>Min level:</strong>
@@ -158,6 +162,9 @@ export default function AdminLogs() {
                                 Logs on disk
                             </h4>
                             <div className="d-flex align-items-center">
+                                <AdminLogsFilterState
+                                    isActive={configs?.adminLogsConfig?.Logs?.CurrentFilters?.length > 0}
+                                />
                                 <Icon icon="logs" addon="arrow-filled-up" />
                                 <span className="lh-1 me-1">
                                     <strong>Min level:</strong>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/bits/AdminLogsFilterState.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/adminLogs/bits/AdminLogsFilterState.tsx
@@ -1,0 +1,21 @@
+import { ConditionalPopover } from "components/common/ConditionalPopover";
+import { Icon } from "components/common/Icon";
+
+export default function AdminLogsFilterState({ isActive }: { isActive: boolean }) {
+    return (
+        <ConditionalPopover
+            conditions={[
+                {
+                    isActive,
+                    message: "There are active filters",
+                },
+                {
+                    isActive: !isActive,
+                    message: "No active filters",
+                },
+            ]}
+        >
+            <Icon icon="filter" color={isActive ? "primary" : "muted"} />
+        </ConditionalPopover>
+    );
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23482/Admin-Logs-Indicate-that-filters-have-been-defined

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
