### PR TITLE
RavenDB-23657 Fixes related to RavenVector

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -671,11 +671,7 @@ public static class CoraxQueryBuilder
             PortableExceptions.ThrowIfNot<InvalidDataException>(vectorObjectFound, "Cannot find vector property in the object.");
 
             var vectorReader = (BlittableJsonReaderVector)vectorObject;
-            var bytesUsed = vectorReader.Length * vectorReader.ElementSize;
-            var memoryScope = builderParameters.Allocator.Allocate(bytesUsed, out Memory<byte> vectorBytes);
-
-            vectorReader.ReadUnderlyingMemory().CopyTo(vectorBytes.Span);
-            transformedEmbedding = GenerateEmbeddings.FromArray(builderParameters.Allocator, memoryScope, vectorBytes, vectorOptions, bytesUsed);
+            transformedEmbedding = QueryBuilderHelper.GetVectorValueFromBlittableJsonVectorReader(builderParameters.Allocator, vectorOptions, vectorReader);
         }
         else
         {

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.VectorSearch.cs
@@ -223,10 +223,35 @@ public partial class AbstractStaticIndexBase
             if (TryGetFirstNonNullElement(data, out var firstNonNull) == false)
                 return VectorValue.Null;
 
+            var values = new object[dataLength];
+            if (firstNonNull is BlittableJsonReaderObject or DynamicBlittableJson)
+            {
+                for (int i = 0; i < dataLength; i++)
+                {
+                    var currentObject = data[i];
+                    if (IsNullValue(currentObject))
+                    {
+                        values[i] = VectorValue.Null;
+                        continue;
+                    }
+                    
+                    var bjro = currentObject as BlittableJsonReaderObject ?? ((DynamicBlittableJson)value).BlittableJson;
+                    if (bjro != null && bjro.TryGetMember(Sparrow.Global.Constants.Naming.VectorPropertyName, out var vector) 
+                        && vector is BlittableJsonReaderVector bjrv)
+                    {
+                        values[i] = HandleBlittableJsonReaderVector(bjrv);
+                        continue;
+                    }
+                    
+                    PortableExceptions.Throw<InvalidDataException>($"Expected BlittableJsonReaderVector, but got {value.GetType().FullName}");
+                }
+
+                return values;
+            }
+
             //Array of base64s
             if (IsBase64(firstNonNull))
             {
-                var values = new object[dataLength];
                 for (var i = 0; i < dataLength; i++)
                     values[i] = Base64ToVector(data[i].ToString());
 
@@ -236,7 +261,6 @@ public partial class AbstractStaticIndexBase
             //Array of arrays
             if (firstNonNull is BlittableJsonReaderArray)
             {
-                var values = new object[dataLength];
                 for (var i = 0; i < dataLength; i++)
                 {
                     values[i] = IsNullValue(data[i]) 
@@ -279,18 +303,52 @@ public partial class AbstractStaticIndexBase
 
         object HandleBlittableJsonReaderVector(BlittableJsonReaderVector bjrv)
         {
-            var type = bjrv[0].GetType();
+            if (vectorOptions.SourceEmbeddingType is VectorEmbeddingType.Int8)
+            {
+                if (bjrv.TryReadArray(out ReadOnlySpan<sbyte> asSbyte))
+                    return HandleBjrvInternal(asSbyte);
 
-            if (type == typeof(float))
-                return HandleBjrvInternal(bjrv.ReadArray<float>());
-            if (type == typeof(double))
-                return HandleBjrvInternal(bjrv.ReadArray<double>());
-            if (type == typeof(byte))
-                return HandleBjrvInternal(bjrv.ReadArray<byte>());
-            if (type == typeof(sbyte))
-                return HandleBjrvInternal(bjrv.ReadArray<sbyte>());
+                using (allocator.Allocate(bjrv.Length, out Span<sbyte> mem))
+                {
+                    var it = 0;
+                    foreach (var itValue in bjrv.ReadAs<sbyte>())
+                        mem[it++] = itValue;
 
-            throw new NotSupportedException($"Embeddings of type {type.FullName} are not supported.");
+                    return HandleBjrvInternal<sbyte>(mem);
+                }
+            }
+
+            if (vectorOptions.SourceEmbeddingType is VectorEmbeddingType.Binary)
+            {
+                if (bjrv.TryReadArray(out ReadOnlySpan<byte> asBytes))
+                    return HandleBjrvInternal(asBytes);
+
+                using (allocator.Allocate(bjrv.Length, out Span<byte> mem))
+                {
+                    var it = 0;
+                    foreach (var itValue in bjrv.ReadAs<byte>())
+                        mem[it++] = itValue;
+
+                    return HandleBjrvInternal<byte>(mem);
+                }
+            }
+
+            if (vectorOptions.SourceEmbeddingType is VectorEmbeddingType.Single)
+            {
+                if (bjrv.TryReadArray(out ReadOnlySpan<float> asFloat))
+                    return HandleBjrvInternal(asFloat);
+
+                using (allocator.Allocate(bjrv.Length, out Span<float> mem))
+                {
+                    var it = 0;
+                    foreach (var itValue in bjrv.ReadAs<float>())
+                        mem[it++] = itValue;
+
+                    return HandleBjrvInternal<float>(mem);
+                }
+            }
+            
+            throw new ArgumentException($"Unknown type. Vector embedding source: {vectorOptions.SourceEmbeddingType}");
         }
 
         object HandleBjrvInternal<T>(ReadOnlySpan<T> embedding) where T : unmanaged

--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -14,6 +14,7 @@ using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Documents.Queries.Vector;
 using Raven.Server.Config;
 using Sparrow;
+using Sparrow.Json;
 using Sparrow.Server;
 using InvalidOperationException = System.InvalidOperationException;
 using VectorValue = Corax.Utils.VectorValue;
@@ -131,7 +132,7 @@ public static class GenerateEmbeddings
 
         return embeddings;
     }
-
+    
     private static (IDisposable MemoryScope, Memory<byte> Memory, int UsedBytes) CreateEmbeddingViaSmartComponentsLocalEmbedding(ByteStringContext allocator, in string text, in int dimensions)
     {
         List ??= new List<string>(1);

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Corax;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
@@ -10,11 +11,13 @@ using Corax.Querying.Matches.SortingMatches.Meta;
 using Corax.Utils;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Spatial;
+using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Exceptions;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Persistence.Corax;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
 using Raven.Server.Documents.Indexes.Static.Spatial;
+using Raven.Server.Documents.Indexes.VectorSearch;
 using Raven.Server.Documents.Queries.AST;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
@@ -23,6 +26,7 @@ using Sparrow.Server;
 using Spatial4n.Shapes;
 using Constants = Raven.Client.Constants;
 using Index = Raven.Server.Documents.Indexes.Index;
+using VectorOptions = Raven.Client.Documents.Indexes.Vector.VectorOptions;
 
 namespace Raven.Server.Documents.Queries;
 
@@ -785,5 +789,52 @@ public static class QueryBuilderHelper
         }
 
         return valueAsString;
+    }
+
+    internal static VectorValue GetVectorValueFromBlittableJsonVectorReader(ByteStringContext allocator, in VectorOptions options, BlittableJsonReaderVector value)
+    {
+        var bytesRequired = value.Length * (options.SourceEmbeddingType is VectorEmbeddingType.Single ? sizeof(float) : sizeof(byte));
+        var scope = allocator.Allocate(bytesRequired, out Memory<byte> memory);
+        
+        
+        switch (options.SourceEmbeddingType)
+        {
+            case VectorEmbeddingType.Single when value.TryReadArray(out ReadOnlySpan<float> asFloats):
+                asFloats.CopyTo(MemoryMarshal.Cast<byte, float>(memory.Span));
+                break;
+            case VectorEmbeddingType.Single:
+            {
+                var floats = MemoryMarshal.Cast<byte, float>(memory.Span);
+                int it = 0;
+                foreach (var v in value.ReadAs<float>())
+                    floats[it++] = v;
+                break;
+            }
+            case VectorEmbeddingType.Int8 when value.TryReadArray(out ReadOnlySpan<sbyte> asSbyte):
+            {
+                asSbyte.CopyTo(MemoryMarshal.Cast<byte, sbyte>(memory.Span));
+                break;
+            }
+            case VectorEmbeddingType.Int8:
+            {
+                var sbytes = MemoryMarshal.Cast<byte, sbyte>(memory.Span);
+                int it = 0;
+                foreach (var v in value.ReadAs<sbyte>())
+                    sbytes[it++] = v;
+                break;
+            }
+            case VectorEmbeddingType.Binary when value.TryReadArray(out ReadOnlySpan<byte> asSbyte):
+                asSbyte.CopyTo(memory.Span);
+                break;
+            case VectorEmbeddingType.Binary:
+            {
+                int it = 0;
+                foreach (var v in value.ReadAs<byte>())
+                    memory.Span[it++] = v;
+                break;
+            }
+        }
+
+        return GenerateEmbeddings.FromArray(allocator, scope, memory, options, bytesRequired);
     }
 }

--- a/src/Sparrow/Json/BlittableJsonReaderVector.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderVector.cs
@@ -519,23 +519,59 @@ namespace Sparrow.Json
             private static TOut FloatConverter(byte* data)
             {
                 var value = Unsafe.ReadUnaligned<float>(data);
-
+                
+                if (typeof(TOut) == typeof(sbyte))
+                    return (TOut)(object)Convert.ToSByte(value);
+                if (typeof(TOut) == typeof(short))
+                    return (TOut)(object)Convert.ToInt16(value);
+                if (typeof(TOut) == typeof(int))
+                    return (TOut)(object)Convert.ToInt32(value);
+                if (typeof(TOut) == typeof(long))
+                    return (TOut)(object)Convert.ToInt64(value);
+                
+                if (typeof(TOut) == typeof(byte))
+                    return (TOut)(object)Convert.ToByte(value);
+                if (typeof(TOut) == typeof(ushort))
+                    return (TOut)(object)Convert.ToUInt16(value);
+                if (typeof(TOut) == typeof(uint))
+                    return (TOut)(object)Convert.ToUInt32(value);
+                if (typeof(TOut) == typeof(ulong))
+                    return (TOut)(object)Convert.ToUInt64(value);
+                
                 if (typeof(TOut) == typeof(double))
                     return (TOut)(object)Convert.ToDouble(value);
 #if NET6_0_OR_GREATER
                 if (typeof(TOut) == typeof(Half))
-                    return (TOut)(object)(Half)value;
+                    return (TOut)(object)(Half)Convert.ToSingle(value);
 #endif
+                
                 return (TOut)(object)value;
             }
             
             private static TOut DoubleConverter(byte* data)
             {
                 var value = Unsafe.ReadUnaligned<double>(data);
-
-                if (typeof(TOut) == typeof(float))
-                    return (TOut)(object)Convert.ToSingle(value);
                 
+                if (typeof(TOut) == typeof(sbyte))
+                    return (TOut)(object)Convert.ToSByte(value);
+                if (typeof(TOut) == typeof(short))
+                    return (TOut)(object)Convert.ToInt16(value);
+                if (typeof(TOut) == typeof(int))
+                    return (TOut)(object)Convert.ToInt32(value);
+                if (typeof(TOut) == typeof(long))
+                    return (TOut)(object)Convert.ToInt64(value);
+                
+                if (typeof(TOut) == typeof(byte))
+                    return (TOut)(object)Convert.ToByte(value);
+                if (typeof(TOut) == typeof(ushort))
+                    return (TOut)(object)Convert.ToUInt16(value);
+                if (typeof(TOut) == typeof(uint))
+                    return (TOut)(object)Convert.ToUInt32(value);
+                if (typeof(TOut) == typeof(ulong))
+                    return (TOut)(object)Convert.ToUInt64(value);
+                
+                if (typeof(TOut) == typeof(double))
+                    return (TOut)(object)Convert.ToDouble(value);
 #if NET6_0_OR_GREATER
                 if (typeof(TOut) == typeof(Half))
                     return (TOut)(object)(Half)Convert.ToSingle(value);

--- a/src/Sparrow/Json/Parsing/JsonParserState.cs
+++ b/src/Sparrow/Json/Parsing/JsonParserState.cs
@@ -220,10 +220,7 @@ namespace Sparrow.Json.Parsing
             Continuation = JsonParserTokenContinuation.None;
             EscapePositions.Clear();
 
-            // We will change this value to MinValue because the 0 magnitude number is valid as the content of a vector.
-            _maxLong = long.MinValue;
-            _minLong = long.MaxValue;
-            _maxDoubleMagnitude = double.MinValue;
+            ClearBuffered();
         }
 
         internal FastList<(JsonParserToken, long)> _bufferedSequence;
@@ -235,12 +232,13 @@ namespace Sparrow.Json.Parsing
 
         internal void ClearBuffered()
         {
-            _bufferedSequence.WeakClear();
+            _bufferedSequence?.WeakClear();
 
             // We will change this value to MinValue because the 0 magnitude number is valid as the content of a vector.
             _maxLong = long.MinValue;
             _minLong = long.MaxValue;
             _maxDoubleMagnitude = double.MinValue;
+            IsBufferedFloat = false;
         }
 
         internal BlittableVectorType GetBufferedOptimalType()

--- a/test/SlowTests/Issues/RavenDB-23657.cs
+++ b/test/SlowTests/Issues/RavenDB-23657.cs
@@ -1,0 +1,201 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Queries.Vector;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23657(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    public async Task CanCreateAutoIndexFromListOfRavenVector()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenAsyncSession();
+        await session.StoreAsync(CreateDocument());
+
+        await session.SaveChangesAsync();
+        //Sbyte
+        var results = await session.Query<Document>()
+            .Statistics(out var statistics)
+            .Customize(c => c.WaitForNonStaleResults())
+            .VectorSearch(f => f.WithEmbedding(s => s.TagsEmbeddedAsInt8, VectorEmbeddingType.Int8),
+                v => v.ByEmbedding(new RavenVector<sbyte>(VectorQuantizer.ToInt8([1, 2]))))
+            .ToListAsync();
+        Assert.Single(results);
+
+        await store.Maintenance.SendAsync(new DeleteIndexOperation(statistics.IndexName));
+
+        //Floats
+        results = await session.Query<Document>()
+            .Statistics(out statistics)
+            .Customize(c => c.WaitForNonStaleResults())
+            .VectorSearch(f => f.WithEmbedding(s => s.TagsEmbeddedAsSingle),
+                v => v.ByEmbedding(new RavenVector<float>([.1f, .2f])))
+            .ToListAsync();
+        Assert.Single(results);
+
+        await store.Maintenance.SendAsync(new DeleteIndexOperation(statistics.IndexName));
+
+        //Int1
+        results = await session.Query<Document>()
+            .Statistics(out statistics)
+            .Customize(c => c.WaitForNonStaleResults())
+            .VectorSearch(f => f.WithEmbedding(s => s.TagsEmbeddedAsBinary, VectorEmbeddingType.Binary),
+                v => v.ByEmbedding(new RavenVector<byte>(VectorQuantizer.ToInt1([0.1f, 0.2f, -1f, 0, 1, 0, 0]))))
+            .ToListAsync();
+
+        WaitForUserToContinueTheTest(store);
+        Assert.Single(results);
+    }
+    
+    [RavenFact(RavenTestCategory.Vector)]
+    public async Task RavenVectorUnderlyingValuesWillBeCorrectlyStored()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenAsyncSession();
+
+        await session.StoreAsync(CreateDocument());
+        await session.SaveChangesAsync();
+
+        await new IndexType().ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
+        IndexType.Map underlyingTypes = await session.Query<IndexType.Map, IndexType>().ProjectInto<IndexType.Map>().SingleAsync();
+        //RavenVector<byte>
+        Assert.Equal("Byte", underlyingTypes.TypeBinary[0]);
+        Assert.Equal("SByte", underlyingTypes.TypeBinary[1]);
+
+        //RavenVector<sbyte>
+        Assert.Equal("SByte", underlyingTypes.TypeInt8[0]);
+        Assert.Equal("SByte", underlyingTypes.TypeInt8[1]);
+
+        //RavenVector<float>
+        Assert.Equal("Float", underlyingTypes.TypeSingle[0]);
+        Assert.Equal("Float", underlyingTypes.TypeSingle[1]);
+    }
+
+    [RavenFact(RavenTestCategory.Vector)]
+    public async Task CanIndexRavenVectorOfInt32AsSingle()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenAsyncSession();
+
+        await session.StoreAsync(CreateDocument());
+        await session.SaveChangesAsync();
+        
+        var result = await session.Query<Document>().Customize(c => c.WaitForNonStaleResults())
+            .VectorSearch(f => f.WithEmbedding(s => s.TagsEmbeddedAsInt), p => p.ByEmbedding(new RavenVector<int>([1, 2, 3])))
+            .ToArrayAsync();
+        Assert.Single(result);
+    }
+
+    private static Document CreateDocument() => new Document()
+    {
+        TagsEmbeddedAsBinary = new()
+        {
+            new RavenVector<byte>(VectorQuantizer.ToInt1([0.1f, 0.2f, -1f, 0, 1, 0, 0])),
+            new RavenVector<byte>(VectorQuantizer.ToInt1([-0.1f, 0.2f, -1f, 0, -1, 0, 0]))
+        },
+        TagsEmbeddedAsInt8 = new List<RavenVector<sbyte>>([
+            new RavenVector<sbyte>(VectorQuantizer.ToInt8([1, 2])),
+            new RavenVector<sbyte>(VectorQuantizer.ToInt8([3, 4]))
+        ]),
+        TagsEmbeddedAsSingle = new() { new RavenVector<float>([.1f, .2f]), new RavenVector<float>([-.1f, -.2f]), },
+        TagsEmbeddedAsInt = [new RavenVector<int>([1, 2, 3]), new RavenVector<int>([-1, -2, -3])]
+    };
+
+    private class Document
+    {
+        public List<RavenVector<sbyte>> TagsEmbeddedAsInt8 { get; set; }
+        public List<RavenVector<float>> TagsEmbeddedAsSingle { get; set; }
+        public List<RavenVector<byte>> TagsEmbeddedAsBinary { get; set; }
+        public List<RavenVector<int>> TagsEmbeddedAsInt { get; set; }
+    }
+
+    private class IndexType : AbstractIndexCreationTask
+    {
+        public class Map
+        {
+            public string[] TypeBinary { get; set; }
+            public string[] TypeInt8 { get; set; }
+            public string[] TypeSingle { get; set; }
+        }
+
+        public override IndexDefinition CreateIndexDefinition()
+        {
+            return new IndexDefinition()
+            {
+                Maps =
+                [
+                    @"
+from doc in docs.Documents 
+select new 
+{
+    TypeBinary = Helper.GetUnderlyingEmbeddingType(doc.TagsEmbeddedAsBinary),
+    TypeInt8 = Helper.GetUnderlyingEmbeddingType(doc.TagsEmbeddedAsInt8),
+    TypeSingle = Helper.GetUnderlyingEmbeddingType(doc.TagsEmbeddedAsSingle)
+}"
+                ],
+                AdditionalSources = new()
+                {
+                    {
+                        "Helper", @"
+using Sparrow.Json;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+public static class Helper
+{
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = ""_inner"")]
+    private static extern ref IEnumerable<object> GetInnerField(DynamicArray dynamicArray);
+
+    public static List<string> GetUnderlyingEmbeddingType(object value)
+    {
+        var bjra = value as BlittableJsonReaderArray;
+        if (value is DynamicArray da)
+        {
+            bjra = (BlittableJsonReaderArray)GetInnerField(da);
+        }
+        List<string> values = new();
+
+        if (bjra == null)
+        {
+            values.Add(value.GetType().FullName);
+            return values;
+        }
+
+        foreach (var currentObject in bjra)
+        {
+            var bjro = currentObject as BlittableJsonReaderObject ?? ((DynamicBlittableJson)value).BlittableJson;
+            if (bjro != null && bjro.TryGetMember(""@vector"", out var vector)
+                 && vector is BlittableJsonReaderVector bjrv)
+            {
+                values.Add(bjrv.Type.ToString());
+            }
+        }
+
+        if (values.Count == 0)
+            values.Add(""Unknown"");
+
+        return values;
+    }
+}"
+                    }
+                },
+                Fields = new Dictionary<string, IndexFieldOptions>()
+                {
+                    { "TypeBinary", new IndexFieldOptions() { Storage = FieldStorage.Yes } },
+                    { "TypeInt8", new IndexFieldOptions() { Storage = FieldStorage.Yes } },
+                    { "TypeSingle", new IndexFieldOptions() { Storage = FieldStorage.Yes } },
+                }
+            };
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23658.cs
+++ b/test/SlowTests/Issues/RavenDB-23658.cs
@@ -1,0 +1,138 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Queries.Vector;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23658(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void CanSearchForVectorFromSingle()
+    {
+        using var store = GetDocumentStore();
+        new Index2().Execute(store);
+        using var session = store.OpenSession();
+        session.Store(CreateItem1());
+        session.Store(CreateItem2());
+        session.SaveChanges();
+
+        Indexes.WaitForIndexing(store);
+        var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
+        Assert.Null(errors);
+
+        var index2Results = session.Query<Index2.IndexEntry, Index2>()
+            .VectorSearch(
+                field => field
+                    .WithField(x => x.VectorFromSingle),
+                searchTerm => searchTerm
+                    .ByEmbedding(new RavenVector<float>([6.599999904632568f, 7.699999809265137f])))
+            .ProjectInto<Item>()
+            .ToList();
+
+        Assert.Equal(1, index2Results.Count);
+        Assert.Equal("Item1", index2Results[0].Name);
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void CanSearchForVectorFromSBytes()
+    {
+        using var store = GetDocumentStore();
+        new Index3().Execute(store);
+        using var session = store.OpenSession();
+        session.Store(CreateItem1());
+        session.Store(CreateItem2());
+        session.SaveChanges();
+
+        Indexes.WaitForIndexing(store);
+        var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
+        Assert.Null(errors);
+        
+        var index3Results = session.Query<Index3.IndexEntry, Index3>()
+            .VectorSearch(
+                field => field
+                    .WithField(x => x.VectorFromInt8Array),
+                searchTerm => searchTerm
+                    .ByEmbedding(VectorQuantizer.ToInt8([0.1f, 0.2f])))
+            .ProjectInto<Item>()
+            .ToList();
+        
+        Assert.NotEmpty(index3Results);
+    }
+
+    private static Item CreateItem1() => new()
+    {
+        Name = "Item1",
+        TagsEmbeddedAsSingle =
+            new RavenVector<float>([6.599999904632568f, 7.699999809265137f]),
+        TagsEmbeddedAsInt8 = new List<RavenVector<sbyte>>([
+            new RavenVector<sbyte>(VectorQuantizer.ToInt8([1, 2])),
+            new RavenVector<sbyte>(VectorQuantizer.ToInt8([3, 4]))
+        ]),
+        TagsEmbeddedAsInt8Regular = new sbyte[][] { VectorQuantizer.ToInt8([0.1f, 0.2f]), VectorQuantizer.ToInt8([0.3f, 0.4f]) }
+    };
+
+    private static Item CreateItem2() => new()
+    {
+        Name = "Item2",
+        TagsEmbeddedAsSingle = new RavenVector<float>([8.800000190734863f, -9.899999618530273f]),
+        TagsEmbeddedAsInt8 = new List<RavenVector<sbyte>>([
+            new RavenVector<sbyte>(VectorQuantizer.ToInt8([5, 6])),
+            new RavenVector<sbyte>(VectorQuantizer.ToInt8([7, 8]))
+        ]),
+        TagsEmbeddedAsInt8Regular = [VectorQuantizer.ToInt8([0.5f, 0.6f]), VectorQuantizer.ToInt8([0.7f, 0.8f])]
+    };
+
+    private class Index2 : AbstractIndexCreationTask<Item, Index2.IndexEntry>
+    {
+        public class IndexEntry()
+        {
+            public object VectorFromSingle { get; set; }
+        }
+
+        public Index2()
+        {
+            Map = items => from item in items
+                select new IndexEntry { VectorFromSingle = CreateVector(item.TagsEmbeddedAsSingle) };
+
+            VectorIndexes.Add(x => x.VectorFromSingle,
+                new VectorOptions() { SourceEmbeddingType = VectorEmbeddingType.Single, DestinationEmbeddingType = VectorEmbeddingType.Single });
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class Index3 : AbstractIndexCreationTask<Item, Index3.IndexEntry>
+    {
+        public class IndexEntry()
+        {
+            public object VectorFromInt8Array { get; set; }
+        }
+
+        public Index3()
+        {
+            Map = items => from item in items
+                select new IndexEntry { VectorFromInt8Array = CreateVector(item.TagsEmbeddedAsInt8Regular) };
+
+            VectorIndexes.Add(x => x.VectorFromInt8Array,
+                new VectorOptions() { SourceEmbeddingType = VectorEmbeddingType.Int8, DestinationEmbeddingType = VectorEmbeddingType.Int8 });
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class Item
+    {
+        public string Name { get; set; }
+        public RavenVector<float> TagsEmbeddedAsSingle { get; set; }
+
+        public List<RavenVector<sbyte>> TagsEmbeddedAsInt8 { get; set; }
+        public sbyte[][] TagsEmbeddedAsInt8Regular { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23657
https://issues.hibernatingrhinos.com/issue/RavenDB-23658

### Additional description

- Support for deserializing Blittable vector from different type than expected during indexing.
- Support for deserializing Blittable vector from different type than expected during querying.
- JsonParser: Reset the state of the properties related to Blittable vector to avoid mixing the state between two properties.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
