### PR TITLE
RavenDB-29429 Fix issue with fifo queue

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Queue/AmazonSqs/AmazonSqsEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/AmazonSqs/AmazonSqsEtl.cs
@@ -59,7 +59,7 @@ public sealed class AmazonSqsEtl : QueueEtl<AmazonSqsItem>
 
         foreach (QueueWithItems<AmazonSqsItem> queue in itemsPerQueue)
         {
-            string queueName = queue.Name.ToLower();
+            string queueName = queue.Name;
             bool isFifoQueue = queueName.EndsWith(FifoQueueIdentifier);
 
             if (_queueClient == null)
@@ -206,7 +206,8 @@ public sealed class AmazonSqsEtl : QueueEtl<AmazonSqsItem>
                 {
                     MessageGroupId = message.MessageGroupId,
                     QueueUrl = GetQueueUrl(_queueClient, queueName),
-                    MessageBody = message.MessageBody
+                    MessageBody = message.MessageBody,
+                    MessageDeduplicationId = message.MessageDeduplicationId
                 };
 
                 AsyncHelpers.RunSync(() => _queueClient.SendMessageAsync(sendMessageRequest));

--- a/test/SlowTests/Server/Documents/ETL/Queue/AmazonSqs/AmazonSqsEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/AmazonSqs/AmazonSqsEtlTestBase.cs
@@ -17,7 +17,7 @@ public class AmazonSqsEtlTestBase : QueueEtlTestBase
     {
     }
 
-    protected string OrdersQueueName => "orders";
+    protected string OrdersQueueName => "Orders";
 
     protected readonly string[] DefaultCollections = { "orders" };
 

--- a/test/SlowTests/Server/Documents/ETL/Queue/AmazonSqs/AmazonSqsEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/AmazonSqs/AmazonSqsEtlTests.cs
@@ -455,7 +455,7 @@ public class AmazonSqsEtlTests : AmazonSqsEtlTestBase
             await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             IAmazonSQS queueClient = CreateQueueClient();
-            var queueUrl = AsyncHelpers.RunSync(() => queueClient.GetQueueUrlAsync("users")).QueueUrl;
+            var queueUrl = AsyncHelpers.RunSync(() => queueClient.GetQueueUrlAsync("Users")).QueueUrl;
             var messagesReadResult = AsyncHelpers.RunSync(() => queueClient.ReceiveMessageAsync(queueUrl));
             var user = JsonConvert.DeserializeObject<CloudEventUserData>(messagesReadResult.Messages.First().Body).Data;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23287

### Additional description

Fix the issue with creating a new queue in lowercase.
Missing MessageDeduplicationId for single message in fifo queue.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
