### PR TITLE
RavenDB-23524 Include scores from others primitives in the VectorSearchMatch score method.

### DIFF
--- a/src/Corax/Querying/Matches/BoostingMatch.cs
+++ b/src/Corax/Querying/Matches/BoostingMatch.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
 using Corax.Querying.Matches.SortingMatches.Meta;
+using Sparrow;
 
 namespace Corax.Querying.Matches
 {
@@ -37,6 +38,8 @@ namespace Corax.Querying.Matches
         public float BoostFactor;
         public BoostingMatch(Querying.IndexSearcher searcher, in IQueryMatch inner, float boostFactor)
         {
+            PortableExceptions.ThrowIf<NotSupportedException>(inner is VectorSearchMatch, $"Boosting the {nameof(VectorSearchMatch)} is not supported yet.");
+            
             _inner = inner;
             BoostFactor = boostFactor;
         }

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -232,7 +232,7 @@ public struct VectorSearchMatch : IQueryMatch
                 if (pos < 0)
                     continue;
 
-                Unsafe.Add(ref scoresRef, i) = _nearestSearch.DistanceToScore(Unsafe.Add(ref distanceRef, pos));
+                Unsafe.Add(ref scoresRef, i) += _nearestSearch.DistanceToScore(Unsafe.Add(ref distanceRef, pos));
             }
         }
         else

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1521,11 +1521,9 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             var fieldName = embeddingFieldFactory.FieldName;
             var sourceQuantizationType = embeddingFieldFactory.SourceQuantizationType;
             var targetQuantizationType = embeddingFieldFactory.DestinationQuantizationType;
-            var isSourceBase64Encoded = embeddingFieldFactory.IsBase64Encoded;
-            
+
             string queryParameterName;
-            var isVectorBase64Encoded = false;
-            
+
             if (embeddingValueFactory.Text != null)
             {
                 queryParameterName = AddQueryParameter(embeddingValueFactory.Text);
@@ -1553,10 +1551,9 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             else
             {
                 queryParameterName = AddQueryParameter(embeddingValueFactory.Base64Embedding);
-                isVectorBase64Encoded = true;
             }
             
-            var vectorSearchToken = new VectorSearchToken(fieldName, queryParameterName, sourceQuantizationType, targetQuantizationType, isSourceBase64Encoded, isVectorBase64Encoded, minimumSimilarity, numberOfCandidates, isExact);
+            var vectorSearchToken = new VectorSearchToken(fieldName, queryParameterName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact);
 
             WhereTokens.AddLast(vectorSearchToken);
         }

--- a/src/Raven.Client/Documents/Session/Tokens/VectorSearchToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/VectorSearchToken.cs
@@ -13,31 +13,27 @@ public sealed class VectorSearchToken : WhereToken
     private readonly float? _similarityThreshold;
     private readonly VectorEmbeddingType _sourceQuantizationType;
     private readonly VectorEmbeddingType _targetQuantizationType;
-    private bool _isSourceBase64Encoded;
-    private bool _isVectorBase64Encoded;
     private readonly int? _numberOfCandidatesForQuerying;
-    private bool _isExact;
-    
-    public VectorSearchToken(string fieldName, string parameterName, VectorEmbeddingType sourceQuantizationType, VectorEmbeddingType targetQuantizationType, bool isSourceBase64Encoded, bool isVectorBase64Encoded, float? similarityThreshold, int? numberOfCandidatesForQuerying, bool isExact)
+    public VectorSearchToken(string fieldName, string parameterName, VectorEmbeddingType sourceQuantizationType, VectorEmbeddingType targetQuantizationType, float? similarityThreshold, int? numberOfCandidatesForQuerying, bool isExact)
     {
         FieldName = fieldName;
         ParameterName = parameterName;
         
         _sourceQuantizationType = sourceQuantizationType;
         _targetQuantizationType = targetQuantizationType;
-                
-        _isSourceBase64Encoded = isSourceBase64Encoded;
-        _isVectorBase64Encoded = isVectorBase64Encoded;
-                
+
         _similarityThreshold = similarityThreshold;
 
         _numberOfCandidatesForQuerying = numberOfCandidatesForQuerying;
-        _isExact = isExact;
+        Options = new(isExact);
     }
     
     public override void WriteTo(StringBuilder writer)
     {
-        if (_isExact)
+        if (Options.Boost.HasValue)
+            writer.Append("boost(");
+            
+        if (Options.Exact)
             writer.Append("exact(");
         
         writer.Append("vector.search(");
@@ -63,7 +59,10 @@ public sealed class VectorSearchToken : WhereToken
         
         writer.Append(')');
 
-        if (_isExact)
+        if (Options.Exact)
             writer.Append(')');
+        
+        if (Options.Boost.HasValue)
+            writer.Append($", {Options.Boost.Value.ToInvariantString()})");
     }
 }

--- a/src/Sparrow/PortableExceptions.cs
+++ b/src/Sparrow/PortableExceptions.cs
@@ -684,7 +684,9 @@ namespace Sparrow
                 throw new EndOfStreamException(message);
             if (typeof(T) == typeof(InvalidDataException))
                 throw new InvalidDataException(message);
-
+            if (typeof(T) == typeof(NotSupportedException))
+                throw new NotSupportedException(message);
+            
             // We will still throw but in a way that we can look
             throw new NotSupportedException($"Exception type '{typeof(T).Name}' is not supported by this {nameof(Throw)} statement.");
         }
@@ -718,7 +720,9 @@ namespace Sparrow
                 throw new ObjectDisposedException(message);
             if (typeof(T) == typeof(InvalidDataException))
                 throw new InvalidDataException(message);
-
+            if (typeof(T) == typeof(NotSupportedException))
+                throw new NotSupportedException(message);
+            
             // We will still throw but in a way that we can look
             throw new NotSupportedException($"Exception type '{typeof(T).Name}' is not supported by this {nameof(Throw)} statement.");
         }

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -75,7 +75,7 @@ public partial class Hnsw
         ref float bufferRef = ref MemoryMarshal.GetReference(scores);
         int N = 0;
 
-        if (AdvInstructionSet.IsAcceleratedVector512)
+        if (AdvInstructionSet.IsAcceleratedVector512 && scores.Length <= Vector512<float>.Count)
         {
             var divisor = Vector512.Create(8f * vectorSizeInBytes);
             N = Vector512<float>.Count;
@@ -85,11 +85,12 @@ public partial class Hnsw
                 var currentScores = Vector512.LoadUnsafe(ref currentPos);
                 var divide = Vector512.Divide(currentScores, divisor);
                 var result = Vector512.Subtract(Vector512.Create(1F), divide);
+                result = Vector512.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }
 
-        if (AdvInstructionSet.IsAcceleratedVector256)
+        if (AdvInstructionSet.IsAcceleratedVector256 && scores.Length - pos <= Vector256<float>.Count)
         {
             var divisor = Vector256.Create(8f * vectorSizeInBytes);
             N = Vector256<float>.Count;
@@ -99,11 +100,12 @@ public partial class Hnsw
                 var currentScores = Vector256.LoadUnsafe(ref currentPos);
                 var divide = Vector256.Divide(currentScores, divisor);
                 var result = Vector256.Subtract(Vector256.Create(1F), divide);
+                result = Vector256.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }
 
-        if (AdvInstructionSet.IsAcceleratedVector128)
+        if (AdvInstructionSet.IsAcceleratedVector128 && scores.Length - pos <= Vector128<float>.Count)
         {
             var divisor = Vector128.Create(8f * vectorSizeInBytes);
             N = Vector128<float>.Count;
@@ -113,6 +115,7 @@ public partial class Hnsw
                 var currentScores = Vector128.LoadUnsafe(ref currentPos);
                 var divide = Vector128.Divide(currentScores, divisor);
                 var result = Vector128.Subtract(Vector128.Create(1F), divide);
+                result = Vector128.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }
@@ -127,7 +130,7 @@ public partial class Hnsw
         ref float bufferRef = ref MemoryMarshal.GetReference(scores);
         int N = 0;
 
-        if (AdvInstructionSet.IsAcceleratedVector512)
+        if (AdvInstructionSet.IsAcceleratedVector512  && scores.Length <= Vector512<float>.Count)
         {
             N = Vector512<float>.Count;
             for (; pos + N < scores.Length; pos += N)
@@ -135,11 +138,12 @@ public partial class Hnsw
                 ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
                 var currentScores = Vector512.LoadUnsafe(ref currentPos);
                 var result = Vector512.Subtract(Vector512.Create(1F), currentScores);
+                result = Vector512.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }
 
-        if (AdvInstructionSet.IsAcceleratedVector256)
+        if (AdvInstructionSet.IsAcceleratedVector256 && scores.Length - pos <= Vector256<float>.Count)
         {
             N = Vector256<float>.Count;
             for (; pos + N < scores.Length; pos += N)
@@ -147,11 +151,12 @@ public partial class Hnsw
                 ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
                 var currentScores = Vector256.LoadUnsafe(ref currentPos);
                 var result = Vector256.Subtract(Vector256.Create(1F), currentScores);
+                result = Vector256.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }
 
-        if (AdvInstructionSet.IsAcceleratedVector128)
+        if (AdvInstructionSet.IsAcceleratedVector128 && scores.Length - pos <= Vector128<float>.Count)
         {
             N = Vector128<float>.Count;
             for (; pos + Vector128<float>.Count < scores.Length; pos += N)
@@ -159,6 +164,7 @@ public partial class Hnsw
                 ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
                 var currentScores = Vector128.LoadUnsafe(ref currentPos);
                 var result = Vector128.Subtract(Vector128.Create(1F), currentScores);
+                result = Vector128.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }

--- a/test/SlowTests/Issues/RavenDB-23524.cs
+++ b/test/SlowTests/Issues/RavenDB-23524.cs
@@ -1,0 +1,48 @@
+﻿using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23524(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public async Task VectorSearchWillNotOverrideTheAlreadyCalculatedScore()
+    {
+        const string spaghetti = "spaghetti";
+        const string rome = "rome";
+        const string cannoli = "cannoli";
+
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenAsyncSession();
+
+        await session.StoreAsync(new Product() { Name = spaghetti });
+        await session.StoreAsync(new Product() { Name = rome });
+        await session.StoreAsync(new Product() { Name = cannoli });
+        await session.SaveChangesAsync();
+
+        var results = await session.Advanced.AsyncDocumentQuery<Product>()
+            .WaitForNonStaleResults()
+            .VectorSearch(f => f.WithText(p => p.Name),
+                v => v.ByText("italian"))
+            .OrElse()
+            .VectorSearch(f => f.WithText(p => p.Name),
+                v => v.ByText("food"))
+            .ToListAsync();
+
+        Assert.Equal(3, results.Count);
+        Assert.Equal(spaghetti, results[0].Name);
+        Assert.Equal(cannoli, results[1].Name);
+        Assert.Equal(rome, results[2].Name);
+
+        var exception = await Assert.ThrowsAsync<Raven.Client.Exceptions.RavenException>(() => session.Advanced.AsyncDocumentQuery<Product>()
+            .VectorSearch(f => f.WithText(p => p.Name),
+                v => v.ByText("italian")).Boost(10)
+            .ToListAsync());
+        
+        Assert.Contains("System.NotSupportedException: Boosting the VectorSearchMatch is not supported yet.", exception.Message);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23524 

### Additional description
- Score from vectorsearch has to be added for upcoming scoring
- Fixing NRE when Boost is added to VectorSearchToken
- Generates correct RQL from Raven.Client
- Throw when boost is used with VectorSearch primitive. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
