### PR TITLE
RavenDB-23532 - [v7.0] Create a new command for each attempt to save it to the cluster

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -267,10 +267,12 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             // at this point we restored a large portion of the database or all of it	
             // we'll retry saving the database record since a failure here will cause us to abort the entire restore operation	
 
+            var raftId = RaftIdGenerator.NewId();
+
             var index = await BackupHelper.RunWithRetriesAsync(maxRetries: 10, async () =>
                 {
                     var result = await ServerStore.WriteDatabaseRecordAsync(
-                        databaseName, databaseRecord, null, RaftIdGenerator.NewId(), databaseValues, isRestore: true);
+                        databaseName, databaseRecord, null, raftId, databaseValues, isRestore: true);
                     return result.Index;
                 },
                 "Saving the database record",

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -570,12 +570,13 @@ internal static class BackupUtils
     {
         try
         {
-            var command = new UpdatePeriodicBackupStatusCommand(databaseName, RaftIdGenerator.NewId()) { PeriodicBackupStatus = status };
+            var raftId = RaftIdGenerator.NewId();
 
             AsyncHelpers.RunSync(async () =>
             {
                 var index = await BackupHelper.RunWithRetriesAsync(maxRetries: 10, async () =>
                     {
+                        var command = new UpdatePeriodicBackupStatusCommand(databaseName, raftId) { PeriodicBackupStatus = status };
                         var result = await serverStore.SendToLeaderAsync(command);
                         return result.Index;
                     },

--- a/src/Sparrow/Threading/SingleUseFlag.cs
+++ b/src/Sparrow/Threading/SingleUseFlag.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -56,7 +57,9 @@ namespace Sparrow.Threading
         /// </summary>
         private static void ThrowException()
         {
-            throw new InvalidOperationException($"Repeated Raise for a {nameof(SingleUseFlag)} instance");
+            const string message = $"Repeated Raise for a {nameof(SingleUseFlag)} instance";
+            Debug.Assert(false, message);
+            throw new InvalidOperationException(message);
         }
 
         /// <summary>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23532/Error-saving-the-periodic-backup-status

### Additional description

Since command reuse is not supported, create a new command for each attempt to save it to the cluster.
Regression was introduced here: https://github.com/ravendb/ravendb/pull/19209.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
