### PR TITLE
RavenDB-23614

### DIFF
--- a/src/Sparrow/Binary/Bits.cs
+++ b/src/Sparrow/Binary/Bits.cs
@@ -358,6 +358,23 @@ namespace Sparrow.Binary
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort SwapBytes(ushort value)
+        {
+#if NET6_0_OR_GREATER
+            return BinaryPrimitives.ReverseEndianness(value);
+#else
+            // Manually swap the bytes of the ushort value
+            return (ushort)((value >> 8) | (value << 8));
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static short SwapBytes(short value)
+        {
+            return (short)SwapBytes((ushort)value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint SwapBytes(uint value)
         {
 #if NET6_0_OR_GREATER
@@ -373,7 +390,7 @@ namespace Sparrow.Binary
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int SwapBytes(int value)
         {
-            return (int) SwapBytes((uint) value);
+            return (int)SwapBytes((uint)value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Sparrow/Collections/FastStack.cs
+++ b/src/Sparrow/Collections/FastStack.cs
@@ -239,14 +239,13 @@ namespace Sparrow.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref T PushByRef()
         {
-            if (_size == _array.Length)
-                goto Grow;
+            if (_size != _array.Length)
+            {
+                ref var item = ref _array[_size++];
+                _version++;
+                return ref item;
+            }
 
-            ref var item = ref _array[_size++];
-            _version++;
-            return ref item;
-
-        Grow:
             return ref PushUnlikelyByRef();
         }
 

--- a/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
@@ -119,6 +119,11 @@ namespace Sparrow.Json
             public CachedProperties.PropertyName Property;
             public byte Type;
 
+            public PropertyTag(CachedProperties.PropertyName property)
+            {
+                Property = property;
+            }
+
             public PropertyTag(byte type, CachedProperties.PropertyName property, int position)
             {
                 Type = type;

--- a/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
@@ -67,9 +67,9 @@ namespace Sparrow.Json
                 throw new ObjectDisposedException(GetType().Name);
         }
 
-        protected struct BuildingState(ContinuationState state, bool partialRead = false)
+        protected struct BuildingState()
         {
-            public ContinuationState State = state;
+            public ContinuationState State;
             public int MaxPropertyId;
             public CachedProperties.PropertyName CurrentProperty;
             public FastList<PropertyTag> Properties;
@@ -77,58 +77,70 @@ namespace Sparrow.Json
             public FastList<int> Positions;
             public long FirstWrite;
 
-            internal bool PartialRead = partialRead;
+            internal bool PartialRead;
+
+            public BuildingState(ContinuationState state) : this()
+            {
+                State = state;
+            }
+            public BuildingState(ContinuationState state, bool partialRead = false) : this()
+            {
+                State = state;
+                PartialRead = partialRead;
+            }
+
+            public BuildingState(ContinuationState state, FastList<BlittableJsonToken> types, FastList<int> positions) : this()
+            {
+                State = state;
+                Types = types;
+                Positions = positions;
+            }
+
+            public BuildingState(ContinuationState state, FastList<PropertyTag> properties = null, long firstWrite = -1) : this()
+            {
+                State = state;
+                Properties = properties;
+                FirstWrite = firstWrite;
+            }
         }
 
-        protected const int AllowedAllStates = 0xFF;
-        protected const int DisallowBufferedStates = 0x7F;
-        protected const int Buffered = 0x80;
-
-        protected enum ContinuationState : int
+        // PERF: The numbers for continuation states have been changed to improve the chance of the
+        // JIT to emit a jump-table instead of complex switch.
+        protected enum ContinuationState 
         {
-            ReadObject = 0x01,
-            ReadArray = 0x02,
-            ReadObjectDocument = 0x03,
-            ReadArrayDocument = 0x04,
-            ReadPropertyName = 0x05,
-            ReadPropertyValue = 0x06,
-            CompleteDocumentArray = 0x07,
-            CompleteReadingPropertyValue = 0x08,
+            // PERF: Code size optimizations for read method.
+            None = 0,
 
-            ReadArrayValue = 0x09,
-            ReadValue = 0x0A,
-            CompleteArray = 0x0B,
-            CompleteArrayValue = 0x0C,
+            ReadValue = 1,  
+            ReadObjectDocument = 2, 
+            ReadArrayDocument = 3,  
+            ReadObject = 4, 
+            ReadPropertyName = 5, 
+            ReadPropertyValue = 6,  
+            CompleteDocumentArray = 7,  
+            CompleteReadingPropertyValue = 8,  
+            ReadArray = 9, 
+            ReadArrayValue = 10, 
+            CompleteArray = 11,
+            CompleteArrayValue = 12, 
 
             // Support for vector type.
-            ReadBufferedArrayValue = ReadArrayValue | Buffered,
-            ReadBufferedValue = ReadValue | Buffered,
-            CompleteBufferedArray = CompleteArray | Buffered,
-            CompleteBufferedArrayValue = CompleteArrayValue | Buffered,
+            ReadBufferedArrayValue = 13, 
+            ReadBufferedValue = 14, 
+            CompleteBufferedArray = 15, 
+            CompleteBufferedArrayValue = 16, 
         }
 
-        public struct PropertyTag
+        public struct PropertyTag(byte type, CachedProperties.PropertyName property, int position)
         {
-            public int Position;
+            public int Position = position;
+            public CachedProperties.PropertyName Property = property;
+            public byte Type = type;
 
+            public PropertyTag(CachedProperties.PropertyName property) : this(0, property, 0) {}
             public override string ToString()
             {
                 return $"{nameof(Position)}: {Position}, {nameof(Property)}: {Property.Comparer} {Property.PropertyId}, {nameof(Type)}: {(BlittableJsonToken)Type}";
-            }
-
-            public CachedProperties.PropertyName Property;
-            public byte Type;
-
-            public PropertyTag(CachedProperties.PropertyName property)
-            {
-                Property = property;
-            }
-
-            public PropertyTag(byte type, CachedProperties.PropertyName property, int position)
-            {
-                Type = type;
-                Property = property;
-                Position = position;
             }
         }
 
@@ -162,9 +174,9 @@ namespace Sparrow.Json
 
         private sealed class GlobalPoolItem
         {
-            public readonly ListCache<PropertyTag> PropertyCache = new ListCache<PropertyTag>();
-            public readonly ListCache<int> PositionsCache = new ListCache<int>();
-            public readonly ListCache<BlittableJsonToken> TokensCache = new ListCache<BlittableJsonToken>();
+            public readonly ListCache<PropertyTag> PropertyCache = new();
+            public readonly ListCache<int> PositionsCache = new();
+            public readonly ListCache<BlittableJsonToken> TokensCache = new();
         }
     }
 }

--- a/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonDocumentBuilder.cs
@@ -23,6 +23,9 @@ namespace Sparrow.Json
 
         static AbstractBlittableJsonDocumentBuilder()
         {
+            // PERF: Utilizing PerCoreContainer to manage GlobalPoolItem instances.
+            // This reduces contention and improves cache locality across multiple cores.
+            // On 32-bit platforms, a smaller pool size is used to conserve memory resources.
             GlobalCache = PlatformDetails.Is32Bits 
                 ? new PerCoreContainer<GlobalPoolItem>(4) 
                 : new PerCoreContainer<GlobalPoolItem>();
@@ -30,8 +33,12 @@ namespace Sparrow.Json
 
         protected AbstractBlittableJsonDocumentBuilder()
         {
+            // PERF: Efficiently pulling a GlobalPoolItem from the global cache.
+            // If the cache is empty, a new GlobalPoolItem is instantiated.
+            // This leverages object pooling to minimize memory allocations and enhance performance.
             if (GlobalCache.TryPull(out _cacheItem) == false)
                 _cacheItem = new GlobalPoolItem();
+
             _propertiesCache = _cacheItem.PropertyCache;
             _positionsCache = _cacheItem.PositionsCache;
             _tokensCache = _cacheItem.TokensCache;
@@ -42,8 +49,10 @@ namespace Sparrow.Json
         {
             GlobalCache.TryPush(_cacheItem);
 
-            // PERF: We are clearing the array without removing the references because the type is an struct.
+            // PERF: Efficiently clearing the continuation stack by using WeakClear,
+            // which avoids removing references since BuildingState is a struct.
             _continuationState.WeakClear();
+
             ContinuationPool.Free(_continuationState);
 
             _disposed = true;
@@ -79,6 +88,9 @@ namespace Sparrow.Json
 
             internal bool PartialRead;
 
+            // PERF: Added multiple constructors to allow efficient initialization
+            // based on different use cases. This reduces the overhead of setting properties
+            // individually and enables better inlining by the JIT compiler.
             public BuildingState(ContinuationState state) : this()
             {
                 State = state;
@@ -104,31 +116,27 @@ namespace Sparrow.Json
             }
         }
 
-        // PERF: The numbers for continuation states have been changed to improve the chance of the
-        // JIT to emit a jump-table instead of complex switch.
+        // PERF: Simplified the ContinuationState enum to use sequential integer values.
+        // This allows the JIT compiler to emit efficient jump tables for switch statements,
+        // reducing branch prediction overhead and improving performance in tight loops.
         protected enum ContinuationState 
         {
-            // PERF: Code size optimizations for read method.
-            None = 0,
-
-            ReadValue = 1,  
-            ReadObjectDocument = 2, 
-            ReadArrayDocument = 3,  
-            ReadObject = 4, 
-            ReadPropertyName = 5, 
-            ReadPropertyValue = 6,  
-            CompleteDocumentArray = 7,  
-            CompleteReadingPropertyValue = 8,  
-            ReadArray = 9, 
-            ReadArrayValue = 10, 
-            CompleteArray = 11,
-            CompleteArrayValue = 12, 
+            ReadValue = 0,  
+            ReadObjectDocument, 
+            ReadArrayDocument,  
+            ReadObject, 
+            ReadPropertyName, 
+            ReadPropertyValue,  
+            CompleteDocumentArray,  
+            CompleteReadingPropertyValue,  
+            ReadArray, 
+            ReadArrayValue, 
+            CompleteArray,
+            CompleteArrayValue, 
 
             // Support for vector type.
-            ReadBufferedArrayValue = 13, 
-            ReadBufferedValue = 14, 
-            CompleteBufferedArray = 15, 
-            CompleteBufferedArrayValue = 16, 
+            ReadBufferedArrayValue, 
+            CompleteBufferedArray, 
         }
 
         public struct PropertyTag(byte type, CachedProperties.PropertyName property, int position)
@@ -148,7 +156,7 @@ namespace Sparrow.Json
         {
             private static readonly int MaxSize = PlatformDetails.Is32Bits ? 256 : 1024;
 
-            private readonly FastList<FastList<T>> _cache = new FastList<FastList<T>>();
+            private readonly FastList<FastList<T>> _cache = new();
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public FastList<T> Allocate()

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Buffers.Text;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Sparrow.Exceptions;
@@ -140,6 +141,8 @@ namespace Sparrow.Json
 
         private unsafe bool ReadInternal<TWriteStrategy>() where TWriteStrategy : IWriteStrategy
         {
+            CachedProperties.PropertyName fakeProperty = null;
+
             var continuationState = _continuationState;
             var currentState = continuationState.Pop();
             var reader = _reader;
@@ -148,31 +151,37 @@ namespace Sparrow.Json
             {
                 switch (currentState.State)
                 {
+                    case ContinuationState.ReadValue:
+                        ReadJsonValue<TWriteStrategy>();
+                        currentState = _continuationState.Pop();
+                        continue;
+
                     case ContinuationState.ReadObjectDocument:
                         if (reader.Read() == false)
                         {
                             continuationState.Push(currentState);
-                            goto ReturnFalse;
+                            return false;
                         }
                         currentState.State = ContinuationState.ReadObject;
-                        continue;
+                        goto case ContinuationState.ReadObject;
+
                     case ContinuationState.ReadArrayDocument:
                         if (reader.Read() == false)
                         {
                             continuationState.Push(currentState);
-                            goto ReturnFalse;
+                            return false;
                         }
 
-                        var fakeProperty = _context.CachedProperties.GetProperty(_fakeFieldName);
+                        fakeProperty ??= _context.CachedProperties.GetProperty(_fakeFieldName);
                         currentState.CurrentProperty = fakeProperty;
                         currentState.MaxPropertyId = fakeProperty.PropertyId;
                         currentState.FirstWrite = _writer.Position;
                         currentState.Properties = _propertiesCache.Allocate();
-                        currentState.Properties.Add(new PropertyTag { Property = fakeProperty });
+                        currentState.Properties.Add(new PropertyTag ( fakeProperty ));
                         currentState.State = ContinuationState.CompleteDocumentArray;
                         continuationState.Push(currentState);
                         currentState = new BuildingState(ContinuationState.ReadArray);
-                        continue;
+                        goto case ContinuationState.ReadArray;
 
                     case ContinuationState.CompleteDocumentArray:
                         currentState.Properties[0] = new PropertyTag(
@@ -184,7 +193,7 @@ namespace Sparrow.Json
                         // Register property position, name id (PropertyId) and type (object type and metadata)
                         _writeToken = _writer.WriteObjectMetadata(currentState.Properties, currentState.FirstWrite, currentState.MaxPropertyId);
                         _propertiesCache.Return(ref currentState.Properties);
-                        goto ReturnTrue;
+                        return true;
 
                     case ContinuationState.ReadObject:
                         if (state.CurrentTokenType == JsonParserToken.StartObject)
@@ -192,14 +201,15 @@ namespace Sparrow.Json
                             currentState.State = ContinuationState.ReadPropertyName;
                             currentState.Properties = _propertiesCache.Allocate();
                             currentState.FirstWrite = _writer.Position;
-                            continue;
+                            goto case ContinuationState.ReadPropertyName;
                         }
 
-                        goto ErrorExpectedStartOfObject;
+                        ThrowExpectedStartOfObject();
+                        break;
 
                     case ContinuationState.ReadArray:
                         if (state.CurrentTokenType != JsonParserToken.StartArray)
-                            goto ErrorExpectedStartOfArray;
+                            ThrowExpectedStartOfArray();
 
                         currentState.Types = _tokensCache.Allocate();
                         currentState.Positions = _positionsCache.Allocate();
@@ -218,25 +228,24 @@ namespace Sparrow.Json
                         if (reader.Read() == false)
                         {
                             continuationState.Push(currentState);
-                            goto ReturnFalse;
+                            return false;
                         }
 
                         if (state.CurrentTokenType == JsonParserToken.EndArray)
                         {
                             currentState.State = ContinuationState.CompleteArray;
-                            continue;
+                            goto case ContinuationState.CompleteArray;
                         }
 
                         currentState.State = ContinuationState.CompleteArrayValue;
                         continuationState.Push(currentState);
-                        currentState = new BuildingState(ContinuationState.ReadValue);
-                        continue;
+                        goto case ContinuationState.ReadValue;
 
                     case ContinuationState.CompleteArrayValue:
                         currentState.Types.Add(_writeToken.WrittenToken);
                         currentState.Positions.Add(_writeToken.ValuePos);
                         currentState.State = ContinuationState.ReadArrayValue;
-                        continue;
+                        goto case ContinuationState.ReadArrayValue;
 
                     case ContinuationState.CompleteArray:
                         var arrayToken = BlittableJsonToken.StartArray;
@@ -251,7 +260,7 @@ namespace Sparrow.Json
                         if (ReadMaybeModifiedPropertyName() == false)
                         {
                             continuationState.Push(currentState);
-                            goto ReturnFalse;
+                            return false;
                         }
 
                         if (state.CurrentTokenType == JsonParserToken.EndObject)
@@ -261,14 +270,14 @@ namespace Sparrow.Json
                             _propertiesCache.Return(ref currentState.Properties);
 
                             if (continuationState.Count == 0)
-                                goto ReturnTrue;
+                                return true;
 
                             currentState = continuationState.Pop();
                             continue;
                         }
 
                         if (state.CurrentTokenType != JsonParserToken.String)
-                            goto ErrorExpectedProperty;
+                            ThrowExpectedProperty();
 
                         var property = CreateLazyStringValueFromParserState();
                         currentState.CurrentProperty = _context.CachedProperties.GetProperty(property);
@@ -276,17 +285,19 @@ namespace Sparrow.Json
 
                         currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
                         currentState.State = ContinuationState.ReadPropertyValue;
-                        continue;
+                        goto case ContinuationState.ReadPropertyValue;
+
                     case ContinuationState.ReadPropertyValue:
                         if (reader.Read() == false)
                         {
                             continuationState.Push(currentState);
-                            goto ReturnFalse;
+                            return false;
                         }
                         currentState.State = ContinuationState.CompleteReadingPropertyValue;
                         continuationState.Push(currentState);
-                        currentState = new BuildingState(ContinuationState.ReadValue);
-                        continue;
+
+                        goto case ContinuationState.ReadValue;
+                        
                     case ContinuationState.CompleteReadingPropertyValue:
                         // Register property position, name id (PropertyId) and type (object type and metadata)
                         currentState.Properties.Add(new PropertyTag(
@@ -301,7 +312,7 @@ namespace Sparrow.Json
                                 _modifier?.EndObject();
                                 _writeToken = _writer.WriteObjectMetadata(currentState.Properties, currentState.FirstWrite, currentState.MaxPropertyId);
                                 _propertiesCache.Return(ref currentState.Properties);
-                                goto ReturnTrue;
+                                return true;
                             }
                         }
 
@@ -416,10 +427,10 @@ namespace Sparrow.Json
 
                         // The change of the current state must happen before as ReadJsonValue may return a new instance.
                         currentState.State = ContinuationState.CompleteArrayValue;
-                        ReadJsonValue<TWriteStrategy>();
+                        continuationState.Push(currentState);
 
                         // Allow the loop to continue to the next iteration
-                        continue;
+                        goto case ContinuationState.ReadValue;
 
                     case ContinuationState.CompleteBufferedArray:
                         int startPos = WriteBufferedVector();
@@ -428,26 +439,8 @@ namespace Sparrow.Json
                         state.ClearBuffered();
                         currentState = _continuationState.Pop();
                         continue;
-
-                    case ContinuationState.ReadValue:
-                        ReadJsonValue<TWriteStrategy>();
-                        currentState = _continuationState.Pop();
-                        break;
                 }
             }
-
-        ReturnTrue:
-            return true;
-        ReturnFalse:
-            return false;
-
-        ErrorExpectedProperty:
-            ThrowExpectedProperty();
-        ErrorExpectedStartOfObject:
-            ThrowExpectedStartOfObject();
-        ErrorExpectedStartOfArray:
-            ThrowExpectedStartOfArray();
-            return false; // Will never execute.
         }
 
         private struct VectorProcessor<T> where T : unmanaged
@@ -532,16 +525,25 @@ namespace Sparrow.Json
             return _reader.Read();
         }
 
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
         private void ThrowExpectedProperty()
         {
             throw new InvalidDataException("Expected property, but got " + _state.CurrentTokenType + _reader.GenerateErrorState());
         }
 
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
         private void ThrowExpectedStartOfArray()
         {
             throw new InvalidStartOfObjectException("Expected start of array, but got " + _state.CurrentTokenType + _reader.GenerateErrorState());
         }
 
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
         private void ThrowExpectedStartOfObject()
         {
             throw new InvalidStartOfObjectException("Expected start of object, but got " + _state.CurrentTokenType + _reader.GenerateErrorState());
@@ -651,16 +653,10 @@ namespace Sparrow.Json
             ToDisk = ValidateDouble | CompressStrings
         }
 
-        public struct WriteToken
+        public struct WriteToken(int position, BlittableJsonToken token)
         {
-            public int ValuePos;
-            public BlittableJsonToken WrittenToken;
-
-            public WriteToken(int position, BlittableJsonToken token)
-            {
-                ValuePos = position;
-                WrittenToken = token;
-            }
+            public int ValuePos = position;
+            public BlittableJsonToken WrittenToken = token;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -95,7 +95,7 @@ namespace Sparrow.Json
 
             _debugTag = null;
             _mode = UsageMode.None;
-            _readInternalFunc = GetReadInternalFunction(_reader, _mode);
+            _readInternalFunc = null;
 
             ClearState();
 

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -18,6 +18,11 @@ namespace Sparrow.Json
         private UsageMode _mode;
         private readonly IJsonParser _reader;
         public IBlittableDocumentModifier _modifier;
+
+        // We introduced a delegate that encapsulates the reading logic.
+        // This avoids branching on every 'Read()' call to figure out which path to take
+        // (WriteNone vs. WriteFull, ObjectJsonParser vs. UnmanagedJsonParser).
+        // Instead, we decide once in the constructor or Renew(...) and store that strategy here.
         private Func<bool> _readInternalFunc;
 
         private readonly BlittableWriter<UnmanagedWriteBuffer> _writer;
@@ -41,6 +46,8 @@ namespace Sparrow.Json
             _modifier = modifier;
             _writer = writer ?? new BlittableWriter<UnmanagedWriteBuffer>(context);
 
+            // Here we bind the specialized read function once, based on the current parser and mode.
+            // This helps eliminate per-call conditionals in Read().
             _readInternalFunc = GetReadInternalFunction(_reader, _mode);
         }
 
@@ -61,6 +68,10 @@ namespace Sparrow.Json
 
         private Func<bool> GetReadInternalFunction(IJsonParser reader, UsageMode mode)
         {
+            // Instead of checking mode and parser type repeatedly in the reading loop,
+            // we perform that check once. We return a specialized generic function
+            // (either ReadInternal<WriteNone, TParser> or ReadInternal<WriteFull, TParser>).
+            // This approach enables better inlining and reduces branching inside Read().
             return mode switch
             {
                 UsageMode.None => reader switch
@@ -99,6 +110,10 @@ namespace Sparrow.Json
             _writeToken = default;
             _debugTag = debugTag;
             _mode = mode;
+
+            // Renew is now also responsible for re-binding the read function
+            // if the UsageMode changes. This resets parsing state and ensures
+            // we're using the correct specialized read routine going forward.
             _readInternalFunc = GetReadInternalFunction(_reader, mode);
 
             ClearState();
@@ -168,6 +183,11 @@ namespace Sparrow.Json
         {
             CachedProperties.PropertyName fakeProperty = null;
 
+            // PERF: This method is performance critical, therefore, we replaced
+            // '_continuationState.Push(...)' with 'PushByRef() = ...' to avoid unnecessary copying
+            // of 'BuildingState' structs and reduce overhead.
+            // This small change can yield noticeable performance improvements under heavy usage.
+
             var continuationState = _continuationState;
             var currentState = continuationState.Pop();
             var reader = (TJsonParser) _reader;
@@ -204,6 +224,9 @@ namespace Sparrow.Json
                                     currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
                                     currentState.State = ContinuationState.ReadPropertyValue;
 
+                                    // PERF: _isVectorProperty is now set by CurrentProperty.IsVectorProperty,
+                                    // removing a string comparison each time. We rely on a cached boolean 
+                                    // from the property lookup to decide if we should read buffered vector data.
                                     _isVectorProperty = currentState.CurrentProperty.IsVectorProperty;
 
                                     goto case ContinuationState.ReadPropertyValue;
@@ -343,6 +366,10 @@ namespace Sparrow.Json
                     
                     case ContinuationState.ReadBufferedArrayValue:
 
+                        // The same approach of buffered vectors is used, but we streamlined the
+                        // transition to/from "vector reading mode" by short-circuiting and returning
+                        // to normal array reading if any token doesn't fit the vector requirements.
+                        // This reduces overhead for large numeric arrays or mixed-type arrays.
                         if (reader.Read() == false)
                         {
                             continuationState.PushByRef() = currentState;
@@ -468,7 +495,7 @@ namespace Sparrow.Json
 
         private struct VectorProcessor<T> where T : unmanaged
         {
-            internal static unsafe int ProcessVector(byte* buffer, int size, JsonParserState state, BlittableWriter<UnmanagedWriteBuffer> writer)
+            internal static int ProcessVector(byte* buffer, int size, JsonParserState state, BlittableWriter<UnmanagedWriteBuffer> writer)
             {
                 Span<T> st = new(buffer, size);
                 int count = state.FillVector(st);
@@ -476,13 +503,17 @@ namespace Sparrow.Json
             }
         }
 
-        private unsafe int WriteBufferedVector()
+        private int WriteBufferedVector()
         {
             int count = _state._bufferedSequence.Count;
             int size = count * sizeof(long);
             using var _ = _context.GetMemoryBuffer(size, out var buffer);
 
             var type = _state.GetBufferedOptimalType();
+
+            // Additional small but impactful detail:
+            // Using 'switch (type)' with specialized method calls (VectorProcessor<double>, etc.)
+            // helps the JIT inline the vector writing logic for each numeric type more effectively.
             switch (type)
             {
                 case BlittableVectorType.Double:

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -204,8 +204,7 @@ namespace Sparrow.Json
                                     currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
                                     currentState.State = ContinuationState.ReadPropertyValue;
 
-                                    if (currentState.CurrentProperty.EqualsPropertyNameToBytes(Global.Constants.Naming.VectorPropertyNameAsSpan))
-                                        _isVectorProperty = true;
+                                    _isVectorProperty = currentState.CurrentProperty.IsVectorProperty;
 
                                     goto case ContinuationState.ReadPropertyValue;
                                 }
@@ -226,7 +225,7 @@ namespace Sparrow.Json
 
                         continuationState.PushByRef() = currentState;
                         return false;
-
+                        
                     case ContinuationState.ReadObjectDocument:
                         if (reader.Read() == false)
                         {

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -10,15 +10,16 @@ using Sparrow.Threading;
 
 namespace Sparrow.Json
 {
-    public sealed class BlittableJsonDocumentBuilder : AbstractBlittableJsonDocumentBuilder
+    public sealed unsafe class BlittableJsonDocumentBuilder : AbstractBlittableJsonDocumentBuilder
     {
         private static readonly StringSegment UnderscoreSegment = new StringSegment("_");
 
         private readonly JsonOperationContext _context;
         private UsageMode _mode;
         private readonly IJsonParser _reader;
-
         public IBlittableDocumentModifier _modifier;
+        private Func<bool> _readInternalFunc;
+
         private readonly BlittableWriter<UnmanagedWriteBuffer> _writer;
         private readonly JsonParserState _state;
         private LazyStringValue _fakeFieldName;
@@ -39,6 +40,8 @@ namespace Sparrow.Json
             _reader = reader;
             _modifier = modifier;
             _writer = writer ?? new BlittableWriter<UnmanagedWriteBuffer>(context);
+
+            _readInternalFunc = GetReadInternalFunction(_reader, _mode);
         }
 
         public BlittableJsonDocumentBuilder(
@@ -56,12 +59,32 @@ namespace Sparrow.Json
             Renew(debugTag, mode);
         }
 
+        private Func<bool> GetReadInternalFunction(IJsonParser reader, UsageMode mode)
+        {
+            return mode switch
+            {
+                UsageMode.None => reader switch
+                {
+                    ObjectJsonParser => ReadInternal<WriteNone, ObjectJsonParser>,
+                    UnmanagedJsonParser => ReadInternal<WriteNone, UnmanagedJsonParser>,
+                    _ => ReadInternal<WriteNone, IJsonParser>
+                },
+                _ => reader switch
+                {
+                    ObjectJsonParser => ReadInternal<WriteFull, ObjectJsonParser>,
+                    UnmanagedJsonParser => ReadInternal<WriteFull, UnmanagedJsonParser>,
+                    _ => ReadInternal<WriteFull, IJsonParser>
+                }
+            };
+        }
+
         public void Reset()
         {
             AssertNotDisposed();
 
             _debugTag = null;
             _mode = UsageMode.None;
+            _readInternalFunc = GetReadInternalFunction(_reader, _mode);
 
             ClearState();
 
@@ -76,6 +99,7 @@ namespace Sparrow.Json
             _writeToken = default;
             _debugTag = debugTag;
             _mode = mode;
+            _readInternalFunc = GetReadInternalFunction(_reader, mode);
 
             ClearState();
 
@@ -89,35 +113,34 @@ namespace Sparrow.Json
         {
             AssertNotDisposed();
 
-            _continuationState.Push(new BuildingState(ContinuationState.ReadArrayDocument));
+            _continuationState.PushByRef() = new BuildingState(ContinuationState.ReadArrayDocument);
         }
 
         public void ReadObjectDocument()
         {
             AssertNotDisposed();
 
-            _continuationState.Push(new BuildingState(ContinuationState.ReadObjectDocument));
+            _continuationState.PushByRef() = new BuildingState(ContinuationState.ReadObjectDocument);
         }
 
         public void ReadNestedObject()
         {
             AssertNotDisposed();
 
-            _continuationState.Push(new BuildingState(ContinuationState.ReadObject));
+            _continuationState.PushByRef() = new BuildingState(ContinuationState.ReadObject);
         }
 
         public void ReadProperty()
         {
             AssertNotDisposed();
 
-            var state = new BuildingState(ContinuationState.ReadPropertyName)
+            _continuationState.PushByRef() = new BuildingState(ContinuationState.ReadPropertyName)
             {
                 State = ContinuationState.ReadPropertyName,
                 Properties = _propertiesCache.Allocate(),
                 FirstWrite = _writer.Position,
                 PartialRead = true
             };
-            _continuationState.Push(state);
         }
 
         public int SizeInBytes
@@ -139,80 +162,57 @@ namespace Sparrow.Json
             base.Dispose();
         }
 
-        private unsafe bool ReadInternal<TWriteStrategy>() where TWriteStrategy : IWriteStrategy
+        private unsafe bool ReadInternal<TWriteStrategy, TJsonParser>() 
+            where TWriteStrategy : IWriteStrategy
+            where TJsonParser : IJsonParser
         {
             CachedProperties.PropertyName fakeProperty = null;
 
             var continuationState = _continuationState;
             var currentState = continuationState.Pop();
-            var reader = _reader;
+            var reader = (TJsonParser) _reader;
             var state = _state;
             while (true)
             {
                 switch (currentState.State)
                 {
+                    case ContinuationState.ReadPropertyValue:
+                        if (reader.Read() == false)
+                        {
+                            continuationState.PushByRef() = currentState;
+                            return false;
+                        }
+                        currentState.State = ContinuationState.CompleteReadingPropertyValue;
+                        continuationState.PushByRef() = currentState;
+
+                        goto case ContinuationState.ReadValue;
+
                     case ContinuationState.ReadValue:
-                        ReadJsonValue<TWriteStrategy>();
+                        ReadJsonValue<TWriteStrategy, TJsonParser>();
                         currentState = _continuationState.Pop();
                         continue;
 
-                    case ContinuationState.ReadObjectDocument:
-                        if (reader.Read() == false)
-                        {
-                            continuationState.Push(currentState);
-                            return false;
-                        }
-                        currentState.State = ContinuationState.ReadObject;
-                        goto case ContinuationState.ReadObject;
-
-                    case ContinuationState.ReadArrayDocument:
-                        if (reader.Read() == false)
-                        {
-                            continuationState.Push(currentState);
-                            return false;
-                        }
-
-                        fakeProperty ??= _context.CachedProperties.GetProperty(_fakeFieldName);
-                        currentState.CurrentProperty = fakeProperty;
-                        currentState.MaxPropertyId = fakeProperty.PropertyId;
-                        currentState.FirstWrite = _writer.Position;
-                        currentState.Properties = _propertiesCache.Allocate();
-                        currentState.Properties.Add(new PropertyTag ( fakeProperty ));
-                        currentState.State = ContinuationState.CompleteDocumentArray;
-                        continuationState.Push(currentState);
-                        currentState = new BuildingState(ContinuationState.ReadArray);
-                        goto case ContinuationState.ReadArray;
-
-                    case ContinuationState.CompleteDocumentArray:
-                        currentState.Properties[0] = new PropertyTag(
-                            type: (byte)_writeToken.WrittenToken,
-                            property: currentState.Properties[0].Property,
-                            position: _writeToken.ValuePos
-                        );
-
-                        // Register property position, name id (PropertyId) and type (object type and metadata)
-                        _writeToken = _writer.WriteObjectMetadata(currentState.Properties, currentState.FirstWrite, currentState.MaxPropertyId);
-                        _propertiesCache.Return(ref currentState.Properties);
-                        return true;
-
-                    case ContinuationState.ReadObject:
-                        if (state.CurrentTokenType != JsonParserToken.StartObject)
-                            ThrowExpectedStartOfObject();
-
-                        currentState.State = ContinuationState.ReadPropertyName;
-                        currentState.Properties = _propertiesCache.Allocate();
-                        currentState.FirstWrite = _writer.Position;
-                        goto case ContinuationState.ReadPropertyName;
-
                     case ContinuationState.ReadPropertyName:
-                        if (ReadMaybeModifiedPropertyName() == false)
+                        if (ReadMaybeModifiedPropertyName(reader))
                         {
-                            continuationState.Push(currentState);
-                            return false;
-                        }
+                            if (state.CurrentTokenType != JsonParserToken.EndObject)
+                            {
+                                if (state.CurrentTokenType == JsonParserToken.String)
+                                {
+                                    var property = CreateLazyStringValueFromParserState();
+                                    currentState.CurrentProperty = _context.CachedProperties.GetProperty(property);
+                                    currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
+                                    currentState.State = ContinuationState.ReadPropertyValue;
 
-                        if (state.CurrentTokenType == JsonParserToken.EndObject)
-                        {
+                                    if (currentState.CurrentProperty.EqualsPropertyNameToBytes(Global.Constants.Naming.VectorPropertyNameAsSpan))
+                                        _isVectorProperty = true;
+
+                                    goto case ContinuationState.ReadPropertyValue;
+                                }
+                                
+                                ThrowExpectedProperty();
+                            }
+
                             _modifier?.EndObject();
                             _writeToken = _writer.WriteObjectMetadata(currentState.Properties, currentState.FirstWrite, currentState.MaxPropertyId);
                             _propertiesCache.Return(ref currentState.Properties);
@@ -224,27 +224,26 @@ namespace Sparrow.Json
                             continue;
                         }
 
-                        if (state.CurrentTokenType != JsonParserToken.String)
-                            ThrowExpectedProperty();
+                        continuationState.PushByRef() = currentState;
+                        return false;
 
-                        var property = CreateLazyStringValueFromParserState();
-                        currentState.CurrentProperty = _context.CachedProperties.GetProperty(property);
-                        _isVectorProperty = currentState.CurrentProperty.IsVectorProperty;
-
-                        currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
-                        currentState.State = ContinuationState.ReadPropertyValue;
-                        goto case ContinuationState.ReadPropertyValue;
-
-                    case ContinuationState.ReadPropertyValue:
+                    case ContinuationState.ReadObjectDocument:
                         if (reader.Read() == false)
                         {
-                            continuationState.Push(currentState);
+                            continuationState.PushByRef() = currentState;
                             return false;
                         }
-                        currentState.State = ContinuationState.CompleteReadingPropertyValue;
-                        continuationState.Push(currentState);
+                        currentState.State = ContinuationState.ReadObject;
+                        goto case ContinuationState.ReadObject;
 
-                        goto case ContinuationState.ReadValue;
+                    case ContinuationState.ReadObject:
+                        if (state.CurrentTokenType != JsonParserToken.StartObject)
+                            ThrowExpectedStartOfObject();
+
+                        currentState.State = ContinuationState.ReadPropertyName;
+                        currentState.Properties = _propertiesCache.Allocate();
+                        currentState.FirstWrite = _writer.Position;
+                        goto case ContinuationState.ReadPropertyName;
 
                     case ContinuationState.CompleteReadingPropertyValue:
                         // Register property position, name id (PropertyId) and type (object type and metadata)
@@ -263,6 +262,36 @@ namespace Sparrow.Json
 
                         currentState.State = ContinuationState.ReadPropertyName;
                         goto case ContinuationState.ReadPropertyName;
+
+                    case ContinuationState.ReadArrayDocument:
+                        if (reader.Read() == false)
+                        {
+                            continuationState.PushByRef() = currentState;
+                            return false;
+                        }
+
+                        fakeProperty ??= _context.CachedProperties.GetProperty(_fakeFieldName);
+                        currentState.CurrentProperty = fakeProperty;
+                        currentState.MaxPropertyId = fakeProperty.PropertyId;
+                        currentState.FirstWrite = _writer.Position;
+                        currentState.Properties = _propertiesCache.Allocate();
+                        currentState.Properties.Add(new PropertyTag(fakeProperty));
+                        currentState.State = ContinuationState.CompleteDocumentArray;
+                        continuationState.PushByRef() = currentState;
+                        currentState = new BuildingState(ContinuationState.ReadArray);
+                        goto case ContinuationState.ReadArray;
+
+                    case ContinuationState.CompleteDocumentArray:
+                        currentState.Properties[0] = new PropertyTag(
+                            type: (byte)_writeToken.WrittenToken,
+                            property: currentState.Properties[0].Property,
+                            position: _writeToken.ValuePos
+                        );
+
+                        // Register property position, name id (PropertyId) and type (object type and metadata)
+                        _writeToken = _writer.WriteObjectMetadata(currentState.Properties, currentState.FirstWrite, currentState.MaxPropertyId);
+                        _propertiesCache.Return(ref currentState.Properties);
+                        return true;
 
                     case ContinuationState.ReadArray:
                         if (state.CurrentTokenType != JsonParserToken.StartArray)
@@ -284,7 +313,7 @@ namespace Sparrow.Json
                     case ContinuationState.ReadArrayValue:
                         if (reader.Read() == false)
                         {
-                            continuationState.Push(currentState);
+                            continuationState.PushByRef() = currentState;
                             return false;
                         }
 
@@ -295,7 +324,7 @@ namespace Sparrow.Json
                         }
 
                         currentState.State = ContinuationState.CompleteArrayValue;
-                        continuationState.Push(currentState);
+                        continuationState.PushByRef() = currentState;
                         goto case ContinuationState.ReadValue;
 
                     case ContinuationState.CompleteArrayValue:
@@ -317,7 +346,7 @@ namespace Sparrow.Json
 
                         if (reader.Read() == false)
                         {
-                            continuationState.Push(currentState);
+                            continuationState.PushByRef() = currentState;
                             return false;
                         }
 
@@ -371,7 +400,7 @@ namespace Sparrow.Json
                                 else
                                 {
                                     if ((_mode & UsageMode.ValidateDouble) == UsageMode.ValidateDouble)
-                                        _reader.ValidateFloat();
+                                        reader.ValidateFloat();
 
                                     _state.AddBuffered(decimal.ToDouble(value));
                                 }
@@ -422,7 +451,7 @@ namespace Sparrow.Json
 
                         // The change of the current state must happen before as ReadJsonValue may return a new instance.
                         currentState.State = ContinuationState.CompleteArrayValue;
-                        continuationState.Push(currentState);
+                        continuationState.PushByRef() = currentState;
 
                         // Allow the loop to continue to the next iteration
                         goto case ContinuationState.ReadValue;
@@ -503,21 +532,16 @@ namespace Sparrow.Json
             if (_continuationState.Count == 0)
                 return false; //nothing to do
 
-            if (_mode == UsageMode.None)
-            {
-                return ReadInternal<WriteNone>();
-            }
-
-            return ReadInternal<WriteFull>();
+            return _readInternalFunc();
         }
 
-        private bool ReadMaybeModifiedPropertyName()
+        private bool ReadMaybeModifiedPropertyName<TJsonParser>(TJsonParser reader)
+            where TJsonParser : IJsonParser
         {
-            if (_modifier != null)
-            {
-                return _modifier.AboutToReadPropertyName(_reader, _state);
-            }
-            return _reader.Read();
+            if (_modifier == null) 
+                return reader.Read();
+
+            return _modifier.AboutToReadPropertyName(reader, _state);
         }
 
 #if NET6_0_OR_GREATER
@@ -551,7 +575,9 @@ namespace Sparrow.Json
         private struct WriteNone : IWriteStrategy { }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe void ReadJsonValue<TWriteStrategy>() where TWriteStrategy : IWriteStrategy
+        private void ReadJsonValue<TWriteStrategy, TJsonParser>() 
+            where TWriteStrategy : IWriteStrategy
+            where TJsonParser : IJsonParser
         {
             int start;
             JsonParserToken current = _state.CurrentTokenType;
@@ -585,26 +611,27 @@ namespace Sparrow.Json
             else if (current == JsonParserToken.StartObject)
             {
                 _modifier?.StartObject();
-                _continuationState.Push(new BuildingState(ContinuationState.ReadObject));
+                _continuationState.PushByRef() = new BuildingState(ContinuationState.ReadObject);
             }
             else if (current != JsonParserToken.EndObject)
             {
-                ReadJsonValueUnlikely<TWriteStrategy>(current);
+                ReadJsonValueUnlikely<TJsonParser>(current);
             }
         }
 
-        private unsafe void ReadJsonValueUnlikely<TWriteStrategy>(JsonParserToken current) where TWriteStrategy : IWriteStrategy
+        private void ReadJsonValueUnlikely<TJsonParser>(JsonParserToken current) 
+            where TJsonParser : IJsonParser
         {
             int start;
             switch (current)
             {
                 case JsonParserToken.StartArray:
-                    _continuationState.Push(new BuildingState(ContinuationState.ReadArray));
+                    _continuationState.PushByRef() = new BuildingState(ContinuationState.ReadArray);
                     return;
 
                 case JsonParserToken.Float:
                     if ((_mode & UsageMode.ValidateDouble) == UsageMode.ValidateDouble)
-                        _reader.ValidateFloat();
+                        ((TJsonParser)_reader).ValidateFloat();
 
                     start = _writer.WriteValue(_state.StringBuffer, _state.StringSize);
 
@@ -633,6 +660,9 @@ namespace Sparrow.Json
             ThrowExpectedValue(current);
         }
 
+#if NET6_0_OR_GREATER
+        [DoesNotReturn]
+#endif
         private void ThrowExpectedValue(JsonParserToken token)
         {
             throw new InvalidDataException("Expected a value, but got " + token);

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -196,16 +196,73 @@ namespace Sparrow.Json
                         return true;
 
                     case ContinuationState.ReadObject:
-                        if (state.CurrentTokenType == JsonParserToken.StartObject)
+                        if (state.CurrentTokenType != JsonParserToken.StartObject)
+                            ThrowExpectedStartOfObject();
+
+                        currentState.State = ContinuationState.ReadPropertyName;
+                        currentState.Properties = _propertiesCache.Allocate();
+                        currentState.FirstWrite = _writer.Position;
+                        goto case ContinuationState.ReadPropertyName;
+
+                    case ContinuationState.ReadPropertyName:
+                        if (ReadMaybeModifiedPropertyName() == false)
                         {
-                            currentState.State = ContinuationState.ReadPropertyName;
-                            currentState.Properties = _propertiesCache.Allocate();
-                            currentState.FirstWrite = _writer.Position;
-                            goto case ContinuationState.ReadPropertyName;
+                            continuationState.Push(currentState);
+                            return false;
                         }
 
-                        ThrowExpectedStartOfObject();
-                        break;
+                        if (state.CurrentTokenType == JsonParserToken.EndObject)
+                        {
+                            _modifier?.EndObject();
+                            _writeToken = _writer.WriteObjectMetadata(currentState.Properties, currentState.FirstWrite, currentState.MaxPropertyId);
+                            _propertiesCache.Return(ref currentState.Properties);
+
+                            if (continuationState.Count == 0)
+                                return true;
+
+                            currentState = continuationState.Pop();
+                            continue;
+                        }
+
+                        if (state.CurrentTokenType != JsonParserToken.String)
+                            ThrowExpectedProperty();
+
+                        var property = CreateLazyStringValueFromParserState();
+                        currentState.CurrentProperty = _context.CachedProperties.GetProperty(property);
+                        _isVectorProperty = currentState.CurrentProperty.IsVectorProperty;
+
+                        currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
+                        currentState.State = ContinuationState.ReadPropertyValue;
+                        goto case ContinuationState.ReadPropertyValue;
+
+                    case ContinuationState.ReadPropertyValue:
+                        if (reader.Read() == false)
+                        {
+                            continuationState.Push(currentState);
+                            return false;
+                        }
+                        currentState.State = ContinuationState.CompleteReadingPropertyValue;
+                        continuationState.Push(currentState);
+
+                        goto case ContinuationState.ReadValue;
+
+                    case ContinuationState.CompleteReadingPropertyValue:
+                        // Register property position, name id (PropertyId) and type (object type and metadata)
+                        currentState.Properties.Add(new PropertyTag(
+                            position: _writeToken.ValuePos,
+                            type: (byte)_writeToken.WrittenToken,
+                            property: currentState.CurrentProperty));
+
+                        if (currentState.PartialRead && continuationState.Count == 0)
+                        {
+                            _modifier?.EndObject();
+                            _writeToken = _writer.WriteObjectMetadata(currentState.Properties, currentState.FirstWrite, currentState.MaxPropertyId);
+                            _propertiesCache.Return(ref currentState.Properties);
+                            return true;
+                        }
+
+                        currentState.State = ContinuationState.ReadPropertyName;
+                        goto case ContinuationState.ReadPropertyName;
 
                     case ContinuationState.ReadArray:
                         if (state.CurrentTokenType != JsonParserToken.StartArray)
@@ -255,69 +312,7 @@ namespace Sparrow.Json
                         _tokensCache.Return(ref currentState.Types);
                         currentState = continuationState.Pop();
                         continue;
-
-                    case ContinuationState.ReadPropertyName:
-                        if (ReadMaybeModifiedPropertyName() == false)
-                        {
-                            continuationState.Push(currentState);
-                            return false;
-                        }
-
-                        if (state.CurrentTokenType == JsonParserToken.EndObject)
-                        {
-                            _modifier?.EndObject();
-                            _writeToken = _writer.WriteObjectMetadata(currentState.Properties, currentState.FirstWrite, currentState.MaxPropertyId);
-                            _propertiesCache.Return(ref currentState.Properties);
-
-                            if (continuationState.Count == 0)
-                                return true;
-
-                            currentState = continuationState.Pop();
-                            continue;
-                        }
-
-                        if (state.CurrentTokenType != JsonParserToken.String)
-                            ThrowExpectedProperty();
-
-                        var property = CreateLazyStringValueFromParserState();
-                        currentState.CurrentProperty = _context.CachedProperties.GetProperty(property);
-                        _isVectorProperty = currentState.CurrentProperty.IsVectorProperty;
-
-                        currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
-                        currentState.State = ContinuationState.ReadPropertyValue;
-                        goto case ContinuationState.ReadPropertyValue;
-
-                    case ContinuationState.ReadPropertyValue:
-                        if (reader.Read() == false)
-                        {
-                            continuationState.Push(currentState);
-                            return false;
-                        }
-                        currentState.State = ContinuationState.CompleteReadingPropertyValue;
-                        continuationState.Push(currentState);
-
-                        goto case ContinuationState.ReadValue;
-                        
-                    case ContinuationState.CompleteReadingPropertyValue:
-                        // Register property position, name id (PropertyId) and type (object type and metadata)
-                        currentState.Properties.Add(new PropertyTag(
-                            position: _writeToken.ValuePos,
-                            type: (byte)_writeToken.WrittenToken,
-                            property: currentState.CurrentProperty));
-
-                        if (currentState.PartialRead)
-                        {
-                            if (continuationState.Count == 0)
-                            {
-                                _modifier?.EndObject();
-                                _writeToken = _writer.WriteObjectMetadata(currentState.Properties, currentState.FirstWrite, currentState.MaxPropertyId);
-                                _propertiesCache.Return(ref currentState.Properties);
-                                return true;
-                            }
-                        }
-
-                        currentState.State = ContinuationState.ReadPropertyName;
-                        continue;
+                    
                     case ContinuationState.ReadBufferedArrayValue:
 
                         if (reader.Read() == false)
@@ -592,11 +587,6 @@ namespace Sparrow.Json
                 _modifier?.StartObject();
                 _continuationState.Push(new BuildingState(ContinuationState.ReadObject));
             }
-            else if (current == JsonParserToken.Blob)
-            {
-                start = _writer.WriteValue(_state.StringBuffer, _state.StringSize);
-                _writeToken = new WriteToken(start, BlittableJsonToken.RawBlob);
-            }
             else if (current != JsonParserToken.EndObject)
             {
                 ReadJsonValueUnlikely<TWriteStrategy>(current);
@@ -626,6 +616,11 @@ namespace Sparrow.Json
                 case JsonParserToken.False:
                     start = _writer.WriteValue(current == JsonParserToken.True ? (byte)1 : (byte)0);
                     _writeToken = new WriteToken(start, BlittableJsonToken.Boolean);
+                    return;
+
+                case JsonParserToken.Blob:
+                    start = _writer.WriteValue(_state.StringBuffer, _state.StringSize);
+                    _writeToken = new WriteToken(start, BlittableJsonToken.RawBlob);
                     return;
 
                 case JsonParserToken.Null:

--- a/src/Sparrow/Json/BlittableWriter.cs
+++ b/src/Sparrow/Json/BlittableWriter.cs
@@ -68,8 +68,16 @@ namespace Sparrow.Json
         {
             get
             {
-                ThrowIfCachedPropertiesWereReset();
-                return _context.CachedProperties;
+                if (_documentNumber == -1)
+                {
+                    _documentNumber = _context.CachedProperties.DocumentNumber;
+                    return _context.CachedProperties;
+                }
+
+                if (_documentNumber == _context.CachedProperties.DocumentNumber) 
+                    return _context.CachedProperties;
+
+                throw new InvalidOperationException($"The {_context.CachedProperties} were reset while building the document");
             }
         }
 
@@ -822,18 +830,6 @@ namespace Sparrow.Json
             }
 
             return _compressionBuffer.Address;
-        }
-
-        internal void ThrowIfCachedPropertiesWereReset()
-        {
-            if (_documentNumber == -1)
-            {
-                _documentNumber = _context.CachedProperties.DocumentNumber;
-            }
-            else if (_documentNumber != _context.CachedProperties.DocumentNumber)
-            {
-                throw new InvalidOperationException($"The {_context.CachedProperties} were reset while building the document");
-            }
         }
 
         public void Dispose()

--- a/src/Sparrow/Json/BlittableWriter.cs
+++ b/src/Sparrow/Json/BlittableWriter.cs
@@ -212,11 +212,7 @@ namespace Sparrow.Json
                 _position += positionSize + propertyIdSize + sizeof(byte);
             }
 
-            return new WriteToken
-            {
-                ValuePos = objectMetadataStart,
-                WrittenToken = objectToken
-            };
+            return new WriteToken(objectMetadataStart, objectToken);
         }
 
         public int WriteArrayMetadata(FastList<int> positions, FastList<BlittableJsonToken> types, ref BlittableJsonToken listToken)

--- a/src/Sparrow/Json/ManualBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/ManualBlittableJsonDocumentBuilder.cs
@@ -32,10 +32,7 @@ namespace Sparrow.Json
 
         public void StartWriteObjectDocument()
         {
-            _continuationState.Push(new BuildingState
-            {
-                State = ContinuationState.ReadObjectDocument
-            });
+            _continuationState.PushByRef() = new BuildingState(ContinuationState.ReadObjectDocument);
         }
 
         public void StartArrayDocument()
@@ -52,7 +49,7 @@ namespace Sparrow.Json
             currentState.FirstWrite = _writer.Position;
             currentState.Properties = _propertiesCache.Allocate();
             currentState.Properties.Add(new PropertyTag { Property = prop });
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WritePropertyName(string propertyName)
@@ -74,7 +71,7 @@ namespace Sparrow.Json
             currentState.CurrentProperty = newPropertyId;
             currentState.MaxPropertyId = Math.Max(currentState.MaxPropertyId, currentState.CurrentProperty.PropertyId);
             currentState.State = ContinuationState.ReadPropertyValue;
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void StartWriteObject()
@@ -87,14 +84,9 @@ namespace Sparrow.Json
                 ThrowIllegalStateException(previousState.State, "WriteObject");
 
             previousState.State = previousState.State == ContinuationState.ReadPropertyValue ? ContinuationState.ReadPropertyName : previousState.State;
-            _continuationState.Push(previousState);
+            _continuationState.PushByRef() = previousState;
 
-            _continuationState.Push(new BuildingState()
-            {
-                State = ContinuationState.ReadPropertyName,
-                Properties = _propertiesCache.Allocate(),
-                FirstWrite = -1
-            });
+            _continuationState.PushByRef() = new BuildingState(ContinuationState.ReadPropertyName, _propertiesCache.Allocate());
         }
 
         public void WriteObjectEnd()
@@ -132,7 +124,7 @@ namespace Sparrow.Json
 
                             if (outerState.FirstWrite == -1)
                                 outerState.FirstWrite = start;
-                            _continuationState.Push(outerState);
+                            _continuationState.PushByRef() = outerState;
                         }
                     }
                     break;
@@ -149,12 +141,12 @@ namespace Sparrow.Json
                             var outerState = _continuationState.Count > 0 ? _continuationState.Pop() : currentState;
                             if (outerState.FirstWrite == -1)
                                 outerState.FirstWrite = start;
-                            _continuationState.Push(outerState);
+                            _continuationState.PushByRef() = outerState;
                         }
 
                         currentState.Types.Add(_writeToken.WrittenToken);
                         currentState.Positions.Add(_writeToken.ValuePos);
-                        _continuationState.Push(currentState);
+                        _continuationState.PushByRef() = currentState;
                     }
                     break;
 
@@ -183,12 +175,7 @@ namespace Sparrow.Json
 
         public void StartWriteArray()
         {
-            _continuationState.Push(new BuildingState
-            {
-                State = ContinuationState.ReadArray,
-                Types = _tokensCache.Allocate(),
-                Positions = _positionsCache.Allocate()
-            });
+            _continuationState.PushByRef() = new BuildingState(ContinuationState.ReadArray, _tokensCache.Allocate(), _positionsCache.Allocate());
         }
 
         public void WriteArrayEnd()
@@ -207,7 +194,7 @@ namespace Sparrow.Json
 
                     // Register property position, name id (PropertyId) and type (object type and metadata)
                     _writeToken = _writer.WriteObjectMetadata(currentState.Properties, currentState.FirstWrite, currentState.MaxPropertyId);
-                    _continuationState.Push(currentState);
+                    _continuationState.PushByRef() = currentState;
                     break;
 
                 case ContinuationState.ReadArray:
@@ -260,7 +247,7 @@ namespace Sparrow.Json
                             ThrowIllegalStateException(outerState.State, "ReadEndArray");
                         }
 
-                        _continuationState.Push(outerState);
+                        _continuationState.PushByRef() = outerState;
                     }
 
                     break;
@@ -285,7 +272,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteValue(BlittableJsonToken token, object value)
@@ -400,7 +387,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteValue(long value)
@@ -417,7 +404,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteValue(float value)
@@ -434,7 +421,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteValue(ulong value)
@@ -451,7 +438,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteValue(double value)
@@ -468,7 +455,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteValue(decimal value)
@@ -485,7 +472,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteValue(LazyNumberValue value)
@@ -502,7 +489,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteValue(string value)
@@ -519,7 +506,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteValue(LazyStringValue value)
@@ -537,7 +524,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteValue(LazyCompressedStringValue value)
@@ -557,7 +544,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public unsafe void WriteEmbeddedBlittableDocument(BlittableJsonReaderObject document)
@@ -579,7 +566,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public unsafe void WriteEmbeddedBlittableDocument(byte* ptr, int size)
@@ -596,7 +583,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         public void WriteVector<T>(ReadOnlySpan<T> array) where T : unmanaged
@@ -610,7 +597,7 @@ namespace Sparrow.Json
                 currentState.FirstWrite = valuePos;
 
             FinishWritingScalarValue(ref currentState);
-            _continuationState.Push(currentState);
+            _continuationState.PushByRef() = currentState;
         }
 
         private void FinishWritingScalarValue(ref BuildingState currentState)

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -24,12 +24,17 @@ namespace Sparrow.Json.Parsing
         public BlittableJsonReaderObject.InsertionOrderProperties SourceProperties;
 
         public int ModificationsIndex = 0;
-        public readonly List<(string Name, object Value)> Properties = new List<(string Name, object Value)>();
+        public readonly List<(string Name, object Value)> Properties = new();
         public HashSet<int> Removals;
         internal readonly BlittableJsonReaderObject _source;
 
         public DynamicJsonValue()
         {
+        }
+
+        public DynamicJsonValue(string key, object value)
+        {
+            Properties.Add((key, value));
         }
 
         public DynamicJsonValue(Type explicitTypeInfo)
@@ -219,10 +224,10 @@ namespace Sparrow.Json.Parsing
         }
     }
 
-    public sealed unsafe class ObjectJsonParser : IJsonParser
+    public sealed unsafe class ObjectJsonParser(JsonParserState state, JsonOperationContext ctx) : IJsonParser
     {
-        private readonly JsonParserState _state;
-        private readonly JsonOperationContext _ctx;
+        private readonly JsonParserState _state = state;
+        private readonly JsonOperationContext _ctx = ctx;
         private readonly FastStack<object> _elements = new FastStack<object>();
 
         private bool _disposed;
@@ -238,17 +243,11 @@ namespace Sparrow.Json.Parsing
                 _currentStateBuffer = null;
             }
 
-            _elements.Clear();
+            _elements.WeakClear();
             _seenValues.Clear();
 
             if (root != null)
                 _elements.Push(root);
-        }
-
-        public ObjectJsonParser(JsonParserState state, JsonOperationContext ctx)
-        {
-            _state = state;
-            _ctx = ctx;
         }
 
         public void Dispose()
@@ -258,6 +257,294 @@ namespace Sparrow.Json.Parsing
             _disposed = true;
             if (_currentStateBuffer != null)
                 _ctx.ReturnMemory(_currentStateBuffer);
+        }
+
+
+        private enum KnownJsonObjectType : byte
+        {
+            // Primary object flows  
+            DynamicJsonValue, // DynamicJsonValue => goto ValueTuple
+            ValueTuple,
+
+            // Simple numeric / boolean
+            // (all are quite common and return immediately)
+            Int64,                    // (covers long)
+            Int32,                    // (covers int)
+            Int16OrLesser,            // (covers short, byte, sbyte, ushort)
+            UInt32,                   // (covers uint)
+            UInt64,                   // (covers ulong)
+            Boolean,
+
+            IDynamicJson, // IDynamicJson => goto DynamicJsonValue             
+            BlittableJsonReaderObject, // BlittableJsonReaderObject => goto DynamicJsonValue
+
+            // Lazy string forms
+            LazyStringValue,
+            LazyCompressedStringValue,
+            LazyNumberValue,
+
+            // Character-like => goto handle string
+            Char,
+            EnumType,
+            String,
+
+            // Special handle cases for string / number
+            HandleSetStringBufferOptimization,
+            HandleSetStringBufferNumberOptimization,
+
+            Float, // Float => goto handle number
+            Double, // Double => goto handle number
+            Decimal, // Decimal => can become long or string
+
+#if NET6_0_OR_GREATER
+            Half, // Half => goto handle number
+#endif
+
+            // All datetime based => goto handle string
+            DateTime,
+            DateTimeOffset,
+            TimeSpan,
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+            TimeOnly,
+            DateOnly,
+#endif
+
+            // Collections => goto DynamicJsonArray
+            ListOfLong,
+            ListOfDouble,
+            DictionaryStringLong,
+
+            IEnumerableObject, // IEnumerableObject => goto DynamicJsonArray
+
+            BlittableJsonReaderArray, // BlittableJsonReaderArray => goto DynamicJsonArray
+            DynamicJsonArray, // DynamicJsonArray => base array type
+            BlittableJsonReaderVector, // BlittableJsonReaderVector => goto DynamicJsonArray
+
+            IBlittableJsonContainer, // IBlittableJsonContainer => goto BlittableJsonReaderObject
+            IDynamicJsonValueConvertible,  // Convertible => goto DynamicJsonValue
+            RawBlob,
+        }
+
+        private static readonly TypeCache<KnownJsonObjectType> TypeCache = new(4096);
+
+        private KnownJsonObjectType GetKnownJsonObjectTypeUnlikely(object current)
+        {
+            var type = current.GetType();
+            if (current is IDynamicJson idj)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.IDynamicJson);
+                return KnownJsonObjectType.IDynamicJson;
+            }
+
+            if (current is DynamicJsonValue value)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.DynamicJsonValue);
+                return KnownJsonObjectType.DynamicJsonValue;
+            }
+
+            if (current is DynamicJsonArray array)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.DynamicJsonArray);
+                return KnownJsonObjectType.DynamicJsonArray;
+            }
+
+            if (current is ValueTuple<string, object> vt)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.ValueTuple);
+                return KnownJsonObjectType.ValueTuple;
+            }
+
+            if (current is BlittableJsonReaderObject bjro)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.BlittableJsonReaderObject);
+                return KnownJsonObjectType.BlittableJsonReaderObject;
+            }
+
+            if (current is BlittableJsonReaderArray bjra)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.BlittableJsonReaderArray);
+                return KnownJsonObjectType.BlittableJsonReaderArray;
+            }
+
+            if (current is BlittableJsonReaderVector bjrv)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.BlittableJsonReaderVector);
+                return KnownJsonObjectType.BlittableJsonReaderVector;
+            }
+
+            if (current is IBlittableJsonContainer dbj)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.IBlittableJsonContainer);
+                return KnownJsonObjectType.IBlittableJsonContainer;
+            }
+
+            if (current is IEnumerable<object> enumerable)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.IEnumerableObject);
+                return KnownJsonObjectType.IEnumerableObject;
+            }
+
+            if (current is LazyStringValue lsv)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.LazyStringValue);
+                return KnownJsonObjectType.LazyStringValue;
+            }
+
+            if (current is BlittableJsonReaderObject.RawBlob bs)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.RawBlob);
+                return KnownJsonObjectType.RawBlob;
+            }
+
+            if (current is LazyCompressedStringValue lcsv)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.LazyCompressedStringValue);
+                return KnownJsonObjectType.LazyCompressedStringValue;
+            }
+
+            if (current is LazyNumberValue ldv)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.LazyNumberValue);
+                return KnownJsonObjectType.LazyNumberValue;
+            }
+
+            if (current is string)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.String);
+                return KnownJsonObjectType.String;
+            }
+
+            if (current is char)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.Char);
+                return KnownJsonObjectType.Char;
+            }
+
+            if (current is byte || current is sbyte || current is short || current is ushort)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.Int16OrLesser);
+                return KnownJsonObjectType.Int16OrLesser;
+            }
+
+            if (current is int)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.Int32);
+                return KnownJsonObjectType.Int32;
+            }
+
+            if (current is long)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.Int64);
+                return KnownJsonObjectType.Int64;
+            }
+
+            if (current is uint)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.UInt32);
+                return KnownJsonObjectType.UInt32;
+            }
+
+            if (current is ulong)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.UInt64);
+                return KnownJsonObjectType.UInt64;
+            }
+
+            if (current is bool)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.Boolean);
+                return KnownJsonObjectType.Boolean;
+            }
+
+            if (current is float)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.Float);
+                return KnownJsonObjectType.Float;
+            }
+
+            if (current is double)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.Double);
+                return KnownJsonObjectType.Double;
+            }
+
+#if NET6_0_OR_GREATER
+            if (current is Half)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.Half);
+                return KnownJsonObjectType.Half;
+            }
+#endif
+
+            if (current is DateTime)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.DateTime);
+                return KnownJsonObjectType.DateTime;
+            }
+
+            if (current is DateTimeOffset)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.DateTimeOffset);
+                return KnownJsonObjectType.DateTimeOffset;
+            }
+
+            if (current is TimeSpan)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.TimeSpan);
+                return KnownJsonObjectType.TimeSpan;
+            }
+
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+            if (current is TimeOnly)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.TimeOnly);
+                return KnownJsonObjectType.TimeOnly;
+            }
+
+            if (current is DateOnly)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.DateOnly);
+                return KnownJsonObjectType.DateOnly;
+            }
+#endif
+
+            if (current is decimal)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.Decimal);
+                return KnownJsonObjectType.Decimal;
+            }
+
+            if (current is List<long>)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.ListOfLong);
+                return KnownJsonObjectType.ListOfLong;
+            }
+
+            if (current is List<double>)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.ListOfDouble);
+                return KnownJsonObjectType.ListOfDouble;
+            }
+
+            if (current is Dictionary<string, long>)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.DictionaryStringLong);
+                return KnownJsonObjectType.DictionaryStringLong;
+            }
+
+            if (current is Enum)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.EnumType);
+                return KnownJsonObjectType.EnumType;
+            }
+
+            if (current is IDynamicJsonValueConvertible)
+            {
+                TypeCache.Put(type, KnownJsonObjectType.IDynamicJsonValueConvertible);
+                return KnownJsonObjectType.IDynamicJsonValueConvertible;
+            }
+
+            throw new InvalidOperationException("Got unknown type: " + current.GetType() + " " + current);
         }
 
         public bool Read()
@@ -270,418 +557,444 @@ namespace Sparrow.Json.Parsing
 
             var current = _elements.Pop();
 
+            var state = _state;
+
+            string auxiliaryString = null;
+            double auxiliaryDouble = 0;
+            JsonParserToken auxiliaryToken = JsonParserToken.None;
+
             while (true)
             {
                 if (current == null)
                 {
-                    _state.CurrentTokenType = JsonParserToken.Null;
+                    state.CurrentTokenType = JsonParserToken.Null;
                     return true;
                 }
 
-                if (current is IDynamicJson idj)
+                // Attempt to get the known type from the cache
+                if (TypeCache.TryGet(current.GetType(), out var knownType) == false)
                 {
-                    current = idj.ToJson();
+                    // If not in cache, determine and cache it
+                    knownType = GetKnownJsonObjectTypeUnlikely(current);
                 }
 
-                if (current is DynamicJsonValue value)
+                switch (knownType)
                 {
-                    if (_seenValues.Add(value))
+                    case KnownJsonObjectType.DynamicJsonValue:
                     {
+                        var value = (DynamicJsonValue)current;
+                        if (_seenValues.Add(value))
+                        {
 #if DEBUG
-                        if (value._source != null)
-                            throw new InvalidOperationException("Trying to directly modify a DynamicJsonValue with a source, but you need to place the source (blittable), not the json value in the parent.");
+                            if (value._source != null)
+                                throw new InvalidOperationException("Trying to directly modify a DynamicJsonValue with a source, but you need to place the source (blittable), not the json value in the parent.");
 #endif
-                        value.SourceIndex = -1;
-                        _state.CurrentTokenType = JsonParserToken.StartObject;
-                        value.ModificationsIndex = 0;
+                            state.CurrentTokenType = JsonParserToken.StartObject;
+                            value.SourceIndex = -1;
+                            value.ModificationsIndex = 0;
+                            _elements.Push(value);
+                            return true;
+                        }
+                        if (value.ModificationsIndex >= value.Properties.Count)
+                        {
+                            _seenValues.Remove(value);
+                            state.CurrentTokenType = JsonParserToken.EndObject;
+                            return true;
+                        }
                         _elements.Push(value);
-                        return true;
-                    }
-                    if (value.ModificationsIndex >= value.Properties.Count)
-                    {
-                        _seenValues.Remove(value);
-                        _state.CurrentTokenType = JsonParserToken.EndObject;
-                        return true;
-                    }
-                    _elements.Push(value);
-                    current = value.Properties[value.ModificationsIndex++];
-                    continue;
-                }
-
-                if (current is DynamicJsonArray array)
-                {
-                    if (_seenValues.Add(array))
-                    {
-                        array.SourceIndex = -1;
-                        array.ModificationsIndex = 0;
-                        _state.CurrentTokenType = JsonParserToken.StartArray;
-                        _elements.Push(array);
-                        return true;
-                    }
-                    if (array.ModificationsIndex >= array.Items.Count)
-                    {
-                        _seenValues.Remove(array);
-                        _state.CurrentTokenType = JsonParserToken.EndArray;
-                        return true;
-                    }
-                    _elements.Push(array);
-                    current = array.Items[array.ModificationsIndex++];
-                    continue;
-                }
-
-                if (current is ValueTuple<string, object> vt)
-                {
-                    _elements.Push(vt.Item2);
-                    current = vt.Item1;
-                    continue;
-                }
-
-                if (current is BlittableJsonReaderObject bjro)
-                {
-                    bjro.Modifications ??= new DynamicJsonValue(bjro);
-
-                    if (_seenValues.Add(bjro.Modifications))
-                    {
-                        _elements.Push(bjro);
-                        bjro.Modifications.SourceIndex = -1;
-                        bjro.Modifications.ModificationsIndex = 0;
-                        bjro.Modifications.SourceProperties = bjro.GetPropertiesByInsertionOrder();
-                        _state.CurrentTokenType = JsonParserToken.StartObject;
-                        return true;
-                    }
-
-                    var modifications = bjro.Modifications;
-                    modifications.SourceIndex++;
-                    var propDetails = new BlittableJsonReaderObject.PropertyDetails();
-                    if (modifications.SourceIndex < modifications.SourceProperties.Size)
-                    {
-                        var propIndex = modifications.SourceProperties.Properties[modifications.SourceIndex];
-                        if (modifications.Removals != null && modifications.Removals.Contains(propIndex))
-                        {
+                        current = value.Properties[value.ModificationsIndex++];
+                        if (current == null)
                             continue;
-                        }
-                        bjro.GetPropertyByIndex(propIndex, ref propDetails);
-                        _elements.Push(bjro);
-                        _elements.Push(propDetails.Value);
-                        current = propDetails.Name;
+
+                        goto case KnownJsonObjectType.ValueTuple;
+                    }
+                    case KnownJsonObjectType.ValueTuple:
+                    {
+                        var vt = (ValueTuple<string, object>)current;
+                        _elements.Push(vt.Item2);
+                        current = vt.Item1;
                         continue;
                     }
-                    modifications.SourceProperties.Dispose();
-                   current = modifications;
-                    continue;
-                }
-
-                if (current is BlittableJsonReaderArray bjra)
-                {
-                    bjra.Modifications ??= new DynamicJsonArray();
-
-                    if (_seenValues.Add(bjra.Modifications))
+                    case KnownJsonObjectType.Int64:
                     {
-                        _elements.Push(bjra);
-                        bjra.Modifications.SourceIndex = bjra.Modifications.SkipOriginalArray  ? bjra.Length : -1;
-                        bjra.Modifications.ModificationsIndex = 0;
-                        _state.CurrentTokenType = JsonParserToken.StartArray;
+                        state.Long = (long)current;
+                        state.CurrentTokenType = JsonParserToken.Integer;
+                        return true;
+                    }
+                    case KnownJsonObjectType.Int32:
+                    {
+                        state.Long = (int)current;
+                        state.CurrentTokenType = JsonParserToken.Integer;
+                        return true;
+                    }
+                    case KnownJsonObjectType.Int16OrLesser:
+                    {
+                        state.Long = Convert.ToInt64(current);
+                        state.CurrentTokenType = JsonParserToken.Integer;
+                        return true;
+                    }
+                    case KnownJsonObjectType.UInt32:
+                    {
+                        state.Long = (uint)current;
+                        state.CurrentTokenType = JsonParserToken.Integer;
+                        return true;
+                    }
+                    case KnownJsonObjectType.UInt64:
+                    {
+                        state.Long = (long)(ulong)current;
+                        state.CurrentTokenType = JsonParserToken.Integer;
                         return true;
                     }
 
-                    var modifications = bjra.Modifications;
-                    modifications.SourceIndex++;
-                    if (modifications.SourceIndex < bjra.Length)
-                    {
-                        if (modifications.Removals != null && modifications.Removals.Contains(modifications.SourceIndex))
-                        {
-                            continue;
-                        }
 
-                        current = bjra[modifications.SourceIndex];
-                        _elements.Push(bjra);
-                        continue;
-                    }
-                    current = modifications;
-                    continue;
-                }
-                
-                if (current is BlittableJsonReaderVector bjrv)
-                {
-                    bjrv.Modifications ??= new DynamicJsonArray();
-                    
-                    if (_seenValues.Add(bjrv.Modifications))
+                    case KnownJsonObjectType.Boolean:
                     {
-                        _elements.Push(bjrv);
-                        bjrv.Modifications.SourceIndex = bjrv.Modifications.SkipOriginalArray ? bjrv.Length : -1;
-                        bjrv.Modifications.ModificationsIndex = 0;
-                        _state.CurrentTokenType = JsonParserToken.StartArray;
+                        state.CurrentTokenType = (bool)current ? JsonParserToken.True : JsonParserToken.False;
                         return true;
                     }
-                    
-                    var modifications = bjrv.Modifications;
-                    modifications.SourceIndex++;
-                    if (modifications.SourceIndex < bjrv.Length)
+                    case KnownJsonObjectType.IDynamicJson:
                     {
-                        if (modifications.Removals != null && modifications.Removals.Contains(modifications.SourceIndex))
+                        var idj = (IDynamicJson)current;
+                        current = idj.ToJson();
+                        goto case KnownJsonObjectType.DynamicJsonValue; // We know where it must go.
+                    }
+                    case KnownJsonObjectType.BlittableJsonReaderObject:
+                    {
+                        var bjro = (BlittableJsonReaderObject)current;
+                        bjro.Modifications ??= new DynamicJsonValue(bjro);
+
+                        var modifications = bjro.Modifications;
+
+                        if (_seenValues.Add(modifications))
                         {
-                            continue;
+                            _elements.Push(bjro);
+                            modifications.SourceIndex = -1;
+                            modifications.ModificationsIndex = 0;
+                            modifications.SourceProperties = bjro.GetPropertiesByInsertionOrder();
+                            state.CurrentTokenType = JsonParserToken.StartObject;
+                            return true;
                         }
 
-                        current = bjrv[modifications.SourceIndex];
-                        _elements.Push(bjrv);
-                        continue;
+                        modifications.SourceIndex++;
+                        var propDetails = new BlittableJsonReaderObject.PropertyDetails();
+                        if (modifications.SourceIndex < modifications.SourceProperties.Size)
+                        {
+                            var propIndex = modifications.SourceProperties.Properties[modifications.SourceIndex];
+                            if (modifications.Removals != null && modifications.Removals.Contains(propIndex))
+                                continue;
+
+                            bjro.GetPropertyByIndex(propIndex, ref propDetails);
+                            _elements.Push(bjro);
+                            _elements.Push(propDetails.Value);
+                            current = propDetails.Name;
+                            continue;
+                        }
+                        modifications.SourceProperties.Dispose();
+                        current = modifications;
+                        goto case KnownJsonObjectType.DynamicJsonValue;
                     }
-                    
-                    current = modifications;
-                    continue;
-                }
 
-                if (current is IBlittableJsonContainer dbj)
-                {
-                    current = dbj.BlittableJson;
-                    continue;
-                }
 
-                if (current is IEnumerable<object> enumerable)
-                {
-                    current = new DynamicJsonArray(enumerable);
-                    continue;
-                }
+                    case KnownJsonObjectType.LazyStringValue:
+                    {
+                        var lsv = (LazyStringValue)current;
+                        state.StringBuffer = lsv.Buffer;
+                        state.StringSize = lsv.Size;
+                        state.CompressedSize = null;// don't even try
+                        state.CurrentTokenType = JsonParserToken.String;
+                        ReadEscapePositions(lsv.Buffer, lsv.Size);
+                        return true;
+                    }
+                    case KnownJsonObjectType.LazyCompressedStringValue:
+                    {
+                        var lcsv = (LazyCompressedStringValue)current;
+                        state.StringBuffer = lcsv.Buffer;
+                        state.StringSize = lcsv.UncompressedSize;
+                        state.CompressedSize = lcsv.CompressedSize;
+                        state.CurrentTokenType = JsonParserToken.String;
+                        ReadEscapePositions(lcsv.Buffer, lcsv.CompressedSize);
+                        return true;
+                    }
+                    case KnownJsonObjectType.LazyNumberValue:
+                    {
+                        // RavenDB-22076: Notice here we are forcing the token type to Float, this is not correct for
+                        // proper handling when we are dealing with Vector so we will need to pay the cost to adjust
+                        // at the level of vector handling because of compatibility concerns. 
+                        var ldv = (LazyNumberValue)current;
+                        state.StringBuffer = ldv.Inner.Buffer;
+                        state.StringSize = ldv.Inner.Size;
+                        state.CompressedSize = null;// don't even try
+                        state.CurrentTokenType = JsonParserToken.Float;
+                        ReadEscapePositions(ldv.Inner.Buffer, ldv.Inner.Size);
+                        return true;
+                    }
 
-                if (current is LazyStringValue lsv)
-                {
-                    _state.StringBuffer = lsv.Buffer;
-                    _state.StringSize = lsv.Size;
-                    _state.CompressedSize = null;// don't even try
-                    _state.CurrentTokenType = JsonParserToken.String;
-                    ReadEscapePositions(lsv.Buffer, lsv.Size);
-                    return true;
-                }
+                    case KnownJsonObjectType.Char:
+                    {
+                        auxiliaryString = new string((char)current, 1);
+                        auxiliaryToken = JsonParserToken.String;
+                        goto case KnownJsonObjectType.HandleSetStringBufferOptimization;
+                    }
+                    case KnownJsonObjectType.EnumType:
+                    {
+                        auxiliaryString = current.ToString();
+                        auxiliaryToken = JsonParserToken.String;
+                        goto case KnownJsonObjectType.HandleSetStringBufferOptimization;
+                    }
+                    case KnownJsonObjectType.String:
+                    {
+                        auxiliaryString = (string)current;
+                        auxiliaryToken = JsonParserToken.String;
+                        goto case KnownJsonObjectType.HandleSetStringBufferOptimization;
+                    }
+                    case KnownJsonObjectType.HandleSetStringBufferOptimization:
+                    {
+                        SetStringBuffer(auxiliaryString);
+                        state.CurrentTokenType = auxiliaryToken;
+                        return true;
+                    }
+                    case KnownJsonObjectType.HandleSetStringBufferNumberOptimization:
+                    {
+                        auxiliaryString = EnsureDecimalPlace(auxiliaryDouble, auxiliaryDouble.ToString("R", CultureInfo.InvariantCulture));
+                        auxiliaryToken = JsonParserToken.Float;
+                        goto case KnownJsonObjectType.HandleSetStringBufferOptimization;
+                    }
+                    case KnownJsonObjectType.Float:
+                    {
+                        auxiliaryDouble = (float)current;
+                        goto case KnownJsonObjectType.HandleSetStringBufferNumberOptimization;
+                    }
+                    case KnownJsonObjectType.Double:
+                    {
+                        auxiliaryDouble = (double)current;
+                        goto case KnownJsonObjectType.HandleSetStringBufferNumberOptimization;
+                    }
+                    case KnownJsonObjectType.Decimal:
+                    {
+                        var d = (decimal)current;
 
-                if (current is BlittableJsonReaderObject.RawBlob bs)
-                {
-                    _state.StringBuffer = bs.Address;
-                    _state.StringSize = bs.Length;
-                    _state.CompressedSize = null;// don't even try
-                    _state.CurrentTokenType = JsonParserToken.Blob;
-                    return true;
-                }
+                        if (DecimalHelper.Instance.IsDouble(ref d) || d > long.MaxValue || d < long.MinValue)
+                        {
+                            auxiliaryString = EnsureDecimalPlace((double)d, d.ToString(CultureInfo.InvariantCulture));
+                            auxiliaryToken = JsonParserToken.Float;
+                            goto case KnownJsonObjectType.HandleSetStringBufferOptimization;
+                        }
 
-                if (current is LazyCompressedStringValue lcsv)
-                {
-                    _state.StringBuffer = lcsv.Buffer;
-                    _state.StringSize = lcsv.UncompressedSize;
-                    _state.CompressedSize = lcsv.CompressedSize;
-                    _state.CurrentTokenType = JsonParserToken.String;
-                    ReadEscapePositions(lcsv.Buffer, lcsv.CompressedSize);
-                    return true;
-                }
-
-                if (current is LazyNumberValue ldv)
-                {
-                    // RavenDB-22076: Notice here we are forcing the token type to Float, this is not correct for
-                    // proper handling when we are dealing with Vector so we will need to pay the cost to adjust
-                    // at the level of vector handling because of compatibility concerns. 
-                    _state.StringBuffer = ldv.Inner.Buffer;
-                    _state.StringSize = ldv.Inner.Size;
-                    _state.CompressedSize = null;// don't even try
-                    _state.CurrentTokenType = JsonParserToken.Float;
-                    ReadEscapePositions(ldv.Inner.Buffer, ldv.Inner.Size);
-                    return true;
-                }
-
-                if (current is string str)
-                {
-                    SetStringBuffer(str);
-                    _state.CurrentTokenType = JsonParserToken.String;
-                    return true;
-                }
-
-                if (current is char @char)
-                {
-                    current = new string(@char, 1);
-                    continue;
-                }
-
-                if (current is int || current is byte || current is sbyte || current is short || current is ushort)
-                {
-                    _state.Long = Convert.ToInt32(current);
-                    _state.CurrentTokenType = JsonParserToken.Integer;
-                    return true;
-                }
-
-                if (current is long l)
-                {
-                    _state.Long = l;
-                    _state.CurrentTokenType = JsonParserToken.Integer;
-                    return true;
-                }
-
-                if (current is ulong ul)
-                {
-                    _state.Long = (long)ul;
-                    _state.CurrentTokenType = JsonParserToken.Integer;
-                    return true;
-                }
-
-                if (current is uint ui)
-                {
-                    _state.Long = (long)ui;
-                    _state.CurrentTokenType = JsonParserToken.Integer;
-                    return true;
-                }
-
-                if (current is bool b)
-                {
-                    _state.CurrentTokenType = b ? JsonParserToken.True : JsonParserToken.False;
-                    return true;
-                }
-
-                if (current is float f)
-                {
-                    var d = (double)f;
-                    var s = EnsureDecimalPlace(d, d.ToString("R", CultureInfo.InvariantCulture));
-                    SetStringBuffer(s);
-                    _state.CurrentTokenType = JsonParserToken.Float;
-                    return true;
-                }
-
-                if (current is double d1)
-                {
-                    var s = EnsureDecimalPlace(d1, d1.ToString("R", CultureInfo.InvariantCulture));
-                    SetStringBuffer(s);
-                    _state.CurrentTokenType = JsonParserToken.Float;
-                    return true;
-                }
+                        current = (long)d;
+                        goto case KnownJsonObjectType.Int64;
+                    }
 #if NET6_0_OR_GREATER
-                if (current is Half h)
-                {
-                    var s = EnsureDecimalPlace((double)h, h.ToString("R", CultureInfo.InvariantCulture));
-                    SetStringBuffer(s);
-                    _state.CurrentTokenType = JsonParserToken.Float;
-                    return true;              
-                }
-#endif
-                if (current is DateTime dateTime1)
-                {
-                    var s = dateTime1.GetDefaultRavenFormat();
-
-                    SetStringBuffer(s);
-                    _state.CurrentTokenType = JsonParserToken.String;
-                    return true;
-                }
-
-                if (current is DateTimeOffset dateTime)
-                {
-                    var s = dateTime.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
-
-                    SetStringBuffer(s);
-                    _state.CurrentTokenType = JsonParserToken.String;
-                    return true;
-                }
-
-                if (current is TimeSpan timeSpan)
-                {
-                    var s = timeSpan.ToString("c");
-
-                    SetStringBuffer(s);
-                    _state.CurrentTokenType = JsonParserToken.String;
-                    return true;
-                }
-                
-#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
-                if (current is TimeOnly timeOnly)
-                {
-                    var s = timeOnly.ToString(DefaultFormat.TimeOnlyFormatToWrite);
-
-                    SetStringBuffer(s);
-                    _state.CurrentTokenType = JsonParserToken.String;
-                    return true;
-                }
-                
-                if (current is DateOnly dateOnly)
-                {
-                    var s = dateOnly.ToString(DefaultFormat.DateOnlyFormatToWrite);
-
-                    SetStringBuffer(s);
-                    _state.CurrentTokenType = JsonParserToken.String;
-                    return true;
-                }
-#endif
-                if (current is decimal d2)
-                {
-                    var d = (decimal)current;
-
-                    if (DecimalHelper.Instance.IsDouble(ref d) || d > long.MaxValue || d < long.MinValue)
+                    case KnownJsonObjectType.Half:
                     {
-                        var s = EnsureDecimalPlace((double)d2, d2.ToString(CultureInfo.InvariantCulture));
-                        SetStringBuffer(s);
-                        _state.CurrentTokenType = JsonParserToken.Float;
+                        auxiliaryDouble = (double)(Half)(current);
+                        goto case KnownJsonObjectType.HandleSetStringBufferNumberOptimization;
+                    }
+#endif
+                    case KnownJsonObjectType.DateTime:
+                    {
+                        auxiliaryString = ((DateTime)current).GetDefaultRavenFormat();
+                        auxiliaryToken = JsonParserToken.String;
+                        goto case KnownJsonObjectType.HandleSetStringBufferOptimization;
+                    }
+                    case KnownJsonObjectType.DateTimeOffset:
+                    {
+                        auxiliaryString = ((DateTimeOffset)current).ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+                        auxiliaryToken = JsonParserToken.String;
+                        goto case KnownJsonObjectType.HandleSetStringBufferOptimization;
+                    }
+                    case KnownJsonObjectType.TimeSpan:
+                    {
+                        auxiliaryString = ((TimeSpan)current).ToString("c");
+                        auxiliaryToken = JsonParserToken.String;
+                        goto case KnownJsonObjectType.HandleSetStringBufferOptimization;
+                    }
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+                    case KnownJsonObjectType.TimeOnly:
+                    {
+                        auxiliaryString = ((TimeOnly)current).ToString(DefaultFormat.TimeOnlyFormatToWrite);
+                        auxiliaryToken = JsonParserToken.String;
+                        goto case KnownJsonObjectType.HandleSetStringBufferOptimization;
+                    }
+
+                    case KnownJsonObjectType.DateOnly:
+                    {
+                        auxiliaryString = ((DateOnly)current).ToString(DefaultFormat.DateOnlyFormatToWrite);
+                        auxiliaryToken = JsonParserToken.String;
+                        goto case KnownJsonObjectType.HandleSetStringBufferOptimization;
+                    }
+#endif
+
+                    case KnownJsonObjectType.ListOfLong:
+                    {
+                        current = HandleLongsList((List<long>)current);
+                        goto case KnownJsonObjectType.DynamicJsonArray;
+                    }
+                    case KnownJsonObjectType.ListOfDouble:
+                    {
+                        current = HandleDoublesList((List<double>)current);
+                        goto case KnownJsonObjectType.DynamicJsonArray;
+                    }
+                    case KnownJsonObjectType.DictionaryStringLong:
+                    {
+                        current = HandleDictionaryType((Dictionary<string, long>)current);
+                        goto case KnownJsonObjectType.DynamicJsonArray;
+                    }
+
+                    case KnownJsonObjectType.IEnumerableObject:
+                    {
+                        var enumerable = (IEnumerable<object>)current;
+                        current = new DynamicJsonArray(enumerable);
+                        goto case KnownJsonObjectType.DynamicJsonArray;
+                    }
+
+                    case KnownJsonObjectType.BlittableJsonReaderArray:
+                    {
+                        var bjra = (BlittableJsonReaderArray)current;
+                        bjra.Modifications ??= new DynamicJsonArray();
+
+                        var modifications = bjra.Modifications;
+
+                        if (_seenValues.Add(bjra.Modifications))
+                        {
+                            _elements.Push(bjra);
+                            modifications.SourceIndex = modifications.SkipOriginalArray ? bjra.Length : -1;
+                            modifications.ModificationsIndex = 0;
+                            state.CurrentTokenType = JsonParserToken.StartArray;
+                            return true;
+                        }
+
+                        modifications.SourceIndex++;
+                        if (modifications.SourceIndex < bjra.Length)
+                        {
+                            if (modifications.Removals != null && modifications.Removals.Contains(modifications.SourceIndex))
+                                continue;
+
+                            current = bjra[modifications.SourceIndex];
+                            _elements.Push(bjra);
+                            continue;
+                        }
+                        current = modifications;
+                        goto case KnownJsonObjectType.DynamicJsonArray;
+                    }
+
+                    case KnownJsonObjectType.DynamicJsonArray:
+                    {
+                        var array = (DynamicJsonArray)current;
+                        if (_seenValues.Add(array))
+                        {
+                            array.SourceIndex = -1;
+                            array.ModificationsIndex = 0;
+                            state.CurrentTokenType = JsonParserToken.StartArray;
+                            _elements.Push(array);
+                            return true;
+                        }
+                        if (array.ModificationsIndex >= array.Items.Count)
+                        {
+                            _seenValues.Remove(array);
+                            state.CurrentTokenType = JsonParserToken.EndArray;
+                            return true;
+                        }
+                        _elements.Push(array);
+                        current = array.Items[array.ModificationsIndex++];
+                        continue;
+                    }
+
+                    case KnownJsonObjectType.BlittableJsonReaderVector:
+                    {
+                        var bjrv = (BlittableJsonReaderVector)current;
+                        bjrv.Modifications ??= new DynamicJsonArray();
+
+                        var modifications = bjrv.Modifications;
+
+                        if (_seenValues.Add(modifications))
+                        {
+                            _elements.Push(bjrv);
+                            modifications.SourceIndex = modifications.SkipOriginalArray ? bjrv.Length : -1;
+                            modifications.ModificationsIndex = 0;
+                            state.CurrentTokenType = JsonParserToken.StartArray;
+                            return true;
+                        }
+
+                        modifications.SourceIndex++;
+                        if (modifications.SourceIndex < bjrv.Length)
+                        {
+                            if (modifications.Removals != null && modifications.Removals.Contains(modifications.SourceIndex))
+                                continue;
+
+                            current = bjrv[modifications.SourceIndex];
+                            _elements.Push(bjrv);
+                            continue;
+                        }
+
+                        current = modifications;
+                        goto case KnownJsonObjectType.DynamicJsonArray;
+                    }
+
+                    case KnownJsonObjectType.IBlittableJsonContainer:
+                    {
+                        var dbj = (IBlittableJsonContainer)current;
+                        current = dbj.BlittableJson;
+                        if (current == null)
+                            continue;
+
+                        goto case KnownJsonObjectType.BlittableJsonReaderObject;
+                    }
+
+                    case KnownJsonObjectType.IDynamicJsonValueConvertible:
+                    {
+                        current = ((IDynamicJsonValueConvertible)current).ToJson();
+                        goto case KnownJsonObjectType.DynamicJsonValue;
+                    }
+
+                    case KnownJsonObjectType.RawBlob:
+                    {
+                        var bs = (BlittableJsonReaderObject.RawBlob)current;
+                        state.StringBuffer = bs.Address;
+                        state.StringSize = bs.Length;
+                        state.CompressedSize = null;// don't even try
+                        state.CurrentTokenType = JsonParserToken.Blob;
                         return true;
                     }
-
-                    current = (long)d2;
-                    continue;
                 }
+            }
 
-                if (current is List<long> ll)
-                {
-                    var dja = new DynamicJsonArray();
-                    foreach (var item in ll)
-                    {
-                        dja.Add(item);
-                    }
-                    current = dja;
-                    continue;
-                }
-                
-                if (current is List<double> dd)
-                {
-                    var dja = new DynamicJsonArray();
-                    foreach (var item in dd)
-                    {
-                        dja.Add(item);
-                    }
-                    current = dja;
-                    continue;
-                }
+            DynamicJsonArray HandleDictionaryType(Dictionary<string, long> dsl)
+            {
+                var dja = new DynamicJsonArray();
+                foreach (var item in dsl)
+                    dja.Add(new DynamicJsonValue(item.Key, item.Value));
+                return dja;
+            }
 
-                if (current is Dictionary<string, long> dsl)
-                {
-                    var dja = new DynamicJsonArray();
-                    foreach (var item in dsl)
-                    {
-                        var djv = new DynamicJsonValue
-                        {
-                            [item.Key] = item.Value
-                        };
-                        dja.Add(djv);
-                    }
-                    current = dja;
-                    continue;
-                }
+            DynamicJsonArray HandleDoublesList(List<double> dd)
+            {
+                var dja = new DynamicJsonArray();
+                foreach (var item in dd)
+                    dja.Add(item);
 
-                if (current is Enum)
-                {
-                    current = current.ToString();
-                    continue;
-                }
+                return dja;
+            }
 
-                if (current is IDynamicJsonValueConvertible convertible)
-                {
-                    current = convertible.ToJson();
-                    continue;
-                }
+            DynamicJsonArray HandleLongsList(List<long> dd)
+            {
+                var dja = new DynamicJsonArray();
+                foreach (var item in dd)
+                    dja.Add(item);
 
-                throw new InvalidOperationException("Got unknown type: " + current.GetType() + " " + current);
+                return dja;
             }
         }
 
         private void ReadEscapePositions(byte* buffer, int escapeSequencePos)
         {
-            _state.EscapePositions.Clear();
+            var escapePositions = _state.EscapePositions;
+            escapePositions.Clear();
             var numberOfEscapeSequences = BlittableJsonReaderBase.ReadVariableSizeInt(buffer, ref escapeSequencePos);
             while (numberOfEscapeSequences > 0)
             {
                 numberOfEscapeSequences--;
                 var bytesToSkip = BlittableJsonReaderBase.ReadVariableSizeInt(buffer, ref escapeSequencePos);
-                _state.EscapePositions.Add(bytesToSkip);
+                escapePositions.Add(bytesToSkip);
             }
         }
 

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -262,6 +262,10 @@ namespace Sparrow.Json.Parsing
 
         private enum KnownJsonObjectType : byte
         {
+            // We introduced a dedicated enum to represent each recognized data shape.
+            // This replaced the repeated, nested 'if (current is X) { ... } else if ...' pattern,
+            // making the parse loop both smaller and easier for the JIT to optimize.
+
             // Primary object flows  
             DynamicJsonValue, // DynamicJsonValue => goto ValueTuple
             ValueTuple,
@@ -571,7 +575,11 @@ namespace Sparrow.Json.Parsing
                     return true;
                 }
 
-                // Attempt to get the known type from the cache
+                // PERF: The central optimization is the "TypeCache.TryGet(...)"
+                // call, which finds or assigns a known classification for the current
+                // object type. This drastically reduces the overhead of the prior
+                // multi-level if/else chain. Repeatedly encountered types are recognized
+                // in O(1) time, letting the parser jump directly to the relevant handling block.
                 if (TypeCache.TryGet(current.GetType(), out var knownType) == false)
                 {
                     // If not in cache, determine and cache it
@@ -582,6 +590,9 @@ namespace Sparrow.Json.Parsing
                 {
                     case KnownJsonObjectType.DynamicJsonValue:
                     {
+                        // PERF: We handle the normal logic for 'DynamicJsonValue' here (which is the most common),
+                        // same as before. The difference is that we get here quickly as 0 is no jump 
+                        // thanks to the TypeCache classification.
                         var value = (DynamicJsonValue)current;
                         if (_seenValues.Add(value))
                         {
@@ -606,6 +617,7 @@ namespace Sparrow.Json.Parsing
                         if (current == null)
                             continue;
 
+                        // PERF: We know we are dealing with a ValueTuple so we just continue to it.
                         goto case KnownJsonObjectType.ValueTuple;
                     }
                     case KnownJsonObjectType.ValueTuple:

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -325,7 +325,7 @@ namespace Sparrow.Json.Parsing
             RawBlob,
         }
 
-        private static readonly TypeCache<KnownJsonObjectType> TypeCache = new(4096);
+        private static readonly ReplacementTypeCache<KnownJsonObjectType> TypeCache = new(4096);
 
         private KnownJsonObjectType GetKnownJsonObjectTypeUnlikely(object current)
         {

--- a/src/Sparrow/Json/UnmanagedWriteBuffer.cs
+++ b/src/Sparrow/Json/UnmanagedWriteBuffer.cs
@@ -255,14 +255,12 @@ namespace Sparrow.Json
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Conditional("DEBUG")]
         private void ThrowOnDisposed()
         {
-#if DEBUG
             // PERF: This check will only happen in debug mode because it will fail with a NRE anyways on release.
             if (IsDisposed)
                 throw new ObjectDisposedException(nameof(UnmanagedWriteBuffer));
-#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Sparrow/Utils/TypeCache.cs
+++ b/src/Sparrow/Utils/TypeCache.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
+using Sparrow.Binary;
 using Sparrow.Collections;
 
 namespace Sparrow.Utils
@@ -90,6 +91,69 @@ namespace Sparrow.Utils
                 hashCode = -hashCode;
 
             return hashCode % _size;
+        }
+    }
+
+    /// <summary>
+    /// A lightweight, hash-based cache for associating .NET <see cref="Type"/> objects with values of a generic type <typeparamref name="T"/>.
+    /// This cache prioritizes performance over strict synchronization, making it suitable for scenarios where occasional cache misses
+    /// are acceptable but incorrect (Type, T) mappings must never occur.
+    /// </summary>
+    internal sealed class ReplacementTypeCache<T>
+    {
+        // The backing store of Type -> (Type, T) pairs.
+        // We do unsynchronized reads/writes, relying on:
+        //  1) Atomic reference assignment in .NET
+        //  2) The check (item.Item1 == type) to avoid incorrect Type mismatches
+        //  3) It's acceptable for TryGet to return false in race conditions
+        private FastList<Tuple<Type, T>> _buckets;
+        private readonly int _size;
+        private readonly int _mask;
+
+        public ReplacementTypeCache(int size = 64)
+        {
+            _size = Bits.PowerOf2(size);
+            _mask = _size - 1;
+            _buckets = new(_size);
+        }
+
+        /// <summary>
+        /// Attempts to retrieve the cached value for the given Type.
+        /// This lookup is thread-safe under races in the sense that
+        /// it will never return an incorrect (Type, T) pair. However,
+        /// it may return false (i.e., a cache miss) if a concurrent
+        /// writer has not yet become visible or if there's a hash collision
+        /// for a different Type.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGet(Type type, out T result)
+        {
+            // Grab the slot. Note that this read is not synchronized.
+            // Under a race, we might see a stale tuple or null => return false.
+            var item = _buckets[type.GetHashCode() & _mask];
+            if (item is not null && item.Item1 == type)
+            {
+                result = item.Item2;
+                return true;
+            }
+
+            // If not matched, return false. 
+            // We do not attempt to handle collisions or partial updates.
+            Unsafe.SkipInit(out result);
+            return false;
+        }
+
+        /// <summary>
+        /// Puts a (Type, T) pair into the cache at the computed bucket index.
+        /// This is unsynchronized and may overwrite an existing entry.
+        /// This design means we can lose old entries under collision but 
+        /// we never produce a wrong (Type, T) on readers. 
+        /// Readers can safely read the tuple reference, but might see it 
+        /// late or see an older one => which we accept as a 'miss'.
+        /// </summary>
+        public void Put(Type type, T value)
+        {
+            _buckets[type.GetHashCode() & _mask] = new Tuple<Type, T>(type, value);
         }
     }
 }

--- a/src/Sparrow/Utils/TypeCache.cs
+++ b/src/Sparrow/Utils/TypeCache.cs
@@ -19,18 +19,18 @@ namespace Sparrow.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGet(Type type, out T result)
         {
-            int bucket = GetBucket(type);
+            Unsafe.SkipInit(out result);
 
-            // We get the data and after that we always work from there to avoid
-            // harmful race conditions.
-            var storage = _buckets[bucket];
+            int typeHash = type.GetHashCode();
+
+            // We get the data and after that we always work from there to avoid harmful race conditions.
+            // 
+            // The new design emphasizes minimal synchronization overhead.
+            // We do direct index lookups and only check a single or small list of items for collisions.
+            // This drastically reduces contention compared to a dictionary-based approach.
+            var storage = _buckets[typeHash % _size];
             if (storage == null)
-                goto NotFound;
-
-            // The idea is that the type cache is big enough so that type collisions are
-            // unlikely occurrences. 
-            if (storage.Count != 1)
-                return TryGetUnlikely(storage, type, out result);
+                return false;
 
             ref var item = ref storage.GetAsRef(0);
             if (item.Item1 == type)
@@ -39,25 +39,33 @@ namespace Sparrow.Utils
                 return true;
             }
 
-            NotFound:
-            result = default;
+            // The idea is that the type cache is big enough so that type collisions are
+            // unlikely occurrences. 
+            if (storage.Count != 1)
+                return TryGetUnlikely(storage, type, out result);
+
             return false;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public bool TryGetUnlikely(FastList<Tuple<Type, T>>  storage, Type type, out T result)
         {
-            for (int i = storage.Count - 1; i >= 0; i--)
+            Unsafe.SkipInit(out result);
+
+            // In the uncommon scenario of collisions or multiple inserts,
+            // we revert to a simple linear scan. This is rare enough not to impact
+            // normal performance, ensuring a good average-case behavior, but since 
+            // we have already checked 0 so we will skip it. 
+            for (int i = storage.Count - 1; i > 0; i--)
             {
                 ref var item = ref storage.GetAsRef(i);
-                if (item.Item1 == type)
-                {
-                    result = item.Item2;
-                    return true;
-                }
+                if (item.Item1 != type) 
+                    continue;
+
+                result = item.Item2;
+                return true;
             }
 
-            result = default;
             return false;
         }
 
@@ -65,9 +73,10 @@ namespace Sparrow.Utils
         {
             int bucket = GetBucket(type);
 
-            // The idea is that this TypeCache<T> is thread safe. It is better to lose some Put
-            // that to allow side effects to happen. The tradeoff is having to recompute in case
-            // of race conditions.
+            // The unsynchronized 'Put' is designed for a high concurrency scenario.
+            // It's "okay" if we lose some new entries under race conditions, so long as
+            // readers never retrieve the wrong (Type, T) pair. This is a beneficial trade-off
+            // for many real-world read-heavy workloads.
             FastList<Tuple<Type,T>> newBucket;
             var storage = _buckets[bucket];
             if (storage == null)
@@ -106,12 +115,20 @@ namespace Sparrow.Utils
         //  1) Atomic reference assignment in .NET
         //  2) The check (item.Item1 == type) to avoid incorrect Type mismatches
         //  3) It's acceptable for TryGet to return false in race conditions
+        // This is a simpler, specialized design used for an even lighter collision approach.
+        // Instead of a collection of items (like in TypeCache<T>), we store a single entry per slot.
+        // Collisions overwrite the previous entry. This drastically reduces overhead in reading
+        // at the cost of occasionally losing older entries.
+
         private FastList<Tuple<Type, T>> _buckets;
         private readonly int _size;
         private readonly int _mask;
 
         public ReplacementTypeCache(int size = 64)
         {
+            // We use power-of-two sizing (rounded up via Bits.PowerOf2)
+            // to make (hash & mask) faster than % operations. This is a micro-optimization
+            // that can matter when this call is extremely hot.
             _size = Bits.PowerOf2(size);
             _mask = _size - 1;
             _buckets = new(_size);
@@ -128,8 +145,9 @@ namespace Sparrow.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGet(Type type, out T result)
         {
-            // Grab the slot. Note that this read is not synchronized.
-            // Under a race, we might see a stale tuple or null => return false.
+            // The simplified approach uses a single entry per bucket.
+            // This yields a very fast read path. If the entry is for a different type
+            // or a race overwrote it, we just return false => 'cache miss'.
             var item = _buckets[type.GetHashCode() & _mask];
             if (item is not null && item.Item1 == type)
             {
@@ -153,6 +171,10 @@ namespace Sparrow.Utils
         /// </summary>
         public void Put(Type type, T value)
         {
+            // Collisions simply overwrite. No chain or recheck.
+            // This drastically cuts memory overhead and lock contention,
+            // making it ideal for a scenario where each type is typically
+            // hashed consistently, with few collisions in practice.
             _buckets[type.GetHashCode() & _mask] = new Tuple<Type, T>(type, value);
         }
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-23614

### Additional description

Regression testing showed that the changes done to the Blittable implementation in order to support vector search would cause massive differences in CPU usage. This PR improves blittable parsing by 28%. 

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
