### PR TITLE
RavenDB-23597: Read balance behavior configuration changes not triggering speed test phase

### DIFF
--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -76,7 +76,7 @@ namespace Raven.Client.Http
 
         public Topology Topology => _state.Topology;
 
-        private Timer _updateFastestNodeTimer;
+        internal Timer _updateFastestNodeTimer;
 
         internal NodeSelectorState _state;
 
@@ -246,6 +246,19 @@ namespace Raven.Client.Http
             Array.Clear(state.FastestRecords,0, state.Failures.Length);
 
             Interlocked.Increment(ref state.SpeedTestMode);
+        }
+
+        internal void DisableFastestNodeReadBalance()
+        {
+            if (_updateFastestNodeTimer != null)
+            {
+                _updateFastestNodeTimer.Dispose();
+                _updateFastestNodeTimer = null;
+            }
+
+            var state = _state;
+            Interlocked.Exchange(ref state.SpeedTestMode, 0);
+            Array.Clear(state.FastestRecords, index: 0, state.FastestRecords.Length);
         }
 
         public bool InSpeedTestPhase => _state.SpeedTestMode > 1;

--- a/src/Raven.Client/Http/NodeSelector.cs
+++ b/src/Raven.Client/Http/NodeSelector.cs
@@ -250,15 +250,21 @@ namespace Raven.Client.Http
 
         internal void DisableFastestNodeReadBalance()
         {
-            if (_updateFastestNodeTimer != null)
+            if (_updateFastestNodeTimer == null)
+                return;
+
+            lock (_timerCreationLocker)
             {
+                if (_updateFastestNodeTimer == null)
+                    return;
+
                 _updateFastestNodeTimer.Dispose();
                 _updateFastestNodeTimer = null;
-            }
 
-            var state = _state;
-            Interlocked.Exchange(ref state.SpeedTestMode, 0);
-            Array.Clear(state.FastestRecords, index: 0, state.FastestRecords.Length);
+                var state = _state;
+                Interlocked.Exchange(ref state.SpeedTestMode, 0);
+                Array.Clear(state.FastestRecords, index: 0, state.FastestRecords.Length);
+            }
         }
 
         public bool InSpeedTestPhase => _state.SpeedTestMode > 1;

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -319,6 +319,14 @@ namespace Raven.Client.Http
             TopologyHash = Http.TopologyHash.GetTopologyHash(initialUrls);
 
             UpdateConnectionLimit(initialUrls);
+
+            ClientConfigurationChanged += (_, args) =>
+            {
+                if (args.Configuration.ReadBalanceBehavior == ReadBalanceBehavior.FastestNode)
+                    _nodeSelector?.ScheduleSpeedTest();
+                else
+                    _nodeSelector?.DisableFastestNodeReadBalance();
+            };
         }
 
         ~RequestExecutor()
@@ -2289,8 +2297,12 @@ namespace Raven.Client.Http
             }
 
             internal int[] NodeSelectorFailures => _requestExecutor._nodeSelector.NodeSelectorFailures;
+
             internal ConcurrentDictionary<ServerNode, Lazy<NodeStatus>> FailedNodesTimers => _requestExecutor._failedNodesTimers;
+
             internal (int Index, ServerNode Node) PreferredNode => _requestExecutor._nodeSelector.GetPreferredNode();
+
+            internal bool HasUpdateFastestNodeTimer => _requestExecutor._nodeSelector._updateFastestNodeTimer != null;
 
             public Action<Task> ExecuteOnAllToFigureOutTheFastestOnTaskCompletion;
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23597

### Additional description

When client connects to the server and receives default configuration with `ReadBalanceBehavior.FastestNode`, the speed test phase wasn't being initiated. This PR adds proper handling of initial configuration to ensure that speed testing mechanism is activated immediately upon receiving client configuration from server.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
