### PR TITLE
RavenDB-23439 Changed handling of VectorSearch in LINQ

### DIFF
--- a/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
+++ b/src/Raven.Client/Documents/Queries/Vector/VectorFieldFactory.cs
@@ -77,14 +77,21 @@ public interface IVectorField
     
 }
 
-internal sealed class VectorEmbeddingFieldFactory<T> : IVectorFieldFactory<T>, IVectorField, IVectorEmbeddingField, IVectorEmbeddingTextField
+public interface IVectorEmbeddingFieldFactoryAccessor
+{
+    internal string FieldName { get; set; }
+    internal VectorEmbeddingType SourceQuantizationType { get; set; }
+    internal VectorEmbeddingType DestinationQuantizationType { get; set; } 
+    internal bool IsBase64Encoded { get; set; }
+}
+
+internal sealed class VectorEmbeddingFieldFactory<T> : IVectorFieldFactory<T>, IVectorField, IVectorEmbeddingField, IVectorEmbeddingTextField, IVectorEmbeddingFieldFactoryAccessor
 {
     private bool _byFieldMethodUsed;
-
-    internal string FieldName { get; set; }
-    internal VectorEmbeddingType SourceQuantizationType { get; set; } = Constants.VectorSearch.DefaultEmbeddingType;
-    internal VectorEmbeddingType DestinationQuantizationType { get; set; } = Constants.VectorSearch.DefaultEmbeddingType;
-    internal bool IsBase64Encoded { get; set; }
+    public string FieldName { get; set; }
+    public VectorEmbeddingType SourceQuantizationType { get; set; } = Constants.VectorSearch.DefaultEmbeddingType;
+    public VectorEmbeddingType DestinationQuantizationType { get; set; } = Constants.VectorSearch.DefaultEmbeddingType;
+    public bool IsBase64Encoded { get; set; }
     
     IVectorEmbeddingTextField IVectorFieldFactory<T>.WithText(Expression<Func<T, object>> propertySelector)
     {
@@ -235,7 +242,14 @@ public interface IVectorFieldValueFactory : IVectorEmbeddingTextFieldValueFactor
     
 }
 
-internal class VectorFieldValueFactory : IVectorFieldValueFactory
+public interface IVectorFieldValueFactoryAccessor
+{
+    internal object Embedding { get; set; }
+    internal string Text { get; set; }
+    internal string Base64Embedding { get; set; }
+}
+
+internal class VectorFieldValueFactory : IVectorFieldValueFactory, IVectorFieldValueFactoryAccessor
 {
     public object Embedding { get; set; }
     public string Text { get; set; }

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1522,13 +1522,12 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             var fieldName = fieldFactoryAccessor.FieldName;
             var sourceQuantizationType = fieldFactoryAccessor.SourceQuantizationType;
             var targetQuantizationType = fieldFactoryAccessor.DestinationQuantizationType;
-            var isSourceBase64Encoded = fieldFactoryAccessor.IsBase64Encoded;
 
             var text = fieldValueFactoryAccessor.Text;
             var embedding = fieldValueFactoryAccessor.Embedding;
             var base64Embedding = fieldValueFactoryAccessor.Base64Embedding;
 
-            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, isSourceBase64Encoded, minimumSimilarity, numberOfCandidates, isExact, text, embedding, base64Embedding);
+            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, text, embedding, base64Embedding);
         }
         
         internal void VectorSearch(VectorEmbeddingFieldFactory<T> embeddingFieldFactory, VectorFieldValueFactory embeddingValueFactory,
@@ -1537,20 +1536,18 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             var fieldName = embeddingFieldFactory.FieldName;
             var sourceQuantizationType = embeddingFieldFactory.SourceQuantizationType;
             var targetQuantizationType = embeddingFieldFactory.DestinationQuantizationType;
-            var isSourceBase64Encoded = embeddingFieldFactory.IsBase64Encoded;
             
             var text = embeddingValueFactory.Text;
             var embedding = embeddingValueFactory.Embedding;
             var base64Embedding = embeddingValueFactory.Base64Embedding;
             
-            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, isSourceBase64Encoded, minimumSimilarity, numberOfCandidates, isExact, text, embedding, base64Embedding);
+            VectorSearch(fieldName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact, text, embedding, base64Embedding);
         }
         
-        private void VectorSearch(string fieldName, VectorEmbeddingType sourceQuantizationType, VectorEmbeddingType targetQuantizationType, bool isSourceBase64Encoded, float? minimumSimilarity,
+        private void VectorSearch(string fieldName, VectorEmbeddingType sourceQuantizationType, VectorEmbeddingType targetQuantizationType, float? minimumSimilarity,
             int? numberOfCandidates, bool isExact, string text, object embedding, string base64Embedding)
         {
             string queryParameterName;
-            var isVectorBase64Encoded = false;
             
             if (text != null)
                 queryParameterName = AddQueryParameter(text);
@@ -1579,7 +1576,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
                 queryParameterName = AddQueryParameter(base64Embedding);
             }
             
-            var vectorSearchToken = new VectorSearchToken(fieldName, queryParameterName, sourceQuantizationType, targetQuantizationType, isSourceBase64Encoded, isVectorBase64Encoded, minimumSimilarity, numberOfCandidates, isExact);
+            var vectorSearchToken = new VectorSearchToken(fieldName, queryParameterName, sourceQuantizationType, targetQuantizationType, minimumSimilarity, numberOfCandidates, isExact);
 
             WhereTokens.AddLast(vectorSearchToken);
         }

--- a/src/Raven.Client/Documents/Session/IAbstractDocumentQueryAccessor.cs
+++ b/src/Raven.Client/Documents/Session/IAbstractDocumentQueryAccessor.cs
@@ -1,0 +1,8 @@
+using Raven.Client.Documents.Queries.Vector;
+
+namespace Raven.Client.Documents.Session;
+
+internal interface IAbstractDocumentQueryAccessor
+{
+    void VectorSearch(IVectorEmbeddingFieldFactoryAccessor fieldFactoryAccessor, IVectorFieldValueFactoryAccessor fieldValueFactoryAccessor, float? minimumSimilarity, int? numberOfCandidates, bool isExact);
+}

--- a/test/SlowTests/Issues/RavenDB-23439.cs
+++ b/test/SlowTests/Issues/RavenDB-23439.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23439 : RavenTestBase
+{
+    public RavenDB_23439(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.ClientApi)]
+    public void CanPerformProjectionWhenUsingVectorSearchViaLINQ()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenSession();
+        session.Store(new Dto1() { Vector = new[] { 1f, 2f, 3f } });
+        session.SaveChanges();
+
+        Dto2 singleOrDefault = session.Query<Dto1>().Customize(x => x.WaitForNonStaleResults())
+            .VectorSearch(x => x.WithEmbedding(p => p.Vector), v => v.ByEmbedding(new[] { 1f, 2f, 3f }))
+            .ProjectInto<Dto2>()
+            .SingleOrDefault();
+
+        Assert.NotNull(singleOrDefault);
+    }
+    
+    private class Dto1
+    {
+        public float[] Vector { get; set; }
+    }
+    
+    private class Dto2 // typeof(Dto1) != typeof(Dto2)
+    {
+        public float[] Vector { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23439/Cannot-perform-projection-via-LINQ-when-using-VectorSearch

### Additional description

Changed handling of VectorSearch in LINQ to support projections

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
