### PR TITLE
RavenDB-23471 Switched from LocalComponents to Microsoft.SemanticKernel.Connectors.Onnx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ src/Sparrow.Server/Utils/VxSort/codegen/__pycache__/
 /UpgradeLog.htm
 
 /bench/Vector.Benchmark/vectors
+/.cache

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,7 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.NETCore.Jit" Version="2.0.8" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Onnx" Version="1.33.0-alpha" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
     <PackageVersion Include="MongoDB.Driver.GridFS" Version="2.30.0" />

--- a/src/DownloadEmbeddings.targets
+++ b/src/DownloadEmbeddings.targets
@@ -1,0 +1,54 @@
+<Project>
+    <PropertyGroup>
+        <LocalEmbeddingsModelCacheDir Condition="'$(LocalEmbeddingsModelCacheDir)' == ''">$(MSBuildThisFileDirectory)..\.cache\</LocalEmbeddingsModelCacheDir>
+
+        <!-- To use a custom model, developers must specify LocalEmbeddingsModelName and either LocalEmbeddingsModelUrl or LocalEmbeddingsModelPath -->
+        <!-- (likewise with LocalEmbeddingsVocabUrl or LocalEmbeddingsVocabPath) -->
+        <!-- Then at runtime, pass the model name to the LocalEmbeddings constructor, and it will use the corresponding model+vocab pair. -->
+        <LocalEmbeddingsModelName Condition="'$(LocalEmbeddingsModelName)' == ''">bge-micro-v2</LocalEmbeddingsModelName>
+
+        <!--
+            bge-micro-v2 comes from https://huggingface.co/TaylorAI/bge-micro-v2, which is forked to
+            https://huggingface.co/SmartComponents/bge-micro-v2 purely to ensure it remains available.
+            The license for the model remains MIT, but it's not redistributed in this repo or the NuGet
+            package anyway, since it's downloaded at build time.
+        -->
+        <LocalEmbeddingsModelUrl Condition="'$(LocalEmbeddingsModelUrl)' == ''">https://huggingface.co/SmartComponents/bge-micro-v2/resolve/72908b7/onnx/model_quantized.onnx</LocalEmbeddingsModelUrl>
+        <LocalEmbeddingsVocabUrl Condition="'$(LocalEmbeddingsVocabUrl)' == ''">https://huggingface.co/SmartComponents/bge-micro-v2/resolve/72908b7/vocab.txt</LocalEmbeddingsVocabUrl>
+
+        <!-- Or, forget the URLs and just give paths to files on disk -->
+        <LocalEmbeddingsModelPath Condition="'$(LocalEmbeddingsModelPath)' == ''">$(LocalEmbeddingsModelCacheDir)$([System.Text.RegularExpressions.Regex]::Replace($(LocalEmbeddingsModelUrl), "[^a-zA-Z0-9\.]", "_"))</LocalEmbeddingsModelPath>
+        <LocalEmbeddingsVocabPath Condition="'$(LocalEmbeddingsVocabPath)' == ''">$(LocalEmbeddingsModelCacheDir)$([System.Text.RegularExpressions.Regex]::Replace($(LocalEmbeddingsVocabUrl), "[^a-zA-Z0-9\.]", "_"))</LocalEmbeddingsVocabPath>
+    </PropertyGroup>
+
+    <Target Name="AttachEmbeddingsContentFiles" BeforeTargets="AssignTargetPaths" DependsOnTargets="AcquireLocalEmbeddingsModel; AcquireLocalEmbeddingsVocab">
+        <ItemGroup>
+            <Content CopyToOutputDirectory="PreserveNewest"
+                     Include="$(LocalEmbeddingsModelPath)"
+                     TargetPath="LocalEmbeddings\$(LocalEmbeddingsModelName)\model.onnx" />
+            <Content CopyToOutputDirectory="PreserveNewest"
+                     Include="$(LocalEmbeddingsVocabPath)"
+                     TargetPath="LocalEmbeddings\$(LocalEmbeddingsModelName)\vocab.txt" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="AcquireLocalEmbeddingsModel" Condition="!Exists('$(LocalEmbeddingsModelPath)')">
+        <PropertyGroup>
+            <_TempFilePath>$([System.IO.Path]::GetTempFileName())</_TempFilePath>
+        </PropertyGroup>
+        <DownloadFile SourceUrl="$(LocalEmbeddingsModelUrl)"
+                      DestinationFolder="$([System.IO.Path]::GetDirectoryName($(_TempFilePath)))"
+                      DestinationFileName="$([System.IO.Path]::GetFileName($(_TempFilePath)))" />
+        <Move SourceFiles="$(_TempFilePath)" DestinationFiles="$(LocalEmbeddingsModelPath)" />
+    </Target>
+
+    <Target Name="AcquireLocalEmbeddingsVocab" Condition="!Exists('$(LocalEmbeddingsVocabPath)')">
+        <PropertyGroup>
+            <_TempFilePath>$([System.IO.Path]::GetTempFileName())</_TempFilePath>
+        </PropertyGroup>
+        <DownloadFile SourceUrl="$(LocalEmbeddingsVocabUrl)"
+                      DestinationFolder="$([System.IO.Path]::GetDirectoryName($(_TempFilePath)))"
+                      DestinationFileName="$([System.IO.Path]::GetFileName($(_TempFilePath)))" />
+        <Move SourceFiles="$(_TempFilePath)" DestinationFiles="$(LocalEmbeddingsVocabPath)" />
+    </Target>
+</Project>

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -620,6 +620,13 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Corax.VectorSearch.OrderByScoreAutomatically", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool CoraxVectorSearchOrderByScoreAutomatically { get; set; }
         
+        [Description("MaxPercentageOfThreadsForEmbeddings")]
+        [DefaultValue(25)]
+        [IndexUpdateType(IndexUpdateType.None)]
+        [ConfigurationEntry("Indexing.Corax.VectorSearch.MaxPercentageOfThreadsForEmbeddings", ConfigurationEntryScope.ServerWideOnly)]
+        public int MaxPercentageOfThreadsForEmbeddings { get; set; }
+
+        
         protected override void ValidateProperty(PropertyInfo property)
         {
             base.ValidateProperty(property);

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -91,6 +91,14 @@ namespace Raven.Server.Config.Categories
             
             EncryptedTransactionSizeLimit = defaultEncryptedTransactionSizeLimit;
             MaxAllocationsAtDictionaryTraining = defaultMaxAllocationsAtDictionaryTraining;
+
+            MaxNumberOfCoresForLocalEmbeddingsGeneration = Environment.ProcessorCount switch
+            {
+                <= 2 => 1,
+                <= 8 => 2,
+                <= 16 => 4,
+                _ => 6
+            };
         }
         
         private static HashSet<string> GetValidIndexingConfigurationKeys()
@@ -620,12 +628,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Corax.VectorSearch.OrderByScoreAutomatically", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool CoraxVectorSearchOrderByScoreAutomatically { get; set; }
         
-        [Description("MaxPercentageOfThreadsForEmbeddings")]
-        [DefaultValue(25)]
+        [Description("Maximum number of processor cores that will be used for generating embedding from text locally.")]
+        [DefaultValue(DefaultValueSetInConstructor)]
         [IndexUpdateType(IndexUpdateType.None)]
-        [ConfigurationEntry("Indexing.Corax.VectorSearch.MaxPercentageOfThreadsForEmbeddings", ConfigurationEntryScope.ServerWideOnly)]
-        public int MaxPercentageOfThreadsForEmbeddings { get; set; }
-
+        [ConfigurationEntry("Indexing.Corax.VectorSearch.MaxNumberOfCoresForLocalEmbeddingsGeneration", ConfigurationEntryScope.ServerWideOnly)]
+        public int MaxNumberOfCoresForLocalEmbeddingsGeneration { get; set; }
         
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -43,18 +43,7 @@ public static class GenerateEmbeddings
         if (Embedder.IsValueCreated)
             throw new InvalidOperationException("Embedder has already been initialized.");
         
-        var numberOfCoresToUse = CalculateNumberOfCoresForOnnx(configuration);
-
-        OnnxSessionOptions = new SessionOptions() { IntraOpNumThreads = numberOfCoresToUse };
-    }
-    
-    private static int CalculateNumberOfCoresForOnnx(RavenConfiguration configuration)
-    {
-        var cores = (int)MathF.Floor(Environment.ProcessorCount * ((float)configuration.Indexing.MaxPercentageOfThreadsForEmbeddings / 100));
-            
-        var numberOfCoresToUse = int.Max(1, cores);
-        
-        return numberOfCoresToUse;
+        OnnxSessionOptions = new SessionOptions() { IntraOpNumThreads = configuration.Indexing.MaxNumberOfCoresForLocalEmbeddingsGeneration };
     }
 
     [ThreadStatic]

--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -146,7 +146,7 @@ public static class GenerateEmbeddings
     private static (IDisposable MemoryScope, Memory<byte> Memory, int UsedBytes) CreateEmbeddingViaSmartComponentsLocalEmbedding(ByteStringContext allocator, in string text, in int dimensions)
     {
         List ??= new List<string>(1);
-        List.Insert(0, text);
+        List.Add(text);
 
         try
         {
@@ -162,7 +162,7 @@ public static class GenerateEmbeddings
         }
         finally
         {
-            List[0] = null;
+            List.Clear();
         }
     }
 

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -14,6 +14,7 @@ using Raven.Server.Commercial;
 using Raven.Server.Config;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents.Indexes.Static.NuGet;
+using Raven.Server.Documents.Indexes.VectorSearch;
 using Raven.Server.EventListener;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide;
@@ -126,6 +127,7 @@ namespace Raven.Server
                 configuration.AddCommandLine(configurationArgs);
 
             configuration.Initialize();
+            GenerateEmbeddings.Configure(configuration);
 
             GlobalFlushingBehavior.NumberOfConcurrentSyncsPerPhysicalDrive = configuration.Storage.NumberOfConcurrentSyncsPerPhysicalDrive;
 

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -166,6 +166,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Onnx" />
     <PackageReference Include="Microsoft.Win32.Registry" />
     <PackageReference Include="MySqlConnector" />
     <PackageReference Include="NCrontab.Advanced" />
@@ -188,7 +189,6 @@
     <PackageReference Include="Raven.CodeAnalysis">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SmartComponents.LocalEmbeddings" />
     <PackageReference Include="Snappier" />
     <PackageReference Include="Snowflake.Data" />
     <PackageReference Include="System.Collections.Immutable" />
@@ -249,4 +249,5 @@
       <ResolvedFileToPublish ExcludeFromSingleFile="true" Condition="'%(ResolvedFileToPublish.Identity)' == '$(ProjectRuntimeConfigFilePath)'" />
     </ItemGroup>
   </Target>
+  <Import Project="../DownloadEmbeddings.targets"/>
 </Project>

--- a/test/SlowTests/Issues/RavenDB-23473.cs
+++ b/test/SlowTests/Issues/RavenDB-23473.cs
@@ -4,11 +4,13 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Subscriptions;
-using SmartComponents.LocalEmbeddings;
+using Raven.Server.Documents.Indexes.VectorSearch;
 using Sparrow;
 using Sparrow.Server;
+using Sparrow.Threading;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -44,11 +46,10 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
         var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
         Assert.Null(errors);
     }
-    
+    /*
     [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
     public async Task CanUpdateNoExplicitlyConfiguredVectorFieldViaSubscriptionWithLoadDocument()
     {
-        using (LocalEmbedder localEmbedder = new())
         using (var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax)))
         {
             await store.ExecuteIndexAsync(new VectorIndex());
@@ -60,6 +61,7 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
             var t = worker.Run(async x =>
             {
                 using var session = x.OpenAsyncSession();
+                using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
                 foreach (var item in x.Items)
                 {
                     var q = item.Result;
@@ -69,9 +71,8 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
                     var localEmbedding = await session.LoadAsync<Embedding>(embeddingId);
                     if (localEmbedding == null)
                     {
-                        // ReSharper disable once AccessToDisposedClosure
-                        var embedding = localEmbedder.Embed(q.Body);
-                        vector = embedding.Values.ToArray().ToList();
+                        var embedding = GenerateEmbeddings.FromText(allocator, new VectorOptions(), q.Body);
+                        vector = embedding.GetEmbedding();
                         localEmbedding = new Embedding { Vector = vector };
                         await session.StoreAsync(localEmbedding, embeddingId);
                     }
@@ -119,6 +120,7 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
             }            
         }
     }
+    */
 
     private class VectorIndex : AbstractIndexCreationTask<Question>
     {

--- a/test/SlowTests/Issues/RavenDB-23473.cs
+++ b/test/SlowTests/Issues/RavenDB-23473.cs
@@ -46,7 +46,7 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
         var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
         Assert.Null(errors);
     }
-    /*
+    
     [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
     public async Task CanUpdateNoExplicitlyConfiguredVectorFieldViaSubscriptionWithLoadDocument()
     {
@@ -61,7 +61,6 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
             var t = worker.Run(async x =>
             {
                 using var session = x.OpenAsyncSession();
-                using var allocator = new ByteStringContext(SharedMultipleUseFlag.None);
                 foreach (var item in x.Items)
                 {
                     var q = item.Result;
@@ -71,8 +70,10 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
                     var localEmbedding = await session.LoadAsync<Embedding>(embeddingId);
                     if (localEmbedding == null)
                     {
-                        var embedding = GenerateEmbeddings.FromText(allocator, new VectorOptions(), q.Body);
-                        vector = embedding.GetEmbedding();
+#pragma warning disable SKEXP0070
+                        var embedding = await GenerateEmbeddings.Embedder.Value.GenerateEmbeddingsAsync(new List<string> {q.Body });
+#pragma warning restore SKEXP0070
+                        vector = embedding[0].ToArray().ToList();
                         localEmbedding = new Embedding { Vector = vector };
                         await session.StoreAsync(localEmbedding, embeddingId);
                     }
@@ -120,7 +121,6 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
             }            
         }
     }
-    */
 
     private class VectorIndex : AbstractIndexCreationTask<Question>
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23471/

### Additional description

After vector search code changes we don't use any features of LocalComponents package, so we can use Microsoft.SemanticKernel.Connectors.Onnx directly

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
