### PR TITLE
RavenDB-23654 Move contex allocation to outer scope to make it valid for tracker dispose

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Queries/AbstractQueriesHandlerProcessorForGet.cs
@@ -96,12 +96,12 @@ internal abstract class AbstractQueriesHandlerProcessorForGet<TRequestHandler, T
 
     public override async ValueTask ExecuteAsync()
     {
+        using (AllocateContextForQueryOperation(out var queryContext, out var context))
         using (var tracker = CreateRequestTimeTracker())
         {
             try
             {
                 using (var token = RequestHandler.CreateHttpRequestBoundTimeLimitedOperationTokenForQuery())
-                using (AllocateContextForQueryOperation(out var queryContext, out var context))
                 {
                     var parameters = QueryStringParameters.Create(HttpContext.Request);
                     var indexQuery = await GetIndexQueryAsync(context, QueryMethod, tracker, parameters.AddSpatialProperties);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23654

### Additional description
The tracker dispose uses a blittable that is located on the context which is returned before the dispose of the tracker.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
