### PR TITLE
RavenDB-23076 Added IsVectorProperty to the blittable property cache to avoid unnecessary comparisons.

### DIFF
--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -272,9 +272,7 @@ namespace Sparrow.Json
 
                         var property = CreateLazyStringValueFromParserState();
                         currentState.CurrentProperty = _context.CachedProperties.GetProperty(property);
-
-                        if (currentState.CurrentProperty.EqualsPropertyNameToBytes(Global.Constants.Naming.VectorPropertyNameAsSpan))
-                            _isVectorProperty = true;
+                        _isVectorProperty = currentState.CurrentProperty.IsVectorProperty;
 
                         currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
                         currentState.State = ContinuationState.ReadPropertyValue;

--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -93,6 +93,7 @@ namespace Sparrow.Json
             public LazyStringValue Comparer;
             public int GlobalSortOrder;
             public int PropertyId;
+            public bool IsVectorProperty;
 
             public PropertyName(int hash, LazyStringValue comparer, int globalSortOrder, int propertyId)
             {
@@ -100,6 +101,7 @@ namespace Sparrow.Json
                 Comparer = comparer;
                 GlobalSortOrder = globalSortOrder;
                 PropertyId = propertyId;
+                IsVectorProperty = Comparer.AsReadOnlySpan().SequenceEqual(Global.Constants.Naming.VectorPropertyNameAsSpan);
             }
 
             public int CompareTo(PropertyName other)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23076

### Additional description

Added `IsVectorProperty` to the blittable property cache to avoid unnecessary comparisons.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
