### PR TITLE
RavenDB-23432 Missing operator after last token will throw correct exception.

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -1114,7 +1114,9 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
                     op = field;
                     return fieldOption == OperatorField.Desired;
                 }
-                ThrowInvalidQueryException($"Expected operator after '{field?.FieldValue ?? "<failed to fetch field name>"}' field, but found '{Scanner.Input[Scanner.Position]}'. Valid operators are: 'in', 'between', =, <, >, <=, >=, !=");
+                
+                var foundInput = Scanner.Input.Length <= Scanner.Position ? "nothing" : $"'{Scanner.Input[Scanner.Position]}'";
+                ThrowInvalidQueryException($"Expected operator after '{field?.FieldValue ?? "<failed to fetch field name>"}' field, but found {foundInput}. Valid operators are: 'in', 'between', =, <, >, <=, >=, !=");
             }
 
 

--- a/test/SlowTests/Issues/RavenDB-23432.cs
+++ b/test/SlowTests/Issues/RavenDB-23432.cs
@@ -1,0 +1,25 @@
+﻿using FastTests;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23432(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Querying)]
+    public void MissingOperatorAfterLastTokenWillThrowCorrectException()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenSession();
+        session.Store(new Product(){Name = "Test",Discontinued = true});
+        session.SaveChanges();
+
+        var invalidFilterClauseRql = @"from ""Products"" where Discontinued = true filter Name";
+
+        var exception = Assert.Throws<InvalidQueryException>(() => session.Advanced.RawQuery<Product>(invalidFilterClauseRql).WaitForNonStaleResults().ToList());
+        Assert.Contains("Expected operator after 'Name' field, but found nothing.", exception.Message);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23432 

### Additional description

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
