### PR TITLE
RavenDB-23327- Allow to delete a revision from the "Revision View"

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/documents/deleteRevisionsForDocumentsCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/deleteRevisionsForDocumentsCommand.ts
@@ -16,7 +16,8 @@ class deleteRevisionsForDocumentsCommand extends commandBase {
     execute(): JQueryPromise<void> {
         const url = endpoints.databases.adminRevisions.adminRevisions;
 
-        return this.del<void>(url, JSON.stringify(this.parameters), this.databaseName, { dataType: undefined });
+        return this.del<void>(url, JSON.stringify(this.parameters), this.databaseName, { dataType: undefined })
+            .fail((response: JQueryXHR) => this.reportError("Failed to delete document revisions", response.responseText, response.statusText));
     }
  }
 

--- a/src/Raven.Studio/typescript/components/pages/database/documents/allRevisions/AllRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/documents/allRevisions/AllRevisions.tsx
@@ -70,11 +70,6 @@ export default function AllRevisions() {
                     collectionsTracker.default.getAllRevisionsCollection().documentCount() - selectedRows.length
                 );
         },
-        {
-            onError() {
-                messagePublisher.reportError("Failed to remove selected revisions");
-            },
-        }
     );
 
     const handleRemoveConfirmation = async () => {

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1439,7 +1439,7 @@ class editDocument extends shardViewModelBase {
             buttons: ["Cancel", "Yes, delete"],
         }).done((result) => {
             if (result.can) {
-                new deleteRevisionsForDocumentsCommand(this.db.name, parameters).execute().always(() => {
+                new deleteRevisionsForDocumentsCommand(this.db.name, parameters).execute().done(() => {
                     router.navigate(appUrl.forAllRevisions(this.db));
                 });
             }

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1438,11 +1438,9 @@ class editDocument extends shardViewModelBase {
         this.confirmationMessage("Are you sure?", "Do you want to delete current revision?", {
             buttons: ["Cancel", "Yes, delete"],
         }).done((result) => {
-            const docsIds = parameters.DocumentIds.join(", ")
-
             if (result.can) {
                 new deleteRevisionsForDocumentsCommand(this.db.name, parameters).execute().done(() => {
-                    messagePublisher.reportSuccess(`Deleted ${docsIds}`)
+                    messagePublisher.reportSuccess(`Deleted revision ${doc.__metadata.changeVector()}`);
                     router.navigate(appUrl.forAllRevisions(this.db));
                 });
             }

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1438,8 +1438,11 @@ class editDocument extends shardViewModelBase {
         this.confirmationMessage("Are you sure?", "Do you want to delete current revision?", {
             buttons: ["Cancel", "Yes, delete"],
         }).done((result) => {
+            const docsIds = parameters.DocumentIds.join(", ")
+
             if (result.can) {
                 new deleteRevisionsForDocumentsCommand(this.db.name, parameters).execute().done(() => {
+                    messagePublisher.reportSuccess(`Deleted ${docsIds}`)
                     router.navigate(appUrl.forAllRevisions(this.db));
                 });
             }

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -64,7 +64,7 @@
                         <span>Clone</span>
                     </button>
                     <button type="button" class="delete-btn btn btn-danger"
-                            data-bind="click: deleteDocument, enable: !isCreatingNewDocument(), visible: !inReadOnlyMode() && !inDiffMode() && !isClone() && !isCreatingNewDocument(), requiredAccess: 'DatabaseReadWrite'">
+                            data-bind="click: isRevision() ? deleteRevision : deleteDocument, enable: !isCreatingNewDocument(), visible: isRevision() || !inReadOnlyMode() && !inDiffMode() && !isClone() && !isCreatingNewDocument(), requiredAccess: 'DatabaseReadWrite'">
                         <i class="icon-trash"></i>
                         <span>Delete</span>
                     </button>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23327

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
