### PR TITLE
RavenDB-22468 - Server-wide backup wakes up all DBs at once causing timeouts

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -1163,10 +1163,19 @@ namespace Raven.Server.Documents
                             var startDatabaseForBackup = _serverStore.ConcurrentBackupsCounter.TryStartDatabaseForBackup();
                             if (startDatabaseForBackup == null)
                             {
+                                // reached max concurrent loading of databases for backup, retry after 1 min
+
+                                if (_logger.IsInfoEnabled)
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent loading of databases for backup, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
+
+                                RescheduleDatabaseWakeup();
+                            }
+                            else if (_serverStore.ConcurrentBackupsCounter.CanRunBackup == false)
+                            {
                                 // reached max concurrent backups, retry after 1 min
 
                                 if (_logger.IsInfoEnabled)
-                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent backups, will retry the wakeup in '{_dueTimeOnRetry}' ms");
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent backups, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
 
                                 RescheduleDatabaseWakeup();
                             }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -12,6 +12,7 @@ using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
 using Raven.Server.Config;
+using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.NotificationCenter.Notifications.Server;
@@ -1160,6 +1161,28 @@ namespace Raven.Server.Documents
                             break;
 
                         case IdleDatabaseActivityType.WakeUpDatabase:
+                            if (_serverStore.ConcurrentBackupsCounter.CanRunBackup == false)
+                            {
+                                // reached max concurrent backups, retry after 1 min
+
+                                if (_logger.IsInfoEnabled)
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent backups, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
+
+                                RescheduleDatabaseWakeup();
+                                break;
+                            }
+
+                            if (CanServerRunBackup() == false)
+                            {
+                                // the server cannot run the backup anyway (low memory, low cpu credits or high dirty memory state)
+
+                                if (_logger.IsInfoEnabled)
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we are in a low memory state, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
+
+                                RescheduleDatabaseWakeup();
+                                break;
+                            }
+
                             var startDatabaseForBackup = _serverStore.ConcurrentBackupsCounter.TryStartDatabaseForBackup();
                             if (startDatabaseForBackup == null)
                             {
@@ -1167,15 +1190,6 @@ namespace Raven.Server.Documents
 
                                 if (_logger.IsInfoEnabled)
                                     _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent loading of databases for backup, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
-
-                                RescheduleDatabaseWakeup();
-                            }
-                            else if (_serverStore.ConcurrentBackupsCounter.CanRunBackup == false)
-                            {
-                                // reached max concurrent backups, retry after 1 min
-
-                                if (_logger.IsInfoEnabled)
-                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent backups, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms");
 
                                 RescheduleDatabaseWakeup();
                             }
@@ -1191,7 +1205,7 @@ namespace Raven.Server.Documents
                                         // database failed to load, retry after 1 min
 
                                         if (_logger.IsInfoEnabled)
-                                            _logger.Info($"Failed to start database '{databaseName}' for running a backup, will retry the wakeup in '{_dueTimeOnRetry}' ms", e);
+                                            _logger.Info($"Failed to start database '{databaseName}' for running a backup, will retry the wakeup in {_dueTimeOnRetry:#,#;;0}ms", e);
 
                                         RescheduleDatabaseWakeup();
                                     }
@@ -1216,6 +1230,19 @@ namespace Raven.Server.Documents
                     _logger.Operations($"Failed to schedule the next activity for the idle database '{databaseName}'.", e);
 
                 ForTestingPurposes?.OnFailedRescheduleNextScheduledActivity?.Invoke(e, databaseName);
+            }
+        }
+
+        private bool CanServerRunBackup()
+        {
+            try
+            {
+                BackupUtils.CheckServerHealthBeforeBackup(_serverStore, name: null);
+                return true;
+            }
+            catch (BackupDelayException)
+            {
+                return false;
             }
         }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
@@ -155,6 +155,9 @@ namespace Raven.Server.Documents.PeriodicBackup
             var utilizedCores = _licenseManager.GetCoresLimitForNode(out _);
             var newMaxConcurrentBackups = GetNumberOfCoresToUseForBackup(utilizedCores);
 
+            if (_maxConcurrentBackups == newMaxConcurrentBackups)
+                return;
+
             lock (_locker)
             {
                 var diff = newMaxConcurrentBackups - _maxConcurrentBackups;

--- a/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Threading;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Util;
 using Raven.Server.Commercial;
 using Sparrow.Logging;
 using BackupConfiguration = Raven.Server.Config.Categories.BackupConfiguration;
@@ -15,6 +17,7 @@ namespace Raven.Server.Documents.PeriodicBackup
         private int _maxConcurrentBackups;
         private readonly TimeSpan _concurrentBackupsDelay;
         private readonly bool _skipModifications;
+        private SemaphoreSlim _concurrentDatabaseWakeup;
 
         public int MaxNumberOfConcurrentBackups
         {
@@ -56,6 +59,7 @@ namespace Raven.Server.Documents.PeriodicBackup
 
             _concurrentBackups = numberOfCoresToUse;
             _maxConcurrentBackups = numberOfCoresToUse;
+            _concurrentDatabaseWakeup = new SemaphoreSlim(numberOfCoresToUse);
             _concurrentBackupsDelay = backupConfiguration.ConcurrentBackupsDelay.AsTimeSpan;
             _skipModifications = skipModifications;
         }
@@ -131,6 +135,18 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
         }
 
+        public IDisposable TryStartDatabaseForBackup()
+        {
+            var sm = _concurrentDatabaseWakeup;
+            if (sm.Wait(TimeSpan.Zero) == false)
+                return null;
+
+            return new DisposableAction(() =>
+            {
+                sm.Release();
+            });
+        }
+
         public void ModifyMaxConcurrentBackups()
         {
             if (_skipModifications)
@@ -143,6 +159,7 @@ namespace Raven.Server.Documents.PeriodicBackup
             {
                 var diff = newMaxConcurrentBackups - _maxConcurrentBackups;
                 _maxConcurrentBackups = newMaxConcurrentBackups;
+                _concurrentDatabaseWakeup = new SemaphoreSlim(newMaxConcurrentBackups);
                 _concurrentBackups += diff;
             }
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/ConcurrentBackupsCounter.cs
@@ -41,6 +41,17 @@ namespace Raven.Server.Documents.PeriodicBackup
             }
         }
 
+        public bool CanRunBackup
+        {
+            get
+            {
+                lock (_locker)
+                {
+                    return _concurrentBackups - 1 > 0;
+                }
+            }
+        }
+
         public ConcurrentBackupsCounter(BackupConfiguration backupConfiguration, LicenseManager licenseManager)
         {
             _licenseManager = licenseManager;

--- a/src/Raven.Server/Utils/BackupUtils.cs
+++ b/src/Raven.Server/Utils/BackupUtils.cs
@@ -383,6 +383,19 @@ internal static class BackupUtils
         }
     }
 
+    public static bool CanServerRunBackup(ServerStore serverStore)
+    {
+        try
+        {
+            CheckServerHealthBeforeBackup(serverStore, name: null);
+            return true;
+        }
+        catch (BackupDelayException)
+        {
+            return false;
+        }
+    }
+
     public static PathSetting GetBackupTempPath(RavenConfiguration configuration, string dir, out PathSetting basePath)
     {
         basePath = configuration.Backup.TempPath ?? configuration.Storage.TempPath ?? configuration.Core.DataDirectory;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22468/Server-wide-backup-wakes-up-all-DBs-at-once-causing-timeouts

### Additional description

Use the `ConcurrentBackupsCounter` when deciding if we need to wakeup the database for backup.
Also take into account if we are in a low memory state, have low CPU credits or in a high dirty memory state which will prevent us from doing the backup anyway.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
