### PR TITLE
RavenDB-23606 Update `entriesToTerms` on a prepared copy of `EntriesModification` to avoid removing terms related to updates for longs/doubles.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -1894,7 +1894,7 @@ namespace Corax.Indexing
                 if (localEntry.HasChanges == false)
                     continue;
                   
-                UpdateEntriesForTerm(entries, term);
+                UpdateEntriesForTerm(localEntry, term);
                 
                 long termId;
                 var hasTerm = fieldTree.TryGetValue(term, out var existing);
@@ -1970,7 +1970,7 @@ namespace Corax.Indexing
                 if (localEntry.HasChanges == false)
                     continue;
 
-                UpdateEntriesForTerm(entries, BitConverter.DoubleToInt64Bits(term));
+                UpdateEntriesForTerm(localEntry, BitConverter.DoubleToInt64Bits(term));
                 
                 var hasTerm = fieldTree.TryGetValue(term, out var existing);
 

--- a/test/FastTests/Corax/Bugs/RavenDB_23606.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB_23606.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Corax;
+using Corax.Indexing;
+using Corax.Mappings;
+using Corax.Querying;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs;
+
+public class RavenDB_23606(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying)]
+    public void CanUpdateAndPersistNumericalValueInEntriesToTerms()
+    {
+        using var mapping = IndexFieldsMappingBuilder.CreateForWriter(isDynamic: false)
+            .AddBinding(0, "id")
+            .AddBinding(1, "month")
+            .AddBinding(2, "year")
+            .Build();
+        
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            using (var entryBuilder = writer.Update("id/1"u8))
+            {
+                entryBuilder.Write(0, "id/1"u8);
+                entryBuilder.Write(1, "1"u8, 1L, 1D);
+                entryBuilder.Write(2, "2024"u8, 2024L, 2024D);
+                entryBuilder.EndWriting();
+            }
+            
+            writer.Commit();
+        }
+        
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            using (var entryBuilder = writer.Update("id/2"u8))
+            {
+                entryBuilder.Write(0, "id/2"u8);
+                entryBuilder.Write(1, "1"u8, 1L, 1D);
+                entryBuilder.Write(2, "2024"u8, 2024L, 2024D);
+                entryBuilder.EndWriting();
+            }
+            
+            writer.Commit();
+        }
+        
+        using (var writer = new IndexWriter(Env, mapping, SupportedFeatures.All))
+        {
+            using (var entryBuilder = writer.Update("id/3"u8))
+            {
+                entryBuilder.Write(0, "id/3"u8);
+                entryBuilder.Write(1, "1"u8, 1L, 1D);
+                entryBuilder.Write(2, "2024"u8, 2024L, 2024D);
+                entryBuilder.EndWriting();
+            }
+            
+            using (var entryBuilder = writer.Update("id/1"u8))
+            {
+                entryBuilder.Write(0, "id/1"u8);
+                entryBuilder.Write(1, "1"u8, 1L, 1D);
+                entryBuilder.Write(2, "2024"u8, 2024L, 2024D);
+                entryBuilder.EndWriting();
+            }
+            
+            writer.Commit();
+        }
+
+        // Tree for longs
+        using (var indexSearcher = new IndexSearcher(Env, mapping))
+        {
+            Span<long> ids = new long[16];
+            var read = indexSearcher.AllEntries().Fill(ids);
+            Assert.Equal(3, read);
+            ids = ids[..read];
+            var terms = new long[read];
+            var lookup = indexSearcher.EntriesToTermsReader(mapping.GetByFieldId(2).FieldNameLong);
+            lookup.GetFor(ids, terms, long.MinValue);
+            Assert.Equal(2024L, terms[0]);
+            Assert.Equal(2024L, terms[1]);
+            Assert.Equal(2024L, terms[2]);
+        }
+        
+        
+        // Tree for doubles
+        using (var indexSearcher = new IndexSearcher(Env, mapping))
+        {
+            Span<long> ids = new long[16];
+            var read = indexSearcher.AllEntries().Fill(ids);
+            Assert.Equal(3, read);
+            ids = ids[..read];
+            var terms = new long[read];
+            var lookup = indexSearcher.EntriesToTermsReader(mapping.GetByFieldId(2).FieldNameDouble);
+            lookup.GetFor(ids, terms, BitConverter.DoubleToInt64Bits(double.MinValue));
+            Assert.Equal(2024D, BitConverter.Int64BitsToDouble(terms[0]));
+            Assert.Equal(2024D, BitConverter.Int64BitsToDouble(terms[1]));
+            Assert.Equal(2024D, BitConverter.Int64BitsToDouble(terms[2]));
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23606

### Additional description



### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
