### PR TITLE
RavenDB-23542 Renamed MaxNumberOfCoresForLocalEmbeddingsGeneration to MaxNumberOfThreadsForLocalEmbeddingsGeneration

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -92,7 +92,7 @@ namespace Raven.Server.Config.Categories
             EncryptedTransactionSizeLimit = defaultEncryptedTransactionSizeLimit;
             MaxAllocationsAtDictionaryTraining = defaultMaxAllocationsAtDictionaryTraining;
 
-            MaxNumberOfCoresForLocalEmbeddingsGeneration = Environment.ProcessorCount switch
+            MaxNumberOfThreadsForLocalEmbeddingsGeneration = Environment.ProcessorCount switch
             {
                 <= 2 => 1,
                 <= 8 => 2,
@@ -628,11 +628,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Corax.VectorSearch.OrderByScoreAutomatically", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool CoraxVectorSearchOrderByScoreAutomatically { get; set; }
         
-        [Description("Maximum number of processor cores that will be used for generating embedding from text locally.")]
+        [Description("Maximum number of threads that will be used for generating embedding from text locally.")]
         [DefaultValue(DefaultValueSetInConstructor)]
         [IndexUpdateType(IndexUpdateType.None)]
-        [ConfigurationEntry("Indexing.Corax.VectorSearch.MaxNumberOfCoresForLocalEmbeddingsGeneration", ConfigurationEntryScope.ServerWideOnly)]
-        public int MaxNumberOfCoresForLocalEmbeddingsGeneration { get; set; }
+        [ConfigurationEntry("Indexing.Corax.VectorSearch.MaxNumberOfThreadsForLocalEmbeddingsGeneration", ConfigurationEntryScope.ServerWideOnly)]
+        public int MaxNumberOfThreadsForLocalEmbeddingsGeneration { get; set; }
         
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -43,7 +43,7 @@ public static class GenerateEmbeddings
         if (Embedder.IsValueCreated)
             throw new InvalidOperationException("Embedder has already been initialized.");
         
-        OnnxSessionOptions = new SessionOptions() { IntraOpNumThreads = configuration.Indexing.MaxNumberOfCoresForLocalEmbeddingsGeneration };
+        OnnxSessionOptions = new SessionOptions() { IntraOpNumThreads = configuration.Indexing.MaxNumberOfThreadsForLocalEmbeddingsGeneration };
     }
 
     [ThreadStatic]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23542/Number-of-cores-for-local-embedding-isnt-respected

### Additional description

Renamed MaxNumberOfCoresForLocalEmbeddingsGeneration to MaxNumberOfThreadsForLocalEmbeddingsGeneration

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
