### PR TITLE
RavenDB-23655 Exact VectorSearch should not impact the matching of the auto index definition for vector search

### DIFF
--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryToIndexMatcher.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryToIndexMatcher.cs
@@ -200,6 +200,9 @@ namespace Raven.Server.Documents.Queries.Dynamic
                                 $"The following field is not vector searchable {indexField.Name}, while the query needs to vector.search() on it"));
                             return new DynamicQueryMatchResult(indexName, DynamicQueryMatchType.Partial);
                         }
+                        
+                        //When both VectorOptions are equal, the field is equal. No other options should be considered.
+                        continue;
                     }
                     if (field.IsFullTextSearch && indexField.Indexing.HasFlag(AutoFieldIndexing.Search) == false)
                     {

--- a/test/FastTests/Corax/Vectors/RavenDB-23655.cs
+++ b/test/FastTests/Corax/Vectors/RavenDB-23655.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Client.Util;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Queries;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Vectors;
+
+public class RavenDB_23655 : RavenTestBase
+{
+    public RavenDB_23655(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ExactVectorSearchHasNoEffectOnIndex(bool firstIsExact)
+    {
+        using var store = GetDocumentStore();
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Product() { Name = "test" });
+            await session.SaveChangesAsync();
+
+            var result = await session.Query<Product>()
+                .Customize(c => c.WaitForNonStaleResults())
+                .VectorSearch(f => f.WithText(s => s.Name),
+                    v => v.ByText("test"), minimumSimilarity: 0.7f, isExact: firstIsExact)
+                .ToArrayAsync();
+            Assert.Single(result);
+        }
+
+        var command = new PutDatabaseStudioConfigurationCommand(new ServerWideStudioConfiguration() { DisableAutoIndexCreation = true, }, store.Database,
+            RaftIdGenerator.NewId());
+        await Server.ServerStore.SendToLeaderAsync(command);
+
+        var dbInstance = await GetDocumentDatabaseInstanceFor(store, store.Database);
+        using (var context = QueryOperationContext.ShortTermSingleUse(dbInstance))
+        {
+            var result = await dbInstance.QueryRunner.ExecuteQuery(
+                new IndexQueryServerSide("from  'Products' where exact(vector.search(embedding.text(Name), 'test', 0.3))") { DisableAutoIndexCreation = true }, context,
+                null,
+                OperationCancelToken.None);
+            
+            Assert.Equal(1, result.TotalResults);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23655

### Additional description

 Exact VectorSearch should not impact the matching of the auto index definition for vector search

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
