### PR TITLE
RavenDB-23549 Admin Logs: Changing MinLevel should hide already rendered logs below the selected level

### DIFF
--- a/src/Raven.Studio/typescript/common/typeUtils.spec.ts
+++ b/src/Raven.Studio/typescript/common/typeUtils.spec.ts
@@ -1,4 +1,4 @@
-import { compareSets, isBoolean, range } from "./typeUtils";
+import { capitalize, compareSets, isBoolean, range } from "./typeUtils";
 
 describe("typeUtils", () => {
     describe("isBoolean", () => {
@@ -49,6 +49,20 @@ describe("typeUtils", () => {
             expect(compareSets([1, 1], [1, 2])).toBe(false);
             expect(compareSets([1, 2], [1, 2, 3])).toBe(false);
             expect(compareSets([1, 2, 3], [1, 2])).toBe(false);
+        });
+    });
+
+    describe("capitalize", () => {
+        it("should capitalize the first letter of a string and lowercase the rest", () => {
+            expect(capitalize(undefined)).toEqual("");
+            expect(capitalize(null)).toEqual("");
+            expect(capitalize("")).toEqual("");
+            expect(capitalize(" ")).toEqual(" ");
+            expect(capitalize("hello")).toEqual("Hello");
+            expect(capitalize("HeLLO")).toEqual("Hello");
+            expect(capitalize("Hello")).toEqual("Hello");
+            expect(capitalize("hello world")).toEqual("Hello world");
+            expect(capitalize(123 as unknown as string)).toEqual("123");
         });
     });
 });

--- a/src/Raven.Studio/typescript/common/typeUtils.ts
+++ b/src/Raven.Studio/typescript/common/typeUtils.ts
@@ -65,3 +65,17 @@ export function compareSets<T extends string | number>(set1: T[], set2: T[]): bo
     }
     return true;
 }
+
+export function capitalize<Value extends string, Result extends Capitalize<Lowercase<Value>>>(value: Value): Result {
+    if (value == null) {
+        return "" as Result;
+    }
+
+    const stringValue = String(value);
+
+    if (!stringValue.length) {
+        return "" as Result;
+    }
+
+    return (stringValue.toLowerCase()[0].toUpperCase() + stringValue.slice(1).toLowerCase()) as Result;
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23549/Admin-Logs-Changing-MinLevel-should-hide-already-rendered-logs-below-the-selected-level

### Additional description

I additionally added `capitalize` function to typeUtils

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
