### PR TITLE
RavenDB-23231 - Add await to all usages of AssertEtlDoneAsync in AzureQueueStorageEtlTests

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Queue/KafkaEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/KafkaEtlTests.cs
@@ -73,7 +73,7 @@ public class KafkaEtlTests : KafkaEtlTestBase
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(DefaultTopics.Select(x => x.Name));
 
@@ -126,7 +126,7 @@ public class KafkaEtlTests : KafkaEtlTestBase
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(DefaultTopics.Select(x => x.Name));
 
@@ -173,7 +173,7 @@ public class KafkaEtlTests : KafkaEtlTestBase
             }
         }
 
-        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(DefaultTopics.Select(x => x.Name));
 
@@ -213,7 +213,7 @@ public class KafkaEtlTests : KafkaEtlTestBase
             await session.SaveChangesAsync();
         }
 
-        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(new List<string> { $"Users{TopicSuffix}" });
 
@@ -385,7 +385,7 @@ output('test output')"
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(new[] { $"Users{TopicSuffix}" });
 
@@ -438,7 +438,7 @@ output('test output')"
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(new[] { $"Users{TopicSuffix}" });
 
@@ -521,7 +521,7 @@ output('test output')"
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), srcStore.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), srcStore.Database, config);
 
             var record = await srcStore.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(srcStore.Database));
 

--- a/test/SlowTests/Server/Documents/ETL/Queue/QueueEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/QueueEtlTestBase.cs
@@ -14,7 +14,7 @@ public abstract class QueueEtlTestBase : RavenTestBase
     {
     }
 
-    protected async Task AssertEtlDone(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, QueueEtlConfiguration config)
+    protected async Task AssertEtlDoneAsync(ManualResetEventSlim etlDone, TimeSpan timeout, string databaseName, QueueEtlConfiguration config)
     {
         if (etlDone.Wait(timeout) == false)
         {

--- a/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RabbitMqEtlTests.cs
@@ -48,7 +48,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);
@@ -102,7 +102,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
             await session.SaveChangesAsync();
         }
         
-        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -163,7 +163,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
             await session.SaveChangesAsync();
         }
 
-        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         channel.BasicConsume(queue: queueName, autoAck: true, consumer: consumer);
 
@@ -208,7 +208,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
             await session.SaveChangesAsync();
         }
 
-        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -249,7 +249,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using var channel = CreateRabbitMqChannel();
 
@@ -299,7 +299,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
             }
         }
 
-        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
         
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -339,7 +339,7 @@ public class RabbitMqEtlTests : RabbitMqEtlTestBase
             await session.SaveChangesAsync();
         }
 
-        await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+        await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
         
         using var channel = CreateRabbitMqChannel();
         var consumer = new TestRabbitMqConsumer(channel);
@@ -533,7 +533,7 @@ output('test output')"
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
             
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);
@@ -576,7 +576,7 @@ output('test output')"
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
             
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);

--- a/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_Kafka.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_Kafka.cs
@@ -39,7 +39,7 @@ public class RavenDB_21659_Kafka : KafkaEtlTestBase
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using IConsumer<string, byte[]> consumer = CreateKafkaConsumer(new[] { $"Users{TopicSuffix}" });
 

--- a/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_RabbitMq.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/RavenDB_21659_RabbitMq.cs
@@ -37,7 +37,7 @@ public class RavenDB_21659_RabbitMq : RabbitMqEtlTestBase
                 await session.SaveChangesAsync();
             }
 
-            await AssertEtlDone(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+            await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
             using var channel = CreateRabbitMqChannel();
             var consumer = new TestRabbitMqConsumer(channel);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23231/Hanged-test-suite

### Additional description

Add missing await to all usages of `AssertEtlDoneAsync` in `AzureQueueStorageEtlTests`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
