### PR TITLE
RavenDB-22907: Enhance backup operation status error reporting (v6.0)

### DIFF
--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -3,15 +3,16 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions.Database;
+using Raven.Client.Http;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.Util;
@@ -20,7 +21,6 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands.PeriodicBackup;
-using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -59,27 +59,28 @@ namespace FastTests
                 var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
                 var periodicBackupRunner = documentDatabase.PeriodicBackupRunner;
 
-                long op;
+                long opId;
                 try
                 {
-                    op = periodicBackupRunner.StartBackupTask(taskId, isFullBackup);
+                    opId = periodicBackupRunner.StartBackupTask(taskId, isFullBackup);
                 }
                 catch (BackupAlreadyRunningException alreadyRunningException)
                 {
-                    op = alreadyRunningException.OperationId;
+                    opId = alreadyRunningException.OperationId;
                 }
 
-                BackupResult result = default;
-                var actual = await WaitForValueAsync(async () =>
+                RavenCommand<OperationState> command = null;
+                await WaitForValueAsync(async () =>
                 {
-                    var state = await store.Maintenance.SendAsync(new GetOperationStateOperation(op));
-                    result = state.Result as BackupResult;
-                    return state.Status;
-                }, opStatus, timeout: timeout ?? _reasonableTimeout);
+                    command = await ExecuteGetOperationStateCommand(store, opId);
+                    return command.Result != null &&
+                           command.Result.Status == opStatus &&
+                           command.StatusCode == HttpStatusCode.OK;
+                }, expectedVal: true, timeout: timeout ?? _reasonableTimeout);
 
-                await CheckBackupOperationStatus(opStatus, actual, store, taskId, op, periodicBackupRunner, result);
-                Assert.Equal(opStatus, actual);
-                return op;
+                await CheckBackupOperationStatus(opStatus, command, store, taskId, opId, periodicBackupRunner);
+                Assert.Equal(opStatus, command.Result.Status);
+                return opId;
             }
 
             /// <summary>
@@ -290,19 +291,28 @@ namespace FastTests
             {
                 var op = await store.Maintenance.SendAsync(new StartBackupOperation(isFullBackup, taskId));
 
-                IOperationResult result = default;
-                var actual = await WaitForValueAsync(async () =>
+                RavenCommand<OperationState> command = null;
+                await WaitForValueAsync(async () =>
                 {
-                    var state = await store.Maintenance.SendAsync(new GetOperationStateOperation(op.Result.OperationId, op.Result.ResponsibleNode));
-                    if (state == null)
-                        return OperationStatus.Canceled;
+                    command = await ExecuteGetOperationStateCommand(store, op.Result.OperationId, op.Result.ResponsibleNode);
+                    return command.Result != null &&
+                           command.Result.Status == opStatus &&
+                           command.StatusCode == HttpStatusCode.OK;
+                }, expectedVal: true, timeout: timeout ?? _reasonableTimeout);
 
-                    result = state.Result;
-                    return state.Status;
-                }, opStatus, timeout: timeout ?? _reasonableTimeout);
+                await CheckBackupOperationStatus(opStatus, command, store, taskId, op.Result.OperationId, periodicBackupRunner: null);
+                Assert.Equal(opStatus, command.Result.Status);
+            }
 
-                await CheckBackupOperationStatus(opStatus, actual, store, taskId, op.Result.OperationId, periodicBackupRunner: null, result);
-                Assert.Equal(opStatus, actual);
+            private static async Task<RavenCommand<OperationState>> ExecuteGetOperationStateCommand(IDocumentStore store, long operationId, string responsibleNode = null)
+            {
+                using (store.GetRequestExecutor().ContextPool.AllocateOperationContext(out JsonOperationContext context))
+                {
+                    var operation = new GetOperationStateOperation(operationId, responsibleNode);
+                    var command = operation.GetCommand(store.GetRequestExecutor().Conventions, context);
+                    await store.GetRequestExecutor().ExecuteAsync(command, context, sessionInfo: null);
+                    return command;
+                }
             }
 
             public IDisposable RestoreDatabase(IDocumentStore store, RestoreBackupConfiguration config, TimeSpan? timeout = null, string nodeTag = null)
@@ -542,58 +552,78 @@ namespace FastTests
                 return sb.ToString();
             }
 
-            private static async Task CheckBackupOperationStatus(OperationStatus expected, OperationStatus actual, IDocumentStore store, long taskId, long opId,
-                PeriodicBackupRunner periodicBackupRunner, IOperationResult backupResult)
+            private static async Task CheckBackupOperationStatus(OperationStatus expected, RavenCommand<OperationState> command, IDocumentStore store, long taskId, long opId,
+                PeriodicBackupRunner periodicBackupRunner)
             {
-                if (expected == OperationStatus.Completed && actual == OperationStatus.Faulted)
+                var backupResult = command.Result?.Result as BackupResult;
+                var actual = command.Result?.Status;
+
+                // Check if GetOperationStateOperation completed successfully
+                // We expect both `backupResult` and `actual` to be `null` here due to HTTP error,
+                // but we'll try to print them anyway to catch any unexpected states
+                if (command.StatusCode != HttpStatusCode.OK)
                 {
-                    // gather debug info
                     var operation = new GetPeriodicBackupStatusOperation(taskId);
                     var status = (await store.Maintenance.SendAsync(operation)).Status;
 
-                    TryGetBackupStatusFromPeriodicBackupAndPrint(expected, actual, opId, periodicBackupRunner, status, result: null);
+                    TryGetBackupStatusFromPeriodicBackupAndPrint(expected, actual: null, opId, periodicBackupRunner, status, backupResult);
 
-                    Assert.Fail($"Backup status expected: '{expected}', actual '{actual}',{Environment.NewLine}" +
-                                $"Backup status from storage for current operation id: '{opId}':{Environment.NewLine}" +
+                    Assert.Fail($"GetOperationStateOperation failed. Expected status: '{expected}', actual: '{actual?.ToString( ) ?? "null"}',{Environment.NewLine}" +
+                                $"HTTP Status Code: {command.StatusCode},{Environment.NewLine}" +
+                                $"Backup status from storage for operation id: '{opId}':{Environment.NewLine}" +
                                 PrintBackupStatusAndResult(status, backupResult));
                 }
 
+                // Check if backup completed with error
+                if (expected == OperationStatus.Completed && actual == OperationStatus.Faulted)
+                {
+                    var operation = new GetPeriodicBackupStatusOperation(taskId);
+                    var status = (await store.Maintenance.SendAsync(operation)).Status;
+
+                    TryGetBackupStatusFromPeriodicBackupAndPrint(expected, actual, opId, periodicBackupRunner, status);
+
+                    Assert.Fail($"Backup operation faulted. Expected status: '{expected}', actual: '{actual}',{Environment.NewLine}" +
+                                $"Backup status from storage for operation id: '{opId}':{Environment.NewLine}" +
+                                PrintBackupStatusAndResult(status, backupResult));
+                }
+
+                // Check if backup didn't complete within the timeout period
                 if (expected == OperationStatus.Completed && actual == OperationStatus.InProgress)
                 {
-                    // backup didn't complete in time, try to print running backup status, and backup result
                     var pb = periodicBackupRunner?.PeriodicBackups.FirstOrDefault(x => x.RunningBackupStatus != null && x.BackupStatus.TaskId == taskId);
                     if (pb == null)
                     {
-                        // print previous backup status saved in memory
                         var operation = new GetPeriodicBackupStatusOperation(taskId);
                         var result = await store.Maintenance.SendAsync(operation);
-                        Assert.Fail($"Backup status expected: '{expected}', actual '{actual}',{Environment.NewLine}" +
-                                    $"Could not fetch running backup status for current task id: '{taskId}', previous backup status:{Environment.NewLine}" +
+                        Assert.Fail($"Backup operation timed out. Expected status: '{expected}', actual: '{actual}',{Environment.NewLine}" +
+                                    $"Could not fetch running backup status for task id: '{taskId}', previous backup status:{Environment.NewLine}" +
                                     PrintBackupStatusAndResult(result.Status, backupResult));
                     }
 
-                    Assert.Fail($"Backup status expected: '{expected}', actual '{actual}',{Environment.NewLine}" +
-                                $"Running backup status for current task id: '{taskId}':{Environment.NewLine}" +
+                    Assert.Fail($"Backup operation timed out. Expected status: '{expected}', actual: '{actual}',{Environment.NewLine}" +
+                                $"Running backup status for task id: '{taskId}':{Environment.NewLine}" +
                                 PrintBackupStatusAndResult(pb.RunningBackupStatus, backupResult));
                 }
             }
 
-            private static void TryGetBackupStatusFromPeriodicBackupAndPrint(OperationStatus expected, OperationStatus actual, long opId,
-                PeriodicBackupRunner periodicBackupRunner, PeriodicBackupStatus status, BackupResult result)
+            private static void TryGetBackupStatusFromPeriodicBackupAndPrint(OperationStatus expected, OperationStatus? actual, long opId,
+                PeriodicBackupRunner periodicBackupRunner, PeriodicBackupStatus status, BackupResult result = null)
             {
                 if (status?.LastOperationId == opId)
                     return;
+
+                var actualString = actual?.ToString() ?? "null";
 
                 // failed to save backup status, lets fetch it from memory
                 var pb = periodicBackupRunner?.PeriodicBackups.FirstOrDefault(x => x.BackupStatus != null && x.BackupStatus.LastOperationId == opId);
                 if (pb == null)
                 {
-                    Assert.Fail($"Backup status expected: '{expected}', actual '{actual}',{Environment.NewLine}" +
+                    Assert.Fail($"Backup status expected: '{expected}', actual '{actualString}',{Environment.NewLine}" +
                                 $"Could not fetch backup status for current operation id: '{opId}', previous backup status:{Environment.NewLine}" +
                                 PrintBackupStatusAndResult(status, result));
                 }
 
-                Assert.Fail($"Backup status expected: '{expected}', actual '{actual}',{Environment.NewLine}" +
+                Assert.Fail($"Backup status expected: '{expected}', actual '{actualString}',{Environment.NewLine}" +
                             $"Could not fetch backup status from storage for current operation id: '{opId}', current in memory backup status:{Environment.NewLine}" +
                             PrintBackupStatusAndResult(pb.BackupStatus, result));
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22907
v5.4: https://github.com/ravendb/ravendb/pull/19898

### Additional description

When running backup tests (`SlowTests.Server.Documents.PeriodicBackup.PeriodicBackupTestsSlow.ShouldDelayBackupOnNotResponsibleNode` for instance), we occasionally encounter a rare failure where the expected operation status is `InProgress` but we receive `Canceled` instead. This PR enhances the error reporting by adding HTTP status code checks and providing more detailed diagnostic information when operation state retrieval fails.

This change is not a fix for the underlying issue - it simply adds more comprehensive error information to help diagnose the root cause when this test fails again in the future.
### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed