### PR TITLE
RavenDB-23534 Skip TombstoneNotifications if not necessary

### DIFF
--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -182,10 +182,15 @@ namespace Raven.Server.Documents
 
         private void UpdateNotifications(List<BlockingTombstoneDetails> detailsSet)
         {
+            var key = AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones));
+
+            if (detailsSet.Count == 0 && _documentDatabase.NotificationCenter.Exists(key) == false)
+                return;
+
             if (detailsSet.Count > 0)
                 _documentDatabase.NotificationCenter.TombstoneNotifications.Add(detailsSet);
             else
-                _documentDatabase.NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones)));
+                _documentDatabase.NotificationCenter.Dismiss(key);
         }
 
         internal TombstonesState GetState(bool addInfoForDebug = false)

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -182,15 +182,10 @@ namespace Raven.Server.Documents
 
         private void UpdateNotifications(List<BlockingTombstoneDetails> detailsSet)
         {
-            var key = AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones));
-
-            if (detailsSet.Count == 0 && _documentDatabase.NotificationCenter.Exists(key) == false)
-                return;
-
             if (detailsSet.Count > 0)
                 _documentDatabase.NotificationCenter.TombstoneNotifications.Add(detailsSet);
             else
-                _documentDatabase.NotificationCenter.Dismiss(key);
+                _documentDatabase.NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones)));
         }
 
         internal TombstonesState GetState(bool addInfoForDebug = false)

--- a/src/Raven.Server/NotificationCenter/NotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationCenter.cs
@@ -206,7 +206,7 @@ namespace Raven.Server.NotificationCenter
 
         public void Dismiss(string id, RavenTransaction existingTransaction = null, bool sendNotificationEvenIfDoesntExist = true)
         {
-            var deleted = _notificationsStorage.Delete(id, existingTransaction);
+            var deleted = Exists(id) && _notificationsStorage.Delete(id, existingTransaction);
             if (deleted == false && sendNotificationEvenIfDoesntExist == false)
                 return;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23534

### Additional description

We want to skip NotificationCenter.Dismiss when it is not necessary, to avoid performing unnecessary write transactions.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
