### PR TITLE
RavenDB-23665 Remove docsHashes test

### DIFF
--- a/src/Raven.Studio/typescript/components/common/helpAndResources/partials/SeeDocumentationButton.tsx
+++ b/src/Raven.Studio/typescript/components/common/helpAndResources/partials/SeeDocumentationButton.tsx
@@ -1,9 +1,8 @@
 import { FlexGrow } from "components/common/FlexGrow";
 import { Icon } from "components/common/Icon";
-import React from "react";
 import router from "plugins/router";
 import { useGetRavenLink } from "components/hooks/useRavenLink";
-import { docsHashes } from "components/utils/docsHashes";
+import { getDocsHash } from "components/utils/docsHashes";
 import { clusterSelectors } from "components/common/shell/clusterSlice";
 import { useAppSelector } from "components/store";
 import genUtils from "common/generalUtils";
@@ -14,10 +13,10 @@ export default function SeeDocumentationButton() {
 
     const handleOpenDocumentation = () => {
         const singleRoute = genUtils.getSingleRoute(router.activeInstruction()?.config?.route);
-        const docsHash = docsHashes[singleRoute];
+        const docsHash = getDocsHash(singleRoute);
 
         const getLink = () => {
-            if (!docsHash || docsHash === "MISSING_DOCS") {
+            if (docsHash === "MISSING_DOCS") {
                 return `https://ravendb.net/docs/article-page/${clientMajorVersion}`;
             }
 

--- a/src/Raven.Studio/typescript/components/utils/docsHashes.spec.ts
+++ b/src/Raven.Studio/typescript/components/utils/docsHashes.spec.ts
@@ -1,46 +1,11 @@
-import genUtils from "common/generalUtils";
-import generateMenuItems from "common/shell/menu/generateMenuItems";
-import intermediateMenuItem from "common/shell/menu/intermediateMenuItem";
-import leafMenuItem from "common/shell/menu/leafMenuItem";
-import { docsHashes } from "components/utils/docsHashes";
+import { getDocsHash } from "components/utils/docsHashes";
 
-const skippedRoutes: string[] = [
-    "databases/tasks/import*details",
-    "databases/status/debug*details",
-    "admin/settings/debug/advanced*details",
-    "whatsNew",
-    "virtual",
-];
+describe("getDocsHash", () => {
+    it("returns 'MISSING_DOCS' when can't find route", () => {
+        expect(getDocsHash("non-existing-route")).toBe("MISSING_DOCS");
+    });
 
-describe("docsHashes", () => {
-    it("should contain all routes hashes", () => {
-        let allRoutes: string[] = [];
-
-        const menuItems = generateMenuItems({
-            db: "someDb",
-            isNewVersionAvailable: true,
-            isWhatsNewVisible: true,
-        });
-
-        const menuLeafs: leafMenuItem[] = [];
-
-        const crawlMenu = (item: menuItem) => {
-            if (item instanceof leafMenuItem) {
-                menuLeafs.push(item);
-            } else if (item instanceof intermediateMenuItem) {
-                item.children.forEach(crawlMenu);
-            }
-        };
-
-        menuItems.forEach(crawlMenu);
-
-        allRoutes = Array.from(new Set(menuLeafs.map((x) => genUtils.getSingleRoute(x.route))))
-            .filter((x) => !skippedRoutes.includes(x))
-            .sort();
-
-        const definedRoutes = Object.keys(docsHashes).sort();
-
-        expect(definedRoutes).toEqual(allRoutes);
-        expect(definedRoutes.every((x: keyof typeof docsHashes) => docsHashes[x])).toBeTruthy();
+    it("returns hash for existing route", () => {
+        expect(getDocsHash("databases/documents")).toBe("H6XJDZ");
     });
 });

--- a/src/Raven.Studio/typescript/components/utils/docsHashes.ts
+++ b/src/Raven.Studio/typescript/components/utils/docsHashes.ts
@@ -1,6 +1,6 @@
 import { StringWithAutocomplete } from "components/utils/common";
 
-export const docsHashes: Record<string, StringWithAutocomplete<"MISSING_DOCS">> = {
+const docsHashes: Record<string, StringWithAutocomplete<"MISSING_DOCS">> = {
     "databases/documents": "H6XJDZ",
     "databases/documents/revisions/bin": "T4Y76K",
     "databases/patch(/:recentPatchHash)": "VXSYQ7",
@@ -70,7 +70,7 @@ export const docsHashes: Record<string, StringWithAutocomplete<"MISSING_DOCS">> 
     "admin/settings/editServerWideExternalReplication": "MZOBO3",
     "admin/settings/serverWideCustomAnalyzers": "VWCQPI",
     "admin/settings/serverWideCustomSorters": "XI6BMT",
-    // missing docs
+    // routs for which the documentation is missing (there may be more)
     "databases/indexes/terms/(:indexName)": "MISSING_DOCS",
     "databases/indexes/cleanup": "MISSING_DOCS",
     "databases/status/buckets/report": "MISSING_DOCS",
@@ -97,4 +97,15 @@ export const docsHashes: Record<string, StringWithAutocomplete<"MISSING_DOCS">> 
     about: "MISSING_DOCS",
     "databases/tasks/editSnowflakeEtlTask": "MISSING_DOCS",
     "databases/documents/revisions/all": "MISSING_DOCS",
+    "databases/settings/revisionsBinCleaner": "MISSING_DOCS",
 };
+
+export function getDocsHash(route: string): StringWithAutocomplete<"MISSING_DOCS"> {
+    const hash = docsHashes[route];
+
+    if (!hash) {
+        return "MISSING_DOCS";
+    }
+
+    return hash;
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23665/Remove-docsHashes-test

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
