### PR TITLE
RavenDB-23282 [docker] remove *latest tag from 6.2

### DIFF
--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -35,7 +35,6 @@ function GetUbuntuImageTags($repo, $version, $arch) {
     switch ($arch) {
         "x64" { 
             return @(
-                "$($repo):ubuntu-latest",
                 "$($repo):ubuntu-latest-lts",
                 "$($repo):6.2-ubuntu-latest",
                 "$($repo):$($version)-ubuntu.22.04-x64"
@@ -44,7 +43,6 @@ function GetUbuntuImageTags($repo, $version, $arch) {
         }
         "arm32v7" {
             return @(
-                "$($repo):ubuntu-arm32v7-latest",
                 "$($repo):ubuntu-arm32v7-latest-lts",
                 "$($repo):6.2-ubuntu-arm32v7-latest",
                 "$($repo):$($version)-ubuntu.22.04-arm32v7"
@@ -53,7 +51,6 @@ function GetUbuntuImageTags($repo, $version, $arch) {
         }
         "arm64v8" {
             return @(
-                "$($repo):ubuntu-arm64v8-latest",
                 "$($repo):ubuntu-arm64v8-latest-lts",
                 "$($repo):6.2-ubuntu-arm64v8-latest",
                 "$($repo):$($version)-ubuntu.22.04-arm64v8"
@@ -71,7 +68,6 @@ function GetWindowsImageTags($repo, $version, $WinVer) {
     switch ($winver) {
         "1809" {
             return @(
-                "$($repo):windows-1809-latest",
                 "$($repo):$($version)-windows-1809",
                 "$($repo):windows-1809-latest-lts",
                 "$($repo):6.2-windows-1809-latest"
@@ -80,7 +76,6 @@ function GetWindowsImageTags($repo, $version, $WinVer) {
         }
         "ltsc2022" {
              return @(
-                "$($repo):windows-ltsc2022-latest",
                 "$($repo):$($version)-windows-ltsc2022",
                 "$($repo):windows-ltsc2022-latest-lts",
                 "$($repo):6.2-windows-ltsc2022-latest"
@@ -100,7 +95,6 @@ function GetManifestTags {
     )
 
     return @(
-        "${repo}:latest",
         "${repo}:latest-lts",
         "${repo}:6.2-latest"
     )


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23282

- Adjust tags in Docker build scripts

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [x] Chore

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. - Containers
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
