### PR TITLE
RavenDB-23505 Add colors for DocumentsCleanup on Indexing Performance

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/indexPerformance.ts
@@ -294,6 +294,7 @@ class indexPerformance extends viewModelBase {
             "Corax/Commit": undefined as string,
             "Corax/Convert": undefined as string,
             "Corax/AddDocument": undefined as string,
+            "DocumentsCleanup": undefined as string,
             "UnknownOperation": undefined as string
         }
     };

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/indexPerformance.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/indexPerformance.html
@@ -116,6 +116,7 @@
                         <div class="coraxCommit" data-property="Corax/Commit"></div>
                         <div class="coraxConvert" data-property="Corax/Convert"></div>
                         <div class="coraxAddDocument" data-property="Corax/AddDocument"></div>
+                        <div class="documentsCleanup" data-property="DocumentsCleanup"></div>
                         <div class="unknownOperation" data-property="UnknownOperation"></div>
                     </div>
                 </div>

--- a/src/Raven.Studio/wwwroot/Content/css/pages/index-performance.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/index-performance.less
@@ -135,7 +135,7 @@
             color: @color-3-1;
         }
 
-        .cleanup {
+        .cleanup, .documentsCleanup {
             color: @color-3-2;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23505

### Additional description

Fixed missing color for DocumentsCleanup

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
