### PR TITLE
RavenDB-23601 Tie `HNSW.Options.Version` to `RavenDB.Version` for consistency.

### DIFF
--- a/src/Voron/Constants.cs
+++ b/src/Voron/Constants.cs
@@ -101,6 +101,13 @@ namespace Voron.Global
             {
                 public const long VectorContainerInternalIndexer = 1;
             }
+
+            internal static class HnswVersion
+            {
+                public const ushort InitialVersion = 7_000;
+                
+                public const ushort CurrentVersion = InitialVersion;
+            }
         }
         
         public static class Tree

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -195,7 +195,7 @@ public unsafe partial class Hnsw
         
         var options = new Options
         {
-            Version = 1,
+            Version = Constants.Graphs.HnswVersion.CurrentVersion,
             VectorSizeBytes = vectorSizeBytes,
             CountOfVectors = 0,
             Container = storage,


### PR DESCRIPTION
…

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23601 

### Additional description

It will make maintenance and ensuring backward compatibility easier and improve readability in the future.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured.
- [ ] Breaking change
- [ ] Not relevant

Currently, the `Version` is not used, and even in the future, if we need to ensure backward compatibility, we can perform a check: `version <= InitialVersion`.

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
