### PR TITLE
RavenDB-23631 Remove duplicates when performing `AndWith` with `TermReader`

### DIFF
--- a/test/SlowTests/Corax/RavenDB_23631.cs
+++ b/test/SlowTests/Corax/RavenDB_23631.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using Corax;
+using Corax.Indexing;
+using Corax.Mappings;
+using Corax.Querying;
+using FastTests.Voron;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_23631(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void MultiTermMatchDoesNotReturnDuplicatesWhenPerformingAndWith()
+    {
+        using var mapping = IndexFieldsMappingBuilder.CreateForWriter(false)
+            .AddBinding(0, "id()")
+            .AddBinding(1, "name")
+            .Build();
+        
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                using (var builder = writer.Index($"id/{i}"))
+                {
+                    builder.Write(0, Encodings.Utf8.GetBytes($"id/{i}"));
+                    builder.IncrementList();
+                    builder.Write(1, Encodings.Utf8.GetBytes("name/0"));
+                    builder.Write(1, Encodings.Utf8.GetBytes("name/1"));
+                    builder.DecrementList();
+                    builder.EndWriting();
+                }
+            }
+            
+            writer.Commit();
+        }
+
+        using (var searcher = new IndexSearcher(Env, mapping))
+        {
+            var @in = searcher.InQuery("id()", ["id/0", "id/10"]);
+            var mtm = searcher.ExistsQuery(mapping.GetByFieldId(1).Metadata);
+
+            var resultMatch = searcher.And(@in, mtm);
+            Span<long> ids = stackalloc long[16];
+            var read = resultMatch.Fill(ids);
+            Assert.Distinct(ids[..read].ToArray());
+            Assert.Equal(2, read);
+            var nothingLeft = resultMatch.Fill(ids) == 0;
+            Assert.True(nothingLeft);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23631

### Additional description

It is possible to have duplicates, as a reader may read more than one posting list.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
