### PR TITLE
RavenDB-23495 Support for indexing attachments content in CreateVector

### DIFF
--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -217,6 +218,18 @@ namespace Raven.Client.Documents.Indexes
         /// </summary>
         /// <param name="value">Source of embedding</param>
         public object CreateVector(IEnumerable<float> value) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
+        
+        /// <summary>
+        /// Creates a vector field in the index from the provided value
+        /// </summary>
+        /// <param name="value">Source of embedding</param>
+        public object CreateVector(Stream value) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
+        
+        /// <summary>
+        /// Creates a vector field in the index from the provided values
+        /// </summary>
+        /// <param name="value">Source of embedding</param>
+        public object CreateVector(IEnumerable<Stream> values) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
         
         /// <summary>
         /// Creates a vector field in the index from the provided values

--- a/test/SlowTests/Issues/RavenDB-23495.cs
+++ b/test/SlowTests/Issues/RavenDB-23495.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics.Tensors;
+using System.Runtime.InteropServices;
+using System.Text;
+using FastTests;
+using Org.BouncyCastle.Crypto.Digests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23495(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private const string EmbeddingName = "embedding";
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public void CanIndexEmbeddingStoredInAttachmentInJavaScriptIndex()
+    {
+        var v1 = new[] { 0.1f, 0.2f, 0.3f };
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenSession();
+
+        var doc1 = new Document { };
+        session.Store(doc1);
+        session.SaveChanges();
+        var vectorInBase64 = Encoding.UTF8.GetBytes(Convert.ToBase64String(MemoryMarshal.Cast<float, byte>(v1)));
+        using var memStream = new MemoryStream(vectorInBase64);
+        session.Advanced.Attachments.Store(doc1, EmbeddingName, memStream);
+        session.SaveChanges();
+
+        var index = new JsIndexWithVector();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+        var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
+        Assert.Null(errors);
+
+        Document doc = session.Query<Document, JsIndexWithVector>()
+            .VectorSearch(f => f.WithField(s => s.Vector),
+                v => v.ByEmbedding(v1))
+            .FirstOrDefault();
+
+        Assert.NotNull(doc);
+    }
+    
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public void CanIndexEmbeddingStoredInAttachmentInCsharpIndex()
+    {
+        var v1 = new[] { 0.1f, 0.2f, 0.3f };
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenSession();
+
+        var doc1 = new Document { };
+        session.Store(doc1);
+        session.SaveChanges();
+        using var memStream = new MemoryStream(MemoryMarshal.Cast<float, byte>(v1).ToArray());
+        session.Advanced.Attachments.Store(doc1, EmbeddingName, memStream);
+        session.SaveChanges();
+
+        var index = new CSharpIndexWithVector();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+        var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
+        Assert.Null(errors);
+
+        Document doc = session.Query<Document, CSharpIndexWithVector>()
+            .VectorSearch(f => f.WithField(s => s.Vector),
+                v => v.ByEmbedding(v1))
+            .FirstOrDefault();
+
+        Assert.NotNull(doc);
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public void CreateVectorFromMultipleAttachments()
+    {
+        var v1 = new[] { 0.1f, 0.2f, 0.3f };
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenSession();
+
+        var doc1 = new Document { };
+        session.Store(doc1);
+        session.SaveChanges();
+        using var memStream1 = new MemoryStream(MemoryMarshal.Cast<float, byte>(v1).ToArray());
+        using var memStream2 = new MemoryStream(MemoryMarshal.Cast<float, byte>(v1.Select(x => -x).ToArray()).ToArray());
+        using var memStream3 = new MemoryStream(MemoryMarshal.Cast<float, byte>(v1.Select(x => x + 1.2f).ToArray()).ToArray());
+        session.Advanced.Attachments.Store(doc1, EmbeddingName + 1, memStream1);
+        session.Advanced.Attachments.Store(doc1, EmbeddingName + 2, memStream2);
+        session.Advanced.Attachments.Store(doc1, EmbeddingName + 3, memStream3);
+        session.SaveChanges();
+
+        var index = new CSharpIndexWithMultipleVector();
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+        var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
+        Assert.Null(errors);
+
+        Document doc = session.Query<Document, CSharpIndexWithMultipleVector>()
+            .VectorSearch(f => f.WithField(s => s.Vector),
+                v => v.ByEmbedding(v1))
+            .FirstOrDefault();
+
+        Assert.NotNull(doc);
+    }
+
+    private class CSharpIndexWithVector : AbstractIndexCreationTask<Document>
+    {
+        public CSharpIndexWithVector()
+        {
+            Map = documents => from document in documents
+                let embeddings = LoadAttachment(document, EmbeddingName)
+                select new { Vector = CreateVector(embeddings.GetContentAsStream()) };
+        }
+    }
+
+    private class CSharpIndexWithMultipleVector : AbstractIndexCreationTask<Document>
+    {
+        public CSharpIndexWithMultipleVector()
+        {
+            Map = documents => from document in documents
+                let embeddings = LoadAttachments(document)
+                select new { Vector = CreateVector(embeddings.Select(e => e.GetContentAsStream())) };
+        }
+    }
+
+    private class JsIndexWithVector : AbstractJavaScriptIndexCreationTask
+    {
+        public JsIndexWithVector()
+        {
+            Maps = new HashSet<string>
+            {
+                $@"map('Documents', function (document) {{
+                var attachment = loadAttachment(document, '{EmbeddingName}');
+                return {{
+                    Vector: createVector(attachment.getContentAsString('utf8'))
+                }};
+            }})"
+            };
+
+            Fields = new Dictionary<string, IndexFieldOptions>()
+            {
+                {
+                    "Vector",
+                    new IndexFieldOptions() { Vector = new() { SourceEmbeddingType = VectorEmbeddingType.Single, DestinationEmbeddingType = VectorEmbeddingType.Single } }
+                }
+            };
+        }
+    }
+
+    private class Document
+    {
+        public string Id { get; set; }
+        public object Vector { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23495

### Additional description

Support:
C#:
- support for stream for indexing byte representation of arrays
- base64 from attachments must be provided via `GetContentAsString`
JS:
- support for indexing base64 from attachment as string (via `getContentAsString`)

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
