### PR TITLE
RavenDB-23528 Free memory must be divisible by 256 for `PForDecoder.Read`.

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -457,8 +457,11 @@ public unsafe partial class Hnsw
         {
             var smallPostingList = Container.Get(Llt, rawPostingListId);
             var count = VariableSizeEncoding.Read<int>(smallPostingList.Address, out var offset);
-            listBuffer.EnsureCapacityFor(Math.Max(256, count + listBuffer.Count));
+            
+            var requiredSize = Math.Max(256, 256 * (int)Math.Ceiling((count + listBuffer.Count) / 256f));
+            listBuffer.EnsureCapacityFor(requiredSize);
             Debug.Assert(listBuffer.Capacity > 0 && listBuffer.Capacity % 256 ==0, "The buffer must be multiple of 256 for PForDecoder.Read");
+            
             pforDecoder.Init(smallPostingList.Address + offset, smallPostingList.Length - offset);
             listBuffer.Count += pforDecoder.Read(listBuffer.RawItems + listBuffer.Count, listBuffer.Capacity - listBuffer.Count);
             postingListSize = smallPostingList.Length;

--- a/test/SlowTests/Issues/RavenDB-23528.cs
+++ b/test/SlowTests/Issues/RavenDB-23528.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23528(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Vector)]
+    [InlineData(266)]
+    [InlineData(787)]
+    [InlineData(513)]
+    public void SmallSetListWillBeAlignedTo256(int stored)
+    {
+        var vector = new[] { 0.1f, 0.1f };
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using (var bulkInsert = store.BulkInsert())
+        {
+            for (int i = 0; i < stored; ++i)
+                bulkInsert.Store(new Dto(){Vector = vector });
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var _ = session.Query<Dto>().VectorSearch(f => f.WithEmbedding(p => p.Vector),
+                    v => v.ByEmbedding(vector))
+                .ToList();
+            Indexes.WaitForIndexing(store);
+            store.Maintenance.Send(new StopIndexingOperation());
+        }
+
+        using (var bulkInsert = store.BulkInsert())
+        {
+            for (int i = 0;  i < 16; ++i)
+                bulkInsert.Store(new Dto(){Vector = vector });
+        }
+        
+        store.Maintenance.Send(new StartIndexingOperation());
+        Indexes.WaitForIndexing(store);
+    }
+
+    private class Dto
+    {
+        public RavenVector<float> Vector { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23528

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
