### PR TITLE
RavenDB-23585 Throw when vector.search is being used in subscription.

### DIFF
--- a/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
+++ b/src/Raven.Server/Documents/Queries/AST/JavascriptCodeQueryVisitor.cs
@@ -12,7 +12,8 @@ namespace Raven.Server.Documents.Queries.AST
         private readonly HashSet<string> _knownAliases = new HashSet<string>();
         private static readonly string[] UnsupportedQueryMethodsInJavascript = {
             "Search","Boost","Lucene","Exact","Count","Sum","Circle","Wkt","Point","Within","Contains","Disjoint","Intersects","MoreLikeThis",
-            "Spatial.Wkt", "Spatial.Point", "Spatial.Intersects", "Spatial.Contains", "Spatial.Disjoint", "Spatial.Sum"
+            "Spatial.Wkt", "Spatial.Point", "Spatial.Intersects", "Spatial.Contains", "Spatial.Disjoint", "Spatial.Sum", "Vector.Search", "Embedding.Text",
+            "Embedding.Text_I8", "Embedding.Text_I1", "Embedding.F32_I8", "Embedding.F32_I1", "Embedding.I8", "Embedding.I1"
         };
 
         public JavascriptCodeQueryVisitor(StringBuilder sb, Query q)

--- a/test/SlowTests/Client/Subscriptions/RavenDB-23585.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-23585.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using FastTests.Client.Subscriptions;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.Subscriptions;
+
+public class RavenDB_23585(ITestOutputHelper output) : SubscriptionTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Vector)]
+    public async Task SubscriptionWillThrowExceptionWhenUsingVectorInQuery()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var subscriptionCreationParams = new SubscriptionCreationOptions
+            {
+                Query = "from People where vector.search(Field, 'hello')"
+            };
+            
+            var exception = await Assert.ThrowsAsync<RavenException>(() => store.Subscriptions.CreateAsync(subscriptionCreationParams));
+            Assert.Contains("'vector.search' query method is not supported for this type of query", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23585 


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
