### PR TITLE
RavenDB-23656 Vector search: different dimensions will not crash the server

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexFieldsPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexFieldsPersistence.cs
@@ -86,6 +86,11 @@ namespace Raven.Server.Documents.Indexes
         {
             return _vectorSourceEmbeddingType.TryGetValue(fieldName, out embeddingType);
         }
+        
+        internal bool TryReadNumberOfDimensions(string fieldName, out int dimensions)
+        {
+            return _vectorFieldsDimensions.TryGetValue(fieldName, out dimensions);
+        }
 
         internal void SetVectorSourceEmbeddingType(string fieldName, VectorEmbeddingType embeddingType)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -730,7 +730,16 @@ public static class CoraxQueryBuilder
                 _ => throw new NotSupportedException("vector.search() minimumMatch must be a float, but was: " + valueType)
             };
         }
+        
+        if (builderParameters.Index.IndexFieldsPersistence.TryReadNumberOfDimensions(fieldName, out var numberOfDimensions) == false)
+            return builderParameters.IndexSearcher.EmptyMatch(); // no vector indexed
 
+        if (numberOfDimensions != transformedEmbedding.Length)
+        {
+            using (transformedEmbedding)
+                ThrowDifferentNumberOfDimensions();
+        }
+            
         return builderParameters.IndexSearcher.VectorSearch(fieldMetadata, transformedEmbedding, minimumMatch, numberOfCandidates, exact, builderParameters.IsVectorSingleClause);
 
         VectorOptions GetOptions(IndexField field)
@@ -748,6 +757,19 @@ public static class CoraxQueryBuilder
                 _ => throw new InvalidDataException(
                     $"Unknown vector source embedding type: {vectorSourceEmbeddingType}. Implicit configuration support only single and text vector source embedding types.")
             };
+        }
+
+        void ThrowDifferentNumberOfDimensions()
+        {
+            var (storedDimensions, inputDimensions) = indexField.Vector.DestinationEmbeddingType switch
+            {
+                VectorEmbeddingType.Single => (numberOfDimensions / sizeof(float), transformedEmbedding.Length / sizeof(float)),
+                VectorEmbeddingType.Int8 => (numberOfDimensions - sizeof(float), transformedEmbedding.Length - sizeof(float)),
+                VectorEmbeddingType.Binary => (numberOfDimensions, transformedEmbedding.Length),
+                _ => throw new InvalidDataException($"Unexpected embedding type - {numberOfDimensions}.")
+            };
+
+            PortableExceptions.Throw<InvalidDataException>($"Vector field `{fieldName}` has {storedDimensions} dimensions, but the vector passed to vector.search() has {inputDimensions} dimensions.");
         }
     }
 

--- a/test/FastTests/Corax/Vectors/RavenDB-23656.cs
+++ b/test/FastTests/Corax/Vectors/RavenDB-23656.cs
@@ -1,0 +1,64 @@
+﻿using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Vectors;
+
+public class RavenDB_23656(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public void DifferentDimensionsWillNotCrashTheServer()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenSession();
+        session.Store(new Vector
+        {
+            Array =
+            [
+                [
+                    106,
+                    127,
+                    -102,
+                    -103,
+                    25,
+                    63
+                ],
+                [
+                    111,
+                    127,
+                    -51,
+                    -52,
+                    76,
+                    63
+                ]
+            ]
+        });
+        session.SaveChanges();
+
+        var result = session.Query<Vector>()
+            .Customize(c => c.WaitForNonStaleResults())
+            .VectorSearch(f => f.WithEmbedding(x => x.Array, VectorEmbeddingType.Int8),
+                v => v.ByEmbedding(new sbyte[] { 106, 127, -102, -103, 25, 63 }))
+            .ToArray();
+
+        Assert.Equal(1, result.Length);
+
+        //query with different dimension size
+        var ex = Assert.Throws<RavenException>(() => session.Query<Vector>()
+            .Customize(c => c.WaitForNonStaleResults())
+            .VectorSearch(f => f.WithEmbedding(x => x.Array, VectorEmbeddingType.Int8),
+                v => v.ByEmbedding(new sbyte[] { 106, 127, -102, -103, 25 }))
+            .ToArray());
+
+        Assert.Contains("Vector field `vector.search(embedding.i8(Array))` has 2 dimensions, but the vector passed to vector.search() has 1 dimensions", ex.Message);
+    }
+
+    private class Vector
+    {
+        public sbyte[][] Array { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23656

### Additional description

Added dimension validation before the query to prevent crashes in HNSW search.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
