### PR TITLE
RavenDB-22849  - Have separate backup status for each node - v6.0

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
@@ -107,14 +107,6 @@ namespace Raven.Client.Documents.Operations.Backups
         {
             return $"{GenerateItemName(databaseName, taskId)}/{base64DbId}";
         }
-
-        public override string ToString()
-        {
-            using (var ctx = JsonOperationContext.ShortTermSingleUse())
-            {
-                return ctx.ReadObject(ToJson(), "backup-status").ToString();
-            }
-        }
     }
 
     public sealed class Error

--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
@@ -1,5 +1,6 @@
 using System;
 using Raven.Client.ServerWide;
+using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Backups
@@ -100,6 +101,19 @@ namespace Raven.Client.Documents.Operations.Backups
         public static string GenerateItemName(string databaseName, long taskId)
         {
             return $"values/{databaseName}/{Prefix}{taskId}";
+        }
+
+        public static string GenerateItemName(string databaseName, string base64DbId, long taskId)
+        {
+            return $"{GenerateItemName(databaseName, taskId)}/{base64DbId}";
+        }
+
+        public override string ToString()
+        {
+            using (var ctx = JsonOperationContext.ShortTermSingleUse())
+            {
+                return ctx.ReadObject(ToJson(), "backup-status").ToString();
+            }
         }
     }
 

--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupStatus.cs
@@ -103,7 +103,7 @@ namespace Raven.Client.Documents.Operations.Backups
             return $"values/{databaseName}/{Prefix}{taskId}";
         }
 
-        public static string GenerateItemName(string databaseName, string base64DbId, long taskId)
+        internal static string GenerateItemName(string databaseName, string base64DbId, long taskId)
         {
             return $"{GenerateItemName(databaseName, taskId)}/{base64DbId}";
         }

--- a/src/Raven.Server/Documents/DatabaseInfoCache.cs
+++ b/src/Raven.Server/Documents/DatabaseInfoCache.cs
@@ -1,5 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Json.Serialization;
+using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -20,6 +26,8 @@ namespace Raven.Server.Documents
 
         private readonly TableSchema _databaseInfoSchema = new TableSchema();
 
+        public BackupStatusStorage BackupStatusStorage { get; }
+
         public DatabaseInfoCache()
         {
             _databaseInfoSchema.DefineKey(new TableSchema.IndexDef
@@ -27,6 +35,8 @@ namespace Raven.Server.Documents
                 StartIndex = 0,
                 Count = 1
             });
+
+            BackupStatusStorage = new BackupStatusStorage();
         }
 
         public void Initialize(StorageEnvironment environment, TransactionContextPool contextPool)
@@ -41,6 +51,8 @@ namespace Raven.Server.Documents
 
                 tx.Commit();
             }
+
+            BackupStatusStorage.Initialize(_environment, _contextPool);
         }
 
         public unsafe void InsertDatabaseInfo(DynamicJsonValue databaseInfo, string databaseName)

--- a/src/Raven.Server/Documents/DatabaseInfoCache.cs
+++ b/src/Raven.Server/Documents/DatabaseInfoCache.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -28,7 +24,7 @@ namespace Raven.Server.Documents
 
         public BackupStatusStorage BackupStatusStorage { get; }
 
-        public DatabaseInfoCache()
+        public DatabaseInfoCache(ServerStore serverStore)
         {
             _databaseInfoSchema.DefineKey(new TableSchema.IndexDef
             {
@@ -36,7 +32,7 @@ namespace Raven.Server.Documents
                 Count = 1
             });
 
-            BackupStatusStorage = new BackupStatusStorage();
+            BackupStatusStorage = new BackupStatusStorage(serverStore);
         }
 
         public void Initialize(StorageEnvironment environment, TransactionContextPool contextPool)

--- a/src/Raven.Server/Documents/OngoingTasks/AbstractOngoingTasks.cs
+++ b/src/Raven.Server/Documents/OngoingTasks/AbstractOngoingTasks.cs
@@ -282,7 +282,7 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
     protected abstract (string Url, OngoingTaskConnectionStatus Status) GetReplicationTaskConnectionStatus<T>(DatabaseTopology databaseTopology, ClusterTopology clusterTopology, T replication, Dictionary<string, RavenConnectionString> connectionStrings, out string responsibleNodeTag, out RavenConnectionString connection)
         where T : ExternalReplicationBase;
 
-    protected abstract PeriodicBackupStatus GetBackupStatus(long taskId, PeriodicBackupConfiguration backupConfiguration, out string responsibleNodeTag, out NextBackup nextBackup, out RunningBackup onGoingBackup, out bool isEncrypted);
+    protected abstract PeriodicBackupStatus GetClusterBackupStatus(long taskId, PeriodicBackupConfiguration backupConfiguration, out string responsibleNodeTag, out NextBackup nextBackup, out RunningBackup onGoingBackup, out bool isEncrypted);
 
     private OngoingTaskReplication CreateExternalReplicationTaskInfo(ClusterTopology clusterTopology, DatabaseRecord databaseRecord, ExternalReplication watcher)
     {
@@ -318,7 +318,7 @@ public abstract class AbstractOngoingTasks<TSubscriptionConnectionsState>
 
     private OngoingTaskBackup CreateBackupTaskInfo(ClusterTopology clusterTopology, PeriodicBackupConfiguration backupConfiguration)
     {
-        var backupStatus = GetBackupStatus(backupConfiguration.TaskId, backupConfiguration, out var responsibleNodeTag, out var nextBackup,
+        var backupStatus = GetClusterBackupStatus(backupConfiguration.TaskId, backupConfiguration, out var responsibleNodeTag, out var nextBackup,
             out var onGoingBackup, out var isEncrypted);
         var backupDestinations = backupConfiguration.GetFullBackupDestinations();
 

--- a/src/Raven.Server/Documents/OngoingTasks/OngoingTasks.cs
+++ b/src/Raven.Server/Documents/OngoingTasks/OngoingTasks.cs
@@ -181,10 +181,10 @@ public sealed class OngoingTasks : AbstractOngoingTasks<SubscriptionConnectionsS
         return result;
     }
 
-    protected override PeriodicBackupStatus GetBackupStatus(long taskId, PeriodicBackupConfiguration backupConfiguration, out string responsibleNodeTag,
+    protected override PeriodicBackupStatus GetClusterBackupStatus(long taskId, PeriodicBackupConfiguration backupConfiguration, out string responsibleNodeTag,
         out NextBackup nextBackup, out RunningBackup onGoingBackup, out bool isEncrypted)
     {
-        var backupStatus = _database.PeriodicBackupRunner.GetBackupStatus(taskId);
+        var backupStatus = _database.PeriodicBackupRunner.GetMostUpdatedClusterBackupStatus(taskId);
         nextBackup = _database.PeriodicBackupRunner.GetNextBackupDetails(backupConfiguration, backupStatus, out responsibleNodeTag);
         onGoingBackup = _database.PeriodicBackupRunner.OnGoingBackup(taskId);
         isEncrypted = BackupTask.IsBackupEncrypted(_database, backupConfiguration);

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupStatusStorage.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupStatusStorage.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Json.Serialization;
+using Raven.Client.Util;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Logging;
+using Sparrow.Server;
+using Voron;
+using Voron.Data.Tables;
+
+namespace Raven.Server.Documents.PeriodicBackup
+{
+    public class BackupStatusStorage
+    {
+        private const string JsonDocumentId = "backup-status-entry";
+
+        private StorageEnvironment _environment;
+        private TransactionContextPool _contextPool;
+
+        private readonly Logger _logger = LoggingSource.Instance.GetLogger<BackupStatusStorage>("Server");
+
+        private static readonly TableSchema BackupStatusTableSchema = new();
+
+        private static readonly Slice BackupStatusSlice;
+
+        public SystemTime Time = new SystemTime();
+
+        static BackupStatusStorage()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, "BackupStatus", ByteStringType.Immutable, out BackupStatusSlice);
+            }
+
+            BackupStatusTableSchema.DefineKey(new TableSchema.SchemaIndexDef { StartIndex = 0, Count = 1 });
+        }
+
+        public void Initialize(StorageEnvironment environment, TransactionContextPool contextPool)
+        {
+            _environment = environment;
+            _contextPool = contextPool;
+
+            using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (var tx = _environment.WriteTransaction(context.PersistentContext))
+            {
+                tx.CreateTree(BackupStatusSlice);
+                BackupStatusTableSchema.Create(tx, BackupStatusSchema.TableName, 16);
+                tx.Commit();
+            }
+        }
+
+        public void InsertBackupStatus(PeriodicBackupStatus backupStatus, string databaseName, string dbId, long taskId)
+        {
+            var status = backupStatus.ToJson();
+            using (_contextPool.AllocateOperationContext(out TransactionOperationContext context))
+            using (var tx = context.OpenWriteTransaction(TimeSpan.FromSeconds(5)))
+            {
+                var statusBlittable = context.ReadObject(status, JsonDocumentId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+                InsertBackupStatusBlittable(context, statusBlittable, databaseName, dbId, taskId);
+                tx.Commit();
+            }
+        }
+
+        public unsafe void InsertBackupStatusBlittable<T>(TransactionOperationContext<T> context, BlittableJsonReaderObject backupStatus, string databaseName,
+            string dbId, long taskId)
+            where T : RavenTransaction
+        {
+            var key = PeriodicBackupStatus.GenerateItemName(databaseName, dbId, taskId);
+            using (var id = context.GetLazyString(key.ToLowerInvariant()))
+            using (backupStatus)
+            {
+                var table = context.Transaction.InnerTransaction.OpenTable(BackupStatusTableSchema, BackupStatusSchema.TableName);
+                using (table.Allocate(out TableValueBuilder tvb))
+                {
+                    tvb.Add(id.Buffer, id.Size);
+                    tvb.Add(backupStatus.BasePointer, backupStatus.Size);
+
+                    table.Set(tvb);
+                }
+            }
+        }
+
+        public unsafe BlittableJsonReaderObject GetBackupStatusBlittable<T>(TransactionOperationContext<T> context, string databaseName, string dbId, long taskId)
+            where T : RavenTransaction
+        {
+            var key = PeriodicBackupStatus.GenerateItemName(databaseName, dbId, taskId);
+            var table = context.Transaction.InnerTransaction.OpenTable(BackupStatusTableSchema, BackupStatusSchema.TableName);
+
+            TableValueReader statusTvr;
+            using (Slice.From(context.Transaction.InnerTransaction.Allocator, key.ToLowerInvariant(), out Slice databaseNameAsSlice))
+            {
+                if (table.ReadByKey(databaseNameAsSlice, out statusTvr) == false)
+                    return null;
+            }
+
+            //it seems like the database was shutdown rudely and never wrote it stats onto the disk
+            if (statusTvr.Pointer == null)
+                return null;
+
+            var ptr = statusTvr.Read(BackupStatusSchema.BackupStatusColumns.Data, out int size);
+            var statusBlittable = new BlittableJsonReaderObject(ptr, size, context);
+
+            return statusBlittable;
+        }
+
+        public PeriodicBackupStatus GetBackupStatus(string databaseName, string dbId, long taskId, TransactionOperationContext context)
+        {
+            PeriodicBackupStatus periodicBackup = null;
+            using (var backupStatusBlittable = GetBackupStatusBlittable(context, databaseName, dbId, taskId))
+            {
+                if (backupStatusBlittable == null)
+                    return null;
+
+                periodicBackup = JsonDeserializationClient.PeriodicBackupStatus(backupStatusBlittable);
+            }
+
+            return periodicBackup;
+        }
+
+        public bool DeleteBackupStatusesByTaskIds(string databaseName, string dbId, HashSet<long> taskIds)
+        {
+            try
+            {
+                using (_contextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+                using (var tx = ctx.OpenWriteTransaction(TimeSpan.FromSeconds(5)))
+                {
+                    foreach (var taskId in taskIds)
+                    {
+                        var backupKey = PeriodicBackupStatus.GenerateItemName(databaseName, dbId, taskId);
+                        using (Slice.From(ctx.Allocator, backupKey.ToLowerInvariant(), out Slice key))
+                        {
+                            var table = ctx.Transaction.InnerTransaction.OpenTable(BackupStatusTableSchema, BackupStatusSchema.TableName);
+                            table.DeleteByKey(key);
+                        }
+                    }
+
+                    tx.Commit();
+                }
+
+                if (_logger.IsInfoEnabled)
+                    _logger.Info(
+                        $"{databaseName}: Deleted local backup statuses for the following ids [{string.Join(",", taskIds)}], because node with db id {dbId} is not responsible anymore and is overdue for a full backup.");
+            }
+            catch (Exception ex)
+            {
+                if (_logger.IsInfoEnabled)
+                    _logger.Info(
+                        $"{databaseName}: Could not delete the local backup statuses for the following ids [{string.Join(",", taskIds)}]. We will not remove any tombstones.",
+                        ex);
+
+                return false;
+            }
+
+            return true;
+        }
+
+        public void DeleteBackupStatus(ClusterOperationContext context, string databaseName, string dbId, long taskId)
+        {
+            // this is called from csm, so commiting will be done outside
+            var backupKey = PeriodicBackupStatus.GenerateItemName(databaseName, dbId, taskId);
+            using (Slice.From(context.Allocator, backupKey.ToLowerInvariant(), out Slice key))
+            {
+                var table = context.Transaction.InnerTransaction.OpenTable(BackupStatusTableSchema, BackupStatusSchema.TableName);
+                table.DeleteByKey(key);
+            }
+        }
+
+        private static class BackupStatusSchema
+        {
+            public const string TableName = "BackupStatusTable";
+            private const string ValuesPrefix = "values/";
+
+            public static class BackupStatusColumns
+
+            {
+#pragma warning disable 169
+                public const int PrimaryKey = 0;
+                public const int Data = 1;
+#pragma warning restore 169
+            }
+        }
+
+    }
+}

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -631,7 +631,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             if (_forTestingPurposes != null && _forTestingPurposes.BackupStatusFromMemoryOnly)
                 return inMemoryBackupStatus;
 
-            using (_serverStore.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (_serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
                 var backupStatus = BackupUtils.GetBackupStatusFromCluster(_serverStore, context, _database.Name, taskId);
@@ -649,7 +649,7 @@ namespace Raven.Server.Documents.PeriodicBackup
         {
             var min = long.MaxValue;
             taskIdsStatusesToDelete = null;
-            using (_serverStore.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (_serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
                 var record = _serverStore.Cluster.ReadRawDatabaseRecord(context, _database.Name);

--- a/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/PeriodicBackupRunner.cs
@@ -32,6 +32,7 @@ using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
 using Constants = Raven.Client.Constants;
+using Exception = System.Exception;
 
 namespace Raven.Server.Documents.PeriodicBackup
 {
@@ -344,18 +345,20 @@ namespace Raven.Server.Documents.PeriodicBackup
                 _serverStore.ConcurrentBackupsCounter.StartBackup(_originalDatabaseName, periodicBackup.Configuration.Name, _logger);
 
                 var tcs = new TaskCompletionSource<IOperationResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-
+                
                 try
                 {
-                    var backupStatus = periodicBackup.BackupStatus = GetBackupStatus(periodicBackup.Configuration.TaskId, periodicBackup.BackupStatus);
+                    // in the case cluster backup status was overridden by a different node since our last backup,
+                    // we fetch the last local backup status to check if we need to continue where we left off or start fresh with a full backup
+                    
+                    var localBackupStatus = periodicBackup.BackupStatus = GetMostUpdatedLocalBackupStatus(periodicBackup.Configuration.TaskId, inMemoryBackupStatus: periodicBackup.BackupStatus);
                     var backupToLocalFolder = BackupConfiguration.CanBackupUsing(periodicBackup.Configuration.LocalSettings);
-
+                    
                     // check if we need to do a new full backup
-                    if (backupStatus.LastFullBackup == null || // no full backup was previously performed
-                        backupStatus.NodeTag != _serverStore.NodeTag || // last backup was performed by a different node
-                        backupStatus.BackupType != periodicBackup.Configuration.BackupType || // backup type has changed
-                        backupStatus.LastEtag == null || // last document etag wasn't updated
-                        backupToLocalFolder && BackupTask.DirectoryContainsBackupFiles(backupStatus.LocalBackup.BackupDirectory, IsFullBackupOrSnapshot) == false)
+                    if (localBackupStatus.LastFullBackup == null || // no full backup was previously performed
+                        localBackupStatus.BackupType != periodicBackup.Configuration.BackupType || // backup type has changed
+                        localBackupStatus.LastEtag == null || // last document etag wasn't updated
+                        backupToLocalFolder && BackupTask.DirectoryContainsBackupFiles(localBackupStatus.LocalBackup.BackupDirectory, IsFullBackupOrSnapshot) == false)
                     // the local folder already includes a full backup or snapshot
                     {
                         isFullBackup = true;
@@ -619,7 +622,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             return taskStatus == TaskStatus.ActiveByCurrentNode;
         }
 
-        public PeriodicBackupStatus GetBackupStatus(long taskId)
+        public PeriodicBackupStatus GetMostUpdatedClusterBackupStatus(long taskId)
         {
             PeriodicBackupStatus inMemoryBackupStatus = null;
             if (_periodicBackups.TryGetValue(taskId, out PeriodicBackup periodicBackup))
@@ -628,29 +631,25 @@ namespace Raven.Server.Documents.PeriodicBackup
             if (_forTestingPurposes != null && _forTestingPurposes.BackupStatusFromMemoryOnly)
                 return inMemoryBackupStatus;
 
-            return GetBackupStatus(taskId, inMemoryBackupStatus);
-        }
-
-        private PeriodicBackupStatus GetBackupStatus(long taskId, PeriodicBackupStatus inMemoryBackupStatus)
-        {
-            var backupStatus = GetBackupStatusFromCluster(_serverStore, _database.Name, taskId);
-            return BackupUtils.ComparePeriodicBackupStatus(taskId, backupStatus, inMemoryBackupStatus);
-        }
-
-        private static PeriodicBackupStatus GetBackupStatusFromCluster(ServerStore serverStore, string databaseName, long taskId)
-        {
-            using (serverStore.Server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (_serverStore.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
-                return BackupUtils.GetBackupStatusFromCluster(serverStore, context, databaseName, taskId);
+                var backupStatus = BackupUtils.GetBackupStatusFromCluster(_serverStore, context, _database.Name, taskId);
+                return BackupUtils.ComparePeriodicBackupStatus(taskId, backupStatus, inMemoryBackupStatus);
             }
         }
-
-        private long GetMinLastEtag()
+        
+        private PeriodicBackupStatus GetMostUpdatedLocalBackupStatus(long taskId, PeriodicBackupStatus inMemoryBackupStatus)
+        {
+            var backupStatus = BackupUtils.GetLocalBackupStatus(_serverStore, _database.Name, taskId);
+            return BackupUtils.ComparePeriodicBackupStatus(taskId, backupStatus, inMemoryBackupStatus);
+        }
+        
+        private long GetMinLastEtag(out HashSet<long> taskIdsStatusesToDelete)
         {
             var min = long.MaxValue;
-
-            using (_serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            taskIdsStatusesToDelete = null;
+            using (_serverStore.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
                 var record = _serverStore.Cluster.ReadRawDatabaseRecord(context, _database.Name);
@@ -662,18 +661,61 @@ namespace Raven.Server.Documents.PeriodicBackup
                         // if there is no status for this, we don't need to take into account tombstones
                         continue; // if the backup is always full, we don't need to take into account the tombstones, since we never back them up.
                     }
-                    var status = BackupUtils.GetBackupStatusFromCluster(_serverStore, context, _database.Name, taskId);
-                    if (status == null)
+
+                    var localStatus = BackupUtils.GetLocalBackupStatus(_serverStore, context, _database.Name, taskId);
+                    
+                    // if we are not the responsible node, we want to avoid gathering tombstones indefinitely since our local status will not be updated
+                    var responsibleNode = BackupUtils.GetResponsibleNodeTag(_serverStore, _database.Name, taskId);
+
+                    if (localStatus == null)
                     {
-                        // if there is no status for this, we don't need to take into account tombstones
-                        return 0; // cannot delete the tombstones until we've done a full backup
+                        if (responsibleNode == null || responsibleNode == _serverStore.NodeTag)
+                        {
+                            // first backup might run on this node, don't delete anything until then
+                            return 0;
+                        }
+                        else
+                        {
+                            // we never ran the backup and aren't in the middle of it either
+                            // our next backup on this node is going to be full (first backup), so we can delete tombstones
+                            continue;
+                        }
                     }
-                    var etag = ChangeVectorUtils.GetEtagById(status.LastDatabaseChangeVector, _database.DbBase64Id);
+                    
+                    if (responsibleNode != null && responsibleNode != _serverStore.NodeTag && config.FullBackupFrequency != null)
+                    {
+                        var nextFullBackup = BackupUtils.GetNextBackupOccurrence(new BackupUtils.NextBackupOccurrenceParameters()
+                        {
+                            BackupFrequency = config.FullBackupFrequency,
+                            Configuration = config,
+                            LastBackupUtc = localStatus.LastFullBackupInternal ?? DateTime.MinValue
+                        });
+                        if (nextFullBackup == null)
+                        {
+                            // this is supposed to only happen if full frequency is null - shouldn't happen
+                            // let's not delete any tombstones
+                            return 0;
+                        }
+                        
+                        var now = DateTime.UtcNow;
+                        if (nextFullBackup.Value.ToUniversalTime() < now)
+                        {
+                            // we are overdue for a full backup, we can delete the local status to ensure the next backup will be full
+                            // this is in order to free the tombstone cleaners (for both local and compare exchange tombstones) to delete freely for this node
+
+                            taskIdsStatusesToDelete ??= new();
+                            taskIdsStatusesToDelete.Add(taskId);
+                            
+                            continue;
+                        }
+                    }
+
+                    var etag = ChangeVectorUtils.GetEtagById(localStatus.LastDatabaseChangeVector, _database.DbBase64Id);
                     min = Math.Min(etag, min);
                 }
-
-                return min;
             }
+
+            return min;
         }
 
         public void UpdateConfigurations(List<PeriodicBackupConfiguration> configurations)
@@ -753,8 +795,9 @@ namespace Raven.Server.Documents.PeriodicBackup
                     if (_logger.IsInfoEnabled)
                         _logger.Info($"New backup task '{taskId}' state is '{taskState}', will arrange a new backup timer.");
 
-                    var backupStatus = GetBackupStatus(taskId, inMemoryBackupStatus: null);
-                    periodicBackup.UpdateTimer(GetNextBackupDetails(newConfiguration, backupStatus, _serverStore.NodeTag), lockTaken: false);
+                    var backupStatus = GetMostUpdatedLocalBackupStatus(taskId, inMemoryBackupStatus: null);
+                    var nextbackup = GetNextBackupDetails(newConfiguration, backupStatus, _serverStore.NodeTag);
+                    periodicBackup.UpdateTimer(nextbackup, lockTaken: false);
                 }
 
                 return;
@@ -809,9 +852,11 @@ namespace Raven.Server.Documents.PeriodicBackup
 
                     if (_logger.IsOperationsEnabled)
                         _logger.Operations($"Backup task '{taskId}' state is '{taskState}', the task has frequency changes or doesn't have scheduled backup, the timer will be rearranged and the task will be executed by current node '{_database.ServerStore.NodeTag}'.");
-
-                    var backupStatus = GetBackupStatus(taskId, inMemoryBackupStatus: null);
-                    existingBackupState.UpdateTimer(GetNextBackupDetails(newConfiguration, backupStatus, _serverStore.NodeTag), lockTaken: false);
+                    
+                    var backupStatus = GetMostUpdatedLocalBackupStatus(taskId, inMemoryBackupStatus: null);
+                    var nextBackup = GetNextBackupDetails(newConfiguration, backupStatus, _serverStore.NodeTag);
+                    
+                    existingBackupState.UpdateTimer(nextBackup, lockTaken: false);
                     return;
 
                 default:
@@ -1013,7 +1058,13 @@ namespace Raven.Server.Documents.PeriodicBackup
 
         public Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType)
         {
-            var minLastEtag = GetMinLastEtag();
+            var minLastEtag = GetMinLastEtag(out var taskIdsStatusesToDelete);
+
+            if (taskIdsStatusesToDelete != null && taskIdsStatusesToDelete.Count > 0)
+            {
+                if (_serverStore.DatabaseInfoCache.BackupStatusStorage.DeleteBackupStatusesByTaskIds(_database.Name, _serverStore._env.Base64Id, taskIdsStatusesToDelete) == false)
+                    minLastEtag = 0; // deleting the local status did not succeed. we can't remove any tombstones because it is not guaranteed next backup will be full.
+            }
 
             if (minLastEtag == long.MaxValue)
                 return null;

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.OngoingTasks.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.OngoingTasks.cs
@@ -63,7 +63,7 @@ public partial class ShardedDatabaseContext
             return (null, OngoingTaskConnectionStatus.None);
         }
 
-        protected override PeriodicBackupStatus GetBackupStatus(long taskId, PeriodicBackupConfiguration backupConfiguration, out string responsibleNodeTag,
+        protected override PeriodicBackupStatus GetClusterBackupStatus(long taskId, PeriodicBackupConfiguration backupConfiguration, out string responsibleNodeTag,
             out NextBackup nextBackup, out RunningBackup onGoingBackup, out bool isEncrypted)
         {
             nextBackup = null;

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/DeleteLocalBackupStatusesCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/DeleteLocalBackupStatusesCommand.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.TransactionMerger.Commands
+{
+    public sealed class DeleteLocalBackupStatusesCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+    {
+        private readonly string _databaseName;
+        private readonly string _dbId;
+        private readonly HashSet<long> _taskIds;
+
+        public DeleteLocalBackupStatusesCommand(HashSet<long> taskIds, string databaseName, string dbId)
+        {
+            _databaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseName));
+            _dbId = dbId ?? throw new ArgumentNullException(nameof(dbId));
+            _taskIds = taskIds ?? throw new ArgumentNullException(nameof(taskIds));
+        }
+
+        protected override long ExecuteCmd(ClusterOperationContext context)
+        {
+            foreach (var taskId in _taskIds)
+            {
+                BackupStatusStorage.DeleteBackupStatus(context, _databaseName, _dbId, taskId);
+            }
+            return _taskIds.Count;
+        }
+
+        public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/UpdateLocalBackupStatusCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/UpdateLocalBackupStatusCommand.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Server.Documents.PeriodicBackup;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.TransactionMerger.Commands
+{
+    public sealed class UpdateLocalBackupStatusCommand : MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>
+    {
+        private readonly DynamicJsonValue _backupStatusAsJson;
+        private readonly string _databaseName;
+        private readonly string _dbId;
+        private readonly long _taskId;
+
+        public UpdateLocalBackupStatusCommand(PeriodicBackupStatus backupStatus, string databaseName, string dbId, long taskId)
+        {
+            _backupStatusAsJson = (backupStatus ?? throw new ArgumentNullException(nameof(backupStatus))).ToJson();
+            _databaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseName));
+            _dbId = dbId;
+            _taskId = taskId;
+        }
+
+        protected override long ExecuteCmd(ClusterOperationContext context)
+        {
+            var statusBlittable = context.ReadObject(_backupStatusAsJson, $"backup-status-update-taskId-{_taskId}", BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+            BackupStatusStorage.InsertBackupStatusBlittable(context, statusBlittable, _databaseName, _dbId, _taskId);
+            return 1;
+        }
+
+        public override IReplayableCommandDto<ClusterOperationContext, ClusterTransaction, MergedTransactionCommand<ClusterOperationContext, ClusterTransaction>> ToDto(ClusterOperationContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -24,6 +24,7 @@ using Raven.Client.Exceptions.Database;
 using Raven.Client.Exceptions.Documents.Subscriptions;
 using Raven.Client.Exceptions.Security;
 using Raven.Client.Http;
+using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations.Certificates;
@@ -1509,6 +1510,7 @@ namespace Raven.Server.ServerWide
                         throw new DatabaseDoesNotExistException($"Cannot set typed value of type {type} for database {updateCommand.DatabaseName}, because it does not exist");
 
                     updateCommand.Execute(context, items, index, databaseRecord, _parent.CurrentState, out result);
+                    updateCommand.AfterExecute(index, databaseRecord, context, _parent.ServerStore);
                 }
             }
             catch (Exception e)
@@ -2698,7 +2700,7 @@ namespace Raven.Server.ServerWide
                         throw new RachisApplyException("Failed to update database record.", e);
                     }
 
-                    updateCommand.AfterDatabaseRecordUpdate(context, items, _clusterAuditLog);
+                    updateCommand.AfterDatabaseRecordUpdate(context, items, serverStore, _clusterAuditLog);
 
                     if (databaseRecord.Topology?.Count == 0 && databaseRecord.DeletionInProgress.Count == 0)
                     {

--- a/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -63,7 +64,8 @@ public sealed class DelayBackupCommand : UpdateValueForDatabaseCommand
         var status = BackupUtils.GetLocalBackupStatusBlittable(serverStore, context, DatabaseName, TaskId);
         var updatedStatus =
             GetUpdatedValue(index, record, context, status);
-        serverStore.DatabaseInfoCache.BackupStatusStorage.InsertBackupStatusBlittable(context, updatedStatus.Value, DatabaseName, serverStore._env.Base64Id, TaskId);
+        
+        BackupStatusStorage.InsertBackupStatusBlittable(context, updatedStatus.Value, DatabaseName, serverStore._env.Base64Id, TaskId);
     }
 
     public override object GetState()

--- a/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DelayBackupCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -54,6 +55,15 @@ public sealed class DelayBackupCommand : UpdateValueForDatabaseCommand
         };
 
         return new UpdatedValue(UpdatedValueActionType.Update, context.ReadObject(status.ToJson(), GetItemId()));
+    }
+
+    public override void AfterExecute(long index, RawDatabaseRecord record, ClusterOperationContext context, ServerStore serverStore)
+    {
+        // get the status from local storage and update only relevant fields
+        var status = BackupUtils.GetLocalBackupStatusBlittable(serverStore, context, DatabaseName, TaskId);
+        var updatedStatus =
+            GetUpdatedValue(index, record, context, status);
+        serverStore.DatabaseInfoCache.BackupStatusStorage.InsertBackupStatusBlittable(context, updatedStatus.Value, DatabaseName, serverStore._env.Base64Id, TaskId);
     }
 
     public override object GetState()

--- a/src/Raven.Server/ServerWide/Commands/DeleteOngoingTaskCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteOngoingTaskCommand.cs
@@ -4,6 +4,7 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
+using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.ServerWide.Commands.PeriodicBackup;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -48,7 +49,7 @@ namespace Raven.Server.ServerWide.Commands
                     Delete(backupStatusKey);
 
                     // delete locally
-                    serverStore.DatabaseInfoCache.BackupStatusStorage.DeleteBackupStatus(ctx, DatabaseName, serverStore._env.Base64Id, TaskId);
+                    BackupStatusStorage.DeleteBackupStatus(ctx, DatabaseName, serverStore._env.Base64Id, TaskId);
 
                     void Delete(string key)
                     {

--- a/src/Raven.Server/ServerWide/Commands/DeleteOngoingTaskCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/DeleteOngoingTaskCommand.cs
@@ -33,7 +33,7 @@ namespace Raven.Server.ServerWide.Commands
         private long? _backupTaskIdToDelete;
         private string _hubNameToDelete;
 
-        public override void AfterDatabaseRecordUpdate(ClusterOperationContext ctx, Table items, Logger clusterAuditLog)
+        public override void AfterDatabaseRecordUpdate(ClusterOperationContext ctx, Table items, ServerStore serverStore, Logger clusterAuditLog)
         {
             switch (TaskType)
             {
@@ -46,6 +46,9 @@ namespace Raven.Server.ServerWide.Commands
 
                     var backupStatusKey = PeriodicBackupStatus.GenerateItemName(DatabaseName, _backupTaskIdToDelete.Value);
                     Delete(backupStatusKey);
+
+                    // delete locally
+                    serverStore.DatabaseInfoCache.BackupStatusStorage.DeleteBackupStatus(ctx, DatabaseName, serverStore._env.Base64Id, TaskId);
 
                     void Delete(string key)
                     {

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupCommand.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
             record.PeriodicBackups.Add(Configuration);
         }
 
-        public override void AfterDatabaseRecordUpdate(ClusterOperationContext ctx, Table items, Logger clusterAuditLog)
+        public override void AfterDatabaseRecordUpdate(ClusterOperationContext ctx, Table items, ServerStore serverStore, Logger clusterAuditLog)
         {
             if (_shouldRemoveBackupStatus == false)
                 return;
@@ -74,6 +74,9 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
             {
                 items.DeleteByKey(keyNameLowered);
             }
+            
+            // also delete the local backup status
+            serverStore.DatabaseInfoCache.BackupStatusStorage.DeleteBackupStatus(ctx, DatabaseName, serverStore._env.Base64Id, Configuration.TaskId);
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupCommand.cs
@@ -76,7 +76,7 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
             }
             
             // also delete the local backup status
-            serverStore.DatabaseInfoCache.BackupStatusStorage.DeleteBackupStatus(ctx, DatabaseName, serverStore._env.Base64Id, Configuration.TaskId);
+            BackupStatusStorage.DeleteBackupStatus(ctx, DatabaseName, serverStore._env.Base64Id, Configuration.TaskId);
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
@@ -5,6 +5,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.PeriodicBackup
 {
+    // This command is for updating the cluster backup status only. We do not want this to touch the local backup status
     public sealed class UpdatePeriodicBackupStatusCommand : UpdateValueForDatabaseCommand
     {
         public PeriodicBackupStatus PeriodicBackupStatus;

--- a/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/PeriodicBackup/UpdatePeriodicBackupStatusCommand.cs
@@ -1,12 +1,13 @@
-﻿using Raven.Client.Documents.Operations.Backups;
+﻿using System;
+using Raven.Client.Documents.Operations.Backups;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands.PeriodicBackup
 {
-    // This command is for updating the cluster backup status only. We do not want this to touch the local backup status
     public sealed class UpdatePeriodicBackupStatusCommand : UpdateValueForDatabaseCommand
     {
         public PeriodicBackupStatus PeriodicBackupStatus;
@@ -37,6 +38,33 @@ namespace Raven.Server.ServerWide.Commands.PeriodicBackup
             {
                 var status = GetUpdatedValue(index, record, context, null);
                 BackupStatusStorage.InsertBackupStatusBlittable(context, status.Value, DatabaseName, serverStore._env.Base64Id, PeriodicBackupStatus.TaskId);
+            }
+
+            // Delete the local status if we are a non responsible node and we are overdue on a full backup
+            var localStatus = BackupUtils.GetLocalBackupStatus(serverStore, context, DatabaseName, PeriodicBackupStatus.TaskId);
+
+            if (localStatus == null)
+                return;
+
+            var responsibleNode = BackupUtils.GetResponsibleNodeTag(serverStore, DatabaseName, PeriodicBackupStatus.TaskId);
+            var config = record.GetPeriodicBackupConfiguration(PeriodicBackupStatus.TaskId);
+            if (responsibleNode != null && responsibleNode != serverStore.NodeTag && config.FullBackupFrequency != null)
+            {
+                var nextFullBackup = BackupUtils.GetNextBackupOccurrence(new BackupUtils.NextBackupOccurrenceParameters()
+                {
+                    BackupFrequency = config.FullBackupFrequency,
+                    Configuration = config,
+                    LastBackupUtc = localStatus.LastFullBackupInternal ?? DateTime.MinValue
+                });
+
+                var now = DateTime.UtcNow;
+                if (nextFullBackup != null && nextFullBackup.Value.ToUniversalTime() < now)
+                {
+                    // we are overdue for a full backup, we can delete the local status to ensure the next backup will be full
+                    // this is in order to free the tombstone cleaners (for both local and compare exchange tombstones) to delete freely for this node
+
+                    BackupStatusStorage.DeleteBackupStatus(context, DatabaseName, serverStore._env.Base64Id, PeriodicBackupStatus.TaskId);
+                }
             }
         }
 

--- a/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Sharding/StartBucketMigrationCommand.cs
@@ -70,7 +70,7 @@ namespace Raven.Server.ServerWide.Commands.Sharding
             record.Sharding.BucketMigrations.Add(Bucket, _migration);
         }
 
-        public override void AfterDatabaseRecordUpdate(ClusterOperationContext ctx, Table items, Logger clusterAuditLog)
+        public override  void AfterDatabaseRecordUpdate(ClusterOperationContext ctx, Table items, ServerStore serverStore, Logger clusterAuditLog)
         {
             if (_migration == null)
                 return;

--- a/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateDatabaseCommand.cs
@@ -23,7 +23,7 @@ namespace Raven.Server.ServerWide.Commands
 
         public abstract void UpdateDatabaseRecord(DatabaseRecord record, long etag);
 
-        public virtual void AfterDatabaseRecordUpdate(ClusterOperationContext ctx, Table items, Logger clusterAuditLog)
+        public virtual void AfterDatabaseRecordUpdate(ClusterOperationContext ctx, Table items, ServerStore serverStore, Logger clusterAuditLog)
         {
 
         }

--- a/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdateValueForDatabaseCommand.cs
@@ -19,6 +19,10 @@ namespace Raven.Server.ServerWide.Commands
 
         protected abstract UpdatedValue GetUpdatedValue(long index, RawDatabaseRecord record, ClusterOperationContext context, BlittableJsonReaderObject existingValue);
 
+        public virtual void AfterExecute(long index, RawDatabaseRecord record, ClusterOperationContext context, ServerStore serverStore)
+        {
+        }
+
         public virtual unsafe void Execute(ClusterOperationContext context, Table items, long index, RawDatabaseRecord record, RachisState state, out object result)
         {
             result = null;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterNodeStatusReport.cs
@@ -69,7 +69,7 @@ namespace Raven.Server.ServerWide.Maintenance
         public Dictionary<string, ObservedIndexStatus> LastIndexStats = new Dictionary<string, ObservedIndexStatus>();
         public Dictionary<string, long> LastSentEtag = new Dictionary<string, long>();
         public Dictionary<int, BucketReport> ReportPerBucket = new Dictionary<int, BucketReport>();
-        public Dictionary<long, PeriodicBackupStatusReport> BackupStatuses = new ();
+        public Dictionary<long, PeriodicBackupStatusReport> BackupStatuses;
 
         public long LastCompareExchangeIndex { get; set; }
         public long LastClusterWideTransactionRaftIndex { get; set; }

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -681,7 +681,8 @@ namespace Raven.Server.ServerWide.Maintenance
                             if (clusterStatus == null)
                             {
                                 // existing backup hasn't run yet for the first time, we don't want to delete anything until we have a first status
-                                return 0;
+                                maxEtag = 0;
+                                return CompareExchangeTombstonesCleanupState.NoMoreTombstones;
                             }
 
                             continue;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -634,7 +634,7 @@ namespace Raven.Server.ServerWide.Maintenance
             NoMoreTombstones
         }
 
-        private CompareExchangeTombstonesCleanupState GetMaxCompareExchangeTombstonesEtagToDelete<TRavenTransaction>(TransactionOperationContext<TRavenTransaction> context, string databaseName, MergedDatabaseObservationState mergedState, out long maxEtag) where TRavenTransaction : RavenTransaction
+        private CompareExchangeTombstonesCleanupState GetMaxCompareExchangeTombstonesEtagToDelete(ClusterOperationContext context, string databaseName, MergedDatabaseObservationState mergedState, out long maxEtag)
         {
             maxEtag = -1;
             long minClusterWideTransactionIndex = -1;
@@ -720,6 +720,10 @@ namespace Raven.Server.ServerWide.Maintenance
                     }
 
                     var clusterWideTransactionIndex = report.LastClusterWideTransactionRaftIndex;
+
+                    if (_server.ForTestingPurposes?.IgnoreClusterTransactionIndexInCompareExchangeCleaner == true)
+                        clusterWideTransactionIndex = long.MaxValue;
+
                     if (minClusterWideTransactionIndex == -1 || clusterWideTransactionIndex < minClusterWideTransactionIndex)
                         minClusterWideTransactionIndex = clusterWideTransactionIndex;
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -664,8 +664,6 @@ namespace Raven.Server.ServerWide.Maintenance
                     if (hasReport == false)
                         return CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState;
 
-                    //Debug.Assert(EnumerableExtension.ElementsEqual(periodicBackupTaskIds, report.BackupStatuses.Select(x => x.Value.TaskId ?? -1).ToList()));
-
                     if (report.BackupStatuses == null)
                     {
                         // the node wasn't updated to a version that supports it

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -199,7 +199,7 @@ namespace Raven.Server.ServerWide
 
             ServerLimitsMonitor = new ServerLimitsMonitor(this, NotificationCenter, _notificationsStorage);
 
-            DatabaseInfoCache = new DatabaseInfoCache();
+            DatabaseInfoCache = new DatabaseInfoCache(this);
 
             Secrets = new SecretProtection(configuration.Security);
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3733,6 +3733,8 @@ namespace Raven.Server.ServerWide
             internal Action RestoreDatabaseAfterSavingDatabaseRecord;
             internal Action AfterCommitInClusterTransaction;
             internal Action<string, List<ClusterTransactionCommand.SingleClusterDatabaseCommand>> BeforeExecuteClusterTransactionBatch;
+            internal Action<ClusterObserver.CompareExchangeTombstonesCleanupState> AfterCompareExchangeTombstonesResult;
+            internal bool IgnoreClusterTransactionIndexInCompareExchangeCleaner;
         }
 
 #if DEBUG

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -585,7 +585,7 @@ internal static class BackupUtils
 
     public static PeriodicBackupStatus GetLocalBackupStatus(ServerStore serverStore, ClusterOperationContext context, string databaseName, long taskId)
     {
-        var localStatus = serverStore.DatabaseInfoCache.BackupStatusStorage.GetBackupStatus(databaseName, serverStore._env.Base64Id, taskId, context);
+        var localStatus = BackupStatusStorage.GetBackupStatus(databaseName, serverStore._env.Base64Id, taskId, context);
         if (localStatus != null)
             return localStatus;
 
@@ -600,7 +600,7 @@ internal static class BackupUtils
 
     public static BlittableJsonReaderObject GetLocalBackupStatusBlittable(ServerStore serverStore, ClusterOperationContext context, string databaseName, long taskId)
     {
-        var localStatus = serverStore.DatabaseInfoCache.BackupStatusStorage.GetBackupStatusBlittable(context, databaseName, serverStore._env.Base64Id, taskId);
+        var localStatus = BackupStatusStorage.GetBackupStatusBlittable(context, databaseName, serverStore._env.Base64Id, taskId);
         if (localStatus != null)
             return localStatus;
 

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -19,7 +19,6 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.PeriodicBackup.DirectUpload;
 using Raven.Server.NotificationCenter;
-using Raven.Server.Documents.TransactionCommands;
 using Raven.Server.Rachis;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands.PeriodicBackup;
@@ -152,7 +151,7 @@ internal static class BackupUtils
         return periodicBackupStatusJson;
     }
 
-    internal static BlittableJsonReaderObject GetBackupStatusFromClusterBlittable<T>(ServerStore serverStore, TransactionOperationContext<T> context, string databaseName, long taskId) where T : RavenTransaction
+    internal static BlittableJsonReaderObject GetBackupStatusFromClusterBlittable(ServerStore serverStore, ClusterOperationContext context, string databaseName, long taskId)
     {
         return serverStore.Cluster.Read(context, PeriodicBackupStatus.GenerateItemName(databaseName, taskId));
     }
@@ -577,14 +576,14 @@ internal static class BackupUtils
 
     public static PeriodicBackupStatus GetLocalBackupStatus(ServerStore serverStore, string databaseName, long taskId)
     {
-        using (serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+        using (serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
         using (context.OpenReadTransaction())
         {
             return GetLocalBackupStatus(serverStore, context, databaseName, taskId);
         }
     }
 
-    public static PeriodicBackupStatus GetLocalBackupStatus(ServerStore serverStore, TransactionOperationContext context, string databaseName, long taskId)
+    public static PeriodicBackupStatus GetLocalBackupStatus(ServerStore serverStore, ClusterOperationContext context, string databaseName, long taskId)
     {
         var localStatus = serverStore.DatabaseInfoCache.BackupStatusStorage.GetBackupStatus(databaseName, serverStore._env.Base64Id, taskId, context);
         if (localStatus != null)
@@ -599,7 +598,7 @@ internal static class BackupUtils
         return clusterStatus;
     }
 
-    public static BlittableJsonReaderObject GetLocalBackupStatusBlittable<T>(ServerStore serverStore, TransactionOperationContext<T> context, string databaseName, long taskId) where T : RavenTransaction
+    public static BlittableJsonReaderObject GetLocalBackupStatusBlittable(ServerStore serverStore, ClusterOperationContext context, string databaseName, long taskId)
     {
         var localStatus = serverStore.DatabaseInfoCache.BackupStatusStorage.GetBackupStatusBlittable(context, databaseName, serverStore._env.Base64Id, taskId);
         if (localStatus != null)

--- a/src/Raven.Server/Web/System/BackupDatabaseHandler.cs
+++ b/src/Raven.Server/Web/System/BackupDatabaseHandler.cs
@@ -3,6 +3,7 @@ using Raven.Server.Documents;
 using Raven.Server.Documents.Commands.OngoingTasks;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Server.Web.System.Processors.Backups;
 using Sparrow;
 using Sparrow.Json;

--- a/src/Raven.Server/Web/System/Processors/Backups/BackupDatabaseHandlerProcessorForGetPeriodicBackupStatus.cs
+++ b/src/Raven.Server/Web/System/Processors/Backups/BackupDatabaseHandlerProcessorForGetPeriodicBackupStatus.cs
@@ -29,7 +29,7 @@ internal sealed class BackupDatabaseHandlerProcessorForGetPeriodicBackupStatus :
         var taskId = RequestHandler.GetLongQueryString("taskId", required: true);
 
         if (StatusType.TryParse(type, ignoreCase: true, out StatusType statusType) == false)
-            throw new ArgumentException($"provided '{type}' has to be `{StatusType.Cluster.ToString()}` or '{StatusType.Local.ToString()}'");
+            throw new ArgumentException($"provided '{nameof(type)}' has to be `{StatusType.Cluster.ToString()}` or '{StatusType.Local.ToString()}'");
 
         using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
         using (context.OpenReadTransaction())

--- a/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
+++ b/test/RachisTests/DatabaseCluster/AtomicClusterReadWriteTests.cs
@@ -497,7 +497,7 @@ namespace RachisTests.DatabaseCluster
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
 
-            var (nodes, leader) = await CreateRaftCluster(3);
+            var (nodes, leader) = await CreateRaftCluster(3, watcherCluster: true);
             options.Server = leader;
             options.ReplicationFactor = nodes.Count;
             using var documentStore = InternalGetDocumentStore(options);

--- a/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
+++ b/test/RachisTests/DatabaseCluster/ClusterDatabaseMaintenance.cs
@@ -1376,7 +1376,7 @@ namespace RachisTests.DatabaseCluster
                 Servers.Add(nodes[1]);
 
                 //make sure leader and follower [2] disconnected
-                var db = await Databases.GetDocumentDatabaseInstanceFor(nodes[0], store);
+                var db = await Databases.GetDocumentDatabaseInstanceFor(nodes[0], store.Database);
                 await WaitAndAssertForValueAsync(() =>
                 {
                     var record = db.ReadDatabaseRecord();

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1546,7 +1546,7 @@ namespace SlowTests.Client.Subscriptions
 
             await store.Subscriptions.DeleteAsync(name);
 
-            var db = await Databases.GetDocumentDatabaseInstanceFor(server, store);
+            var db = await Databases.GetDocumentDatabaseInstanceFor(server, store.Database);
             await AssertWaitForExceptionAsync<KeyNotFoundException>(async () => await Task.Run(() => db.SubscriptionStorage.GetSubscriptionStateById(state.SubscriptionId)), interval: 1000);
         }
 

--- a/test/SlowTests/Issues/RavenDB-13553.cs
+++ b/test/SlowTests/Issues/RavenDB-13553.cs
@@ -64,7 +64,7 @@ namespace SlowTests.Issues
                 }
 
                 var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var status = documentDatabase.PeriodicBackupRunner.GetBackupStatus(config.TaskId);
+                var status = documentDatabase.PeriodicBackupRunner.GetMostUpdatedClusterBackupStatus(config.TaskId);
                 var nextBackupDetails = documentDatabase.PeriodicBackupRunner.GetNextBackupDetails(record.PeriodicBackups.First(), status, out var responsibleNode);
                 
                 Assert.True(nextBackupDetails.IsFull);

--- a/test/SlowTests/Issues/RavenDB-19379.cs
+++ b/test/SlowTests/Issues/RavenDB-19379.cs
@@ -46,7 +46,7 @@ namespace SlowTests.Issues
             {
                 server.ServerStore.Configuration.Databases.FrequencyToCheckForIdle = new TimeSetting(1000, TimeUnit.Seconds);
 
-                var database = await Databases.GetDocumentDatabaseInstanceFor(server, store);
+                var database = await Databases.GetDocumentDatabaseInstanceFor(server, store.Database);
                 var dbIdEtagDictionary = new Dictionary<string, long>();
                 using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
                 using (documentsContext.OpenReadTransaction())

--- a/test/SlowTests/Issues/RavenDB-22573.cs
+++ b/test/SlowTests/Issues/RavenDB-22573.cs
@@ -23,7 +23,7 @@ namespace SlowTests.Issues
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "0 1 * * *", backupType: BackupType.Backup, disabled: false);
                 var id = await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
                 var documentDatabase = await Databases.GetDocumentDatabaseInstanceFor(store);
-                var status = documentDatabase.PeriodicBackupRunner.GetBackupStatus(id);
+                var status = documentDatabase.PeriodicBackupRunner.GetMostUpdatedClusterBackupStatus(id);
                 config.TaskId = id;
                 var nextBackupDetails = periodicBackupRunner.GetNextBackupDetails(config, status, out string _);
                 var nextBackup = nextBackupDetails.DateTime.ToLocalTime();

--- a/test/SlowTests/Issues/RavenDB_20206.cs
+++ b/test/SlowTests/Issues/RavenDB_20206.cs
@@ -36,10 +36,6 @@ public class RavenDB_20206 : RavenTestBase
                 indexesList2.Add($"{i}", res2.Index);
             }
 
-            // incremental backup on store2 db so observer ob store2 won't delete its tombstones
-            var config = Backup.CreateBackupConfiguration("backupFolder", incrementalBackupFrequency: "0 0 1 * *");
-            var taskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store2, isFullBackup: false);
-
             // delete 1 unique value
             var del1 = await store1.Operations.SendAsync(new DeleteCompareExchangeValueOperation<int>("2", indexesList1["2"]));
             Assert.NotNull(del1.Value);

--- a/test/SlowTests/Issues/RavenDB_20206.cs
+++ b/test/SlowTests/Issues/RavenDB_20206.cs
@@ -36,6 +36,10 @@ public class RavenDB_20206 : RavenTestBase
                 indexesList2.Add($"{i}", res2.Index);
             }
 
+            // incremental backup on store2 db so observer ob store2 won't delete its tombstones
+            var config = Backup.CreateBackupConfiguration("backupFolder", incrementalBackupFrequency: "0 0 1 * *");
+            var taskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store2, isFullBackup: false);
+
             // delete 1 unique value
             var del1 = await store1.Operations.SendAsync(new DeleteCompareExchangeValueOperation<int>("2", indexesList1["2"]));
             Assert.NotNull(del1.Value);

--- a/test/SlowTests/Issues/RavenDB_21553.cs
+++ b/test/SlowTests/Issues/RavenDB_21553.cs
@@ -96,7 +96,7 @@ namespace SlowTests.Issues
                 {
                     try
                     {
-                        await Databases.GetDocumentDatabaseInstanceFor(removedServer, leaderStore);
+                        await Databases.GetDocumentDatabaseInstanceFor(removedServer, leaderStore.Database);
                     }
                     catch (DatabaseNotRelevantException)
                     {

--- a/test/SlowTests/Issues/RavenDB_21780.cs
+++ b/test/SlowTests/Issues/RavenDB_21780.cs
@@ -54,7 +54,7 @@ public class RavenDB_21780 : ClusterTestBase
 
 
         // enforce
-        var db = await Databases.GetDocumentDatabaseInstanceFor(Server, store, store.Database);
+        var db = await Databases.GetDocumentDatabaseInstanceFor(Server, store.Database);
         using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
             await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Users" }, token: token);
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
@@ -2,16 +2,21 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NCrontab.Advanced;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.Backups.Sharding;
 using Raven.Client.Documents.Operations.CompareExchange;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.ServerWide.Commands.PeriodicBackup;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Issues;
 using Tests.Infrastructure;
@@ -54,10 +59,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     Disabled = false,
                     FullBackupFrequency = "0 0 1 1 *",
                     IncrementalBackupFrequency = "0 0 * * *",
-                    LocalSettings = new LocalSettings
-                    {
-                        FolderPath = backupPath
-                    }
+                    LocalSettings = new LocalSettings { FolderPath = backupPath }
                 };
                 var taskId = await Backup.UpdateConfigAsync(leader, config, store);
                 var originalNode = Backup.GetBackupResponsibleNode(leader, taskId, store.Database);
@@ -122,6 +124,158 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 await WaitForValueAsync(async () =>
                 {
                     status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    return status?.NodeTag == originalNode;
+                }, true, timeout: 70_000);
+                Assert.NotNull(status);
+                Assert.Equal(originalNode, status.NodeTag);
+                Assert.False(status.IsFull, "Backup should be incremental but is full");
+                Assert.NotNull(status.LastIncrementalBackup);
+
+                // assert no new dirs of full backup - original node directory should have a file for full and a file for incremental
+                var dirsAfterSwitchBack = Directory.GetFiles(nodesBackupDir);
+                Assert.Equal(2, dirsAfterSwitchBack.Length);
+
+                // other node directory should only have a file for full
+                dirsAfterSwitchBack = Directory.GetFiles(otherNodeDir[0]);
+                Assert.Equal(1, dirsAfterSwitchBack.Length);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        public async Task DontRunFullBackupAgainIfComingBackFromAnotherNodeSharded()
+        {
+            var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Cluster.CompareExchangeTombstonesCleanupInterval), "0" }, };
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true, customSettings: settings);
+            var options = Sharding.GetOptionsForCluster(leader, shards: 1, shardReplicationFactor: 3, orchestratorReplicationFactor: 3);
+
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Stav" }, "users/1");
+                    await session.SaveChangesAsync();
+                    var exists = await WaitForDocumentInClusterAsync<User>(nodes, store.Database, "users/1", x => x.Name == "Stav", TimeSpan.FromSeconds(10));
+                    Assert.True(exists);
+                }
+
+                var nextBackup = GetTimeUntilBackupNextOccurence("0 0 * * *", DateTime.UtcNow);
+                if (nextBackup < TimeSpan.FromSeconds(10))
+                    await Task.Delay(nextBackup);
+
+                // put backup config
+                var config = new PeriodicBackupConfiguration()
+                {
+                    Disabled = false,
+                    FullBackupFrequency = "0 0 1 1 *",
+                    IncrementalBackupFrequency = "0 0 * * *",
+                    LocalSettings = new LocalSettings { FolderPath = backupPath }
+                };
+
+                var shardName = ShardHelper.ToShardName(store.Database, 0);
+                var taskId = await Sharding.Backup.UpdateConfigAsync(leader, config, store);
+                var originalNode = Backup.GetBackupResponsibleNode(leader, taskId, shardName);
+                var originalNodeServer = nodes.Single(x => x.ServerStore.NodeTag == originalNode);
+
+                await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: false);
+
+                var otherNodeServer = nodes.First(x => x.ServerStore.NodeTag != originalNode);
+
+                // check the backup status
+                await WaitForAssertionAsync(async () =>
+                {
+                    var backupStatus = await store.Maintenance.SendAsync(new GetShardedPeriodicBackupStatusOperation(taskId));
+                    Assert.NotNull(backupStatus?.Statuses.SingleOrDefault().Value);
+                    Assert.Equal(originalNode, backupStatus.Statuses.Single().Value.NodeTag);
+                });
+
+                // assert number of directories
+                var dirs = Directory.GetDirectories(backupPath);
+                Assert.Equal(1, dirs.Length);
+                var nodesBackupDir = dirs[0];
+
+                var innerDirs = Directory.GetFiles(nodesBackupDir);
+                Assert.Equal(1, innerDirs.Length);
+                Assert.True(innerDirs[0].Contains(originalNode));
+
+                // change responsible node to other node
+                var command = new UpdateResponsibleNodeForTasksCommand(
+                    new UpdateResponsibleNodeForTasksCommand.Parameters()
+                    {
+                        ResponsibleNodePerDatabase = new Dictionary<string, List<ResponsibleNodeInfo>>()
+                        {
+                            {
+                                shardName,
+                                new List<ResponsibleNodeInfo>()
+                                {
+                                    new ResponsibleNodeInfo() { TaskId = taskId, ResponsibleNode = otherNodeServer.ServerStore.NodeTag }
+                                }
+                            }
+                        }
+                    }, RaftIdGenerator.NewId());
+                var result = await leader.ServerStore.SendToLeaderAsync(command);
+                await leader.ServerStore.Cluster.WaitForIndexNotification(result.Index);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, shardName, differentThan: originalNode);
+
+                // run full backup on new node
+                await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: false);
+
+                // wait until status is updated with new node
+                PeriodicBackupStatus status = null;
+                await WaitForValueAsync(async () =>
+                {
+                    status = (await store.Maintenance.SendAsync(new GetShardedPeriodicBackupStatusOperation(taskId))).Statuses?.SingleOrDefault().Value;
+                    return status?.NodeTag == otherNodeServer.ServerStore.NodeTag;
+                }, true, timeout: 70_000);
+                Assert.NotNull(status);
+                Assert.Equal(otherNodeServer.ServerStore.NodeTag, status.NodeTag);
+                Assert.True(status.IsFull);
+                Assert.NotNull(status.LastFullBackup);
+
+                // assert number of directories grew
+                var otherNodeDir = Directory.GetDirectories(backupPath).Except(dirs).ToArray();
+                Assert.Equal(1, otherNodeDir.Length);
+                Assert.True(otherNodeDir[0].Contains(otherNodeServer.ServerStore.NodeTag));
+
+                // change responsible node back to original
+                command = new UpdateResponsibleNodeForTasksCommand(
+                    new UpdateResponsibleNodeForTasksCommand.Parameters()
+                    {
+                        ResponsibleNodePerDatabase = new Dictionary<string, List<ResponsibleNodeInfo>>()
+                        {
+                            {
+                                shardName,
+                                new List<ResponsibleNodeInfo>()
+                                {
+                                    new ResponsibleNodeInfo() { TaskId = taskId, ResponsibleNode = originalNode }
+                                }
+                            }
+                        }
+                    }, RaftIdGenerator.NewId());
+                result = await leader.ServerStore.SendToLeaderAsync(command);
+                await leader.ServerStore.Cluster.WaitForIndexNotification(result.Index);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, shardName, differentThan: otherNodeServer.ServerStore.NodeTag);
+
+                // add doc so incremental has something to save
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Stav" }, "users/2");
+                    await session.SaveChangesAsync();
+                    var exists = await WaitForDocumentInClusterAsync<User>(nodes, store.Database, "users/2", x => x.Name == "Stav", TimeSpan.FromSeconds(10));
+                    Assert.True(exists);
+                }
+
+                // run the backup again - should be running incremental this time
+                await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: false);
+                
+                // wait until backup finishes and saves the backup statuses - should be incremental backup and not a full one
+                status = null;
+                await WaitForValueAsync(async () =>
+                {
+                    status = (await store.Maintenance.SendAsync(new GetShardedPeriodicBackupStatusOperation(taskId))).Statuses?.SingleOrDefault().Value;
                     return status?.NodeTag == originalNode;
                 }, true, timeout: 70_000);
                 Assert.NotNull(status);
@@ -254,7 +408,141 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 Assert.Equal(0, stats.CountOfCompareExchange);
             }
         }
-        
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster | RavenTestCategory.CompareExchange | RavenTestCategory.Sharding)]
+        public async Task CompareExchangeTombstonesShouldNotBeCleanedIfNotBackedUpForLocalNodeSharded()
+        {
+            // A does full backup on compare exchanges, backup moves to B, cx deleted, B does full backup on their tombstones, backup moves back to A, A should still have the tombstones to back up
+            // they should not have been deleted by the observer because of A's low index should prevent it
+            var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Cluster.MaxClusterTransactionCompareExchangeTombstoneCheckInterval), "0" }, };
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var incrementalFrequency = "0 0 * * *";
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true, customSettings: settings);
+            var options = Sharding.GetOptionsForCluster(leader, shards: 1, shardReplicationFactor: 3, orchestratorReplicationFactor: 3);
+
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Stav" }, "users/1");
+                    await session.SaveChangesAsync();
+                    var exists = await WaitForDocumentInClusterAsync<User>(nodes, store.Database, "users/1", x => x.Name == "Stav", TimeSpan.FromSeconds(10));
+                    Assert.True(exists);
+                }
+
+                var nextBackup = GetTimeUntilBackupNextOccurence(incrementalFrequency, DateTime.UtcNow);
+                if (nextBackup < TimeSpan.FromSeconds(8))
+                    await Task.Delay(nextBackup);
+
+                // put compare exchanges
+                var cmpxchngRes1 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/1", new User { Name = "Stav1" }, 0));
+                var cmpxchngRes2 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/2", new User { Name = "Stav2" }, 0));
+                var cmpxchngRes3 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/3", new User { Name = "Stav3" }, 0));
+                Assert.True(cmpxchngRes1.Successful);
+                Assert.True(cmpxchngRes2.Successful);
+                Assert.True(cmpxchngRes3.Successful);
+
+                var shardName = ShardHelper.ToShardName(store.Database, 0);
+                var stats = store.Maintenance.ForDatabase(store.Database).ForNode("A").ForShard(0).Send(new GetDetailedStatisticsOperation());
+                Assert.Equal(3, stats.CountOfCompareExchange);
+                
+                // node backs up compare exchanges
+                var config = new PeriodicBackupConfiguration()
+                {
+                    Disabled = false,
+                    FullBackupFrequency = "0 0 1 1 *",
+                    IncrementalBackupFrequency = incrementalFrequency,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                };
+                var taskId = await Sharding.Backup.UpdateConfigAsync(leader, config, store);
+                var originalNode = Backup.GetBackupResponsibleNode(leader, taskId, shardName);
+                var originalNodeServer = nodes.Single(x => x.ServerStore.NodeTag == originalNode);
+                var otherNodeServer = nodes.First(x => x.ServerStore.NodeTag != originalNode);
+
+                // first backup will be full
+                await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: false);
+
+                // check the backup status
+                await WaitForAssertionAsync(async () =>
+                {
+                    var backupStatus = (await store.Maintenance.ForShard(0).SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    Assert.NotNull(backupStatus);
+                    Assert.Equal(originalNode, backupStatus.NodeTag);
+                    Assert.True(backupStatus.IsFull);
+                });
+
+                // assert number of directories
+                var dirs = Directory.GetDirectories(backupPath);
+                Assert.Equal(1, dirs.Length);
+
+                var nodesBackupDir = dirs[0];
+                var originalNodeFiles = Directory.GetFiles(nodesBackupDir);
+                Assert.Equal(1, originalNodeFiles.Length);
+                Assert.True(originalNodeFiles[0].Contains(originalNode));
+
+                // change responsible node to other node
+                var command = new UpdateResponsibleNodeForTasksCommand(
+                    new UpdateResponsibleNodeForTasksCommand.Parameters()
+                    {
+                        ResponsibleNodePerDatabase = new Dictionary<string, List<ResponsibleNodeInfo>>()
+                        {
+                            {
+                                shardName,
+                                new List<ResponsibleNodeInfo>()
+                                {
+                                    new ResponsibleNodeInfo() { TaskId = taskId, ResponsibleNode = otherNodeServer.ServerStore.NodeTag }
+                                }
+                            }
+                        }
+                    }, RaftIdGenerator.NewId());
+                var result = await leader.ServerStore.SendToLeaderAsync(command);
+                await leader.ServerStore.Cluster.WaitForIndexNotification(result.Index);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, databaseName: shardName, differentThan: originalNode);
+
+                // delete compare exchanges -> tombstones created
+                var delRes1 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/1", cmpxchngRes1.Index));
+                var delRes2 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/2", cmpxchngRes2.Index));
+                var delRes3 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/3", cmpxchngRes3.Index));
+                Assert.True(delRes1.Successful);
+                Assert.True(delRes2.Successful);
+                Assert.True(delRes3.Successful);
+
+                // first backup on new node will be full - this includes the tombstones
+                await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: false);
+
+                PeriodicBackupStatus status = null;
+                // wait until status is updated with new node
+                var res = await WaitForValueAsync(async () =>
+                {
+                    status = (await store.Maintenance.ForShard(0).SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    return status.NodeTag == otherNodeServer.ServerStore.NodeTag;
+                }, true, timeout: 70_000);
+                Assert.Equal(otherNodeServer.ServerStore.NodeTag, status.NodeTag);
+                Assert.True(status.IsFull, "Backup wasn't full");
+                Assert.NotNull(status.LastFullBackup);
+                Assert.True(status.LastRaftIndex.LastEtag >= delRes3.Index, "tombstones raft index is not included in the backup");
+
+                // assert number of directories grew
+                var otherNodeDir = Directory.GetDirectories(backupPath).Except(dirs).ToArray();
+                Assert.Equal(1, otherNodeDir.Length);
+                Assert.True(otherNodeDir[0].Contains(otherNodeServer.ServerStore.NodeTag));
+                var otherNodeFiles = Directory.GetFiles(otherNodeDir[0]);
+                Assert.Equal(1, otherNodeFiles.Length);
+
+                // run cx tombstone cleaner
+                await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
+
+                // tombstones should not have been deleted
+                stats = store.Maintenance.ForDatabase(store.Database).ForNode("A").ForShard(0).Send(new GetDetailedStatisticsOperation());
+                Assert.Equal(3, stats.CountOfCompareExchangeTombstones);
+                Assert.Equal(0, stats.CountOfCompareExchange);
+            }
+        }
+
         [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster | RavenTestCategory.CompareExchange)]
         public async Task CompareExchangeTombstonesShouldNotGatherIndefinitelyAndShouldBeDeletedAfterNextFull()
         {
@@ -373,6 +661,152 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
                     stats = store.Maintenance.ForDatabase(store.Database).Send(new GetDetailedStatisticsOperation());
+                    return stats.CountOfCompareExchangeTombstones == 0;
+                }, true);
+                Assert.Equal(0, stats.CountOfCompareExchangeTombstones);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster | RavenTestCategory.CompareExchange | RavenTestCategory.Sharding)]
+        public async Task CompareExchangeTombstonesShouldNotGatherIndefinitelyAndShouldBeDeletedAfterNextFullSharded()
+        {
+            // This test checks tombstones don't gather indefinitely because a non-responsible node is stuck with a backup status of low index that won't increase.
+            // Once the non-responsible node is overdue on its full backup, the local status is deleted and tombstones will be deleted.
+
+            var fullBackupFrequency = "*/2 * * * *";
+            var incrementalFrequency = "* * * * *";
+
+            var settings = new Dictionary<string, string>
+            {
+                { RavenConfiguration.GetKey(x => x.Cluster.MaxClusterTransactionCompareExchangeTombstoneCheckInterval), "0" },
+                { RavenConfiguration.GetKey(x => x.Tombstones.CleanupInterval), 1.ToString()},
+                { RavenConfiguration.GetKey(x => x.Cluster.WorkerSamplePeriod), 1000.ToString()}
+            };
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true, customSettings: settings);
+            var options = Sharding.GetOptionsForCluster(leader, shards: 1, shardReplicationFactor: 3, orchestratorReplicationFactor: 3);
+
+            using (var store = GetDocumentStore(options))
+            {
+                // create cx
+                var cmpxchngRes1 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/1", new User { Name = "Stav1" }, 0));
+                var cmpxchngRes2 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/2", new User { Name = "Stav2" }, 0));
+                Assert.True(cmpxchngRes1.Successful);
+                Assert.True(cmpxchngRes2.Successful);
+
+                // stabilize test - if next full is very close, wait it out
+                var timeUntilNextOccurence = GetTimeUntilBackupNextOccurence(fullBackupFrequency, DateTime.UtcNow);
+                if (timeUntilNextOccurence < TimeSpan.FromSeconds(20))
+                    await Task.Delay(timeUntilNextOccurence);
+
+                var shardName = ShardHelper.ToShardName(store.Database, 0);
+
+                // setup config with full and incremental freq and do first full backup
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: fullBackupFrequency, incrementalBackupFrequency: incrementalFrequency);
+                var taskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(nodes, store, config, isFullBackup: false);
+
+                var originalNode = Backup.GetBackupResponsibleNode(leader, taskId, shardName);
+                var originalNodeServer = nodes.Single(x => x.ServerStore.NodeTag == originalNode);
+                var otherNodeServer = nodes.First(x => x.ServerStore.NodeTag != originalNode);
+                var db = await Databases.GetDocumentDatabaseInstanceFor(originalNodeServer, shardName);
+
+                await WaitForAssertionAsync(async () =>
+                {
+                    var status = (await store.Maintenance.ForShard(0).SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    Assert.NotNull(status);
+                    Assert.Equal(originalNodeServer.ServerStore.NodeTag, status.NodeTag);
+                    Assert.True(status.IsFull);
+                });
+
+                // delete cx
+                var delRes1 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/1", cmpxchngRes1.Index));
+                Assert.True(delRes1.Successful);
+
+                // change responsible node
+                var command = new UpdateResponsibleNodeForTasksCommand(
+                    new UpdateResponsibleNodeForTasksCommand.Parameters()
+                    {
+                        ResponsibleNodePerDatabase = new Dictionary<string, List<ResponsibleNodeInfo>>()
+                        {
+                            {
+                                shardName,
+                                new List<ResponsibleNodeInfo>()
+                                {
+                                    new ResponsibleNodeInfo() { TaskId = taskId, ResponsibleNode = otherNodeServer.ServerStore.NodeTag }
+                                }
+                            }
+                        }
+                    }, RaftIdGenerator.NewId());
+                var result = await leader.ServerStore.SendToLeaderAsync(command);
+                await leader.ServerStore.Cluster.WaitForIndexNotification(result.Index);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, databaseName: shardName, differentThan: originalNode);
+                await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: false); // don't force full. should happen by itself
+
+                // check cluster backup status is as expected
+                await WaitForAssertionAsync(async () =>
+                {
+                    var status = (await store.Maintenance.ForShard(0).SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    Assert.NotNull(status);
+                    Assert.Equal(otherNodeServer.ServerStore.NodeTag, status.NodeTag);
+                    Assert.True(status.IsFull);
+                });
+
+                // run cleaner
+                await db.TombstoneCleaner.ExecuteCleanup();
+                await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
+
+                // check tombstones not deleted
+                var stats = store.Maintenance.ForDatabase(store.Database).ForShard(0).ForNode("A").Send(new GetDetailedStatisticsOperation());
+                Assert.Equal(1, stats.CountOfCompareExchangeTombstones);
+                Assert.Equal(1, stats.CountOfCompareExchange);
+
+                // delete another cx
+                var delRes2 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/2", cmpxchngRes2.Index));
+                Assert.True(delRes2.Successful);
+
+                // run the incremental
+                await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: false);
+
+                await WaitForAssertionAsync(async () =>
+                {
+                    var status = (await store.Maintenance.ForShard(0).SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    Assert.NotNull(status.LastIncrementalBackup);
+                    Assert.False(status.IsFull);
+                });
+                
+                // run the cleaner - this should not delete anything
+                await db.TombstoneCleaner.ExecuteCleanup();
+                await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
+
+                // check local status not null and tombstones not deleted
+                var localStatus = BackupUtils.GetLocalBackupStatus(originalNodeServer.ServerStore, shardName, taskId);
+                Assert.NotNull(localStatus);
+                Assert.NotNull(localStatus.LastFullBackupInternal);
+
+                stats = store.Maintenance.ForDatabase(store.Database).ForShard(0).ForNode("A").Send(new GetDetailedStatisticsOperation());
+                Assert.Equal(2, stats.CountOfCompareExchangeTombstones);
+                Assert.Equal(0, stats.CountOfCompareExchange);
+
+                // wait until full is overdue on not-responsible
+                await Task.Delay(GetTimeUntilBackupNextOccurence(fullBackupFrequency, localStatus.LastFullBackupInternal ?? DateTime.UtcNow));
+
+                // run cleaner
+                await db.TombstoneCleaner.ExecuteCleanup();
+                await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
+
+                // wait for local backup status to be deleted
+                await WaitForValueAsync(() =>
+                {
+                    localStatus = BackupUtils.GetLocalBackupStatus(originalNodeServer.ServerStore, shardName, taskId);
+                    return localStatus == null;
+                }, true);
+                Assert.Null(localStatus);
+
+                await WaitForValueAsync(async () =>
+                {
+                    await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
+                    stats = store.Maintenance.ForDatabase(store.Database).ForShard(0).ForNode("A").Send(new GetDetailedStatisticsOperation());
                     return stats.CountOfCompareExchangeTombstones == 0;
                 }, true);
                 Assert.Equal(0, stats.CountOfCompareExchangeTombstones);
@@ -513,6 +947,179 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 await WaitForValueAsync(() =>
                 {
                     localStatus = BackupUtils.GetLocalBackupStatus(originalNodeServer.ServerStore, store.Database, taskId);
+                    return localStatus == null;
+                }, true);
+                Assert.Null(localStatus);
+
+                // wait for tombstones to be deleted
+                await WaitForValueAsync(() =>
+                {
+                    using (dbOriginal.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        var count = dbOriginal.DocumentsStorage.GetNumberOfTombstones(context);
+                        return count;
+                    }
+                }, 0);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        public async Task TombstonesShouldNotGatherIndefinitelyAndShouldBeDeletedAfterNextFullSharded()
+        {
+            // This test checks tombstones don't gather indefinitely because on a node because the backup moved from it to a different node.
+            // Tombstones on the non-responsible node can't be deleted until it is guaranteed the next backup will be full.
+            // Once the non-responsible node is overdue on its full backup, the local status is deleted and tombstones will be deleted.
+
+            var fullBackupFrequency = "*/2 * * * *";
+            var incrementalFrequency = "* * * * *";
+
+            var settings = new Dictionary<string, string>
+            {
+                { RavenConfiguration.GetKey(x => x.Tombstones.CleanupInterval), 1.ToString()}
+            };
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true, customSettings: settings);
+            var options = Sharding.GetOptionsForCluster(leader, shards: 1, shardReplicationFactor: 3, orchestratorReplicationFactor: 3);
+
+            using (var store = GetDocumentStore(options))
+            {
+                // create docs
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), "users/1");
+                    session.Store(new User(), "users/2");
+                    session.SaveChanges();
+                }
+
+                // stabilize test - if next full is very close, wait it out
+                var timeUntilNextOccurence = GetTimeUntilBackupNextOccurence(fullBackupFrequency, DateTime.UtcNow);
+                await Task.Delay(timeUntilNextOccurence);
+
+                // setup config with full and incremental freq and do first full backup
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: fullBackupFrequency, incrementalBackupFrequency: incrementalFrequency);
+                var taskId = await Sharding.Backup.UpdateConfigurationAndRunBackupAsync(nodes[0], store, config, isFullBackup: false);
+
+                var shardName = ShardHelper.ToShardName(store.Database, 0);
+                var originalNode = Backup.GetBackupResponsibleNode(leader, taskId, shardName);
+                var originalNodeServer = nodes.Single(x => x.ServerStore.NodeTag == originalNode);
+                var otherNodeServer = nodes.First(x => x.ServerStore.NodeTag != originalNode);
+                var dbOriginal = await Databases.GetDocumentDatabaseInstanceFor(originalNodeServer, shardName);
+                var dbOther = await Databases.GetDocumentDatabaseInstanceFor(otherNodeServer, shardName);
+
+                await WaitForAssertionAsync(async () =>
+                {
+                    var status = (await store.Maintenance.ForShard(0).SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    Assert.NotNull(status);
+                    Assert.Equal(originalNodeServer.ServerStore.NodeTag, status.NodeTag);
+                    Assert.True(status.IsFull);
+                });
+
+                // delete doc - create tombstone
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/1");
+                    session.SaveChanges();
+                }
+
+                // move backup to another node and wait to finish
+                var command = new UpdateResponsibleNodeForTasksCommand(
+                    new UpdateResponsibleNodeForTasksCommand.Parameters()
+                    {
+                        ResponsibleNodePerDatabase = new Dictionary<string, List<ResponsibleNodeInfo>>()
+                        {
+                            {
+                                shardName,
+                                new List<ResponsibleNodeInfo>()
+                                {
+                                    new ResponsibleNodeInfo() { TaskId = taskId, ResponsibleNode = otherNodeServer.ServerStore.NodeTag }
+                                }
+                            }
+                        }
+                    }, RaftIdGenerator.NewId());
+                var result = await leader.ServerStore.SendToLeaderAsync(command);
+                await leader.ServerStore.Cluster.WaitForIndexNotification(result.Index);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, databaseName: shardName, differentThan: originalNode);
+                await Sharding.Backup.RunBackupAsync(store, taskId, isFullBackup: false); // don't force full. should happen by itself
+
+                // check cluster backup status is as expected
+                PeriodicBackupStatus status = null;
+                await WaitForAssertionAsync(async () =>
+                {
+                    status = (await store.Maintenance.ForShard(0).SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    Assert.NotNull(status);
+                    Assert.Equal(otherNodeServer.ServerStore.NodeTag, status.NodeTag);
+                    Assert.True(status.IsFull);
+                });
+
+                // run cleaner
+                await dbOriginal.TombstoneCleaner.ExecuteCleanup();
+                await dbOther.TombstoneCleaner.ExecuteCleanup();
+
+                // check tombstone not deleted - we are not yet overdue
+                using (dbOriginal.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var tombstonesCount = dbOriginal.DocumentsStorage.GetNumberOfTombstones(context);
+                    var docCount = dbOriginal.DocumentsStorage.GetNumberOfDocuments(context);
+                    Assert.Equal(1, docCount);
+                    Assert.Equal(1, tombstonesCount);
+                }
+
+                // delete another doc
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/2");
+                    session.SaveChanges();
+                }
+
+                // run the incremental
+                await Task.Delay(GetTimeUntilBackupNextOccurence(incrementalFrequency, status.LastFullBackupInternal ?? DateTime.UtcNow));
+                var res = await WaitForValueAsync(async () =>
+                {
+                    status = (await store.Maintenance.ForShard(0).SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    return status.LastIncrementalBackup != null;
+                }, true, timeout: 70_000);
+                Assert.True(res, $"Incremental hasn't happened");
+                Assert.False(status.IsFull);
+
+                // run cleaner
+                await dbOriginal.TombstoneCleaner.ExecuteCleanup();
+                await dbOther.TombstoneCleaner.ExecuteCleanup();
+
+                // check local status not null and tombstones not deleted
+                var localStatus = BackupUtils.GetLocalBackupStatus(originalNodeServer.ServerStore, shardName, taskId);
+                Assert.NotNull(localStatus);
+                Assert.NotNull(localStatus.LastFullBackupInternal);
+
+                // on original server not deleted
+                using (dbOriginal.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var count = dbOriginal.DocumentsStorage.GetNumberOfTombstones(context);
+                    Assert.Equal(2, count);
+                }
+
+                // on responsible node already deleted by incremental
+                using (dbOther.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var count = dbOther.DocumentsStorage.GetNumberOfTombstones(context);
+                    Assert.Equal(0, count);
+                }
+
+                // wait until full is overdue on not-responsible
+                await Task.Delay(GetTimeUntilBackupNextOccurence(fullBackupFrequency, localStatus.LastFullBackupInternal ?? DateTime.UtcNow));
+
+                // run cleaner
+                await dbOriginal.TombstoneCleaner.ExecuteCleanup();
+                await dbOther.TombstoneCleaner.ExecuteCleanup();
+
+                // wait for local backup status to be deleted
+                await WaitForValueAsync(() =>
+                {
+                    localStatus = BackupUtils.GetLocalBackupStatus(originalNodeServer.ServerStore, shardName, taskId);
                     return localStatus == null;
                 }, true);
                 Assert.Null(localStatus);

--- a/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/ClusterBackupTests.cs
@@ -1,0 +1,617 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NCrontab.Advanced;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Issues;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using BackupUtils = Raven.Server.Utils.BackupUtils;
+
+namespace SlowTests.Server.Documents.PeriodicBackup
+{
+    internal class ClusterBackupTests : ClusterTestBase
+    {
+        public ClusterBackupTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster)]
+        public async Task DontRunFullBackupAgainIfComingBackFromAnotherNode()
+        {
+            var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Cluster.CompareExchangeTombstonesCleanupInterval), "0" }, };
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true, customSettings: settings);
+
+            using (var store = GetDocumentStore(new Options { ReplicationFactor = 3, Server = leader }))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Stav" }, "users/1");
+                    await session.SaveChangesAsync();
+                    var exists = await WaitForDocumentInClusterAsync<User>(nodes, store.Database, "users/1", x => x.Name == "Stav", TimeSpan.FromSeconds(10));
+                    Assert.True(exists);
+                }
+
+                var nextBackup = GetTimeUntilBackupNextOccurence("0 0 * * *", DateTime.UtcNow);
+                if (nextBackup < TimeSpan.FromSeconds(10))
+                    await Task.Delay(nextBackup);
+
+                // put backup config
+                var config = new PeriodicBackupConfiguration()
+                {
+                    Disabled = false,
+                    FullBackupFrequency = "0 0 1 1 *",
+                    IncrementalBackupFrequency = "0 0 * * *",
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                };
+                var taskId = await Backup.UpdateConfigAsync(leader, config, store);
+                var originalNode = Backup.GetBackupResponsibleNode(leader, taskId, store.Database);
+                var originalNodeServer = nodes.Single(x => x.ServerStore.NodeTag == originalNode);
+                await Backup.RunBackupAsync(originalNodeServer, taskId, store, isFullBackup: false);
+                
+                var otherNodeServer = nodes.First(x => x.ServerStore.NodeTag != originalNode);
+                
+                // check the backup status
+                var backupStatus = await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId));
+                Assert.NotNull(backupStatus.Status);
+                Assert.Equal(originalNode, backupStatus.Status.NodeTag);
+
+                // assert number of directories
+                var dirs = Directory.GetDirectories(backupPath);
+                Assert.Equal(1, dirs.Length);
+                var nodesBackupDir = dirs[0];
+
+                var innerDirs = Directory.GetFiles(nodesBackupDir);
+                Assert.Equal(1, innerDirs.Length);
+                Assert.True(innerDirs[0].Contains(originalNode));
+                
+                // change responsible node to other node
+                config.TaskId = taskId;
+                config.MentorNode = otherNodeServer.ServerStore.NodeTag;
+                config.PinToMentorNode = true;
+                await Backup.UpdateConfigAsync(leader, config, store);
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, differentThan: originalNode);
+
+                // run full backup on new node
+                await Backup.RunBackupAsync(otherNodeServer, taskId, store, isFullBackup: false);
+
+                // wait until status is updated with new node
+                PeriodicBackupStatus status = null;
+                await WaitForValueAsync(async () =>
+                {
+                    status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    return status?.NodeTag == otherNodeServer.ServerStore.NodeTag;
+                }, true, timeout: 70_000);
+                Assert.NotNull(status);
+                Assert.Equal(otherNodeServer.ServerStore.NodeTag, status.NodeTag);
+                Assert.True(status.IsFull);
+                Assert.NotNull(status.LastFullBackup);
+
+                // assert number of directories grew
+                var otherNodeDir = Directory.GetDirectories(backupPath).Except(dirs).ToArray();
+                Assert.Equal(1, otherNodeDir.Length);
+                Assert.True(otherNodeDir[0].Contains(otherNodeServer.ServerStore.NodeTag));
+
+                // change responsible node back to original
+                config.TaskId = taskId;
+                config.MentorNode = originalNode;
+                config.PinToMentorNode = true;
+                await Backup.UpdateConfigAsync(leader, config, store);
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, differentThan: otherNodeServer.ServerStore.NodeTag);
+
+                // run the backup again - should be running incremental this time
+                await Backup.RunBackupAsync(originalNodeServer, taskId, store, isFullBackup: false);
+
+                // wait until backup finishes and saves the backup statuses - should be incremental backup and not a full one
+                status = null;
+                await WaitForValueAsync(async () =>
+                {
+                    status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    return status?.NodeTag == originalNode;
+                }, true, timeout: 70_000);
+                Assert.NotNull(status);
+                Assert.Equal(originalNode, status.NodeTag);
+                Assert.False(status.IsFull, "Backup should be incremental but is full");
+                Assert.NotNull(status.LastIncrementalBackup);
+
+                // assert no new dirs of full backup - original node directory should have a file for full and a file for incremental
+                var dirsAfterSwitchBack = Directory.GetFiles(nodesBackupDir);
+                Assert.Equal(2, dirsAfterSwitchBack.Length);
+
+                // other node directory should only have a file for full
+                dirsAfterSwitchBack = Directory.GetFiles(otherNodeDir[0]);
+                Assert.Equal(1, dirsAfterSwitchBack.Length);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster | RavenTestCategory.CompareExchange)]
+        public async Task CompareExchangeTombstonesShouldNotBeCleanedIfNotBackedUpForLocalNode()
+        {
+            // A does full backup on compare exchanges, backup moves to B, cx deleted, B does full backup on their tombstones, backup moves back to A, A should still have the tombstones to back up
+            // they should not have been deleted by the observer because of A's low index should prevent it
+            var settings = new Dictionary<string, string> { { RavenConfiguration.GetKey(x => x.Cluster.MaxClusterTransactionCompareExchangeTombstoneCheckInterval), "0" }, };
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var incrementalFrequency = "0 0 * * *";
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true, customSettings: settings);
+
+            using (var store = GetDocumentStore(new Options { ReplicationFactor = 3, Server = leader }))
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Stav" }, "users/1");
+                    await session.SaveChangesAsync();
+                    var exists = await WaitForDocumentInClusterAsync<User>(nodes, store.Database, "users/1", x => x.Name == "Stav", TimeSpan.FromSeconds(10));
+                    Assert.True(exists);
+                }
+
+                var nextBackup = GetTimeUntilBackupNextOccurence(incrementalFrequency, DateTime.UtcNow);
+                if (nextBackup < TimeSpan.FromSeconds(8))
+                    await Task.Delay(nextBackup);
+
+                // put compare exchanges
+                var cmpxchngRes1 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/1", new User { Name = "Stav1" }, 0));
+                var cmpxchngRes2 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/2", new User { Name = "Stav2" }, 0));
+                var cmpxchngRes3 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/3", new User { Name = "Stav3" }, 0));
+                Assert.True(cmpxchngRes1.Successful);
+                Assert.True(cmpxchngRes2.Successful);
+                Assert.True(cmpxchngRes3.Successful);
+
+                var stats = store.Maintenance.ForDatabase(store.Database).Send(new GetDetailedStatisticsOperation());
+                Assert.Equal(3, stats.CountOfCompareExchange);
+
+                // node backs up compare exchanges
+                var config = new PeriodicBackupConfiguration()
+                {
+                    Disabled = false,
+                    FullBackupFrequency = "0 0 1 1 *",
+                    IncrementalBackupFrequency = incrementalFrequency,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                };
+                var taskId = await Backup.UpdateConfigAsync(leader, config, store);
+                var originalNode = Backup.GetBackupResponsibleNode(leader, taskId, store.Database);
+                var originalNodeServer = nodes.Single(x => x.ServerStore.NodeTag == originalNode);
+                var otherNodeServer = nodes.First(x => x.ServerStore.NodeTag != originalNode);
+
+                // first backup will be full
+                await Backup.RunBackupAsync(originalNodeServer, taskId, store, isFullBackup: false);
+
+                // check the backup status
+                var backupStatus = await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId));
+                Assert.NotNull(backupStatus.Status);
+                Assert.Equal(originalNode, backupStatus.Status.NodeTag);
+                Assert.True(backupStatus.Status.IsFull);
+
+                // assert number of directories
+                var dirs = Directory.GetDirectories(backupPath);
+                Assert.Equal(1, dirs.Length);
+
+                var nodesBackupDir = dirs[0];
+                var originalNodeFiles = Directory.GetFiles(nodesBackupDir);
+                Assert.Equal(1, originalNodeFiles.Length);
+                Assert.True(originalNodeFiles[0].Contains(originalNode));
+
+                // change responsible node to other node
+                config.TaskId = taskId;
+                config.MentorNode = otherNodeServer.ServerStore.NodeTag;
+                await Backup.UpdateConfigAsync(leader, config, store);
+                
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, differentThan: originalNode);
+
+                // delete compare exchanges -> tombstones created
+                var delRes1 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/1", cmpxchngRes1.Index));
+                var delRes2 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/2", cmpxchngRes2.Index));
+                var delRes3 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/3", cmpxchngRes3.Index));
+                Assert.True(delRes1.Successful);
+                Assert.True(delRes2.Successful);
+                Assert.True(delRes3.Successful);
+
+                // first backup on new node will be full - this includes the tombstones
+                await Backup.RunBackupAsync(otherNodeServer, taskId, store, isFullBackup: false);
+
+                PeriodicBackupStatus status = null;
+                // wait until status is updated with new node
+                var res = await WaitForValueAsync(async () =>
+                {
+                    status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    return status.NodeTag == otherNodeServer.ServerStore.NodeTag;
+                }, true, timeout: 70_000);
+                Assert.Equal(otherNodeServer.ServerStore.NodeTag, status.NodeTag);
+                Assert.True(status.IsFull, "Backup wasn't full");
+                Assert.NotNull(status.LastFullBackup);
+                Assert.True(status.LastRaftIndex.LastEtag >= delRes3.Index, "tombstones raft index is not included in the backup");
+
+                // assert number of directories grew
+                var otherNodeDir = Directory.GetDirectories(backupPath).Except(dirs).ToArray();
+                Assert.Equal(1, otherNodeDir.Length);
+                Assert.True(otherNodeDir[0].Contains(otherNodeServer.ServerStore.NodeTag));
+                var otherNodeFiles = Directory.GetFiles(otherNodeDir[0]);
+                Assert.Equal(1, otherNodeFiles.Length);
+
+                // run cx tombstone cleaner
+                await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
+
+                // tombstones should not have been deleted
+                stats = store.Maintenance.ForDatabase(store.Database).Send(new GetDetailedStatisticsOperation());
+                Assert.Equal(3, stats.CountOfCompareExchangeTombstones);
+                Assert.Equal(0, stats.CountOfCompareExchange);
+            }
+        }
+        
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster | RavenTestCategory.CompareExchange)]
+        public async Task CompareExchangeTombstonesShouldNotGatherIndefinitelyAndShouldBeDeletedAfterNextFull()
+        {
+            // This test checks tombstones don't gather indefinitely because a non-responsible node is stuck with a backup status of low index that won't increase.
+            // Once the non-responsible node is overdue on its full backup, the local status is deleted and tombstones will be deleted.
+
+            var fullBackupFrequency = "*/2 * * * *";
+            var incrementalFrequency = "* * * * *";
+
+            var settings = new Dictionary<string, string>
+            {
+                { RavenConfiguration.GetKey(x => x.Cluster.MaxClusterTransactionCompareExchangeTombstoneCheckInterval), "0" },
+                { RavenConfiguration.GetKey(x => x.Tombstones.CleanupInterval), 1.ToString()},
+                { RavenConfiguration.GetKey(x => x.Cluster.WorkerSamplePeriod), 1000.ToString()}
+            };
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true, customSettings: settings);
+
+            using (var store = GetDocumentStore(new Options { ReplicationFactor = 3, Server = leader }))
+            {
+                // create cx
+                var cmpxchngRes1 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/1", new User { Name = "Stav1" }, 0));
+                var cmpxchngRes2 = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<User>("users/2", new User { Name = "Stav2" }, 0));
+                Assert.True(cmpxchngRes1.Successful);
+                Assert.True(cmpxchngRes2.Successful);
+
+                // stabilize test - if next full is very close, wait it out
+                var timeUntilNextOccurence = GetTimeUntilBackupNextOccurence(fullBackupFrequency, DateTime.UtcNow);
+                if(timeUntilNextOccurence < TimeSpan.FromSeconds(20))
+                    await Task.Delay(timeUntilNextOccurence);
+
+                // setup config with full and incremental freq and do first full backup
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: fullBackupFrequency, incrementalBackupFrequency: incrementalFrequency);
+                var taskId = await Backup.CreateAndRunBackupInClusterAsync(config, store, new List<RavenServer>() { nodes[0] }, isFullBackup: false);
+
+                var originalNode = Backup.GetBackupResponsibleNode(leader, taskId, store.Database);
+                var originalNodeServer = nodes.Single(x => x.ServerStore.NodeTag == originalNode);
+                var otherNodeServer = nodes.First(x => x.ServerStore.NodeTag != originalNode);
+                var db = await Databases.GetDocumentDatabaseInstanceFor(originalNodeServer, store.Database);
+
+                var status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                Assert.NotNull(status);
+                Assert.Equal(originalNodeServer.ServerStore.NodeTag, status.NodeTag);
+                Assert.True(status.IsFull);
+
+                // delete cx
+                var delRes1 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/1", cmpxchngRes1.Index));
+                Assert.True(delRes1.Successful);
+
+                config.TaskId = taskId;
+                config.MentorNode = otherNodeServer.ServerStore.NodeTag;
+                await Backup.UpdateConfigAsync(leader, config, store);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, differentThan: originalNode);
+                await Backup.RunBackupAsync(otherNodeServer, taskId, store, isFullBackup: false); // don't force full. should happen by itself
+
+                // check cluster backup status is as expected
+                status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                Assert.NotNull(status);
+                Assert.Equal(otherNodeServer.ServerStore.NodeTag, status.NodeTag);
+                Assert.True(status.IsFull);
+                
+                // run cleaner
+                await db.TombstoneCleaner.ExecuteCleanup();
+                await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
+
+                // check tombstones not deleted
+                var stats = store.Maintenance.ForDatabase(store.Database).Send(new GetDetailedStatisticsOperation());
+                Assert.Equal(1, stats.CountOfCompareExchangeTombstones);
+                Assert.Equal(1, stats.CountOfCompareExchange);
+
+                // delete another cx
+                var delRes2 = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<User>("users/2", cmpxchngRes2.Index));
+                Assert.True(delRes2.Successful);
+
+                // run the incremental
+                await Backup.RunBackupAsync(otherNodeServer, taskId, store, isFullBackup: false);
+                
+                var res = await WaitForValueAsync(async () =>
+                {
+                    status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    return status.LastIncrementalBackup != null;
+                }, true);
+                Assert.True(res, $"Incremental hasn't happened");
+                Assert.False(status.IsFull);
+
+                // run the cleaner - this should not delete anything
+                await db.TombstoneCleaner.ExecuteCleanup();
+                await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
+
+                // check local status not null and tombstones not deleted
+                var localStatus = BackupUtils.GetLocalBackupStatus(originalNodeServer.ServerStore, store.Database, taskId);
+                Assert.NotNull(localStatus);
+                Assert.NotNull(localStatus.LastFullBackupInternal);
+
+                stats = store.Maintenance.ForDatabase(store.Database).Send(new GetDetailedStatisticsOperation());
+                Assert.Equal(2, stats.CountOfCompareExchangeTombstones);
+                Assert.Equal(0, stats.CountOfCompareExchange);
+
+                // wait until full is overdue on not-responsible
+                await Task.Delay(GetTimeUntilBackupNextOccurence(fullBackupFrequency, localStatus.LastFullBackupInternal ?? DateTime.UtcNow));
+
+                // run cleaner
+                await db.TombstoneCleaner.ExecuteCleanup();
+                await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
+
+                // wait for local backup status to be deleted
+                await WaitForValueAsync(() =>
+                {
+                    localStatus = BackupUtils.GetLocalBackupStatus(originalNodeServer.ServerStore, store.Database, taskId);
+                    return localStatus == null;
+                }, true);
+                Assert.Null(localStatus);
+                
+                await WaitForValueAsync(async () =>
+                {
+                    await Cluster.RunCompareExchangeTombstoneCleaner(leader, simulateClusterTransactionIndex: false);
+                    stats = store.Maintenance.ForDatabase(store.Database).Send(new GetDetailedStatisticsOperation());
+                    return stats.CountOfCompareExchangeTombstones == 0;
+                }, true);
+                Assert.Equal(0, stats.CountOfCompareExchangeTombstones);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Cluster)]
+        public async Task TombstonesShouldNotGatherIndefinitelyAndShouldBeDeletedAfterNextFull()
+        {
+            // This test checks tombstones don't gather indefinitely because on a node because the backup moved from it to a different node.
+            // Tombstones on the non-responsible node can't be deleted until it is guaranteed the next backup will be full.
+            // Once the non-responsible node is overdue on its full backup, the local status is deleted and tombstones will be deleted.
+
+            var fullBackupFrequency = "*/2 * * * *";
+            var incrementalFrequency = "* * * * *";
+
+            var settings = new Dictionary<string, string>
+            {
+                { RavenConfiguration.GetKey(x => x.Tombstones.CleanupInterval), 1.ToString()}
+            };
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var (nodes, leader) = await CreateRaftCluster(3, leaderIndex: 0, watcherCluster: true, customSettings: settings);
+
+            using (var store = GetDocumentStore(new Options { ReplicationFactor = 3, Server = leader }))
+            {
+                // create docs
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), "users/1");
+                    session.Store(new User(), "users/2");
+                    session.SaveChanges();
+                }
+
+                // stabilize test - if next full is very close, wait it out
+                var timeUntilNextOccurence = GetTimeUntilBackupNextOccurence(fullBackupFrequency, DateTime.UtcNow);
+                await Task.Delay(timeUntilNextOccurence);
+
+                // setup config with full and incremental freq and do first full backup
+                var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: fullBackupFrequency, incrementalBackupFrequency: incrementalFrequency);
+                var taskId = await Backup.CreateAndRunBackupInClusterAsync(config, store, new List<RavenServer>() { nodes[0] }, isFullBackup: false);
+
+                var originalNode = Backup.GetBackupResponsibleNode(leader, taskId, store.Database);
+                var originalNodeServer = nodes.Single(x => x.ServerStore.NodeTag == originalNode);
+                var otherNodeServer = nodes.First(x => x.ServerStore.NodeTag != originalNode);
+                var dbOriginal = await Databases.GetDocumentDatabaseInstanceFor(originalNodeServer, store.Database);
+                var dbOther = await Databases.GetDocumentDatabaseInstanceFor(otherNodeServer, store.Database);
+
+                var status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                Assert.NotNull(status);
+                Assert.Equal(originalNodeServer.ServerStore.NodeTag, status.NodeTag);
+                Assert.True(status.IsFull);
+
+                // delete doc - create tombstone
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/1");
+                    session.SaveChanges();
+                }
+
+                // move backup to another node and wait to finish
+                config.TaskId = taskId;
+                config.MentorNode = otherNodeServer.ServerStore.NodeTag;
+                await Backup.UpdateConfigAsync(leader, config, store);
+
+                Backup.WaitForResponsibleNodeUpdateInCluster(store, nodes, taskId, differentThan: originalNode);
+                await Backup.RunBackupAsync(otherNodeServer, taskId, store, isFullBackup: false); // don't force full. should happen by itself
+
+                // check cluster backup status is as expected
+                status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                Assert.NotNull(status);
+                Assert.Equal(otherNodeServer.ServerStore.NodeTag, status.NodeTag);
+                Assert.True(status.IsFull);
+
+                // run cleaner
+                await dbOriginal.TombstoneCleaner.ExecuteCleanup();
+                await dbOther.TombstoneCleaner.ExecuteCleanup();
+
+                // check tombstone not deleted - we are not yet overdue
+                using (dbOriginal.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var tombstonesCount = dbOriginal.DocumentsStorage.GetNumberOfTombstones(context);
+                    var docCount = dbOriginal.DocumentsStorage.GetNumberOfDocuments(context);
+                    Assert.Equal(1, docCount);
+                    Assert.Equal(1, tombstonesCount);
+                }
+
+                // delete another doc
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/2");
+                    session.SaveChanges();
+                }
+
+                // run the incremental
+                await Task.Delay(GetTimeUntilBackupNextOccurence(incrementalFrequency, status.LastFullBackupInternal ?? DateTime.UtcNow));
+                var res = await WaitForValueAsync(async () =>
+                {
+                    status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    return status.LastIncrementalBackup != null;
+                }, true, timeout: 70_000);
+                Assert.True(res, $"Incremental hasn't happened");
+                Assert.False(status.IsFull);
+
+                // run cleaner
+                await dbOriginal.TombstoneCleaner.ExecuteCleanup();
+                await dbOther.TombstoneCleaner.ExecuteCleanup();
+
+                // check local status not null and tombstones not deleted
+                var localStatus = BackupUtils.GetLocalBackupStatus(originalNodeServer.ServerStore, store.Database, taskId);
+                Assert.NotNull(localStatus);
+                Assert.NotNull(localStatus.LastFullBackupInternal);
+
+                // on original server not deleted
+                using (dbOriginal.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var count = dbOriginal.DocumentsStorage.GetNumberOfTombstones(context);
+                    Assert.Equal(2, count);
+                }
+
+                // on responsible node already deleted by incremental
+                using (dbOther.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var count = dbOther.DocumentsStorage.GetNumberOfTombstones(context);
+                    Assert.Equal(0, count);
+                }
+
+                // wait until full is overdue on not-responsible
+                await Task.Delay(GetTimeUntilBackupNextOccurence(fullBackupFrequency, localStatus.LastFullBackupInternal ?? DateTime.UtcNow));
+
+                // run cleaner
+                await dbOriginal.TombstoneCleaner.ExecuteCleanup();
+                await dbOther.TombstoneCleaner.ExecuteCleanup();
+
+                // wait for local backup status to be deleted
+                await WaitForValueAsync(() =>
+                {
+                    localStatus = BackupUtils.GetLocalBackupStatus(originalNodeServer.ServerStore, store.Database, taskId);
+                    return localStatus == null;
+                }, true);
+                Assert.Null(localStatus);
+
+                // wait for tombstones to be deleted
+                await WaitForValueAsync(() =>
+                {
+                    using (dbOriginal.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        var count = dbOriginal.DocumentsStorage.GetNumberOfTombstones(context);
+                        return count;
+                    }
+                }, 0);
+            }
+        }
+
+        public static TimeSpan GetTimeUntilBackupNextOccurence(string frequency, DateTime fromUtc)
+        {
+            var fromUtcSpecified = DateTime.SpecifyKind(fromUtc, DateTimeKind.Utc);
+            var fromLocal = fromUtcSpecified.ToLocalTime();
+            var nowLocal = DateTime.Now.ToLocalTime();
+
+            var backupParser = CrontabSchedule.Parse(frequency);
+            var nextLocal = backupParser.GetNextOccurrence(fromLocal);
+            var timeUntilNextOccurence = nextLocal - nowLocal + TimeSpan.FromSeconds(2);
+            return timeUntilNextOccurence > TimeSpan.Zero ? timeUntilNextOccurence : TimeSpan.FromSeconds(1);
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Smuggler)]
+        public async Task ChangingBackupConfigurationToAlsoIncrementalShouldNotCauseTombstoneLoss()
+        {
+            // have a full backup with only full frequency configuration, change config to include incremental frequency, make sure that cleaner did not rely on only having full backups to delete tombstones freely
+            var backupPath1 = NewDataPath(suffix: "BackupFolder1");
+            
+            using (var server = GetNewServer())
+            using (var store = GetDocumentStore(new Options { Server = server }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), "users/1");
+                    session.SaveChanges();
+                }
+
+                // full backup without incremental
+                var config = Backup.CreateBackupConfiguration(backupPath1);
+
+                var documentDatabase = await server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database).ConfigureAwait(false);
+                Assert.NotNull(documentDatabase);
+                
+                // run full backup
+                var taskId = await Backup.UpdateConfigAndRunBackupAsync(server, config, store);
+                
+                // create tombstone
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/1");
+                    session.SaveChanges();
+                }
+
+                // wait for tombstone cleaner
+                await documentDatabase.TombstoneCleaner.ExecuteCleanup();
+
+                var beforeChangeConfig = DateTime.UtcNow;
+
+                // change configuration to include incremental
+                config.TaskId = taskId;
+                config.IncrementalBackupFrequency = "* * * * *";
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+                // check change applied
+                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                Assert.Equal(1, record.PeriodicBackups.Count);
+                Assert.Equal("* * * * *", record.PeriodicBackups.First().IncrementalBackupFrequency);
+
+                // wait for next backup
+                PeriodicBackupStatus status;
+                var res = await WaitForValueAsync(async () =>
+                {
+                    status = (await store.Maintenance.SendAsync(new GetPeriodicBackupStatusOperation(taskId))).Status;
+                    return status.LastIncrementalBackup > beforeChangeConfig;
+                }, true, timeout: 70_000, interval: 1000);
+                Assert.True(res, "Incremental backup didn't happen");
+
+                // restore from backup
+                var newDb = store.Database + "-restored";
+                var backupDir = Directory.GetDirectories(backupPath1).First();
+                var restoreConfig = new RestoreBackupConfiguration { BackupLocation = backupDir, DatabaseName = newDb };
+                var restoreOperation = new RestoreBackupOperation(restoreConfig);
+                var o = await store.Maintenance.Server.SendAsync(restoreOperation);
+                await o.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+                // check the original document is not included in the restored db
+                using (var session = store.OpenSession(newDb))
+                {
+                    var user = session.Load<User>("users/1");
+                    Assert.Null(user);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -3401,7 +3401,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                             PeriodicBackupStatus inMemoryStatus = null;
                             WaitForValue(() =>
                             {
-                                inMemoryStatus = documentDatabase.PeriodicBackupRunner.GetBackupStatus(taskId);
+                                inMemoryStatus = documentDatabase.PeriodicBackupRunner.GetMostUpdatedClusterBackupStatus(taskId);
                                 return inMemoryStatus != null;
                             }, true);
 

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
@@ -1264,14 +1264,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     }
 
                     await Backup.RunBackupAsync(server, backupTaskId, store, isFullBackup: false);
-
-                    using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
-                    using (context.OpenReadTransaction())
-                    {
-                        // clean tombstones
-                    var cleanupState = await CompareExchangeTombstoneCleanerTestHelper.Clean(context, store.Database, server, true);
-                        Assert.Equal(ClusterObserver.CompareExchangeTombstonesCleanupState.NoMoreTombstones, cleanupState);
-                    }
+                    await Cluster.RunCompareExchangeTombstoneCleaner(server, simulateClusterTransactionIndex: true);
 
                     using (server.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
                     using (context.OpenReadTransaction())

--- a/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/RavenDB-11139.cs
@@ -1751,7 +1751,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
         }
 
         [Fact, Trait("Category", "Smuggler")]
-        public async Task ShouldClearAllCompareExchangeTombstonesIfThereIsABackupThatNeverOccur()
+        public async Task ShouldNotDeleteCompareExchangeTombstonesIfThereIsABackupThatNeverOccur()
         {
             using (var server = GetNewServer())
             using (var store = GetDocumentStore(new Options { Server = server }))
@@ -1793,7 +1793,7 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 {
                     var numOfCompareExchangeTombstones = server.ServerStore.Cluster.GetNumberOfCompareExchangeTombstones(context, store.Database);
                     var numOfCompareExchanges = server.ServerStore.Cluster.GetNumberOfCompareExchange(context, store.Database);
-                    Assert.Equal(0, numOfCompareExchangeTombstones);
+                    Assert.Equal(1, numOfCompareExchangeTombstones);
                     Assert.Equal(2, numOfCompareExchanges);
                 }
             }

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -133,7 +133,7 @@ namespace FastTests
                 string responsibleNode = null;
                 var value = WaitForValue(() =>
                 {
-                    var responsibleNode = BackupUtils.GetResponsibleNodeTag(serverStore, databaseName, taskId);
+                    responsibleNode = BackupUtils.GetResponsibleNodeTag(serverStore, databaseName, taskId);
                     return responsibleNode != differentThan;
                 }, true);
 
@@ -270,11 +270,11 @@ namespace FastTests
                 return backupTaskId;
             }
 
-            public void WaitForResponsibleNodeUpdateInCluster(IDocumentStore store, List<RavenServer> nodes, long backupTaskId, string differentThan = null)
+            public void WaitForResponsibleNodeUpdateInCluster(IDocumentStore store, List<RavenServer> nodes, long backupTaskId, string databaseName = null, string differentThan = null)
             {
                 foreach (var server in nodes)
                 {
-                    WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, backupTaskId, differentThan);
+                    WaitForResponsibleNodeUpdate(server.ServerStore, databaseName ?? store.Database, backupTaskId, differentThan);
                 }
             }
 

--- a/test/Tests.Infrastructure/RavenTestBase.Backup.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Backup.cs
@@ -270,7 +270,7 @@ namespace FastTests
                 return backupTaskId;
             }
 
-            public void WaitForResponsibleNodeUpdateInCluster(DocumentStore store, List<RavenServer> nodes, long backupTaskId, string differentThan = null)
+            public void WaitForResponsibleNodeUpdateInCluster(IDocumentStore store, List<RavenServer> nodes, long backupTaskId, string differentThan = null)
             {
                 foreach (var server in nodes)
                 {

--- a/test/Tests.Infrastructure/RavenTestBase.Databases.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Databases.cs
@@ -41,9 +41,9 @@ public partial class RavenTestBase
             return server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
         }
 
-        public Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(RavenServer server, IDocumentStore store, string database = null)
+        public Task<DocumentDatabase> GetDocumentDatabaseInstanceFor(RavenServer server, string database)
         {
-            return server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database ?? store.Database);
+            return server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(database);
         }
 
         public async Task SetDatabaseId(DocumentStore store, Guid dbId)


### PR DESCRIPTION
### Issue link

v6.0 PR for

https://issues.hibernatingrhinos.com/issue/RavenDB-22849

### Additional description


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
