### PR TITLE
RavenDB-23525 Added a hint in the exception for non-base64 strings in…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
@@ -37,7 +37,7 @@ public sealed class CoraxDocumentConverter : CoraxDocumentConverterBase
             {
                 if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, ((AutoVectorOptions)indexField.Vector).SourceFieldName, out value) == false)
                     continue;
-                var vector = AbstractStaticIndexBase.CreateVector(indexField, value);
+                var vector = AbstractStaticIndexBase.CreateVector(indexField, value, isAutoIndex: true);
                 InsertRegularField(indexField, vector, indexContext, builder, sourceDocument,  out innerShouldSkip);
             }
             else if (indexField.Spatial is AutoSpatialOptions spatialOptions)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -256,7 +256,7 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
                     }
 
                     var indexField = GetFieldObjectForProcessing(field.Name, indexingScope);
-                    object objectForIndexing = AbstractStaticIndexBase.CreateVector(indexField, valueJsv.IsString() ? valueJsv.AsString() : (object)valueJsv);
+                    object objectForIndexing = AbstractStaticIndexBase.CreateVector(indexField, valueJsv.IsString() ? valueJsv.AsString() : (object)valueJsv, isAutoIndex: false);
 
                     InsertRegularField(indexField, objectForIndexing, indexContext, builder, sourceDocument, out shouldSkip);
                     shouldProcessAsBlittable = false;

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -407,12 +407,12 @@ namespace Raven.Server.Documents.Indexes.Static
         }
 
         /// <summary>
-        /// Create vector field object. This method is used by AutoIndexes.
+        /// Create vector field object. This method is used by AutoIndexes and JavaScript indexes.
         /// </summary>
         /// <param name="indexField">IndexField from IndexDefinition</param>
         /// <param name="value">Data source to create vector field.</param>
         /// <returns></returns>
-        internal static object CreateVector(IndexField indexField, object value)
+        internal static object CreateVector(IndexField indexField, object value, bool isAutoIndex)
         {
             if (IsDictionaryTrainingPhase(CurrentIndexingScope.Current))
                 return null;
@@ -420,11 +420,11 @@ namespace Raven.Server.Documents.Indexes.Static
             return indexField!.Vector!.SourceEmbeddingType switch
             {
                 VectorEmbeddingType.Text => VectorFromText(indexField, value),
-                _ => VectorFromEmbedding(indexField, value)
+                _ => VectorFromEmbedding(indexField, value, isAutoIndex)
             };
         }
 
-        private static object VectorFromEmbedding(IndexField currentIndexingField, object value)
+        private static object VectorFromEmbedding(IndexField currentIndexingField, object value, bool isAutoIndex = false)
         {
             if (value is null)
                 return VectorValue.Null;
@@ -462,7 +462,7 @@ namespace Raven.Server.Documents.Indexes.Static
             object Base64ToVector(object base64)
             {
                 var str = base64.ToString();
-                return GenerateEmbeddings.FromBase64Array(vectorOptions, allocator, str);
+                return GenerateEmbeddings.FromBase64Array(vectorOptions, allocator, str, isAutoIndex);
             }
 
             object HandleEnumerable(IEnumerable enumerable)

--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -42,12 +42,12 @@ public static class GenerateEmbeddings
         }
     }
 
-    public static VectorValue FromBase64Array(in VectorOptions options, ByteStringContext allocator, string base64)
+    public static VectorValue FromBase64Array(in VectorOptions options, ByteStringContext allocator, string base64, bool isAutoIndex = false)
     {
         var bytesRequired = (int)Math.Ceiling((base64.Length * 3) / 4.0); //this is approximation
         var memScope = allocator.Allocate(bytesRequired, out Memory<byte> mem);
         var result = Convert.TryFromBase64String(base64, mem.Span, out var bytesWritten);
-        PortableExceptions.ThrowIf<InvalidDataException>(result == false, $"Excepted array encoded with base64, however got: '{base64}'");
+        PortableExceptions.ThrowIf<InvalidDataException>(result == false, $"Excepted array encoded with base64, however got: '{base64}'. {(isAutoIndex == false ? string.Empty : $"{Environment.NewLine}If you want to create an embedding from a text, please wrap the field name in the method 'embedding.text(FieldName)'.")}");
         return FromArray(allocator, memScope, mem, options, bytesWritten);
     }
 


### PR DESCRIPTION
… an auto-index.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23525 

### Additional description



### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
