### PR TITLE
RavenDB-22988 - Verify the licensed attribute of Snowflake ETL

### DIFF
--- a/src/Raven.Client/Exceptions/Commercial/LimitType.cs
+++ b/src/Raven.Client/Exceptions/Commercial/LimitType.cs
@@ -52,7 +52,6 @@ namespace Raven.Client.Exceptions.Commercial
         [Description("Snowflake ETL")]
         SnowflakeEtl,
 
-
         [Description("Cores Limit")]
         Cores,
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -161,6 +161,10 @@ public sealed partial class ClusterStateMachine
             case nameof(AddElasticSearchEtlCommand):
                 AssertElasticSearchEtlLicenseLimits(serverStore, databaseRecord, context);
                 break;
+            case nameof(AddSnowflakeEtlCommand):
+            case nameof(UpdateSnowflakeEtlCommand):
+                AssertSnowflakeEtl(databaseRecord, serverStore.LicenseManager.LicenseStatus);
+                break;
             case nameof(EditTimeSeriesConfigurationCommand):
                 AssertTimeSeriesConfigurationLicenseLimits(serverStore, databaseRecord, context);
                 break;
@@ -180,6 +184,7 @@ public sealed partial class ClusterStateMachine
         var command = (PutLicenseCommand)CommandBase.CreateFrom(bjro);
         if (command.SkipLicenseAssertion)
             return;
+
         try
         {
             newLicenseLimits = LicenseManager.GetLicenseStatus(command.Value);
@@ -203,6 +208,8 @@ public sealed partial class ClusterStateMachine
             AssertRefreshFrequency(databaseRecord, newLicenseLimits, context);
             AssertSorters(databaseRecord, newLicenseLimits, context, items, type);
             AssertAnalyzers(databaseRecord, newLicenseLimits, context, items, type);
+            AssertSnowflakeEtl(databaseRecord, newLicenseLimits);
+
             if (AssertPeriodicBackup(newLicenseLimits, context) == false && databaseRecord.PeriodicBackups.Count > 0)
                 throw new LicenseLimitException(LimitType.PeriodicBackup, $"Your license doesn't support periodic backup.");
             AssertDatabaseClientConfiguration(databaseRecord, newLicenseLimits, context);
@@ -902,6 +909,17 @@ public sealed partial class ClusterStateMachine
             return;
 
         throw new LicenseLimitException(LimitType.QueueEtl, "Your license doesn't support adding Elastic Search ETL feature.");
+    }
+
+    private static void AssertSnowflakeEtl(DatabaseRecord databaseRecord, LicenseStatus licenseStatus)
+    {
+        if (licenseStatus.HasSnowflakeEtl)
+            return;
+
+        if (databaseRecord.SnowflakeEtls.Count == 0)
+            return;
+
+        throw new LicenseLimitException(LimitType.SnowflakeEtl, "Your license doesn't support using the Snowflake ETL feature.");
     }
 
     private void AssertTimeSeriesConfigurationLicenseLimits(ServerStore serverStore, DatabaseRecord databaseRecord, ClusterOperationContext context)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22988/Snowflake-ETL-License-Work

### Additional description

Verify the licensed attribute of Snowflake ETL.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
