### PR TITLE
RavenDB-22833 forbid creating subscription with both predicate and query

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/DocumentSubscriptions.cs
+++ b/src/Raven.Client/Documents/Subscriptions/DocumentSubscriptions.cs
@@ -58,11 +58,23 @@ namespace Raven.Client.Documents.Subscriptions
         /// </summary>
         /// <typeparam name="T">Type of the collection to be processed by the subscription</typeparam>
         /// <returns>Created subscription</returns>
-        public string Create<T>(Expression<Func<T, bool>> predicate = null,
+        public string Create<T>(
             SubscriptionCreationOptions options = null,
             string database = null)
         {
-            return Create(CreateSubscriptionOptionsFromGeneric(_store.Conventions, options, predicate, null, includes: null), database);
+            return Create(CreateSubscriptionOptionsFromGeneric<T>(_store.Conventions, options, null, null, includes: null), database);
+        }
+
+        /// <summary>
+        /// Creates a data subscription in a database. The subscription will expose all documents that match the specified subscription options for a given type.
+        /// </summary>
+        /// <typeparam name="T">Type of the collection to be processed by the subscription</typeparam>
+        /// <returns>Created subscription</returns>
+        public string Create<T>(Expression<Func<T, bool>> predicate,
+            PredicateSubscriptionCreationOptions options = null,
+            string database = null)
+        {
+            return Create(CreateSubscriptionOptionsFromGeneric(_store.Conventions, options?.ToSubscriptionCreationOptions(), predicate, null, includes: null), database);
         }
 
         /// <summary>
@@ -86,12 +98,24 @@ namespace Raven.Client.Documents.Subscriptions
         /// </summary>
         /// <returns>Created subscription name.</returns>
         public Task<string> CreateAsync<T>(
-            Expression<Func<T, bool>> predicate = null,
             SubscriptionCreationOptions options = null,
             string database = null,
             CancellationToken token = default)
         {
-            return CreateAsync(CreateSubscriptionOptionsFromGeneric(_store.Conventions, options, predicate, null, includes: null), database, token);
+            return CreateAsync(CreateSubscriptionOptionsFromGeneric<T>(_store.Conventions, options, null, null, includes: null), database, token);
+        }
+
+        /// <summary>
+        /// It creates a data subscription in a database. The subscription will expose all documents that match the specified subscription options for a given type.
+        /// </summary>
+        /// <returns>Created subscription name.</returns>
+        public Task<string> CreateAsync<T>(
+            Expression<Func<T, bool>> predicate,
+            PredicateSubscriptionCreationOptions options = null,
+            string database = null,
+            CancellationToken token = default)
+        {
+            return CreateAsync(CreateSubscriptionOptionsFromGeneric(_store.Conventions, options?.ToSubscriptionCreationOptions(), predicate, null, includes: null), database, token);
         }
 
         internal static SubscriptionCreationOptions CreateSubscriptionOptionsFromGeneric<T>(

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionCriteria.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionCriteria.cs
@@ -2,8 +2,6 @@ using System;
 using System.Linq.Expressions;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.DataArchival;
-using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Operations.DataArchival;
 using Raven.Client.Documents.Session.Loaders;
 
 namespace Raven.Client.Documents.Subscriptions
@@ -15,7 +13,40 @@ namespace Raven.Client.Documents.Subscriptions
         public ArchivedDataProcessingBehavior? ArchivedDataProcessingBehavior { get; set; }
     }
 
-    public class SubscriptionCreationOptions
+    internal interface ISubscriptionCreationOptions
+    {
+        public string Name { get; set; }
+        public string ChangeVector { get; set; }
+        public string MentorNode { get; set; }
+        public  bool Disabled { get; set; }
+        public  bool PinToMentorNode { get; set; }
+        public ArchivedDataProcessingBehavior? ArchivedDataProcessingBehavior { get; set; }
+    }
+
+    public sealed class PredicateSubscriptionCreationOptions : ISubscriptionCreationOptions
+    {
+        public string Name { get; set; }
+        public string ChangeVector { get; set; }
+        public string MentorNode { get; set; }
+        public bool Disabled { get; set; }
+        public bool PinToMentorNode { get; set; }
+        public ArchivedDataProcessingBehavior? ArchivedDataProcessingBehavior { get; set; }
+
+        internal SubscriptionCreationOptions ToSubscriptionCreationOptions()
+        {
+            return new SubscriptionCreationOptions
+            {
+                Name = Name,
+                ChangeVector = ChangeVector,
+                MentorNode = MentorNode,
+                PinToMentorNode = PinToMentorNode,
+                Disabled = Disabled,
+                ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior
+            };
+        }
+    }
+
+    public class SubscriptionCreationOptions : ISubscriptionCreationOptions
     {
         public string Name { get; set; }
         public string Query { get; set; }
@@ -47,7 +78,8 @@ namespace Raven.Client.Documents.Subscriptions
                 ChangeVector = ChangeVector,
                 MentorNode = MentorNode,
                 PinToMentorNode = PinToMentorNode,
-                Disabled = Disabled
+                Disabled = Disabled,
+                ArchivedDataProcessingBehavior = ArchivedDataProcessingBehavior
             };
             return DocumentSubscriptions.CreateSubscriptionOptionsFromGeneric(conventions, 
                 subscriptionCreationOptions, Filter, Projection, Includes);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22833/Creating-subscription-A-problematic-overload

### Additional description

This pull request includes several changes to the `DocumentSubscriptions` and `SubscriptionCriteria` classes to introduce support for predicate-based subscription creation options and to refactor the existing subscription creation methods.

### Changes to `DocumentSubscriptions`:

* Added a new overload of the `Create<T>` method to support `PredicateSubscriptionCreationOptions` and a predicate parameter.
* Added a new overload of the `CreateAsync<T>` method to support `PredicateSubscriptionCreationOptions` and a predicate parameter.

### Changes to `SubscriptionCriteria`:

* Removed unused imports from `SubscriptionCriteria.cs` to clean up the codebase.
* Introduced the `ISubscriptionCreationOptions` interface and implemented it in `SubscriptionCreationOptions` and the new `PredicateSubscriptionCreationOptions` class.
* Added a method to convert `PredicateSubscriptionCreationOptions` to `SubscriptionCreationOptions` for internal use.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change, now need to use new class if using create subscription overload with predicate
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
