### PR TITLE
RavenDB-23249 - Support for referenced documents from any collection

### DIFF
--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2247,9 +2247,19 @@ namespace Raven.Server.Documents
             return GetNumberOfItemsToProcess(context, collection, afterEtag, tombstones: false, totalCount: out totalCount, overallDuration);
         }
 
+        public long GetNumberOfDocumentsToProcess(DocumentsOperationContext context, long afterEtag, out long totalCount, Stopwatch overallDuration)
+        {
+            return GetNumberOfItemsToProcess(context, afterEtag, tombstones: false, totalCount: out totalCount, overallDuration);
+        }
+
         public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collection, long afterEtag, out long totalCount, Stopwatch overallDuration)
         {
             return GetNumberOfItemsToProcess(context, collection, afterEtag, tombstones: true, totalCount: out totalCount, overallDuration);
+        }
+
+        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, out long totalCount, Stopwatch overallDuration)
+        {
+            return GetNumberOfItemsToProcess(context, afterEtag, tombstones: true, totalCount: out totalCount, overallDuration);
         }
 
         private long GetNumberOfItemsToProcess(DocumentsOperationContext context, string collection, long afterEtag, bool tombstones, out long totalCount,
@@ -2282,6 +2292,25 @@ namespace Raven.Server.Documents
             {
                 totalCount = 0;
                 return 0;
+            }
+
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out totalCount, overallDuration);
+        }
+
+        private long GetNumberOfItemsToProcess(DocumentsOperationContext context, long afterEtag, bool tombstones, out long totalCount,
+            Stopwatch overallDuration)
+        {
+            Table table;
+            TableSchema.FixedSizeKeyIndexDef indexDef;
+            if (tombstones)
+            {
+                table = new Table(TombstonesSchema, context.Transaction.InnerTransaction);
+                indexDef = TombstonesSchema.FixedSizeIndexes[AllTombstonesEtagsSlice];
+            }
+            else
+            {
+                table = new Table(DocsSchema, context.Transaction.InnerTransaction);
+                indexDef = DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice];
             }
 
             return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out totalCount, overallDuration);

--- a/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Auto/AutoMapIndex.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Indexes.Auto
     internal sealed class AutoMapIndex : MapIndexBase<AutoMapIndexDefinition, AutoIndexField>
     {
         private AutoMapIndex(AutoMapIndexDefinition definition)
-            : base(IndexType.AutoMap, IndexSourceType.Documents, definition)
+            : base(IndexType.AutoMap, IndexSourceType.Documents, definition, compiled: null)
         {
         }
 

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.Indexes.Errors
         }
 
         private FaultyInMemoryIndex(Exception e, IndexingConfiguration configuration, IndexDefinitionBaseServerSide definition, SearchEngineType searchEngineType)
-            : base(IndexType.Faulty, IndexSourceType.None, definition)
+            : base(IndexType.Faulty, IndexSourceType.None, definition, compiled: null)
         {
             _e = e;
             _createdAt = DateTime.UtcNow;

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3062,13 +3062,17 @@ namespace Raven.Server.Documents.Indexes
         internal virtual void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
             Stopwatch overallDuration)
         {
-            progressStats.NumberOfItemsToProcess +=
-                DocumentDatabase.DocumentsStorage.GetNumberOfDocumentsToProcess(
-                    queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, out var totalCount, overallDuration);
+            progressStats.NumberOfItemsToProcess += collectionName == Constants.Documents.Collections.AllDocumentsCollection
+                ? DocumentDatabase.DocumentsStorage.GetNumberOfDocumentsToProcess(
+                    queryContext.Documents, progressStats.LastProcessedItemEtag, out var totalCount, overallDuration)
+                : DocumentDatabase.DocumentsStorage.GetNumberOfDocumentsToProcess(
+                    queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, out totalCount, overallDuration);
             progressStats.TotalNumberOfItems += totalCount;
 
-            progressStats.NumberOfTombstonesToProcess +=
-                DocumentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(
+            progressStats.NumberOfTombstonesToProcess += collectionName == Constants.Documents.Collections.AllDocumentsCollection
+                ? DocumentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(
+                    queryContext.Documents, progressStats.LastProcessedTombstoneEtag, out totalCount, overallDuration)
+                : DocumentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(
                     queryContext.Documents, collectionName, progressStats.LastProcessedTombstoneEtag, out totalCount, overallDuration);
             progressStats.TotalNumberOfTombstones += totalCount;
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -212,7 +212,7 @@ namespace Raven.Server.Documents.Indexes
         private string _lastPendingStatus;
         public MultipleUseFlag ForceReplace = new MultipleUseFlag();
 
-        protected readonly bool HandleAllDocs;
+        protected bool HandleAllDocs;
 
         protected internal MeterMetric MapsPerSec;
         protected internal MeterMetric ReducesPerSec;

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes.Persistence;
+using Raven.Server.Documents.Indexes.Static;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Documents.Indexes.Workers.Cleanup;
 using Raven.Server.Documents.Queries;
@@ -19,7 +20,7 @@ namespace Raven.Server.Documents.Indexes
         private IndexingStatsScope _statsInstance;
         private readonly MapStats _stats = new MapStats();
 
-        protected MapIndexBase(IndexType type, IndexSourceType sourceType, T definition) : base(type, sourceType, definition)
+        protected MapIndexBase(IndexType type, IndexSourceType sourceType, T definition, AbstractStaticIndexBase compiled) : base(type, sourceType, definition, compiled)
         {
         }
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndex.cs
@@ -30,7 +30,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Auto
         private readonly MapOutput _output;
 
         private AutoMapReduceIndex(AutoMapReduceIndexDefinition definition)
-            : base(IndexType.AutoMapReduce, IndexSourceType.Documents, definition)
+            : base(IndexType.AutoMapReduce, IndexSourceType.Documents, definition, compiled: null)
         {
             _isFanout = definition.GroupByFields.Any(x => x.Value.GroupByArrayBehavior == GroupByArrayBehavior.ByIndividualValues);
             _output = new MapOutput(_isFanout);

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexBase.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         private IndexingStatsScope _statsInstance;
         private readonly MapPhaseStats _stats = new MapPhaseStats();
 
-        protected MapReduceIndexBase(IndexType type, IndexSourceType sourceType, T definition) : base(type, sourceType, definition)
+        protected MapReduceIndexBase(IndexType type, IndexSourceType sourceType, T definition, AbstractStaticIndexBase compiled) : base(type, sourceType, definition, compiled)
         {
         }
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -56,7 +56,12 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
+                {
                     _referencedCollections.Add(referencedCollection.Name);
+
+                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
+                        HandleAllDocs = true;
+                }
             }
         }
 
@@ -511,6 +516,9 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
 
             if (_referencedCollections == null)
                 return false;
+
+            if (HandleAllDocs)
+                return true;
 
             return _referencedCollections.Overlaps(collections);
         }

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -46,7 +46,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
         public IPropertyAccessor OutputReduceToCollectionPropertyAccessor;
 
         protected MapReduceIndex(MapReduceIndexDefinition definition, AbstractStaticIndexBase compiled)
-            : base(definition.IndexDefinition.Type, definition.IndexDefinition.SourceType, definition)
+            : base(definition.IndexDefinition.Type, definition.IndexDefinition.SourceType, definition, compiled)
         {
             _compiled = compiled;
 
@@ -56,12 +56,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
-                {
                     _referencedCollections.Add(referencedCollection.Name);
-
-                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
-                        HandleAllDocs = true;
-                }
             }
         }
 
@@ -516,9 +511,6 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
 
             if (_referencedCollections == null)
                 return false;
-
-            if (HandleAllDocs)
-                return true;
 
             return _referencedCollections.Overlaps(collections);
         }

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
@@ -42,7 +42,12 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
+                {
                     _referencedCollections.Add(referencedCollection.Name);
+
+                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
+                        HandleAllDocs = true;
+                }
             }
         }
 
@@ -81,7 +86,7 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
                 return;
             }
 
-            if (_referencedCollections.Contains(change.CollectionName))
+            if (HandleAllDocs || _referencedCollections.Contains(change.CollectionName))
             {
                 _mre.Set();
             }
@@ -155,6 +160,9 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
 
             if (_referencedCollections == null)
                 return false;
+
+            if (HandleAllDocs)
+                return true;
 
             return _referencedCollections.Overlaps(collections);
         }

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
         private HandleCompareExchangeCountersReferences _handleCompareExchangeReferences;
 
         private MapCountersIndex(MapIndexDefinition definition, AbstractStaticIndexBase compiled)
-            : base(definition.IndexDefinition.Type, definition.IndexDefinition.SourceType, definition)
+            : base(definition.IndexDefinition.Type, definition.IndexDefinition.SourceType, definition, compiled)
         {
             _compiled = compiled;
 
@@ -42,12 +42,7 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
-                {
                     _referencedCollections.Add(referencedCollection.Name);
-
-                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
-                        HandleAllDocs = true;
-                }
             }
         }
 
@@ -160,9 +155,6 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
 
             if (_referencedCollections == null)
                 return false;
-
-            if (HandleAllDocs)
-                return true;
 
             return _referencedCollections.Overlaps(collections);
         }

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
@@ -30,7 +30,12 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
+                {
                     _referencedCollections.Add(referencedCollection.Name);
+
+                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
+                        HandleAllDocs = true;
+                }
             }
         }
 
@@ -117,7 +122,7 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
                 return;
             }
 
-            if (_referencedCollections.Contains(change.CollectionName))
+            if (HandleAllDocs || _referencedCollections.Contains(change.CollectionName))
             {
                 _mre.Set();
             }

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
@@ -30,12 +30,7 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
-                {
                     _referencedCollections.Add(referencedCollection.Name);
-
-                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
-                        HandleAllDocs = true;
-                }
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -245,7 +245,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
                 if (document.TryGetMetadata(out var metadata) && metadata.TryGet(Constants.Documents.Metadata.Collection, out string collection))
                 {
-                    if (string.Equals(collection, collectionName, StringComparison.OrdinalIgnoreCase) == false)
+                    if (string.Equals(collection, collectionName, StringComparison.OrdinalIgnoreCase) == false && collectionName != Constants.Documents.Collections.AllDocumentsCollection)
                     {
                         MismatchedReferencesWarningHandler ??= new MismatchedReferencesWarningHandler();
 

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -47,7 +47,12 @@ namespace Raven.Server.Documents.Indexes.Static
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
+                {
                     _referencedCollections.Add(referencedCollection.Name);
+
+                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
+                        HandleAllDocs = true;
+                }
             }
         }
 
@@ -171,6 +176,9 @@ namespace Raven.Server.Documents.Indexes.Static
 
             if (_referencedCollections == null)
                 return false;
+
+            if (HandleAllDocs)
+                return true;
 
             return _referencedCollections.Overlaps(collections);
         }

--- a/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/MapIndex.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Documents.Indexes.Static
         private HandleCompareExchangeReferences _handleCompareExchangeReferences;
 
         private MapIndex(MapIndexDefinition definition, AbstractStaticIndexBase compiled)
-            : base(definition.IndexDefinition.Type, definition.IndexDefinition.SourceType, definition)
+            : base(definition.IndexDefinition.Type, definition.IndexDefinition.SourceType, definition, compiled)
         {
             _compiled = compiled;
 
@@ -47,12 +47,7 @@ namespace Raven.Server.Documents.Indexes.Static
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
-                {
                     _referencedCollections.Add(referencedCollection.Name);
-
-                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
-                        HandleAllDocs = true;
-                }
             }
         }
 
@@ -176,9 +171,6 @@ namespace Raven.Server.Documents.Indexes.Static
 
             if (_referencedCollections == null)
                 return false;
-
-            if (HandleAllDocs)
-                return true;
 
             return _referencedCollections.Overlaps(collections);
         }

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
@@ -33,12 +33,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
-                {
                     _referencedCollections.Add(referencedCollection.Name);
-
-                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
-                        HandleAllDocs = true;
-                }
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
@@ -33,7 +33,12 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
+                {
                     _referencedCollections.Add(referencedCollection.Name);
+
+                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
+                        HandleAllDocs = true;
+                }
             }
         }
 
@@ -143,7 +148,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
                 return;
             }
 
-            if (_referencedCollections.Contains(change.CollectionName))
+            if (HandleAllDocs || _referencedCollections.Contains(change.CollectionName))
             {
                 _mre.Set();
             }

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
@@ -44,7 +44,12 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
+                {
                     _referencedCollections.Add(referencedCollection.Name);
+
+                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
+                        HandleAllDocs = true;
+                }
             }
         }
 
@@ -83,7 +88,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
                 return;
             }
 
-            if (_referencedCollections.Contains(change.CollectionName))
+            if (HandleAllDocs || _referencedCollections.Contains(change.CollectionName))
             {
                 _mre.Set();
             }
@@ -159,6 +164,9 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
 
             if (_referencedCollections == null)
                 return false;
+
+            if (HandleAllDocs)
+                return true;
 
             return _referencedCollections.Overlaps(collections);
         }

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
@@ -34,7 +34,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
         private HandleCompareExchangeTimeSeriesReferences _handleCompareExchangeReferences;
 
         private MapTimeSeriesIndex(MapIndexDefinition definition, AbstractStaticIndexBase compiled)
-            : base(definition.IndexDefinition.Type, definition.IndexDefinition.SourceType, definition)
+            : base(definition.IndexDefinition.Type, definition.IndexDefinition.SourceType, definition, compiled)
         {
             _compiled = compiled;
 
@@ -44,12 +44,7 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
             foreach (var collection in _compiled.ReferencedCollections)
             {
                 foreach (var referencedCollection in collection.Value)
-                {
                     _referencedCollections.Add(referencedCollection.Name);
-
-                    if (referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection)
-                        HandleAllDocs = true;
-                }
             }
         }
 
@@ -164,9 +159,6 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
 
             if (_referencedCollections == null)
                 return false;
-
-            if (HandleAllDocs)
-                return true;
 
             return _referencedCollections.Overlaps(collections);
         }

--- a/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
+++ b/src/Raven.Server/Documents/Indexes/StaticIndexHelper.cs
@@ -61,7 +61,10 @@ namespace Raven.Server.Documents.Indexes
                     {
                         foreach (var referencedCollection in referencedCollections)
                         {
-                            var lastDocEtag = queryContext.Documents.DocumentDatabase.DocumentsStorage.GetLastDocumentEtag(queryContext.Documents.Transaction.InnerTransaction, referencedCollection.Name);
+                            var lastDocEtag = referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection
+                                ? DocumentsStorage.ReadLastDocumentEtag(queryContext.Documents.Transaction.InnerTransaction)
+                                : queryContext.Documents.DocumentDatabase.DocumentsStorage.GetLastDocumentEtag(queryContext.Documents.Transaction.InnerTransaction, referencedCollection.Name);
+
                             var lastProcessedReferenceEtag = index._indexStorage.ReferencesForDocuments.ReadLastProcessedReferenceEtag(indexContext.Transaction.InnerTransaction, collection, referencedCollection);
                             var lastProcessedTombstoneEtag = index._indexStorage.ReferencesForDocuments.ReadLastProcessedReferenceTombstoneEtag(indexContext.Transaction.InnerTransaction, collection, referencedCollection);
 
@@ -81,7 +84,9 @@ namespace Raven.Server.Documents.Indexes
                                                          $"but last processed document etag for that collection is '{lastProcessedReferenceEtag:#,#;;0}'.");
                                 }
 
-                                var lastTombstoneEtag = queryContext.Documents.DocumentDatabase.DocumentsStorage.GetLastTombstoneEtag(queryContext.Documents.Transaction.InnerTransaction, referencedCollection.Name);
+                                var lastTombstoneEtag = referencedCollection.Name == Constants.Documents.Collections.AllDocumentsCollection
+                                    ? DocumentsStorage.ReadLastTombstoneEtag(queryContext.Documents.Transaction.InnerTransaction)
+                                    : queryContext.Documents.DocumentDatabase.DocumentsStorage.GetLastTombstoneEtag(queryContext.Documents.Transaction.InnerTransaction, referencedCollection.Name);
 
                                 if (lastTombstoneEtag > lastProcessedTombstoneEtag)
                                 {

--- a/test/FastTests/Server/Documents/Indexing/BasicAnalyzers.cs
+++ b/test/FastTests/Server/Documents/Indexing/BasicAnalyzers.cs
@@ -208,7 +208,7 @@ namespace FastTests.Server.Documents.Indexing
 
     internal class TestIndex : Index
     {
-        public TestIndex(DocumentDatabase database, IndexingConfiguration configuration) : base(IndexType.None, IndexSourceType.None, new TestIndexDefinitions())
+        public TestIndex(DocumentDatabase database, IndexingConfiguration configuration) : base(IndexType.None, IndexSourceType.None, new TestIndexDefinitions(), compiled: null)
         {
             DocumentDatabase = database;
             Configuration = configuration;

--- a/test/FastTests/Server/Documents/Indexing/Lucene/LuceneDocumentConverterTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/Lucene/LuceneDocumentConverterTests.cs
@@ -499,7 +499,7 @@ namespace FastTests.Server.Documents.Indexing.Lucene
         public class FakeIndex : Index
         {
             public FakeIndex()
-                : base(IndexType.Map, IndexSourceType.Documents, new AutoMapIndexDefinition("Orders", new AutoIndexField[0]))
+                : base(IndexType.Map, IndexSourceType.Documents, new AutoMapIndexDefinition("Orders", new AutoIndexField[0]), compiled: null)
             {
             }
 

--- a/test/SlowTests/Issues/RavenDB-23249.cs
+++ b/test/SlowTests/Issues/RavenDB-23249.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23249 : RavenTestBase
+{
+    private const int EmployeesCount = 10;
+    private const string CommonName = "Companies";
+    private const string CompanyName1 = "Hibernating Rhinos";
+    private const string CompanyName2 = "RavenDB";
+
+    public RavenDB_23249(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task CanIndexAllDocumentsReferencesMapIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var company = new Company { Name = CompanyName1 };
+
+            await new MapIndex().ExecuteAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(company);
+
+                for (var i = 0; i < EmployeesCount; i++)
+                {
+                    await session.StoreAsync(new Employee
+                    {
+                        CompanyId = company.Id
+                    });
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Query<MapIndex.Result, MapIndex>()
+                    .Where(x => x.CompanyName == CompanyName1).CountAsync();
+
+                Assert.Equal(EmployeesCount, count);
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                company.Name = CompanyName2;
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                await session.StoreAsync(company, company.Id);
+                await session.SaveChangesAsync();
+            }
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Query<MapIndex.Result, MapIndex>()
+                    .Where(x => x.CompanyName == CompanyName1).CountAsync();
+
+                Assert.Equal(0, count);
+
+                count = await session.Query<MapIndex.Result, MapIndex>()
+                    .Where(x => x.CompanyName == CompanyName2).CountAsync();
+
+                Assert.Equal(EmployeesCount, count);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task CanIndexAllDocumentsReferencesMapReduceIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var company = new Company { Name = CompanyName1 };
+
+            await new MapReduceIndex().ExecuteAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(company);
+
+                for (var i = 0; i < EmployeesCount; i++)
+                {
+                    await session.StoreAsync(new Employee
+                    {
+                        CompanyId = company.Id
+                    });
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var result = await session.Query<MapReduceIndex.Result, MapReduceIndex>().ToListAsync();
+
+                Assert.Equal(1, result.Count);
+                Assert.Equal(CompanyName1, result[0].CompanyName);
+                Assert.Equal(10, result[0].Count);
+            }
+            using (var session = store.OpenAsyncSession())
+            {
+                company.Name = CompanyName2;
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                await session.StoreAsync(company, company.Id);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var result = await session.Query<MapReduceIndex.Result, MapReduceIndex>().ToListAsync();
+
+                Assert.Equal(1, result.Count);
+                Assert.Equal(CompanyName2, result[0].CompanyName);
+                Assert.Equal(10, result[0].Count);
+            }
+        }
+    }
+
+    private class Company
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    private class Employee
+    {
+        public string Id { get; set; }
+
+        public string CompanyId { get; set; }
+    }
+
+    private class MapIndex : AbstractIndexCreationTask<Employee>
+    {
+        public class Result
+        {
+            public string CompanyName { get; set; }
+        }
+
+        public MapIndex()
+        {
+            Map = employees =>
+                from employee in employees
+                select new Result
+                {
+                    CompanyName = LoadDocument<Company>(employee.CompanyId, Constants.Documents.Collections.AllDocumentsCollection).Name
+                };
+        }
+    }
+
+
+    private class MapReduceIndex : AbstractIndexCreationTask<Employee, MapReduceIndex.Result>
+    {
+        public class Result
+        {
+            public string CompanyName { get; set; }
+
+            public int Count { get; set; }
+        }
+
+        public MapReduceIndex()
+        {
+            Map = employees =>
+                from employee in employees
+                select new Result
+                {
+                    CompanyName = LoadDocument<Company>(employee.CompanyId, Constants.Documents.Collections.AllDocumentsCollection).Name,
+                    Count = 1
+                };
+
+            Reduce = results =>
+                from result in results
+                group result by result.CompanyName into g
+                select new Result
+                {
+                    CompanyName = g.Key,
+                    Count = g.Sum(x => x.Count)
+                };
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23249.cs
+++ b/test/SlowTests/Issues/RavenDB-23249.cs
@@ -6,6 +6,7 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Counters;
+using Raven.Client.Documents.Indexes.TimeSeries;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -258,6 +259,144 @@ public class RavenDB_23249 : RavenTestBase
         }
     }
 
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task CanIndexAllDocumentsReferencesMapTimeSeriesIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var company = new Company
+            {
+                Id = CommonName,
+                Name = CompanyName1
+            };
+
+            await new MapTimeSeriesIndex().ExecuteAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(company);
+                await session.SaveChangesAsync();
+            }
+
+            using (var bulk = store.BulkInsert())
+            {
+                var baseDate = DateTime.UtcNow;
+
+                for (var i = 0; i < EmployeesCount; i++)
+                {
+                    var employee = new Employee();
+                    await bulk.StoreAsync(employee);
+
+                    using (var ts = bulk.TimeSeriesFor(employee.Id, CommonName))
+                    {
+                        await ts.AppendAsync(baseDate, 1, company.Id);
+                    }
+                }
+            }
+
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Query<MapTimeSeriesIndex.Result, MapTimeSeriesIndex>()
+                    .Where(x => x.CompanyName == CompanyName1).CountAsync();
+
+                Assert.Equal(EmployeesCount, count);
+            }
+
+            WaitForUserToContinueTheTest(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+
+                company.Name = CompanyName2;
+                await session.StoreAsync(company, company.Id);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var count = await session.Query<MapTimeSeriesIndex.Result, MapTimeSeriesIndex>()
+                    .Where(x => x.CompanyName == CompanyName1).CountAsync();
+
+                Assert.Equal(0, count);
+
+                count = await session.Query<MapTimeSeriesIndex.Result, MapTimeSeriesIndex>()
+                    .Where(x => x.CompanyName == CompanyName2).CountAsync();
+
+                Assert.Equal(EmployeesCount, count);
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task CanIndexAllDocumentsReferencesMapReduceTimeSeriesIndex()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var company = new Company
+            {
+                Name = CompanyName1
+            };
+
+            await new MapReduceTimeSeriesIndex().ExecuteAsync(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(company);
+                await session.SaveChangesAsync();
+            }
+
+            using (var bulk = store.BulkInsert())
+            {
+                var baseDate = DateTime.UtcNow;
+
+                for (var i = 0; i < EmployeesCount; i++)
+                {
+                    var employee = new Employee();
+                    await bulk.StoreAsync(employee);
+
+                    using (var ts = bulk.TimeSeriesFor(employee.Id, CommonName))
+                    {
+                        await ts.AppendAsync(baseDate, 1, company.Id);
+                    }
+                }
+            }
+
+            await Indexes.WaitForIndexingAsync(store, timeout: TimeSpan.FromMinutes(3));
+
+            WaitForUserToContinueTheTest(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var result = await session.Query<MapReduceTimeSeriesIndex.Result, MapReduceTimeSeriesIndex>().ToListAsync();
+
+                Assert.Equal(1, result.Count);
+                Assert.Equal(CompanyName1, result[0].CompanyName);
+                Assert.Equal(EmployeesCount, result[0].Count);
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+
+                company.Name = CompanyName2;
+                await session.StoreAsync(company, company.Id);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var result = await session.Query<MapReduceTimeSeriesIndex.Result, MapReduceTimeSeriesIndex>().ToListAsync();
+
+                Assert.Equal(1, result.Count);
+                Assert.Equal(CompanyName2, result[0].CompanyName);
+                Assert.Equal(EmployeesCount, result[0].Count);
+            }
+        }
+    }
+
     private class Company
     {
         public string Id { get; set; }
@@ -362,6 +501,57 @@ public class RavenDB_23249 : RavenTestBase
                 select new Result
                 {
                     CompanyName = g.Select(x => x.CompanyName).FirstOrDefault(),
+                    Count = g.Sum(x => x.Count)
+                };
+        }
+    }
+
+    private class MapTimeSeriesIndex : AbstractTimeSeriesIndexCreationTask<Employee>
+    {
+        public class Result
+        {
+            public string CompanyName { get; set; }
+        }
+
+        public MapTimeSeriesIndex()
+        {
+            AddMap(
+                CommonName,
+                timeSeries => from ts in timeSeries
+                    from entry in ts.Entries
+                    select new Result
+                    {
+                        CompanyName = LoadDocument<Company>(entry.Tag, Constants.Documents.Collections.AllDocumentsCollection).Name
+                    });
+        }
+    }
+
+    private class MapReduceTimeSeriesIndex : AbstractTimeSeriesIndexCreationTask<Employee, MapReduceTimeSeriesIndex.Result>
+    {
+        public class Result
+        {
+            public string CompanyName { get; set; }
+
+            public int Count { get; set; }
+        }
+
+        public MapReduceTimeSeriesIndex()
+        {
+            AddMap(
+                CommonName,
+                timeSeries => from ts in timeSeries
+                    from entry in ts.Entries
+                    select new Result
+                    {
+                        CompanyName = LoadDocument<Company>(entry.Tag, Constants.Documents.Collections.AllDocumentsCollection).Name,
+                        Count = 1
+                    });
+
+            Reduce = results => from r in results
+                group r by r.CompanyName into g
+                select new Result
+                {
+                    CompanyName = g.Key,
                     Count = g.Sum(x => x.Count)
                 };
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23249/Support-for-referenced-documents-from-any-collection

### Additional description

We've added support for handling references from any collection.
Now, whenever there is a change in any document, the index will become stale - regardless of whether the document is relevant to the index - and will remain stale until the document is processed.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
